### PR TITLE
Allow to configure logback logger with env variables

### DIFF
--- a/assembly/assembly-ide-war/pom.xml
+++ b/assembly/assembly-ide-war/pom.xml
@@ -57,6 +57,16 @@
             <artifactId>che-core-commons-j2ee</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-logback</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>che-core-api-core</artifactId>
+                    <groupId>org.eclipse.che.core</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <scope>provided</scope>
@@ -112,6 +122,7 @@
                                 <!-- dependency is required just to overlay it's content -->
                                 <dep>org.eclipse.che:che-ide-gwt-app</dep>
                                 <dep>org.eclipse.che.core:che-core-commons-j2ee</dep>
+                                <dep>org.eclipse.che.core:che-core-commons-logback</dep>
                                 <dep>ch.qos.logback:logback-classic</dep>
                             </ignoredUnusedDeclaredDependencies>
                         </configuration>

--- a/core/commons/che-core-commons-logback/pom.xml
+++ b/core/commons/che-core-commons-logback/pom.xml
@@ -23,6 +23,14 @@
     <name>Che Core :: Commons :: Commons Logback</name>
     <dependencies>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
@@ -10,8 +10,6 @@
  */
 package org.eclipse.che.commons.logback;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -52,7 +50,7 @@ public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
     String loggerName = parts[0];
     String levelStr = parts[1];
 
-    if (isNullOrEmpty(loggerName) || isNullOrEmpty(levelStr)) {
+    if (levelStr.isEmpty() || loggerName.isEmpty()) {
       return;
     }
 

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
@@ -71,10 +71,12 @@ public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
     }
   }
 
+  @Override
   public void stop() {
     isStarted = false;
   }
 
