### PR TITLE
fix CLI ENV vars setting / overriding

### DIFF
--- a/dockerfiles/base/scripts/base/commands/cmd_config.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_config.sh
@@ -160,17 +160,17 @@ generate_configuration_with_puppet() {
     fi
   fi
 
-  for element in "${CLI_ENV_ARRAY[@]}" 
-  do
-    var1=$(echo $element | cut -f1 -d=)
-    var2=$(echo $element | cut -f2 -d=)
-
+  che_cli_env_arr_index="0"
+  while [ $che_cli_env_arr_index -lt ${#CLI_ENV_ARRAY[@]} ]; do
+    var1=$(echo ${CLI_ENV_ARRAY[$che_cli_env_arr_index]} | cut -f1 -d=)
+    var2=$(echo ${CLI_ENV_ARRAY[$che_cli_env_arr_index]} | cut -f2 -d=)
     if [[ $var1 == CHE_* ]] ||
        [[ $var1 == IMAGE_* ]]  ||
        [[ $var1 == *_IMAGE_* ]]  ||
        [[ $var1 == ${CHE_PRODUCT_NAME}_* ]]; then
-      WRITE_PARAMETERS+=" -e \"$var1=$var2\""
+      WRITE_PARAMETERS+=" -e $var1='$var2'"
     fi
+    che_cli_env_arr_index=$[$che_cli_env_arr_index+1]
   done
 
   GENERATE_CONFIG_COMMAND="docker_run \

--- a/dockerfiles/base/scripts/base/commands/cmd_config.sh
+++ b/dockerfiles/base/scripts/base/commands/cmd_config.sh
@@ -160,17 +160,17 @@ generate_configuration_with_puppet() {
     fi
   fi
 
-  che_cli_env_arr_index="0"
-  while [ $che_cli_env_arr_index -lt ${#CLI_ENV_ARRAY[@]} ]; do
-    var1=$(echo ${CLI_ENV_ARRAY[$che_cli_env_arr_index]} | cut -f1 -d=)
-    var2=$(echo ${CLI_ENV_ARRAY[$che_cli_env_arr_index]} | cut -f2 -d=)
+  for element in "${CLI_ENV_ARRAY[@]}"
+  do
+    var1=$(echo $element | cut -f1 -d=)
+    var2=$(echo $element | cut -f2 -d=)
+
     if [[ $var1 == CHE_* ]] ||
        [[ $var1 == IMAGE_* ]]  ||
        [[ $var1 == *_IMAGE_* ]]  ||
        [[ $var1 == ${CHE_PRODUCT_NAME}_* ]]; then
       WRITE_PARAMETERS+=" -e $var1='$var2'"
     fi
-    che_cli_env_arr_index=$[$che_cli_env_arr_index+1]
   done
 
   GENERATE_CONFIG_COMMAND="docker_run \

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -383,7 +383,6 @@ get_value_of_var_from_env_file() {
 
 # Returns the value of variable from environment array.
 get_value_of_var_from_env() {
-
   for element in "${CLI_ENV_ARRAY[@]}"
   do
     var1=$(echo $element | cut -f1 -d=)

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -384,14 +384,14 @@ get_value_of_var_from_env_file() {
 # Returns the value of variable from environment array.
 get_value_of_var_from_env() {
 
-  che_cli_env_arr_index="0"
-  while [ $che_cli_env_arr_index -lt ${#CLI_ENV_ARRAY[@]} ]; do
-    var1=$(echo ${CLI_ENV_ARRAY[$che_cli_env_arr_index]} | cut -f1 -d=)
-    var2=$(echo ${CLI_ENV_ARRAY[$che_cli_env_arr_index]} | cut -f2 -d=)
+  for element in "${CLI_ENV_ARRAY[@]}"
+  do
+    var1=$(echo $element | cut -f1 -d=)
+    var2=$(echo $element | cut -f2 -d=)
+
     if [ $var1 = $1 ]; then
       echo $var2
     fi
-    che_cli_env_arr_index=$[$che_cli_env_arr_index+1]
   done
   echo ""
 }

--- a/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
+++ b/dockerfiles/base/scripts/base/startup_04_pre_cli_init.sh
@@ -31,10 +31,14 @@ cli_init() {
     return 2;
   fi
 
-  CLI_ENV=$(docker inspect --format='{{.Config.Env}}' $(get_this_container_id))
-  CLI_ENV=${CLI_ENV#*[}
-  CLI_ENV=${CLI_ENV%*]}
-  IFS=' ' read -r -a CLI_ENV_ARRAY <<< "$CLI_ENV"
+  CLI_ENV_ARRAY_LENGTH=$(docker inspect --format='{{json .Config.Env}}' $(get_this_container_id) | jq '. | length')
+  CLI_ENV_ARRAY=()
+  # fill an array
+  che_cli_env_arr_index="0"
+  while [ $che_cli_env_arr_index -lt $CLI_ENV_ARRAY_LENGTH ]; do
+      CLI_ENV_ARRAY[$che_cli_env_arr_index]=$(docker inspect --format='{{json .Config.Env}}' $(get_this_container_id) | jq -r .[$che_cli_env_arr_index])
+      che_cli_env_arr_index=$[$che_cli_env_arr_index+1]
+  done
 
   CHE_HOST_PROTOCOL="http"
   if is_initialized; then
@@ -379,14 +383,15 @@ get_value_of_var_from_env_file() {
 
 # Returns the value of variable from environment array.
 get_value_of_var_from_env() {
-  for element in "${CLI_ENV_ARRAY[@]}" 
-  do
-    var1=$(echo $element | cut -f1 -d=)
-    var2=$(echo $element | cut -f2 -d=)
 
+  che_cli_env_arr_index="0"
+  while [ $che_cli_env_arr_index -lt ${#CLI_ENV_ARRAY[@]} ]; do
+    var1=$(echo ${CLI_ENV_ARRAY[$che_cli_env_arr_index]} | cut -f1 -d=)
+    var2=$(echo ${CLI_ENV_ARRAY[$che_cli_env_arr_index]} | cut -f2 -d=)
     if [ $var1 = $1 ]; then
       echo $var2
     fi
+    che_cli_env_arr_index=$[$che_cli_env_arr_index+1]
   done
   echo ""
 }


### PR DESCRIPTION
This PR fixes CLI ability to override or set complex ENV vars

first problem was that internal ENV array was filled like this:
```
-  IFS=' ' read -r -a CLI_ENV_ARRAY <<< "$CLI_ENV"
```
which means that array will be filled by splitting elements by space char, so env var like: 
`-e CHE_TEST="TEST ME"` will appear in CHE as `CHE_TEST=TEST`

the second issue was that if user passes env var with JSON like:
`-e CHE_TEST='{"key":"value"}'`

the resulting env in CHE container will look like this:
`CHE_TEST={key:value}`

which was caused by this:
```
-      WRITE_PARAMETERS+=" -e \"$var1=$var2\""
+      WRITE_PARAMETERS+=" -e $var1='$var2'"
```



## PR Test

So with changes that this PR provides, if I pass following ENVs the CHE CLI:
```
                     ...       
                    -e CHE_TEST='{"key":"value"}' \
                    -e CHE_TEST2='{"key2": "value2"}' \
                    -e CHE_TEST3="TEST ME PLEASE" \
                     ...
```

they are properly set in the CHE container:

inspect:
```
$ docker inspect che | grep TEST

                "CHE_TEST={\"key\":\"value\"}",
                "CHE_TEST2={\"key2\": \"value2\"}",
                "CHE_TEST3=TEST ME PLEASE",
```

test ENVs in a CHE container:
```
$ echo $CHE_TEST
{"key":"value"}

$ echo $CHE_TEST2
{"key2": "value2"}

$ echo $CHE_TEST3
TEST ME PLEASE

```





fixes: https://github.com/eclipse/che/issues/8638
