### PR TITLE
Selenium: fix unstable CheckStopStartWsTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Ide.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Ide.java
@@ -10,6 +10,9 @@
  */
 package org.eclipse.che.selenium.pageobject;
 
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Profile.PROFILE_MENU;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.net.URL;
@@ -18,6 +21,7 @@ import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.entrance.Entrance;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceUrlResolver;
+import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 
 /**
  * @author Vitaliy Gulyy
@@ -28,21 +32,36 @@ public class Ide {
   private final SeleniumWebDriver seleniumWebDriver;
   private final TestWorkspaceUrlResolver testWorkspaceUrlResolver;
   private final Entrance entrance;
+  private final ProjectExplorer projectExplorer;
+  private final MachineTerminal terminal;
+  private final Menu menu;
 
   @Inject
   public Ide(
       SeleniumWebDriver seleniumWebDriver,
       TestWorkspaceUrlResolver testWorkspaceUrlResolver,
-      Entrance entrance) {
+      Entrance entrance,
+      ProjectExplorer projectExplorer,
+      MachineTerminal terminal,
+      Menu menu) {
     this.seleniumWebDriver = seleniumWebDriver;
     this.testWorkspaceUrlResolver = testWorkspaceUrlResolver;
     this.entrance = entrance;
+    this.projectExplorer = projectExplorer;
+    this.terminal = terminal;
+    this.menu = menu;
   }
 
   public void open(TestWorkspace testWorkspace) throws Exception {
     URL workspaceUrl = testWorkspaceUrlResolver.resolve(testWorkspace);
     seleniumWebDriver.get(workspaceUrl.toString());
     entrance.login(testWorkspace.getOwner());
+  }
+
+  public void waitOpenedWorkspaceIsReadyToUse() {
+    projectExplorer.waitProjectExplorer(PREPARING_WS_TIMEOUT_SEC);
+    terminal.waitTerminalTab(PREPARING_WS_TIMEOUT_SEC);
+    menu.waitMenuItemIsEnabled(PROFILE_MENU);
   }
 
   @PreDestroy

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
@@ -10,29 +10,23 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
-import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Profile.PROFILE_MENU;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.STOP_WORKSPACE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
-import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.ToastLoader;
-import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
 public class CheckStopStartWsTest {
   @Inject private TestWorkspace testWorkspace;
-  @Inject private Ide ide;
-  @Inject private ProjectExplorer projectExplorer;
-  @Inject private MachineTerminal terminal;
   @Inject private ToastLoader toastLoader;
   @Inject private Menu menu;
+  @Inject private Ide ide;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -41,16 +35,12 @@ public class CheckStopStartWsTest {
 
   @Test
   public void checkStopStartWorkspaceTest() {
-    projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab(EXPECTED_MESS_IN_CONSOLE_SEC);
-    menu.waitMenuItemIsEnabled(PROFILE_MENU);
+    ide.waitOpenedWorkspaceIsReadyToUse();
 
     menu.runCommand(WORKSPACE, STOP_WORKSPACE);
     toastLoader.waitExpectedTextInToastLoader("Workspace is not running");
 
     toastLoader.clickOnStartButton();
-    projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab(EXPECTED_MESS_IN_CONSOLE_SEC);
-    menu.waitMenuItemIsEnabled(PROFILE_MENU);
+    ide.waitOpenedWorkspaceIsReadyToUse();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CheckStopStartWsTest.java
@@ -10,14 +10,14 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Profile.PROFILE_MENU;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.STOP_WORKSPACE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.ToastLoader;
@@ -30,7 +30,6 @@ public class CheckStopStartWsTest {
   @Inject private TestWorkspace testWorkspace;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private Loader loader;
   @Inject private MachineTerminal terminal;
   @Inject private ToastLoader toastLoader;
   @Inject private Menu menu;
@@ -43,16 +42,15 @@ public class CheckStopStartWsTest {
   @Test
   public void checkStopStartWorkspaceTest() {
     projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
-    loader.waitOnClosed();
+    terminal.waitTerminalTab(EXPECTED_MESS_IN_CONSOLE_SEC);
+    menu.waitMenuItemIsEnabled(PROFILE_MENU);
 
     menu.runCommand(WORKSPACE, STOP_WORKSPACE);
-    toastLoader.waitExpectedTextInToastLoader("Stopping the workspace");
-    toastLoader.waitExpectedTextInToastLoader("Workspace is not running", 60);
+    toastLoader.waitExpectedTextInToastLoader("Workspace is not running");
 
     toastLoader.clickOnStartButton();
-    loader.waitOnClosed();
     projectExplorer.waitProjectExplorer();
-    terminal.waitTerminalTab(LOADER_TIMEOUT_SEC);
+    terminal.waitTerminalTab(EXPECTED_MESS_IN_CONSOLE_SEC);
+    menu.waitMenuItemIsEnabled(PROFILE_MENU);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
@@ -15,7 +15,6 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.W
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.STOP_WORKSPACE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
 import static org.eclipse.che.selenium.core.constant.TestStacksConstants.JAVA;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.Wizard.SamplesName.WEB_JAVA_SPRING;
 
@@ -24,6 +23,7 @@ import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -32,7 +32,6 @@ import org.eclipse.che.selenium.pageobject.Wizard;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
-import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -50,13 +49,13 @@ public class CreateWorkspaceOnDashboardTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private NewWorkspace newWorkspace;
   @Inject private TestUser defaultTestUser;
-  @Inject private MachineTerminal terminal;
   @Inject private ToastLoader toastLoader;
   @Inject private Workspaces workspaces;
   @Inject private CodenvyEditor editor;
   @Inject private Dashboard dashboard;
   @Inject private Wizard wizard;
   @Inject private Menu menu;
+  @Inject private Ide ide;
 
   @AfterClass
   public void tearDown() throws Exception {
@@ -81,9 +80,7 @@ public class CreateWorkspaceOnDashboardTest {
     seleniumWebDriver.switchFromDashboardIframeToIde();
 
     // wait that the workspace is started
-    projectExplorer.waitProjectExplorer(PREPARING_WS_TIMEOUT_SEC); // we need long timeout for OSIO
-    terminal.waitTerminalTab(PREPARING_WS_TIMEOUT_SEC); // we need long timeout for OSIO
-    menu.waitMenuItemIsEnabled(WORKSPACE);
+    ide.waitOpenedWorkspaceIsReadyToUse();
 
     // Import the "web-java-spring" project
     menu.runCommand(WORKSPACE, CREATE_PROJECT);


### PR DESCRIPTION
### What does this PR do?
This PR fix **CheckStopStartWsTest** selenium test :
- increase timeout for checking for the **Terminal** when a workspace is starting;
- add waiting that the **Profile** menu is enabled for checking that workspace is fully started.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8647