### PR TITLE
Store logs and test workspace state in CheckFactoryWithPerUserCreatePolicyTest

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.selenium.core;
 
 import static java.lang.String.format;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
 
 import com.google.inject.Inject;
@@ -316,7 +316,7 @@ public class SeleniumWebDriver
   }
 
   public void switchFromDashboardIframeToIde() {
-    new WebDriverWait(this, APPLICATION_START_TIMEOUT_SEC)
+    new WebDriverWait(this, LOADER_TIMEOUT_SEC * 6)
         .until(ExpectedConditions.frameToBeAvailableAndSwitchToIt(By.id("ide-application-iframe")));
   }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/factory/TestFactory.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/factory/TestFactory.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.core.factory;
 
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestFactoryServiceClient;
@@ -50,7 +51,7 @@ public class TestFactory {
   }
 
   /** Login to factory and open it by url. */
-  public void authenticateAndOpen() throws Exception {
+  public void authenticateAndOpen() {
     seleniumWebDriver.get(dashboardUrl.get().toString());
     entrance.login(owner);
     seleniumWebDriver.get(factoryUrl);
@@ -58,7 +59,7 @@ public class TestFactory {
   }
 
   /** Opens factory url. */
-  public void open(WebDriver driver) throws Exception {
+  public void open(WebDriver driver) {
     driver.get(factoryUrl);
   }
 
@@ -68,7 +69,7 @@ public class TestFactory {
     deleteFactory();
   }
 
-  private void deleteFactory() throws Exception {
+  private void deleteFactory() {
     if (isNamedFactory()) {
       testFactoryServiceClient.deleteFactory(factoryDto.getName());
     }
@@ -76,5 +77,11 @@ public class TestFactory {
 
   private boolean isNamedFactory() {
     return factoryDto.getName() != null;
+  }
+
+  public WorkspaceStatus getWorkspaceStatusAssociatedWithFactory() throws Exception {
+    return workspaceServiceClient
+        .getByName(factoryDto.getWorkspace().getName(), owner.getName())
+        .getStatus();
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/DashboardFactory.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/DashboardFactory.java
@@ -22,6 +22,7 @@ import org.eclipse.che.selenium.core.action.ActionsFactory;
 import org.eclipse.che.selenium.core.provider.TestIdeUrlProvider;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.Loader;
+import org.eclipse.che.selenium.pageobject.SeleniumWebDriverHelper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -63,6 +64,7 @@ public class DashboardFactory {
     }
   }
 
+  private final SeleniumWebDriverHelper seleniumWebDriverHelper;
   private final SeleniumWebDriver seleniumWebDriver;
   private final Loader loader;
   private final ActionsFactory actionsFactory;
@@ -71,11 +73,13 @@ public class DashboardFactory {
 
   @Inject
   public DashboardFactory(
+      SeleniumWebDriverHelper seleniumWebDriverHelper,
       SeleniumWebDriver seleniumWebDriver,
       Loader loader,
       ActionsFactory actionsFactory,
       Dashboard dashboard,
       TestIdeUrlProvider ideUrlProvider) {
+    this.seleniumWebDriverHelper = seleniumWebDriverHelper;
     this.seleniumWebDriver = seleniumWebDriver;
     this.loader = loader;
     this.actionsFactory = actionsFactory;
@@ -192,8 +196,11 @@ public class DashboardFactory {
 
   /** wait any data in the json editor */
   public void waitJsonFactoryIsNotEmpty() {
+    WebElement jsonArea =
+        seleniumWebDriverHelper.waitPresence(By.cssSelector(Locators.JSON_FACTORY_EDITOR_AREA_CSS));
+    seleniumWebDriverHelper.moveCursorTo(jsonArea);
     new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until((WebDriver driver) -> jsonAreaEditor.getText().length() > LOAD_PAGE_TIMEOUT_SEC);
+        .until((WebDriver driver) -> jsonArea.getText().length() > LOAD_PAGE_TIMEOUT_SEC);
   }
 
   /** click on 'Create factory button' */

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerClickCreatePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerClickCreatePolicyTest.java
@@ -50,7 +50,7 @@ public class CheckFactoryWithPerClickCreatePolicyTest {
   }
 
   @Test
-  public void checkFactoryAcceptingWithPerClickPolicy() throws Exception {
+  public void checkFactoryAcceptingWithPerClickPolicy() {
     // accept factory
     dashboard.open();
     testFactory.open(seleniumWebDriver);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithSincePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithSincePolicyTest.java
@@ -64,7 +64,7 @@ public class CheckFactoryWithSincePolicyTest {
   }
 
   @Test
-  public void checkFactoryAcceptingWithSincePolicy() throws Exception {
+  public void checkFactoryAcceptingWithSincePolicy() {
     // check factory now, make sure its restricted
     dashboard.open();
     testFactory.open(seleniumWebDriver);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithUntilPolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithUntilPolicyTest.java
@@ -63,7 +63,7 @@ public class CheckFactoryWithUntilPolicyTest {
   }
 
   @Test
-  public void checkFactoryAcceptingWithUntilPolicy() throws Exception {
+  public void checkFactoryAcceptingWithUntilPolicy() {
     dashboard.open();
     testFactory.open(seleniumWebDriver);
     seleniumWebDriver.switchFromDashboardIframeToIde();


### PR DESCRIPTION
### What does this PR do?
1) Add info about state workspace which is created by ```CheckFactoryWithPerUserCreatePolicyTest```. Sometimes the workspace does not finish loading and we do not have any information what happens.
2) Increase timeout for ```switchFromDashboardIframeToIde()``` method. The default timeout sometimes is not enough for loading factory on CI. The timeout was increased from 300 sec to 360 sec.
3) Add scrolling to JSON area editor into method ```DashboardFactory->waitJsonFactoryIsNotEmpty()```; sometimes the editor may be under scroll and not visible.
4) Remove unnecessary  trows.
@dmytro-ndp @Ohrimenko1988 
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8799