### PR TITLE
Revert "Fix orion document changing event getting text from native orion event instead of guessing it"

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionDocument.java
@@ -91,7 +91,7 @@ public class OrionDocument extends AbstractDocument {
     int addedCharCount = param.addedCharCount();
     int removedCharCount = param.removedCharCount();
 
-    String text = param.getText();
+    String text = editorOverlay.getModel().getText(startOffset, startOffset + addedCharCount);
 
     final DocumentChangedEvent event =
         new DocumentChangedEvent(this, startOffset, addedCharCount, text, removedCharCount);
@@ -104,7 +104,7 @@ public class OrionDocument extends AbstractDocument {
     int addedCharCount = param.addedCharCount();
     int removedCharCount = param.removedCharCount();
 
-    String text = param.getText();
+    String text = editorOverlay.getModel().getText(startOffset, startOffset + addedCharCount);
 
     final DocumentChangingEvent event =
         new DocumentChangingEvent(this, startOffset, addedCharCount, text, removedCharCount);

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/ModelChangedEventOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/ModelChangedEventOverlay.java
@@ -42,8 +42,4 @@ public class ModelChangedEventOverlay extends OrionEventOverlay {
   public final native int start() /*-{
         return this.start;
     }-*/;
-
-  public final native String getText() /*-{
-        return this.text;
-  }-*/;
 }


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This reverts commit 523b823dc991e6b7d4b955f61f29adf4c86923ad.

### What issues does this PR fix or reference?
#8812

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
