### PR TITLE
set correct version for image traefik in 6.2.0

### DIFF
--- a/dockerfiles/cli/version/6.2.0/images
+++ b/dockerfiles/cli/version/6.2.0/images
@@ -1,6 +1,6 @@
 IMAGE_INIT=eclipse/che-init:6.2.0
 IMAGE_CHE=eclipse/che-server:6.2.0
 IMAGE_COMPOSE=docker/compose:1.10.1
-IMAGE_TRAEFIK=traefik:v1.3.0-rc3
+IMAGE_TRAEFIK=traefik:v1.5.0
 IMAGE_POSTGRES=centos/postgresql-96-centos7:9.6
 IMAGE_KEYCLOACK=jboss/keycloak-openshift:3.3.0.CR2-3


### PR DESCRIPTION
set correct version for image traefik in 6.2.0