### PR TITLE
replace duplicate env var with check if it's defined

### DIFF
--- a/dockerfiles/init/modules/openshift/files/scripts/multi-user/deploy_postgres_and_keycloak.sh
+++ b/dockerfiles/init/modules/openshift/files/scripts/multi-user/deploy_postgres_and_keycloak.sh
@@ -40,7 +40,7 @@ fi
 
 # apply all yaml files from "$COMMAND_DIR"/keycloak/
 
-IMAGE_KEYCLOAK=${IMAGE_KEYCLOAK:-"eclipse/che-keycloak:nightly"}
+if [ -z "${IMAGE_KEYCLOAK+x}" ]; then echo "[CHE] **ERROR**Env var IMAGE_KEYCLOAK is unset. You need to set it to continue. Aborting"; exit 1; fi
 
 for i in $(ls -Iconfig "$COMMAND_DIR"/keycloak ); do
     cat "${COMMAND_DIR}"/keycloak/"${i}" | sed "s#\${IMAGE_KEYCLOAK}#${IMAGE_KEYCLOAK}#" | oc apply -f -


### PR DESCRIPTION
since `IMAGE_KEYCLOAK` var was moved to `deploy_che.sh` that was a duplicate
