### PR TITLE
Set up default file encoding to utf8 in workspace agent configuration

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -75,7 +75,7 @@ che.workspace.java_options=-XX:MaxRAM=150m -XX:MaxRAMFraction=2 -XX:+UseParallel
 che.workspace.maven_options=-XX:MaxRAM=150m -XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
 
 # Default java command line options to be added to JVM that run workspace agent.
-che.workspace.wsagent_java_options=-XX:MaxRAM=600m -XX:MaxRAMFraction=1 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms50m -Djava.security.egd=file:/dev/./urandom
+che.workspace.wsagent_java_options=-XX:MaxRAM=600m -XX:MaxRAMFraction=1 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms50m -Dfile.encoding=UTF8 -Djava.security.egd=file:/dev/./urandom
 
 # Default java command line options to be added to JVM that run maven server.
 che.workspace.maven_server_java_options=-XX:MaxRAM=128m -XX:MaxRAMFraction=1 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -139,7 +139,7 @@
 
 # Workspace Agent Java Options
 #   Default java command line options to be added to JVM that run workspace agent.
-#CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS=-XX:MaxRAM=600m -XX:MaxRAMFraction=1 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms50m -Djava.security.egd=file:/dev/./urandom
+#CHE_WORKSPACE_WSAGENT__JAVA__OPTIONS=-XX:MaxRAM=600m -XX:MaxRAMFraction=1 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms50m -Dfile.encoding=UTF8 -Djava.security.egd=file:/dev/./urandom
 
 # Workspace Maven server java Options
 #   Default java command line options to be added to JVM that run maven server.


### PR DESCRIPTION
### What does this PR do?
This changes proposal sets up default file encoding in ws agent to utf8.

The problem is in code:

https://github.com/eclipse/che/blob/master/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-filebuffers/src/main/java/org/eclipse/core/internal/filebuffers/FileStoreTextFileBuffer.java#L419

```java
protected void commitFileBufferContent(IProgressMonitor monitor, boolean overwrite)
      throws CoreException {
    //		if (!isSynchronized() && !overwrite)
    //			throw new CoreException(new Status(IStatus.WARNING, FileBuffersPlugin.PLUGIN_ID,
    // IResourceStatus.OUT_OF_SYNC_LOCAL, FileBuffersMessages.FileBuffer_error_outOfSync, null));

    String encoding = computeEncoding();  <<<<-----

    ....
```

which calls:

https://github.com/eclipse/che/blob/master/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-core-filebuffers/src/main/java/org/eclipse/core/internal/filebuffers/TextFileBufferManager.java#L443

```java
  /*
   * @see org.eclipse.core.buffer.text.IBufferedFileManager#getDefaultEncoding()
   */
  public String getDefaultEncoding() {
    return System.getProperty("file.encoding"); // $NON-NLS-1$;
  }
```

and on che-in-che stacks it returns `ANSI_X3.4-1968`. If user project sources contain some characters which are not supported by this encoding then during refactoring session we'll get `JavaModelException` with message: 

>Some characters cannot be mapped using "ANSI_X3.4-1968" character encoding.
Either change the encoding or remove the characters which are not supported by the "ANSI_X3.4-1968" character encoding.

This issue can be solved by:

* Setting up default locale into stack _(which is not preferable)_
* Setting up default file encoding in java options via `-Dfile.encoding=UTF8`

Second variant is more preferable because our users source code is stored in UTF8 locale.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#7768 

#### Release Notes
N/A

#### Docs PR
N/A
