### PR TITLE
Set active line after Find Definition action

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/OpenFileInEditorHelper.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/OpenFileInEditorHelper.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.plugin.languageserver.ide.util;
 
+import static org.eclipse.che.ide.api.editor.text.LinearRange.createWithStart;
+
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
@@ -35,8 +37,6 @@ import org.eclipse.che.plugin.languageserver.ide.location.LanguageServerFile;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
-
-import static org.eclipse.che.ide.api.editor.text.LinearRange.createWithStart;
 
 /**
  * Util class, helps to open file by path in editor

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/OpenFileInEditorHelper.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/util/OpenFileInEditorHelper.java
@@ -24,6 +24,7 @@ import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.OpenEditorCallbackImpl;
+import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.editor.text.TextRange;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
@@ -34,6 +35,8 @@ import org.eclipse.che.plugin.languageserver.ide.location.LanguageServerFile;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Range;
+
+import static org.eclipse.che.ide.api.editor.text.LinearRange.createWithStart;
 
 /**
  * Util class, helps to open file by path in editor
@@ -89,7 +92,9 @@ public class OpenFileInEditorHelper {
 
   private Consumer<TextEditor> selectRange(TextRange range) {
     return (editor) -> {
-      editor.getDocument().setSelectedRange(range, true);
+      Document document = editor.getDocument();
+      document.setSelectedRange(
+          createWithStart(document.getIndexFromPosition(range.getFrom())).andLength(0), true);
     };
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix a bug when Find Definition action doesn't set the line, where the definition is located, active. It's just highlight the definition.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
