### PR TITLE
Added a meaningful error message when OAuth token has expired or credentials are incorrect

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfrastructureException.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfrastructureException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+
+/**
+ * An exception thrown by {@link KubernetesInfrastructure} and related components. Indicates that an
+ * infrastructure operation can't be performed or an error occurred during operation execution.
+ *
+ * @author Sergii Leshchenko
+ */
+public class KubernetesInfrastructureException extends InfrastructureException {
+  public KubernetesInfrastructureException(KubernetesClientException e) {
+    super(extractMessage(e), e);
+  }
+
+  private static String extractMessage(KubernetesClientException e) {
+    int code = e.getCode();
+    if (code == 401 || code == 403) {
+      return e.getMessage()
+          + " The error may be caused by an expired token or changed password. "
+          + "Update Che server deployment with a new token or password.";
+    } else {
+      return e.getMessage();
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesIngresses.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesIngresses.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 
 /**
  * Defines an internal API for managing {@link Ingress} instances in {@link
@@ -57,7 +58,7 @@ public class KubernetesIngresses {
           .withName(ingress.getMetadata().getName())
           .create(ingress);
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -105,7 +106,7 @@ public class KubernetesIngresses {
         throw new InfrastructureException("Waiting for ingress '" + name + "' was interrupted");
       }
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     } finally {
       if (watch != null) {
         watch.close();
@@ -123,7 +124,7 @@ public class KubernetesIngresses {
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
           .delete();
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -32,6 +32,7 @@ import java.util.function.Predicate;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -161,7 +162,7 @@ public class KubernetesNamespace {
           .done();
       waitDefaultServiceAccount(namespaceName, client);
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -215,7 +216,7 @@ public class KubernetesNamespace {
             "Waiting for service account '" + DEFAULT_SERVICE_ACCOUNT_NAME + "' was interrupted");
       }
     } catch (KubernetesClientException ex) {
-      throw new InfrastructureException(ex.getMessage());
+      throw new KubernetesInfrastructureException(ex);
     } finally {
       if (watch != null) {
         watch.close();
@@ -232,7 +233,7 @@ public class KubernetesNamespace {
         // namespace is foreign or doesn't exist
         return null;
       } else {
-        throw new InfrastructureException(e.getMessage(), e);
+        throw new KubernetesInfrastructureException(e);
       }
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPersistentVolumeClaims.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPersistentVolumeClaims.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Set;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 
 /**
  * Defines an internal API for managing {@link PersistentVolumeClaim} instances in {@link
@@ -46,7 +47,7 @@ public class KubernetesPersistentVolumeClaims {
     try {
       return clientFactory.create().persistentVolumeClaims().inNamespace(namespace).create(pvc);
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -64,7 +65,7 @@ public class KubernetesPersistentVolumeClaims {
           .list()
           .getItems();
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -87,7 +88,7 @@ public class KubernetesPersistentVolumeClaims {
           .list()
           .getItems();
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPods.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPods.java
@@ -41,6 +41,7 @@ import java.util.regex.Pattern;
 import okhttp3.Response;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.ContainerEvent;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.ContainerEventHandler;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodActionHandler;
@@ -97,7 +98,7 @@ public class KubernetesPods {
     try {
       return clientFactory.create().pods().inNamespace(namespace).create(pod);
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -116,7 +117,7 @@ public class KubernetesPods {
           .list()
           .getItems();
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -130,7 +131,7 @@ public class KubernetesPods {
       return Optional.ofNullable(
           clientFactory.create().pods().inNamespace(namespace).withName(name).get());
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -190,7 +191,7 @@ public class KubernetesPods {
         throw new InfrastructureException("Waiting for pod '" + name + "' was interrupted");
       }
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     } finally {
       if (watch != null) {
         watch.close();
@@ -227,7 +228,7 @@ public class KubernetesPods {
                 .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
                 .watch(watcher);
       } catch (KubernetesClientException ex) {
-        throw new InfrastructureException(ex.getMessage());
+        throw new KubernetesInfrastructureException(ex);
       }
     }
     podActionHandlers.add(handler);
@@ -273,7 +274,7 @@ public class KubernetesPods {
       try {
         containerWatch = clientFactory.create().events().inNamespace(namespace).watch(watcher);
       } catch (KubernetesClientException ex) {
-        throw new InfrastructureException(ex.getMessage());
+        throw new KubernetesInfrastructureException(ex);
       }
     }
     containerEventsHandlers.add(handler);
@@ -336,7 +337,7 @@ public class KubernetesPods {
         throw new InfrastructureException(e.getMessage(), e);
       }
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage());
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -406,7 +407,7 @@ public class KubernetesPods {
         throw new InfrastructureException("Pods removal timeout reached " + ex.getMessage());
       }
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -426,7 +427,7 @@ public class KubernetesPods {
             watch.close();
           });
     } catch (KubernetesClientException ex) {
-      throw new InfrastructureException(ex.getMessage(), ex);
+      throw new KubernetesInfrastructureException(ex);
     }
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesServices.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesServices.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 
 /**
  * Defines an internal API for managing {@link Service} instances in {@link
@@ -50,7 +51,7 @@ public class KubernetesServices {
     try {
       return clientFactory.create().services().inNamespace(namespace).create(service);
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -69,7 +70,7 @@ public class KubernetesServices {
           .list()
           .getItems();
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -87,7 +88,7 @@ public class KubernetesServices {
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
           .delete();
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/RemoveNamespaceOnWorkspaceRemove.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/RemoveNamespaceOnWorkspaceRemove.java
@@ -23,6 +23,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +72,7 @@ public class RemoveNamespaceOnWorkspaceRemove implements EventSubscriber<Workspa
       clientFactory.create().namespaces().withName(namespaceName).delete();
     } catch (KubernetesClientException e) {
       if (!(e.getCode() == 403)) {
-        throw new InfrastructureException(e.getMessage(), e);
+        throw new KubernetesInfrastructureException(e);
       }
       // namespace doesn't exist
     }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -16,6 +16,7 @@ import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
@@ -78,7 +79,7 @@ public class OpenShiftProject extends KubernetesNamespace {
           .done();
       waitDefaultServiceAccount(projectName, client);
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -90,7 +91,7 @@ public class OpenShiftProject extends KubernetesNamespace {
         // project is foreign or doesn't exist
         return null;
       } else {
-        throw new InfrastructureException(e.getMessage(), e);
+        throw new KubernetesInfrastructureException(e);
       }
     }
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftRoutes.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftRoutes.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.Route;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 
 /**
@@ -48,7 +49,7 @@ public class OpenShiftRoutes {
     try {
       return clientFactory.create().routes().inNamespace(namespace).create(route);
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -67,7 +68,7 @@ public class OpenShiftRoutes {
           .list()
           .getItems();
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 
@@ -85,7 +86,7 @@ public class OpenShiftRoutes {
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
           .delete();
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(e.getMessage(), e);
+      throw new KubernetesInfrastructureException(e);
     }
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemove.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/RemoveProjectOnWorkspaceRemove.java
@@ -22,6 +22,7 @@ import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,7 +73,7 @@ public class RemoveProjectOnWorkspaceRemove implements EventSubscriber<Workspace
       clientFactory.create().projects().withName(projectName).delete();
     } catch (KubernetesClientException e) {
       if (!(e.getCode() == 403)) {
-        throw new InfrastructureException(e.getMessage(), e);
+        throw new KubernetesInfrastructureException(e);
       }
       // project doesn't exist
     }


### PR DESCRIPTION
### What does this PR do?
Added a meaningful error message when OAuth token has expired or credentials are incorrect.

Before these changes, the following was displayed when the token is expired:
```
Caused by: io.fabric8.kubernetes.client.KubernetesClientException: Failure executing: GET at: 
https://kubernetes.default.svc/apis/project.openshift.io/v1/projects/workspacex8w4wt70e7bm3kec. 
Message: Unauthorized! Configured service account doesn't have access. 
Service account may have been revoked. Unauthorized
```
With these changes the following messages will be shown:
1. When configured invalid credentials:
```
Failure executing: POST at: https://172.19.20.21:8443/apis/project.openshift.io/v1/projectrequests.
Message: Forbidden!Configured service account doesn't have access. 
Service account may have been revoked. User "system:serviceaccount:eclipse-che:che" 
cannot create projectrequests.project.openshift.io at the cluster scope: 
You may not request a new project via this API. 
The error may be caused by an expired token or changed password. 
Update Che server deployment with a new token or password.
```
2. When the configured token is invalid or expired
```
Failure executing: GET at: https://172.19.20.21:8443/apis/project.openshift.io/v1/projects/workspace8hl1cfa4m3j7n0wb. 
Message: Unauthorized! Configured service account doesn't have access. 
Service account may have been revoked. Unauthorized The error may be caused by an 
expired token or changed password. 
Update Che server deployment with a new token or password.
```
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8223

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
