### PR TITLE
Save meaningful logs of failed tests workspaces in the target directory

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -830,7 +830,7 @@ storeTestReport() {
     if [[ -f ${TMP_SUITE_PATH} ]]; then
         cp ${TMP_SUITE_PATH} target/suite;
     fi
-    zip -qr ${report} target/screenshots target/htmldumps target/site target/failsafe-reports target/log target/bin target/suite
+    zip -qr ${report} target/screenshots target/htmldumps target/workspace-logs target/site target/failsafe-reports target/log target/bin target/suite
 
     echo -e "[TEST] Tests results and reports are saved to ${BLUE}${report}${NO_COLOUR}"
     echo "[TEST]"

--- a/selenium/che-selenium-core/pom.xml
+++ b/selenium/che-selenium-core/pom.xml
@@ -39,6 +39,10 @@
             <artifactId>guice-assistedinject</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
         </dependency>

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestOrganizationServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestOrganizationServiceClient.java
@@ -53,7 +53,7 @@ public class TestOrganizationServiceClient {
     List<OrganizationDto> organizations =
         requestFactory.fromUrl(getApiUrl()).request().asList(OrganizationDto.class);
 
-    organizations.removeIf(o -> o.getParent() != parent);
+    organizations.removeIf(o -> !o.getParent().equals(parent));
     return organizations;
   }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestWorkspaceServiceClient.java
@@ -224,6 +224,11 @@ public class TestWorkspaceServiceClient {
     return requestFactory.fromUrl(getIdBasedUrl(workspaceId)).request().asDto(WorkspaceDto.class);
   }
 
+  /** Gets workspace status by id. */
+  public WorkspaceStatus getStatus(String workspaceId) throws Exception {
+    return getById(workspaceId).getStatus();
+  }
+
   /**
    * Return server URL related with defined port
    *

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/user/TestUserImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/user/TestUserImpl.java
@@ -89,6 +89,7 @@ public class TestUserImpl implements TestUser {
     return id;
   }
 
+  @Override
   public String getOfflineToken() {
     return offlineToken;
   }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/DockerUtil.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/DockerUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.utils;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import javax.inject.Singleton;
+import org.eclipse.che.selenium.core.utils.process.ProcessAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** @author Dmytro Nochevnov */
+@Singleton
+public class DockerUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(DockerUtil.class);
+
+  @Inject
+  @Named("che.host")
+  private String cheHost;
+
+  @Inject private ProcessAgent processAgent;
+
+  public boolean isCheRunLocally() {
+    String command =
+        String.format(
+            "[[ $(docker run --rm --net host eclipse/che-ip:nightly) == '%s' ]] && echo true",
+            cheHost);
+
+    try {
+      String result = processAgent.execute(command);
+
+      if (result != null && result.equals("true")) {
+        return true;
+      }
+    } catch (Exception e) {
+      LOG.warn("Can't check if Eclipse Che run locally.", e);
+    }
+
+    return false;
+  }
+}

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/FileUtil.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/FileUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.utils;
+
+import static java.util.stream.Collectors.toList;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** @author Dmytro Nochevnov */
+public class FileUtil {
+
+  /**
+   * Checks if directoryToRemove is empty itself and remove it if it is empty only.
+   *
+   * @param directoryToRemove directory which is verified for emptiness
+   * @throws IOException
+   */
+  public static void removeDirectoryIfItIsEmpty(Path directoryToRemove) throws IOException {
+    if (Files.exists(directoryToRemove)
+        && Files.isDirectory(directoryToRemove)
+        && Files.list(directoryToRemove).collect(toList()).isEmpty()) {
+
+      Files.delete(directoryToRemove);
+    }
+  }
+}

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/UrlUtil.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/UrlUtil.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.selenium.core;
+package org.eclipse.che.selenium.core.utils;
 
 import java.net.MalformedURLException;
 import java.net.URL;

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/process/ProcessAgent.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/process/ProcessAgent.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.utils.process;
+
+import static java.lang.String.format;
+
+import com.google.inject.Singleton;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** @author Dmytro Nochevnov */
+@Singleton
+public class ProcessAgent {
+  private static final Logger LOG = LoggerFactory.getLogger(ProcessAgent.class);
+
+  public String execute(String command) throws ProcessAgentException {
+    try {
+      Process process = getProcess(command);
+
+      int exitStatus = process.waitFor();
+      InputStream in = process.getInputStream();
+      InputStream err = process.getErrorStream();
+
+      return processOutput(exitStatus, in, err);
+    } catch (Exception e) {
+      String errMessage = format("Can't execute command '%s'.", command);
+      throw new ProcessAgentException(errMessage, e);
+    }
+  }
+
+  private Process getProcess(String command) throws IOException {
+    ProcessBuilder pb = new ProcessBuilder("/bin/bash", "-c", command);
+    return pb.start();
+  }
+
+  private String processOutput(int exitStatus, InputStream in, InputStream error) throws Exception {
+    String output = readOutput(in);
+    String errorOutput = readOutput(error);
+
+    if (exitStatus == 0 && errorOutput.isEmpty()) {
+      return output;
+    }
+
+    throw new Exception(format("Output: %s; Error: %s.", output, errorOutput));
+  }
+
+  private String readOutput(InputStream in) throws IOException {
+    try {
+      String output = IOUtils.toString(in, Charset.forName("UTF-8"));
+      if (output.endsWith("\n")) {
+        output = output.substring(0, output.length() - 1);
+      }
+      return output;
+    } finally {
+      in.close();
+    }
+  }
+}

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/process/ProcessAgentException.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/utils/process/ProcessAgentException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.utils.process;
+
+import java.io.IOException;
+
+/** @author Dmytro Nochevnov */
+public class ProcessAgentException extends IOException {
+  public ProcessAgentException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReader.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReader.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.workspace;
+
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
+import static org.eclipse.che.selenium.core.utils.FileUtil.removeDirectoryIfItIsEmpty;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.util.AbstractLineConsumer;
+import org.eclipse.che.api.core.util.LineConsumer;
+import org.eclipse.che.api.core.util.ListLineConsumer;
+import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
+import org.eclipse.che.selenium.core.utils.process.ProcessAgent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reads and stores the workspace logs by using command line operations. It ignores absent or empty
+ * logs directory.
+ *
+ * @author Dmytro Nochevnov
+ */
+public abstract class TestWorkspaceLogsReader {
+
+  private static final String READ_LOGS_ERROR_MESSAGE_TEMPLATE =
+      "Can't obtain '{}' logs from workspace with id='{}' from directory '{}'.";
+
+  @VisibleForTesting Logger log = LoggerFactory.getLogger(this.getClass());
+
+  @Inject @VisibleForTesting TestWorkspaceServiceClient workspaceServiceClient;
+
+  @Inject @VisibleForTesting ProcessAgent processAgent;
+
+  /**
+   * Read logs from workspace. It ignores absent or empty logs directory.
+   *
+   * @param workspace workspace which logs should be read.
+   * @param pathToStore location of directory where logs should be stored.
+   */
+  public void read(TestWorkspace workspace, Path pathToStore) {
+    if (!canWorkspaceLogsBeRead()) {
+      return;
+    }
+
+    final String workspaceId;
+    try {
+      workspaceId = workspace.getId();
+    } catch (ExecutionException | InterruptedException e) {
+      log.warn("It's impossible to get id of test workspace.", e);
+      return;
+    }
+
+    // check if workspace is running
+    try {
+      WorkspaceStatus status = workspaceServiceClient.getStatus(workspaceId);
+      if (status != RUNNING) {
+        log.warn(
+            "It's impossible to get logs of workspace with id='{}' because of improper status '{}'",
+            workspaceId,
+            status);
+        return;
+      }
+    } catch (Exception e) {
+      log.warn("It's impossible to get status of workspace with id='{}'", workspaceId, e);
+      return;
+    }
+
+    getLogInfos().forEach(logInfo -> readLog(logInfo, workspaceId, pathToStore));
+  }
+
+  private void readLog(LogInfo logInfo, String workspaceId, Path pathToStore) {
+    Path testLogsDirectory = pathToStore.resolve(workspaceId).resolve(logInfo.getName());
+
+    try {
+      Files.createDirectories(testLogsDirectory.getParent());
+
+      // execute command to copy logs from workspace container to the workspaceLogsDir
+      processAgent.execute(
+          getReadLogsCommand(workspaceId, testLogsDirectory, logInfo.getLocationInsideWorkspace()));
+    } catch (Exception e) {
+      log.warn(
+          READ_LOGS_ERROR_MESSAGE_TEMPLATE,
+          logInfo.getName(),
+          workspaceId,
+          logInfo.getLocationInsideWorkspace(),
+          e);
+    } finally {
+      try {
+        removeDirectoryIfItIsEmpty(testLogsDirectory);
+      } catch (IOException e) {
+        log.warn("Error of removal of empty log directory {}.", testLogsDirectory, e);
+      }
+    }
+  }
+
+  /**
+   * Returns bash command to read logs from workspace by path to them inside workspace.
+   *
+   * @param workspaceId ID of workspace
+   * @param testLogsDirectory location of directory to save the logs
+   * @param logLocationInsideWorkspace location of logs inside workspace
+   * @return command to read logs from workspace
+   */
+  abstract String getReadLogsCommand(
+      String workspaceId, Path testLogsDirectory, Path logLocationInsideWorkspace);
+
+  /**
+   * Gets list of available workspace log providers which are dedicated to read certain logs.
+   *
+   * @return list of log providers
+   */
+  abstract List<LogInfo> getLogInfos();
+
+  /**
+   * Checks if it is possible to read logs from workspace.
+   *
+   * @return <b>true</b> if it is possible to read logs from workspace, or <b>false</b> otherwise.
+   */
+  abstract boolean canWorkspaceLogsBeRead();
+
+  @VisibleForTesting
+  LineConsumer getStdoutConsumer() {
+    return new AbstractLineConsumer() {};
+  }
+
+  @VisibleForTesting
+  ListLineConsumer getStderrConsumer() {
+    return new ListLineConsumer();
+  }
+
+  /** Holds information about log to read. */
+  static class LogInfo {
+    private final String name;
+    private final Path locationInsideWorkspace;
+
+    private LogInfo(String name, Path locationInsideWorkspace) {
+      this.name = name;
+      this.locationInsideWorkspace = locationInsideWorkspace;
+    }
+
+    String getName() {
+      return name;
+    }
+
+    Path getLocationInsideWorkspace() {
+      return locationInsideWorkspace;
+    }
+
+    static LogInfo create(String name, Path locationInsideWorkspace) {
+      return new LogInfo(name, locationInsideWorkspace);
+    }
+  }
+}

--- a/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReaderTest.java
+++ b/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReaderTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.workspace;
+
+import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.workspace.TestWorkspaceLogsReader.LogInfo.create;
+import static org.mockito.ArgumentCaptor.forClass;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
+import org.eclipse.che.selenium.core.utils.process.ProcessAgent;
+import org.eclipse.che.selenium.core.utils.process.ProcessAgentException;
+import org.eclipse.che.selenium.core.workspace.TestWorkspaceLogsReader.LogInfo;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+import org.mockito.testng.MockitoTestNGListener;
+import org.slf4j.Logger;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for the {@link TestWorkspaceLogsReader}
+ *
+ * @author Dmytro Nochevnov
+ */
+@Listeners(value = MockitoTestNGListener.class)
+public class TestWorkspaceLogsReaderTest {
+
+  private static final LogInfo FIRST_LOG_INFO = create("log-1", Paths.get("log-1-location"));
+  private static final LogInfo SECOND_LOG_INFO = create("log-2", Paths.get("log-2-location"));
+  private static final ImmutableList<LogInfo> TEST_LOG_INFOS =
+      ImmutableList.of(FIRST_LOG_INFO, SECOND_LOG_INFO);
+  private static final String TEST_READ_FIRST_LOG_COMMAND = "echo 'read-log-1'";
+  private static final String TEST_READ_SECOND_LOG_COMMAND = "echo 'read-log-2'";
+  private static final String UNKNOWN_COMMAND = "command-435f4q6we3as5va5s";
+  private static final String TEST_WORKSPACE_ID = "workspace-id";
+  private static final Path PATH_TO_STORE_LOGS = Paths.get("path-to-store-logs");
+  private static final WorkspaceStatus WRONG_WORKSPACE_STATUS = WorkspaceStatus.STOPPED;
+  private static final NullPointerException EXCEPTION_TO_BE_THROWN = new NullPointerException();
+
+  @Spy private TestWorkspaceLogsReader testWorkspaceLogsReader;
+
+  @Mock private TestWorkspace testWorkspace;
+  @Mock private TestWorkspaceServiceClient testWorkspaceServiceClient;
+  @Mock private Logger log;
+
+  @BeforeMethod
+  public void setup() throws ExecutionException, InterruptedException {
+    MockitoAnnotations.initMocks(this);
+
+    testWorkspaceLogsReader.workspaceServiceClient = testWorkspaceServiceClient;
+    testWorkspaceLogsReader.log = log;
+    testWorkspaceLogsReader.processAgent = new ProcessAgent();
+
+    doReturn(TEST_WORKSPACE_ID).when(testWorkspace).getId();
+
+    // init logs read commands
+    doReturn(TEST_LOG_INFOS).when(testWorkspaceLogsReader).getLogInfos();
+
+    doReturn(TEST_READ_FIRST_LOG_COMMAND)
+        .when(testWorkspaceLogsReader)
+        .getReadLogsCommand(
+            TEST_WORKSPACE_ID,
+            Paths.get(
+                format(
+                    "%s/%s/%s", PATH_TO_STORE_LOGS, TEST_WORKSPACE_ID, FIRST_LOG_INFO.getName())),
+            FIRST_LOG_INFO.getLocationInsideWorkspace());
+
+    doReturn(TEST_READ_SECOND_LOG_COMMAND)
+        .when(testWorkspaceLogsReader)
+        .getReadLogsCommand(
+            TEST_WORKSPACE_ID,
+            Paths.get(
+                format(
+                    "%s/%s/%s", PATH_TO_STORE_LOGS, TEST_WORKSPACE_ID, SECOND_LOG_INFO.getName())),
+            SECOND_LOG_INFO.getLocationInsideWorkspace());
+  }
+
+  @Test
+  public void shouldReadLogSuccessfully() throws Exception {
+    // given
+    doReturn(true).when(testWorkspaceLogsReader).canWorkspaceLogsBeRead();
+    doReturn(WorkspaceStatus.RUNNING).when(testWorkspaceServiceClient).getStatus(TEST_WORKSPACE_ID);
+
+    // when
+    testWorkspaceLogsReader.read(testWorkspace, PATH_TO_STORE_LOGS);
+
+    // then
+    verifyZeroInteractions(log);
+  }
+
+  @Test
+  public void shouldAbortExecutionIfWorkspaceIsNotRunning() throws Exception {
+    // given
+    doReturn(true).when(testWorkspaceLogsReader).canWorkspaceLogsBeRead();
+    doReturn(WRONG_WORKSPACE_STATUS).when(testWorkspaceServiceClient).getStatus(TEST_WORKSPACE_ID);
+
+    // when
+    testWorkspaceLogsReader.read(testWorkspace, PATH_TO_STORE_LOGS);
+
+    // then
+    verify(testWorkspaceLogsReader, never()).getLogInfos();
+    verify(log)
+        .warn(
+            "It's impossible to get logs of workspace with id='{}' because of improper status '{}'",
+            "workspace-id",
+            WRONG_WORKSPACE_STATUS);
+  }
+
+  @Test
+  public void shouldAbortExecutionIfWorkspaceCannotBeRead() throws Exception {
+    // given
+    doReturn(false).when(testWorkspaceLogsReader).canWorkspaceLogsBeRead();
+    doReturn(WorkspaceStatus.RUNNING).when(testWorkspaceServiceClient).getStatus(TEST_WORKSPACE_ID);
+
+    // when
+    testWorkspaceLogsReader.read(testWorkspace, PATH_TO_STORE_LOGS);
+
+    // then
+    verify(testWorkspaceLogsReader, never()).getLogInfos();
+    verifyZeroInteractions(log);
+  }
+
+  @Test
+  public void shouldAbortExecutionIfItIsImpossibleToGetWorkspaceStatus() throws Exception {
+    // given
+    doReturn(true).when(testWorkspaceLogsReader).canWorkspaceLogsBeRead();
+    doThrow(EXCEPTION_TO_BE_THROWN).when(testWorkspaceServiceClient).getStatus(TEST_WORKSPACE_ID);
+
+    // when
+    testWorkspaceLogsReader.read(testWorkspace, PATH_TO_STORE_LOGS);
+
+    // then
+    verify(testWorkspaceLogsReader, never()).getLogInfos();
+    verify(log)
+        .warn(
+            "It's impossible to get status of workspace with id='{}'",
+            "workspace-id",
+            EXCEPTION_TO_BE_THROWN);
+  }
+
+  @Test
+  public void shouldHandleCommandError() throws Exception {
+    // given
+    doReturn(UNKNOWN_COMMAND)
+        .when(testWorkspaceLogsReader)
+        .getReadLogsCommand(
+            TEST_WORKSPACE_ID,
+            Paths.get(
+                format(
+                    "%s/%s/%s", PATH_TO_STORE_LOGS, TEST_WORKSPACE_ID, FIRST_LOG_INFO.getName())),
+            FIRST_LOG_INFO.getLocationInsideWorkspace());
+
+    doReturn(true).when(testWorkspaceLogsReader).canWorkspaceLogsBeRead();
+    doReturn(WorkspaceStatus.RUNNING).when(testWorkspaceServiceClient).getStatus(TEST_WORKSPACE_ID);
+
+    // when
+    testWorkspaceLogsReader.read(testWorkspace, PATH_TO_STORE_LOGS);
+
+    // then
+    ArgumentCaptor<String> logArgumentCaptor1 = forClass(String.class);
+    ArgumentCaptor<String> logArgumentCaptor2 = forClass(String.class);
+    ArgumentCaptor<String> logArgumentCaptor3 = forClass(String.class);
+    ArgumentCaptor<Path> logArgumentCaptor4 = forClass(Path.class);
+    ArgumentCaptor<ProcessAgentException> logArgumentCaptor5 =
+        forClass(ProcessAgentException.class);
+
+    verify(log)
+        .warn(
+            logArgumentCaptor1.capture(),
+            logArgumentCaptor2.capture(),
+            logArgumentCaptor3.capture(),
+            logArgumentCaptor4.capture(),
+            logArgumentCaptor5.capture());
+
+    assertEquals(
+        logArgumentCaptor1.getValue(),
+        "Can't obtain '{}' logs from workspace with id='{}' from directory '{}'.");
+    assertEquals(logArgumentCaptor2.getValue(), FIRST_LOG_INFO.getName());
+    assertEquals(logArgumentCaptor3.getValue(), TEST_WORKSPACE_ID);
+    assertEquals(logArgumentCaptor4.getValue(), FIRST_LOG_INFO.getLocationInsideWorkspace());
+
+    assertNotNull(logArgumentCaptor5.getValue());
+    String errorMessage = logArgumentCaptor5.getValue().getMessage();
+    assertTrue(
+        errorMessage.contains(UNKNOWN_COMMAND), "Actual errorMessage content: " + errorMessage);
+  }
+}

--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -187,9 +187,6 @@
                         <exclude>**/.keep</exclude>
                         <exclude>**/*.txt</exclude>
                         <exclude>**/*.zip</exclude>
-                        <exclude>**/*.zip</exclude>
-                        <exclude>**/resources/**/.gitkeep</exclude>
-                        <exclude>**/resources/**/.keep</exclude>
                         <exclude>**/resources/**/another</exclude>
                         <exclude>**/resources/**/classpath</exclude>
                         <exclude>**/resources/**/editor</exclude>

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumDockerModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumDockerModule.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core;
+
+import com.google.inject.AbstractModule;
+import org.eclipse.che.selenium.core.workspace.CheTestDockerWorkspaceLogsReader;
+import org.eclipse.che.selenium.core.workspace.TestWorkspaceLogsReader;
+
+/** @author Dmytro Nochevnov */
+public class CheSeleniumDockerModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(TestWorkspaceLogsReader.class).to(CheTestDockerWorkspaceLogsReader.class);
+  }
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumOpenshiftModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumOpenshiftModule.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core;
+
+import com.google.inject.AbstractModule;
+import org.eclipse.che.selenium.core.workspace.CheTestOpenshiftWorkspaceLogsReader;
+import org.eclipse.che.selenium.core.workspace.TestWorkspaceLogsReader;
+
+/** @author Dmytro Nochevnov */
+public class CheSeleniumOpenshiftModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    bind(TestWorkspaceLogsReader.class).to(CheTestOpenshiftWorkspaceLogsReader.class);
+  }
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.core;
 
 import static java.lang.Boolean.parseBoolean;
