### PR TITLE
Print selenium test statistics in log during execution

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestStatistics.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestStatistics.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.inject;
+
+import static java.lang.String.format;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** @author Dmytro Nochevnov */
+public class SeleniumTestStatistics {
+  private static final String statisticsTemplate = "Passed: %d, failed: %d, skipped: %d.";
+
+  private final AtomicInteger runTests = new AtomicInteger();
+  private final AtomicInteger failedTests = new AtomicInteger();
+  private final AtomicInteger passedTests = new AtomicInteger();
+  private final AtomicInteger skippedTests = new AtomicInteger();
+
+  public int hitStart() {
+    return runTests.incrementAndGet();
+  }
+
+  public int hitPass() {
+    return passedTests.incrementAndGet();
+  }
+
+  public int hitFail() {
+    return failedTests.incrementAndGet();
+  }
+
+  public int hitSkip() {
+    return skippedTests.incrementAndGet();
+  }
+
+  @Override
+  public String toString() {
+    synchronized (this) {
+      return format(statisticsTemplate, passedTests.get(), failedTests.get(), skippedTests.get());
+    }
+  }
+}

--- a/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/SeleniumTestStatisticsTest.java
+++ b/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/SeleniumTestStatisticsTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.inject;
+
+import static java.util.stream.IntStream.range;
+import static org.testng.Assert.assertEquals;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/** @author Dmytro Nochevnov */
+public class SeleniumTestStatisticsTest {
+  private static final Logger LOG = LoggerFactory.getLogger(SeleniumTestStatisticsTest.class);
+
+  @Test(dataProvider = "testData")
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void testSimultaneousUsage(
+      int hitStart,
+      int hitPass,
+      int hitFail,
+      int hitSkip,
+      String initialToString,
+      String finalToString)
+      throws InterruptedException {
+    // given
+    SeleniumTestStatistics seleniumTestStatistics = new SeleniumTestStatistics();
+
+    // when
+    String actualString = seleniumTestStatistics.toString();
+
+    // then
+    assertEquals(actualString, initialToString);
+
+    // when
+    ExecutorService executor = Executors.newFixedThreadPool(10);
+
+    range(0, hitStart).forEach(i -> executor.submit(seleniumTestStatistics::hitStart));
+    range(0, hitPass).forEach(i -> executor.submit(seleniumTestStatistics::hitPass));
+    range(0, hitFail).forEach(i -> executor.submit(seleniumTestStatistics::hitFail));
+    range(0, hitSkip).forEach(i -> executor.submit(seleniumTestStatistics::hitSkip));
+
+    executor.awaitTermination(20, TimeUnit.SECONDS);
+
+    // then
+    assertEquals(seleniumTestStatistics.toString(), finalToString);
+    assertEquals(seleniumTestStatistics.hitStart(), hitStart + 1);
+    assertEquals(seleniumTestStatistics.hitPass(), hitPass + 1);
+    assertEquals(seleniumTestStatistics.hitFail(), hitFail + 1);
+    assertEquals(seleniumTestStatistics.hitSkip(), hitSkip + 1);
+  }
+
+  @DataProvider
+  public Object[][] testData() {
+    return new Object[][] {
+      {0, 0, 0, 0, "Passed: 0, failed: 0, skipped: 0.", "Passed: 0, failed: 0, skipped: 0."},
+      {31, 21, 5, 4, "Passed: 0, failed: 0, skipped: 0.", "Passed: 21, failed: 5, skipped: 4."}
+    };
+  }
+}

