### PR TITLE
Selenium: remove unnecessary steps from CreateWorkspaceOnDashboardTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
@@ -101,7 +101,6 @@ public class CreateWorkspaceOnDashboardTest {
 
     // stop the workspace
     menu.runCommand(WORKSPACE, STOP_WORKSPACE);
-    toastLoader.waitExpectedTextInToastLoader("Stopping the workspace");
     toastLoader.waitExpectedTextInToastLoader("Workspace is not running");
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR removes checking "Stopping the workspace" message in the **Toast Loader** from **CreateWorkspaceOnDashboardTest** selenium test. Checking "Workspace is not running" message is enough to know that a test workspace is stopped.