### PR TITLE
Fix displaying the editor annotations for the corresponding diagnostics notifications

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -327,6 +327,7 @@ public class EditorAgentImpl
             openEditorCallback.onEditorOpened(editor);
 
             eventBus.fireEvent(new EditorOpenedEvent(file, editor));
+            eventBus.fireEvent(FileEvent.createFileOpenedEvent(file));
           }
 
           @Override
@@ -361,8 +362,6 @@ public class EditorAgentImpl
             if (editor instanceof TextEditor) {
               editorContentSynchronizer.trackEditor(editor);
             }
-
-            eventBus.fireEvent(FileEvent.createFileOpenedEvent(file));
           }
         });
   }


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR fixes displaying the editor annotations for the corresponding diagnostics notifications received from a language server.
The problem was related to the fact that IDE fired FileOpenedEvent without waiting for the finishing of editor initialization.

### What issues does this PR fix or reference?
fixes #6355 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
