### PR TITLE
Adding Eclipse Che to SonarCloud.io for getting reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Eclipse Che - Eclipse Next-Generation IDE
 [![Eclipse License](https://img.shields.io/badge/license-Eclipse-brightgreen.svg)](https://github.com/codenvy/che/blob/master/LICENSE)
 [![Build Status](https://ci.codenvycorp.com/buildStatus/icon?job=che-master-ci)](https://ci.codenvycorp.com/job/che-master-ci)
+<a href="https://sonarcloud.io/dashboard?id=org.eclipse.che%3Ache-parent%3Amaster">
+<img src="https://sonarcloud.io/images/project_badges/sonarcloud-black.svg" width="94" height="20" href="" />
+</a>
+
 
 https://www.eclipse.org/che/. Next-generation Eclipse platform, developer workspace server and cloud IDE. Che defines workspaces that include their dependencies including embedded containerized runtimes, Web IDE, and project code. This makes workspaces distributed, collaborative, and portable to run anywhere on a desktop or a server ... [Read More](https://www.eclipse.org/che/features/)
 


### PR DESCRIPTION
for each build on CI (master branch) we will run sonar scanning and upload reports to SonarCloud.io

fixes: https://github.com/eclipse/che/issues/8643

original logo is too big so I used html injection to adjust badge size

other projects: https://sonarcloud.io/organizations/eclipse-che/projects

I've picked most neutral badge without any data in it because I don't want to have always "red" badge :) nor lines of code or something very specific.