### PR TITLE
[dashboard] Avoid the usage of ng-annotate which slow down the build

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -137,7 +137,8 @@ list-projects
 ## AngularJS recommandation
 As classes are available, the controller will be designed as es6 classes.
 
-All injection required will be done through the constructor by adding also the @ngInject annotation.
+All injection required will be done through the constructor by adding also the  static $inject = ['$toBeInjected']; line.
+
 
 Also properties are bound with this. scope (so avoid to use $scope in injection as this will be more aligned with AngularJS 2.0 where scope will disappear)
 
@@ -149,9 +150,10 @@ example
  */
 class CheToggleCtrl {
 
+  static $inject = ['$http'];
+
   /**
    * Constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor ($http) {
     this.$http = $http; // to use $http in other methods, use this.$http

--- a/dashboard/gulp/scripts.js
+++ b/dashboard/gulp/scripts.js
@@ -26,7 +26,7 @@ function webpackWrapper(watch, test, callback) {
     watch: watch,
     module: {
       preLoaders: [{ test: /\.ts$/, exclude: /node_modules/, loader: 'tslint-loader'}],
-      loaders: [{ test: /\.ts$/, exclude: /node_modules/, loaders: ['ng-annotate', 'babel-loader', 'awesome-typescript-loader']}]
+      loaders: [{ test: /\.ts$/, exclude: /node_modules/, loaders: ['babel-loader', 'awesome-typescript-loader']}]
     },
     output: { filename: 'index.module.js' }
   };

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -53,7 +53,6 @@
     "lodash": "~3.10.1",
     "main-bower-files": "~2.9.0",
     "minimist": "^1.2.0",
-    "ng-annotate-loader": "0.0.10",
     "phantomjs": "^2.1.3",
     "protractor-jasmine2-screenshot-reporter": "^0.3.3",
     "proxy-middleware": "^0.15.0",

--- a/dashboard/src/app/admin/user-management/account-profile/account-profile.directive.ts
+++ b/dashboard/src/app/admin/user-management/account-profile/account-profile.directive.ts
@@ -39,6 +39,9 @@ interface IAccountProfileScope extends ng.IScope {
  * @author Florent Benoit
  */
 export class AccountProfile implements ng.IDirective {
+
+  static $inject = ['jsonCountries', 'jsonJobs'];
+
   restrict = 'E';
   templateUrl = 'app/account/account-profile/account-profile.html';
   replace = true;
@@ -52,7 +55,6 @@ export class AccountProfile implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(jsonCountries: string, jsonJobs: string) {
     this.jsonCountries = jsonCountries;

--- a/dashboard/src/app/admin/user-management/add-user/add-user.controller.ts
+++ b/dashboard/src/app/admin/user-management/add-user/add-user.controller.ts
@@ -16,6 +16,9 @@ import {AdminsUserManagementCtrl} from '../user-management.controller';
  * @author Oleksii Orel
  */
 export class AdminsAddUserController {
+
+  static $inject = ['$mdDialog', 'cheUser', 'cheNotification', 'lodash', 'cheOrganization', 'chePermissions', 'resourcesService'];
+
   private $mdDialog: ng.material.IDialogService;
   private lodash: any;
   private cheNotification: any;
@@ -32,7 +35,6 @@ export class AdminsAddUserController {
 
   /**
    * Default constructor.
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService,
               cheUser: any,

--- a/dashboard/src/app/admin/user-management/user-details/user-details.controller.ts
+++ b/dashboard/src/app/admin/user-management/user-details/user-details.controller.ts
@@ -27,6 +27,9 @@ const MAX_ITEMS = 12;
  * @author Oleksii Orel
  */
 export class AdminUserDetailsController {
+
+  static $inject = ['cheProfile', '$location', '$timeout', '$scope', 'cheNotification', 'cheOrganization', 'initData'];
+
   tab: Object = Tab;
 
  /**
@@ -76,7 +79,6 @@ export class AdminUserDetailsController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(cheProfile: CheProfile,
               $location: ng.ILocationService,

--- a/dashboard/src/app/admin/user-management/user-management-config.ts
+++ b/dashboard/src/app/admin/user-management/user-management-config.ts
@@ -49,7 +49,7 @@ export class AdminsUserManagementConfig {
     };
 
     // configure routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/admin/usermanagement', {
         title: 'Users',
         templateUrl: 'app/admin/user-management/user-management.html',
@@ -70,7 +70,7 @@ export class AdminsUserManagementConfig {
         }
       })
         .accessWhen('/admin/userdetails/:userId', userDetailLocationProvider);
-    });
+    }]);
 
   }
 }

--- a/dashboard/src/app/admin/user-management/user-management.controller.ts
+++ b/dashboard/src/app/admin/user-management/user-management.controller.ts
@@ -21,6 +21,9 @@ const MAX_ITEMS = 12;
  * @author Oleksii Orel
  */
 export class AdminsUserManagementCtrl {
+
+  static $inject = ['$q', '$rootScope', '$log', '$mdDialog', 'cheUser', '$location', 'cheNotification', 'confirmDialogService', 'cheOrganization', '$scope', 'cheListHelperFactory'];
+
   $q: ng.IQService;
   $log: ng.ILogService;
   $mdDialog: ng.material.IDialogService;
@@ -41,7 +44,6 @@ export class AdminsUserManagementCtrl {
 
   /**
    * Default constructor.
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService,
               $rootScope: che.IRootScopeService,

--- a/dashboard/src/app/administration/administration-config.ts
+++ b/dashboard/src/app/administration/administration-config.ts
@@ -25,12 +25,12 @@ export class AdministrationConfig {
     register.controller('EditRegistryController', EditRegistryController);
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/administration', {
         title: 'Administration',
         templateUrl: 'app/administration/administration.html'
       });
-    });
+    }]);
 
   }
 }

--- a/dashboard/src/app/administration/docker-registry/docker-registry-list/docker-registry-list.controller.ts
+++ b/dashboard/src/app/administration/docker-registry/docker-registry-list/docker-registry-list.controller.ts
@@ -21,6 +21,8 @@ import {CheNotification} from '../../../../components/notification/che-notificat
  * @author Oleksii Orel
  */
 export class DockerRegistryListController {
+  static $inject = ['$q', '$log', '$mdDialog', '$document', 'chePreferences', 'cheNotification', 'confirmDialogService', '$scope', 'cheListHelperFactory'];
+
   private $q: ng.IQService;
   private $log: ng.ILogService;
   private $scope: ng.IScope;
@@ -39,9 +41,9 @@ export class DockerRegistryListController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
-  constructor($q: ng.IQService, $log: ng.ILogService, $mdDialog: ng.material.IDialogService, $document: ng.IDocumentService, chePreferences: ChePreferences, cheNotification: CheNotification, confirmDialogService: ConfirmDialogService, $scope: ng.IScope, cheListHelperFactory: che.widget.ICheListHelperFactory) {
+  constructor($q: ng.IQService, $log: ng.ILogService, $mdDialog: ng.material.IDialogService, $document: ng.IDocumentService,
+    chePreferences: ChePreferences, cheNotification: CheNotification, confirmDialogService: ConfirmDialogService, $scope: ng.IScope, cheListHelperFactory: che.widget.ICheListHelperFactory) {
     this.$q = $q;
     this.$log = $log;
     this.$scope = $scope;

--- a/dashboard/src/app/administration/docker-registry/docker-registry-list/edit-registry/edit-registry.controller.ts
+++ b/dashboard/src/app/administration/docker-registry/docker-registry-list/edit-registry/edit-registry.controller.ts
@@ -17,6 +17,8 @@ import {CheNotification} from '../../../../../components/notification/che-notifi
  * @author Oleksii Orel
  */
 export class EditRegistryController {
+  static $inject = ['$mdDialog', 'chePreferences', 'cheNotification'];
+
   registry: {
     url: string,
     username: string,
@@ -29,7 +31,6 @@ export class EditRegistryController {
 
   /**
    * Default constructor.
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService, chePreferences: ChePreferences, cheNotification: CheNotification) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/dashboard/dashboard-config.ts
+++ b/dashboard/src/app/dashboard/dashboard-config.ts
@@ -27,7 +27,7 @@ export class DashboardConfig {
     register.directive('dashboardPanel', DashboardPanel);
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/', {
         title: 'Dashboard',
         templateUrl: 'app/dashboard/dashboard.html',
@@ -45,7 +45,7 @@ export class DashboardConfig {
           }]
         }
       });
-    });
+    }]);
   }
 }
 

--- a/dashboard/src/app/dashboard/last-workspaces/last-workspaces.controller.ts
+++ b/dashboard/src/app/dashboard/last-workspaces/last-workspaces.controller.ts
@@ -19,6 +19,9 @@ import {CheNotification} from '../../../components/notification/che-notification
  * @author Oleksii Orel
  */
 export class DashboardLastWorkspacesController {
+
+  static $inject = ['cheWorkspace', 'cheNotification'];
+
   cheWorkspace: CheWorkspace;
   cheNotification: CheNotification;
   workspaces: Array<che.IWorkspace>;
@@ -26,7 +29,6 @@ export class DashboardLastWorkspacesController {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(cheWorkspace: CheWorkspace, cheNotification: CheNotification) {
     this.cheWorkspace = cheWorkspace;

--- a/dashboard/src/app/demo-components/demo-components.controller.ts
+++ b/dashboard/src/app/demo-components/demo-components.controller.ts
@@ -26,6 +26,8 @@ enum Tab {Font, Panel, Selecter, Icons, Dropdown_button,  Buttons, Input, List, 
  */
 export class DemoComponentsController {
 
+  static $inject = ['$location', 'cheNotification'];
+
   $location: ng.ILocationService;
   cheNotification: CheNotification;
   selectedIndex: number;
@@ -56,7 +58,6 @@ export class DemoComponentsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService,
               cheNotification: CheNotification) {

--- a/dashboard/src/app/diagnostics/diagnostics-config.ts
+++ b/dashboard/src/app/diagnostics/diagnostics-config.ts
@@ -33,12 +33,12 @@ export class DiagnosticsConfig {
     register.controller('DiagnosticsController', DiagnosticsController);
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/diagnostic', {
         title: 'Diagnostic',
         templateUrl: 'app/diagnostics/diagnostics.html'
       });
-    });
+    }]);
 
   }
 }

--- a/dashboard/src/app/diagnostics/diagnostics.controller.ts
+++ b/dashboard/src/app/diagnostics/diagnostics.controller.ts
@@ -26,6 +26,8 @@ import {CheBranding} from '../../components/branding/che-branding.factory';
  */
 export class DiagnosticsController {
 
+  static $inject = ['$log', '$q', 'lodash', '$timeout', 'diagnosticsWebsocketWsMaster', 'cheWebsocket', 'cheBranding', 'diagnosticsRunningWorkspaceCheck', 'diagnosticsWorkspaceStartCheck'];
+
   /**
    * Promise service handling.
    */
@@ -118,7 +120,6 @@ export class DiagnosticsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService, $q: ng.IQService, lodash: any,
               $timeout: ng.ITimeoutService,

--- a/dashboard/src/app/diagnostics/diagnostics.directive.ts
+++ b/dashboard/src/app/diagnostics/diagnostics.directive.ts
@@ -39,7 +39,6 @@ export class Diagnostics implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/app/diagnostics/test/diagnostics-websocket-wsmaster.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-websocket-wsmaster.factory.ts
@@ -18,6 +18,8 @@ import {DiagnosticCallback} from '../diagnostic-callback';
  */
 export class DiagnosticsWebsocketWsMaster {
 
+  static $inject = ['cheWebsocket', '$timeout'];
+
   /**
    * Websocket handling.
    */
@@ -30,7 +32,6 @@ export class DiagnosticsWebsocketWsMaster {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(cheWebsocket: CheWebsocket, $timeout: ng.ITimeoutService) {
     this.cheWebsocket = cheWebsocket;

--- a/dashboard/src/app/diagnostics/test/diagnostics-workspace-check-workspace.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-workspace-check-workspace.factory.ts
@@ -20,6 +20,8 @@ import {CheBranding} from '../../../components/branding/che-branding.factory';
  */
 export class DiagnosticsRunningWorkspaceCheck {
 
+  static $inject = ['$q', 'lodash', 'cheWebsocket', 'cheWorkspace', '$resource', '$location', 'cheBranding'];
+
   /**
    * Q service for creating delayed promises.
    */
@@ -57,7 +59,6 @@ export class DiagnosticsRunningWorkspaceCheck {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, lodash: any, cheWebsocket: CheWebsocket, cheWorkspace: CheWorkspace,
               $resource: ng.resource.IResourceService, $location: ng.ILocationService, cheBranding: CheBranding) {

--- a/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
@@ -22,6 +22,8 @@ import {CheJsonRpcMasterApi} from '../../../components/api/json-rpc/che-json-rpc
  */
 export class DiagnosticsWorkspaceStartCheck {
 
+  static $inject = ['$q', 'lodash', 'cheWorkspace', 'diagnosticsRunningWorkspaceCheck', 'cheBranding', '$location', 'cheJsonRpcApi', 'userDashboardConfig', 'keycloakAuth', 'proxySettings'];
+
   /**
    * Q service for creating delayed promises.
    */
@@ -84,7 +86,6 @@ export class DiagnosticsWorkspaceStartCheck {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService,
               lodash: any,

--- a/dashboard/src/app/factories/create-factory/action/factory-action-box.controller.ts
+++ b/dashboard/src/app/factories/create-factory/action/factory-action-box.controller.ts
@@ -17,6 +17,9 @@
  * @author Florent Benoit
  */
 export class FactoryActionBoxController {
+
+  static $inject = ['$mdDialog'];
+
   private $mdDialog: ng.material.IDialogService;
   private actions: Array<any>;
   private selectedAction: string;
@@ -27,7 +30,6 @@ export class FactoryActionBoxController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/factories/create-factory/action/factory-action-box.directive.ts
+++ b/dashboard/src/app/factories/create-factory/action/factory-action-box.directive.ts
@@ -28,7 +28,6 @@ export class FactoryActionBox implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/factories/create-factory/action/factory-action-edit.controller.ts
+++ b/dashboard/src/app/factories/create-factory/action/factory-action-edit.controller.ts
@@ -18,6 +18,9 @@ import {FactoryActionBoxController} from './factory-action-box.controller';
  * @author Florent Benoit
  */
 export class FactoryActionDialogEditController {
+
+  static $inject = ['$mdDialog'];
+
   isName: boolean;
   isFile: boolean;
   selectedValue: { name: string; file: string };
@@ -28,7 +31,6 @@ export class FactoryActionDialogEditController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/factories/create-factory/command/factory-command-edit.controller.ts
+++ b/dashboard/src/app/factories/create-factory/command/factory-command-edit.controller.ts
@@ -17,6 +17,9 @@
  * @author Florent Benoit
  */
 export class FactoryCommandDialogEditController {
+
+  static $inject = ['$mdDialog'];
+
   private $mdDialog: ng.material.IDialogService;
   private callbackController: any;
   private index: number;
@@ -24,7 +27,6 @@ export class FactoryCommandDialogEditController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/factories/create-factory/command/factory-command.controller.ts
+++ b/dashboard/src/app/factories/create-factory/command/factory-command.controller.ts
@@ -17,6 +17,9 @@
  * @author Florent Benoit
  */
 export class FactoryCommandController {
+
+  static $inject = ['$mdDialog'];
+
   private $mdDialog: ng.material.IDialogService;
   private factoryObject: any;
   private onChange: Function;
@@ -25,7 +28,6 @@ export class FactoryCommandController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/factories/create-factory/command/factory-command.directive.ts
+++ b/dashboard/src/app/factories/create-factory/command/factory-command.directive.ts
@@ -28,7 +28,6 @@ export class FactoryCommand implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/factories/create-factory/config-file-tab/factory-from-file.controller.ts
+++ b/dashboard/src/app/factories/create-factory/config-file-tab/factory-from-file.controller.ts
@@ -19,6 +19,9 @@ import {CheAPI} from '../../../../components/api/che-api.factory';
  * @author Oleksii Orel
  */
 export class FactoryFromFileCtrl {
+
+  static $inject = ['$filter', 'cheAPI', 'cheNotification', 'FileUploader'];
+
   private cheAPI: CheAPI;
   private cheNotification: CheNotification;
   private uploader: any;
@@ -27,12 +30,8 @@ export class FactoryFromFileCtrl {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($filter: ng.IFilterService, cheAPI: CheAPI, cheNotification: CheNotification, FileUploader: any) {
-    /* tslint:disable */
-    'ngInject';
-    /* tslint:enable */
 
     this.cheAPI = cheAPI;
     this.cheNotification = cheNotification;

--- a/dashboard/src/app/factories/create-factory/config-file-tab/factory-from-file.directive.ts
+++ b/dashboard/src/app/factories/create-factory/config-file-tab/factory-from-file.directive.ts
@@ -32,7 +32,6 @@ export class FactoryFromFile implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/factories/create-factory/create-factory-config.ts
+++ b/dashboard/src/app/factories/create-factory/create-factory-config.ts
@@ -58,7 +58,7 @@ export class CreateFactoryConfig {
 
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/factories/create-factory', {
         title: 'New Factory',
         templateUrl: 'app/factories/create-factory/create-factory.html',
@@ -66,7 +66,7 @@ export class CreateFactoryConfig {
         controllerAs: 'createFactoryCtrl'
       });
 
-    });
+    }]);
 
   }
 }

--- a/dashboard/src/app/factories/create-factory/create-factory.controller.ts
+++ b/dashboard/src/app/factories/create-factory/create-factory.controller.ts
@@ -18,6 +18,9 @@ import {CheNotification} from '../../../components/notification/che-notification
  * @author Florent Benoit
  */
 export class CreateFactoryCtrl {
+
+  static $inject = ['$location', 'cheAPI', '$log', 'cheNotification', '$scope', '$filter', 'lodash', '$document'];
+
   private gitLocation: string;
   private $location: ng.ILocationService;
   private $log: ng.ILogService;
@@ -41,7 +44,6 @@ export class CreateFactoryCtrl {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService,
               cheAPI: CheAPI,

--- a/dashboard/src/app/factories/create-factory/git/create-factory-git.directive.ts
+++ b/dashboard/src/app/factories/create-factory/git/create-factory-git.directive.ts
@@ -27,7 +27,6 @@ export class CreateFactoryGit implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.controller = 'CreateFactoryGitController';

--- a/dashboard/src/app/factories/create-factory/template-tab/factory-from-template.controller.ts
+++ b/dashboard/src/app/factories/create-factory/template-tab/factory-from-template.controller.ts
@@ -17,6 +17,9 @@ import {CheFactoryTemplate} from '../../../../components/api/che-factory-templat
  * @author Oleksii Orel
  */
 export class FactoryFromTemplateController {
+
+  static $inject = ['$filter', 'cheFactoryTemplate', 'cheNotification'];
+
   editorState: {isValid: boolean; errors: Array<string>} = {isValid: true, errors: []};
   private $filter: ng.IFilterService;
   private cheFactoryTemplate: CheFactoryTemplate;
@@ -27,7 +30,6 @@ export class FactoryFromTemplateController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($filter: ng.IFilterService, cheFactoryTemplate: CheFactoryTemplate, cheNotification: CheNotification) {
     this.$filter = $filter;

--- a/dashboard/src/app/factories/create-factory/template-tab/factory-from-template.directive.ts
+++ b/dashboard/src/app/factories/create-factory/template-tab/factory-from-template.directive.ts
@@ -29,7 +29,6 @@ export class FactoryFromTemplate implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/factories/create-factory/workspaces-tab/factory-from-workpsace.controller.ts
+++ b/dashboard/src/app/factories/create-factory/workspaces-tab/factory-from-workpsace.controller.ts
@@ -18,6 +18,9 @@ import {CheNotification} from '../../../../components/notification/che-notificat
  * @author Michail Kuznyetsov
  */
 export class FactoryFromWorkspaceCtrl {
+
+  static $inject = ['$filter', 'cheAPI', 'cheNotification'];
+
   private $filter: ng.IFilterService;
   private cheAPI: CheAPI;
   private cheNotification: CheNotification;
@@ -31,7 +34,6 @@ export class FactoryFromWorkspaceCtrl {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($filter: ng.IFilterService, cheAPI: CheAPI, cheNotification: CheNotification) {
     this.$filter = $filter;

--- a/dashboard/src/app/factories/factories-config.ts
+++ b/dashboard/src/app/factories/factories-config.ts
@@ -32,7 +32,7 @@ export class FactoryConfig {
     register.service('loadFactoryService', LoadFactoryService);
 
     // config routes
-    register.app.config(function ($routeProvider: che.route.IRouteProvider) {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/factories', {
         title: 'Factories',
         templateUrl: 'app/factories/list-factories/list-factories.html',
@@ -52,7 +52,7 @@ export class FactoryConfig {
         controllerAs: 'loadFactoryController'
       });
 
-    });
+    }]);
 
     // config files
     /* tslint:disable */

--- a/dashboard/src/app/factories/factory-details/factory-details-config.ts
+++ b/dashboard/src/app/factories/factory-details/factory-details-config.ts
@@ -20,7 +20,7 @@ export class FactoryDetailsConfig {
     register.controller('FactoryDetailsController', FactoryDetailsController);
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       let locationProvider = {
         title: 'Factory',
         templateUrl: 'app/factories/factory-details/factory-details.html',
@@ -31,7 +31,7 @@ export class FactoryDetailsConfig {
       $routeProvider.accessWhen('/factory/:id', locationProvider)
         .accessWhen('/factory/:id/:tabName', locationProvider);
 
-    });
+    }]);
 
     // config files
     /* tslint:disable */

--- a/dashboard/src/app/factories/factory-details/factory-details.controller.ts
+++ b/dashboard/src/app/factories/factory-details/factory-details.controller.ts
@@ -17,17 +17,16 @@ import {CheFactory} from '../../../components/api/che-factory.factory';
  * @author Florent Benoit
  */
 export class FactoryDetailsController {
+
+  static $inject = ['$route', 'cheFactory', 'cheNotification'];
+
   private cheFactory: CheFactory;
   private factory: che.IFactory;
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($route: ng.route.IRouteService, cheFactory: CheFactory, cheNotification: CheNotification) {
-    /* tslint:disable */
-    'ngInject';
-    /* tslint:enable */
 
     this.cheFactory = cheFactory;
     let factoryId = $route.current.params.id;

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
@@ -19,6 +19,8 @@ import {ConfirmDialogService} from '../../../../../components/service/confirm-di
  */
 export class FactoryInformationController {
 
+  static $inject = ['$scope', 'cheAPI', 'cheNotification', '$location', '$log', '$timeout', 'lodash', '$filter', '$q', 'confirmDialogService'];
+
   private confirmDialogService: ConfirmDialogService;
   private cheAPI: CheAPI;
   private cheNotification: CheNotification;
@@ -47,7 +49,6 @@ export class FactoryInformationController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope,
               cheAPI: CheAPI,

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.directive.ts
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.directive.ts
@@ -28,7 +28,6 @@ export class FactoryInformation {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/factories/last-factories/last-factories.controller.ts
+++ b/dashboard/src/app/factories/last-factories/last-factories.controller.ts
@@ -19,16 +19,17 @@ import {CheFactory} from '../../../components/api/che-factory.factory';
  */
 export class LastFactoriesController {
 
+
+  static $inject = ['cheFactory'];
+
   private cheFactory: CheFactory;
   private factories: Array<che.IFactory>;
   private factoriesOrderBy: string;
   private maxItems: number;
   private isLoading: boolean;
 
-
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(cheFactory: CheFactory) {
     this.cheFactory = cheFactory;

--- a/dashboard/src/app/factories/last-factories/last-factories.directive.ts
+++ b/dashboard/src/app/factories/last-factories/last-factories.directive.ts
@@ -26,7 +26,6 @@ export class LastFactories implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/factories/list-factories/factory-item/factory-item.controller.ts
+++ b/dashboard/src/app/factories/list-factories/factory-item/factory-item.controller.ts
@@ -17,6 +17,9 @@ import {CheEnvironmentRegistry} from '../../../../components/api/environment/che
  * @author Oleksii Orel
  */
 export class FactoryItemController {
+
+  static $inject = ['$location', 'cheFactory', 'cheEnvironmentRegistry', 'lodash'];
+
   private $location: ng.ILocationService;
   private cheFactory: CheFactory;
   private cheEnvironmentRegistry: CheEnvironmentRegistry;
@@ -25,7 +28,6 @@ export class FactoryItemController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService,
               cheFactory: CheFactory,

--- a/dashboard/src/app/factories/list-factories/list-factories.controller.ts
+++ b/dashboard/src/app/factories/list-factories/list-factories.controller.ts
@@ -20,6 +20,8 @@ import {CheNotification} from '../../../components/notification/che-notification
  */
 export class ListFactoriesController {
 
+  static $inject = ['$q', '$log', 'cheAPI', 'cheNotification', 'confirmDialogService', '$scope', 'cheListHelperFactory'];
+
   private confirmDialogService: ConfirmDialogService;
   private cheAPI: CheAPI;
   private cheNotification: CheNotification;
@@ -38,7 +40,6 @@ export class ListFactoriesController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $log: ng.ILogService, cheAPI: CheAPI, cheNotification: CheNotification,
               confirmDialogService: ConfirmDialogService, $scope: ng.IScope, cheListHelperFactory: che.widget.ICheListHelperFactory) {

--- a/dashboard/src/app/factories/load-factory/load-factory.controller.ts
+++ b/dashboard/src/app/factories/load-factory/load-factory.controller.ts
@@ -23,6 +23,9 @@ const WS_AGENT_STEP: number = 3;
  * @author Ann Shumilova
  */
 export class LoadFactoryController {
+
+  static $inject = ['cheAPI', 'cheJsonRpcApi', '$route', '$timeout', '$mdDialog', 'loadFactoryService', 'lodash', 'cheNotification', '$location', 'routeHistory', '$window'];
+
   private cheAPI: CheAPI;
   private $timeout: ng.ITimeoutService;
   private $mdDialog: ng.material.IDialogService;
@@ -41,10 +44,8 @@ export class LoadFactoryController {
   private factory: che.IFactory;
   private jsonRpcMasterApi: CheJsonRpcMasterApi;
 
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheAPI: CheAPI,
               cheJsonRpcApi: CheJsonRpcApi,

--- a/dashboard/src/app/factories/load-factory/load-factory.service.ts
+++ b/dashboard/src/app/factories/load-factory/load-factory.service.ts
@@ -21,7 +21,6 @@ export class LoadFactoryService {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.loadFactoryInProgress = false;

--- a/dashboard/src/app/ide/ide-config.ts
+++ b/dashboard/src/app/ide/ide-config.ts
@@ -36,10 +36,10 @@ export class IdeConfig {
     };
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/ide', ideProvider)
         .accessWhen('/ide/:namespace*/:workspaceName', ideProvider);
-    });
+    }]);
   }
 }
 

--- a/dashboard/src/app/ide/ide-iframe/ide-iframe.directive.ts
+++ b/dashboard/src/app/ide/ide-iframe/ide-iframe.directive.ts
@@ -20,7 +20,6 @@ class IdeIframe  implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.restrict = 'E';

--- a/dashboard/src/app/ide/ide-iframe/ide-iframe.service.ts
+++ b/dashboard/src/app/ide/ide-iframe/ide-iframe.service.ts
@@ -25,6 +25,8 @@ interface IIdeIFrameRootScope extends ng.IRootScopeService {
  * @author Florent Benoit
  */
 class IdeIFrameSvc {
+  static $inject = ['$window', '$timeout', '$compile', '$location', '$rootScope', '$mdSidenav', 'cheUIElementsInjectorService'];
+
   private cheUIElementsInjectorService: CheUIElementsInjectorService;
   private $timeout: ng.ITimeoutService;
   private $compile: ng.ICompileService;
@@ -33,7 +35,6 @@ class IdeIFrameSvc {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($window: ng.IWindowService,
               $timeout: ng.ITimeoutService,

--- a/dashboard/src/app/ide/ide.controller.ts
+++ b/dashboard/src/app/ide/ide.controller.ts
@@ -19,6 +19,8 @@ import {CheWorkspace} from '../../components/api/workspace/che-workspace.factory
  * @author Florent Benoit
  */
 class IdeCtrl {
+  static $inject = ['$location', '$rootScope', '$routeParams', '$timeout', 'ideSvc', 'ideIframeSvc', 'cheWorkspace', 'routeHistory'];
+
   $rootScope: che.IRootScopeService;
   $routeParams: che.route.IRouteParamsService;
   $timeout: ng.ITimeoutService;
@@ -34,7 +36,6 @@ class IdeCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService, $rootScope: ng.IRootScopeService,
               $routeParams: ng.route.IRouteParamsService, $timeout: ng.ITimeoutService, ideSvc: IdeSvc,

--- a/dashboard/src/app/ide/ide.controller.ts
+++ b/dashboard/src/app/ide/ide.controller.ts
@@ -19,7 +19,7 @@ import {CheWorkspace} from '../../components/api/workspace/che-workspace.factory
  * @author Florent Benoit
  */
 class IdeCtrl {
-  static $inject = ['$location', '$rootScope', '$routeParams', '$timeout', 'ideSvc', 'ideIframeSvc', 'cheWorkspace', 'routeHistory'];
+  static $inject = ['$location', '$rootScope', '$routeParams', '$timeout', 'ideSvc', 'ideIFrameSvc', 'cheWorkspace', 'routeHistory'];
 
   $rootScope: che.IRootScopeService;
   $routeParams: che.route.IRouteParamsService;

--- a/dashboard/src/app/ide/ide.service.ts
+++ b/dashboard/src/app/ide/ide.service.ts
@@ -19,6 +19,8 @@ import {CheUIElementsInjectorService} from '../../components/service/injector/ch
  * @author Florent Benoit
  */
 class IdeSvc {
+  static $inject = ['$location', '$log', '$mdDialog', '$q', '$rootScope', '$sce', '$timeout', 'cheAPI', 'cheWorkspace', 'lodash', 'proxySettings', 'routeHistory', 'userDashboardConfig', 'cheUIElementsInjectorService'];
+
   $location: ng.ILocationService;
   $log: ng.ILogService;
   $mdDialog: ng.material.IDialogService;
@@ -42,7 +44,6 @@ class IdeSvc {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService, $log: ng.ILogService, $mdDialog: ng.material.IDialogService,
               $q: ng.IQService, $rootScope: ng.IRootScopeService, $sce: ng.ISCEService, $timeout: ng.ITimeoutService,

--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -243,7 +243,7 @@ initModule.run(['$rootScope', '$location', '$routeParams', 'routingRedirect', '$
   }
 ]);
 
-initModule.config(($mdThemingProvider: ng.material.IThemingProvider, jsonColors: any) => {
+initModule.config(['$mdThemingProvider', 'jsonColors', ($mdThemingProvider: ng.material.IThemingProvider, jsonColors: any) => {
 
   const cheColors = angular.fromJson(jsonColors);
   const getColor = (key: string) => {
@@ -383,7 +383,7 @@ initModule.config(($mdThemingProvider: ng.material.IThemingProvider, jsonColors:
   $mdThemingProvider.theme('maincontent-theme')
     .primaryPalette('che')
     .accentPalette('cheAccent');
-});
+}]);
 
 initModule.constant('userDashboardConfig', {
   developmentMode: DEV

--- a/dashboard/src/app/navbar/navbar-dropdown-menu/navbar-dropdown-menu.controller.ts
+++ b/dashboard/src/app/navbar/navbar-dropdown-menu/navbar-dropdown-menu.controller.ts
@@ -16,6 +16,9 @@
  * @author Oleksii Kurinnyi
  */
 export class NavbarDropdownMenuController {
+
+  static $inject = ['$window'];
+
   /**
    * Reference to the browser's <code>window</code> object.
    */
@@ -26,7 +29,6 @@ export class NavbarDropdownMenuController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($window: ng.IWindowService) {
     this.$window = $window;

--- a/dashboard/src/app/navbar/navbar-dropdown-menu/navbar-dropdown-menu.directive.ts
+++ b/dashboard/src/app/navbar/navbar-dropdown-menu/navbar-dropdown-menu.directive.ts
@@ -25,6 +25,9 @@ interface IDropdonwMenuRootScope extends ng.IRootScopeService {
  * @author Oleksii Kurinnyi
  */
 export class NavbarDropdownMenu implements ng.IDirective {
+
+  static $inject = ['$timeout', '$document', '$rootScope'];
+
   /**
    * Timeout service.
    */
@@ -58,7 +61,6 @@ export class NavbarDropdownMenu implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService,
               $document: ng.IDocumentService,

--- a/dashboard/src/app/navbar/navbar-selected.controller.ts
+++ b/dashboard/src/app/navbar/navbar-selected.controller.ts
@@ -18,11 +18,12 @@
  */
 export class NavBarSelectedCtrl {
 
+  static $inject = ['$mdSidenav'];
+
   $mdSidenav: ng.material.ISidenavService;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($mdSidenav: ng.material.ISidenavService) {
     this.$mdSidenav = $mdSidenav;

--- a/dashboard/src/app/navbar/navbar-selected.directive.ts
+++ b/dashboard/src/app/navbar/navbar-selected.directive.ts
@@ -25,6 +25,9 @@ interface INavBarSelectedRootScopeService extends ng.IRootScopeService {
  * @author Florent Benoit
  */
 export class NavBarSelected  implements ng.IDirective {
+
+  static $inject = ['$rootScope', '$location'];
+
   restrict = 'A';
   replace = false;
   controller = 'NavBarSelectedCtrl';
@@ -36,7 +39,6 @@ export class NavBarSelected  implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($rootScope: ng.IRootScopeService, $location: ng.ILocationService) {
     this.$rootScope = <INavBarSelectedRootScopeService>$rootScope;

--- a/dashboard/src/app/navbar/navbar.controller.ts
+++ b/dashboard/src/app/navbar/navbar.controller.ts
@@ -14,6 +14,9 @@ import {CheKeycloak} from '../../components/api/che-keycloak.factory';
 import {CheService} from '../../components/api/che-service.factory';
 
 export class CheNavBarController {
+
+  static $inject = ['$mdSidenav', '$scope', '$location', '$route', 'cheAPI', '$window', 'chePermissions', 'cheKeycloak', 'cheService'];
+
   menuItemUrl = {
     dashboard: '#/',
     workspaces: '#/workspaces',
@@ -59,7 +62,6 @@ export class CheNavBarController {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor($mdSidenav: ng.material.ISidenavService,
               $scope: ng.IScope,

--- a/dashboard/src/app/navbar/navbar.directive.ts
+++ b/dashboard/src/app/navbar/navbar.directive.ts
@@ -23,7 +23,6 @@ export class CheNavBar implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.restrict = 'E';

--- a/dashboard/src/app/navbar/notification/navbar-notification.controller.ts
+++ b/dashboard/src/app/navbar/notification/navbar-notification.controller.ts
@@ -18,11 +18,12 @@ import {ApplicationNotifications} from '../../../components/notification/applica
  */
 export class NavbarNotificationController {
 
+  static $inject = ['applicationNotifications', '$scope'];
+
   private applicationNotifications: ApplicationNotifications;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(applicationNotifications: ApplicationNotifications, $scope: ng.IScope) {
     this.applicationNotifications = applicationNotifications;

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -23,6 +23,9 @@ const MAX_RECENT_WORKSPACES_ITEMS: number = 5;
  * @author Oleksii Kurinnyi
  */
 export class NavbarRecentWorkspacesController {
+
+  static $inject = ['ideSvc', 'cheWorkspace', 'cheBranding', '$window', '$log', '$scope', '$rootScope', 'workspacesService'];
+
   cheWorkspace: CheWorkspace;
   dropdownItemTempl: Array<any>;
   workspaces: Array<che.IWorkspace>;
@@ -40,7 +43,6 @@ export class NavbarRecentWorkspacesController {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(ideSvc: IdeSvc,
               cheWorkspace: CheWorkspace,

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.directive.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.directive.ts
@@ -25,7 +25,6 @@ export class NavbarRecentWorkspaces implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/organizations/create-organizations/create-organizations.controller.ts
+++ b/dashboard/src/app/organizations/create-organizations/create-organizations.controller.ts
@@ -17,6 +17,9 @@
  * @author Oleksii Orel
  */
 export class CreateOrganizationController {
+
+  static $inject = ['cheOrganization', 'chePermissions', 'cheUser', 'cheNotification', '$location', '$q', '$log', '$rootScope', 'initData'];
+
   /**
    * Organization API interaction.
    */
@@ -72,7 +75,6 @@ export class CreateOrganizationController {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(cheOrganization: che.api.ICheOrganization, chePermissions: che.api.IChePermissions, cheUser: any, cheNotification: any,
               $location: ng.ILocationService, $q: ng.IQService, $log: ng.ILogService, $rootScope: che.IRootScopeService,

--- a/dashboard/src/app/organizations/list-organizations/list-organizations.controller.ts
+++ b/dashboard/src/app/organizations/list-organizations/list-organizations.controller.ts
@@ -18,6 +18,10 @@ import {OrganizationsPermissionService} from '../organizations-permission.servic
  * @author Oleksii Orel
  */
 export class ListOrganizationsController {
+
+  static $inject = ['$q', '$scope', 'chePermissions', 'cheResourcesDistribution', 'cheOrganization', 'cheNotification', 'confirmDialogService', '$route',
+'organizationsPermissionService', 'cheListHelperFactory', 'resourcesService'];
+
   /**
    * Organization API interaction.
    */
@@ -106,9 +110,10 @@ export class ListOrganizationsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
-  constructor($q: ng.IQService, $scope: ng.IScope, chePermissions: che.api.IChePermissions, cheResourcesDistribution: che.api.ICheResourcesDistribution, cheOrganization: che.api.ICheOrganization, cheNotification: any, confirmDialogService: any, $route: ng.route.IRouteService, organizationsPermissionService: OrganizationsPermissionService, cheListHelperFactory: che.widget.ICheListHelperFactory, resourcesService: che.service.IResourcesService) {
+  constructor($q: ng.IQService, $scope: ng.IScope, chePermissions: che.api.IChePermissions, cheResourcesDistribution: che.api.ICheResourcesDistribution,
+     cheOrganization: che.api.ICheOrganization, cheNotification: any, confirmDialogService: any, $route: ng.route.IRouteService,
+     organizationsPermissionService: OrganizationsPermissionService, cheListHelperFactory: che.widget.ICheListHelperFactory, resourcesService: che.service.IResourcesService) {
     this.$q = $q;
     this.cheNotification = cheNotification;
     this.chePermissions = chePermissions;

--- a/dashboard/src/app/organizations/list-organizations/organizations-item/organizations-item.controller.ts
+++ b/dashboard/src/app/organizations/list-organizations/organizations-item/organizations-item.controller.ts
@@ -18,6 +18,9 @@ import {OrganizationsPermissionService} from '../../organizations-permission.ser
  * @author Oleksii Orel
  */
 export class OrganizationsItemController {
+
+  static $inject = ['$location', 'cheOrganization', 'confirmDialogService', 'cheNotification', 'organizationsPermissionService', 'chePermissions', 'resourcesService'];
+
   /**
    * Service for displaying dialogs.
    */
@@ -57,9 +60,9 @@ export class OrganizationsItemController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
-  constructor($location: ng.ILocationService, cheOrganization: che.api.ICheOrganization, confirmDialogService: any, cheNotification: any,  organizationsPermissionService: OrganizationsPermissionService, chePermissions: che.api.IChePermissions, resourcesService: che.service.IResourcesService) {
+  constructor($location: ng.ILocationService, cheOrganization: che.api.ICheOrganization, confirmDialogService: any, cheNotification: any,
+      organizationsPermissionService: OrganizationsPermissionService, chePermissions: che.api.IChePermissions, resourcesService: che.service.IResourcesService) {
     this.$location = $location;
     this.confirmDialogService = confirmDialogService;
     this.cheOrganization = cheOrganization;

--- a/dashboard/src/app/organizations/organization-details/organization-details.controller.ts
+++ b/dashboard/src/app/organizations/organization-details/organization-details.controller.ts
@@ -19,6 +19,10 @@ enum Tab {Settings, Members, Organization}
  * @author Oleksii Orel
  */
 export class OrganizationDetailsController {
+
+  static $inject = ['cheResourcesDistribution', 'chePermissions', 'cheUser', '$route', '$location', '$rootScope', '$scope', 'confirmDialogService',
+'cheNotification', 'lodash', 'cheOrganization', 'organizationsPermissionService', 'resourcesService', 'initData'];
+
   tab: Object = Tab;
 
   /**
@@ -114,7 +118,6 @@ export class OrganizationDetailsController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(cheResourcesDistribution: che.api.ICheResourcesDistribution, chePermissions: che.api.IChePermissions,
               cheUser: any, $route: ng.route.IRouteService, $location: ng.ILocationService, $rootScope: che.IRootScopeService,

--- a/dashboard/src/app/organizations/organization-details/organization-invite-members/list-organization-invite-members.controller.ts
+++ b/dashboard/src/app/organizations/organization-details/organization-invite-members/list-organization-invite-members.controller.ts
@@ -17,6 +17,9 @@
  * @author Oleksii Orel
  */
 export class ListOrganizationInviteMembersController {
+
+  static $inject = ['$mdDialog', 'lodash', 'cheUser', 'resourcesService'];
+
   /**
    * Lodash library.
    */
@@ -68,7 +71,6 @@ export class ListOrganizationInviteMembersController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: angular.material.IDialogService, lodash: any, cheUser: any, resourcesService: che.service.IResourcesService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/organizations/organization-details/organization-member-dialog/organization-member-dialog.controller.ts
+++ b/dashboard/src/app/organizations/organization-details/organization-member-dialog/organization-member-dialog.controller.ts
@@ -17,6 +17,9 @@
  * @author Oleksii Orel
  */
 export class OrganizationMemberDialogController {
+
+  static $inject = ['$q', '$mdDialog', 'cheUser', 'cheOrganization', 'lodash', 'resourcesService'];
+
   /**
    * User API interaction.
    */
@@ -100,7 +103,6 @@ export class OrganizationMemberDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $mdDialog: angular.material.IDialogService, cheUser: any, cheOrganization: che.api.ICheOrganization, lodash: any, resourcesService: che.service.IResourcesService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/organizations/organization-details/organization-members/list-organization-members.controller.ts
+++ b/dashboard/src/app/organizations/organization-details/organization-members/list-organization-members.controller.ts
@@ -26,6 +26,10 @@ interface IOrganizationMember extends che.IUser {
  * @author Oleksii Orel
  */
 export class ListOrganizationMembersController {
+
+  static $inject = ['chePermissions', 'cheUser', 'cheProfile', 'cheOrganization', 'confirmDialogService', '$mdDialog',
+'$q', 'cheNotification', 'lodash', '$location', 'organizationsPermissionService', '$scope', 'cheListHelperFactory', 'resourcesService', '$log'];
+
   /**
    * Location service.
    */
@@ -113,7 +117,6 @@ export class ListOrganizationMembersController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(chePermissions: che.api.IChePermissions, cheUser: CheUser, cheProfile: CheProfile, cheOrganization: che.api.ICheOrganization,
               confirmDialogService: ConfirmDialogService, $mdDialog: angular.material.IDialogService, $q: ng.IQService, cheNotification: CheNotification,

--- a/dashboard/src/app/organizations/organization-details/organization-select-members-dialog/organization-select-members-dialog.controller.ts
+++ b/dashboard/src/app/organizations/organization-details/organization-select-members-dialog/organization-select-members-dialog.controller.ts
@@ -21,6 +21,9 @@ interface IOrganizationMember extends che.IMember {
  * @author Oleksii Kurinnyi
  */
 export class OrganizationSelectMembersDialogController {
+
+  static $inject = ['$q', '$mdDialog', 'lodash', 'cheProfile', 'cheUser', 'resourcesService'];
+
   /**
    * User profile API interaction.
    */
@@ -88,7 +91,6 @@ export class OrganizationSelectMembersDialogController {
 
   /**
    * Default constructor.
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $mdDialog: angular.material.IDialogService, lodash: any, cheProfile: any, cheUser: any, resourcesService: che.service.IResourcesService) {
     this.$q = $q;

--- a/dashboard/src/app/organizations/organizations-config.service.mock.ts
+++ b/dashboard/src/app/organizations/organizations-config.service.mock.ts
@@ -33,9 +33,10 @@ export class OrganizationsConfigServiceMock {
   private permissions: any[] = [];
   private usersByOrgs: Map<string, any[]> = new Map();
 
+  static $inject = ['cheAPIBuilder', 'cheHttpBackend'];
+
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(cheAPIBuilder: CheAPIBuilder, cheHttpBackend: CheHttpBackend) {
     this.cheAPIBuilder = cheAPIBuilder;

--- a/dashboard/src/app/organizations/organizations-config.service.ts
+++ b/dashboard/src/app/organizations/organizations-config.service.ts
@@ -11,6 +11,9 @@
 'use strict';
 
 export class OrganizationsConfigService {
+
+  static $inject = ['$log', '$q', '$route', 'cheOrganization', 'chePermissions', 'cheResourcesDistribution', 'cheUser'];
+
   /**
    * Log service.
    */
@@ -41,7 +44,6 @@ export class OrganizationsConfigService {
   private cheUser: any;
 
   /** Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService,
               $q: ng.IQService,

--- a/dashboard/src/app/organizations/organizations-config.ts
+++ b/dashboard/src/app/organizations/organizations-config.ts
@@ -91,7 +91,7 @@ export class OrganizationsConfig {
     };
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/organizations', {
         title: 'organizations',
         templateUrl: 'app/organizations/organizations.html',
@@ -101,6 +101,6 @@ export class OrganizationsConfig {
         .accessWhen('/admin/create-organization', createOrganizationLocationProvider)
         .accessWhen('/admin/create-organization/:parentQualifiedName*', createOrganizationLocationProvider)
         .accessWhen('/organization/:organizationName*', organizationDetailsLocationProvider);
-    });
+    }]);
   }
 }

--- a/dashboard/src/app/organizations/organizations-permission.service.ts
+++ b/dashboard/src/app/organizations/organizations-permission.service.ts
@@ -17,6 +17,8 @@
  */
 export class OrganizationsPermissionService {
 
+  static $inject = ['chePermissions', 'cheUser'];
+
   /**
    * Permissions API interaction.
    */
@@ -33,7 +35,6 @@ export class OrganizationsPermissionService {
   private fetchingMap: Map<string, ng.IPromise<any>> = new Map();
 
   /**
-   * @ngInject for Dependency injection
    */
   constructor(chePermissions: che.api.IChePermissions, cheUser: any) {
     this.chePermissions = chePermissions;

--- a/dashboard/src/app/organizations/organizations.controller.ts
+++ b/dashboard/src/app/organizations/organizations.controller.ts
@@ -19,6 +19,9 @@ const MAX_ITEMS = 12;
  * @author Oleksii Orel
  */
 export class OrganizationsController {
+
+  static $inject = ['cheOrganization', 'cheNotification', 'cheTeamEventsManager', '$scope', '$q', 'chePermissions', '$rootScope'];
+
   /**
    * Promises service.
    */
@@ -50,7 +53,6 @@ export class OrganizationsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheOrganization: che.api.ICheOrganization, cheNotification: any,
               cheTeamEventsManager: che.api.ICheTeamEventsManager, $scope: ng.IScope,

--- a/dashboard/src/app/profile/profile-config.ts
+++ b/dashboard/src/app/profile/profile-config.ts
@@ -24,8 +24,8 @@ export class ProfileConfig {
     };
 
     // config routes
-    register.app.config(function ($routeProvider: che.route.IRouteProvider) {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/account', locationProvider);
-    });
+    }]);
   }
 }

--- a/dashboard/src/app/profile/profile.controller.ts
+++ b/dashboard/src/app/profile/profile.controller.ts
@@ -17,6 +17,9 @@ import {CheProfile} from '../../components/api/che-profile.factory';
  * @author Anna Shumilova
  */
 export class ProfileController {
+
+  static $inject = ['cheKeycloak', 'cheProfile', '$window'];
+
   private profileUrl: string;
   private firstName: string;
   private lastName: string;
@@ -26,7 +29,6 @@ export class ProfileController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheKeycloak: CheKeycloak, cheProfile: CheProfile, $window: ng.IWindowService) {
     this.$window = $window;

--- a/dashboard/src/app/stacks/list-stacks/build-stack/build-stack.controller.ts
+++ b/dashboard/src/app/stacks/list-stacks/build-stack/build-stack.controller.ts
@@ -28,6 +28,8 @@ const DEFAULT_WORKSPACE_RAM: number = 2 * Math.pow(1024, 3);
  */
 export class BuildStackController {
 
+  static $inject = ['$mdDialog', '$location', 'cheStack', 'importStackService', 'cheEnvironmentRegistry', 'cheBranding', 'cheWorkspace'];
+
   importStackService: ImportStackService;
   cheEnvironmentRegistry: CheEnvironmentRegistry;
   stackDocsUrl: string;
@@ -40,7 +42,6 @@ export class BuildStackController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService,
               $location: ng.ILocationService,

--- a/dashboard/src/app/stacks/list-stacks/build-stack/recipe-editor/recipe-editor.controller.ts
+++ b/dashboard/src/app/stacks/list-stacks/build-stack/recipe-editor/recipe-editor.controller.ts
@@ -18,6 +18,8 @@ import {IRecipeEditorControllerScope} from './recipe-editor.directive';
  */
 export class RecipeEditorController implements IRecipeEditorControllerScope {
 
+  static $inject = ['$timeout', '$scope'];
+
   /**
    * Allows to pass a not valid recipe to onChange callback if `true`
    * Passed from parent controller.
@@ -76,7 +78,6 @@ export class RecipeEditorController implements IRecipeEditorControllerScope {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService,
               $scope: ng.IScope) {

--- a/dashboard/src/app/stacks/list-stacks/list-stacks.controller.ts
+++ b/dashboard/src/app/stacks/list-stacks/list-stacks.controller.ts
@@ -21,6 +21,9 @@ import {ConfirmDialogService} from '../../../components/service/confirm-dialog/c
  * @author Ann Shumilova
  */
 export class ListStacksController {
+
+  static $inject = ['cheStack', 'cheProfile', '$log', '$mdDialog', 'cheNotification', '$rootScope', 'lodash', '$q', 'confirmDialogService', '$scope', 'cheListHelperFactory'];
+
   cheStack: CheStack;
   cheNotification: CheNotification;
   $log: ng.ILogService;
@@ -42,7 +45,6 @@ export class ListStacksController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheStack: CheStack, cheProfile: CheProfile, $log: ng.ILogService, $mdDialog: ng.material.IDialogService, cheNotification: CheNotification, $rootScope: ng.IRootScopeService, lodash: any, $q: ng.IQService, confirmDialogService: ConfirmDialogService, $scope: ng.IScope, cheListHelperFactory: che.widget.ICheListHelperFactory) {
     this.cheStack = cheStack;

--- a/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.controller.ts
+++ b/dashboard/src/app/stacks/list-stacks/stack-item/stack-item.controller.ts
@@ -18,6 +18,8 @@
  */
 export class StackItemController {
 
+  static $inject = ['$location', 'lodash'];
+
   $location: ng.ILocationService;
   lodash: any;
 
@@ -25,7 +27,6 @@ export class StackItemController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService,
               lodash: any) {

--- a/dashboard/src/app/stacks/stack-details/import-stack.service.ts
+++ b/dashboard/src/app/stacks/stack-details/import-stack.service.ts
@@ -17,13 +17,14 @@ import {StackValidationService} from './stack-validation.service';
  * @author Oleksii Orel
  */
 export class ImportStackService {
+
+  static $inject = ['stackValidationService'];
+
   private stackValidationService: StackValidationService;
   private stack: che.IStack;
 
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(stackValidationService: StackValidationService) {
     this.stackValidationService = stackValidationService;

--- a/dashboard/src/app/stacks/stack-details/list-components/edit-component-dialog/edit-component-dialog.controller.ts
+++ b/dashboard/src/app/stacks/stack-details/list-components/edit-component-dialog/edit-component-dialog.controller.ts
@@ -23,6 +23,9 @@ interface IComponent {
  * @author Oleksii Orel
  */
 export class EditComponentDialogController {
+
+  static $inject = ['$mdDialog'];
+
   $mdDialog: ng.material.IDialogService;
 
   index: number;
@@ -34,7 +37,6 @@ export class EditComponentDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/stacks/stack-details/list-components/list-components.controller.ts
+++ b/dashboard/src/app/stacks/stack-details/list-components/list-components.controller.ts
@@ -23,6 +23,9 @@ interface IComponent {
  * @author Oleksii Orel
  */
 export class ListComponentsController {
+
+  static $inject = ['$mdDialog', 'confirmDialogService'];
+
   $mdDialog: ng.material.IDialogService;
 
   components: Array<any>;
@@ -38,7 +41,6 @@ export class ListComponentsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService, confirmDialogService: ConfirmDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/stacks/stack-details/list-components/list-components.directive.ts
+++ b/dashboard/src/app/stacks/stack-details/list-components/list-components.directive.ts
@@ -35,7 +35,6 @@ export class ListComponents {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/stacks/stack-details/select-template/select-template.controller.ts
+++ b/dashboard/src/app/stacks/stack-details/select-template/select-template.controller.ts
@@ -19,6 +19,9 @@ import {StackController} from '../stack.controller';
  * @author Oleksii Orel
  */
 export class SelectTemplateController {
+
+  static $inject = ['cheAPI', '$mdDialog'];
+
   stack: che.IStack;
   selectedTemplates: Array<che.IProjectTemplate>;
   projectsOrderBy: string;
@@ -27,10 +30,8 @@ export class SelectTemplateController {
   private templates: Array<che.IProject>;
   private callbackController: StackController;
 
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheAPI: CheAPI, $mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/stacks/stack-details/stack.controller.ts
+++ b/dashboard/src/app/stacks/stack-details/stack.controller.ts
@@ -25,7 +25,11 @@ const STACK_TEST_POPUP_ID: string = 'stackTestPopup';
  * @author Oleksii Orel
  */
 export class StackController {
-  GENERAL_SCOPE: string = 'general';
+
+  static $inject = ['$q', '$timeout', '$route', '$location', '$log', '$filter', 'cheStack', 'cheWorkspace', '$mdDialog', 'cheNotification',
+   '$document', 'cheUIElementsInjectorService', '$scope', '$window', 'importStackService', 'confirmDialogService'];
+
+   GENERAL_SCOPE: string = 'general';
   ADVANCED_SCOPE: string = 'advanced';
   $q: ng.IQService;
   $log: ng.ILogService;
@@ -63,9 +67,11 @@ export class StackController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
-  constructor($q: ng.IQService, $timeout: ng.ITimeoutService, $route: ng.route.IRoute, $location: ng.ILocationService, $log: ng.ILogService, $filter: ng.IFilterService, cheStack: CheStack, cheWorkspace: CheWorkspace, $mdDialog: ng.material.IDialogService, cheNotification: CheNotification, $document: ng.IDocumentService, cheUIElementsInjectorService: CheUIElementsInjectorService, $scope: ng.IScope, $window: ng.IWindowService, importStackService: ImportStackService, confirmDialogService: ConfirmDialogService) {
+  constructor($q: ng.IQService, $timeout: ng.ITimeoutService, $route: ng.route.IRoute, $location: ng.ILocationService,
+    $log: ng.ILogService, $filter: ng.IFilterService, cheStack: CheStack, cheWorkspace: CheWorkspace, $mdDialog: ng.material.IDialogService,
+     cheNotification: CheNotification, $document: ng.IDocumentService, cheUIElementsInjectorService: CheUIElementsInjectorService,
+     $scope: ng.IScope, $window: ng.IWindowService, importStackService: ImportStackService, confirmDialogService: ConfirmDialogService) {
     this.$q = $q;
     this.$timeout = $timeout;
     this.$location = $location;

--- a/dashboard/src/app/stacks/stacks-config.ts
+++ b/dashboard/src/app/stacks/stacks-config.ts
@@ -54,7 +54,7 @@ export class StacksConfig {
     register.directive('recipeEditor', RecipeEditorDirective);
 
     // config routes
-    register.app.config(($routeProvider: any) => {
+    register.app.config(['$routeProvider', ($routeProvider: any) => {
       $routeProvider.accessWhen('/stacks', {
         title: 'Stacks',
         templateUrl: 'app/stacks/list-stacks/list-stacks.html',
@@ -69,6 +69,6 @@ export class StacksConfig {
           controller: 'StackController',
           controllerAs: 'stackController'
         });
-    });
+    }]);
   }
 }

--- a/dashboard/src/app/teams/create-team/create-team.controller.ts
+++ b/dashboard/src/app/teams/create-team/create-team.controller.ts
@@ -17,6 +17,9 @@
  * @author Ann Shumilova
  */
 export class CreateTeamController {
+
+  static $inject = ['cheTeam', 'cheInvite', 'cheUser', 'chePermissions', 'cheNotification', '$location', '$q', 'lodash', '$log', '$rootScope'];
+
   /**
    * Team API interaction.
    */
@@ -76,7 +79,6 @@ export class CreateTeamController {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(cheTeam: che.api.ICheTeam, cheInvite: che.api.ICheInvite, cheUser: any, chePermissions: che.api.IChePermissions, cheNotification: any,
               $location: ng.ILocationService, $q: ng.IQService, lodash: any, $log: ng.ILogService, $rootScope: che.IRootScopeService) {

--- a/dashboard/src/app/teams/invite-members/list-members.controller.ts
+++ b/dashboard/src/app/teams/invite-members/list-members.controller.ts
@@ -19,6 +19,8 @@ import {CheTeamRoles} from '../../../components/api/che-team-roles';
  */
 export class ListMembersController {
 
+  static $inject = ['$mdDialog', 'lodash', 'cheTeam'];
+
   /**
    * Team API interaction.
    */
@@ -62,7 +64,6 @@ export class ListMembersController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: angular.material.IDialogService, lodash: any, cheTeam: che.api.ICheTeam) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/teams/list/list-teams.controller.ts
+++ b/dashboard/src/app/teams/list/list-teams.controller.ts
@@ -18,6 +18,9 @@
  */
 export class ListTeamsController {
 
+  static $inject = ['cheTeam', 'chePermissions', 'cheResourcesDistribution', 'cheNotification', 'cheTeamEventsManager', 'confirmDialogService',
+'$scope', '$q', '$location', 'resourcesService'];
+
   /**
    * Team API interaction.
    */
@@ -85,7 +88,6 @@ export class ListTeamsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheTeam: che.api.ICheTeam, chePermissions: che.api.IChePermissions, cheResourcesDistribution: che.api.ICheResourcesDistribution,
               cheNotification: any, cheTeamEventsManager: che.api.ICheTeamEventsManager, confirmDialogService: any, $scope: ng.IScope,

--- a/dashboard/src/app/teams/list/team-item/team-item.controller.ts
+++ b/dashboard/src/app/teams/list/team-item/team-item.controller.ts
@@ -16,6 +16,9 @@
  * @author Ann Shumilova
  */
 export class TeamItemController {
+
+  static $inject = ['$location', 'cheTeam', 'confirmDialogService', 'cheNotification'];
+
   /**
    * Service for displaying dialogs.
    */
@@ -43,7 +46,6 @@ export class TeamItemController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService, cheTeam: che.api.ICheTeam, confirmDialogService: any, cheNotification: any) {
     this.$location = $location;

--- a/dashboard/src/app/teams/member-dialog/member-dialog.controller.ts
+++ b/dashboard/src/app/teams/member-dialog/member-dialog.controller.ts
@@ -18,6 +18,9 @@ import {CheTeamRoles} from '../../../components/api/che-team-roles';
  * @author Ann Shumilova
  */
 export class MemberDialogController {
+
+  static $inject = ['$mdDialog', 'cheTeam', 'cheUser', '$q', 'lodash'];
+
   /**
    * Team API interaction.
    */
@@ -90,7 +93,6 @@ export class MemberDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: angular.material.IDialogService, cheTeam: che.api.ICheTeam, cheUser: any, $q: ng.IQService, lodash: any) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/teams/navbar-teams/navbar-teams.controller.ts
+++ b/dashboard/src/app/teams/navbar-teams/navbar-teams.controller.ts
@@ -17,6 +17,9 @@
  * @author Ann Shumilova
  */
 export class NavbarTeamsController {
+
+  static $inject = ['cheTeam'];
+
   /**
    * Team API interaction.
    */
@@ -24,7 +27,6 @@ export class NavbarTeamsController {
 
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(cheTeam: che.api.ICheTeam) {
     this.cheTeam = cheTeam;

--- a/dashboard/src/app/teams/team-details/team-details.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-details.controller.ts
@@ -19,7 +19,11 @@ enum Tab {Settings, Members, Workspaces}
  * @author Ann Shumilova
  */
 export class TeamDetailsController {
-  tab: Object = Tab;
+
+  static $inject = ['cheTeam', 'cheResourcesDistribution', 'chePermissions', 'cheUser', '$route', '$location', '$rootScope', '$scope', 'confirmDialogService',
+'cheTeamEventsManager', 'cheNotification', 'lodash', 'teamDetailsService', 'resourcesService'];
+
+tab: Object = Tab;
 
   /**
    * Team API interaction.
@@ -99,10 +103,8 @@ export class TeamDetailsController {
   private hasTeamAccess: boolean;
 
   private resourceLimits: che.resource.ICheResourceLimits;
-
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(cheTeam: che.api.ICheTeam, cheResourcesDistribution: che.api.ICheResourcesDistribution, chePermissions: che.api.IChePermissions,
               cheUser: any, $route: ng.route.IRouteService, $location: ng.ILocationService, $rootScope: che.IRootScopeService,

--- a/dashboard/src/app/teams/team-details/team-details.service.ts
+++ b/dashboard/src/app/teams/team-details/team-details.service.ts
@@ -17,6 +17,8 @@
  */
 export class TeamDetailsService {
 
+  static $inject = ['$q', 'cheUser', 'cheTeam', '$route'];
+
   /**
    * Promises service.
    */
@@ -42,9 +44,7 @@ export class TeamDetailsService {
    */
   private owner: any;
 
-
   /**
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, cheUser: any, cheTeam: che.api.ICheTeam, $route: ng.route.IRouteService) {
     this.$q = $q;

--- a/dashboard/src/app/teams/team-details/team-members/list-team-members.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-members/list-team-members.controller.ts
@@ -22,6 +22,10 @@ import {CheUser} from '../../../../components/api/che-user.factory';
  * @author Ann Shumilova
  */
 export class ListTeamMembersController {
+
+  static $inject = ['cheTeam', 'chePermissions', 'cheInvite', 'cheUser', 'cheProfile', 'confirmDialogService', '$mdDialog',
+      '$q', 'cheNotification', 'lodash', '$location', 'teamDetailsService', '$scope', 'cheListHelperFactory'];
+
   /**
    * Location service.
    */
@@ -98,7 +102,6 @@ export class ListTeamMembersController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheTeam: che.api.ICheTeam,
               chePermissions: che.api.IChePermissions,

--- a/dashboard/src/app/teams/team-details/team-members/member-item/member-item.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-members/member-item/member-item.controller.ts
@@ -16,6 +16,9 @@
  * @author Ann Shumilova
  */
 export class MemberItemController {
+
+  static $inject = ['$mdDialog', 'cheTeam', 'lodash', 'confirmDialogService'];
+
   /**
    * Team API interaction.
    */
@@ -52,7 +55,6 @@ export class MemberItemController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: angular.material.IDialogService, cheTeam: che.api.ICheTeam, lodash: any, confirmDialogService: any) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/teams/team-details/team-owners/list-team-owners.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-owners/list-team-owners.controller.ts
@@ -18,6 +18,9 @@ import {TeamDetailsService} from '../team-details.service';
  * @author Ann Shumilova
  */
 export class ListTeamOwnersController {
+
+  static $inject = ['cheTeam', 'cheUser', 'chePermissions', 'cheProfile', 'cheNotification', 'lodash', 'teamDetailsService'];
+
   /**
    * Team API interaction.
    */
@@ -57,7 +60,6 @@ export class ListTeamOwnersController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheTeam: che.api.ICheTeam, cheUser: any, chePermissions: che.api.IChePermissions, cheProfile: any, cheNotification: any,
               lodash: any, teamDetailsService: TeamDetailsService) {

--- a/dashboard/src/app/teams/team-details/team-workspaces/list-team-workspaces.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-workspaces/list-team-workspaces.controller.ts
@@ -18,6 +18,9 @@ import {TeamDetailsService} from '../team-details.service';
  */
 export class ListTeamWorkspacesController {
 
+  static $inject = ['cheTeam', 'chePermissions', 'cheUser', 'cheWorkspace', 'cheNotification', 'lodash', '$mdDialog', '$q', 'teamDetailsService',
+'$scope', 'cheListHelperFactory'];
+
   /**
    * Team API interaction.
    */
@@ -71,7 +74,6 @@ export class ListTeamWorkspacesController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheTeam: che.api.ICheTeam, chePermissions: che.api.IChePermissions, cheUser: any, cheWorkspace: any,
               cheNotification: any, lodash: any, $mdDialog: angular.material.IDialogService, $q: ng.IQService,

--- a/dashboard/src/app/teams/teams-config.ts
+++ b/dashboard/src/app/teams/teams-config.ts
@@ -124,7 +124,7 @@ export class TeamsConfig {
     };
 
     // config routes
-    register.app.config(function ($routeProvider: che.route.IRouteProvider) {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/team/create', {
         title: 'New Team',
         templateUrl: 'app/teams/create-team/create-team.html',
@@ -134,6 +134,6 @@ export class TeamsConfig {
           check: ['$q', 'cheTeam', checkPersonalTeam]
         }
       }).accessWhen('/team/:teamName*', locationProvider);
-    });
+    }]);
   }
 }

--- a/dashboard/src/app/workspaces/create-workspace/after-creation-dialog/after-creation-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/after-creation-dialog/after-creation-dialog.controller.ts
@@ -12,6 +12,8 @@
 
 export class AfterCreationDialogController {
 
+  static $inject = ['$mdDialog'];
+
   /**
    * Service for displaying dialogs.
    */
@@ -19,7 +21,6 @@ export class AfterCreationDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.controller.ts
@@ -29,6 +29,10 @@ import {
  * @author Oleksii Kurinnyi
  */
 export class CreateWorkspaceController {
+
+  static $inject = ['$mdDialog', '$timeout', 'cheEnvironmentRegistry', 'createWorkspaceSvc', 'namespaceSelectorSvc', 'stackSelectorSvc',
+   'randomSvc', '$log', 'cheNotification'];
+
   /**
    * Dropdown button config.
    */
@@ -108,7 +112,6 @@ export class CreateWorkspaceController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService,
               $timeout: ng.ITimeoutService,

--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
@@ -23,6 +23,9 @@ import {CheWorkspace} from '../../../components/api/workspace/che-workspace.fact
  * @author Oleksii Kurinnyi
  */
 export class CreateWorkspaceSvc {
+
+  static $inject = ['$location', '$log', '$q', 'cheWorkspace', 'namespaceSelectorSvc', 'stackSelectorSvc', 'projectSourceSelectorService', 'cheNotification', 'confirmDialogService', '$document'];
+
   /**
    * Location service.
    */
@@ -72,7 +75,6 @@ export class CreateWorkspaceSvc {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService, $log: ng.ILogService, $q: ng.IQService, cheWorkspace: CheWorkspace, namespaceSelectorSvc: NamespaceSelectorSvc, stackSelectorSvc: StackSelectorSvc, projectSourceSelectorService: ProjectSourceSelectorService, cheNotification: CheNotification, confirmDialogService: ConfirmDialogService, $document: ng.IDocumentService) {
     this.$location = $location;

--- a/dashboard/src/app/workspaces/create-workspace/namespace-selector/namespace-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/namespace-selector/namespace-selector.controller.ts
@@ -17,6 +17,9 @@ import {NamespaceSelectorSvc} from './namespace-selector.service';
  * @author Oleksii Kurinnyi
  */
 export class NamespaceSelectorController {
+
+  static $inject = ['namespaceSelectorSvc'];
+
   /**
    * Namespace selector service.
    */
@@ -28,7 +31,6 @@ export class NamespaceSelectorController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(namespaceSelectorSvc: NamespaceSelectorSvc) {
     this.namespaceSelectorSvc = namespaceSelectorSvc;

--- a/dashboard/src/app/workspaces/create-workspace/namespace-selector/namespace-selector.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/namespace-selector/namespace-selector.directive.ts
@@ -31,7 +31,6 @@ export class NamespaceSelector implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/namespace-selector/namespace-selector.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/namespace-selector/namespace-selector.service.ts
@@ -19,6 +19,9 @@ import {CheUser} from '../../../../components/api/che-user.factory';
  * @author Oleksii Kurinnyi
  */
 export class NamespaceSelectorSvc {
+
+  static $inject = ['$location', '$log', '$q', 'cheNamespaceRegistry', 'cheUser'];
+
   /**
    * Location service.
    */
@@ -57,7 +60,6 @@ export class NamespaceSelectorSvc {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService, $log: ng.ILogService, $q: ng.IQService,
               cheNamespaceRegistry: CheNamespaceRegistry, cheUser: CheUser) {

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/add-import-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/add-import-project.controller.ts
@@ -19,6 +19,9 @@ import {ProjectSourceSelectorService} from '../project-source-selector.service';
  * @author Oleksii Kurinyi
  */
 export class AddImportProjectController {
+
+  static $inject = ['$scope', 'addImportProjectService', 'projectSourceSelectorService'];
+
   /**
    * Project selector service.
    */
@@ -49,7 +52,6 @@ export class AddImportProjectController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, addImportProjectService: AddImportProjectService, projectSourceSelectorService: ProjectSourceSelectorService) {
     this.addImportProjectService = addImportProjectService;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/add-import-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/add-import-project.service.ts
@@ -25,6 +25,9 @@ import {editingProgress} from '../project-source-selector-editing-progress';
  * @author Oleksii Kurinnyi
  */
 export class AddImportProjectService {
+
+  static $inject = ['templateSelectorSvc', 'importBlankProjectService', 'importGitProjectService', 'importGithubProjectService', 'importZipProjectService'];
+
   /**
    * Template selector service.
    */
@@ -56,7 +59,6 @@ export class AddImportProjectService {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(templateSelectorSvc: TemplateSelectorSvc, importBlankProjectService: ImportBlankProjectService, importGitProjectService: ImportGitProjectService, importGithubProjectService: ImportGithubProjectService, importZipProjectService: ImportZipProjectService) {
     this.templateSelectorSvc = templateSelectorSvc;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-blank-project/import-blank-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-blank-project/import-blank-project.controller.ts
@@ -20,6 +20,9 @@ import {AddImportProjectService} from '../add-import-project.service';
  * @author Oleksii Kurinnyi
  */
 export class ImportBlankProjectController {
+
+  static $inject = ['$scope', 'addImportProjectService', 'importBlankProjectService'];
+
   /**
    * Service for adding or importing projects.
    */
@@ -48,7 +51,6 @@ export class ImportBlankProjectController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, addImportProjectService: AddImportProjectService, importBlankProjectService: ImportBlankProjectService) {
     this.addImportProjectService = addImportProjectService;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-blank-project/import-blank-project.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-blank-project/import-blank-project.directive.ts
@@ -31,7 +31,6 @@ export class ImportBlankProject implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-blank-project/import-blank-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-blank-project/import-blank-project.service.ts
@@ -28,7 +28,6 @@ export class ImportBlankProjectService implements IEditingProgress {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this._name = '';

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-git-project/import-git-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-git-project/import-git-project.controller.ts
@@ -20,6 +20,9 @@ import {AddImportProjectService} from '../add-import-project.service';
  * @author Oleksii Kurinnyi
  */
 export class ImportGitProjectController {
+
+  static $inject = ['$scope', 'importGitProjectService', 'addImportProjectService'];
+
   /**
    * Import Git project service.
    */
@@ -39,7 +42,6 @@ export class ImportGitProjectController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, importGitProjectService: ImportGitProjectService, addImportProjectService: AddImportProjectService) {
     this.importGitProjectService = importGitProjectService;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-git-project/import-git-project.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-git-project/import-git-project.directive.ts
@@ -31,7 +31,6 @@ export class ImportGitProject implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {};

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-git-project/import-git-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-git-project/import-git-project.service.ts
@@ -24,7 +24,6 @@ export class ImportGitProjectService implements IEditingProgress {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this._location = '';

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/github-repository-item/github-repository-item.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/github-repository-item/github-repository-item.directive.ts
@@ -21,7 +21,6 @@ export class GithubRepositoryItem implements ng.IDirective {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.controller.ts
@@ -23,6 +23,10 @@ import {AddImportProjectService} from '../add-import-project.service';
  * @author Oleksii Kurinnyi
  */
 export class ImportGithubProjectController {
+
+  static $inject = ['$q', '$mdDialog', '$location', '$browser', '$scope', 'githubPopup', 'cheBranding', 'githubOrganizationNameResolver',
+'importGithubProjectService', 'cheListHelperFactory', 'addImportProjectService', 'keycloakAuth'];
+
   /**
    * Promises service.
    */
@@ -115,10 +119,9 @@ export class ImportGithubProjectController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($q: ng.IQService, $mdDialog: ng.material.IDialogService, $location: ng.ILocationService,
-               $browser: ng.IBrowserService, $scope: ng.IScope, githubPopup: any, cheBranding: CheBranding,
+               $browser: any, $scope: ng.IScope, githubPopup: any, cheBranding: CheBranding,
                githubOrganizationNameResolver: any, importGithubProjectService: ImportGithubProjectService,
                cheListHelperFactory: che.widget.ICheListHelperFactory, addImportProjectService: AddImportProjectService, keycloakAuth: any) {
     this.$q = $q;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.directive.ts
@@ -31,7 +31,6 @@ export class ImportGithubProject implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {};

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.service.ts
@@ -24,6 +24,9 @@ export enum LoadingState {
  * @author Oleksii Kurinnyi
  */
 export class ImportGithubProjectService implements IEditingProgress {
+
+  static $inject = ['cheAPI', '$http', '$q', '$filter', 'GitHub', 'gitHubTokenStore'];
+
   /**
    * API entry point.
    */
@@ -83,7 +86,6 @@ export class ImportGithubProjectService implements IEditingProgress {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor (cheAPI: CheAPI, $http: ng.IHttpService, $q: ng.IQService, $filter: ng.IFilterService, GitHub: any, gitHubTokenStore: any) {
     this.cheAPI = cheAPI;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/oauth-dialog/no-github-oauth-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/oauth-dialog/no-github-oauth-dialog.controller.ts
@@ -17,6 +17,9 @@
  * @author Florent Benoit
  */
 export class NoGithubOauthDialogController {
+
+  static $inject = ['$mdDialog'];
+
   /**
    * Material's dialog service.
    */
@@ -26,7 +29,6 @@ export class NoGithubOauthDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService, $rootScope: ng.IRootScopeService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/oauth-dialog/no-github-oauth-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/oauth-dialog/no-github-oauth-dialog.controller.ts
@@ -18,7 +18,7 @@
  */
 export class NoGithubOauthDialogController {
 
-  static $inject = ['$mdDialog'];
+  static $inject = ['$mdDialog', '$rootScope'];
 
   /**
    * Material's dialog service.

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-zip-project/import-zip-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-zip-project/import-zip-project.controller.ts
@@ -20,6 +20,9 @@ import {AddImportProjectService} from '../add-import-project.service';
  * @author Oleksii Kurinnyi
  */
 export class ImportZipProjectController {
+
+  static $inject = ['$scope', 'importZipProjectService', 'addImportProjectService'];
+
   /**
    * Import Zip project service.
    */
@@ -43,7 +46,6 @@ export class ImportZipProjectController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, importZipProjectService: ImportZipProjectService, addImportProjectService: AddImportProjectService) {
     this.importZipProjectService = importZipProjectService;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-zip-project/import-zip-project.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-zip-project/import-zip-project.directive.ts
@@ -31,7 +31,6 @@ export class ImportZipProject implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {};

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-zip-project/import-zip-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-zip-project/import-zip-project.service.ts
@@ -29,7 +29,6 @@ export class ImportZipProjectService implements IEditingProgress {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this._location = '';

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/template-selector/template-selector-item/template-selector-item.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/template-selector/template-selector-item/template-selector-item.directive.ts
@@ -25,7 +25,6 @@ export class TemplateSelectorItem implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/template-selector/template-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/template-selector/template-selector.controller.ts
@@ -21,6 +21,9 @@ import {AddImportProjectService} from '../add-import-project.service';
  * @author Oleksii Kurinnyi
  */
 export class TemplateSelectorController {
+
+  static $inject = ['$filter', '$scope', 'addImportProjectService', 'templateSelectorSvc', 'stackSelectorSvc', 'cheListHelperFactory'];
+
   /**
    * Filter service.
    */
@@ -60,9 +63,9 @@ export class TemplateSelectorController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
-  constructor($filter: ng.IFilterService, $scope: ng.IScope, addImportProjectService: AddImportProjectService, templateSelectorSvc: TemplateSelectorSvc, stackSelectorSvc: StackSelectorSvc, cheListHelperFactory: che.widget.ICheListHelperFactory) {
+  constructor($filter: ng.IFilterService, $scope: ng.IScope, addImportProjectService: AddImportProjectService, templateSelectorSvc: TemplateSelectorSvc,
+     stackSelectorSvc: StackSelectorSvc, cheListHelperFactory: che.widget.ICheListHelperFactory) {
 
     this.$filter = $filter;
     this.templateSelectorSvc = templateSelectorSvc;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/template-selector/template-selector.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/template-selector/template-selector.directive.ts
@@ -31,7 +31,6 @@ export class TemplateSelector implements ng.IDirective {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/template-selector/template-selector.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/template-selector/template-selector.service.ts
@@ -19,6 +19,9 @@ import {editingProgress, IEditingProgress} from '../../project-source-selector-e
  * @author Oleksii Kurinnyi
  */
 export class TemplateSelectorSvc implements IEditingProgress {
+
+  static $inject = ['$filter', '$q', 'cheProjectTemplate'];
+
   /**
    * Filter service.
    */
@@ -38,7 +41,6 @@ export class TemplateSelectorSvc implements IEditingProgress {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($filter: ng.IFilterService, $q: ng.IQService, cheProjectTemplate: CheProjectTemplate) {
     this.$filter = $filter;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/edit-project.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/edit-project.controller.ts
@@ -17,6 +17,9 @@ import {EditProjectService} from './edit-project.service';
  * @author Oleksii Kurinnyi
  */
 export class EditProjectController {
+
+  static $inject = ['$scope', 'editProjectService'];
+
   /**
    * Edit project section service.
    */
@@ -41,7 +44,6 @@ export class EditProjectController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, editProjectService: EditProjectService) {
     this.editProjectService = editProjectService;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/edit-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/edit-project.service.ts
@@ -19,6 +19,9 @@ import {editingProgress} from '../project-source-selector-editing-progress';
  * @author Oleksii Kurinnyi
  */
 export class EditProjectService {
+
+  static $inject = ['projectMetadataService'];
+
   /**
    * Service for editing project's metadata.
    */
@@ -27,7 +30,6 @@ export class EditProjectService {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(projectMetadataService: ProjectMetadataService) {
     this.projectMetadataService = projectMetadataService;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/project-metadata/project-metadata.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/project-metadata/project-metadata.controller.ts
@@ -20,6 +20,9 @@ import {EditProjectService} from '../edit-project.service';
  * @author Oleksii Kurinnyi
  */
 export class ProjectMetadataController {
+
+  static $inject = ['$scope', 'projectMetadataService', 'projectSourceSelectorService', 'editProjectService'];
+
   /**
    * Project metadata service.
    */
@@ -56,9 +59,9 @@ export class ProjectMetadataController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
-  constructor($scope: ng.IScope, projectMetadataService: ProjectMetadataService, projectSourceSelectorService: ProjectSourceSelectorService, editProjectService: EditProjectService) {
+  constructor($scope: ng.IScope, projectMetadataService: ProjectMetadataService, projectSourceSelectorService: ProjectSourceSelectorService,
+     editProjectService: EditProjectService) {
 
     this.projectMetadataService = projectMetadataService;
     this.projectSourceSelectorService = projectSourceSelectorService;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/project-metadata/project-metadata.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/project-metadata/project-metadata.directive.ts
@@ -31,7 +31,6 @@ export class ProjectMetadata implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.controller.ts
@@ -20,6 +20,9 @@ import {ActionType} from './project-source-selector-action-type.enum';
  * @author Oleksii Orel
  */
 export class ProjectSourceSelectorController {
+
+  static $inject = ['$scope', 'projectSourceSelectorService'];
+
   /**
    * Directive's scope.
    */
@@ -60,7 +63,6 @@ export class ProjectSourceSelectorController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($scope: IProjectSourceSelectorScope, projectSourceSelectorService: ProjectSourceSelectorService) {
     this.$scope = $scope;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.directive.ts
@@ -21,6 +21,9 @@ export interface IProjectSourceSelectorScope extends ng.IScope {
  * @author Oleksii Orel
  */
 export class ProjectSourceSelector implements ng.IDirective {
+
+  static $inject = ['$timeout'];
+
   restrict: string = 'E';
   templateUrl: string = 'app/workspaces/create-workspace/project-source-selector/project-source-selector.html';
   replace: boolean = true;
@@ -36,7 +39,6 @@ export class ProjectSourceSelector implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService) {
     this.$timeout = $timeout;

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.service.ts
@@ -21,6 +21,9 @@ import {RandomSvc} from '../../../../components/utils/random.service';
  * @author Oleksii Kurinnyi
  */
 export class ProjectSourceSelectorService {
+
+  static $inject = ['randomSvc', 'addImportProjectService', 'editProjectService'];
+
   /**
    * Service for project adding or importing.
    */
@@ -44,7 +47,6 @@ export class ProjectSourceSelectorService {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(randomSvc: RandomSvc, addImportProjectService: AddImportProjectService, editProjectService: EditProjectService) {
     this.randomSvc = randomSvc;

--- a/dashboard/src/app/workspaces/create-workspace/ram-settings/ram-settings-machine-item/ram-settings-machine-item.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/ram-settings/ram-settings-machine-item/ram-settings-machine-item.directive.ts
@@ -31,7 +31,6 @@ export class RamSettingsMachineItem implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/ram-settings/ram-settings.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/ram-settings/ram-settings.controller.ts
@@ -26,6 +26,9 @@ type machine = {
  * @author Oleksii Kurinnyi
  */
 export class RamSettingsController {
+
+  static $inject = ['$filter', '$scope'];
+
   /**
    * Filter service.
    */
@@ -49,7 +52,6 @@ export class RamSettingsController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($filter: ng.IFilterService, $scope: ng.IScope) {
     this.$filter = $filter;

--- a/dashboard/src/app/workspaces/create-workspace/ram-settings/ram-settings.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/ram-settings/ram-settings.directive.ts
@@ -31,7 +31,6 @@ export class RamSettings implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-library-filter/che-stack-library-filter.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-library-filter/che-stack-library-filter.controller.ts
@@ -15,6 +15,9 @@
  * @author Oleksii Kurinnyi
  */
 export class CheStackLibraryFilterController {
+
+  static $inject = ['$scope', '$mdConstant', '$timeout'];
+
   selectSuggestion: Function;
   suggestions: Array<string>;
   selectedIndex: number;
@@ -26,9 +29,9 @@ export class CheStackLibraryFilterController {
   private stackTags: Array<string>;
   private selectedTags: Array<string>;
   private onTagsChanges: Function;
+
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, $mdConstant: any, $timeout: ng.ITimeoutService) {
     this.$scope = $scope;

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector-item/stack-selector-item.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector-item/stack-selector-item.directive.ts
@@ -26,7 +26,6 @@ export class StackSelectorItem implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.controller.ts
@@ -25,6 +25,9 @@ import {CheWorkspace} from '../../../../components/api/workspace/che-workspace.f
  * @author Oleksii Kurinnyi
  */
 export class StackSelectorController {
+
+  static $inject = ['$filter', '$mdDialog', '$q', 'lodash', 'cheStack', 'cheWorkspace', 'confirmDialogService', '$location', 'cheBranding', 'cheEnvironmentRegistry', 'stackSelectorSvc'];
+
   /**
    * Filter service.
    */
@@ -140,7 +143,6 @@ export class StackSelectorController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($filter: ng.IFilterService,
               $mdDialog: ng.material.IDialogService,

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.directive.ts
@@ -31,7 +31,6 @@ export class StackSelector implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.service.ts
@@ -19,6 +19,9 @@ import {Observable} from '../../../../components/utils/observable';
  * @author Oleksii Kurinnyi
  */
 export class StackSelectorSvc extends Observable<any> {
+
+  static $inject = ['$log', '$q', 'cheStack'];
+
   /**
    * Log service.
    */
@@ -38,7 +41,6 @@ export class StackSelectorSvc extends Observable<any> {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService, $q: ng.IQService, cheStack: CheStack) {
     super();

--- a/dashboard/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
+++ b/dashboard/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
@@ -23,7 +23,11 @@ import {CheBranding} from '../../../components/branding/che-branding.factory';
  * @author Ann Shumilova
  */
 export class ListWorkspacesCtrl {
-  $q: ng.IQService;
+
+  static $inject = ['$log', '$mdDialog', '$q', 'lodash', 'cheAPI', 'cheNotification', 'cheBranding', 'cheWorkspace', 'cheNamespaceRegistry',
+   'confirmDialogService', '$scope', 'cheListHelperFactory'];
+
+   $q: ng.IQService;
   $log: ng.ILogService;
   lodash: any;
   $mdDialog: ng.material.IDialogService;
@@ -53,7 +57,6 @@ export class ListWorkspacesCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService, $mdDialog: ng.material.IDialogService, $q: ng.IQService, lodash: any,
               cheAPI: CheAPI, cheNotification: CheNotification, cheBranding: CheBranding,

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-item/usage-chart.directive.ts
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-item/usage-chart.directive.ts
@@ -35,7 +35,6 @@ export class UsageChart implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
     constructor () {
     this.restrict = 'E';

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-item/workspace-item.controller.ts
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-item/workspace-item.controller.ts
@@ -19,6 +19,9 @@ import {WorkspacesService} from '../../workspaces.service';
  * @author Ann Shumilova
  */
 export class WorkspaceItemCtrl {
+
+  static $inject = ['$location', 'lodash', 'cheWorkspace', 'workspacesService'];
+
   $location: ng.ILocationService;
   lodash: any;
   cheWorkspace: CheWorkspace;
@@ -28,7 +31,6 @@ export class WorkspaceItemCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService,
               lodash: any,

--- a/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.controller.ts
+++ b/dashboard/src/app/workspaces/list-workspaces/workspace-status-action/workspace-status.controller.ts
@@ -19,6 +19,9 @@ import {CheWorkspace, WorkspaceStatus} from '../../../../components/api/workspac
  * @author Oleksii Orel
  */
 export class WorkspaceStatusController {
+
+  static $inject = ['$rootScope', 'cheWorkspace', 'cheNotification'];
+
   /**
    * Root scope service.
    */
@@ -31,7 +34,6 @@ export class WorkspaceStatusController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($rootScope: ng.IRootScopeService, cheWorkspace: CheWorkspace, cheNotification: CheNotification) {
     this.$rootScope = $rootScope;

--- a/dashboard/src/app/workspaces/share-workspace/add-developers/add-developers.controller.ts
+++ b/dashboard/src/app/workspaces/share-workspace/add-developers/add-developers.controller.ts
@@ -16,6 +16,9 @@ import {ShareWorkspaceController} from '../share-workspace.controller';
  * @author Oleksii Kurinnyi
  */
 export class AddDeveloperController {
+
+  static $inject = ['$q', '$mdDialog'];
+
   /**
    * Promises service.
    */
@@ -41,7 +44,6 @@ export class AddDeveloperController {
 
   /**
    * Default constructor.
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $mdDialog: ng.material.IDialogService) {
     this.$q = $q;

--- a/dashboard/src/app/workspaces/share-workspace/add-members/add-members.controller.ts
+++ b/dashboard/src/app/workspaces/share-workspace/add-members/add-members.controller.ts
@@ -19,6 +19,8 @@ import {CheUser} from '../../../../components/api/che-user.factory';
  */
 export class AddMemberController {
 
+  static $inject = ['$q', '$mdDialog', 'lodash', 'cheTeam', 'chePermissions', 'cheProfile', 'cheUser', '$log', '$scope', 'cheListHelperFactory'];
+
   private $mdDialog: angular.material.IDialogService;
   private $q: ng.IQService;
   private lodash: any;
@@ -67,7 +69,6 @@ export class AddMemberController {
 
   /**
    * Default constructor.
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $mdDialog: angular.material.IDialogService, lodash: any, cheTeam: che.api.ICheTeam,
               chePermissions: che.api.IChePermissions, cheProfile: CheProfile, cheUser: CheUser, $log: ng.ILogService,

--- a/dashboard/src/app/workspaces/share-workspace/share-workspace.controller.ts
+++ b/dashboard/src/app/workspaces/share-workspace/share-workspace.controller.ts
@@ -27,6 +27,10 @@ interface ISharedWorkspaceUser extends che.IUser {
  * @author Ann Shumilova
  */
 export class ShareWorkspaceController {
+
+  static $inject = ['cheWorkspace', 'cheUser', 'cheNotification', '$mdDialog', '$document', '$mdConstant', '$route', '$q', 'lodash',
+   'confirmDialogService', 'cheTeam', '$log', '$scope', 'cheListHelperFactory'];
+
   /**
    * Workspace API interaction.
    */
@@ -93,7 +97,6 @@ export class ShareWorkspaceController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheWorkspace: CheWorkspace,
               cheUser: CheUser,
@@ -110,9 +113,6 @@ export class ShareWorkspaceController {
               $log: ng.ILogService,
               $scope: ng.IScope,
               cheListHelperFactory: che.widget.ICheListHelperFactory) {
-    /* tslint:disable */
-    'ngInject';
-    /* tslint:enable */
 
     this.cheWorkspace = cheWorkspace;
     this.cheUser = cheUser;

--- a/dashboard/src/app/workspaces/share-workspace/user-item/user-item.controller.ts
+++ b/dashboard/src/app/workspaces/share-workspace/user-item/user-item.controller.ts
@@ -17,6 +17,7 @@ import {ShareWorkspaceController} from '../share-workspace.controller';
  * @author Ann Shumilova
  */
 export class UserItemController {
+  static $inject = ['confirmDialogService', 'chePermissions', '$mdDialog'];
 
   user: { id: string; email: string; permissions: { actions: Array<string> } };
 
@@ -27,7 +28,6 @@ export class UserItemController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(confirmDialogService: any, chePermissions: che.api.IChePermissions, $mdDialog: ng.material.IDialogService) {
     this.confirmDialogService = confirmDialogService;

--- a/dashboard/src/app/workspaces/workspace-config.service.ts
+++ b/dashboard/src/app/workspaces/workspace-config.service.ts
@@ -23,6 +23,9 @@ import {ImportGithubProjectService} from './create-workspace/project-source-sele
  * @author Oleksii Kurinnyi
  */
 export class WorkspaceConfigService {
+
+  static $inject = ['$log', '$q', 'cheWorkspace', 'namespaceSelectorSvc', 'createWorkspaceSvc', 'stackSelectorSvc', 'templateSelectorSvc', 'importGithubProjectService'];
+
   /**
    * Log service.
    */
@@ -57,9 +60,9 @@ export class WorkspaceConfigService {
   private importGithubProjectService: ImportGithubProjectService;
 
   /** Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
-  constructor($log: ng.ILogService, $q: ng.IQService, cheWorkspace: CheWorkspace, namespaceSelectorSvc: NamespaceSelectorSvc, createWorkspaceSvc: CreateWorkspaceSvc, stackSelectorSvc: StackSelectorSvc, templateSelectorSvc: TemplateSelectorSvc, importGithubProjectService: ImportGithubProjectService) {
+  constructor($log: ng.ILogService, $q: ng.IQService, cheWorkspace: CheWorkspace, namespaceSelectorSvc: NamespaceSelectorSvc, createWorkspaceSvc: CreateWorkspaceSvc,
+     stackSelectorSvc: StackSelectorSvc, templateSelectorSvc: TemplateSelectorSvc, importGithubProjectService: ImportGithubProjectService) {
     this.$log = $log;
     this.$q = $q;
     this.cheWorkspace = cheWorkspace;

--- a/dashboard/src/app/workspaces/workspace-details/che-recipe.service.ts
+++ b/dashboard/src/app/workspaces/workspace-details/che-recipe.service.ts
@@ -17,6 +17,9 @@ import {CheRecipeTypes} from '../../../components/api/recipe/che-recipe-types';
  * @author Oleksii Orel
  */
 export class CheRecipeService {
+
+  static $inject = ['$log'];
+
   /**
    * Logging service.
    */
@@ -24,7 +27,6 @@ export class CheRecipeService {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($log: ng.ILogService) {
     this.$log = $log;

--- a/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.controller.ts
@@ -19,6 +19,9 @@ import {StackValidationService} from '../../../stacks/stack-details/stack-valida
  * @author Oleksii Kurinnyi
  */
 export class WorkspaceConfigImportController {
+
+  static $inject = ['$log', '$scope', '$timeout', 'cheErrorMessagesService', 'stackValidationService'];
+
   $log: ng.ILogService;
   $scope: ng.IScope;
   $timeout: ng.ITimeoutService;
@@ -45,11 +48,12 @@ export class WorkspaceConfigImportController {
   newWorkspaceConfig: any;
   workspaceConfigOnChange: Function;
 
+
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
-  constructor($log: ng.ILogService, $scope: ng.IScope, $timeout: ng.ITimeoutService, cheErrorMessagesService: CheErrorMessagesService, stackValidationService: StackValidationService) {
+  constructor($log: ng.ILogService, $scope: ng.IScope, $timeout: ng.ITimeoutService, cheErrorMessagesService: CheErrorMessagesService,
+     stackValidationService: StackValidationService) {
     this.$log = $log;
     this.$scope = $scope;
     this.$timeout = $timeout;

--- a/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.directive.ts
@@ -30,7 +30,6 @@ export class WorkspaceConfigImport {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/environments/environments.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/environments.controller.ts
@@ -26,6 +26,9 @@ const MAX_WORKSPACE_RAM: number = 100 * MIN_WORKSPACE_RAM;
 const DEFAULT_WORKSPACE_RAM: number = 2 * MIN_WORKSPACE_RAM;
 
 export class WorkspaceEnvironmentsController {
+
+  static $inject = ['$q', '$scope', '$timeout', '$mdDialog', 'cheEnvironmentRegistry', '$log', 'cheNotification', 'cheRecipeService'];
+
   cheEnvironmentRegistry: CheEnvironmentRegistry;
   environmentManager: EnvironmentManager;
   $mdDialog: ng.material.IDialogService;
@@ -68,9 +71,9 @@ export class WorkspaceEnvironmentsController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
-  constructor($q: ng.IQService, $scope: ng.IScope, $timeout: ng.ITimeoutService, $mdDialog: ng.material.IDialogService, cheEnvironmentRegistry: CheEnvironmentRegistry, $log: ng.ILogService, cheNotification: CheNotification, cheRecipeService: CheRecipeService) {
+  constructor($q: ng.IQService, $scope: ng.IScope, $timeout: ng.ITimeoutService, $mdDialog: ng.material.IDialogService,
+    cheEnvironmentRegistry: CheEnvironmentRegistry, $log: ng.ILogService, cheNotification: CheNotification, cheRecipeService: CheRecipeService) {
     this.$q = $q;
     this.$mdDialog = $mdDialog;
     this.cheEnvironmentRegistry = cheEnvironmentRegistry;

--- a/dashboard/src/app/workspaces/workspace-details/environments/environments.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/environments.directive.ts
@@ -38,7 +38,6 @@ export class WorkspaceEnvironments {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.controller.ts
@@ -25,6 +25,8 @@ const DISABLED_AGENTS: Array<string> = ['org.eclipse.che.ws-agent',
                                         'com.codenvy.external_rsync'];
 
 export class ListAgentsController {
+  static $inject = ['cheAPI'];
+
   cheAgent: CheAgent;
 
   agents: string[];
@@ -35,7 +37,6 @@ export class ListAgentsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheAPI: CheAPI) {
     this.cheAgent = cheAPI.getAgent();

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-agents/list-agents.directive.ts
@@ -38,7 +38,6 @@ export class ListAgents {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/edit-variable-dialog/edit-variable-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/edit-variable-dialog/edit-variable-dialog.controller.ts
@@ -18,6 +18,8 @@ import {ListEnvVariablesController} from '../list-env-variables.controller';
  * @author Oleksii Kurinnyi
  */
 export class EditVariableDialogController {
+  static $inject = ['$mdDialog'];
+
   $mdDialog: ng.material.IDialogService;
 
   popupTitle: string;
@@ -34,7 +36,6 @@ export class EditVariableDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.controller.ts
@@ -23,6 +23,8 @@ interface IEnvironmentVariable {
  * @author Oleksii Kurinnyi
  */
 export class ListEnvVariablesController {
+  static $inject = ['$mdDialog', 'lodash', 'confirmDialogService'];
+
   $mdDialog: ng.material.IDialogService;
   lodash: any;
 
@@ -44,7 +46,6 @@ export class ListEnvVariablesController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService,
               lodash: any,

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.directive.ts
@@ -38,7 +38,6 @@ export class ListEnvVariables {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/edit-server-dialog/edit-server-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/edit-server-dialog/edit-server-dialog.controller.ts
@@ -19,6 +19,9 @@ import {IEnvironmentManagerMachineServer} from '../../../../../../components/api
  * @author Oleksii Kurinnyi
  */
 export class EditServerDialogController {
+
+  static $inject = ['$mdDialog', 'lodash'];
+
   $mdDialog: ng.material.IDialogService;
   lodash: any;
 
@@ -42,7 +45,6 @@ export class EditServerDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService,
               lodash: any) {

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.controller.ts
@@ -23,6 +23,9 @@ interface IServerListItem extends IEnvironmentManagerMachineServer {
  * @author Oleksii Kurinnyi
  */
 export class ListServersController {
+
+  static $inject = ['$mdDialog', 'lodash', 'confirmDialogService'];
+
   $mdDialog: ng.material.IDialogService;
   lodash: any;
 
@@ -44,7 +47,6 @@ export class ListServersController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService,
               lodash: any,

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.directive.ts
@@ -38,7 +38,6 @@ export class ListServers {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/environments/machine-config/delete-dev-machine-dialog/delete-dev-machine-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/machine-config/delete-dev-machine-dialog/delete-dev-machine-dialog.controller.ts
@@ -17,6 +17,9 @@ import {IMachinesListItem, WorkspaceMachineConfigController} from '../machine-co
  * @author Oleksii Kurinnyi
  */
 export class DeleteDevMachineDialogController {
+
+  static $inject = ['$mdDialog'];
+
   /**
    * Material design Dialog service.
    */
@@ -50,7 +53,6 @@ export class DeleteDevMachineDialogController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/environments/machine-config/edit-machine-name-dialog/edit-machine-name-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/machine-config/edit-machine-name-dialog/edit-machine-name-dialog.controller.ts
@@ -18,6 +18,9 @@ import {WorkspaceMachineConfigController} from '../machine-config.controller';
  * @author Oleksii Kurinnyi
  */
 export class EditMachineNameDialogController {
+
+  static $inject = ['$mdDialog'];
+
   private $mdDialog: ng.material.IDialogService;
   private name: string;
   private origName: string;
@@ -27,7 +30,6 @@ export class EditMachineNameDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/environments/machine-config/machine-config.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/machine-config/machine-config.controller.ts
@@ -24,6 +24,9 @@ export interface IMachinesListItem extends che.IWorkspaceRuntimeMachine {
  * @author Oleksii Kurinnyi
  */
 export class WorkspaceMachineConfigController {
+
+  static $inject = ['$mdDialog', '$q', '$scope', '$timeout', 'lodash', 'confirmDialogService'];
+
   $mdDialog: ng.material.IDialogService;
   $q: ng.IQService;
   $timeout: ng.ITimeoutService;
@@ -50,7 +53,6 @@ export class WorkspaceMachineConfigController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService,
               $q: ng.IQService,

--- a/dashboard/src/app/workspaces/workspace-details/export-workspace/dialog/export-workspace-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/export-workspace/dialog/export-workspace-dialog.controller.ts
@@ -19,6 +19,9 @@ import {CheRemote} from '../../../../../components/api/remote/che-remote.factory
  * @author Florent Benoit
  */
 export class ExportWorkspaceDialogController {
+
+  static $inject = ['$q', '$filter', 'lodash', 'cheRemote', 'cheNotification', '$mdDialog', '$log', '$window', '$scope'];
+
   private $q: ng.IQService;
   private $filter: ng.IFilterService;
   private cheNotification: CheNotification;
@@ -40,10 +43,8 @@ export class ExportWorkspaceDialogController {
   private workspaceDetails: any;
   private exportInCloudSteps: string;
 
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService,
               $filter: ng.IFilterService,

--- a/dashboard/src/app/workspaces/workspace-details/export-workspace/export-workspace.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/export-workspace/export-workspace.controller.ts
@@ -18,6 +18,8 @@
  */
 export class ExportWorkspaceController {
 
+  static $inject = ['$mdDialog'];
+
   $mdDialog: ng.material.IDialogService;
 
   workspaceId: string;
@@ -25,7 +27,6 @@ export class ExportWorkspaceController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/list-commands/edit-command-dialog/edit-command-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/edit-command-dialog/edit-command-dialog.controller.ts
@@ -18,6 +18,9 @@ import {ListCommandsController} from '../list-commands.controller';
  * @author Oleksii Orel
  */
 export class EditCommandDialogController {
+
+  static $inject = ['$mdDialog'];
+
   $mdDialog: ng.material.IDialogService;
   index: number;
   name: string;
@@ -29,7 +32,6 @@ export class EditCommandDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.controller.ts
@@ -18,6 +18,9 @@ import {ConfirmDialogService} from '../../../../components/service/confirm-dialo
  * @author Oleksii Orel
  */
 export class ListCommandsController {
+
+  static $inject = ['$mdDialog', 'confirmDialogService'];
+
   $mdDialog: ng.material.IDialogService;
 
   commands: Array<che.IWorkspaceCommand>;
@@ -33,7 +36,6 @@ export class ListCommandsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService, confirmDialogService: ConfirmDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.directive.ts
@@ -37,7 +37,6 @@ export class ListCommands {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.restrict = 'E';

--- a/dashboard/src/app/workspaces/workspace-details/machine-selector/machine-selector.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/machine-selector/machine-selector.controller.ts
@@ -31,6 +31,9 @@ type machine = {
  * @author Oleksii Orel
  */
 export class MachineSelectorController {
+
+  static $inject = ['$scope', 'cheEnvironmentRegistry', 'workspaceDetailsService'];
+
   /**
    * The selected machine.
    */
@@ -74,7 +77,6 @@ export class MachineSelectorController {
 
   /**
    * Default constructor that is using resource injection.
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, cheEnvironmentRegistry: CheEnvironmentRegistry, workspaceDetailsService: WorkspaceDetailsService) {
     this.$scope = $scope;

--- a/dashboard/src/app/workspaces/workspace-details/machine-selector/machine-selector.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/machine-selector/machine-selector.directive.ts
@@ -58,7 +58,6 @@ export class MachineSelector implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/ready-to-go-stacks/ready-to-go-stacks.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/ready-to-go-stacks/ready-to-go-stacks.controller.ts
@@ -19,6 +19,8 @@ import {CheBranding} from '../../../../../components/branding/che-branding.facto
  */
 export class ReadyToGoStacksController {
 
+  static $inject = ['$scope', 'lodash', 'cheStack', 'cheBranding'];
+
   private $scope: ng.IScope;
   private lodash: any;
   private tabName: string;
@@ -33,7 +35,6 @@ export class ReadyToGoStacksController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope,
               lodash: any,

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.controller.ts
@@ -24,6 +24,9 @@ const COMPOSE = 'compose';
  * @author Oleksii Kurinnyi
  */
 export class WorkspaceRecipeAuthoringController {
+
+  static $inject = ['$scope', '$timeout', 'cheBranding'];
+
   $timeout: ng.ITimeoutService;
 
   composeParser: ComposeParser;
@@ -49,7 +52,6 @@ export class WorkspaceRecipeAuthoringController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, $timeout: ng.ITimeoutService, cheBranding: CheBranding) {
     this.$timeout = $timeout;

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-authoring/workspace-recipe-authoring.directive.ts
@@ -31,7 +31,6 @@ export class WorkspaceRecipeAuthoring {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-import/workspace-recipe-import.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-import/workspace-recipe-import.controller.ts
@@ -18,6 +18,9 @@
  * @author Oleksii Kurinnyi
  */
 export class WorkspaceRecipeImportController {
+
+  static $inject = ['$scope', '$timeout'];
+
   $timeout: ng.ITimeoutService;
 
   recipeUrl: string;
@@ -28,7 +31,6 @@ export class WorkspaceRecipeImportController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, $timeout: ng.ITimeoutService) {
     this.recipeFormat = this.recipeFormat || 'compose';

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-import/workspace-recipe-import.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/recipe-import/workspace-recipe-import.directive.ts
@@ -31,7 +31,6 @@ export class WorkspaceRecipeImport {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/create-project-stack-library.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/create-project-stack-library.controller.ts
@@ -18,6 +18,8 @@ import {CheStack} from '../../../../../components/api/che-stack.factory';
  */
 export class CreateProjectStackLibraryController {
 
+  static $inject = ['$scope', 'cheStack', 'lodash'];
+
   private $scope: ng.IScope;
   private lodash: any;
   private tabName: string;
@@ -28,7 +30,6 @@ export class CreateProjectStackLibraryController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope,
               cheStack: CheStack,

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/stack-library/stack-library-selecter/che-stack-library-selecter.directive.ts
@@ -29,7 +29,6 @@ export class CheStackLibrarySelecter implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/workspace-select-stack.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/workspace-select-stack.controller.ts
@@ -19,6 +19,9 @@ import {CheEnvironmentRegistry} from '../../../../components/api/environment/che
  * @author Oleksii Orel
  */
 export class WorkspaceSelectStackController {
+
+  static $inject = ['$log', '$timeout', '$scope', 'lodash', 'cheStack', 'cheEnvironmentRegistry'];
+
   $log: ng.ILogService;
   $timeout: ng.ITimeoutService;
   $scope: ng.IScope;
@@ -49,7 +52,6 @@ export class WorkspaceSelectStackController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService, $timeout: ng.ITimeoutService, $scope: ng.IScope, lodash: any, cheStack: CheStack, cheEnvironmentRegistry: CheEnvironmentRegistry) {
     this.$log = $log;

--- a/dashboard/src/app/workspaces/workspace-details/select-stack/workspace-select-stack.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/select-stack/workspace-select-stack.directive.ts
@@ -28,7 +28,6 @@ export class WorkspaceSelectStack {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/status-button/workspace-status-button.directive.ts
@@ -43,6 +43,9 @@ const STOPPING = WorkspaceStatus[WorkspaceStatus.STOPPING];
 
 
 export class CheWorkspaceStatusButton {
+
+  static $inject = ['cheWorkspace'];
+
   restrict = 'E';
   templateUrl = 'app/workspaces/workspace-details/status-button/workspace-status-button.html';
 
@@ -58,7 +61,6 @@ export class CheWorkspaceStatusButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheWorkspace: CheWorkspace) {
     this.cheWorkspace = cheWorkspace;

--- a/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.controller.ts
@@ -27,7 +27,6 @@ export class WorkspaceWarningsController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.warnings = [];

--- a/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.directive.ts
@@ -29,7 +29,6 @@ export class WorkspaceWarnings implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details-config.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details-config.ts
@@ -173,7 +173,7 @@ export class WorkspaceDetailsConfig {
 
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider
         .accessWhen('/workspace/:namespace*/:workspaceName/:projectName', {
           title: (params: any) => {
@@ -201,6 +201,6 @@ export class WorkspaceDetailsConfig {
             }]
           }
         });
-    });
+    }]);
   }
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -33,6 +33,9 @@ const TAB: Array<string> = ['Overview', 'Projects', 'Machines', 'Installers', 'S
  * @author Oleksii Orel
  */
 export class WorkspaceDetailsController {
+
+  static $inject = ['$location', '$log', '$scope', 'cheNotification', 'cheWorkspace', 'ideSvc', 'workspaceDetailsService', 'initData', '$timeout', 'workspacesService'];
+
   /**
    * Overlay panel configuration.
    */
@@ -66,7 +69,6 @@ export class WorkspaceDetailsController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService,
               $log: ng.ILogService,

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
@@ -37,6 +37,9 @@ interface ISection {
  * @author Oleksii Orel
  */
 export class WorkspaceDetailsService {
+
+  static $inject = ['$log', '$q', 'cheWorkspace', 'cheNotification', 'ideSvc', 'createWorkspaceSvc', 'workspaceDetailsProjectsService', 'cheService', 'chePermissions'];
+
   /**
    * Logging service.
    */
@@ -79,7 +82,6 @@ export class WorkspaceDetailsService {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor (
     $log: ng.ILogService,

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.controller.ts
@@ -27,6 +27,9 @@ const LATEST: string = 'latest';
  * @author Oleksii Orel
  */
 export class MachineAgentsController {
+
+  static $inject = ['$scope', 'cheAgent'];
+
   onChange: Function;
   agentOrderBy = 'name';
   agentsList: Array<IAgentItem>;
@@ -36,10 +39,8 @@ export class MachineAgentsController {
   private environmentManager: EnvironmentManager;
   private agents: Array<string>;
 
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, cheAgent: CheAgent) {
     this.cheAgent = cheAgent;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.directive.ts
@@ -36,7 +36,6 @@ export class MachineAgents implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/edit-variable-dialog/edit-variable-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/edit-variable-dialog/edit-variable-dialog.controller.ts
@@ -17,6 +17,9 @@
  * @author Oleksii Orel
  */
 export class EditEnvVariableDialogController {
+
+  static $inject = ['$mdDialog'];
+
   private $mdDialog: ng.material.IDialogService;
   private popupTitle: string;
   private toEdit: string;
@@ -30,7 +33,6 @@ export class EditEnvVariableDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.controller.ts
@@ -25,6 +25,9 @@ interface IEnvironmentVariable {
  * @author Oleksii Orel
  */
 export class EnvVariablesController {
+
+  static $inject = ['$scope', '$mdDialog', 'confirmDialogService'];
+
   envVariableOrderBy = 'name';
 
   private $mdDialog: ng.material.IDialogService;
@@ -41,7 +44,6 @@ export class EnvVariablesController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, $mdDialog: ng.material.IDialogService, confirmDialogService: ConfirmDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.directive.ts
@@ -36,7 +36,6 @@ export class EnvVariables implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/edit-machine-server-dialog/edit-server-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/edit-machine-server-dialog/edit-server-dialog.controller.ts
@@ -21,6 +21,9 @@ const PORT_MAX = 65535;
  * @author Oleksii Orel
  */
 export class EditMachineServerDialogController {
+
+  static $inject = ['$mdDialog'];
+
   updateServer: (port: number, protocol: string, reference: string, oldReference?: string) => void;
 
   private $mdDialog: ng.material.IDialogService;
@@ -38,7 +41,6 @@ export class EditMachineServerDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.controller.ts
@@ -27,6 +27,9 @@ interface IServerListItem extends IEnvironmentManagerMachineServer {
  * @author Oleksii Orel
  */
 export class MachineServersController {
+
+  static $inject = ['$scope', '$mdDialog', 'confirmDialogService'];
+
   serversOrderBy = 'reference';
 
   private $mdDialog: ng.material.IDialogService;
@@ -43,7 +46,6 @@ export class MachineServersController {
 
   /**
    * Default constructor that is using resource.
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, $mdDialog: ng.material.IDialogService, confirmDialogService: ConfirmDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.directive.ts
@@ -36,7 +36,6 @@ export class MachineServers implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/edit-volume-dialog/edit-volume-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/edit-volume-dialog/edit-volume-dialog.controller.ts
@@ -17,6 +17,9 @@
  * @author Oleksii Orel
  */
 export class EditMachineVolumeDialogController {
+
+  static $inject = ['$mdDialog'];
+
   editorState = {isValid: true};
   private $mdDialog: ng.material.IDialogService;
   private popupTitle: string;
@@ -31,7 +34,6 @@ export class EditMachineVolumeDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/machine-volumes.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/machine-volumes.controller.ts
@@ -21,6 +21,9 @@ import {CheListHelperFactory} from '../../../../components/widget/list/che-list-
  * @author Oleksii Orel
  */
 export class MachineVolumesController {
+
+  static $inject = ['$scope', '$mdDialog', 'confirmDialogService', 'cheListHelperFactory'];
+
   machineVolumeOrderBy = 'name';
 
   private $mdDialog: ng.material.IDialogService;
@@ -34,7 +37,6 @@ export class MachineVolumesController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, $mdDialog: ng.material.IDialogService, confirmDialogService: ConfirmDialogService, cheListHelperFactory: CheListHelperFactory) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/change-dev-machine-dialog/change-dev-machine-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/change-dev-machine-dialog/change-dev-machine-dialog.controller.ts
@@ -17,6 +17,9 @@ import {IEnvironmentManagerMachine} from '../../../../../components/api/environm
  * @author Oleksii Orel
  */
 export class ChangeDevMachineDialogController {
+
+  static $inject = ['$mdDialog'];
+
   /**
    * Material design Dialog service.
    */
@@ -57,7 +60,6 @@ export class ChangeDevMachineDialogController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService) {
     this.$mdDialog = $mdDialog;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/edit-machine-dialog/edit-machine-dialog.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/edit-machine-dialog/edit-machine-dialog.controller.ts
@@ -27,6 +27,9 @@ interface IPodItem {
  * @author Oleksii Orel
  */
 export class EditMachineDialogController {
+
+  static $inject = ['$mdDialog', 'cheEnvironmentRegistry', 'cheRecipeService'];
+
   errors: Array<string> = [];
   private $mdDialog: ng.material.IDialogService;
   private $log: ng.ILogService;
@@ -54,7 +57,6 @@ export class EditMachineDialogController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($mdDialog: ng.material.IDialogService,
               cheEnvironmentRegistry: CheEnvironmentRegistry,

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/machine-item/workspace-machine-item.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/machine-item/workspace-machine-item.directive.ts
@@ -51,7 +51,6 @@ export class WorkspaceMachineItem implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.controller.ts
@@ -35,6 +35,9 @@ const MACHINE_LIST_HELPER_ID = 'workspace-machine-list';
  */
 export class WorkspaceMachinesController {
 
+  static $inject = ['$q', '$log', '$filter', '$scope', '$mdDialog', 'confirmDialogService', 'cheRecipeService', '$location', 'cheEnvironmentRegistry',
+  'cheListHelperFactory', 'workspaceDetailsService'];
+
   /**
    * Angular Promise service.
    */
@@ -106,9 +109,10 @@ export class WorkspaceMachinesController {
 
   /**
    * Default constructor that is using resource injection.
-   * @ngInject for Dependency injection
    */
-  constructor($q: ng.IQService, $log: ng.ILogService, $filter: ng.IFilterService, $scope: ng.IScope, $mdDialog: ng.material.IDialogService, confirmDialogService: ConfirmDialogService, cheRecipeService: CheRecipeService, $location: ng.ILocationService, cheEnvironmentRegistry: CheEnvironmentRegistry, cheListHelperFactory: che.widget.ICheListHelperFactory, workspaceDetailsService: WorkspaceDetailsService) {
+  constructor($q: ng.IQService, $log: ng.ILogService, $filter: ng.IFilterService, $scope: ng.IScope, $mdDialog: ng.material.IDialogService,
+    confirmDialogService: ConfirmDialogService, cheRecipeService: CheRecipeService, $location: ng.ILocationService, cheEnvironmentRegistry: CheEnvironmentRegistry,
+     cheListHelperFactory: che.widget.ICheListHelperFactory, workspaceDetailsService: WorkspaceDetailsService) {
     this.$q = $q;
     this.$log = $log;
     this.$filter = $filter;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.directive.ts
@@ -41,7 +41,6 @@ export class WorkspaceMachines implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
@@ -26,6 +26,9 @@ const STOPPED = WorkspaceStatus[WorkspaceStatus.STOPPED];
  * @author Oleksii Orel
  */
 export class WorkspaceDetailsOverviewController {
+
+  static $inject = ['$q', '$route', '$timeout', '$location', 'cheWorkspace', 'cheNotification', 'confirmDialogService', 'namespaceSelectorSvc', 'workspaceDetailsService'];
+
   onChange: Function;
 
   private $q: ng.IQService;
@@ -47,9 +50,10 @@ export class WorkspaceDetailsOverviewController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
-  constructor($q: ng.IQService, $route: ng.route.IRouteService, $timeout: ng.ITimeoutService, $location: ng.ILocationService, cheWorkspace: CheWorkspace, cheNotification: CheNotification, confirmDialogService: ConfirmDialogService, namespaceSelectorSvc: NamespaceSelectorSvc, workspaceDetailsService: WorkspaceDetailsService) {
+  constructor($q: ng.IQService, $route: ng.route.IRouteService, $timeout: ng.ITimeoutService, $location: ng.ILocationService,
+    cheWorkspace: CheWorkspace, cheNotification: CheNotification, confirmDialogService: ConfirmDialogService,
+    namespaceSelectorSvc: NamespaceSelectorSvc, workspaceDetailsService: WorkspaceDetailsService) {
     this.$q = $q;
     this.$route = $route;
     this.$timeout = $timeout;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.directive.ts
@@ -45,7 +45,6 @@ export class WorkspaceDetailsOverview implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/add-project-popover/add-project-popover.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/add-project-popover/add-project-popover.controller.ts
@@ -36,7 +36,6 @@ export class AddProjectPopoverController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.isOpen = false;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-details/project-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-details/project-details.controller.ts
@@ -20,6 +20,9 @@ import {CheProject} from '../../../../../components/api/che-project';
  * @author Oleksii Orel
  */
 export class ProjectDetailsController {
+
+  static $inject = ['$scope', '$log', '$route', '$location', '$timeout', 'cheAPI', 'confirmDialogService', 'cheNotification', 'lodash'];
+
   private $log: ng.ILogService;
   private cheNotification: CheNotification;
   private cheAPI: CheAPI;
@@ -42,7 +45,6 @@ export class ProjectDetailsController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope,
               $log: ng.ILogService,

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-details/repository/project-repository.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-details/repository/project-repository.controller.ts
@@ -16,6 +16,9 @@ import {WorkspaceStatus} from '../../../../../../components/api/workspace/che-wo
 import {CheWorkspaceAgent} from '../../../../../../components/api/che-workspace-agent';
 
 export class ProjectRepositoryController {
+
+  static $inject = ['$route', 'cheAPI', 'lodash'];
+
   private cheAPI: CheAPI;
   private lodash: any;
 
@@ -27,7 +30,6 @@ export class ProjectRepositoryController {
 
   /**
    * Controller for the project local repository and remote repositories details
-   * @ngInject for Dependency injection
    * @author Oleksii Orel
    */
   constructor($route: ng.route.IRouteService,

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-item/project-item.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/project-item/project-item.controller.ts
@@ -18,6 +18,9 @@ import {CheWorkspace} from '../../../../../components/api/workspace/che-workspac
  * @author Florent Benoit
  */
 export class ProjectItemCtrl {
+
+  static $inject = ['$location', 'cheWorkspace'];
+
   private $location: ng.ILocationService;
   private cheWorkspace: CheWorkspace;
 
@@ -26,7 +29,6 @@ export class ProjectItemCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService,
               cheWorkspace: CheWorkspace) {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.controller.ts
@@ -27,6 +27,9 @@ import {WorkspaceStatus} from '../../../../components/api/workspace/che-workspac
  * @author Oleksii Kurinnyi
  */
 export class WorkspaceDetailsProjectsCtrl {
+
+  static $inject = ['cheAPI', '$mdDialog', 'confirmDialogService', '$scope', 'cheListHelperFactory', 'stackSelectorSvc', 'randomSvc', 'createWorkspaceSvc', 'workspaceDetailsService', 'workspaceDetailsProjectsService'];
+
   /**
    * Material design Dialog service.
    */
@@ -74,7 +77,6 @@ export class WorkspaceDetailsProjectsCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheAPI: CheAPI,
               $mdDialog: ng.material.IDialogService,

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.directive.ts
@@ -43,7 +43,6 @@ export class WorkspaceDetailsProjects implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.scope = {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.service.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.service.ts
@@ -20,6 +20,9 @@ import {CheWorkspace} from '../../../../components/api/workspace/che-workspace.f
  * @author Oleksii Kurinnyi
  */
 export class WorkspaceDetailsProjectsService {
+
+  static $inject = ['$log', '$q', 'cheAPI', 'cheNotification'];
+
   /**
    * Log service.
    */
@@ -51,7 +54,6 @@ export class WorkspaceDetailsProjectsService {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService,
               $q: ng.IQService,

--- a/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.controller.ts
@@ -21,6 +21,8 @@ import {CheSsh} from '../../../../components/api/che-ssh.factory';
  */
 export class WorkspaceDetailsSshCtrl {
 
+  static $inject = ['$route', 'cheSsh', 'cheWorkspace', 'cheNotification', '$mdDialog', '$log', '$q'];
+
   /**
    * Workspace.
    */
@@ -70,7 +72,6 @@ export class WorkspaceDetailsSshCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($route: ng.route.IRouteService,
               cheSsh: CheSsh,

--- a/dashboard/src/app/workspaces/workspace-edit-mode/workspace-edit-mode-overlay.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-edit-mode/workspace-edit-mode-overlay.directive.ts
@@ -46,7 +46,6 @@ export class WorkspaceEditModeOverlay implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.scope = {

--- a/dashboard/src/app/workspaces/workspace-edit-mode/workspace-edit-mode-toolbar-button.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-edit-mode/workspace-edit-mode-toolbar-button.directive.ts
@@ -44,7 +44,6 @@ export class WorkspaceEditModeToolbarButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.scope = {

--- a/dashboard/src/app/workspaces/workspace-ram-slider/che-workspace-ram-allocation-slider.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-ram-slider/che-workspace-ram-allocation-slider.controller.ts
@@ -15,6 +15,9 @@
  * @author Florent Benoit
  */
 export class CheWorkspaceRamAllocationSliderController {
+
+  static $inject = ['$timeout', '$scope'];
+
   onChangeTimeoutPromise: ng.IPromise<any>;
   $timeout: ng.ITimeoutService;
   ngModel: number;
@@ -23,12 +26,8 @@ export class CheWorkspaceRamAllocationSliderController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($timeout: ng.ITimeoutService, $scope: ng.IScope) {
-    /* tslint:disable */
-    'ngInject';
-    /* tslint:enable */
     this.$timeout = $timeout;
 
     $scope.$watch(() => {

--- a/dashboard/src/app/workspaces/workspace-status/workspace-status-indicator.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-status/workspace-status-indicator.directive.ts
@@ -21,7 +21,6 @@ export class WorkspaceStatusIndicator implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.restrict = 'E';

--- a/dashboard/src/app/workspaces/workspaces-config.ts
+++ b/dashboard/src/app/workspaces/workspaces-config.ts
@@ -168,7 +168,7 @@ export class WorkspacesConfig {
     register.service('workspacesService', WorkspacesService);
 
     // config routes
-    register.app.config(($routeProvider: che.route.IRouteProvider) => {
+    register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/workspaces', {
         title: 'Workspaces',
         templateUrl: 'app/workspaces/list-workspaces/list-workspaces.html',
@@ -186,6 +186,6 @@ export class WorkspacesConfig {
             }]
           }
         });
-    });
+    }]);
   }
 }

--- a/dashboard/src/app/workspaces/workspaces.service.ts
+++ b/dashboard/src/app/workspaces/workspaces.service.ts
@@ -19,6 +19,8 @@ import {CheWorkspace} from '../../components/api/workspace/che-workspace.factory
  */
 export class WorkspacesService {
 
+  static $inject = ['cheWorkspace'];
+
   /**
    * Workspace API interaction.
    */
@@ -26,7 +28,6 @@ export class WorkspacesService {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheWorkspace: CheWorkspace) {
     this.cheWorkspace = cheWorkspace;

--- a/dashboard/src/components/api/che-agent.factory.ts
+++ b/dashboard/src/components/api/che-agent.factory.ts
@@ -20,6 +20,9 @@ interface IAgentsResource<T> extends ng.resource.IResourceClass<T> {
  * @author Ilya Buziuk
  */
 export class CheAgent {
+
+  static $inject = ['$resource', '$q'];
+
   private $resource: ng.resource.IResourceService;
   private $q: ng.IQService;
   private agentsMap: Map<string, che.IAgent> = new Map();
@@ -28,7 +31,6 @@ export class CheAgent {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService, $q: ng.IQService) {
     this.$resource = $resource;

--- a/dashboard/src/components/api/che-api.factory.ts
+++ b/dashboard/src/components/api/che-api.factory.ts
@@ -30,6 +30,11 @@ import {CheUser} from './che-user.factory';
  */
 export class CheAPI {
 
+  static $inject = ['cheWorkspace', 'cheFactory', 'cheFactoryTemplate',
+               'cheProfile', 'chePreferences', 'cheProjectTemplate',
+              'cheService', 'cheStack', 'cheOAuthProvider', 'cheAgent',
+            'cheSsh', 'cheUser', 'chePermissions', 'cheOrganization'];
+
   private cheWorkspace: CheWorkspace;
   private cheProfile: CheProfile;
   private chePreferences: ChePreferences;
@@ -47,7 +52,6 @@ export class CheAPI {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheWorkspace: CheWorkspace, cheFactory: CheFactory, cheFactoryTemplate: CheFactoryTemplate,
               cheProfile: CheProfile, chePreferences: ChePreferences, cheProjectTemplate: CheProjectTemplate,

--- a/dashboard/src/components/api/che-factory-template.factory.ts
+++ b/dashboard/src/components/api/che-factory-template.factory.ts
@@ -21,7 +21,6 @@ export class CheFactoryTemplate {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.factoryTemplatesByName = new Map<string, string>();

--- a/dashboard/src/components/api/che-factory.factory.ts
+++ b/dashboard/src/components/api/che-factory.factory.ts
@@ -30,6 +30,9 @@ const DEFAULT_MAX_ITEMS = 15;
  * @author Oleksii Orel
  */
 export class CheFactory {
+
+  static $inject = ['$resource', '$q', 'lodash', 'cheUser'];
+
   private $resource: ng.resource.IResourceService;
   private $q: ng.IQService;
   private lodash: any;
@@ -48,7 +51,6 @@ export class CheFactory {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService, $q: ng.IQService, lodash: any, cheUser: CheUser) {
     // keep resource

--- a/dashboard/src/components/api/che-invite.factory.ts
+++ b/dashboard/src/components/api/che-invite.factory.ts
@@ -22,6 +22,9 @@ interface IInviteResource<T> extends ng.resource.IResourceClass<T> {
  * @author Ann Shumilova
  */
 export class CheInvite implements che.api.ICheInvite {
+
+  static $inject = ['$q', '$resource'];
+
   /**
    * Angular promise service.
    */
@@ -42,7 +45,6 @@ export class CheInvite implements che.api.ICheInvite {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $resource: ng.resource.IResourceService) {
     this.$q = $q;

--- a/dashboard/src/components/api/che-keycloak.factory.ts
+++ b/dashboard/src/components/api/che-keycloak.factory.ts
@@ -24,13 +24,15 @@ export type keycloakUserInfo = {
  * @author Oleksii Kurinnyi
  */
 export class CheKeycloak {
+
+  static $inject = ['$q', 'keycloakAuth'];
+
   $q: ng.IQService;
   keycloak: any;
   keycloakConfig: any;
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, keycloakAuth: any) {
     this.$q = $q;

--- a/dashboard/src/components/api/che-o-auth-provider.factory.ts
+++ b/dashboard/src/components/api/che-o-auth-provider.factory.ts
@@ -15,6 +15,9 @@
  * @author Ann Shumilova
  */
 export class CheOAuthProvider {
+
+  static $inject = ['$http'];
+
   private $http: ng.IHttpService;
 
   private providersByName: Map<string, any>;
@@ -22,7 +25,6 @@ export class CheOAuthProvider {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($http: ng.IHttpService) {
     this.$http = $http;

--- a/dashboard/src/components/api/che-organizations.factory.ts
+++ b/dashboard/src/components/api/che-organizations.factory.ts
@@ -32,6 +32,9 @@ const MAIN_URL = '/api/organization';
  * @author Oleksii Orel
  */
 export class CheOrganization implements che.api.ICheOrganization {
+
+  static $inject = ['$resource', '$q', 'cheUser', 'lodash', 'chePageObject', 'resourcesService', 'cheNamespaceRegistry', 'cheResourcesDistribution'];
+
   /**
    * Angular Resource service.
    */
@@ -87,7 +90,6 @@ export class CheOrganization implements che.api.ICheOrganization {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService,
               $q: ng.IQService,

--- a/dashboard/src/components/api/che-permissions.factory.ts
+++ b/dashboard/src/components/api/che-permissions.factory.ts
@@ -23,6 +23,9 @@ interface IPermissionsResource<T> extends ng.resource.IResourceClass<T> {
  * @author Oleksii Orel
  */
 export class ChePermissions implements che.api.IChePermissions {
+
+  static $inject = ['$q', '$resource'];
+
   /**
    * Angular promise service.
    */
@@ -54,7 +57,6 @@ export class ChePermissions implements che.api.IChePermissions {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $resource: ng.resource.IResourceService) {
     this.$q = $q;

--- a/dashboard/src/components/api/che-preferences.factory.ts
+++ b/dashboard/src/components/api/che-preferences.factory.ts
@@ -16,6 +16,9 @@
  * @author Oleksii Orel
  */
 export class ChePreferences {
+
+  static $inject = ['$resource', '$http', '$window'];
+
   private $window: ng.IWindowService;
   private $resource: ng.resource.IResourceService;
   private $http: ng.IHttpService;
@@ -25,7 +28,6 @@ export class ChePreferences {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService,
               $http: ng.IHttpService,

--- a/dashboard/src/components/api/che-profile.factory.ts
+++ b/dashboard/src/components/api/che-profile.factory.ts
@@ -22,6 +22,8 @@ interface IProfileResource<T> extends ng.resource.IResourceClass<T> {
  */
 export class CheProfile {
 
+  static $inject = ['$q', '$resource', '$http'];
+
   /**
    * Angular Promise service.
    */
@@ -41,7 +43,6 @@ export class CheProfile {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $resource: ng.resource.IResourceService, $http: ng.IHttpService) {
     this.$q = $q;

--- a/dashboard/src/components/api/che-project-template.factory.ts
+++ b/dashboard/src/components/api/che-project-template.factory.ts
@@ -16,6 +16,9 @@
  * @author Florent Benoit
  */
 export class CheProjectTemplate {
+
+  static $inject = ['$resource'];
+
   $resource: ng.resource.IResourceService;
   templatesPerCategory: {
     [category: string]: Array<che.IProjectTemplate>;
@@ -26,7 +29,6 @@ export class CheProjectTemplate {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($resource: ng.resource.IResourceService) {
 

--- a/dashboard/src/components/api/che-resources-distribution.factory.ts
+++ b/dashboard/src/components/api/che-resources-distribution.factory.ts
@@ -25,6 +25,9 @@ interface IResourcesResource<T> extends ng.resource.IResourceClass<T> {
  * @author Ann Shumilova
  */
 export class CheResourcesDistribution implements che.api.ICheResourcesDistribution {
+
+  static $inject = ['$q', '$resource', 'lodash'];
+
   /**
    * Angular promise service.
    */
@@ -60,7 +63,6 @@ export class CheResourcesDistribution implements che.api.ICheResourcesDistributi
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $resource: ng.resource.IResourceService, lodash: any) {
     this.$q = $q;

--- a/dashboard/src/components/api/che-service.factory.ts
+++ b/dashboard/src/components/api/che-service.factory.ts
@@ -15,6 +15,9 @@
  * @author Ann Shumilova
  */
 export class CheService {
+
+  static $inject = ['$http'];
+
   /**
    * Service for performing HTTP requests.
    */
@@ -32,7 +35,6 @@ export class CheService {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($http: ng.IHttpService) {
     this.$http = $http;

--- a/dashboard/src/components/api/che-ssh.factory.ts
+++ b/dashboard/src/components/api/che-ssh.factory.ts
@@ -16,6 +16,8 @@
  */
 export class CheSsh {
 
+  static $inject = ['$resource', '$q'];
+
   /**
    * Angular Resource service.
    */
@@ -35,7 +37,6 @@ export class CheSsh {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource : ng.resource.IResourceService, $q : ng.IQService) {
 

--- a/dashboard/src/components/api/che-stack.factory.ts
+++ b/dashboard/src/components/api/che-stack.factory.ts
@@ -25,6 +25,9 @@ interface IRemoteStackAPI<T> extends ng.resource.IResourceClass<T> {
  * @author Ann Shumilova
  */
 export class CheStack {
+
+  static $inject = ['$resource', '$q'];
+
   $resource: ng.resource.IResourceService;
   stacksById: { [stackId: string]: che.IStack };
   stacks: Array<any>;
@@ -37,7 +40,6 @@ export class CheStack {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService, $q: ng.IQService) {
 

--- a/dashboard/src/components/api/che-svn.ts
+++ b/dashboard/src/components/api/che-svn.ts
@@ -15,13 +15,15 @@
  * @author Oleksii Orel
  */
 export class CheSvn {
+
+  static $inject = ['$resource', 'wsagentPath'];
+
   private $resource: ng.resource.IResourceService;
   private remoteUrlMap: Map<string, any>;
   private remoteSvnAPI: any;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService,
               wsagentPath: string) {

--- a/dashboard/src/components/api/che-team-events-manager.factory.ts
+++ b/dashboard/src/components/api/che-team-events-manager.factory.ts
@@ -26,6 +26,9 @@ enum TEAM_EVENTS {
  * @author Ann Shumilova
  */
 export class CheTeamEventsManager implements che.api.ICheTeamEventsManager {
+
+  static $inject = ['cheAPI', 'cheJsonRpcApi', 'applicationNotifications', '$log', 'cheUser'];
+
   cheUser: any;
   cheJsonRpcMasterApi: CheJsonRpcMasterApi;
   $log: ng.ILogService;
@@ -37,7 +40,6 @@ export class CheTeamEventsManager implements che.api.ICheTeamEventsManager {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(cheAPI: CheAPI, cheJsonRpcApi: CheJsonRpcApi, applicationNotifications: any, $log: ng.ILogService, cheUser: any) {
     this.cheUser = cheUser;

--- a/dashboard/src/components/api/che-team.factory.ts
+++ b/dashboard/src/components/api/che-team.factory.ts
@@ -23,6 +23,9 @@ interface ITeamsResource<T> extends ng.resource.IResourceClass<T> {
  * @author Ann Shumilova
  */
 export class CheTeam implements che.api.ICheTeam {
+
+  static $inject = ['$resource', '$q', 'lodash', 'cheNamespaceRegistry', 'cheUser', 'cheOrganization', 'cheTeamEventsManager', 'cheResourcesDistribution', 'resourcesService'];
+
   /**
    * Angular Resource service.
    */
@@ -70,7 +73,6 @@ export class CheTeam implements che.api.ICheTeam {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService,
               $q: ng.IQService, lodash: any, cheNamespaceRegistry: any, cheUser: any,

--- a/dashboard/src/components/api/che-user.factory.ts
+++ b/dashboard/src/components/api/che-user.factory.ts
@@ -25,6 +25,9 @@ interface IUsersResource<T> extends ng.resource.IResourceClass<T> {
  * @author Oleksii Orel
  */
 export class CheUser {
+
+  static $inject = ['$resource', '$q', '$cookies'];
+
   private $resource: ng.resource.IResourceService;
   private $q: ng.IQService;
   private $cookies: ng.cookies.ICookiesService;
@@ -44,7 +47,6 @@ export class CheUser {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService, $q: ng.IQService, $cookies: ng.cookies.ICookiesService) {
     this.$q = $q;

--- a/dashboard/src/components/api/che-websocket.factory.ts
+++ b/dashboard/src/components/api/che-websocket.factory.ts
@@ -18,6 +18,8 @@
  */
 export class CheWebsocket {
 
+  static $inject = ['$websocket', '$location', '$interval', 'proxySettings', 'userDashboardConfig', 'keycloakAuth'];
+
   private bus : MessageBus;
   private wsBaseUrl : string;
   private remoteBus : MessageBus;
@@ -26,7 +28,6 @@ export class CheWebsocket {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($websocket: any,
                $location: ng.ILocationService,

--- a/dashboard/src/components/api/environment/che-environment-manager.factory.ts
+++ b/dashboard/src/components/api/environment/che-environment-manager.factory.ts
@@ -19,11 +19,12 @@ import {OpenshiftEnvironmentManager} from './openshift-environment-manager';
 
 export class CheEnvironmentManager {
 
+  static $inject = ['$log'];
+
   private $log: ng.ILogService;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService) {
     this.$log = $log;

--- a/dashboard/src/components/api/json-rpc/che-json-rpc-api.factory.ts
+++ b/dashboard/src/components/api/json-rpc/che-json-rpc-api.factory.ts
@@ -19,6 +19,9 @@ import {WebsocketClient} from './websocket-client';
  * @author Ann Shumilova
  */
 export class CheJsonRpcApi {
+
+  static $inject = ['$q', '$websocket', '$log'];
+
   private $q: ng.IQService;
   private $websocket: any;
   private $log: ng.ILogService;
@@ -26,7 +29,6 @@ export class CheJsonRpcApi {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $websocket: any, $log: ng.ILogService) {
     this.$q = $q;

--- a/dashboard/src/components/api/namespace/che-namespace-registry.factory.ts
+++ b/dashboard/src/components/api/namespace/che-namespace-registry.factory.ts
@@ -16,6 +16,9 @@
  * @author Ann Shumilova
  */
 export class CheNamespaceRegistry {
+
+  static $inject = ['$q', '$interval', '$timeout'];
+
   private $q: ng.IQService;
   private $interval: ng.IIntervalService;
   private $timeout: ng.ITimeoutService;
@@ -27,7 +30,6 @@ export class CheNamespaceRegistry {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService, $interval: ng.IIntervalService, $timeout: ng.ITimeoutService) {
     this.$q = $q;

--- a/dashboard/src/components/api/paging-resource/page-object.factory.ts
+++ b/dashboard/src/components/api/paging-resource/page-object.factory.ts
@@ -20,6 +20,8 @@ import {PageObjectResource} from './page-object-resource';
  */
 export class ChePageObject {
 
+  static $inject = ['$resource', '$q'];
+
   /**
    * Angular services
    */
@@ -28,7 +30,6 @@ export class ChePageObject {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService, $q: ng.IQService) {
     // keep resource

--- a/dashboard/src/components/api/paging-resource/page-object.mock.ts
+++ b/dashboard/src/components/api/paging-resource/page-object.mock.ts
@@ -40,9 +40,10 @@ export class PageObjectMock {
   private pageLabels: Array<string>;
   private pageBackendMap: Map<string, PageBackend> = new Map();
 
+  static $inject = ['pageObjectResource', 'maxItems', 'countObjects'];
+
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor(pageObjectResource: PageObjectResource, maxItems: number, countObjects: number) {
     this.countObjects = countObjects;

--- a/dashboard/src/components/api/remote/che-remote.factory.ts
+++ b/dashboard/src/components/api/remote/che-remote.factory.ts
@@ -21,13 +21,15 @@ import {CheJsonRpcApi} from '../json-rpc/che-json-rpc-api.factory';
  * @author Florent Benoit
  */
 export class CheRemote {
+
+  static $inject = ['$resource', '$q', 'cheJsonRpcApi'];
+
   private $resource: ng.resource.IResourceService;
   private $q: ng.IQService;
   private cheJsonRpcApi: CheJsonRpcApi;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService, $q: ng.IQService, cheJsonRpcApi: CheJsonRpcApi) {
     this.$resource = $resource;

--- a/dashboard/src/components/api/test/che-http-backend.factory.ts
+++ b/dashboard/src/components/api/test/che-http-backend.factory.ts
@@ -19,9 +19,10 @@ import {CheAPIBuilder} from '../builder/che-api-builder.factory';
  */
 export class CheHttpBackendFactory extends CheHttpBackend {
 
+  static $inject = ['$httpBackend', 'cheAPIBuilder'];
+
   /**
    * Default constructor
-   * @ngInject for Dependency injection
    */
   constructor($httpBackend: ng.IHttpBackendService,
               cheAPIBuilder: CheAPIBuilder) {

--- a/dashboard/src/components/api/test/che-http-backend.ts
+++ b/dashboard/src/components/api/test/che-http-backend.ts
@@ -16,6 +16,8 @@ import {CheAPIBuilder} from '../builder/che-api-builder.factory';
  * @author Florent Benoit
  */
 export class CheHttpBackend {
+  static $inject = ['$httpBackend', 'cheAPIBuilder'];
+
   private $httpBackend: ng.IHttpBackendService;
   private projectsPerWorkspace: Map<string, any>;
   private workspaces: Map<string, any>;

--- a/dashboard/src/components/api/workspace/che-workspace.factory.ts
+++ b/dashboard/src/components/api/workspace/che-workspace.factory.ts
@@ -58,6 +58,9 @@ export enum WorkspaceStatus {
  * @author Florent Benoit
  */
 export class CheWorkspace {
+
+  static $inject = ['$resource', '$http', '$q', 'cheJsonRpcApi', '$websocket', '$location', 'proxySettings', 'userDashboardConfig', 'lodash', 'cheEnvironmentRegistry', '$log', 'cheBranding', 'keycloakAuth', 'cheEnvironmentManager'];
+
   private $resource: ng.resource.IResourceService;
   private $http: ng.IHttpService;
   private $q: ng.IQService;
@@ -85,10 +88,8 @@ export class CheWorkspace {
    */
   private workspacePromises: Map<string, ng.IHttpPromise<any>> = new Map();
 
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($resource: ng.resource.IResourceService,
               $http: ng.IHttpService,

--- a/dashboard/src/components/attribute/format-output/che-format-output.directive.ts
+++ b/dashboard/src/components/attribute/format-output/che-format-output.directive.ts
@@ -19,6 +19,9 @@ interface ICheFormatOutputAttributes extends ng.IAttributes {
  * @author Ann Shumilova
  */
 export class CheFormatOutput implements ng.IDirective {
+
+  static $inject = ['jsonOutputColors', '$compile'];
+
   restrict = 'A';
 
   outputColors: any;
@@ -26,7 +29,6 @@ export class CheFormatOutput implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor(jsonOutputColors: string,
               $compile: ng.ICompileService) {

--- a/dashboard/src/components/attribute/img-src/img-src.directive.ts
+++ b/dashboard/src/components/attribute/img-src/img-src.directive.ts
@@ -16,6 +16,9 @@
  * @author Oleksii Kurinnyi
  */
 export class ImgSrc implements ng.IDirective {
+
+  static $inject = ['$http', 'userDashboardConfig'];
+
   $http: ng.IHttpService;
   isDev: boolean;
 
@@ -23,7 +26,6 @@ export class ImgSrc implements ng.IDirective {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($http: ng.IHttpService, userDashboardConfig: any) {
     this.$http = $http;

--- a/dashboard/src/components/attribute/multi-transclude/che-multi-transclude.directive.ts
+++ b/dashboard/src/components/attribute/multi-transclude/che-multi-transclude.directive.ts
@@ -42,6 +42,9 @@
  * @author Oleksii Kurinnyi
  */
 export abstract class CheMultiTransclude implements ng.IDirective {
+
+  static $inject = ['$compile'];
+
   restrict: string = 'AE';
   transclude: boolean = false;
 
@@ -52,7 +55,6 @@ export abstract class CheMultiTransclude implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($compile: ng.ICompileService) {
     this.$compile = $compile;

--- a/dashboard/src/components/attribute/reload-href/che-reload-href.directive.ts
+++ b/dashboard/src/components/attribute/reload-href/che-reload-href.directive.ts
@@ -30,6 +30,9 @@ interface ICheReloadHrefAttributes extends ng.IAttributes {
  * @author Florent Benoit
  */
 export class CheReloadHref implements ng.IDirective {
+
+  static $inject = ['$location', '$route'];
+
   restrict = 'A';
 
   $location: ng.ILocationService;
@@ -37,7 +40,6 @@ export class CheReloadHref implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService,
               $route: ng.route.IRouteService) {

--- a/dashboard/src/components/attribute/scroll/che-automatic-scroll.directive.ts
+++ b/dashboard/src/components/attribute/scroll/che-automatic-scroll.directive.ts
@@ -30,13 +30,15 @@ interface ICheAutoScrollAttributes extends ng.IAttributes {
  * @author Florent Benoit
  */
 export class CheAutoScroll {
+
+  static $inject = ['$timeout'];
+
   restrict = 'A';
 
   $timeout: ng.ITimeoutService;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/attribute/touch/che-on-long-touch.directive.ts
+++ b/dashboard/src/components/attribute/touch/che-on-long-touch.directive.ts
@@ -34,13 +34,14 @@ interface ICheOnLongTouchAttributes extends ng.IAttributes {
  * @author Oleksii Kurinnyi
  */
 export class CheOnLongTouch {
+
+  static $inject = ['$timeout'];
+
   restrict = 'A';
 
   $timeout: ng.ITimeoutService;
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/branding/che-branding.factory.ts
+++ b/dashboard/src/components/branding/che-branding.factory.ts
@@ -68,6 +68,9 @@ const DEFAULT_WEBSOCKET_CONTEXT = '/api/websocket';
  * @author Oleksii Orel
  */
 export class CheBranding {
+
+  static $inject = ['$http', '$rootScope', 'cheService'];
+
   private $rootScope: che.IRootScopeService;
   private $http: ng.IHttpService;
   private cheService: CheService;
@@ -76,7 +79,6 @@ export class CheBranding {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($http: ng.IHttpService, $rootScope: che.IRootScopeService, cheService: CheService) {
     this.$http = $http;

--- a/dashboard/src/components/error-messages/che-error-messages.directive.ts
+++ b/dashboard/src/components/error-messages/che-error-messages.directive.ts
@@ -44,6 +44,8 @@ interface IErrorMessagesScope extends ng.IScope {
  * @author Oleksii Kurinnyi
  */
 export class CheErrorMessages {
+  static $inject = ['cheErrorMessagesService'];
+
   restrict: string = 'AE';
   replace: boolean = true;
 
@@ -53,9 +55,9 @@ export class CheErrorMessages {
 
   cheErrorMessagesService: CheErrorMessagesService;
 
+
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor(cheErrorMessagesService: CheErrorMessagesService) {
     this.cheErrorMessagesService = cheErrorMessagesService;

--- a/dashboard/src/components/filter/change-memory-unit/change-memory-unit.filter.ts
+++ b/dashboard/src/components/filter/change-memory-unit/change-memory-unit.filter.ts
@@ -35,7 +35,6 @@ export class ChangeMemoryUnitFilter {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   static filter($log: ng.ILogService) {
     return (num: number|string, units: [string, string]) => {

--- a/dashboard/src/components/filter/filter-config.ts
+++ b/dashboard/src/components/filter/filter-config.ts
@@ -16,7 +16,7 @@ export class FilterConfig {
 
   constructor(register: che.IRegisterService) {
     register.filter('numberRound', CheNumberRoundFilter.filter);
-    register.filter('changeMemoryUnit', ChangeMemoryUnitFilter.filter);
+    register.filter('changeMemoryUnit', ['$log', ChangeMemoryUnitFilter.filter]);
   }
 
 }

--- a/dashboard/src/components/ide-fetcher/che-ide-fetcher.service.ts
+++ b/dashboard/src/components/ide-fetcher/che-ide-fetcher.service.ts
@@ -19,6 +19,9 @@ const IDE_FETCHER_CALLBACK_ID = 'cheIdeFetcherCallback';
  * @author Oleksii Orel
  */
 export class CheIdeFetcher {
+
+  static $inject = ['$log', '$http', '$window', 'cheBranding'];
+
   private $log: ng.ILogService;
   private $http: ng.IHttpService;
   private $window: ng.IWindowService;
@@ -27,7 +30,6 @@ export class CheIdeFetcher {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService, $http: ng.IHttpService, $window: ng.IWindowService, cheBranding: CheBranding) {
     this.$log = $log;

--- a/dashboard/src/components/interceptor/e-tag-interceptor.ts
+++ b/dashboard/src/components/interceptor/e-tag-interceptor.ts
@@ -16,13 +16,14 @@ import {HttpInterceptorBase} from './interceptor-base';
  * @author Oleksii Kurinnyi
  */
 export class ETagInterceptor extends HttpInterceptorBase {
+  static $inject = ['$q'];
+
   $q: ng.IQService;
 
   etagMap: any;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($q: ng.IQService) {
     super();

--- a/dashboard/src/components/interceptor/keycloak-token-interceptor.ts
+++ b/dashboard/src/components/interceptor/keycloak-token-interceptor.ts
@@ -18,6 +18,8 @@ const GITHUB_API = 'api.github.com';
  * @author Oleksii Kurinnyi
  */
 export class KeycloakTokenInterceptor extends HttpInterceptorBase {
+  static $inject = ['$log', '$q', 'keycloakAuth'];
+
   $log: ng.ILogService;
   $q: ng.IQService;
   keycloak: any;
@@ -25,7 +27,6 @@ export class KeycloakTokenInterceptor extends HttpInterceptorBase {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($log: ng.ILogService,
               $q: ng.IQService,

--- a/dashboard/src/components/notification/application-notifications.factory.ts
+++ b/dashboard/src/components/notification/application-notifications.factory.ts
@@ -21,7 +21,6 @@ export class ApplicationNotifications {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     this.notifications = [];

--- a/dashboard/src/components/notification/che-notification.factory.ts
+++ b/dashboard/src/components/notification/che-notification.factory.ts
@@ -21,6 +21,9 @@ const MAX_NOTIFICATION_COUNT = 10;
  * @author Oleksii Orel
  */
 export class CheNotification {
+
+  static $inject = ['$timeout', '$document', 'cheUIElementsInjectorService'];
+
   private $timeout: ng.ITimeoutService;
   private $document: ng.IDocumentService;
   private cheUIElementsInjectorService: CheUIElementsInjectorService;
@@ -30,7 +33,6 @@ export class CheNotification {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService, $document: ng.IDocumentService, cheUIElementsInjectorService: CheUIElementsInjectorService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/routing/route-history.service.ts
+++ b/dashboard/src/components/routing/route-history.service.ts
@@ -16,11 +16,12 @@
  */
 export class RouteHistory {
 
+  static $inject = ['$rootScope', '$location'];
+
   history: string[];
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($rootScope: ng.IRootScopeService,
               $location: ng.ILocationService) {

--- a/dashboard/src/components/routing/routing-redirect.factory.ts
+++ b/dashboard/src/components/routing/routing-redirect.factory.ts
@@ -17,12 +17,13 @@
  */
 export class RoutingRedirect {
 
+  static $inject = ['$location'];
+
   $location: ng.ILocationService;
   routeCallbacks: Array<any>;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($location: ng.ILocationService) {
     this.$location = $location;

--- a/dashboard/src/components/service/confirm-dialog/confirm-dialog.service.ts
+++ b/dashboard/src/components/service/confirm-dialog/confirm-dialog.service.ts
@@ -17,11 +17,12 @@
  */
 export class ConfirmDialogService {
 
+  static $inject = ['$mdDialog'];
+
   private $mdDialog: ng.material.IDialogService;
 
     /**
      * Default constructor that is using resource
-     * @ngInject for Dependency injection
      */
     constructor ($mdDialog: ng.material.IDialogService) {
       this.$mdDialog = $mdDialog;

--- a/dashboard/src/components/service/injector/che-ui-elements-injector.service.ts
+++ b/dashboard/src/components/service/injector/che-ui-elements-injector.service.ts
@@ -16,6 +16,9 @@
  * @author Oleksii Orel
  */
 export class CheUIElementsInjectorService {
+
+  static $inject = ['$timeout', '$document', '$compile'];
+
   $compile: ng.ICompileService;
   $timeout: ng.ITimeoutService;
   $document: ng.IDocumentService;
@@ -23,7 +26,6 @@ export class CheUIElementsInjectorService {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService, $document: ng.IDocumentService, $compile: ng.ICompileService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -238,7 +238,7 @@ declare namespace che {
   export interface IRegisterService {
     app: ng.IModule;
     directive(name: string, constructorFn: Function);
-    filter(name: string, constructorFn: Function): IRegisterService;
+    filter(name: string, constructorFn: any): IRegisterService;
     controller(name: string, constructorFn: Function): IRegisterService;
     service(name: string, constructorFn: Function): IRegisterService;
     provider(name: string, constructorFn: ng.IServiceProvider): IRegisterService;

--- a/dashboard/src/components/utils/observable.ts
+++ b/dashboard/src/components/utils/observable.ts
@@ -33,7 +33,6 @@ export class Observable<T> implements IObservable<T> {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.actions = [];

--- a/dashboard/src/components/utils/register.ts
+++ b/dashboard/src/components/utils/register.ts
@@ -64,7 +64,7 @@ export class Register implements che.IRegisterService {
     return this;
   }
 
-  service(name: string, constructorFn: Function): che.IRegisterService {
+  service(name: string, constructorFn: any): che.IRegisterService {
     this.app.service(name, constructorFn);
     return this;
   }

--- a/dashboard/src/components/validator/unique-factory-name-validator.directive.ts
+++ b/dashboard/src/components/validator/unique-factory-name-validator.directive.ts
@@ -25,6 +25,9 @@ interface IFactoryNameValidatorAttributes extends ng.IAttributes {
  * @author Oleksii Kurinnyi
  */
 export class UniqueFactoryNameValidator implements ng.IDirective {
+
+  static $inject = ['cheAPI', '$q'];
+
   $q: ng.IQService;
   cheAPI: CheAPI;
 
@@ -35,7 +38,6 @@ export class UniqueFactoryNameValidator implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor (cheAPI: CheAPI, $q: ng.IQService) {
     this.cheAPI = cheAPI;

--- a/dashboard/src/components/validator/unique-project-name-validator.directive.ts
+++ b/dashboard/src/components/validator/unique-project-name-validator.directive.ts
@@ -20,6 +20,9 @@ interface IUniqueProjectNameValidatorAttributes extends ng.IAttributes {
  * @author Florent Benoit
  */
 export class UniqueProjectNameValidator implements ng.IDirective {
+
+  static $inject = ['cheAPI', '$q'];
+
   restrict = 'A';
   require = 'ngModel';
 
@@ -28,7 +31,6 @@ export class UniqueProjectNameValidator implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor (cheAPI: CheAPI, $q: ng.IQService) {
     this.cheAPI = cheAPI;

--- a/dashboard/src/components/validator/unique-stack-name-validator.directive.ts
+++ b/dashboard/src/components/validator/unique-stack-name-validator.directive.ts
@@ -21,6 +21,9 @@ interface IUniqueStackNameValidatorAttributes extends ng.IAttributes {
  * @author Ann Shumilova
  */
 export class UniqueStackNameValidator implements ng.IDirective {
+
+  static $inject = ['cheAPI', '$q'];
+
   restrict = 'A';
   require = 'ngModel';
 
@@ -29,7 +32,6 @@ export class UniqueStackNameValidator implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor (cheAPI: CheAPI, $q: ng.IQService) {
     this.cheAPI = cheAPI;

--- a/dashboard/src/components/validator/unique-team-name-validator.directive.ts
+++ b/dashboard/src/components/validator/unique-team-name-validator.directive.ts
@@ -22,6 +22,8 @@ interface IUniqueTeamNameValidatorAttributes {
  */
 export class UniqueTeamNameValidator {
 
+  static $inject = ['cheTeam', '$q'];
+
   /**
    * Team interection API.
    */
@@ -35,7 +37,6 @@ export class UniqueTeamNameValidator {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor (cheTeam: che.api.ICheTeam, $q: ng.IQService) {
     this.cheTeam = cheTeam;

--- a/dashboard/src/components/validator/unique-workspace-name-validator.directive.ts
+++ b/dashboard/src/components/validator/unique-workspace-name-validator.directive.ts
@@ -20,6 +20,9 @@ interface IUniqueWorkspaceNameValidatorAttributes extends ng.IAttributes {
  * @author Oleksii Kurinnyi
  */
 export class UniqueWorkspaceNameValidator implements ng.IDirective {
+
+  static $inject = ['cheAPI', '$q'];
+
   restrict = 'A';
   require = 'ngModel';
 
@@ -28,7 +31,6 @@ export class UniqueWorkspaceNameValidator implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor (cheAPI: CheAPI, $q: ng.IQService) {
     this.cheAPI = cheAPI;

--- a/dashboard/src/components/widget/accordion/che-accordion.directive.ts
+++ b/dashboard/src/components/widget/accordion/che-accordion.directive.ts
@@ -20,6 +20,8 @@ interface ICheAccordionScope extends ng.IScope {
  */
 export class CheAccordion implements ng.IDirective {
 
+  static $inject = ['$timeout'];
+
   restrict = 'E';
   transclude = true;
   replace = true;
@@ -34,7 +36,6 @@ export class CheAccordion implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/widget/button/che-button-cancel-flat.directive.ts
+++ b/dashboard/src/components/widget/button/che-button-cancel-flat.directive.ts
@@ -41,7 +41,6 @@ export class CheButtonCancelFlat extends CheButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     super();

--- a/dashboard/src/components/widget/button/che-button-danger.directive.ts
+++ b/dashboard/src/components/widget/button/che-button-danger.directive.ts
@@ -41,7 +41,6 @@ export class CheButtonDanger extends CheButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     super();

--- a/dashboard/src/components/widget/button/che-button-default.directive.ts
+++ b/dashboard/src/components/widget/button/che-button-default.directive.ts
@@ -41,7 +41,6 @@ export class CheButtonDefault extends CheButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     super();

--- a/dashboard/src/components/widget/button/che-button-notice.directive.ts
+++ b/dashboard/src/components/widget/button/che-button-notice.directive.ts
@@ -41,7 +41,6 @@ export class CheButtonNotice extends CheButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     super();

--- a/dashboard/src/components/widget/button/che-button-primary-flat.directive.ts
+++ b/dashboard/src/components/widget/button/che-button-primary-flat.directive.ts
@@ -41,7 +41,6 @@ export class CheButtonPrimaryFlat extends CheButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     super();

--- a/dashboard/src/components/widget/button/che-button-primary.directive.ts
+++ b/dashboard/src/components/widget/button/che-button-primary.directive.ts
@@ -41,7 +41,6 @@ export class CheButtonPrimary extends CheButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     super();

--- a/dashboard/src/components/widget/button/che-button-save-flat.directive.ts
+++ b/dashboard/src/components/widget/button/che-button-save-flat.directive.ts
@@ -41,7 +41,6 @@ export class CheButtonSaveFlat extends CheButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     super();

--- a/dashboard/src/components/widget/button/che-button-warning.directive.ts
+++ b/dashboard/src/components/widget/button/che-button-warning.directive.ts
@@ -41,7 +41,6 @@ export class CheButtonWarning extends CheButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor () {
     super();

--- a/dashboard/src/components/widget/compile/che-compile.directive.ts
+++ b/dashboard/src/components/widget/compile/che-compile.directive.ts
@@ -17,13 +17,14 @@
  */
 export class CheCompile implements ng.IDirective {
 
+  static $inject = ['$compile'];
+
   restrict = 'A';
 
   $compile: ng.ICompileService;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($compile: ng.ICompileService) {
     this.$compile = $compile;

--- a/dashboard/src/components/widget/copy-clipboard/che-clipboard.directive.ts
+++ b/dashboard/src/components/widget/copy-clipboard/che-clipboard.directive.ts
@@ -21,6 +21,9 @@ interface ICheClipboardScope extends ng.IScope {
  * @author Oleksii Orel
  */
 export class CheClipboard implements ng.IDirective {
+
+  static $inject = ['$window', '$log'];
+
   restrict = 'E';
   replace = true;
   templateUrl = 'components/widget/copy-clipboard/che-clipboard.html';
@@ -30,10 +33,8 @@ export class CheClipboard implements ng.IDirective {
   private $window: ng.IWindowService;
   private $log: ng.ILogService;
 
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($window: ng.IWindowService, $log: ng.ILogService) {
     this.$window = $window;

--- a/dashboard/src/components/widget/dropzone/che-dropzone.controller.ts
+++ b/dashboard/src/components/widget/dropzone/che-dropzone.controller.ts
@@ -18,6 +18,9 @@ import {ICheDropZoneEventObject} from './che-dropzone.directive';
  * @author Florent Benoit
  */
 export class CheDropZoneCtrl {
+
+  static $inject = ['$scope', 'lodash'];
+
   $scope: ng.IScope;
   lodash: any;
   HOVER_KO_CLASS = 'che-dropzone-hover-ko';
@@ -29,7 +32,6 @@ export class CheDropZoneCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope, lodash: any) {
     this.$scope = $scope;

--- a/dashboard/src/components/widget/editor/che-editor.controller.ts
+++ b/dashboard/src/components/widget/editor/che-editor.controller.ts
@@ -35,6 +35,9 @@ interface IEditorState {
  * @author Oleksii Orel
  */
 export class CheEditorController {
+
+  static $inject = ['$timeout'];
+
   setEditorValue: (content: string) => void;
   /**
    * Editor options object.
@@ -70,7 +73,6 @@ export class CheEditorController {
 
   /**
    * Default constructor that is using resource injection
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService) {
     this.editorOptions = {

--- a/dashboard/src/components/widget/filter-selector/che-filter-selector.controller.ts
+++ b/dashboard/src/components/widget/filter-selector/che-filter-selector.controller.ts
@@ -23,7 +23,6 @@ export class CheFilterSelectorController {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.width = this.width || '150px';

--- a/dashboard/src/components/widget/filter-selector/che-filter-selector.directive.ts
+++ b/dashboard/src/components/widget/filter-selector/che-filter-selector.directive.ts
@@ -29,7 +29,6 @@ export class CheFilterSelector implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/components/widget/html-source/che-html-source.directive.ts
+++ b/dashboard/src/components/widget/html-source/che-html-source.directive.ts
@@ -15,6 +15,9 @@
  * @author Florent Benoit
  */
 export class CheHtmlSource {
+
+  static $inject = ['$sce'];
+
   $sce: ng.ISCEService;
 
   restrict: string = 'E';
@@ -27,7 +30,6 @@ export class CheHtmlSource {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($sce: ng.ISCEService) {
     this.$sce = $sce;

--- a/dashboard/src/components/widget/html-source/demo-source-render.directive.ts
+++ b/dashboard/src/components/widget/html-source/demo-source-render.directive.ts
@@ -34,6 +34,8 @@
  */
 
 export class DemoSourceRender {
+  static $inject = ['$compile'];
+
   $compile: ng.ICompileService;
 
   restrict: string = 'EA';
@@ -41,7 +43,6 @@ export class DemoSourceRender {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($compile: ng.ICompileService) {
     this.$compile = $compile;

--- a/dashboard/src/components/widget/input/che-input.directive.ts
+++ b/dashboard/src/components/widget/input/che-input.directive.ts
@@ -43,7 +43,6 @@ export class CheInput implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/components/widget/input/che-number-spinner.directive.ts
+++ b/dashboard/src/components/widget/input/che-number-spinner.directive.ts
@@ -83,7 +83,6 @@ export class CheNumberSpinner {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($timeout: ng.ITimeoutService, $interval: ng.IIntervalService) {
     this.$interval = $interval;

--- a/dashboard/src/components/widget/input/che-textarea.directive.ts
+++ b/dashboard/src/components/widget/input/che-textarea.directive.ts
@@ -28,7 +28,6 @@ export class CheTextarea extends CheInput {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     super();

--- a/dashboard/src/components/widget/learn-more/che-learn-more-template.directive.ts
+++ b/dashboard/src/components/widget/learn-more/che-learn-more-template.directive.ts
@@ -28,6 +28,9 @@ interface ICheLearmMoreTemplateScope extends ng.IScope {
  * @author Florent Benoit
  */
 export class CheLearnMoreTemplate implements ng.IDirective {
+
+  static $inject = ['$compile', '$mdUtil'];
+
   $compile: ng.ICompileService;
   $mdUtil: any;
 
@@ -42,7 +45,6 @@ export class CheLearnMoreTemplate implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor ($compile: ng.ICompileService, $mdUtil: any) {
     this.$compile = $compile;

--- a/dashboard/src/components/widget/learn-more/che-learn-more.controller.ts
+++ b/dashboard/src/components/widget/learn-more/che-learn-more.controller.ts
@@ -19,6 +19,9 @@ import {ICheLearmMoreAttributes} from './che-learn-more.directive';
  * @author Florent Benoit
  */
 export class CheLearnMoreCtrl {
+
+  static $inject = ['$scope', '$element', '$attrs', '$compile', 'chePreferences'];
+
   $scope: ng.IScope;
   $element: ng.IAugmentedJQuery;
   $attrs: ICheLearmMoreAttributes;
@@ -32,9 +35,9 @@ export class CheLearnMoreCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
-  constructor($scope: ng.IScope, $element: ng.IAugmentedJQuery, $attrs: ICheLearmMoreAttributes, $compile: ng.ICompileService, chePreferences: ChePreferences) {
+  constructor($scope: ng.IScope, $element: ng.IAugmentedJQuery, $attrs: ICheLearmMoreAttributes, $compile: ng.ICompileService,
+     chePreferences: ChePreferences) {
     this.items = [];
 
     this.WIDGET_PREFERENCES_PREFIX = 'learn-widget-';

--- a/dashboard/src/components/widget/list/che-list-header-column.directive.ts
+++ b/dashboard/src/components/widget/list/che-list-header-column.directive.ts
@@ -22,6 +22,9 @@ interface ICheListHeaderColumnScope extends ng.IScope {
  * @author Oleksii Orel
  */
 export class CheListHeaderColumn implements ng.IDirective {
+
+  static $inject = ['$timeout'];
+
   restrict = 'E';
   replace = true;
   templateUrl = 'components/widget/list/che-list-header-column.html';
@@ -38,7 +41,6 @@ export class CheListHeaderColumn implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/widget/list/che-list-header.directive.ts
+++ b/dashboard/src/components/widget/list/che-list-header.directive.ts
@@ -25,7 +25,6 @@ export class CheListHeader {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/components/widget/list/che-list-helper.factory.ts
+++ b/dashboard/src/components/widget/list/che-list-helper.factory.ts
@@ -17,6 +17,9 @@ import {CheListHelper} from './che-list-helper';
  * @author Oleksii Kurinnyi
  */
 export class CheListHelperFactory implements che.widget.ICheListHelperFactory {
+
+  static $inject = ['$filter'];
+
   /**
    * Angular filter service
    */
@@ -24,10 +27,8 @@ export class CheListHelperFactory implements che.widget.ICheListHelperFactory {
 
   private helpers: Map<string, CheListHelper>;
 
-
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($filter: ng.IFilterService) {
     this.$filter = $filter;

--- a/dashboard/src/components/widget/loader/che-loader-crane.directive.ts
+++ b/dashboard/src/components/widget/loader/che-loader-crane.directive.ts
@@ -22,6 +22,9 @@ interface ICheLoaderCraneScope extends ng.IScope {
  * @author Oleksii Kurinnyi
  */
 export class CheLoaderCrane implements ng.IDirective {
+
+  static $inject = ['$timeout', '$window'];
+
   $timeout: ng.ITimeoutService;
   $window: ng.IWindowService;
 
@@ -39,7 +42,6 @@ export class CheLoaderCrane implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService, $window: ng.IWindowService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/widget/logs-output/che-logs-output.directive.ts
+++ b/dashboard/src/components/widget/logs-output/che-logs-output.directive.ts
@@ -23,6 +23,8 @@ interface ICheLogsOutputScope extends ng.IScope {
  */
 export class CheLogsOutput implements ng.IDirective {
 
+  static $inject = ['$timeout'];
+
   restrict = 'E';
   templateUrl = 'components/widget/logs-output/che-logs-output.html';
 
@@ -38,7 +40,6 @@ export class CheLogsOutput implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/widget/panel/che-panel.controller.ts
+++ b/dashboard/src/components/widget/panel/che-panel.controller.ts
@@ -18,6 +18,8 @@
  */
 export class ChePanelCtrl {
 
+  static $inject = ['$scope'];
+
   $scope: ng.IScope;
 
   collapse: boolean;
@@ -27,7 +29,6 @@ export class ChePanelCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope) {
     this.collapse = false;

--- a/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.ts
+++ b/dashboard/src/components/widget/popover/che-toggle-button-popover.directive.ts
@@ -44,6 +44,9 @@ interface IPopoverScope extends ng.IScope {
  * @author Oleksii Orel
  */
 export class CheToggleButtonPopover implements ng.IDirective {
+
+  static $inject = ['$timeout'];
+
   restrict = 'E';
   transclude = true;
   scope = {
@@ -60,7 +63,6 @@ export class CheToggleButtonPopover implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($timeout: ng.ITimeoutService) {
     this.$timeout = $timeout;

--- a/dashboard/src/components/widget/popover/che-toggle-popover.directive.ts
+++ b/dashboard/src/components/widget/popover/che-toggle-popover.directive.ts
@@ -56,6 +56,8 @@ interface IPopoverScope extends ng.IScope {
  * @author Oleksii Kurinnyi
  */
 export class CheTogglePopover implements ng.IDirective {
+  static $inject = ['$compile', '$timeout'];
+
   restrict = 'E';
   transclude = true;
   scope = {
@@ -71,7 +73,6 @@ export class CheTogglePopover implements ng.IDirective {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($compile: ng.ICompileService, $timeout: ng.ITimeoutService) {
     this.$compile = $compile;

--- a/dashboard/src/components/widget/popup/che-modal-popup.directive.ts
+++ b/dashboard/src/components/widget/popup/che-modal-popup.directive.ts
@@ -35,7 +35,6 @@ export class CheModalPopup {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/components/widget/popup/che-popup.directive.ts
+++ b/dashboard/src/components/widget/popup/che-popup.directive.ts
@@ -35,7 +35,6 @@ export class ChePopup {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/components/widget/search/search-input.directive.ts
+++ b/dashboard/src/components/widget/search/search-input.directive.ts
@@ -42,7 +42,6 @@ export class SearchInput {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.scope = {

--- a/dashboard/src/components/widget/select/che-select.directive.ts
+++ b/dashboard/src/components/widget/select/che-select.directive.ts
@@ -30,7 +30,6 @@ export class CheSelect {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/components/widget/selecter/che-selecter.controller.ts
+++ b/dashboard/src/components/widget/selecter/che-selecter.controller.ts
@@ -17,6 +17,8 @@ import {ICheSelecterScope} from './che-selecter.directive';
  */
 export class CheSelecterCtrl {
 
+  static $inject = ['$scope'];
+
   $scope: ICheSelecterScope;
 
   globalSelecterName: string;
@@ -24,7 +26,6 @@ export class CheSelecterCtrl {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ICheSelecterScope) {
     this.$scope = $scope;

--- a/dashboard/src/components/widget/show-area/che-show-area.directive.ts
+++ b/dashboard/src/components/widget/show-area/che-show-area.directive.ts
@@ -30,7 +30,6 @@ export class CheShowArea {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/components/widget/toggle-button/che-toggle-button.directive.ts
+++ b/dashboard/src/components/widget/toggle-button/che-toggle-button.directive.ts
@@ -23,7 +23,6 @@ export class CheToggleButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/components/widget/toggle-button/che-toggle-joined-button.directive.ts
+++ b/dashboard/src/components/widget/toggle-button/che-toggle-joined-button.directive.ts
@@ -19,7 +19,6 @@ export class CheToggleJoinedButton extends CheToggleButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     super();

--- a/dashboard/src/components/widget/toggle-button/che-toggle-joined.directive.ts
+++ b/dashboard/src/components/widget/toggle-button/che-toggle-joined.directive.ts
@@ -19,7 +19,6 @@ export class CheToggleJoined extends CheToggle {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     super();

--- a/dashboard/src/components/widget/toggle-button/che-toggle.controller.ts
+++ b/dashboard/src/components/widget/toggle-button/che-toggle.controller.ts
@@ -15,11 +15,13 @@
  * @author Florent Benoit
  */
 export class CheToggleController {
+
+  static $inject = ['$scope'];
+
   $scope: ng.IScope;
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor($scope: ng.IScope) {
     this.$scope = $scope;

--- a/dashboard/src/components/widget/toggle-button/che-toggle.directive.ts
+++ b/dashboard/src/components/widget/toggle-button/che-toggle.directive.ts
@@ -26,7 +26,6 @@ export class CheToggle {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';

--- a/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.ts
+++ b/dashboard/src/components/widget/toggle-button/toggle-single-button.directive.ts
@@ -59,7 +59,6 @@ export class ToggleSingleButton {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     // scope values

--- a/dashboard/src/components/widget/toolbar/che-toolbar.directive.ts
+++ b/dashboard/src/components/widget/toolbar/che-toolbar.directive.ts
@@ -72,7 +72,6 @@ export class CheToolbar {
 
   /**
    * Default constructor that is using resource
-   * @ngInject for Dependency injection
    */
   constructor() {
     this.restrict = 'E';


### PR DESCRIPTION
### What does this PR do?
Removes the use of `@ngInject` javadoc style annotation
`@nInject` in 'javadoc' style is deprecated (should be used as string in method) and original project is EOL.
As we have now a lot of injection and as parser is not so efficient, the build is slow due to this parsing.


### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A


Change-Id: I17850e10bd66e810a823538497d77696826ee9d0
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
