### PR TITLE
Cleaning MDC at the end of the request

### DIFF
--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/filter/IdentityIdLoggerFilter.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/filter/IdentityIdLoggerFilter.java
@@ -48,7 +48,11 @@ public class IdentityIdLoggerFilter implements Filter {
       MDC.put(IDENTITY_ID_MDC_KEY, subject.getUserId());
     }
 
-    filterChain.doFilter(request, response);
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      MDC.remove(IDENTITY_ID_MDC_KEY);
+    }
   }
 
   @Override

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/filter/RequestIdLoggerFilter.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/filter/RequestIdLoggerFilter.java
@@ -45,7 +45,11 @@ public class RequestIdLoggerFilter implements Filter {
       MDC.put(REQUEST_ID_MDC_KEY, requestId);
     }
 
-    filterChain.doFilter(request, response);
+    try {
+      filterChain.doFilter(request, response);
+    } finally {
+      MDC.remove(REQUEST_ID_MDC_KEY);
+    }
   }
 
   @Override


### PR DESCRIPTION
### What does this PR do?
Cleaning MDC at the end of the request, avoid keeping MDC from one request to another when a thread is reused. Fix for request id and identity id filters.
Doing  something similar to https://github.com/qos-ch/logback/blob/master/logback-classic/src/main/java/ch/qos/logback/classic/helpers/MDCInsertingServletFilter.java#L75