### PR TITLE
Restore Che5 factory behavior.

### DIFF
--- a/plugins/plugin-urlfactory/src/main/java/org/eclipse/che/plugin/urlfactory/URLFactoryBuilder.java
+++ b/plugins/plugin-urlfactory/src/main/java/org/eclipse/che/plugin/urlfactory/URLFactoryBuilder.java
@@ -11,12 +11,12 @@
 package org.eclipse.che.plugin.urlfactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -108,7 +108,9 @@ public class URLFactoryBuilder {
     }
     MachineConfigDto machine =
         newDto(MachineConfigDto.class)
-            .withInstallers(singletonList("org.eclipse.che.ws-agent"))
+            .withInstallers(
+                ImmutableList.of(
+                    "org.eclipse.che.ws-agent", "org.eclipse.che.exec", "org.eclipse.che.terminal"))
             .withAttributes(singletonMap(MEMORY_LIMIT_ATTRIBUTE, DEFAULT_MEMORY_LIMIT_BYTES));
 
     // setup environment

--- a/plugins/plugin-urlfactory/src/test/java/org/eclipse/che/plugin/urlfactory/URLFactoryBuilderTest.java
+++ b/plugins/plugin-urlfactory/src/test/java/org/eclipse/che/plugin/urlfactory/URLFactoryBuilderTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.plugin.urlfactory;
 
 import static java.lang.Boolean.FALSE;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
@@ -22,6 +21,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
+import com.google.common.collect.ImmutableList;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.MachineConfigDto;
@@ -59,7 +59,9 @@ public class URLFactoryBuilderTest {
         newDto(RecipeDto.class).withContent(DEFAULT_DOCKER_IMAGE).withType("dockerimage");
     MachineConfigDto machine =
         newDto(MachineConfigDto.class)
-            .withInstallers(singletonList("org.eclipse.che.ws-agent"))
+            .withInstallers(
+                ImmutableList.of(
+                    "org.eclipse.che.ws-agent", "org.eclipse.che.exec", "org.eclipse.che.terminal"))
             .withAttributes(singletonMap(MEMORY_LIMIT_ATTRIBUTE, DEFAULT_MEMORY_LIMIT_BYTES));
 
     // setup environment
@@ -95,7 +97,9 @@ public class URLFactoryBuilderTest {
             .withContentType("text/x-dockerfile");
     MachineConfigDto machine =
         newDto(MachineConfigDto.class)
-            .withInstallers(singletonList("org.eclipse.che.ws-agent"))
+            .withInstallers(
+                ImmutableList.of(
+                    "org.eclipse.che.ws-agent", "org.eclipse.che.exec", "org.eclipse.che.terminal"))
             .withAttributes(singletonMap(MEMORY_LIMIT_ATTRIBUTE, DEFAULT_MEMORY_LIMIT_BYTES));
 
     // setup environment
@@ -129,7 +133,9 @@ public class URLFactoryBuilderTest {
         newDto(RecipeDto.class).withContent(DEFAULT_DOCKER_IMAGE).withType("dockerimage");
     MachineConfigDto machine =
         newDto(MachineConfigDto.class)
-            .withInstallers(singletonList("org.eclipse.che.ws-agent"))
+            .withInstallers(
+                ImmutableList.of(
+                    "org.eclipse.che.ws-agent", "org.eclipse.che.exec", "org.eclipse.che.terminal"))
             .withAttributes(singletonMap(MEMORY_LIMIT_ATTRIBUTE, DEFAULT_MEMORY_LIMIT_BYTES));
 
     // setup environment


### PR DESCRIPTION


### What does this PR do?
Restore Che5 factory behavior.
Factories without configuration will have terminal and exec agent enabled.

#### Release Notes
Restore Che5 factory behavior.
Factories without configuration will have terminal and exec agent enabled.

#### Docs PR
n/a
