### PR TITLE
Increase postgres claim for OpenShift to be 1gb

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/keycloak/keycloak-data-claim.yaml
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/keycloak/keycloak-data-claim.yaml
@@ -16,5 +16,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: 1Gi
 status: {}

--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/keycloak/keycloak-log-claim.yaml
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/keycloak/keycloak-log-claim.yaml
@@ -16,5 +16,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: 1Gi
 status: {}

--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/postgres/postgres-data-claim.yaml
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/postgres/postgres-data-claim.yaml
@@ -10,5 +10,5 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 100Mi
+      storage: 1Gi
 status: {}


### PR DESCRIPTION
For compatibility and portability between OSO, OSD, and OCP this needs to be 1Gi as anything under that is not allowed in Online environments.  Having it set to 100Mi results in errors and the deployment fails.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
