### PR TITLE
Fix che.workspace.auto_start property not returning from workspace service

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
@@ -85,14 +86,17 @@ public class WorkspaceService extends Service {
   private final MachineTokenProvider machineTokenProvider;
   private final WorkspaceLinksGenerator linksGenerator;
   private final String apiEndpoint;
+  private final boolean cheWorkspaceAutoStart;
 
   @Inject
   public WorkspaceService(
       @Named("che.api") String apiEndpoint,
+      @Named(CHE_WORKSPACE_AUTO_START) boolean cheWorkspaceAutoStart,
       WorkspaceManager workspaceManager,
       MachineTokenProvider machineTokenProvider,
       WorkspaceLinksGenerator linksGenerator) {
     this.apiEndpoint = apiEndpoint;
+    this.cheWorkspaceAutoStart = cheWorkspaceAutoStart;
     this.workspaceManager = workspaceManager;
     this.machineTokenProvider = machineTokenProvider;
     this.linksGenerator = linksGenerator;
@@ -685,7 +689,9 @@ public class WorkspaceService extends Service {
   public Map<String, String> getSettings() {
     return ImmutableMap.of(
         Constants.SUPPORTED_RECIPE_TYPES,
-        Joiner.on(",").join(workspaceManager.getSupportedRecipes()));
+        Joiner.on(",").join(workspaceManager.getSupportedRecipes()),
+        CHE_WORKSPACE_AUTO_START,
+        Boolean.toString(cheWorkspaceAutoStart));
   }
 
   private static Map<String, String> parseAttrs(List<String> attributes)

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -120,7 +120,8 @@ public class WorkspaceServiceTest {
 
   @BeforeMethod
   public void setup() {
-    service = new WorkspaceService(API_ENDPOINT, wsManager, machineTokenProvider, linksGenerator);
+    service =
+        new WorkspaceService(API_ENDPOINT, true, wsManager, machineTokenProvider, linksGenerator);
   }
 
   @Test
@@ -1128,7 +1129,10 @@ public class WorkspaceServiceTest {
     final Map<String, String> settings =
         new Gson().fromJson(response.print(), new TypeToken<Map<String, String>>() {}.getType());
     assertEquals(
-        settings, singletonMap(Constants.SUPPORTED_RECIPE_TYPES, "dockerimage,dockerfile"));
+        settings,
+        ImmutableMap.of(
+            Constants.SUPPORTED_RECIPE_TYPES, "dockerimage,dockerfile",
+            Constants.CHE_WORKSPACE_AUTO_START, "true"));
   }
 
   private static String unwrapError(Response response) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Return the "che.workspace.auto_start" property from the api/workspace/settings service

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8885