+  @Override
   public boolean isStarted() {
     return isStarted;
   }

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
@@ -42,19 +42,18 @@ public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
   }
 
   private void setLoggerLevel(String loggerConfig) {
-    String[] parts = loggerConfig.split("=");
+    String[] parts = loggerConfig.split("=", 2);
 
     if (parts.length < 2) {
       return;
     }
     String loggerName = parts[0];
     String levelStr = parts[1];
-    if (loggerName == null) {
+
+    if (loggerName == null || levelStr == null || levelStr.isEmpty() || loggerName.isEmpty()) {
       return;
     }
-    if (levelStr == null) {
-      return;
-    }
+
     loggerName = loggerName.trim();
     levelStr = levelStr.trim();
 

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.commons.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggerContextListener;
+import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.spi.LifeCycle;
+import java.util.Arrays;
+
+public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
+    implements LoggerContextListener, LifeCycle {
+
+  private boolean isStarted;
+
+  private void setLoggerLevel(String loggerConfig) {
+    int i = loggerConfig.indexOf('=');
+    if (i < 0) {
+      return;
+    }
+    String loggerName = loggerConfig.substring(0, i);
+    String levelStr = loggerConfig.substring(i + 1);
+    if (loggerName == null) {
+      return;
+    }
+    if (levelStr == null) {
+      return;
+    }
+    loggerName = loggerName.trim();
+    levelStr = levelStr.trim();
+
+    addInfo("Trying to set level " + levelStr + " to logger " + loggerName);
+    LoggerContext lc = (LoggerContext) context;
+
+    Logger logger = lc.getLogger(loggerName);
+    if ("null".equalsIgnoreCase(levelStr)) {
+      logger.setLevel(null);
+    } else {
+      Level level = Level.toLevel(levelStr, null);
+      if (level != null) {
+        logger.setLevel(level);
+      }
+    }
+  }
+
+  @Override
+  public void start() {
+
+    String config = System.getenv("CHE_LOGGER_CONFIG");
+    if (config != null && !config.isEmpty()) {
+      Arrays.stream(config.split(",")).map(String::trim).forEach(this::setLoggerLevel);
+    }
+    isStarted = true;
+  }
+
+  public void stop() {
+    isStarted = false;
+  }
+
+  public boolean isStarted() {
+    return isStarted;
+  }
+
+  @Override
+  public boolean isResetResistant() {
+    return false;
+  }
+
+  @Override
+  public void onStart(LoggerContext context) {}
+
+  @Override
+  public void onReset(LoggerContext context) {}
+
+  @Override
+  public void onStop(LoggerContext context) {}
+
+  @Override
+  public void onLevelChange(Logger logger, Level level) {}
+}

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.commons.logback;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.LoggerContext;
@@ -50,7 +52,7 @@ public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
     String loggerName = parts[0];
     String levelStr = parts[1];
 
-    if (loggerName == null || levelStr == null || levelStr.isEmpty() || loggerName.isEmpty()) {
+    if (isNullOrEmpty(loggerName) || isNullOrEmpty(levelStr)) {
       return;
     }
 

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
@@ -42,12 +42,13 @@ public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
   }
 
   private void setLoggerLevel(String loggerConfig) {
-    int i = loggerConfig.indexOf('=');
-    if (i < 0) {
+    String[] parts = loggerConfig.split("=");
+
+    if (parts.length < 2) {
       return;
     }
-    String loggerName = loggerConfig.substring(0, i);
-    String levelStr = loggerConfig.substring(i + 1);
+    String loggerName = parts[0];
+    String levelStr = parts[1];
     if (loggerName == null) {
       return;
     }
@@ -57,7 +58,6 @@ public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
     loggerName = loggerName.trim();
     levelStr = levelStr.trim();
 
-    addInfo("Trying to set level " + levelStr + " to logger " + loggerName);
     LoggerContext lc = (LoggerContext) context;
 
     Logger logger = lc.getLogger(loggerName);

--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
@@ -18,10 +18,28 @@ import ch.qos.logback.core.spi.ContextAwareBase;
 import ch.qos.logback.core.spi.LifeCycle;
 import java.util.Arrays;
 
+/**
+ * Class searches environment variable CHE_LOGGER_CONFIG Value of this variable is expected in such
+ * format:
+ *
+ * <p>CHE_LOGGER_CONFIG=logger1_name=logger1_level,logger2_name=logger2_level
+ *
+ * <p>In case if some logger name or logger level are omitted this pair will be silently ignored.
+ */
 public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
     implements LoggerContextListener, LifeCycle {
 
   private boolean isStarted;
+
+  @Override
+  public void start() {
+
+    String config = System.getenv("CHE_LOGGER_CONFIG");
+    if (config != null && !config.isEmpty()) {
+      Arrays.stream(config.split(",")).map(String::trim).forEach(this::setLoggerLevel);
+    }
+    isStarted = true;
+  }
 
   private void setLoggerLevel(String loggerConfig) {
     int i = loggerConfig.indexOf('=');
@@ -51,16 +69,6 @@ public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
         logger.setLevel(level);
       }
     }
-  }
-
-  @Override
-  public void start() {
-
-    String config = System.getenv("CHE_LOGGER_CONFIG");
-    if (config != null && !config.isEmpty()) {
-      Arrays.stream(config.split(",")).map(String::trim).forEach(this::setLoggerLevel);
-    }
-    isStarted = true;
   }
 
   public void stop() {

--- a/wsagent/che-wsagent-core/pom.xml
+++ b/wsagent/che-wsagent-core/pom.xml
@@ -93,6 +93,16 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-logback</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>che-core-api-core</artifactId>
+                    <groupId>org.eclipse.che.core</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-schedule</artifactId>
         </dependency>
         <dependency>
@@ -162,6 +172,7 @@
                                 <ignoredDependency>org.slf4j:jul-to-slf4j</ignoredDependency>
                                 <ignoredDependency>org.slf4j:jcl-over-slf4j</ignoredDependency>
                                 <ignoredDependency>org.slf4j:log4j-over-slf4j</ignoredDependency>
+                                <ignoredDependency>org.eclipse.che.core:che-core-commons-logback</ignoredDependency>
                             </ignoredDependencies>
                         </configuration>
                     </execution>


### PR DESCRIPTION
### What does this PR do?
Allow to configure logback logger with env variables
Example.
```
CHE_LOGGER_CONFIG=org.eclipse.che=DEBUG,org.eclipse.che.api.installer.server.impl.LocalInstallerRegistry=OFF 
```
To be able to configure ws-master  - a user will have to add this variable to che.env
<img width="786" alt="2018-03-03 09 42 00" src="https://user-images.githubusercontent.com/1614429/36931827-298cfcd2-1ec7-11e8-9119-1cc28198dcb6.png">

In case of ws-agent - a user will have to add this variable to env configuration of the desired machine.
![2018-03-02 15 36 28](https://user-images.githubusercontent.com/1614429/36931823-120f02c6-1ec7-11e8-9885-95f5a42544a8.png)


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/8997
Depend on https://github.com/eclipse/che-lib/pull/79

#### Release Notes
CHE_LOGGER_CONFIG environment variable is used to configure logback logger
#### Docs PR
https://github.com/eclipse/che-docs/pull/369