--- a/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReaderTest.java
+++ b/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReaderTest.java
@@ -37,6 +37,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -57,7 +58,8 @@ public class TestWorkspaceLogsReaderTest {
   private static final String TEST_READ_SECOND_LOG_COMMAND = "echo 'read-log-2'";
   private static final String UNKNOWN_COMMAND = "command-435f4q6we3as5va5s";
   private static final String TEST_WORKSPACE_ID = "workspace-id";
-  private static final Path PATH_TO_STORE_LOGS = Paths.get("path-to-store-logs");
+  private static final Path PATH_TO_STORE_LOGS =
+      Paths.get(TestWorkspaceLogsReaderTest.class.getResource("").getPath());
   private static final WorkspaceStatus WRONG_WORKSPACE_STATUS = WorkspaceStatus.STOPPED;
   private static final NullPointerException EXCEPTION_TO_BE_THROWN = new NullPointerException();
 


### PR DESCRIPTION
### What does this PR do?
It prints selenium tests statistics in test log at the start of each test, for example:
<details>
 <summary>An example of logs</summary>
 <pre>
2018-02-21 20:01:06,134[main]             [INFO ] [.e.c.s.c.i.SeleniumTestHandler 203]  - Starting suite 'Multi-thread Eclipse Che tests' with 2 test methods.
2018-02-21 20:01:06,168[pool-1-thread-1]  [INFO ] [.e.c.s.c.i.SeleniumTestHandler 161]  - Starting test #1 NavigateToFileTest.shouldNavigateToFileForFirstProject. Passed: 0, failed: 0, skipped: 0.
2018-02-21 20:01:06,174[pool-1-thread-1]  [INFO ] [.e.c.s.c.i.SeleniumTestHandler 236]  - Dependencies injection in org.eclipse.che.selenium.miscellaneous.NavigateToFileTest
2018-02-21 20:01:06,236[pool-1-thread-1]  [ERROR] [.e.c.s.c.i.SeleniumTestHandler 287]  - Test NavigateToFileTest.shouldNavigateToFileForFirstProject failed. Error: ------ shouldNavigateToFileForFirstProject
2018-02-21 20:01:06,256[pool-1-thread-1]  [INFO ] [.e.c.s.c.i.SeleniumTestHandler 161]  - Starting test #2 NavigateToFileTest.shouldNavigateToFileForFirstProject (run 2). Passed: 0, failed: 1, skipped: 0.
2018-02-21 20:01:06,257[pool-1-thread-1]  [ERROR] [.e.c.s.c.i.SeleniumTestHandler 287]  - Test NavigateToFileTest.shouldNavigateToFileForFirstProject (run 2) failed. Error: ------ shouldNavigateToFileForFirstProject
2018-02-21 20:01:06,260[pool-1-thread-1]  [INFO ] [.e.c.s.c.i.SeleniumTestHandler 161]  - Starting test #3 NavigateToFileTest.shouldNavigateToFileForFirstProject (run 3). Passed: 0, failed: 2, skipped: 0.
2018-02-21 20:01:06,261[pool-1-thread-1]  [ERROR] [.e.c.s.c.i.SeleniumTestHandler 287]  - Test NavigateToFileTest.shouldNavigateToFileForFirstProject (run 3) failed. Error: ------ shouldNavigateToFileForFirstProject
2018-02-21 20:01:06,265[pool-1-thread-1]  [INFO ] [.e.c.s.c.i.SeleniumTestHandler 161]  - Starting test #4 NavigateToFileTest.shouldNotDisplayHiddenFilesAndFoldersInDropDown. Passed: 0, failed: 3, skipped: 0.
2018-02-21 20:01:06,331[main]             [INFO ] [.e.c.s.c.i.SeleniumTestHandler 487]  - Cleaning up test environment...
2018-02-21 20:01:06,332[main]             [INFO ] [.e.c.s.c.i.SeleniumTestHandler 339]  - Processing @PreDestroy annotation in org.eclipse.che.selenium.miscellaneous.NavigateToFileTest
[ERROR] Tests run: 5, Failures: 4, Errors: 0, Skipped: 0, Time elapsed: 7.255 s <<< FAILURE! - in TestSuite
...
[ERROR] Tests run: 3, Failures: 2, Errors: 0, Skipped: 0
 </pre>
</details>

### What issues does this PR fix or reference?
#7719 