### PR TITLE
Preserve active part while switching parts layout

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/selector/PanelSelectorPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/toolbar/selector/PanelSelectorPresenter.java
@@ -14,28 +14,35 @@ import static org.eclipse.che.ide.api.parts.PartStack.State.HIDDEN;
 
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.web.bindery.event.shared.EventBus;
 import javax.inject.Singleton;
 import org.eclipse.che.ide.api.mvp.Presenter;
+import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.PartStack;
 import org.eclipse.che.ide.api.parts.PartStackStateChangedEvent;
 import org.eclipse.che.ide.api.parts.PartStackType;
 import org.eclipse.che.ide.api.parts.Perspective;
 import org.eclipse.che.ide.api.parts.PerspectiveManager;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 
 /** Presenter to manage Panel selector widget and perspective layout. */
 @Singleton
 public class PanelSelectorPresenter implements Presenter, PanelSelectorView.ActionDelegate {
 
+  private final Provider<WorkspaceAgent> workspaceAgentProvider;
   private PanelSelectorView view;
-
   private PerspectiveManager perspectiveManager;
 
   @Inject
   public PanelSelectorPresenter(
-      PanelSelectorView view, PerspectiveManager perspectiveManager, EventBus eventBus) {
+      PanelSelectorView view,
+      PerspectiveManager perspectiveManager,
+      EventBus eventBus,
+      Provider<WorkspaceAgent> workspaceAgentProvider) {
     this.view = view;
     this.perspectiveManager = perspectiveManager;
+    this.workspaceAgentProvider = workspaceAgentProvider;
 
     view.setDelegate(this);
 
@@ -102,6 +109,8 @@ public class PanelSelectorPresenter implements Presenter, PanelSelectorView.Acti
       return;
     }
 
+    PartPresenter activePart = workspaceAgentProvider.get().getActivePart();
+
     PartStack editorPartStack = perspective.getPartStack(PartStackType.EDITING);
     editorPartStack.restore();
 
@@ -140,6 +149,8 @@ public class PanelSelectorPresenter implements Presenter, PanelSelectorView.Acti
     }
 
     updateButtonState();
+
+    workspaceAgentProvider.get().setActivePart(activePart);
   }
 
   /** Updates icon for panel selector button displaying the current state of panels. */


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds preserving active part after switching parts layout which allows saving focus in the editor.

### What issues does this PR fix or reference?
fixes #7616 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
