### PR TITLE
Thread-unsafe collections used for subscription contexts

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionManager.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionManager.java
@@ -14,7 +14,6 @@ import static java.util.Collections.emptySet;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -61,7 +60,7 @@ public class RemoteSubscriptionManager {
     eventService.subscribe(
         event ->
             subscriptionContexts
-                .getOrDefault(method, new HashSet<>())
+                .getOrDefault(method, emptySet())
                 .stream()
                 .filter(context -> biPredicate.test(event, context.scope))
                 .forEach(context -> transmit(context.endpointId, method, event)),
@@ -70,7 +69,7 @@ public class RemoteSubscriptionManager {
 
   private void consumeSubscriptionRequest(String endpointId, EventSubscription eventSubscription) {
     subscriptionContexts
-        .computeIfAbsent(eventSubscription.getMethod(), k -> new HashSet<>())
+        .computeIfAbsent(eventSubscription.getMethod(), k -> ConcurrentHashMap.newKeySet(1))
         .add(new SubscriptionContext(endpointId, eventSubscription.getScope()));
   }
 


### PR DESCRIPTION
Signed-off-by: Dmytro Kulieshov <dkuliesh@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Replaced to thread safe collections

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/7700

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

