### PR TITLE
Fix incorrect usage of k8s property in openshift infra

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -33,7 +33,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
 
   @Inject
   public OpenShiftProjectFactory(
-      @Nullable @Named("che.infra.kubernetes.namespace") String projectName,
+      @Nullable @Named("che.infra.openshift.project") String projectName,
       OpenShiftClientFactory clientFactory) {
     super(projectName, clientFactory);
     this.projectName = projectName;


### PR DESCRIPTION
### What does this PR do?
Fixes mistaken usage of property `che.infra.kubernetes.namespace` instead of `che.infra.openshift.project` in OpenshiftProject class.

### What issues does this PR fix or reference?
Related to https://github.com/minishift/minishift-addons/pull/88
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
