### PR TITLE
CHE-8557: No Dto available for FormattingOptions

### DIFF
--- a/core/che-core-api-dto/pom.xml
+++ b/core/che-core-api-dto/pom.xml
@@ -47,6 +47,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.lsp4j</groupId>
+            <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>

--- a/core/che-core-api-dto/pom.xml
+++ b/core/che-core-api-dto/pom.xml
@@ -47,10 +47,6 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.lsp4j</groupId>
-            <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
@@ -33,6 +33,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -41,7 +42,6 @@ import org.eclipse.che.commons.lang.reflect.ParameterizedTypeImpl;
 import org.eclipse.che.dto.shared.DTO;
 import org.eclipse.che.dto.shared.JsonArray;
 import org.eclipse.che.dto.shared.JsonStringMap;
-import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapterFactory;
 
 /**
  * Provides implementations of DTO interfaces.
@@ -102,13 +102,11 @@ public final class DtoFactory {
   // It helps avoid reflection when need create copy of exited DTO instance.
   private final Map<Class<?>, DtoProvider<?>> dtoImpl2Providers = new ConcurrentHashMap<>();
   private final Gson dtoGson =
-      new GsonBuilder()
-          .registerTypeAdapterFactory(
-              new NullAsEmptyTAF<>(Collection.class, Collections.emptyList()))
-          .registerTypeAdapterFactory(new NullAsEmptyTAF<>(Map.class, Collections.emptyMap()))
-          .registerTypeAdapterFactory(new DtoInterfaceTAF())
-          .registerTypeAdapterFactory(new EitherTypeAdapterFactory())
-          .create();
+      buildDtoParser(
+          ServiceLoader.load(TypeAdapterFactory.class).iterator(),
+          new NullAsEmptyTAF<>(Collection.class, Collections.emptyList()),
+          new NullAsEmptyTAF<>(Map.class, Collections.emptyMap()),
+          new DtoInterfaceTAF());
 
   /**
    * Created deep copy of DTO object.
@@ -492,4 +490,19 @@ public final class DtoFactory {
   }
 
   private DtoFactory() {}
+
+  private static Gson buildDtoParser(
+      Iterator<TypeAdapterFactory> factoryIterator, TypeAdapterFactory... factories) {
+    GsonBuilder builder = new GsonBuilder();
+
+    for (Iterator<TypeAdapterFactory> it = factoryIterator; it.hasNext(); ) {
+      TypeAdapterFactory factory = it.next();
+      builder.registerTypeAdapterFactory(factory);
+    }
+
+    for (TypeAdapterFactory factory : factories) {
+      builder.registerTypeAdapterFactory(factory);
+    }
+    return builder.create();
+  }
 }

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
@@ -41,6 +41,7 @@ import org.eclipse.che.commons.lang.reflect.ParameterizedTypeImpl;
 import org.eclipse.che.dto.shared.DTO;
 import org.eclipse.che.dto.shared.JsonArray;
 import org.eclipse.che.dto.shared.JsonStringMap;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapterFactory;
 
 /**
  * Provides implementations of DTO interfaces.
@@ -106,6 +107,7 @@ public final class DtoFactory {
               new NullAsEmptyTAF<>(Collection.class, Collections.emptyList()))
           .registerTypeAdapterFactory(new NullAsEmptyTAF<>(Map.class, Collections.emptyMap()))
           .registerTypeAdapterFactory(new DtoInterfaceTAF())
+          .registerTypeAdapterFactory(new EitherTypeAdapterFactory())
           .create();
 
   /**

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
@@ -188,7 +188,7 @@ public class LanguageServerFormatter implements ContentFormatter {
   }
 
   private FormattingOptions getFormattingOptions() {
-    FormattingOptions options = dtoFactory.createDto(FormattingOptions.class);
+    FormattingOptions options = new FormattingOptions();
     options.setInsertSpaces(Boolean.parseBoolean(getEditorProperty(EditorProperties.EXPAND_TAB)));
     options.setTabSize(Integer.parseInt(getEditorProperty(EditorProperties.TAB_SIZE)));
     return options;

--- a/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/FromJsonGenerator.java
+++ b/wsagent/che-core-api-languageserver-maven-plugin/src/main/java/org/eclipse/che/api/languageserver/generator/FromJsonGenerator.java
@@ -87,7 +87,8 @@ public class FromJsonGenerator extends ConversionGenerator {
   }
 
   private void generateMapConversion(
-      String indent, PrintWriter out, String varName, String jsonValName, Type paramType) {
+      String indent, PrintWriter out, String varName, String jsonValName, Type inputParamType) {
+    Type paramType = inputParamType;
     if (!(paramType instanceof ParameterizedType)) {
       paramType = ((Class<?>) paramType).getGenericSuperclass();
     }
@@ -95,11 +96,18 @@ public class FromJsonGenerator extends ConversionGenerator {
     Type containedType = genericType.getActualTypeArguments()[1];
     String objectName = varName + "o";
     String containedName = objectName + "X";
+    String typeName = inputParamType.getTypeName();
+    String instantiateTypeName = typeName;
+    if (getRawClass(inputParamType).isInterface()) {
+      if (inputParamType instanceof ParameterizedType) {
+        instantiateTypeName = String.format("HashMap<String, %1$s>", containedType.getTypeName());
+      } else {
+        throw new RuntimeException(
+            "Unsupported Map Conversion. Generator needs to be updated for new LSP4J construct");
+      }
+    }
     out.println(
-        indent
-            + String.format(
-                "HashMap<String, %1$s> %2$s= new HashMap<String, %3$s>();",
-                containedType.getTypeName(), varName, containedType.getTypeName()));
+        indent + String.format("%1$s %2$s= new %3$s();", typeName, varName, instantiateTypeName));
     out.println(
         indent
             + String.format(

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/util/EitherUtil.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/util/EitherUtil.java
@@ -48,6 +48,10 @@ public class EitherUtil {
       }
     }
 
-    return element.isJsonObject();
+    if (decision == JsonDecision.OBJECT) {
+      return element.isJsonObject();
+    }
+
+    return false;
   }
 }

--- a/wsagent/che-core-api-languageserver/src/main/resources/META-INF/services/com.google.gson.TypeAdapterFactory
+++ b/wsagent/che-core-api-languageserver/src/main/resources/META-INF/services/com.google.gson.TypeAdapterFactory
@@ -1,0 +1,1 @@
+org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapterFactory


### PR DESCRIPTION
The Dto isn't needed for FormattingOptions as it is really a specialized
Map and the types that contain a FormattingOptions field handle
the field as a Map during JSON serialize/deserialize

Signed-off-by: Jonah Graham <jonah@kichwacoders.com>

### What does this PR do?

Fixes formatting when using Language server

### What issues does this PR fix or reference?

#8557 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
