### PR TITLE
Selenium: increase timeout to check that a menu item is enabled

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Menu.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Menu.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.selenium.pageobject;
 
 import static java.lang.String.format;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MINIMUM_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
@@ -260,7 +260,7 @@ public class Menu {
    * @param idCommand is name of command in the menu
    */
   public void waitMenuItemIsEnabled(String idCommand) {
-    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+    new WebDriverWait(seleniumWebDriver, LOADER_TIMEOUT_SEC)
         .until(visibilityOfElementLocated(By.id(idCommand)));
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR increases timeout for checking that a menu item enabled. It need because sometimes existed 20 sec is not enough for selenium tests on CI.

![selection_172](https://user-images.githubusercontent.com/7760565/36154050-dab31926-10d8-11e8-809a-fe6b8150092b.png)

**Log:**
```
org.openqa.selenium.TimeoutException:  Expected condition failed: waiting for visibility of element located by By.id: gwt-debug-MenuItem/profileGroup-true (tried for 20 second(s) with 500 MILLISECONDS interval) Build info: version: '3.0.1', revision: '1969d75', time: '2016-10-18 09:49:13 -0700' System info: host: 'slave7.codenvycorp.com', ip: '127.0.0.1', os.name: 'Linux', os.arch: 'amd64', os.version: '3.10.0-514.16.1.el7.x86_64', java.version: '1.8.0_102' Driver info: org.eclipse.che.selenium.core.SeleniumWebDriver 	at org.eclipse.che.selenium.workspaces.WorkingWithNodeWsTest.checkNodeJsWsAndRunApp(WorkingWithNodeWsTest.java:89) Caused by: org.openqa.selenium.NoSuchElementException:  no such element: Unable to locate element: {"method":"id","selector":"gwt-debug-MenuItem/profileGroup-true"}   (Session info: chrome=56.0.2924.87)   (Driver info: chromedriver=2.27.440175 (9bc1d90b8bfa4dd181fbbf769a5eb5e575574320),platform=Linux 3.10.0-514.16.1.el7.x86_64 x86_64) (WARNING: The server did not provide any stacktrace information)
```

**Report with reproduced problem:**
https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-docker/178/Selenium_tests_report/