### PR TITLE
Enable single-level DNS domains (*.domain.tld) in SINGLE_PORT mode to simplify HTTPS setup

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -454,5 +454,5 @@ che.infra.openshift.tls_enabled=false
 che.singleport.wildcard_domain.host=NULL
 che.singleport.wildcard_domain.port=NULL
 
-# Single port custom DNS
+# Enable single port custom DNS without inserting the IP
 che.singleport.wildcard_domain.ipless=false

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -453,3 +453,6 @@ che.infra.openshift.tls_enabled=false
 # Single port mode wildcard domain host & port. nip.io is used by default
 che.singleport.wildcard_domain.host=NULL
 che.singleport.wildcard_domain.port=NULL
+
+# Single port custom DNS
+che.singleport.wildcard_domain.ipless=false

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -249,6 +249,10 @@ CHE_SINGLE_PORT=false
 #CHE_SINGLEPORT_WILDCARD__DOMAIN_HOST=NULL
 #CHE_SINGLEPORT_WILDCARD__DOMAIN_PORT=NULL
 
+# IP-less wildcard dns in single mode. This needs a *.domain.tld DNS entry. (Use it instead of
+# nip.io)
+#CHE_SINGLEPORT_WILDCARD__DOMAIN_IPLESS=false
+
 # Default rewriter for URLs in links.
 # This variable is automatically overridden in single port mode.
 #CHE_INFRA_DOCKER_URL__REWRITER=DEFAULT

