### PR TITLE
Support Compose memory limit byte units

### DIFF
--- a/infrastructures/docker/environment/pom.xml
+++ b/infrastructures/docker/environment/pom.xml
@@ -75,6 +75,10 @@
             <artifactId>che-core-api-workspace-shared</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>

--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/deserializer/MemLimitDeserializer.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/deserializer/MemLimitDeserializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.environment.compose.deserializer;
+
+import static java.lang.String.format;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import org.eclipse.che.commons.lang.Size;
+
+public class MemLimitDeserializer extends JsonDeserializer<Long> {
+  private static final String UNSUPPORTED_VALUE_MESSAGE = "Unsupported value '%s'.";
+
+  @Override
+  public Long deserialize(JsonParser jsonParser, DeserializationContext ctxt)
+      throws IOException, JsonProcessingException {
+    Object memLimit = jsonParser.readValueAs(Object.class);
+    if (memLimit instanceof Long) {
+      return (Long) memLimit;
+    }
+    if (memLimit instanceof Integer) {
+      return ((Integer) memLimit).longValue();
+    }
+    if (memLimit instanceof String) {
+      try {
+        return Size.parseSize((String) memLimit);
+      } catch (IllegalArgumentException e) {
+        throw ctxt.mappingException(format(UNSUPPORTED_VALUE_MESSAGE, memLimit));
+      }
+    }
+    throw ctxt.mappingException(format(UNSUPPORTED_VALUE_MESSAGE, memLimit));
+  }
+}

--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/deserializer/MemLimitDeserializer.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/deserializer/MemLimitDeserializer.java
@@ -39,7 +39,7 @@ public class MemLimitDeserializer extends JsonDeserializer<Long> {
       return ((Integer) memLimit).longValue();
     }
     if (memLimit instanceof String) {
-        return Size.parseSize((String) memLimit);
+      return Size.parseSize((String) memLimit);
     }
     throw ctxt.mappingException(format(UNSUPPORTED_VALUE_MESSAGE, memLimit));
   }

--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/deserializer/MemLimitDeserializer.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/deserializer/MemLimitDeserializer.java
@@ -19,6 +19,12 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import java.io.IOException;
 import org.eclipse.che.commons.lang.Size;
 
+/**
+ * Deserialize Compose memory limit value, which could be either a plain byte number, or a string
+ * followed by byte units (e.g. "1mb"), which is parsed, using {@link Size} class.
+ *
+ * @author Mykhailo Kuznietsov
+ */
 public class MemLimitDeserializer extends JsonDeserializer<Long> {
   private static final String UNSUPPORTED_VALUE_MESSAGE = "Unsupported value '%s'.";
 

--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/deserializer/MemLimitDeserializer.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/deserializer/MemLimitDeserializer.java
@@ -39,11 +39,7 @@ public class MemLimitDeserializer extends JsonDeserializer<Long> {
       return ((Integer) memLimit).longValue();
     }
     if (memLimit instanceof String) {
-      try {
         return Size.parseSize((String) memLimit);
-      } catch (IllegalArgumentException e) {
-        throw ctxt.mappingException(format(UNSUPPORTED_VALUE_MESSAGE, memLimit));
-      }
     }
     throw ctxt.mappingException(format(UNSUPPORTED_VALUE_MESSAGE, memLimit));
   }

--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/model/ComposeService.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/model/ComposeService.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.eclipse.che.workspace.infrastructure.docker.environment.compose.deserializer.CommandDeserializer;
 import org.eclipse.che.workspace.infrastructure.docker.environment.compose.deserializer.EnvironmentDeserializer;
