### PR TITLE
Fix Command Editor initialization after saving a command

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/CommandEditor.java
@@ -240,7 +240,7 @@ public class CommandEditor extends AbstractEditorPresenter
 
               updateDirtyState(false);
 
-              view.setSaveEnabled(false);
+              initializePages();
 
               callback.onSuccess(getEditorInput());
             })

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/text/AbstractPageWithTextEditor.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/text/AbstractPageWithTextEditor.java
@@ -103,16 +103,15 @@ public abstract class AbstractPageWithTextEditor extends AbstractCommandEditorPa
   protected void initialize() {
     initialValue = getCommandPropertyValue();
 
-    setContent(initialValue);
-  }
-
-  /** Sets editor's content. */
-  private void setContent(String content) {
-    VirtualFile file = new SyntheticFile(editedCommand.getName() + getType(), content);
-
-    editor.init(
-        new EditorInputImpl(fileTypeRegistry.getFileTypeByFile(file), file),
-        new OpenEditorCallbackImpl());
+    Document document = editor.getDocument();
+    if (document != null) {
+      document.replace(0, document.getContentsCharCount(), initialValue);
+    } else {
+      VirtualFile file = new SyntheticFile(editedCommand.getName() + getType(), initialValue);
+      editor.init(
+          new EditorInputImpl(fileTypeRegistry.getFileTypeByFile(file), file),
+          new OpenEditorCallbackImpl());
+    }
   }
 
   @Override

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/CommandEditorTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/command/editor/CommandEditorTest.java
@@ -107,15 +107,7 @@ public class CommandEditorTest {
     verify(view).setDelegate(editor);
     verify(eventBus).addHandler(CommandRemovedEvent.getType(), editor);
 
-    verify(commandLinePage).setDirtyStateListener(any(DirtyStateListener.class));
-    verify(goalPage).setDirtyStateListener(any(DirtyStateListener.class));
-    verify(projectsPage).setDirtyStateListener(any(DirtyStateListener.class));
-    verify(previewUrlPage).setDirtyStateListener(any(DirtyStateListener.class));
-
-    verify(commandLinePage).edit(editor.editedCommand);
-    verify(goalPage).edit(editor.editedCommand);
-    verify(projectsPage).edit(editor.editedCommand);
-    verify(previewUrlPage).edit(editor.editedCommand);
+    verifyPagesInitialized();
   }
 
   @Test
@@ -154,10 +146,7 @@ public class CommandEditorTest {
     editor.doSave();
 
     verify(commandManager).updateCommand(anyString(), eq(editor.editedCommand));
-    verify(commandPromise).then(operationCaptor.capture());
-    operationCaptor.getValue().apply(editedCommand);
-
-    verify(view).setSaveEnabled(false);
+    verifyPagesInitialized();
   }
 
   @Test(expected = OperationException.class)
@@ -210,5 +199,17 @@ public class CommandEditorTest {
 
     verify(editorAgent).closeEditor(editor);
     verify(handlerRegistration).removeHandler();
+  }
+
+  private void verifyPagesInitialized() throws Exception {
+    verify(commandLinePage).setDirtyStateListener(any(DirtyStateListener.class));
+    verify(goalPage).setDirtyStateListener(any(DirtyStateListener.class));
+    verify(projectsPage).setDirtyStateListener(any(DirtyStateListener.class));
+    verify(previewUrlPage).setDirtyStateListener(any(DirtyStateListener.class));
+
+    verify(commandLinePage).edit(editor.editedCommand);
+    verify(goalPage).edit(editor.editedCommand);
+    verify(projectsPage).edit(editor.editedCommand);
+    verify(previewUrlPage).edit(editor.editedCommand);
   }
 }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Added reinitialization of all pages of Command Editor after saving a command.

### What issues does this PR fix or reference?
#8475 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
