### PR TITLE
CHE CLI: Space in NO_PROXY leads to failed startup

### DIFF
--- a/dockerfiles/init/modules/che/templates/che.env.erb
+++ b/dockerfiles/init/modules/che/templates/che.env.erb
@@ -81,7 +81,7 @@ JAVA_HTTPS_PROXY_PORT=-Dhttps.proxyPort=<%= @che_https_proxy.gsub(/^https?\:\/\/
 <% end -%>
 <% end -%>
 <% if ! @che_no_proxy.empty? -%>
-JAVA_NO_PROXY=-Dhttp.nonProxyHosts='<%= @che_no_proxy.gsub(/^https?\:\/\//, '').gsub(/^www./,'').split(",").uniq.join("|") %>|'
+JAVA_NO_PROXY=-Dhttp.nonProxyHosts='<%= @che_no_proxy.gsub(/^https?\:\/\//, '').gsub(/^www./,'').gsub(/[[:space:]]/,'').split(",").uniq.join("|") %>'
 <% end -%>
 JAVA_OPTS=-XX:MaxRAMFraction=2 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true -Xms20m <% if ! @che_http_proxy.empty? or ! @che_https_proxy.empty? -%>$JAVA_HTTP_PROXY_SET<% end -%> <% if ! @che_http_proxy.empty? -%>$JAVA_HTTP_PROXY_HOST $JAVA_HTTP_PROXY_PORT<% end -%> <% if ! @che_https_proxy.empty? -%>$JAVA_HTTPS_PROXY_HOST $JAVA_HTTPS_PROXY_PORT<% end -%><%- if ! @che_no_proxy.empty? -%> $JAVA_NO_PROXY<% end -%><% if @che_http_proxy.include? '@' -%> $JAVA_HTTP_USER_NAME $JAVA_HTTP_USER_PASSWORD<% end -%><% if @che_https_proxy.include? '@' -%> $JAVA_HTTPS_USER_NAME $JAVA_HTTPS_USER_PASSWORD<% end %>
 


### PR DESCRIPTION
fixes: https://github.com/eclipse/che/issues/8368
when user define `CHE_NO_PROXY` CHE CLI using it to provision various components including JVM. 
 CLI inject value of `CHE_NO_PROXY` to `-Dhttp.nonProxyHosts=` where [the value of this property must be a list of hosts, separated by the '|' character](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html), which leads to failure because spaces are not allowed here.
So this PR simply removes all spaces from `CHE_NO_PROXY` value before provision JVM