### PR TITLE
Selenium: wait that all notifications are closed before deleting project in CreateAndDeleteProjectsTest test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NotificationsPopupPanel.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/NotificationsPopupPanel.java
@@ -135,7 +135,7 @@ public class NotificationsPopupPanel {
   }
 
   /** wait disappearance of notification popups */
-  public void waitPopUpPanelsIsClosed() {
+  public void waitPopupPanelsAreClosed() {
     new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC)
         .until(ExpectedConditions.invisibilityOfElementLocated(By.id(PROGRESS_POPUP_PANEL_ID)));
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -87,11 +87,11 @@ public class CreateAndDeleteProjectsTest {
     loader.waitOnClosed();
     explorer.waitProjectExplorer();
     explorer.waitItem(CONSOLE_JAVA_SIMPLE);
-    notificationsPopupPanel.waitPopUpPanelsIsClosed();
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
     mavenPluginStatusBar.waitClosingInfoPanel();
     explorer.waitFolderDefinedTypeOfFolderByPath(CONSOLE_JAVA_SIMPLE, PROJECT_FOLDER);
     explorer.waitFolderDefinedTypeOfFolderByPath(WEB_JAVA_SPRING, PROJECT_FOLDER);
-    notificationsPopupPanel.waitPopUpPanelsIsClosed();
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
 
     switchToWindow(dashboardWindow);
     dashboard.selectWorkspacesItemOnDashboard();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -91,6 +91,7 @@ public class CreateAndDeleteProjectsTest {
     mavenPluginStatusBar.waitClosingInfoPanel();
     explorer.waitFolderDefinedTypeOfFolderByPath(CONSOLE_JAVA_SIMPLE, PROJECT_FOLDER);
     explorer.waitFolderDefinedTypeOfFolderByPath(WEB_JAVA_SPRING, PROJECT_FOLDER);
+    notificationsPopupPanel.waitPopUpPanelsIsClosed();
 
     switchToWindow(dashboardWindow);
     dashboard.selectWorkspacesItemOnDashboard();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckReplaceFeatureInEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckReplaceFeatureInEditorTest.java
@@ -77,7 +77,7 @@ public class CheckReplaceFeatureInEditorTest {
   public void checkReplace() {
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
-    notificationsPopupPanel.waitPopUpPanelsIsClosed();
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
     consoles.closeProcessesArea();
     projectExplorer.quickExpandWithJavaScript();
     loader.waitOnClosed();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
@@ -106,7 +106,7 @@ public class CheckRestoringSplitEditorTest {
       fail("Known issue https://github.com/eclipse/che/issues/7551", ex);
     }
 
-    notificationsPopupPanel.waitPopUpPanelsIsClosed();
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
     checkSplitdEditorAfterRefreshing(
         1, javaClassTab, expectedTextFromEditor.get(0), cursorPositionForJavaFile);
     checkSplitdEditorAfterRefreshing(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateNamedFactoryFromDashBoard.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateNamedFactoryFromDashBoard.java
@@ -95,7 +95,7 @@ public class CreateNamedFactoryFromDashBoard {
     events.clickEventLogBtn();
     events.waitExpectedMessage(CONFIGURING_PROJECT_AND_CLONING_SOURCE_CODE);
     events.waitExpectedMessage("Project " + PROJECT_NAME + " imported");
-    notificationsPopupPanel.waitPopUpPanelsIsClosed();
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
     projectExplorer.selectItem(PROJECT_NAME);
     pullRequestPanel.waitOpenPanel();
     projectExplorer.openItemByPath(PROJECT_NAME);


### PR DESCRIPTION
### What does this PR do?
This PR adds checking that all notifications is closed before deleting project from workspace details in unstable **CreateAndDeleteProjectsTest** selenium test. It seems that checking that the created projects have the status **PROJECT_FOLDER** does not mean that the projects are initialized and we need to wait for all notifications to close.

**Report with reproduced problem:**
https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-docker/173/Selenium_tests_report/

**Log:** 
```
org.openqa.selenium.TimeoutException: 
Expected condition failed: waiting for visibility of element located by By.xpath: //button/span[text()='Delete'] (tried for 5 second(s) with 500 MILLISECONDS interval)
Build info: version: '3.0.1', revision: '1969d75', time: '2016-10-18 09:49:13 -0700'
System info: host: 'slave6.codenvycorp.com', ip: '127.0.0.1', os.name: 'Linux', os.arch: 'amd64', os.version: '3.10.0-514.16.1.el7.x86_64', java.version: '1.8.0_102'
Driver info: org.eclipse.che.selenium.core.SeleniumWebDriver
	at org.eclipse.che.selenium.dashboard.CreateAndDeleteProjectsTest.createAndDeleteProjectTest(CreateAndDeleteProjectsTest.java:102)
```

