### PR TITLE
Fix displaying Pull Request Panel

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateConstants.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateConstants.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.statepersistance;
+
+/**
+ * Constants for the mappings in user preferences to store/restore app state.
+ *
+ * @author Roman Nikitenko
+ */
+public final class AppStateConstants {
+
+  public static final String APP_STATE = "IdeAppStates";
+  public static final String PERSPECTIVES = "perspectives";
+  public static final String PART_STACKS = "PART_STACKS";
+  public static final String PART_STACK_STATE = "STATE";
+  public static final String PART_STACK_PARTS = "PARTS";
+  public static final String PART_STACK_SIZE = "SIZE";
+  public static final String ACTIVE_PART = "ACTIVE_PART";
+  public static final String PART_CLASS_NAME = "CLASS";
+  public static final String HIDDEN_STATE = "HIDDEN";
+
+  private AppStateConstants() {}
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspacePresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/WorkspacePresenter.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.ide.workspace;
 
+import static org.eclipse.che.ide.statepersistance.AppStateConstants.PERSPECTIVES;
+
 import com.google.gwt.user.client.ui.AcceptsOneWidget;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -168,7 +170,7 @@ public class WorkspacePresenter
   public JsonObject getState() {
     JsonObject state = Json.createObject();
     JsonObject perspectivesJs = Json.createObject();
-    state.put("perspectives", perspectivesJs);
+    state.put(PERSPECTIVES, perspectivesJs);
     Map<String, Perspective> perspectives = perspectiveManagerProvider.get().getPerspectives();
     for (Map.Entry<String, Perspective> entry : perspectives.entrySet()) {
       // store only default perspective
@@ -181,8 +183,8 @@ public class WorkspacePresenter
 
   @Override
   public Promise<Void> loadState(JsonObject state) {
-    if (state.hasKey("perspectives")) {
-      JsonObject perspectives = state.getObject("perspectives");
+    if (state.hasKey(PERSPECTIVES)) {
+      JsonObject perspectives = state.getObject(PERSPECTIVES);
       Map<String, Perspective> perspectiveMap = perspectiveManagerProvider.get().getPerspectives();
       ArrayOf<Promise<?>> perspectivePromises = Collections.arrayOf();
       for (String key : perspectives.keys()) {

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/statepersistance/AppStateManagerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/statepersistance/AppStateManagerTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.ide.statepersistance;
 
+import static org.eclipse.che.ide.statepersistance.AppStateConstants.APP_STATE;
 import static org.fest.assertions.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -31,6 +32,7 @@ import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.parts.PerspectiveManager;
 import org.eclipse.che.ide.api.preferences.PreferencesManager;
 import org.eclipse.che.ide.api.statepersistance.StateComponent;
 import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
@@ -55,6 +57,7 @@ public class AppStateManagerTest {
 
   @Mock private StateComponentRegistry stateComponentRegistry;
   @Mock private Provider<StateComponentRegistry> stateComponentRegistryProvider;
+  @Mock private Provider<PerspectiveManager> perspectiveManagerProvider;
   @Mock private StateComponent component1;
   @Mock private StateComponent component2;
   @Mock private Provider<StateComponent> component1Provider;
@@ -97,10 +100,11 @@ public class AppStateManagerTest {
     when(component1.getId()).thenReturn("component1");
     when(component2.getId()).thenReturn("component2");
     when(preferencesManager.flushPreferences()).thenReturn(promise);
-    when(preferencesManager.getValue(AppStateManager.PREFERENCE_PROPERTY_NAME)).thenReturn("");
+    when(preferencesManager.getValue(APP_STATE)).thenReturn("");
     when(jsonFactory.parse(anyString())).thenReturn(pref = Json.createObject());
     appStateManager =
         new AppStateManager(
+            perspectiveManagerProvider,
             stateComponentRegistryProvider,
             preferencesManager,
             jsonFactory,
@@ -160,7 +164,7 @@ public class AppStateManagerTest {
     pref.put(WS_ID, Json.createObject());
     appStateManager.restoreWorkspaceState();
 
-    verify(preferencesManager).getValue(AppStateManager.PREFERENCE_PROPERTY_NAME);
+    verify(preferencesManager).getValue(APP_STATE);
   }
 
   @Test

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/pom.xml
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/pom.xml
@@ -31,6 +31,10 @@
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>
+            <artifactId>gwt-elemental</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.gwt</groupId>
             <artifactId>gwt-user</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributionMixinProvider.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributionMixinProvider.java
@@ -11,8 +11,10 @@
 package org.eclipse.che.plugin.pullrequest.client;
 
 import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.ide.api.constraints.Constraints.FIRST;
 import static org.eclipse.che.ide.api.parts.PartStackType.TOOLING;
+import static org.eclipse.che.ide.statepersistance.AppStateConstants.HIDDEN_STATE;
 import static org.eclipse.che.plugin.pullrequest.shared.ContributionProjectTypeConstants.CONTRIBUTE_TO_BRANCH_VARIABLE_NAME;
 import static org.eclipse.che.plugin.pullrequest.shared.ContributionProjectTypeConstants.CONTRIBUTION_PROJECT_TYPE_ID;
 
@@ -21,12 +23,16 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 import com.google.web.bindery.event.shared.HandlerRegistration;
+import elemental.json.JsonObject;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.factory.FactoryAcceptedEvent;
+import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.PartStack;
+import org.eclipse.che.ide.api.parts.PartStack.State;
+import org.eclipse.che.ide.api.parts.PartStackStateChangedEvent;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.ide.api.project.MutableProjectConfig;
 import org.eclipse.che.ide.api.resources.Project;
@@ -35,6 +41,7 @@ import org.eclipse.che.ide.api.selection.Selection;
 import org.eclipse.che.ide.api.selection.SelectionChangedEvent;
 import org.eclipse.che.ide.api.workspace.WorkspaceReadyEvent;
 import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppedEvent;
+import org.eclipse.che.ide.statepersistance.AppStateManager;
 import org.eclipse.che.ide.ui.smartTree.data.HasDataObject;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.plugin.pullrequest.client.parts.contribute.ContributePartPresenter;
@@ -57,6 +64,7 @@ public class ContributionMixinProvider {
   private final EventBus eventBus;
   private final AppContext appContext;
   private final WorkspaceAgent workspaceAgent;
+  private final AppStateManager appStateManager;
   private final ContributePartPresenter contributePart;
   private final WorkflowExecutor workflowExecutor;
   private final VcsServiceProvider vcsServiceProvider;
@@ -73,6 +81,7 @@ public class ContributionMixinProvider {
       EventBus eventBus,
       AppContext appContext,
       WorkspaceAgent workspaceAgent,
+      AppStateManager appStateManager,
       ContributePartPresenter contributePart,
       WorkflowExecutor workflowExecutor,
       VcsServiceProvider vcsServiceProvider,
@@ -82,6 +91,7 @@ public class ContributionMixinProvider {
     this.eventBus = eventBus;
     this.appContext = appContext;
     this.workspaceAgent = workspaceAgent;
+    this.appStateManager = appStateManager;
     this.contributePart = contributePart;
     this.workflowExecutor = workflowExecutor;
     this.vcsServiceProvider = vcsServiceProvider;
@@ -89,62 +99,158 @@ public class ContributionMixinProvider {
     this.promiseProvider = promiseProvider;
     this.messages = messages;
 
+    eventBus.addHandler(WorkspaceStoppedEvent.TYPE, this::onWorkspaceStopped);
+    eventBus.addHandler(PartStackStateChangedEvent.TYPE, this::onPartStackStateChanged);
+
     if (appContext.getFactory() != null) {
       eventBus.addHandler(FactoryAcceptedEvent.TYPE, event -> subscribeToSelectionChangedEvent());
     } else {
       eventBus.addHandler(
           WorkspaceReadyEvent.getType(), event -> subscribeToSelectionChangedEvent());
     }
-
-    eventBus.addHandler(
-        WorkspaceStoppedEvent.TYPE,
-        event -> {
-          lastSelected = null;
-          contributePart.showStub("");
-          if (selectionHandlerReg != null) {
-            selectionHandlerReg.removeHandler();
-          }
-        });
   }
 
-  private void subscribeToSelectionChangedEvent() {
-    selectionHandlerReg =
-        eventBus.addHandler(
-            SelectionChangedEvent.TYPE, event -> processCurrentProject(event.getSelection()));
+  private void onPartStackStateChanged(PartStackStateChangedEvent event) {
+    PartStack toolingPartStack = workspaceAgent.getPartStack(TOOLING);
+    if (event.getPartStack() != toolingPartStack || isPartStackHidden(toolingPartStack)) {
+      return;
+    }
+
+    PartPresenter activePart = toolingPartStack.getActivePart();
+    if (activePart == null || activePart == contributePart) {
+      handleCurrentProject();
+    }
   }
 
-  private void processCurrentProject(Selection<?> selection) {
-    if (WorkspaceStatus.RUNNING != appContext.getWorkspace().getStatus()) {
+  private void onSelectionChanged(Selection<?> selection) {
+    WorkspaceStatus workspaceStatus = appContext.getWorkspace().getStatus();
+    if (RUNNING != workspaceStatus
+        || !isSupportedSelection(selection)
+        || isContributePartHiddenByUser()) {
       return;
     }
 
-    if (!isSupportedSelection(selection)) {
+    if (appContext.getRootProject() != null) {
+      handleCurrentProject();
       return;
     }
 
-    final Project rootProject = appContext.getRootProject();
+    String message =
+        selection.isMultiSelection()
+            ? messages.stubTextShouldBeSelectedOnlyOneProject()
+            : messages.stubTextProjectIsNotSelected();
 
-    if (lastSelected != null && lastSelected.equals(rootProject) && hasVcsService(rootProject)) {
-      return;
-    }
+    contributePart.showStub(message);
+    invalidateContext(lastSelected);
+  }
 
-    contributePart.showStub(messages.stubTextLoading());
-
-    if (rootProject == null) {
+  private void handleCurrentProject() {
+    Project project = appContext.getRootProject();
+    if (project == null) {
       invalidateContext(lastSelected);
-      lastSelected = null;
-      if (selection.isMultiSelection()) {
-        contributePart.showStub(messages.stubTextShouldBeSelectedOnlyOneProject());
-      } else {
-        contributePart.showStub(messages.stubTextProjectIsNotSelected());
-      }
-    } else if (hasVcsService(rootProject)) {
-      handleProjectWithVCS(rootProject);
-    } else {
-      invalidateContext(rootProject);
-      contributePart.showStub(messages.stubTextProjectNotProvideSupportedVCS());
-      lastSelected = null;
+      contributePart.showStub(messages.stubTextProjectIsNotSelected());
+      return;
     }
+
+    if (hasVcsService(project)) {
+      initializeContributionWorkflow(project);
+    } else {
+      invalidateContext(project);
+      contributePart.showStub(messages.stubTextProjectNotProvideSupportedVCS());
+    }
+  }
+
+  private void initializeContributionWorkflow(Project project) {
+    if (lastSelected != null && lastSelected.equals(project) && hasVcsService(lastSelected)) {
+      return;
+    }
+
+    vcsHostingServiceProvider
+        .getVcsHostingService(project)
+        .then(
+            vcsHostingService -> {
+              provideMixin(project)
+                  .then(
+                      updatedProject -> {
+                        workflowExecutor.init(vcsHostingService, updatedProject);
+                        lastSelected = updatedProject;
+                        setContributePart();
+                      })
+                  .catchError(
+                      error -> {
+                        handleVCSError(
+                            project,
+                            messages.failedToApplyVCSMixin(project.getName(), error.getMessage()));
+                      });
+            })
+        .catchError(
+            error -> {
+              handleVCSError(
+                  project, messages.failedToGetVCSService(project.getName(), error.getMessage()));
+            });
+  }
+
+  private void setContributePart() {
+    PartStack partStack = workspaceAgent.getPartStack(TOOLING);
+    if (!partStack.containsPart(contributePart)) {
+      partStack.addPart(contributePart, FIRST);
+    }
+
+    PartPresenter activePart = partStack.getActivePart();
+    if (activePart != contributePart) {
+      partStack.setActivePart(contributePart);
+    }
+
+    contributePart.showContent();
+  }
+
+  private Promise<Project> provideMixin(Project project) {
+    VcsService vcsService = vcsServiceProvider.getVcsService(project);
+    if (!hasVcsService(project) || hasContributionMixin(project)) {
+      return promiseProvider.resolve(project);
+    }
+
+    return vcsService
+        .getBranchName(project)
+        .thenPromise(
+            branchName -> {
+              MutableProjectConfig mutableConfig = new MutableProjectConfig(project);
+              mutableConfig.getMixins().add(CONTRIBUTION_PROJECT_TYPE_ID);
+              mutableConfig
+                  .getAttributes()
+                  .put(CONTRIBUTE_TO_BRANCH_VARIABLE_NAME, singletonList(branchName));
+
+              return project.update().withBody(mutableConfig).send();
+            });
+  }
+
+  private void handleVCSError(Project project, String logError) {
+    Log.error(getClass(), logError);
+    invalidateContext(project);
+    contributePart.showStub(messages.stubTextNothingToShow());
+  }
+
+  private void invalidateContext(Project project) {
+    if (project != null) {
+      final Optional<Context> context = workflowExecutor.getContext(project.getName());
+      if (context.isPresent()) {
+        workflowExecutor.invalidateContext(context.get().getProject());
+      }
+    }
+    lastSelected = null;
+  }
+
+  private boolean hasVcsService(Project project) {
+    return vcsServiceProvider.getVcsService(project) != null;
+  }
+
+  private boolean hasContributionMixin(Project project) {
+    return project.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID);
+  }
+
+  private boolean isPartStackHidden(PartStack partStack) {
+    State partStackState = partStack.getPartStackState();
+    return partStackState == State.HIDDEN || partStackState == State.MINIMIZED;
   }
 
   private boolean isSupportedSelection(Selection<?> selection) {
@@ -162,102 +268,26 @@ public class ContributionMixinProvider {
     return headElem == null || isResourceSelection || isHasDataWithResource;
   }
 
-  private void handleProjectWithVCS(Project prj) {
-    if (hasContributionMixin(prj)) {
-      vcsHostingServiceProvider
-          .getVcsHostingService(prj)
-          .then(
-              vcsHostingService -> {
-                workflowExecutor.init(vcsHostingService, prj);
-                addPart();
-                contributePart.showContent();
-
-                lastSelected = prj;
-              })
-          .catchError(
-              err -> {
-                handleVCSError(
-                    prj, messages.failedToGetVCSService(prj.getName(), err.getMessage()));
-              });
-    } else {
-      vcsHostingServiceProvider
-          .getVcsHostingService(prj)
-          .then(
-              vcsHostingService -> {
-                addMixin(prj)
-                    .then(
-                        prjWithMixin -> {
-                          workflowExecutor.init(vcsHostingService, prjWithMixin);
-                          addPart();
-                          contributePart.showContent();
-
-                          lastSelected = prjWithMixin;
-                        })
-                    .catchError(
-                        err -> {
-                          handleVCSError(
-                              prj, messages.failedToApplyVCSMixin(prj.getName(), err.getMessage()));
-                        });
-              })
-          .catchError(
-              err -> {
-                handleVCSError(
-                    prj, messages.failedToGetVCSService(prj.getName(), err.getMessage()));
-              });
-    }
-  }
-
-  private void handleVCSError(Project project, String logError) {
-    Log.error(getClass(), logError);
-    invalidateContext(project);
-    contributePart.showStub(messages.stubTextNothingToShow());
-  }
-
-  private void invalidateContext(Project project) {
-    if (project != null) {
-      final Optional<Context> context = workflowExecutor.getContext(project.getName());
-      if (context.isPresent()) {
-        workflowExecutor.invalidateContext(context.get().getProject());
-      }
-    }
-  }
-
-  private void addPart() {
-    PartStack partStack = workspaceAgent.getPartStack(TOOLING);
-    if (!partStack.containsPart(contributePart)) {
-      partStack.addPart(contributePart, FIRST);
-      if (partStack.getActivePart() == null) {
-        partStack.setActivePart(contributePart);
-      }
-    }
-  }
-
-  private boolean hasVcsService(Project project) {
-    return vcsServiceProvider.getVcsService(project) != null;
-  }
-
-  private boolean hasContributionMixin(Project project) {
-    return project.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID);
-  }
-
-  private Promise<Project> addMixin(final Project project) {
-    final VcsService vcsService = vcsServiceProvider.getVcsService(project);
-
-    if (vcsService == null || project.getMixins().contains(CONTRIBUTION_PROJECT_TYPE_ID)) {
-      return promiseProvider.resolve(project);
+  private boolean isContributePartHiddenByUser() {
+    JsonObject toolingPartStackState = appStateManager.getStateFor(TOOLING);
+    if (toolingPartStackState != null && toolingPartStackState.hasKey(HIDDEN_STATE)) {
+      return toolingPartStackState.getBoolean(HIDDEN_STATE);
     }
 
-    return vcsService
-        .getBranchName(project)
-        .thenPromise(
-            branchName -> {
-              MutableProjectConfig mutableConfig = new MutableProjectConfig(project);
-              mutableConfig.getMixins().add(CONTRIBUTION_PROJECT_TYPE_ID);
-              mutableConfig
-                  .getAttributes()
-                  .put(CONTRIBUTE_TO_BRANCH_VARIABLE_NAME, singletonList(branchName));
+    return false;
+  }
 
-              return project.update().withBody(mutableConfig).send();
-            });
+  private void subscribeToSelectionChangedEvent() {
+    selectionHandlerReg =
+        eventBus.addHandler(
+            SelectionChangedEvent.TYPE, event -> onSelectionChanged(event.getSelection()));
+  }
+
+  private void onWorkspaceStopped(WorkspaceStoppedEvent event) {
+    lastSelected = null;
+    contributePart.showStub("");
+    if (selectionHandlerReg != null) {
+      selectionHandlerReg.removeHandler();
+    }
   }
 }

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/actions/ContributePartDisplayingModeAction.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/actions/ContributePartDisplayingModeAction.java
@@ -78,6 +78,7 @@ public class ContributePartDisplayingModeAction extends AbstractPerspectiveActio
 
     workspaceAgent.openPart(contributePartPresenter, TOOLING);
     workspaceAgent.setActivePart(contributePartPresenter);
+    contributePartPresenter.showContent();
   }
 
   @Override

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/parts/contribute/ContributePartPresenter.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/parts/contribute/ContributePartPresenter.java
@@ -59,6 +59,7 @@ import org.eclipse.che.plugin.pullrequest.client.workflow.Context;
 import org.eclipse.che.plugin.pullrequest.client.workflow.Step;
 import org.eclipse.che.plugin.pullrequest.client.workflow.WorkflowExecutor;
 import org.eclipse.che.plugin.pullrequest.client.workflow.WorkflowStatus;
+import org.eclipse.che.providers.DynaObject;
 import org.vectomatic.dom.svg.ui.SVGResource;
 
 /**
@@ -67,6 +68,7 @@ import org.vectomatic.dom.svg.ui.SVGResource;
  * @author Kevin Pollet
  */
 @Singleton
+@DynaObject
 public class ContributePartPresenter extends BasePresenter
     implements ContributePartView.ActionDelegate,
         StepHandler,


### PR DESCRIPTION
### What does this PR do?
- Fix restoring state of Pull Request Panel after refreshing page, start/stop workspace
- Control the PR Panel displaying corresponding to saved state when selection is changed
- Provide content for the PR Panel when Tooling part stack is opening (by Panel selector, for example)

So at first we show the PR Panel, once it is closed, it must stay closed
User can display the panel:
- using Panel selector
- from menu Assistant -> Tool Windows ->Contribute action
- by hot key

![panelselector](https://user-images.githubusercontent.com/5676062/36630577-5c7c5ce2-1971-11e8-8a2b-f928c0d58664.png)

![contributeaction](https://user-images.githubusercontent.com/5676062/36630545-e6bd2cb6-1970-11e8-8a0d-0558db572e14.png)

### What issues does this PR fix or reference?
#7975 
#7771
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>