### PR TITLE
Allow configuring the dispatcher and connection pool of the `KubernetesClient` shared underlying http client.

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -431,7 +431,7 @@ che.infra.kubernetes.client.http.connection_pool.max_idle=5
 # Keep-alive timeout of the connection pool
 # of the Kubernetes-client shared http client
 # in minutes
-che.infra.kubernetes.client.http.connection_pool.keep_alive.mins=5
+che.infra.kubernetes.client.http.connection_pool.keep_alive_min=5
 
 ### OpenShift Infra parameters
 #

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -413,6 +413,25 @@ che.infra.kubernetes.ingress.annotations_json=NULL
 che.infra.kubernetes.pod.security_context.run_as_user=NULL
 che.infra.kubernetes.pod.security_context.fs_group=NULL
 
+# Number of maximum concurrent async web requests
+# (http requests or ongoing  web socket calls)
+# supported in the underlying shared http client
+# of the `KubernetesClient` instances.
+# Default values are 64, and 5 per-host, which 
+# doesn't seem correct for multi-user scenarios
+# knowing that Che keeps a number of connections
+# opened (e.g. for command or ws-agent logs)
+che.infra.kubernetes.client.http.async_requests.max=1000
+che.infra.kubernetes.client.http.async_requests.max_per_host=1000
+
+# Max number of idle connections in the connection pool
+# of the Kubernetes-client shared http client 
+che.infra.kubernetes.client.http.connection_pool.max_idle=5
+
+# Keep-alive timeout of the connection pool
+# of the Kubernetes-client shared http client
+# in minutes
+che.infra.kubernetes.client.http.connection_pool.keep_alive.mins=5
 
 ### OpenShift Infra parameters
 #

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
@@ -68,7 +68,7 @@ public class KubernetesClientFactory {
       @Named("che.infra.kubernetes.client.http.async_requests.max_per_host")
           int maxConcurrentRequestsPerHost,
       @Named("che.infra.kubernetes.client.http.connection_pool.max_idle") int maxIdleConnections,
-      @Named("che.infra.kubernetes.client.http.connection_pool.keep_alive.mins")
+      @Named("che.infra.kubernetes.client.http.connection_pool.keep_alive_min")
           int connectionPoolKeepAlive) {
     this.defaultConfig =
         buildDefaultConfig(masterUrl, username, password, oauthToken, doTrustCerts);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.client.utils.HttpClientUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import java.io.IOException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -62,10 +63,24 @@ public class KubernetesClientFactory {
       @Nullable @Named("che.infra.kubernetes.username") String username,
       @Nullable @Named("che.infra.kubernetes.password") String password,
       @Nullable @Named("che.infra.kubernetes.oauth_token") String oauthToken,
-      @Nullable @Named("che.infra.kubernetes.trust_certs") Boolean doTrustCerts) {
+      @Nullable @Named("che.infra.kubernetes.trust_certs") Boolean doTrustCerts,
+      @Named("che.infra.kubernetes.client.http.async_requests.max") int maxConcurrentRequests,
+      @Named("che.infra.kubernetes.client.http.async_requests.max_per_host")
+          int maxConcurrentRequestsPerHost,
+      @Named("che.infra.kubernetes.client.http.connection_pool.max_idle") int maxIdleConnections,
+      @Named("che.infra.kubernetes.client.http.connection_pool.keep_alive.mins")
+          int connectionPoolKeepAlive) {
     this.defaultConfig =
         buildDefaultConfig(masterUrl, username, password, oauthToken, doTrustCerts);
-    this.httpClient = HttpClientUtils.createHttpClient(defaultConfig);
+    OkHttpClient temporary = HttpClientUtils.createHttpClient(defaultConfig);
+    OkHttpClient.Builder builder = temporary.newBuilder();
+    ConnectionPool oldPool = temporary.connectionPool();
+    builder.connectionPool(
+        new ConnectionPool(maxIdleConnections, connectionPoolKeepAlive, TimeUnit.MINUTES));
+    oldPool.evictAll();
+    this.httpClient = builder.build();
+    httpClient.dispatcher().setMaxRequests(maxConcurrentRequests);
+    httpClient.dispatcher().setMaxRequestsPerHost(maxConcurrentRequestsPerHost);
   }
 
   /**

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
@@ -68,7 +68,7 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
       @Named("che.infra.kubernetes.client.http.async_requests.max_per_host")
           int maxConcurrentRequestsPerHost,
       @Named("che.infra.kubernetes.client.http.connection_pool.max_idle") int maxIdleConnections,
-      @Named("che.infra.kubernetes.client.http.connection_pool.keep_alive.mins")
+      @Named("che.infra.kubernetes.client.http.connection_pool.keep_alive_min")
           int connectionPoolKeepAlive) {
     super(
         masterUrl,

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
@@ -63,8 +63,23 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
       @Nullable @Named("che.infra.kubernetes.username") String username,
       @Nullable @Named("che.infra.kubernetes.password") String password,
       @Nullable @Named("che.infra.kubernetes.oauth_token") String oauthToken,
-      @Nullable @Named("che.infra.kubernetes.trust_certs") Boolean doTrustCerts) {
-    super(masterUrl, username, password, oauthToken, doTrustCerts);
+      @Nullable @Named("che.infra.kubernetes.trust_certs") Boolean doTrustCerts,
+      @Named("che.infra.kubernetes.client.http.async_requests.max") int maxConcurrentRequests,
+      @Named("che.infra.kubernetes.client.http.async_requests.max_per_host")
+          int maxConcurrentRequestsPerHost,
+      @Named("che.infra.kubernetes.client.http.connection_pool.max_idle") int maxIdleConnections,
+      @Named("che.infra.kubernetes.client.http.connection_pool.keep_alive.mins")
+          int connectionPoolKeepAlive) {
+    super(
+        masterUrl,
+        username,
+        password,
+        oauthToken,
+        doTrustCerts,
+        maxConcurrentRequests,
+        maxConcurrentRequestsPerHost,
+        maxIdleConnections,
+        connectionPoolKeepAlive);
   }
 
   protected Config buildDefaultConfig(


### PR DESCRIPTION
### What does this PR do?

Allow configuring the dispatcher and connection pool of
the `KubernetesClient` shared underlying http client.

For example, default values are 64 concurrent asynchronous
requests, and **only 5 concurrent asynchronous requests per-host**,
which obviously doesn't seem correct for multi-user scenarios,
knowing that Che keeps a number of connections opened
(e.g. for commands or ws-agent logs)

Leaving these wrong default values can lead to workspace
starts being stuck in the middle of the process while waiting 
for an available request, as soon as several users start
a workspace on the same che-server.
