### PR TITLE
Remove redundant import from the TestWorkspaceLogsReaderTest

### DIFF
--- a/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReaderTest.java
+++ b/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReaderTest.java
@@ -37,7 +37,6 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.mockito.testng.MockitoTestNGListener;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;


### PR DESCRIPTION
### What does this PR do?
It remove redundant import from TestWorkspaceLogsReaderTest class

### What issues does this PR fix or reference?
#7719 