### PR TITLE
Perform liveness checks of wsagent by dedicated URL

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/LivenessProbeService.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/LivenessProbeService.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che;
+package org.eclipse.che.api.core.rest;
 
 import javax.inject.Singleton;
 import javax.ws.rs.GET;

--- a/plugins/plugin-activity/che-plugin-activity-server/src/main/java/org/eclipse/che/plugin/activity/ActivityServletModule.java
+++ b/plugins/plugin-activity/che-plugin-activity-server/src/main/java/org/eclipse/che/plugin/activity/ActivityServletModule.java
@@ -19,6 +19,7 @@ public class ActivityServletModule extends ServletModule {
 
   @Override
   protected void configureServlets() {
-    filter("/*").through(org.eclipse.che.plugin.activity.LastAccessTimeFilter.class);
+    filterRegex("^(?!.*(/liveness/?)$).*") // Not ends with /liveness or /liveness/
+        .through(org.eclipse.che.plugin.activity.LastAccessTimeFilter.class);
   }
 }

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
@@ -11,7 +11,7 @@
 package org.eclipse.che.wsagent.server;
 
 import com.google.inject.AbstractModule;
-import org.eclipse.che.LivenessProbeService;
+import org.eclipse.che.api.core.rest.LivenessProbeService;
 import org.eclipse.che.api.core.rest.ApiInfoService;
 import org.eclipse.che.inject.DynaModule;
 

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentModule.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.wsagent.server;
 
 import com.google.inject.AbstractModule;
+import org.eclipse.che.LivenessProbeService;
 import org.eclipse.che.api.core.rest.ApiInfoService;
 import org.eclipse.che.inject.DynaModule;
 
@@ -25,6 +26,7 @@ public class WsAgentModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(ApiInfoService.class);
+    bind(LivenessProbeService.class);
     install(new org.eclipse.che.security.oauth.OAuthAgentModule());
     install(new org.eclipse.che.api.core.rest.CoreRestModule());
     install(new org.eclipse.che.api.core.util.FileCleaner.FileCleanerModule());

--- a/wsagent/wsagent-local/src/main/java/org/eclipse/che/LivenessProbeService.java
+++ b/wsagent/wsagent-local/src/main/java/org/eclipse/che/LivenessProbeService.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che;
+
+import javax.inject.Singleton;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+
+/**
+ * Endpoint for the liveness checks.
+ *
+ * @author Max Shaposhnik (mshaposh@redhat.com)
+ */
+@Singleton
+@Path("/liveness")
+public class LivenessProbeService {
+  @GET
+  public Response checkAlive() {
+    return Response.ok().build();
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
@@ -44,7 +44,7 @@ public class WsAgentServerLivenessProbeConfigFactory implements HttpProbeConfigF
       throws InternalInfrastructureException {
 
     try {
-      // add trailing slash
+      // add check path
       URI uri = UriBuilder.fromUri(server.getUrl()).path("/liveness").build();
 
       int port;

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
@@ -45,7 +45,7 @@ public class WsAgentServerLivenessProbeConfigFactory implements HttpProbeConfigF
 
     try {
       // add trailing slash
-      URI uri = UriBuilder.fromUri(server.getUrl()).path("/").build();
+      URI uri = UriBuilder.fromUri(server.getUrl()).path("/liveness").build();
 
       int port;
       if (uri.getPort() == -1) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactoryTest.java
@@ -76,7 +76,7 @@ public class WorkspaceProbesFactoryTest {
         10,
         10,
         120,
-        "/path1/",
+        "/path1/liveness",
         "localhost",
         4040,
         "https",


### PR DESCRIPTION
### What does this PR do?
Perform liveness checks of wsagent by dedicated URL to avoid them to prolong ws shutdown by timeout.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8487


#### Release Notes
N/A


#### Docs PR
N/A