### PR TITLE
Selenium: Add logs with catched libraries, project type and language for investigate bug

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0093Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0093Test.java
@@ -25,6 +25,8 @@ import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,6 +37,7 @@ import org.testng.annotations.Test;
 public class Eclipse0093Test {
 
   private static final String PATH_TO_PACKAGE_PREFIX = "/src/main/java/org/eclipse/qa/examples/";
+  private static final Logger LOG = LoggerFactory.getLogger(Eclipse0093Test.class);
   private static final String PROJECT_NAME =
       NameGenerator.generate(Eclipse0093Test.class.getSimpleName(), 4);
 
@@ -59,17 +62,43 @@ public class Eclipse0093Test {
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByPath(PROJECT_NAME + PATH_TO_PACKAGE_PREFIX + "Test.java");
     editor.waitActive();
-
-    try {
-      editor.waitMarkerInPosition(WARNING_MARKER, 12);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
-    }
-
+    waitMarkerInPosition();
     editor.goToCursorPositionVisible(17, 26);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("MyEnum");
     editor.waitSpecifiedValueForLineAndChar(14, 3);
+  }
+
+  private void waitMarkerInPosition() throws Exception {
+    try {
+      editor.waitMarkerInPosition(WARNING_MARKER, 12);
+    } catch (TimeoutException ex) {
+      logExternalLibraries();
+      logProjectTypeChecking();
+      logProjectLanguageChecking();
+
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
+    }
+  }
+
+  private void logExternalLibraries() throws Exception {
+    testProjectServiceClient
+        .getExternalLibraries(ws.getId(), PROJECT_NAME)
+        .forEach(library -> LOG.info("project external library:  {}", library));
+  }
+
+  private void logProjectTypeChecking() throws Exception {
+    LOG.info(
+        "Project type of the {} project is \"maven\" - {}",
+        PROJECT_NAME,
+        testProjectServiceClient.checkProjectType(ws.getId(), PROJECT_NAME, "maven"));
+  }
+
+  private void logProjectLanguageChecking() throws Exception {
+    LOG.info(
+        "Project language of the {} project is \"java\" - {}",
+        PROJECT_NAME,
+        testProjectServiceClient.checkProjectLanguage(ws.getId(), PROJECT_NAME, "java"));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0115Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0115Test.java
@@ -25,6 +25,8 @@ import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.TimeoutException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,6 +37,7 @@ import org.testng.annotations.Test;
 public class Eclipse0115Test {
 
   private static final String PATH_TO_PACKAGE_PREFIX = "/src/main/java/org/eclipse/qa/examples/";
+  private static final Logger LOG = LoggerFactory.getLogger(Eclipse0115Test.class);
   private static final String PROJECT_NAME =
       NameGenerator.generate(Eclipse0115Test.class.getSimpleName(), 4);
 
@@ -59,16 +62,42 @@ public class Eclipse0115Test {
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByPath(PROJECT_NAME + PATH_TO_PACKAGE_PREFIX + "X.java");
     editor.waitActive();
-
-    try {
-      editor.waitMarkerInPosition(WARNING_MARKER, 14);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
-    }
-
+    waitMarkerInPosition();
     editor.goToCursorPositionVisible(32, 14);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitSpecifiedValueForLineAndChar(35, 24);
+  }
+
+  private void waitMarkerInPosition() throws Exception {
+    try {
+      editor.waitMarkerInPosition(WARNING_MARKER, 14);
+    } catch (TimeoutException ex) {
+      logExternalLibraries();
+      logProjectTypeChecking();
+      logProjectLanguageChecking();
+
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
+    }
+  }
+
+  private void logExternalLibraries() throws Exception {
+    testProjectServiceClient
+        .getExternalLibraries(ws.getId(), PROJECT_NAME)
+        .forEach(library -> LOG.info("project external library:  {}", library));
+  }
+
+  private void logProjectTypeChecking() throws Exception {
+    LOG.info(
+        "Project type of the {} project is \"maven\" - {}",
+        PROJECT_NAME,
+        testProjectServiceClient.checkProjectType(ws.getId(), PROJECT_NAME, "maven"));
+  }
+
+  private void logProjectLanguageChecking() throws Exception {
+    LOG.info(
+        "Project language of the {} project is \"java\" - {}",
+        PROJECT_NAME,
+        testProjectServiceClient.checkProjectLanguage(ws.getId(), PROJECT_NAME, "java"));
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add logs with catched libraries, project type and language for investigate https://github.com/eclipse/che/issues/8527

**Log output:**
```
2018-02-06 17:32:19,527[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  servlet-api-2.5.jar
2018-02-06 17:32:19,528[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-asm-3.0.5.RELEASE.jar
2018-02-06 17:32:19,528[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-beans-3.0.5.RELEASE.jar
2018-02-06 17:32:19,528[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  commons-logging-1.1.1.jar
2018-02-06 17:32:19,528[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-web-3.0.5.RELEASE.jar
2018-02-06 17:32:19,528[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  junit-4.12.jar
2018-02-06 17:32:19,529[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-core-3.0.5.RELEASE.jar
2018-02-06 17:32:19,529[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-context-support-3.0.5.RELEASE.jar
2018-02-06 17:32:19,529[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  aopalliance-1.0.jar
2018-02-06 17:32:19,529[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-webmvc-3.0.5.RELEASE.jar
2018-02-06 17:32:19,530[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-expression-3.0.5.RELEASE.jar
2018-02-06 17:32:19,530[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-context-3.0.5.RELEASE.jar
2018-02-06 17:32:19,530[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  hamcrest-core-1.3.jar
2018-02-06 17:32:19,530[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  spring-aop-3.0.5.RELEASE.jar
2018-02-06 17:32:19,531[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  rt.jar
2018-02-06 17:32:19,531[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  jfxrt.jar
2018-02-06 17:32:19,531[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  sunpkcs11.jar
2018-02-06 17:32:19,531[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  sunjce_provider.jar
2018-02-06 17:32:19,531[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  sunec.jar
2018-02-06 17:32:19,532[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  cldrdata.jar
2018-02-06 17:32:19,532[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  localedata.jar
2018-02-06 17:32:19,532[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  zipfs.jar
2018-02-06 17:32:19,532[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  nashorn.jar
2018-02-06 17:32:19,533[main]             [INFO ] [.a.AutocompleteWithInheritTest 138]  - project external library:  dnsns.jar
2018-02-06 17:32:19,545[main]             [INFO ] [.a.AutocompleteWithInheritTest 142]  - Project type of the AutocompleteWithInheritTesttbnj project is "maven" - true
2018-02-06 17:32:19,557[main]             [INFO ] [.a.AutocompleteWithInheritTest 149]  - Project language of the AutocompleteWithInheritTesttbnj project is "java" - true
```


### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/8527
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