+import org.eclipse.che.workspace.infrastructure.docker.environment.compose.deserializer.MemLimitDeserializer;
 
 /**
  * Description of docker compose service.
@@ -55,6 +56,7 @@ public class ComposeService {
   @JsonProperty("volumes_from")
   private List<String> volumesFrom;
 
+  @JsonDeserialize(using = MemLimitDeserializer.class)
   @JsonProperty("mem_limit")
   private Long memLimit;
 

--- a/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/MemLimitDeserializerTest.java
+++ b/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/MemLimitDeserializerTest.java
@@ -72,9 +72,9 @@ public class MemLimitDeserializerTest {
   public Object[][] validValues() {
     return new Object[][] {
       {"2048", 2048L},
-      {"1gb", G},
+      {"1gb", 1 * G},
       {"2g", 2 * G},
-      {"1073741824", G},
+      {"1073741824", 1 * G},
       {"8m", 8 * M},
       {"200mb", 200 * M},
       {"5k", 5 * K},

--- a/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/MemLimitDeserializerTest.java
+++ b/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/MemLimitDeserializerTest.java
@@ -16,12 +16,18 @@ import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.installer.server.InstallerRegistry;
 import org.eclipse.che.api.workspace.server.spi.environment.MachineConfigsValidator;
 import org.eclipse.che.api.workspace.server.spi.environment.RecipeRetriever;
+import org.eclipse.che.workspace.infrastructure.docker.environment.compose.deserializer.MemLimitDeserializer;
 import org.eclipse.che.workspace.infrastructure.docker.environment.compose.model.ComposeRecipe;
 import org.mockito.Mock;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+/**
+ * Test of {@link MemLimitDeserializer} functionality.
+ *
+ * @author Mykhailo Kuznietsov
+ */
 public class MemLimitDeserializerTest {
 
   @Mock InstallerRegistry installerRegistry;

--- a/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/MemLimitDeserializerTest.java
+++ b/infrastructures/docker/environment/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/MemLimitDeserializerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.docker.environment.compose;
+
+import static org.testng.Assert.assertEquals;
+
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.installer.server.InstallerRegistry;
+import org.eclipse.che.api.workspace.server.spi.environment.MachineConfigsValidator;
+import org.eclipse.che.api.workspace.server.spi.environment.RecipeRetriever;
+import org.eclipse.che.workspace.infrastructure.docker.environment.compose.model.ComposeRecipe;
+import org.mockito.Mock;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class MemLimitDeserializerTest {
+
+  @Mock InstallerRegistry installerRegistry;
+  @Mock RecipeRetriever recipeRetriever;
+  @Mock MachineConfigsValidator machinesValidator;
+  @Mock ComposeEnvironmentValidator composeValidator;
+  @Mock ComposeServicesStartStrategy startStrategy;
+
+  private ComposeEnvironmentFactory factory;
+
+  private static final String RECIPE_WITHOUT_COMMAND_VALUE =
+      "services:\n"
+          + " machine1:\n"
+          + "  image: codenvy/mysql\n"
+          + "  environment:\n"
+          + "   MYSQL_USER: petclinic\n"
+          + "   MYSQL_PASSWORD: password\n"
+          + "  mem_limit: %s\n"
+          + // <- test target
+          "  expose: [4403, 5502]";
+
+  @BeforeMethod
+  public void setup() {
+    factory =
+        new ComposeEnvironmentFactory(
+            installerRegistry,
+            recipeRetriever,
+            machinesValidator,
+            composeValidator,
+            startStrategy,
+            2048);
+  }
+
+  @Test(dataProvider = "validValues")
+  public void shouldDeserializeValues(Object memoryLimit, Object parsedLimit)
+      throws ValidationException {
+    ComposeRecipe service =
+        factory.doParse(String.format(RECIPE_WITHOUT_COMMAND_VALUE, memoryLimit));
+    assertEquals(service.getServices().get("machine1").getMemLimit(), parsedLimit);
+  }
+
+  @Test(dataProvider = "invalidValues", expectedExceptions = ValidationException.class)
+  public void shouldThrowExceptionOnDeseralization(Object memoryLimit) throws ValidationException {
+    factory.doParse(String.format(RECIPE_WITHOUT_COMMAND_VALUE, memoryLimit));
+  }
+
+  @DataProvider(name = "validValues")
+  public Object[][] validValues() {
+    return new Object[][] {
+      {"2048", 2048L},
+      {"1gb", 1073741824L},
+      {"2g", 2147483648L},
+      {"1073741824", 1073741824L},
+      {"8m", 8388608L},
+      {"200mb", 209715200L},
+      {"5k", 5120L},
+      {"10kb", 10240L},
+    };
+  }
+
+  @DataProvider(name = "invalidValues")
+  public Object[][] invalidValues() {
+    return new Object[][] {{"1m1"}, {"notanumber"}, {1024.5}};
+  }
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Allow using byte units for defining memory limit in Compose configuration (numbers followed my "b, kb", etc.)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8232

