### PR TITLE
Selenium: Update CheckErrorMessageWhenCreationDuplicateFolderOrFileTest for increasing stability

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckErrorMessageWhenCreationDuplicateFolderOrFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckErrorMessageWhenCreationDuplicateFolderOrFileTest.java
@@ -72,8 +72,8 @@ public class CheckErrorMessageWhenCreationDuplicateFolderOrFileTest {
     askForValueDialog.waitFormToOpen();
     askForValueDialog.typeAndWaitText(DUPLICATED_FILE_NAME);
     askForValueDialog.clickOkBtn();
-    askForValueDialog.waitFormToClose();
     notificationsPopupPanel.waitExpectedMessageOnProgressPanelAndClosed(NOTIFICATION_MESSAGE);
+    askForValueDialog.waitFormToClose();
     events.clickEventLogBtn();
     events.waitExpectedMessage(NOTIFICATION_MESSAGE);
   }


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Move check a notification message to the position before 'waitFormToClose' method

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/8716
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
