### PR TITLE
CHE-8575: Do not show .che folder in the project explorer

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/OnWorkspaceStartProjectInitializer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/OnWorkspaceStartProjectInitializer.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.api.project.server.impl;
 
 import static org.eclipse.che.api.fs.server.WsPathUtils.ROOT;
+import static org.eclipse.che.api.project.shared.Constants.CHE_DIR;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,8 +61,11 @@ public class OnWorkspaceStartProjectInitializer {
     }
   }
 
-  private void initializeNotRegisteredProjects() throws ServerException {
+  private void initializeNotRegisteredProjects() {
     for (String wsPath : fsManager.getDirWsPaths(ROOT)) {
+      if (wsPath.endsWith(CHE_DIR)) {
+        continue;
+      }
       projectConfigRegistry.putIfAbsent(wsPath, true, true);
     }
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Do not show `.che` folder in project explorer. When applying a code formatter for workspace `.che` folder appears in the project explorer as a project.

### What issues does this PR fix or reference?
#8575 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
Fix bug: Do not show `.che` folder in project explorer when applying a code formatter for workspace.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A