+import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.utils.PlatformUtils.isMac;
 import static org.eclipse.che.selenium.core.workspace.WorkspaceTemplate.DEFAULT;
 
@@ -41,8 +42,8 @@ import org.eclipse.che.selenium.core.provider.TestDashboardUrlProvider;
 import org.eclipse.che.selenium.core.provider.TestIdeUrlProvider;
 import org.eclipse.che.selenium.core.provider.TestOfflineToAccessTokenExchangeApiEndpointUrlProvider;
 import org.eclipse.che.selenium.core.provider.TestWorkspaceAgentApiEndpointUrlProvider;
+import org.eclipse.che.selenium.core.requestfactory.CheTestAdminHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.requestfactory.CheTestDefaultUserHttpJsonRequestFactory;
-import org.eclipse.che.selenium.core.requestfactory.TestCheAdminHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactoryCreator;
 import org.eclipse.che.selenium.core.user.CheDefaultTestUser;
@@ -62,7 +63,10 @@ import org.eclipse.che.selenium.pageobject.PageObjectsInjectorImpl;
  */
 public class CheSeleniumSuiteModule extends AbstractModule {
 
-  public static final String CHE_MULTIUSER_VARIABLE = "CHE_MULTIUSER";
+  private static final String CHE_MULTIUSER_VARIABLE = "CHE_MULTIUSER";
+  private static final String CHE_INFRASTRUCTURE_VARIABLE = "CHE_INFRASTRUCTURE";
+  private static final String DOCKER_INFRASTRUCTURE = "docker";
+  private static final String OPENSHIFT_INFRASTRUCTURE = "openshift";
 
   @Override
   public void configure() {
@@ -101,6 +105,21 @@ public class CheSeleniumSuiteModule extends AbstractModule {
     } else {
       install(new CheSeleniumSingleUserModule());
     }
+
+    String cheInfrastructure = System.getenv(CHE_INFRASTRUCTURE_VARIABLE);
+    if (cheInfrastructure == null || cheInfrastructure.isEmpty()) {
+      throw new RuntimeException(
+          format(
+              "Che infrastructure should be defined by environment variable '%s'.",
+              CHE_INFRASTRUCTURE_VARIABLE));
+    } else if (cheInfrastructure.equalsIgnoreCase(DOCKER_INFRASTRUCTURE)) {
+      install(new CheSeleniumDockerModule());
+    } else if (cheInfrastructure.equalsIgnoreCase(OPENSHIFT_INFRASTRUCTURE)) {
+      install(new CheSeleniumOpenshiftModule());
+    } else {
+      throw new RuntimeException(
+          format("Infrastructure '%s' hasn't been supported by tests.", cheInfrastructure));
+    }
   }
 
   @Provides
@@ -118,7 +137,7 @@ public class CheSeleniumSuiteModule extends AbstractModule {
   @Named("admin")
   public TestOrganizationServiceClient getAdminOrganizationServiceClient(
       TestApiEndpointUrlProvider apiEndpointUrlProvider,
-      TestCheAdminHttpJsonRequestFactory requestFactory) {
+      CheTestAdminHttpJsonRequestFactory requestFactory) {
     return new TestOrganizationServiceClient(apiEndpointUrlProvider, requestFactory);
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestApiEndpointUrlProvider.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestApiEndpointUrlProvider.java
@@ -12,9 +12,9 @@ package org.eclipse.che.selenium.core.provider;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import java.net.URL;
-import javax.inject.Named;
-import org.eclipse.che.selenium.core.UrlUtil;
+import org.eclipse.che.selenium.core.utils.UrlUtil;
 
 /** @author Anatolii Bazko */
 @Singleton

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestDashboardUrlProvider.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestDashboardUrlProvider.java
@@ -14,7 +14,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.net.URL;
 import javax.inject.Named;
-import org.eclipse.che.selenium.core.UrlUtil;
+import org.eclipse.che.selenium.core.utils.UrlUtil;
 
 /** @author Anatolii Bazko */
 @Singleton

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestIdeUrlProvider.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestIdeUrlProvider.java
@@ -14,7 +14,7 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.net.URL;
 import javax.inject.Named;
-import org.eclipse.che.selenium.core.UrlUtil;
+import org.eclipse.che.selenium.core.utils.UrlUtil;
 
 /** @author Anatolii Bazko */
 @Singleton

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/requestfactory/CheTestAdminHttpJsonRequestFactory.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/requestfactory/CheTestAdminHttpJsonRequestFactory.java
@@ -15,10 +15,10 @@ import javax.inject.Inject;
 import org.eclipse.che.selenium.core.client.TestAuthServiceClient;
 
 /** @author Dmytro Nochevnov */
-public class TestCheAdminHttpJsonRequestFactory extends TestUserHttpJsonRequestFactory {
+public class CheTestAdminHttpJsonRequestFactory extends TestUserHttpJsonRequestFactory {
 
   @Inject
-  public TestCheAdminHttpJsonRequestFactory(
+  public CheTestAdminHttpJsonRequestFactory(
       TestAuthServiceClient authServiceClient,
       @Named("che.admin.name") String adminName,
       @Named("che.admin.password") String adminPassword,

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/workspace/CheTestDockerWorkspaceLogsReader.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/workspace/CheTestDockerWorkspaceLogsReader.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.workspace;
+
+import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.workspace.TestWorkspaceLogsReader.LogInfo.create;
+
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import javax.inject.Singleton;
+import org.eclipse.che.selenium.core.utils.DockerUtil;
+
+/** @author Dmytro Nochevnov */
+@Singleton
+public class CheTestDockerWorkspaceLogsReader extends TestWorkspaceLogsReader {
+
+  @Inject private DockerUtil dockerUtil;
+
+  private final List<LogInfo> logInfos =
+      ImmutableList.of(
+          create("ws-agent", Paths.get("/home/user/che/ws-agent/logs")),
+          create("exec-agent", Paths.get("/home/user/che/exec-agent/logs")),
+          create("tomcat", Paths.get("/home/user/tomcat8/logs")),
+          create("apache", Paths.get("/var/log/apache2")),
+          create("traefik", Paths.get("/home/user/che/traefik/log.txt")));
+
+  @Override
+  String getReadLogsCommand(
+      String workspaceId, Path testLogsDirectory, Path logLocationInsideWorkspace) {
+    return format(
+        "if [[ $(docker exec -i $(docker ps -q -f name=%1$s) bash -c '[ -d %2$s ] && echo true || echo false') == true ]]; then "
+            + "docker cp $(docker ps -q -f name=%1$s | head -1):%2$s %3$s; fi",
+        workspaceId, logLocationInsideWorkspace, testLogsDirectory);
+  }
+
+  @Override
+  List<LogInfo> getLogInfos() {
+    return logInfos;
+  }
+
+  @Override
+  boolean canWorkspaceLogsBeRead() {
+    return dockerUtil.isCheRunLocally();
+  }
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/workspace/CheTestOpenshiftWorkspaceLogsReader.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/workspace/CheTestOpenshiftWorkspaceLogsReader.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.workspace;
+
+import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.workspace.TestWorkspaceLogsReader.LogInfo.create;
+
+import com.google.common.collect.ImmutableList;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+/** @author Dmytro Nochevnov */
+public class CheTestOpenshiftWorkspaceLogsReader extends TestWorkspaceLogsReader {
+
+  private final List<LogInfo> logInfos =
+      ImmutableList.of(
+          create("bootstrapper", Paths.get("/workspace_logs/bootstrapper")),
+          create("exec-agent", Paths.get("/workspace_logs/exec-agent")),
+          create("ws-agent", Paths.get("/workspace_logs/ws-agent")));
+
+  @Override
+  String getReadLogsCommand(
+      String workspaceId, Path testLogsDirectory, Path logLocationInsideWorkspace) {
+    return format(
+        "docker cp $(docker ps -q -f name=k8s_container_%s | head -1):%s %s",
+        workspaceId, logLocationInsideWorkspace, testLogsDirectory);
+  }
+
+  @Override
+  List<LogInfo> getLogInfos() {
+    return logInfos;
+  }
+
+  @Override
+  boolean canWorkspaceLogsBeRead() {
+    return true;
+  }
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/account/KeycloakHeaderButtons.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/account/KeycloakHeaderButtons.java
@@ -31,7 +31,7 @@ public class KeycloakHeaderButtons {
 
     private static final String BUTTON_XPATH_TEMPLATE = "//div[@id='tabs-menu']//a[text()='%s']";
 
-    private String text;
+    private final String text;
 
     Button(String text) {
       this.text = text;

--- a/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
+++ b/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
@@ -9,8 +9,10 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-# Directory to store screenshot of failed tests
-tests.screenshot_dir=target/screenshots
+# Directory to store test resources
+tests.screenshots_dir=target/screenshots
+tests.htmldumps_dir=target/htmldumps
+tests.workspacelogs_dir=target/workspace-logs
 
 # Workspace default size
 workspace.default_memory_gb=2


### PR DESCRIPTION
### What does this PR do?
Sometimes it is needed to have workspace logs to investigate the reasons of selenium tests failures.
This request add functionality to store non-empty workspace logs of failed tests into the test **target** directory taking into account _Docker_ and _OpenShift_ infrastructure.

### What issues does this PR fix or reference?
#7889