### PR TITLE
[WIP] Selenium: Add checking of item selection to the "CodenvyEditor#enterTextIntoFixErrorPropByEnter(String item)" method

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
@@ -58,6 +58,7 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.textToBePresentI
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfAllElements;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfAllElementsLocatedBy;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfNestedElementsLocatedBy;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.inject.Inject;
@@ -959,7 +960,23 @@ public class CodenvyEditor {
     seleniumWebDriverHelper.waitAndClick(
         propositionContainer.findElement(By.xpath(format("//li//span[text()=\"%s\"]", item))));
 
+    waitProposalItemSelection(item);
+
     seleniumWebDriverHelper.sendKeys(ENTER.toString());
+  }
+
+  /**
+   * Waits until {@code item} from "Proposal Container" will be selected
+   *
+   * @param item item's visible name
+   */
+  public void waitProposalItemSelection(String item) {
+    webDriverWaitFactory
+        .get()
+        .until(
+            visibilityOfNestedElementsLocatedBy(
+                propositionContainer,
+                By.xpath(format("//li[@selected='true']//span[text()=\"%s\"]", item))));
   }
 
   /**

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/OrganizeImportsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/OrganizeImportsTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.assistant;
 
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -28,6 +29,7 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.OrganizeImports;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.openqa.selenium.TimeoutException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -110,7 +112,13 @@ public class OrganizeImportsTest {
     loader.waitOnClosed();
     editor.goToCursorPositionVisible(20, 8);
     editor.launchPropositionAssistPanel();
-    editor.enterTextIntoFixErrorPropByEnter("Organize imports");
+    try {
+      editor.enterTextIntoFixErrorPropByEnter("Organize imports");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/8972");
+    }
+
     loader.waitOnClosed();
 
     try {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/CodeAssistAfterMoveItemTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/CodeAssistAfterMoveItemTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.refactor.move;
 
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -25,6 +26,7 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -99,7 +101,13 @@ public class CodeAssistAfterMoveItemTest {
     editor.launchPropositionAssistPanel();
     loader.waitOnClosed();
     editor.waitTextIntoFixErrorProposition("Import 'A5' (p1)");
-    editor.enterTextIntoFixErrorPropByEnter("Import 'A5' (p1)");
+    try {
+      editor.enterTextIntoFixErrorPropByEnter("Import 'A5' (p1)");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/8972");
+    }
+
     editor.waitTextIntoEditor("import p1.A5;");
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add checking of item selection to the "CodenvyEditor#enterTextIntoFixErrorPropByEnter(String item)" method

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/8972
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
