### PR TITLE
Property rename: old value to new support

### DIFF
--- a/core/commons/che-core-commons-inject/pom.xml
+++ b/core/commons/che-core-commons-inject/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/commons/che-core-commons-inject/pom.xml
+++ b/core/commons/che-core-commons-inject/pom.xml
@@ -61,7 +61,7 @@
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
+            <artifactId>logback-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java
+++ b/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java
@@ -100,9 +100,21 @@ import org.slf4j.LoggerFactory;
  * <tr><td>${root_data}/input/</td><td>&nbsp;</td><td>&nbsp;</td><td>${root_data}/input/</td></tr>
  * </table>
  *
+ * During code evolution might be the case then someone will want to rename some property. This
+ * brings a couple of problems like support of old property name in external plugins and support old
+ * configuration values in code with the new property name.
+ *
+ * <p>To cover this cases there is a file che_aliases.properties that contains old names of all
+ * existed properties. It has such format current_name =old_name, very_old_name. In this case will
+ * be such binding. Always current_name = current_value if old_name property exist it will be binded
+ * to old_value and current_name = old_value and very_old_name = old_value if very_old_name property
+ * exist it will be binded to very_old_value, and current_name = very_old_value and old_name =
+ * very_old_value
+ *
  * @author gazarenkov
  * @author andrew00x
  * @author Florent Benoit
+ * @author Sergii Kabashniuk
  */
 public class CheBootstrap extends EverrestGuiceContextListener {
   private static final Logger LOG = LoggerFactory.getLogger(CheBootstrap.class);

--- a/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java
+++ b/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java
@@ -102,14 +102,13 @@ import org.slf4j.LoggerFactory;
  *
  * During code evolution might be the case then someone will want to rename some property. This
  * brings a couple of problems like support of old property name in external plugins and support old
- * configuration values in code with the new property name.
+ * configuration values in code with the new property name. To cover these cases there is a file
+ * che_aliases.properties that contains old names of all existed properties. It has such format
+ * current_name =old_name, very_old_name. In this case will be such binding.
  *
- * <p>To cover this cases there is a file che_aliases.properties that contains old names of all
- * existed properties. It has such format current_name =old_name, very_old_name. In this case will
- * be such binding. Always current_name = current_value if old_name property exist it will be binded
- * to old_value and current_name = old_value and very_old_name = old_value if very_old_name property
- * exist it will be binded to very_old_value, and current_name = very_old_value and old_name =
- * very_old_value
+ * <p>Always current_name = current_value if old_name property exist it will be binded to old_value
+ * and current_name = old_value and very_old_name = old_value if very_old_name property exist it
+ * will be binded to very_old_value, and current_name = very_old_value and old_name = very_old_value
  *
  * @author gazarenkov
  * @author andrew00x

--- a/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java
+++ b/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java
@@ -110,6 +110,10 @@ import org.slf4j.LoggerFactory;
  * and current_name = old_value and very_old_name = old_value if very_old_name property exist it
  * will be binded to very_old_value, and current_name = very_old_value and old_name = very_old_value
  *
+ * <p>NOTE: its prohibited to use a different name for same property on the same level. From the
+ * example above - you can use environment property CHE_CURRENT_NAME and CHE_OLD_NAME. But you can
+ * use it on a different level, for instance, environment property and system property.
+ *
  * @author gazarenkov
  * @author andrew00x
  * @author Florent Benoit

--- a/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java
+++ b/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/CheBootstrap.java
@@ -100,7 +100,7 @@ import org.slf4j.LoggerFactory;
  * <tr><td>${root_data}/input/</td><td>&nbsp;</td><td>&nbsp;</td><td>${root_data}/input/</td></tr>
  * </table>
  *
- * During code evolution might be the case then someone will want to rename some property. This
+ * During code evolution might be the case when someone will want to rename some property. This
  * brings a couple of problems like support of old property name in external plugins and support old
  * configuration values in code with the new property name. To cover these cases there is a file
  * che_aliases.properties that contains old names of all existed properties. It has such format
@@ -110,7 +110,7 @@ import org.slf4j.LoggerFactory;
  * and current_name = old_value and very_old_name = old_value if very_old_name property exist it
  * will be binded to very_old_value, and current_name = very_old_value and old_name = very_old_value
  *
- * <p>NOTE: its prohibited to use a different name for same property on the same level. From the
+ * <p>NOTE: it's prohibited to use a different name for same property on the same level. From the
  * example above - you can use environment property CHE_CURRENT_NAME and CHE_OLD_NAME. But you can
  * use it on a different level, for instance, environment property and system property.
  *

--- a/core/commons/che-core-commons-inject/src/test/java/org/eclipse/che/inject/CheBootstrapTest.java
+++ b/core/commons/che-core-commons-inject/src/test/java/org/eclipse/che/inject/CheBootstrapTest.java
@@ -297,6 +297,30 @@ public class CheBootstrapTest {
     assertEquals(testComponent.otherOtherString, "some_value");
   }
 
+
+
+  @Test
+  public void processesOld2NewPropertyAliases() throws Exception {
+    Properties cheProperties = new Properties();
+    cheProperties.put("che.some.name", "some_value");
+    writePropertiesFile(che, "che.properties", cheProperties);
+
+    Properties aliases = new Properties();
+    aliases.put("very.new.some.name", "new.some.name, che.some.name");
+    writePropertiesFile(che.getParentFile(), PROPERTIES_ALIASES_CONFIG_FILE, aliases);
+
+    ModuleScanner.modules.add(binder -> binder.bind(TestConfAliasComponent.class));
+
+    cheBootstrap.contextInitialized(new ServletContextEvent(servletContext));
+
+    Injector injector = retrieveComponentFromServletContext(Injector.class);
+
+    TestConfAliasComponent testComponent = injector.getInstance(TestConfAliasComponent.class);
+    assertEquals(testComponent.string, "some_value");
+    assertEquals(testComponent.otherString, "some_value");
+    assertEquals(testComponent.otherOtherString, "some_value");
+  }
+
   static class TestChePropertiesComponent {
     @Named("test_int")
     @Inject

--- a/core/commons/che-core-commons-inject/src/test/java/org/eclipse/che/inject/CheBootstrapTest.java
+++ b/core/commons/che-core-commons-inject/src/test/java/org/eclipse/che/inject/CheBootstrapTest.java
@@ -297,8 +297,6 @@ public class CheBootstrapTest {
     assertEquals(testComponent.otherOtherString, "some_value");
   }
 
-
-
   @Test
   public void processesOld2NewPropertyAliases() throws Exception {
     Properties cheProperties = new Properties();


### PR DESCRIPTION
### What does this PR do?
During code evolution might be the case then someone will want to rename some property. This brings a couple of problems like support of old property name in external plugins and support old configuration values in code with the new property name. To cover these cases there is a file  che_aliases.properties that contains old names of all existed properties.  It has such format current_name =old_name, very_old_name. In this case will be such binding.
1. Always current_name = current_value
2. if old_name property exist it will be binded to old_value, and current_name = old_value and very_old_name = old_value
3. if very_old_name property exist it will be binded to very_old_value, and current_name = very_old_value and old_name = very_old_value

NOTE: its prohibited to use a different name for same property on the same level. From the example above - you can use environment property CHE_CURRENT_NAME and CHE_OLD_NAME. But you can use it on a different level, for instance, environment property and system property.


### What issues does this PR fix or reference?


#### Release Notes
Extended support for property renaming.

#### Docs PR
n/a