--- a/dockerfiles/init/manifests/che.pp
+++ b/dockerfiles/init/manifests/che.pp
@@ -40,6 +40,8 @@ node default {
   #
   $che_single_port = getValue("CHE_SINGLE_PORT","false")
   $che_single_port_wildcard_domain_host = getValue("CHE_SINGLEPORT_WILDCARD__DOMAIN_HOST","nip.io")
+  $che_single_port_custom_dns = getValue("CHE_SINGLEPORT_CUSTOM_DNS","false")
+
 
   ###############################
   # Che multiuser
@@ -66,6 +68,7 @@ node default {
   $system_super_privileged_mode=getValue("SYSTEM_SUPER__PRIVILEGED__MODE", "false")
 
   $che_keycloak_admin_require_update_password=getValue("CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD", "true")
+  $che_keycloak_auth__server__url=getValue("CHE_KEYCLOAK_AUTH__SERVER__URL","")
 
   ###############################
   # Include base module

--- a/dockerfiles/init/manifests/che.pp
+++ b/dockerfiles/init/manifests/che.pp
@@ -67,7 +67,6 @@ node default {
   $system_super_privileged_mode=getValue("SYSTEM_SUPER__PRIVILEGED__MODE", "false")
 
   $che_keycloak_admin_require_update_password=getValue("CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD", "true")
-  $che_keycloak_auth__server__url=getValue("CHE_KEYCLOAK_AUTH__SERVER__URL","")
 
   ###############################
   # Include base module

--- a/dockerfiles/init/manifests/che.pp
+++ b/dockerfiles/init/manifests/che.pp
@@ -40,8 +40,7 @@ node default {
   #
   $che_single_port = getValue("CHE_SINGLE_PORT","false")
   $che_single_port_wildcard_domain_host = getValue("CHE_SINGLEPORT_WILDCARD__DOMAIN_HOST","nip.io")
-  $che_single_port_custom_dns = getValue("CHE_SINGLEPORT_CUSTOM_DNS","false")
-
+  $che_single_port_wildcard_domain_ipless = getValue("CHE_SINGLEPORT_WILDCARD__DOMAIN_IPLESS","false")
 
   ###############################
   # Che multiuser

--- a/dockerfiles/init/modules/che/templates/che.env.erb
+++ b/dockerfiles/init/modules/che/templates/che.env.erb
@@ -93,7 +93,9 @@ CHE_WORKSPACE_HTTP__PROXY__JAVA__OPTIONS=<% if ! @http_proxy_for_che_workspaces.
 CHE_INFRA_DOCKER_URL__REWRITER=singleport
 
 <% if scope.lookupvar('che::che_multiuser') == 'true' -%>
-<% if ! @che_docker_ip_external.empty? -%>
+<% if scope.lookupvar('che::che_single_port') == 'true' and scope.lookupvar('che::che_single_port_custom_dns') == 'true' -%>
+CHE_KEYCLOAK_AUTH__SERVER__URL=http://keycloak.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>/auth
+<% elsif ! @che_docker_ip_external.empty? -%>
 CHE_KEYCLOAK_AUTH__SERVER__URL=http://keycloak.<%= scope.lookupvar('che::che_docker_ip_external') -%>.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>:<%= scope.lookupvar('che::che_port') -%>/auth
 <% else -%>
 CHE_KEYCLOAK_AUTH__SERVER__URL=http://keycloak.<%= scope.lookupvar('che::docker_ip') -%>.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>:<%= scope.lookupvar('che::che_port') -%>/auth

--- a/dockerfiles/init/modules/che/templates/che.env.erb
+++ b/dockerfiles/init/modules/che/templates/che.env.erb
@@ -93,7 +93,7 @@ CHE_WORKSPACE_HTTP__PROXY__JAVA__OPTIONS=<% if ! @http_proxy_for_che_workspaces.
 CHE_INFRA_DOCKER_URL__REWRITER=singleport
 
 <% if scope.lookupvar('che::che_multiuser') == 'true' -%>
-<% if scope.lookupvar('che::che_single_port') == 'true' and scope.lookupvar('che::che_single_port_custom_dns') == 'true' -%>
+<% if scope.lookupvar('che::che_single_port') == 'true' and scope.lookupvar('che::che_single_port_wildcard_domain_ipless') == 'true' -%>
 CHE_KEYCLOAK_AUTH__SERVER__URL=http://keycloak.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>/auth
 <% elsif ! @che_docker_ip_external.empty? -%>
 CHE_KEYCLOAK_AUTH__SERVER__URL=http://keycloak.<%= scope.lookupvar('che::che_docker_ip_external') -%>.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>:<%= scope.lookupvar('che::che_port') -%>/auth

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -98,7 +98,7 @@ services:
 <% end -%>
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - '<%= scope.lookupvar('che::che_instance') -%>/config/traefik/traefik.toml:/etc/traefik/traefik.toml'
+      - '<%= scope.lookupvar('che::che_instance') -%>/config/traefik:/etc/traefik'
     restart: always
 <% end -%>
 

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -162,7 +162,7 @@ services:
     labels:
       traefik.keycloak.frontend.entryPoints: "http"
       traefik.keycloak.port: "8080"
-<% if scope.lookupvar('che::che_single_port') == 'true' and scope.lookupvar('che::che_single_port_custom_dns') == 'true' -%>
+<% if scope.lookupvar('che::che_single_port') == 'true' and scope.lookupvar('che::che_single_port_wildcard_domain_ipless') == 'true' -%>
       traefik.keycloak.frontend.rule: "Host:keycloak.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>"
 <% elsif ! @che_docker_ip_external.empty? -%>
       traefik.keycloak.frontend.rule: "Host:keycloak.<%= scope.lookupvar('che::che_docker_ip_external') -%>.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>"

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -162,7 +162,9 @@ services:
     labels:
       traefik.keycloak.frontend.entryPoints: "http"
       traefik.keycloak.port: "8080"
-<% if ! @che_docker_ip_external.empty? -%>
+<% if scope.lookupvar('che::che_single_port') == 'true' and scope.lookupvar('che::che_single_port_custom_dns') == 'true' -%>
+      traefik.keycloak.frontend.rule: "Host:keycloak.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>"
+<% elsif ! @che_docker_ip_external.empty? -%>
       traefik.keycloak.frontend.rule: "Host:keycloak.<%= scope.lookupvar('che::che_docker_ip_external') -%>.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>"
 <% else -%>
       traefik.keycloak.frontend.rule: "Host:keycloak.<%= scope.lookupvar('che::docker_ip') -%>.<%= scope.lookupvar('che::che_single_port_wildcard_domain_host') -%>"

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
@@ -40,25 +40,16 @@ public class SinglePortLabelsProvisioner implements ConfigurationProvisioner {
   private final String internalIpOfContainers;
   private final String externalIpOfContainers;
   private final String dockerNetwork;
-  private final String cheHostProtocol;
-  private final Boolean singleportWildcardIPless;
-  private final String singleportWildcardDomainHost;
 
   @Inject
   public SinglePortLabelsProvisioner(
       @Nullable @Named("che.docker.ip") String internalIpOfContainers,
       @Nullable @Named("che.docker.ip.external") String externalIpOfContainers,
       @Nullable @Named("che.docker.network") String dockerNetwork,
-      @Nullable @Named("che.host.protocol") String cheHostProtocol,
-      @Nullable @Named("che.singleport.wildcard_domain.ipless") Boolean singleportWildcardIPless,
-      @Nullable @Named("che.singleport.wildcard_domain.host") String singleportWildcardDomainHost,
       Provider<SinglePortHostnameBuilder> hostnameBuilderProvider) {
     this.hostnameBuilderProvider = hostnameBuilderProvider;
     this.internalIpOfContainers = internalIpOfContainers;
     this.externalIpOfContainers = externalIpOfContainers;
-    this.singleportWildcardIPless = singleportWildcardIPless;
-    this.cheHostProtocol = cheHostProtocol;
-    this.singleportWildcardDomainHost = singleportWildcardDomainHost;
     this.dockerNetwork = dockerNetwork;
   }
 
@@ -100,7 +91,7 @@ public class SinglePortLabelsProvisioner implements ConfigurationProvisioner {
   /**
    * Constructs unique traefik service name - contains server, machine names and workspace ID. Dots
    * is not allowed and replaced by dashes. Result is like:
-   * exec-agent-http-dev-machine-workspaceao6k83hkdav975g5
+   * exec-agent-http_dev-machine_workspaceao6k83hkdav975g5
    */
   private String getServiceName(String host) {
     int idx =

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
@@ -91,7 +91,7 @@ public class SinglePortLabelsProvisioner implements ConfigurationProvisioner {
   /**
    * Constructs unique traefik service name - contains server, machine names and workspace ID. Dots
    * is not allowed and replaced by dashes. Result is like:
-   * exec-agent-http_dev-machine_workspaceao6k83hkdav975g5
+   * exec-agent-http-dev-machine-workspaceao6k83hkdav975g5
    */
   private String getServiceName(String host) {
     int idx = host.indexOf(".");

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
@@ -107,7 +107,7 @@ public class SinglePortLabelsProvisioner implements ConfigurationProvisioner {
         (externalIpOfContainers != null && host.contains(externalIpOfContainers))
             ? host.indexOf(externalIpOfContainers)
             : host.indexOf(internalIpOfContainers);
-    if (idx <= 1) {
+    if (idx > 1) {
       return host.substring(0, idx - 1).replaceAll("\\.", "-");
     } else {
       // the hostname does not contain the external or internal IPs

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
@@ -75,7 +75,7 @@ public class SinglePortLabelsProvisioner implements ConfigurationProvisioner {
 
         containerLabels.put(format("traefik.%s.port", serviceName), port);
         containerLabels.put(
-            format("traefik.%s.frontend.entryPoints", serviceName), "http,https,ws,wss");
+            format("traefik.%s.frontend.entryPoints", serviceName), "http");
         containerLabels.put(format("traefik.%s.frontend.rule", serviceName), "Host:" + host);
         // Needed to activate per-service rules
         containerLabels.put("traefik.frontend.rule", machineName);

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
@@ -74,7 +74,8 @@ public class SinglePortLabelsProvisioner implements ConfigurationProvisioner {
         final String port = serverEntry.getValue().getPort().split("/")[0];
 
         containerLabels.put(format("traefik.%s.port", serviceName), port);
-        containerLabels.put(format("traefik.%s.frontend.entryPoints", serviceName), "http");
+        containerLabels.put(
+            format("traefik.%s.frontend.entryPoints", serviceName), "http,https,ws,wss");
         containerLabels.put(format("traefik.%s.frontend.rule", serviceName), "Host:" + host);
         // Needed to activate per-service rules
         containerLabels.put("traefik.frontend.rule", machineName);
@@ -94,10 +95,11 @@ public class SinglePortLabelsProvisioner implements ConfigurationProvisioner {
    * exec-agent-http-dev-machine-workspaceao6k83hkdav975g5
    */
   private String getServiceName(String host) {
-    int idx =
-        (externalIpOfContainers != null && host.contains(externalIpOfContainers))
-            ? host.indexOf(externalIpOfContainers)
-            : host.indexOf(internalIpOfContainers);
-    return host.substring(0, idx - 1).replaceAll("\\.", "-");
+    // int idx =
+    //     (externalIpOfContainers != null && host.contains(externalIpOfContainers))
+    //         ? host.indexOf(externalIpOfContainers)
+    //         : host.indexOf(internalIpOfContainers);
+    // return host.substring(0, idx - 1).replaceAll("\\.", "-");
+    return host.replaceAll("\\.", "-");
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/provisioner/labels/SinglePortLabelsProvisioner.java
@@ -94,15 +94,12 @@ public class SinglePortLabelsProvisioner implements ConfigurationProvisioner {
    * exec-agent-http_dev-machine_workspaceao6k83hkdav975g5
    */
   private String getServiceName(String host) {
-    int idx =
-        (externalIpOfContainers != null && host.contains(externalIpOfContainers))
-            ? host.indexOf(externalIpOfContainers)
-            : host.indexOf(internalIpOfContainers);
+    int idx = host.indexOf(".");
     if (idx > 1) {
-      return host.substring(0, idx - 1).replaceAll("\\.", "-");
+      return host.substring(0, idx - 1);
     } else {
-      // the hostname does not contain the external or internal IPs
-      return host.replaceAll("\\.", "-");
+      // the hostname does not contain the external or internal IPs (or in general any dots)
+      return host;
     }
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
@@ -54,7 +54,7 @@ public class SinglePortHostnameBuilder {
    * @return composite hostname
    */
   public String build(String serverName, String machineName, String workspaceID) {
-    StringJoiner joiner = new StringJoiner(".");
+    StringJoiner joiner = new StringJoiner("_");
     if (serverName != null) {
       joiner.add(normalize(serverName));
     }
@@ -64,8 +64,8 @@ public class SinglePortHostnameBuilder {
     if (workspaceID != null) {
       joiner.add(normalize(workspaceID));
     }
-    joiner.add(wildcardDomain);
-    return joiner.toString();
+    // joiner.add(wildcardDomain);
+    return joiner.toString() + "." + wildcardDomain;
   }
 
   /**
@@ -74,8 +74,13 @@ public class SinglePortHostnameBuilder {
    * @return wildcard domain
    */
   private String getWildcardDomain(String localAddress, String wildcardHost) {
-    return String.format(
-        "%s.%s", getExternalIp(localAddress), wildcardHost == null ? "nip.io" : wildcardHost);
+    // todo: reenable nip.io etc if these are selected (not null) as wildcard (no ip added right
+    // now)
+    return wildcardHost == null
+        ? String.format("%s.%s", getExternalIp(localAddress), "nip.io")
+        : wildcardHost;
+    // return String.format(
+    //     "%s.%s", getExternalIp(localAddress), wildcardHost == null ? "nip.io" : wildcardHost);
   }
 
   private String getExternalIp(String localAddress) {

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
@@ -22,7 +22,7 @@ import org.eclipse.che.inject.ConfigurationException;
 
 /**
  * Produces host names in form:
- * [serverName].[machineName].[workspaceId].<external_or_internal_address>.<wildcardNipDomain> If
+ * [serverName]_[machineName]_[workspaceId].<external_or_internal_address>.<wildcardNipDomain> If
  * some of the server name or machine name or workspace id is null, they will be not included.
  *
  * @author Max Shaposhnik (mshaposh@redhat.com)
@@ -39,7 +39,6 @@ public class SinglePortHostnameBuilder {
 
   public SinglePortHostnameBuilder(
       String externalAddress, String internalAddress, String wildcardHost) {
-
     this.wildcardDomain =
         externalAddress != null
             ? getWildcardDomain(externalAddress, wildcardHost)
@@ -65,12 +64,12 @@ public class SinglePortHostnameBuilder {
     if (workspaceID != null) {
       joiner.add(normalize(workspaceID));
     }
-    // joiner.add(wildcardDomain);
     return joiner.toString() + "." + wildcardDomain;
   }
 
   /**
    * Gets a Wildcard domain based on the ip using an external provider like nip.io
+   * or by providing an IP-less DNS yourself
    *
    * @return wildcard domain
    */
@@ -80,7 +79,7 @@ public class SinglePortHostnameBuilder {
     } else if (wildcardHost.contains("nip.io") || wildcardHost.contains("xip.io")) {
       return String.format("%s.%s", getExternalIp(localAddress), wildcardHost);
     } else {
-      // custom dns
+      // IP-less DNS
       return wildcardHost;
     }
   }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
@@ -22,7 +22,7 @@ import org.eclipse.che.inject.ConfigurationException;
 
 /**
  * Produces host names in form:
- * [serverName]_[machineName]_[workspaceId].<external_or_internal_address>.<wildcardNipDomain> If
+ * [serverName]-[machineName]-[workspaceId].<external_or_internal_address>.<wildcardNipDomain> If
  * some of the server name or machine name or workspace id is null, they will be not included.
  *
  * @author Max Shaposhnik (mshaposh@redhat.com)
@@ -54,7 +54,7 @@ public class SinglePortHostnameBuilder {
    * @return composite hostname
    */
   public String build(String serverName, String machineName, String workspaceID) {
-    StringJoiner joiner = new StringJoiner("_");
+    StringJoiner joiner = new StringJoiner("-");
     if (serverName != null) {
       joiner.add(normalize(serverName));
     }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
@@ -39,6 +39,7 @@ public class SinglePortHostnameBuilder {
 
   public SinglePortHostnameBuilder(
       String externalAddress, String internalAddress, String wildcardHost) {
+
     this.wildcardDomain =
         externalAddress != null
             ? getWildcardDomain(externalAddress, wildcardHost)
@@ -74,13 +75,14 @@ public class SinglePortHostnameBuilder {
    * @return wildcard domain
    */
   private String getWildcardDomain(String localAddress, String wildcardHost) {
-    // todo: reenable nip.io etc if these are selected (not null) as wildcard (no ip added right
-    // now)
-    return wildcardHost == null
-        ? String.format("%s.%s", getExternalIp(localAddress), "nip.io")
-        : wildcardHost;
-    // return String.format(
-    //     "%s.%s", getExternalIp(localAddress), wildcardHost == null ? "nip.io" : wildcardHost);
+    if (wildcardHost == null) {
+      return String.format("%s.%s", getExternalIp(localAddress), "nip.io");
+    } else if (wildcardHost.contains("nip.io") || wildcardHost.contains("xip.io")) {
+      return String.format("%s.%s", getExternalIp(localAddress), wildcardHost);
+    } else {
+      // custom dns
+      return wildcardHost;
+    }
   }
 
   private String getExternalIp(String localAddress) {

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/server/mapping/SinglePortHostnameBuilder.java
@@ -68,8 +68,8 @@ public class SinglePortHostnameBuilder {
   }
 
   /**
-   * Gets a Wildcard domain based on the ip using an external provider like nip.io
-   * or by providing an IP-less DNS yourself
+   * Gets a Wildcard domain based on the ip using an external provider like nip.io or by providing
+   * an IP-less DNS yourself
    *
    * @return wildcard domain
    */


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR changes the behavior how DNS names for `SINGLE_PORT` mode are generated, if the new ENV variable `CHE_SINGLEPORT_CUSTOM_DNS` is set to `true`. It will then generate DNS names with underscores instead of dots, such that all subdomains are conforming to `*.domain.tld`, which is important for a HTTPS setup using a wildcard certificate (usually only `*.domain.tld` is supported by wildcard certificates, not `*.*.domain.tld` and so on). This requires a wildcard DNS entry for your domain in the form of `*.domain.tld` and **won't** use any service like `nip.io`.

`CHE_SINGLEPORT_WILDCARD__DOMAIN_HOST` needs to be set to `domain.tld` in that case.

Work to do:
- change the Java part to enable this only if the  `CHE_SINGLEPORT_CUSTOM_DNS` flag is set (currently hardcoded)

I would like to get feedback if this is something upstream che would want. If yes, I will solve the outstanding issues and write documentation for it. It would certainly make HTTPS setup easier for everyone and I would not need to maintain a patched fork of che.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
SINGLE_PORT mode now supports custom single level DNS domains `*.domain.tld`

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
https://github.com/eclipse/che-docs/pull/371