### PR TITLE
Fix orion document changing event getting text from native orion event instead of guessing it

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
@@ -91,7 +91,7 @@ public class OrionDocument extends AbstractDocument {
     int addedCharCount = param.addedCharCount();
     int removedCharCount = param.removedCharCount();
 
-    String text = editorOverlay.getModel().getText(startOffset, startOffset + addedCharCount);
+    String text = param.getText();
 
     final DocumentChangedEvent event =
         new DocumentChangedEvent(this, startOffset, addedCharCount, text, removedCharCount);
@@ -104,7 +104,7 @@ public class OrionDocument extends AbstractDocument {
     int addedCharCount = param.addedCharCount();
     int removedCharCount = param.removedCharCount();
 
-    String text = editorOverlay.getModel().getText(startOffset, startOffset + addedCharCount);
+    String text = param.getText();
 
     final DocumentChangingEvent event =
         new DocumentChangingEvent(this, startOffset, addedCharCount, text, removedCharCount);

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/ModelChangedEventOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/ModelChangedEventOverlay.java
@@ -42,4 +42,8 @@ public class ModelChangedEventOverlay extends OrionEventOverlay {
   public final native int start() /*-{
         return this.start;
     }-*/;
+
+  public final native String getText() /*-{
+        return this.text;
+  }-*/;
 }


### PR DESCRIPTION
### What does this PR do?
Fix orion document changing event getting text from native orion event instead of guessing it.
"Changing" events were getting their new changed text from the document based on the new text range positions. While this way of doing works fine for "changed" events, it doesn't work for "changing" events as the change has not been performed yet to the document yet. The result is that the event send the previous text instead of the new added text. This fix is getting the new text from native orion event data object.
