### PR TITLE
Add back primary style for start workspace button

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/StartWorkspaceNotification.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/StartWorkspaceNotification.java
@@ -27,6 +27,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
 import org.eclipse.che.ide.bootstrap.BasicIDEInitializedEvent;
+import org.eclipse.che.ide.ui.window.WindowClientBundle;
 
 /**
  * Toast notification appearing on the top of the IDE and containing a proposal message to start
@@ -41,6 +42,7 @@ class StartWorkspaceNotification {
   private final WorkspaceStatusNotification wsStatusNotification;
   private final Provider<CurrentWorkspaceManager> currentWorkspaceManagerProvider;
   private final RestartingStateHolder restartingStateHolder;
+  private final WindowClientBundle windowClientBundle;
 
   @UiField Button button;
 
@@ -51,11 +53,13 @@ class StartWorkspaceNotification {
       Provider<CurrentWorkspaceManager> currentWorkspaceManagerProvider,
       EventBus eventBus,
       AppContext appContext,
-      RestartingStateHolder restartingStateHolder) {
+      RestartingStateHolder restartingStateHolder,
+      WindowClientBundle windowClientBundle) {
     this.wsStatusNotification = wsStatusNotification;
     this.uiBinder = uiBinder;
     this.currentWorkspaceManagerProvider = currentWorkspaceManagerProvider;
     this.restartingStateHolder = restartingStateHolder;
+    this.windowClientBundle = windowClientBundle;
 
     eventBus.addHandler(
         BasicIDEInitializedEvent.TYPE,
@@ -76,6 +80,7 @@ class StartWorkspaceNotification {
       return;
     }
     Widget widget = uiBinder.createAndBindUi(StartWorkspaceNotification.this);
+    button.addStyleName(windowClientBundle.getStyle().windowFrameFooterButtonPrimary());
     wsStatusNotification.show(WORKSPACE_STOPPED, widget);
   }
 


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds back primary style for workspace start button.

Needs to be like this:
<img width="452" alt="eclipse che 2018-02-14 11-04-46" src="https://user-images.githubusercontent.com/1968177/36195876-90e243f4-1177-11e8-89a5-842ef73eea07.png">

But now it is like this:
<img width="452" alt="eclipse che 2018-02-14 11-06-01" src="https://user-images.githubusercontent.com/1968177/36195892-9a5872be-1177-11e8-87e2-5df637f907a6.png">

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
N/A
