### PR TITLE
Use JWT instead of machine token to be able recover workspaces

### DIFF
--- a/agents/go-agents/Godeps/Godeps.json
+++ b/agents/go-agents/Godeps/Godeps.json
@@ -1,8 +1,16 @@
 {
 	"ImportPath": "github.com/eclipse/che/agents/go-agents",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v74",
+	"GodepVersion": "v80",
+	"Packages": [
+		"./..."
+	],
 	"Deps": [
+		{
+			"ImportPath": "github.com/dgrijalva/jwt-go",
+			"Comment": "v3.1.0",
+			"Rev": "dbeaa9332f19a944acb5736b4456cfcc02140e29"
+		},
 		{
 			"ImportPath": "github.com/eclipse/che-lib/pty",
 			"Comment": "4.6.0-2-g69a9cee",

--- a/agents/go-agents/core/auth/auth_test.go
+++ b/agents/go-agents/core/auth/auth_test.go
@@ -1,0 +1,107 @@
+//
+// Copyright (c) 2012-2018 Red Hat, Inc.
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Eclipse Public License v1.0
+// which accompanies this distribution, and is available at
+// http://www.eclipse.org/legal/epl-v10.html
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package auth
+
+import (
+	"crypto/x509"
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+const (
+	Token                    = "eyJraW5kIjoibWFjaGluZV90b2tlbiIsImFsZyI6IlJTNTEyIn0.eyJ3c2lkIjoid29ya3NwYWNla3JoOTl4amVuZWs3amN5ZSIsInVpZCI6InRlc3RfdXNlcjMxIiwidW5hbWUiOiJ0ZXN0X3VzZXIiLCJqdGkiOiI4MzEyLTIxMy0xd2UzMSJ9.TX3ZyWgIyFmOPe8yHQWGXNOwmuAxp1lIZEdzXAmhf6nnUKLHV5QLV2qNI1iuDta0fLXtB_Wwf6Mpqkx8J1ighNhgUfbro7OujIlAezx3sEBHI-Ntzb1JHsbr_xKxrzhEVT7NuvkJuB1RlFEpZmRt0Sf86UOoKZSsYypuCOA1vZU"
+	EncodedPublicKey         = "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC85cPsQ8FLvvI6NY5DGiq2YIdAlq2MkNcGgrQggQqTwTyQ7MgPYO7o4BYc5BjOljQ93g/vzyN9Ku9YahHjQTT9X3IdZSk7+UINvKF/3gPjprHYQ2t1PswNNCViqwEN1nktvbugJjI3FYnr5eiBxkV+7wwggxEILGfKL67I+HnA0QIDAQAB"
+	TestWorkspaceId          = "workspacekrh99xjenek7jcye"
+	TokenWithDifferentSigAlg = "eyJraW5kIjoibWFjaGluZV90b2tlbiIsImFsZyI6IkVTNTEyIn0.eyJ3c2lkIjoid29ya3NwYWNla3JoOTl4amVuZWs3amN5ZSIsInVpZCI6InRlc3RfdXNlcjMxIiwidW5hbWUiOiJ0ZXN0X3VzZXIiLCJqdGkiOiI4MzEyLTIxMy0xd2UzMSJ9.ATHOy78MXfi9e2MzS_GENXwI7wddmdeEzcMKQfKCgw78n-_YoI0vWowNS-AOMiJKeBtNlgTMRnsY_H1lsK8QxRZMOFg-KaRwAQkZTJBB1D107KPNbI-FYBORhMu0PNV2-j9_DwIUiv_lek9bmE02ibY28VzPOhl-V9iTYWecsgzAsC0ACzyRbZaZIkRShlN7"
+)
+
+type ConstSignKeyProvider struct{}
+
+func (enk ConstSignKeyProvider) GetKey() (interface{}, error) {
+	bytes, _ := base64.StdEncoding.DecodeString(EncodedPublicKey)
+	key, _ := x509.ParsePKIXPublicKey(bytes)
+	return key, nil
+}
+
+func TestAuthenticateWithValidRSAToken(t *testing.T) {
+	WorkspaceId = TestWorkspaceId
+	KeyProvider = &ConstSignKeyProvider{}
+	if err := authenticate(Token); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAuthenticationFailedWhenNoWorkspaceIdInEnv(t *testing.T) {
+	WorkspaceId = ""
+	KeyProvider = &ConstSignKeyProvider{}
+	err := authenticate(Token)
+	if err == nil {
+		t.Fatal("Expecting error when no workspace id in an environment")
+	}
+	expectedError := "Authentication failed, due to kind: 'machine_token' or workspace id: '' is wrong"
+	if err.Error() != expectedError {
+		t.Fatalf("Expecting error message: '%v'", expectedError)
+	}
+}
+
+func TestAuthenticationFailedWhenFailedToGetKey(t *testing.T) {
+	WorkspaceId = TestWorkspaceId
+	KeyProvider = &EnvSignKeyProvider{}
+	err := authenticate(Token)
+	if err == nil {
+		t.Fatal("Expecting error when no signature key in environment")
+	}
+	errorPrefix := "Authentication failed. Failed to parse public key cause:"
+	if !strings.HasPrefix(err.Error(), errorPrefix) {
+		t.Fatalf("Expecting error prefix: '%v'", errorPrefix)
+	}
+}
+
+func TestAuthenticationFailedWhenEmptyTokenProvided(t *testing.T) {
+	WorkspaceId = TestWorkspaceId
+	KeyProvider = &ConstSignKeyProvider{}
+	err := authenticate("")
+	if err == nil {
+		t.Fatal("Expecting error when no empty token provided")
+	}
+	expectedError := "Authentication failed because: missing 'token' query parameter"
+	if err.Error() != expectedError {
+		t.Fatalf("Expecting error message: '%v'", expectedError)
+	}
+}
+
+func TestAuthenticationFailedWhenTokenWithInvalidSignatureProvided(t *testing.T) {
+	WorkspaceId = TestWorkspaceId
+	KeyProvider = &ConstSignKeyProvider{}
+	err := authenticate("invalid_token")
+	if err == nil {
+		t.Fatal("Expecting error when no signature key in environment")
+	}
+	errorPrefix := "Authentication failed."
+	if !strings.HasPrefix(err.Error(), errorPrefix) {
+		t.Fatalf("Expecting error prefix: '%v'", errorPrefix)
+	}
+}
+
+func TestAuthenticationFailedWhenTokenSignedWithDifferentAlgorithmProvided(t *testing.T) {
+	WorkspaceId = TestWorkspaceId
+	KeyProvider = &ConstSignKeyProvider{}
+	err := authenticate(TokenWithDifferentSigAlg)
+	if err == nil {
+		t.Fatal("Expecting error when token with different signature algorithm provided")
+	}
+	expectedError := "Authentication failed. token with unsupported signing method 'ES512' provided"
+	if err.Error() != expectedError {
+		t.Fatalf("Expecting error message: '%v'", expectedError)
+	}
+}

--- a/agents/go-agents/core/auth/sign_key.go
+++ b/agents/go-agents/core/auth/sign_key.go
@@ -1,0 +1,47 @@
+//
+// Copyright (c) 2012-2018 Red Hat, Inc.
+// All rights reserved. This program and the accompanying materials
+// are made available under the terms of the Eclipse Public License v1.0
+// which accompanies this distribution, and is available at
+// http://www.eclipse.org/legal/epl-v10.html
+//
+// Contributors:
+//   Red Hat, Inc. - initial API and implementation
+//
+
+package auth
+
+import (
+	"encoding/base64"
+	"os"
+	"errors"
+	"crypto/x509"
+)
+
+const SignatureKeyEnv = "CHE_MACHINE_AUTH_SIGNATURE__PUBLIC__KEY"
+
+// SignKeyProvider provides signature key
+type SignKeyProvider interface {
+	GetKey() (interface{}, error)
+}
+
+// EnvSignKeyProvider provides public key retrieved from environment
+type EnvSignKeyProvider struct {
+	PublicKey interface{}
+}
+
+func (enk EnvSignKeyProvider) GetKey() (interface{}, error) {
+	if enk.PublicKey == nil {
+		// Key may contain symbols that are unacceptable for environment variables values, so it must be encoded in base64
+		bytes, err := base64.StdEncoding.DecodeString(os.Getenv(SignatureKeyEnv))
+		if err != nil {
+			return nil, errors.New("Failed to encode public key cause: " + err.Error())
+		}
+		key, err := x509.ParsePKIXPublicKey(bytes)
+		if err != nil {
+			return nil, errors.New("Failed to parse public key cause: " + err.Error())
+		}
+		enk.PublicKey = key
+	}
+	return enk.PublicKey, nil
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/.gitignore
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+bin
+
+

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/.travis.yml
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+script:
+    - go vet ./...
+    - go test -v ./...
+
+go:
+  - 1.3
+  - 1.4
+  - 1.5
+  - 1.6
+  - 1.7
+  - tip

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/LICENSE
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/LICENSE
@@ -1,0 +1,8 @@
+Copyright (c) 2012 Dave Grijalva
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/MIGRATION_GUIDE.md
@@ -1,0 +1,97 @@
+## Migration Guide from v2 -> v3
+
+Version 3 adds several new, frequently requested features.  To do so, it introduces a few breaking changes.  We've worked to keep these as minimal as possible.  This guide explains the breaking changes and how you can quickly update your code.
+
+### `Token.Claims` is now an interface type
+
+The most requested feature from the 2.0 verison of this library was the ability to provide a custom type to the JSON parser for claims. This was implemented by introducing a new interface, `Claims`, to replace `map[string]interface{}`.  We also included two concrete implementations of `Claims`: `MapClaims` and `StandardClaims`.
+
+`MapClaims` is an alias for `map[string]interface{}` with built in validation behavior.  It is the default claims type when using `Parse`.  The usage is unchanged except you must type cast the claims property.
+
+The old example for parsing a token looked like this..
+
+```go
+	if token, err := jwt.Parse(tokenString, keyLookupFunc); err == nil {
+		fmt.Printf("Token for user %v expires %v", token.Claims["user"], token.Claims["exp"])
+	}
+```
+
+is now directly mapped to...
+
+```go
+	if token, err := jwt.Parse(tokenString, keyLookupFunc); err == nil {
+		claims := token.Claims.(jwt.MapClaims)
+		fmt.Printf("Token for user %v expires %v", claims["user"], claims["exp"])
+	}
+```
+
+`StandardClaims` is designed to be embedded in your custom type.  You can supply a custom claims type with the new `ParseWithClaims` function.  Here's an example of using a custom claims type.
+
+```go
+	type MyCustomClaims struct {
+		User string
+		*StandardClaims
+	}
+	
+	if token, err := jwt.ParseWithClaims(tokenString, &MyCustomClaims{}, keyLookupFunc); err == nil {
+		claims := token.Claims.(*MyCustomClaims)
+		fmt.Printf("Token for user %v expires %v", claims.User, claims.StandardClaims.ExpiresAt)
+	}
+```
+
+### `ParseFromRequest` has been moved
+
+To keep this library focused on the tokens without becoming overburdened with complex request processing logic, `ParseFromRequest` and its new companion `ParseFromRequestWithClaims` have been moved to a subpackage, `request`.  The method signatues have also been augmented to receive a new argument: `Extractor`.
+
+`Extractors` do the work of picking the token string out of a request.  The interface is simple and composable.
+
+This simple parsing example:
+
+```go
+	if token, err := jwt.ParseFromRequest(tokenString, req, keyLookupFunc); err == nil {
+		fmt.Printf("Token for user %v expires %v", token.Claims["user"], token.Claims["exp"])
+	}
+```
+
+is directly mapped to:
+
+```go
+	if token, err := request.ParseFromRequest(req, request.OAuth2Extractor, keyLookupFunc); err == nil {
+		claims := token.Claims.(jwt.MapClaims)
+		fmt.Printf("Token for user %v expires %v", claims["user"], claims["exp"])
+	}
+```
+
+There are several concrete `Extractor` types provided for your convenience:
+
+* `HeaderExtractor` will search a list of headers until one contains content.
+* `ArgumentExtractor` will search a list of keys in request query and form arguments until one contains content.
+* `MultiExtractor` will try a list of `Extractors` in order until one returns content.
+* `AuthorizationHeaderExtractor` will look in the `Authorization` header for a `Bearer` token.
+* `OAuth2Extractor` searches the places an OAuth2 token would be specified (per the spec): `Authorization` header and `access_token` argument
+* `PostExtractionFilter` wraps an `Extractor`, allowing you to process the content before it's parsed.  A simple example is stripping the `Bearer ` text from a header
+
+
+### RSA signing methods no longer accept `[]byte` keys
+
+Due to a [critical vulnerability](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/), we've decided the convenience of accepting `[]byte` instead of `rsa.PublicKey` or `rsa.PrivateKey` isn't worth the risk of misuse.
+
+To replace this behavior, we've added two helper methods: `ParseRSAPrivateKeyFromPEM(key []byte) (*rsa.PrivateKey, error)` and `ParseRSAPublicKeyFromPEM(key []byte) (*rsa.PublicKey, error)`.  These are just simple helpers for unpacking PEM encoded PKCS1 and PKCS8 keys. If your keys are encoded any other way, all you need to do is convert them to the `crypto/rsa` package's types.
+
+```go 
+	func keyLookupFunc(*Token) (interface{}, error) {
+		// Don't forget to validate the alg is what you expect:
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
+		}
+		
+		// Look up key 
+		key, err := lookupPublicKey(token.Header["kid"])
+		if err != nil {
+			return nil, err
+		}
+		
+		// Unpack key from PEM encoded PKCS8
+		return jwt.ParseRSAPublicKeyFromPEM(key)
+	}
+```

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/README.md
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/README.md
@@ -1,0 +1,85 @@
+A [go](http://www.golang.org) (or 'golang' for search engine friendliness) implementation of [JSON Web Tokens](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html)
+
+[![Build Status](https://travis-ci.org/dgrijalva/jwt-go.svg?branch=master)](https://travis-ci.org/dgrijalva/jwt-go)
+
+**BREAKING CHANGES:*** Version 3.0.0 is here. It includes _a lot_ of changes including a few that break the API.  We've tried to break as few things as possible, so there should just be a few type signature changes.  A full list of breaking changes is available in `VERSION_HISTORY.md`.  See `MIGRATION_GUIDE.md` for more information on updating your code.
+
+**NOTICE:** It's important that you [validate the `alg` presented is what you expect](https://auth0.com/blog/2015/03/31/critical-vulnerabilities-in-json-web-token-libraries/). This library attempts to make it easy to do the right thing by requiring key types match the expected alg, but you should take the extra step to verify it in your usage.  See the examples provided.
+
+
+## What the heck is a JWT?
+
+JWT.io has [a great introduction](https://jwt.io/introduction) to JSON Web Tokens.
+
+In short, it's a signed JSON object that does something useful (for example, authentication).  It's commonly used for `Bearer` tokens in Oauth 2.  A token is made of three parts, separated by `.`'s.  The first two parts are JSON objects, that have been [base64url](http://tools.ietf.org/html/rfc4648) encoded.  The last part is the signature, encoded the same way.
+
+The first part is called the header.  It contains the necessary information for verifying the last part, the signature.  For example, which encryption method was used for signing and what key was used.
+
+The part in the middle is the interesting bit.  It's called the Claims and contains the actual stuff you care about.  Refer to [the RFC](http://self-issued.info/docs/draft-jones-json-web-token.html) for information about reserved keys and the proper way to add your own.
+
+## What's in the box?
+
+This library supports the parsing and verification as well as the generation and signing of JWTs.  Current supported signing algorithms are HMAC SHA, RSA, RSA-PSS, and ECDSA, though hooks are present for adding your own.
+
+## Examples
+
+See [the project documentation](https://godoc.org/github.com/dgrijalva/jwt-go) for examples of usage:
+
+* [Simple example of parsing and validating a token](https://godoc.org/github.com/dgrijalva/jwt-go#example-Parse--Hmac)
+* [Simple example of building and signing a token](https://godoc.org/github.com/dgrijalva/jwt-go#example-New--Hmac)
+* [Directory of Examples](https://godoc.org/github.com/dgrijalva/jwt-go#pkg-examples)
+
+## Extensions
+
+This library publishes all the necessary components for adding your own signing methods.  Simply implement the `SigningMethod` interface and register a factory method using `RegisterSigningMethod`.  
+
+Here's an example of an extension that integrates with the Google App Engine signing tools: https://github.com/someone1/gcp-jwt-go
+
+## Compliance
+
+This library was last reviewed to comply with [RTF 7519](http://www.rfc-editor.org/info/rfc7519) dated May 2015 with a few notable differences: 
+
+* In order to protect against accidental use of [Unsecured JWTs](http://self-issued.info/docs/draft-ietf-oauth-json-web-token.html#UnsecuredJWT), tokens using `alg=none` will only be accepted if the constant `jwt.UnsafeAllowNoneSignatureType` is provided as the key.
+
+## Project Status & Versioning
+
+This library is considered production ready.  Feedback and feature requests are appreciated.  The API should be considered stable.  There should be very few backwards-incompatible changes outside of major version updates (and only with good reason).
+
+This project uses [Semantic Versioning 2.0.0](http://semver.org).  Accepted pull requests will land on `master`.  Periodically, versions will be tagged from `master`.  You can find all the releases on [the project releases page](https://github.com/dgrijalva/jwt-go/releases).
+
+While we try to make it obvious when we make breaking changes, there isn't a great mechanism for pushing announcements out to users.  You may want to use this alternative package include: `gopkg.in/dgrijalva/jwt-go.v2`.  It will do the right thing WRT semantic versioning.
+
+## Usage Tips
+
+### Signing vs Encryption
+
+A token is simply a JSON object that is signed by its author. this tells you exactly two things about the data:
+
+* The author of the token was in the possession of the signing secret
+* The data has not been modified since it was signed
+
+It's important to know that JWT does not provide encryption, which means anyone who has access to the token can read its contents. If you need to protect (encrypt) the data, there is a companion spec, `JWE`, that provides this functionality. JWE is currently outside the scope of this library.
+
+### Choosing a Signing Method
+
+There are several signing methods available, and you should probably take the time to learn about the various options before choosing one.  The principal design decision is most likely going to be symmetric vs asymmetric.
+
+Symmetric signing methods, such as HSA, use only a single secret. This is probably the simplest signing method to use since any `[]byte` can be used as a valid secret. They are also slightly computationally faster to use, though this rarely is enough to matter. Symmetric signing methods work the best when both producers and consumers of tokens are trusted, or even the same system. Since the same secret is used to both sign and validate tokens, you can't easily distribute the key for validation.
+
+Asymmetric signing methods, such as RSA, use different keys for signing and verifying tokens. This makes it possible to produce tokens with a private key, and allow any consumer to access the public key for verification.
+
+### JWT and OAuth
+
+It's worth mentioning that OAuth and JWT are not the same thing. A JWT token is simply a signed JSON object. It can be used anywhere such a thing is useful. There is some confusion, though, as JWT is the most common type of bearer token used in OAuth2 authentication.
+
+Without going too far down the rabbit hole, here's a description of the interaction of these technologies:
+
+* OAuth is a protocol for allowing an identity provider to be separate from the service a user is logging in to. For example, whenever you use Facebook to log into a different service (Yelp, Spotify, etc), you are using OAuth.
+* OAuth defines several options for passing around authentication data. One popular method is called a "bearer token". A bearer token is simply a string that _should_ only be held by an authenticated user. Thus, simply presenting this token proves your identity. You can probably derive from here why a JWT might make a good bearer token.
+* Because bearer tokens are used for authentication, it's important they're kept secret. This is why transactions that use bearer tokens typically happen over SSL.
+ 
+## More
+
+Documentation can be found [on godoc.org](http://godoc.org/github.com/dgrijalva/jwt-go).
+
+The command line utility included in this project (cmd/jwt) provides a straightforward example of token creation and parsing as well as a useful tool for debugging your own integration. You'll also find several implementation examples in the documentation.

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/VERSION_HISTORY.md
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/VERSION_HISTORY.md
@@ -1,0 +1,111 @@
+## `jwt-go` Version History
+
+#### 3.1.0
+
+* Improvements to `jwt` command line tool
+* Added `SkipClaimsValidation` option to `Parser`
+* Documentation updates
+
+#### 3.0.0
+
+* **Compatibility Breaking Changes**: See MIGRATION_GUIDE.md for tips on updating your code
+	* Dropped support for `[]byte` keys when using RSA signing methods.  This convenience feature could contribute to security vulnerabilities involving mismatched key types with signing methods.
+	* `ParseFromRequest` has been moved to `request` subpackage and usage has changed
+	* The `Claims` property on `Token` is now type `Claims` instead of `map[string]interface{}`.  The default value is type `MapClaims`, which is an alias to `map[string]interface{}`.  This makes it possible to use a custom type when decoding claims.
+* Other Additions and Changes
+	* Added `Claims` interface type to allow users to decode the claims into a custom type
+	* Added `ParseWithClaims`, which takes a third argument of type `Claims`.  Use this function instead of `Parse` if you have a custom type you'd like to decode into.
+	* Dramatically improved the functionality and flexibility of `ParseFromRequest`, which is now in the `request` subpackage
+	* Added `ParseFromRequestWithClaims` which is the `FromRequest` equivalent of `ParseWithClaims`
+	* Added new interface type `Extractor`, which is used for extracting JWT strings from http requests.  Used with `ParseFromRequest` and `ParseFromRequestWithClaims`.
+	* Added several new, more specific, validation errors to error type bitmask
+	* Moved examples from README to executable example files
+	* Signing method registry is now thread safe
+	* Added new property to `ValidationError`, which contains the raw error returned by calls made by parse/verify (such as those returned by keyfunc or json parser)
+
+#### 2.7.0
+
+This will likely be the last backwards compatible release before 3.0.0, excluding essential bug fixes.
+
+* Added new option `-show` to the `jwt` command that will just output the decoded token without verifying
+* Error text for expired tokens includes how long it's been expired
+* Fixed incorrect error returned from `ParseRSAPublicKeyFromPEM`
+* Documentation updates
+
+#### 2.6.0
+
+* Exposed inner error within ValidationError
+* Fixed validation errors when using UseJSONNumber flag
+* Added several unit tests
+
+#### 2.5.0
+
+* Added support for signing method none.  You shouldn't use this.  The API tries to make this clear.
+* Updated/fixed some documentation
+* Added more helpful error message when trying to parse tokens that begin with `BEARER `
+
+#### 2.4.0
+
+* Added new type, Parser, to allow for configuration of various parsing parameters
+	* You can now specify a list of valid signing methods.  Anything outside this set will be rejected.
+	* You can now opt to use the `json.Number` type instead of `float64` when parsing token JSON
+* Added support for [Travis CI](https://travis-ci.org/dgrijalva/jwt-go)
+* Fixed some bugs with ECDSA parsing
+
+#### 2.3.0
+
+* Added support for ECDSA signing methods
+* Added support for RSA PSS signing methods (requires go v1.4)
+
+#### 2.2.0
+
+* Gracefully handle a `nil` `Keyfunc` being passed to `Parse`.  Result will now be the parsed token and an error, instead of a panic.
+
+#### 2.1.0
+
+Backwards compatible API change that was missed in 2.0.0.
+
+* The `SignedString` method on `Token` now takes `interface{}` instead of `[]byte`
+
+#### 2.0.0
+
+There were two major reasons for breaking backwards compatibility with this update.  The first was a refactor required to expand the width of the RSA and HMAC-SHA signing implementations.  There will likely be no required code changes to support this change.
+
+The second update, while unfortunately requiring a small change in integration, is required to open up this library to other signing methods.  Not all keys used for all signing methods have a single standard on-disk representation.  Requiring `[]byte` as the type for all keys proved too limiting.  Additionally, this implementation allows for pre-parsed tokens to be reused, which might matter in an application that parses a high volume of tokens with a small set of keys.  Backwards compatibilty has been maintained for passing `[]byte` to the RSA signing methods, but they will also accept `*rsa.PublicKey` and `*rsa.PrivateKey`.
+
+It is likely the only integration change required here will be to change `func(t *jwt.Token) ([]byte, error)` to `func(t *jwt.Token) (interface{}, error)` when calling `Parse`.
+
+* **Compatibility Breaking Changes**
+	* `SigningMethodHS256` is now `*SigningMethodHMAC` instead of `type struct`
+	* `SigningMethodRS256` is now `*SigningMethodRSA` instead of `type struct`
+	* `KeyFunc` now returns `interface{}` instead of `[]byte`
+	* `SigningMethod.Sign` now takes `interface{}` instead of `[]byte` for the key
+	* `SigningMethod.Verify` now takes `interface{}` instead of `[]byte` for the key
+* Renamed type `SigningMethodHS256` to `SigningMethodHMAC`.  Specific sizes are now just instances of this type.
+    * Added public package global `SigningMethodHS256`
+    * Added public package global `SigningMethodHS384`
+    * Added public package global `SigningMethodHS512`
+* Renamed type `SigningMethodRS256` to `SigningMethodRSA`.  Specific sizes are now just instances of this type.
+    * Added public package global `SigningMethodRS256`
+    * Added public package global `SigningMethodRS384`
+    * Added public package global `SigningMethodRS512`
+* Moved sample private key for HMAC tests from an inline value to a file on disk.  Value is unchanged.
+* Refactored the RSA implementation to be easier to read
+* Exposed helper methods `ParseRSAPrivateKeyFromPEM` and `ParseRSAPublicKeyFromPEM`
+
+#### 1.0.2
+
+* Fixed bug in parsing public keys from certificates
+* Added more tests around the parsing of keys for RS256
+* Code refactoring in RS256 implementation.  No functional changes
+
+#### 1.0.1
+
+* Fixed panic if RS256 signing method was passed an invalid key
+
+#### 1.0.0
+
+* First versioned release
+* API stabilized
+* Supports creating, signing, parsing, and validating JWT tokens
+* Supports RS256 and HS256 signing methods

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/claims.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/claims.go
@@ -1,0 +1,134 @@
+package jwt
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"time"
+)
+
+// For a type to be a Claims object, it must just have a Valid method that determines
+// if the token is invalid for any supported reason
+type Claims interface {
+	Valid() error
+}
+
+// Structured version of Claims Section, as referenced at
+// https://tools.ietf.org/html/rfc7519#section-4.1
+// See examples for how to use this with your own claim types
+type StandardClaims struct {
+	Audience  string `json:"aud,omitempty"`
+	ExpiresAt int64  `json:"exp,omitempty"`
+	Id        string `json:"jti,omitempty"`
+	IssuedAt  int64  `json:"iat,omitempty"`
+	Issuer    string `json:"iss,omitempty"`
+	NotBefore int64  `json:"nbf,omitempty"`
+	Subject   string `json:"sub,omitempty"`
+}
+
+// Validates time based claims "exp, iat, nbf".
+// There is no accounting for clock skew.
+// As well, if any of the above claims are not in the token, it will still
+// be considered a valid claim.
+func (c StandardClaims) Valid() error {
+	vErr := new(ValidationError)
+	now := TimeFunc().Unix()
+
+	// The claims below are optional, by default, so if they are set to the
+	// default value in Go, let's not fail the verification for them.
+	if c.VerifyExpiresAt(now, false) == false {
+		delta := time.Unix(now, 0).Sub(time.Unix(c.ExpiresAt, 0))
+		vErr.Inner = fmt.Errorf("token is expired by %v", delta)
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if c.VerifyIssuedAt(now, false) == false {
+		vErr.Inner = fmt.Errorf("Token used before issued")
+		vErr.Errors |= ValidationErrorIssuedAt
+	}
+
+	if c.VerifyNotBefore(now, false) == false {
+		vErr.Inner = fmt.Errorf("token is not valid yet")
+		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	if vErr.valid() {
+		return nil
+	}
+
+	return vErr
+}
+
+// Compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyAudience(cmp string, req bool) bool {
+	return verifyAud(c.Audience, cmp, req)
+}
+
+// Compares the exp claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+	return verifyExp(c.ExpiresAt, cmp, req)
+}
+
+// Compares the iat claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+	return verifyIat(c.IssuedAt, cmp, req)
+}
+
+// Compares the iss claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyIssuer(cmp string, req bool) bool {
+	return verifyIss(c.Issuer, cmp, req)
+}
+
+// Compares the nbf claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (c *StandardClaims) VerifyNotBefore(cmp int64, req bool) bool {
+	return verifyNbf(c.NotBefore, cmp, req)
+}
+
+// ----- helpers
+
+func verifyAud(aud string, cmp string, required bool) bool {
+	if aud == "" {
+		return !required
+	}
+	if subtle.ConstantTimeCompare([]byte(aud), []byte(cmp)) != 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func verifyExp(exp int64, now int64, required bool) bool {
+	if exp == 0 {
+		return !required
+	}
+	return now <= exp
+}
+
+func verifyIat(iat int64, now int64, required bool) bool {
+	if iat == 0 {
+		return !required
+	}
+	return now >= iat
+}
+
+func verifyIss(iss string, cmp string, required bool) bool {
+	if iss == "" {
+		return !required
+	}
+	if subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func verifyNbf(nbf int64, now int64, required bool) bool {
+	if nbf == 0 {
+		return !required
+	}
+	return now >= nbf
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/doc.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/doc.go
@@ -1,0 +1,4 @@
+// Package jwt is a Go implementation of JSON Web Tokens: http://self-issued.info/docs/draft-jones-json-web-token.html
+//
+// See README.md for more info.
+package jwt

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/ecdsa.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/ecdsa.go
@@ -1,0 +1,147 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rand"
+	"errors"
+	"math/big"
+)
+
+var (
+	// Sadly this is missing from crypto/ecdsa compared to crypto/rsa
+	ErrECDSAVerification = errors.New("crypto/ecdsa: verification error")
+)
+
+// Implements the ECDSA family of signing methods signing methods
+type SigningMethodECDSA struct {
+	Name      string
+	Hash      crypto.Hash
+	KeySize   int
+	CurveBits int
+}
+
+// Specific instances for EC256 and company
+var (
+	SigningMethodES256 *SigningMethodECDSA
+	SigningMethodES384 *SigningMethodECDSA
+	SigningMethodES512 *SigningMethodECDSA
+)
+
+func init() {
+	// ES256
+	SigningMethodES256 = &SigningMethodECDSA{"ES256", crypto.SHA256, 32, 256}
+	RegisterSigningMethod(SigningMethodES256.Alg(), func() SigningMethod {
+		return SigningMethodES256
+	})
+
+	// ES384
+	SigningMethodES384 = &SigningMethodECDSA{"ES384", crypto.SHA384, 48, 384}
+	RegisterSigningMethod(SigningMethodES384.Alg(), func() SigningMethod {
+		return SigningMethodES384
+	})
+
+	// ES512
+	SigningMethodES512 = &SigningMethodECDSA{"ES512", crypto.SHA512, 66, 521}
+	RegisterSigningMethod(SigningMethodES512.Alg(), func() SigningMethod {
+		return SigningMethodES512
+	})
+}
+
+func (m *SigningMethodECDSA) Alg() string {
+	return m.Name
+}
+
+// Implements the Verify method from SigningMethod
+// For this verify method, key must be an ecdsa.PublicKey struct
+func (m *SigningMethodECDSA) Verify(signingString, signature string, key interface{}) error {
+	var err error
+
+	// Decode the signature
+	var sig []byte
+	if sig, err = DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	// Get the key
+	var ecdsaKey *ecdsa.PublicKey
+	switch k := key.(type) {
+	case *ecdsa.PublicKey:
+		ecdsaKey = k
+	default:
+		return ErrInvalidKeyType
+	}
+
+	if len(sig) != 2*m.KeySize {
+		return ErrECDSAVerification
+	}
+
+	r := big.NewInt(0).SetBytes(sig[:m.KeySize])
+	s := big.NewInt(0).SetBytes(sig[m.KeySize:])
+
+	// Create hasher
+	if !m.Hash.Available() {
+		return ErrHashUnavailable
+	}
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Verify the signature
+	if verifystatus := ecdsa.Verify(ecdsaKey, hasher.Sum(nil), r, s); verifystatus == true {
+		return nil
+	} else {
+		return ErrECDSAVerification
+	}
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, key must be an ecdsa.PrivateKey struct
+func (m *SigningMethodECDSA) Sign(signingString string, key interface{}) (string, error) {
+	// Get the key
+	var ecdsaKey *ecdsa.PrivateKey
+	switch k := key.(type) {
+	case *ecdsa.PrivateKey:
+		ecdsaKey = k
+	default:
+		return "", ErrInvalidKeyType
+	}
+
+	// Create the hasher
+	if !m.Hash.Available() {
+		return "", ErrHashUnavailable
+	}
+
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Sign the string and return r, s
+	if r, s, err := ecdsa.Sign(rand.Reader, ecdsaKey, hasher.Sum(nil)); err == nil {
+		curveBits := ecdsaKey.Curve.Params().BitSize
+
+		if m.CurveBits != curveBits {
+			return "", ErrInvalidKey
+		}
+
+		keyBytes := curveBits / 8
+		if curveBits%8 > 0 {
+			keyBytes += 1
+		}
+
+		// We serialize the outpus (r and s) into big-endian byte arrays and pad
+		// them with zeros on the left to make sure the sizes work out. Both arrays
+		// must be keyBytes long, and the output must be 2*keyBytes long.
+		rBytes := r.Bytes()
+		rBytesPadded := make([]byte, keyBytes)
+		copy(rBytesPadded[keyBytes-len(rBytes):], rBytes)
+
+		sBytes := s.Bytes()
+		sBytesPadded := make([]byte, keyBytes)
+		copy(sBytesPadded[keyBytes-len(sBytes):], sBytes)
+
+		out := append(rBytesPadded, sBytesPadded...)
+
+		return EncodeSegment(out), nil
+	} else {
+		return "", err
+	}
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/ecdsa_utils.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/ecdsa_utils.go
@@ -1,0 +1,67 @@
+package jwt
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	ErrNotECPublicKey  = errors.New("Key is not a valid ECDSA public key")
+	ErrNotECPrivateKey = errors.New("Key is not a valid ECDSA private key")
+)
+
+// Parse PEM encoded Elliptic Curve Private Key Structure
+func ParseECPrivateKeyFromPEM(key []byte) (*ecdsa.PrivateKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParseECPrivateKey(block.Bytes); err != nil {
+		return nil, err
+	}
+
+	var pkey *ecdsa.PrivateKey
+	var ok bool
+	if pkey, ok = parsedKey.(*ecdsa.PrivateKey); !ok {
+		return nil, ErrNotECPrivateKey
+	}
+
+	return pkey, nil
+}
+
+// Parse PEM encoded PKCS1 or PKCS8 public key
+func ParseECPublicKeyFromPEM(key []byte) (*ecdsa.PublicKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+		if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			parsedKey = cert.PublicKey
+		} else {
+			return nil, err
+		}
+	}
+
+	var pkey *ecdsa.PublicKey
+	var ok bool
+	if pkey, ok = parsedKey.(*ecdsa.PublicKey); !ok {
+		return nil, ErrNotECPublicKey
+	}
+
+	return pkey, nil
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/errors.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/errors.go
@@ -1,0 +1,59 @@
+package jwt
+
+import (
+	"errors"
+)
+
+// Error constants
+var (
+	ErrInvalidKey      = errors.New("key is invalid")
+	ErrInvalidKeyType  = errors.New("key is of invalid type")
+	ErrHashUnavailable = errors.New("the requested hash function is unavailable")
+)
+
+// The errors that might occur when parsing and validating a token
+const (
+	ValidationErrorMalformed        uint32 = 1 << iota // Token is malformed
+	ValidationErrorUnverifiable                        // Token could not be verified because of signing problems
+	ValidationErrorSignatureInvalid                    // Signature validation failed
+
+	// Standard Claim validation errors
+	ValidationErrorAudience      // AUD validation failed
+	ValidationErrorExpired       // EXP validation failed
+	ValidationErrorIssuedAt      // IAT validation failed
+	ValidationErrorIssuer        // ISS validation failed
+	ValidationErrorNotValidYet   // NBF validation failed
+	ValidationErrorId            // JTI validation failed
+	ValidationErrorClaimsInvalid // Generic claims validation error
+)
+
+// Helper for constructing a ValidationError with a string error message
+func NewValidationError(errorText string, errorFlags uint32) *ValidationError {
+	return &ValidationError{
+		text:   errorText,
+		Errors: errorFlags,
+	}
+}
+
+// The error from Parse if token is not valid
+type ValidationError struct {
+	Inner  error  // stores the error returned by external dependencies, i.e.: KeyFunc
+	Errors uint32 // bitfield.  see ValidationError... constants
+	text   string // errors that do not have a valid error just have text
+}
+
+// Validation error is an error type
+func (e ValidationError) Error() string {
+	if e.Inner != nil {
+		return e.Inner.Error()
+	} else if e.text != "" {
+		return e.text
+	} else {
+		return "token is invalid"
+	}
+}
+
+// No errors
+func (e *ValidationError) valid() bool {
+	return e.Errors == 0
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/hmac.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/hmac.go
@@ -1,0 +1,94 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/hmac"
+	"errors"
+)
+
+// Implements the HMAC-SHA family of signing methods signing methods
+type SigningMethodHMAC struct {
+	Name string
+	Hash crypto.Hash
+}
+
+// Specific instances for HS256 and company
+var (
+	SigningMethodHS256  *SigningMethodHMAC
+	SigningMethodHS384  *SigningMethodHMAC
+	SigningMethodHS512  *SigningMethodHMAC
+	ErrSignatureInvalid = errors.New("signature is invalid")
+)
+
+func init() {
+	// HS256
+	SigningMethodHS256 = &SigningMethodHMAC{"HS256", crypto.SHA256}
+	RegisterSigningMethod(SigningMethodHS256.Alg(), func() SigningMethod {
+		return SigningMethodHS256
+	})
+
+	// HS384
+	SigningMethodHS384 = &SigningMethodHMAC{"HS384", crypto.SHA384}
+	RegisterSigningMethod(SigningMethodHS384.Alg(), func() SigningMethod {
+		return SigningMethodHS384
+	})
+
+	// HS512
+	SigningMethodHS512 = &SigningMethodHMAC{"HS512", crypto.SHA512}
+	RegisterSigningMethod(SigningMethodHS512.Alg(), func() SigningMethod {
+		return SigningMethodHS512
+	})
+}
+
+func (m *SigningMethodHMAC) Alg() string {
+	return m.Name
+}
+
+// Verify the signature of HSXXX tokens.  Returns nil if the signature is valid.
+func (m *SigningMethodHMAC) Verify(signingString, signature string, key interface{}) error {
+	// Verify the key is the right type
+	keyBytes, ok := key.([]byte)
+	if !ok {
+		return ErrInvalidKeyType
+	}
+
+	// Decode signature, for comparison
+	sig, err := DecodeSegment(signature)
+	if err != nil {
+		return err
+	}
+
+	// Can we use the specified hashing method?
+	if !m.Hash.Available() {
+		return ErrHashUnavailable
+	}
+
+	// This signing method is symmetric, so we validate the signature
+	// by reproducing the signature from the signing string and key, then
+	// comparing that against the provided signature.
+	hasher := hmac.New(m.Hash.New, keyBytes)
+	hasher.Write([]byte(signingString))
+	if !hmac.Equal(sig, hasher.Sum(nil)) {
+		return ErrSignatureInvalid
+	}
+
+	// No validation errors.  Signature is good.
+	return nil
+}
+
+// Implements the Sign method from SigningMethod for this signing method.
+// Key must be []byte
+func (m *SigningMethodHMAC) Sign(signingString string, key interface{}) (string, error) {
+	if keyBytes, ok := key.([]byte); ok {
+		if !m.Hash.Available() {
+			return "", ErrHashUnavailable
+		}
+
+		hasher := hmac.New(m.Hash.New, keyBytes)
+		hasher.Write([]byte(signingString))
+
+		return EncodeSegment(hasher.Sum(nil)), nil
+	}
+
+	return "", ErrInvalidKey
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/map_claims.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/map_claims.go
@@ -1,0 +1,94 @@
+package jwt
+
+import (
+	"encoding/json"
+	"errors"
+	// "fmt"
+)
+
+// Claims type that uses the map[string]interface{} for JSON decoding
+// This is the default claims type if you don't supply one
+type MapClaims map[string]interface{}
+
+// Compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
+	aud, _ := m["aud"].(string)
+	return verifyAud(aud, cmp, req)
+}
+
+// Compares the exp claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+	switch exp := m["exp"].(type) {
+	case float64:
+		return verifyExp(int64(exp), cmp, req)
+	case json.Number:
+		v, _ := exp.Int64()
+		return verifyExp(v, cmp, req)
+	}
+	return req == false
+}
+
+// Compares the iat claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+	switch iat := m["iat"].(type) {
+	case float64:
+		return verifyIat(int64(iat), cmp, req)
+	case json.Number:
+		v, _ := iat.Int64()
+		return verifyIat(v, cmp, req)
+	}
+	return req == false
+}
+
+// Compares the iss claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
+	iss, _ := m["iss"].(string)
+	return verifyIss(iss, cmp, req)
+}
+
+// Compares the nbf claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
+	switch nbf := m["nbf"].(type) {
+	case float64:
+		return verifyNbf(int64(nbf), cmp, req)
+	case json.Number:
+		v, _ := nbf.Int64()
+		return verifyNbf(v, cmp, req)
+	}
+	return req == false
+}
+
+// Validates time based claims "exp, iat, nbf".
+// There is no accounting for clock skew.
+// As well, if any of the above claims are not in the token, it will still
+// be considered a valid claim.
+func (m MapClaims) Valid() error {
+	vErr := new(ValidationError)
+	now := TimeFunc().Unix()
+
+	if m.VerifyExpiresAt(now, false) == false {
+		vErr.Inner = errors.New("Token is expired")
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if m.VerifyIssuedAt(now, false) == false {
+		vErr.Inner = errors.New("Token used before issued")
+		vErr.Errors |= ValidationErrorIssuedAt
+	}
+
+	if m.VerifyNotBefore(now, false) == false {
+		vErr.Inner = errors.New("Token is not valid yet")
+		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	if vErr.valid() {
+		return nil
+	}
+
+	return vErr
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/none.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/none.go
@@ -1,0 +1,52 @@
+package jwt
+
+// Implements the none signing method.  This is required by the spec
+// but you probably should never use it.
+var SigningMethodNone *signingMethodNone
+
+const UnsafeAllowNoneSignatureType unsafeNoneMagicConstant = "none signing method allowed"
+
+var NoneSignatureTypeDisallowedError error
+
+type signingMethodNone struct{}
+type unsafeNoneMagicConstant string
+
+func init() {
+	SigningMethodNone = &signingMethodNone{}
+	NoneSignatureTypeDisallowedError = NewValidationError("'none' signature type is not allowed", ValidationErrorSignatureInvalid)
+
+	RegisterSigningMethod(SigningMethodNone.Alg(), func() SigningMethod {
+		return SigningMethodNone
+	})
+}
+
+func (m *signingMethodNone) Alg() string {
+	return "none"
+}
+
+// Only allow 'none' alg type if UnsafeAllowNoneSignatureType is specified as the key
+func (m *signingMethodNone) Verify(signingString, signature string, key interface{}) (err error) {
+	// Key must be UnsafeAllowNoneSignatureType to prevent accidentally
+	// accepting 'none' signing method
+	if _, ok := key.(unsafeNoneMagicConstant); !ok {
+		return NoneSignatureTypeDisallowedError
+	}
+	// If signing method is none, signature must be an empty string
+	if signature != "" {
+		return NewValidationError(
+			"'none' signing method with non-empty signature",
+			ValidationErrorSignatureInvalid,
+		)
+	}
+
+	// Accept 'none' signing method.
+	return nil
+}
+
+// Only allow 'none' signing if UnsafeAllowNoneSignatureType is specified as the key
+func (m *signingMethodNone) Sign(signingString string, key interface{}) (string, error) {
+	if _, ok := key.(unsafeNoneMagicConstant); ok {
+		return "", nil
+	}
+	return "", NoneSignatureTypeDisallowedError
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/parser.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/parser.go
@@ -1,0 +1,131 @@
+package jwt
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type Parser struct {
+	ValidMethods         []string // If populated, only these methods will be considered valid
+	UseJSONNumber        bool     // Use JSON Number format in JSON decoder
+	SkipClaimsValidation bool     // Skip claims validation during token parsing
+}
+
+// Parse, validate, and return a token.
+// keyFunc will receive the parsed token and should return the key for validating.
+// If everything is kosher, err will be nil
+func (p *Parser) Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
+	return p.ParseWithClaims(tokenString, MapClaims{}, keyFunc)
+}
+
+func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+	parts := strings.Split(tokenString, ".")
+	if len(parts) != 3 {
+		return nil, NewValidationError("token contains an invalid number of segments", ValidationErrorMalformed)
+	}
+
+	var err error
+	token := &Token{Raw: tokenString}
+
+	// parse Header
+	var headerBytes []byte
+	if headerBytes, err = DecodeSegment(parts[0]); err != nil {
+		if strings.HasPrefix(strings.ToLower(tokenString), "bearer ") {
+			return token, NewValidationError("tokenstring should not contain 'bearer '", ValidationErrorMalformed)
+		}
+		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+	if err = json.Unmarshal(headerBytes, &token.Header); err != nil {
+		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+
+	// parse Claims
+	var claimBytes []byte
+	token.Claims = claims
+
+	if claimBytes, err = DecodeSegment(parts[1]); err != nil {
+		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+	dec := json.NewDecoder(bytes.NewBuffer(claimBytes))
+	if p.UseJSONNumber {
+		dec.UseNumber()
+	}
+	// JSON Decode.  Special case for map type to avoid weird pointer behavior
+	if c, ok := token.Claims.(MapClaims); ok {
+		err = dec.Decode(&c)
+	} else {
+		err = dec.Decode(&claims)
+	}
+	// Handle decode error
+	if err != nil {
+		return token, &ValidationError{Inner: err, Errors: ValidationErrorMalformed}
+	}
+
+	// Lookup signature method
+	if method, ok := token.Header["alg"].(string); ok {
+		if token.Method = GetSigningMethod(method); token.Method == nil {
+			return token, NewValidationError("signing method (alg) is unavailable.", ValidationErrorUnverifiable)
+		}
+	} else {
+		return token, NewValidationError("signing method (alg) is unspecified.", ValidationErrorUnverifiable)
+	}
+
+	// Verify signing method is in the required set
+	if p.ValidMethods != nil {
+		var signingMethodValid = false
+		var alg = token.Method.Alg()
+		for _, m := range p.ValidMethods {
+			if m == alg {
+				signingMethodValid = true
+				break
+			}
+		}
+		if !signingMethodValid {
+			// signing method is not in the listed set
+			return token, NewValidationError(fmt.Sprintf("signing method %v is invalid", alg), ValidationErrorSignatureInvalid)
+		}
+	}
+
+	// Lookup key
+	var key interface{}
+	if keyFunc == nil {
+		// keyFunc was not provided.  short circuiting validation
+		return token, NewValidationError("no Keyfunc was provided.", ValidationErrorUnverifiable)
+	}
+	if key, err = keyFunc(token); err != nil {
+		// keyFunc returned an error
+		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
+	}
+
+	vErr := &ValidationError{}
+
+	// Validate Claims
+	if !p.SkipClaimsValidation {
+		if err := token.Claims.Valid(); err != nil {
+
+			// If the Claims Valid returned an error, check if it is a validation error,
+			// If it was another error type, create a ValidationError with a generic ClaimsInvalid flag set
+			if e, ok := err.(*ValidationError); !ok {
+				vErr = &ValidationError{Inner: err, Errors: ValidationErrorClaimsInvalid}
+			} else {
+				vErr = e
+			}
+		}
+	}
+
+	// Perform validation
+	token.Signature = parts[2]
+	if err = token.Method.Verify(strings.Join(parts[0:2], "."), token.Signature, key); err != nil {
+		vErr.Inner = err
+		vErr.Errors |= ValidationErrorSignatureInvalid
+	}
+
+	if vErr.valid() {
+		token.Valid = true
+		return token, nil
+	}
+
+	return token, vErr
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/rsa.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/rsa.go
@@ -1,0 +1,100 @@
+package jwt
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+// Implements the RSA family of signing methods signing methods
+type SigningMethodRSA struct {
+	Name string
+	Hash crypto.Hash
+}
+
+// Specific instances for RS256 and company
+var (
+	SigningMethodRS256 *SigningMethodRSA
+	SigningMethodRS384 *SigningMethodRSA
+	SigningMethodRS512 *SigningMethodRSA
+)
+
+func init() {
+	// RS256
+	SigningMethodRS256 = &SigningMethodRSA{"RS256", crypto.SHA256}
+	RegisterSigningMethod(SigningMethodRS256.Alg(), func() SigningMethod {
+		return SigningMethodRS256
+	})
+
+	// RS384
+	SigningMethodRS384 = &SigningMethodRSA{"RS384", crypto.SHA384}
+	RegisterSigningMethod(SigningMethodRS384.Alg(), func() SigningMethod {
+		return SigningMethodRS384
+	})
+
+	// RS512
+	SigningMethodRS512 = &SigningMethodRSA{"RS512", crypto.SHA512}
+	RegisterSigningMethod(SigningMethodRS512.Alg(), func() SigningMethod {
+		return SigningMethodRS512
+	})
+}
+
+func (m *SigningMethodRSA) Alg() string {
+	return m.Name
+}
+
+// Implements the Verify method from SigningMethod
+// For this signing method, must be an rsa.PublicKey structure.
+func (m *SigningMethodRSA) Verify(signingString, signature string, key interface{}) error {
+	var err error
+
+	// Decode the signature
+	var sig []byte
+	if sig, err = DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	var rsaKey *rsa.PublicKey
+	var ok bool
+
+	if rsaKey, ok = key.(*rsa.PublicKey); !ok {
+		return ErrInvalidKeyType
+	}
+
+	// Create hasher
+	if !m.Hash.Available() {
+		return ErrHashUnavailable
+	}
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Verify the signature
+	return rsa.VerifyPKCS1v15(rsaKey, m.Hash, hasher.Sum(nil), sig)
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, must be an rsa.PrivateKey structure.
+func (m *SigningMethodRSA) Sign(signingString string, key interface{}) (string, error) {
+	var rsaKey *rsa.PrivateKey
+	var ok bool
+
+	// Validate type of key
+	if rsaKey, ok = key.(*rsa.PrivateKey); !ok {
+		return "", ErrInvalidKey
+	}
+
+	// Create the hasher
+	if !m.Hash.Available() {
+		return "", ErrHashUnavailable
+	}
+
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Sign the string and return the encoded bytes
+	if sigBytes, err := rsa.SignPKCS1v15(rand.Reader, rsaKey, m.Hash, hasher.Sum(nil)); err == nil {
+		return EncodeSegment(sigBytes), nil
+	} else {
+		return "", err
+	}
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/rsa_pss.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/rsa_pss.go
@@ -1,0 +1,126 @@
+// +build go1.4
+
+package jwt
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+// Implements the RSAPSS family of signing methods signing methods
+type SigningMethodRSAPSS struct {
+	*SigningMethodRSA
+	Options *rsa.PSSOptions
+}
+
+// Specific instances for RS/PS and company
+var (
+	SigningMethodPS256 *SigningMethodRSAPSS
+	SigningMethodPS384 *SigningMethodRSAPSS
+	SigningMethodPS512 *SigningMethodRSAPSS
+)
+
+func init() {
+	// PS256
+	SigningMethodPS256 = &SigningMethodRSAPSS{
+		&SigningMethodRSA{
+			Name: "PS256",
+			Hash: crypto.SHA256,
+		},
+		&rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+			Hash:       crypto.SHA256,
+		},
+	}
+	RegisterSigningMethod(SigningMethodPS256.Alg(), func() SigningMethod {
+		return SigningMethodPS256
+	})
+
+	// PS384
+	SigningMethodPS384 = &SigningMethodRSAPSS{
+		&SigningMethodRSA{
+			Name: "PS384",
+			Hash: crypto.SHA384,
+		},
+		&rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+			Hash:       crypto.SHA384,
+		},
+	}
+	RegisterSigningMethod(SigningMethodPS384.Alg(), func() SigningMethod {
+		return SigningMethodPS384
+	})
+
+	// PS512
+	SigningMethodPS512 = &SigningMethodRSAPSS{
+		&SigningMethodRSA{
+			Name: "PS512",
+			Hash: crypto.SHA512,
+		},
+		&rsa.PSSOptions{
+			SaltLength: rsa.PSSSaltLengthAuto,
+			Hash:       crypto.SHA512,
+		},
+	}
+	RegisterSigningMethod(SigningMethodPS512.Alg(), func() SigningMethod {
+		return SigningMethodPS512
+	})
+}
+
+// Implements the Verify method from SigningMethod
+// For this verify method, key must be an rsa.PublicKey struct
+func (m *SigningMethodRSAPSS) Verify(signingString, signature string, key interface{}) error {
+	var err error
+
+	// Decode the signature
+	var sig []byte
+	if sig, err = DecodeSegment(signature); err != nil {
+		return err
+	}
+
+	var rsaKey *rsa.PublicKey
+	switch k := key.(type) {
+	case *rsa.PublicKey:
+		rsaKey = k
+	default:
+		return ErrInvalidKey
+	}
+
+	// Create hasher
+	if !m.Hash.Available() {
+		return ErrHashUnavailable
+	}
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	return rsa.VerifyPSS(rsaKey, m.Hash, hasher.Sum(nil), sig, m.Options)
+}
+
+// Implements the Sign method from SigningMethod
+// For this signing method, key must be an rsa.PrivateKey struct
+func (m *SigningMethodRSAPSS) Sign(signingString string, key interface{}) (string, error) {
+	var rsaKey *rsa.PrivateKey
+
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		rsaKey = k
+	default:
+		return "", ErrInvalidKeyType
+	}
+
+	// Create the hasher
+	if !m.Hash.Available() {
+		return "", ErrHashUnavailable
+	}
+
+	hasher := m.Hash.New()
+	hasher.Write([]byte(signingString))
+
+	// Sign the string and return the encoded bytes
+	if sigBytes, err := rsa.SignPSS(rand.Reader, rsaKey, m.Hash, hasher.Sum(nil), m.Options); err == nil {
+		return EncodeSegment(sigBytes), nil
+	} else {
+		return "", err
+	}
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/rsa_utils.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/rsa_utils.go
@@ -1,0 +1,69 @@
+package jwt
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+)
+
+var (
+	ErrKeyMustBePEMEncoded = errors.New("Invalid Key: Key must be PEM encoded PKCS1 or PKCS8 private key")
+	ErrNotRSAPrivateKey    = errors.New("Key is not a valid RSA private key")
+	ErrNotRSAPublicKey     = errors.New("Key is not a valid RSA public key")
+)
+
+// Parse PEM encoded PKCS1 or PKCS8 private key
+func ParseRSAPrivateKeyFromPEM(key []byte) (*rsa.PrivateKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+		if parsedKey, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+			return nil, err
+		}
+	}
+
+	var pkey *rsa.PrivateKey
+	var ok bool
+	if pkey, ok = parsedKey.(*rsa.PrivateKey); !ok {
+		return nil, ErrNotRSAPrivateKey
+	}
+
+	return pkey, nil
+}
+
+// Parse PEM encoded PKCS1 or PKCS8 public key
+func ParseRSAPublicKeyFromPEM(key []byte) (*rsa.PublicKey, error) {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		return nil, ErrKeyMustBePEMEncoded
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+		if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			parsedKey = cert.PublicKey
+		} else {
+			return nil, err
+		}
+	}
+
+	var pkey *rsa.PublicKey
+	var ok bool
+	if pkey, ok = parsedKey.(*rsa.PublicKey); !ok {
+		return nil, ErrNotRSAPublicKey
+	}
+
+	return pkey, nil
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/signing_method.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/signing_method.go
@@ -1,0 +1,35 @@
+package jwt
+
+import (
+	"sync"
+)
+
+var signingMethods = map[string]func() SigningMethod{}
+var signingMethodLock = new(sync.RWMutex)
+
+// Implement SigningMethod to add new methods for signing or verifying tokens.
+type SigningMethod interface {
+	Verify(signingString, signature string, key interface{}) error // Returns nil if signature is valid
+	Sign(signingString string, key interface{}) (string, error)    // Returns encoded signature or error
+	Alg() string                                                   // returns the alg identifier for this method (example: 'HS256')
+}
+
+// Register the "alg" name and a factory function for signing method.
+// This is typically done during init() in the method's implementation
+func RegisterSigningMethod(alg string, f func() SigningMethod) {
+	signingMethodLock.Lock()
+	defer signingMethodLock.Unlock()
+
+	signingMethods[alg] = f
+}
+
+// Get a signing method from an "alg" string
+func GetSigningMethod(alg string) (method SigningMethod) {
+	signingMethodLock.RLock()
+	defer signingMethodLock.RUnlock()
+
+	if methodF, ok := signingMethods[alg]; ok {
+		method = methodF()
+	}
+	return
+}

--- a/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/token.go
+++ b/agents/go-agents/vendor/github.com/dgrijalva/jwt-go/token.go
@@ -1,0 +1,108 @@
+package jwt
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// TimeFunc provides the current time when parsing token to validate "exp" claim (expiration time).
+// You can override it to use another time value.  This is useful for testing or if your
+// server uses a different time zone than your tokens.
+var TimeFunc = time.Now
+
+// Parse methods use this callback function to supply
+// the key for verification.  The function receives the parsed,
+// but unverified Token.  This allows you to use properties in the
+// Header of the token (such as `kid`) to identify which key to use.
+type Keyfunc func(*Token) (interface{}, error)
+
+// A JWT Token.  Different fields will be used depending on whether you're
+// creating or parsing/verifying a token.
+type Token struct {
+	Raw       string                 // The raw token.  Populated when you Parse a token
+	Method    SigningMethod          // The signing method used or to be used
+	Header    map[string]interface{} // The first segment of the token
+	Claims    Claims                 // The second segment of the token
+	Signature string                 // The third segment of the token.  Populated when you Parse a token
+	Valid     bool                   // Is the token valid?  Populated when you Parse/Verify a token
+}
+
+// Create a new Token.  Takes a signing method
+func New(method SigningMethod) *Token {
+	return NewWithClaims(method, MapClaims{})
+}
+
+func NewWithClaims(method SigningMethod, claims Claims) *Token {
+	return &Token{
+		Header: map[string]interface{}{
+			"typ": "JWT",
+			"alg": method.Alg(),
+		},
+		Claims: claims,
+		Method: method,
+	}
+}
+
+// Get the complete, signed token
+func (t *Token) SignedString(key interface{}) (string, error) {
+	var sig, sstr string
+	var err error
+	if sstr, err = t.SigningString(); err != nil {
+		return "", err
+	}
+	if sig, err = t.Method.Sign(sstr, key); err != nil {
+		return "", err
+	}
+	return strings.Join([]string{sstr, sig}, "."), nil
+}
+
+// Generate the signing string.  This is the
+// most expensive part of the whole deal.  Unless you
+// need this for something special, just go straight for
+// the SignedString.
+func (t *Token) SigningString() (string, error) {
+	var err error
+	parts := make([]string, 2)
+	for i, _ := range parts {
+		var jsonValue []byte
+		if i == 0 {
+			if jsonValue, err = json.Marshal(t.Header); err != nil {
+				return "", err
+			}
+		} else {
+			if jsonValue, err = json.Marshal(t.Claims); err != nil {
+				return "", err
+			}
+		}
+
+		parts[i] = EncodeSegment(jsonValue)
+	}
+	return strings.Join(parts, "."), nil
+}
+
+// Parse, validate, and return a token.
+// keyFunc will receive the parsed token and should return the key for validating.
+// If everything is kosher, err will be nil
+func Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
+	return new(Parser).Parse(tokenString, keyFunc)
+}
+
+func ParseWithClaims(tokenString string, claims Claims, keyFunc Keyfunc) (*Token, error) {
+	return new(Parser).ParseWithClaims(tokenString, claims, keyFunc)
+}
+
+// Encode JWT specific base64url encoding with padding stripped
+func EncodeSegment(seg []byte) string {
+	return strings.TrimRight(base64.URLEncoding.EncodeToString(seg), "=")
+}
+
+// Decode JWT specific base64url encoding with padding stripped
+func DecodeSegment(seg string) ([]byte, error) {
+	if l := len(seg) % 4; l > 0 {
+		seg += strings.Repeat("=", 4-l)
+	}
+
+	return base64.URLEncoding.DecodeString(seg)
+}

--- a/assembly/assembly-wsmaster-war/src/main/resources/META-INF/persistence.xml
+++ b/assembly/assembly-wsmaster-war/src/main/resources/META-INF/persistence.xml
@@ -65,6 +65,8 @@
         <class>org.eclipse.che.multiuser.organization.spi.impl.OrganizationDistributedResourcesImpl</class>
 
         <class>org.eclipse.che.api.workspace.activity.WorkspaceExpiration</class>
+        <class>org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyImpl</class>
+        <class>org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyPairImpl</class>
         <exclude-unlisted-classes>true</exclude-unlisted-classes>
     </persistence-unit>
 </persistence>

--- a/multiuser/keycloak/che-multiuser-keycloak-server/pom.xml
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/pom.xml
@@ -123,6 +123,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-personal-account</artifactId>
         </dependency>
         <dependency>

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/test/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilterTest.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/test/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilterTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.keycloak.server;
+
+import static io.jsonwebtoken.SignatureAlgorithm.RS256;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.MACHINE_TOKEN_KIND;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import io.jsonwebtoken.Jwts;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManager;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link AbstractKeycloakFilter}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class AbstractKeycloakFilterTest {
+
+  @Mock private HttpServletRequest request;
+  @Mock private SignatureKeyManager signatureKeyManager;
+
+  @InjectMocks private TestLoginFilter abstractKeycloakFilter;
+
+  private String machineToken;
+
+  @BeforeMethod
+  public void setup() throws Exception {
+    final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(512);
+    final KeyPair keyPair = kpg.generateKeyPair();
+    final Map<String, Object> header = new HashMap<>();
+    header.put("kind", MACHINE_TOKEN_KIND);
+    machineToken =
+        Jwts.builder()
+            .setPayload("payload")
+            .setHeader(header)
+            .signWith(RS256, keyPair.getPrivate())
+            .compact();
+
+    when(signatureKeyManager.getKeyPair()).thenReturn(keyPair);
+  }
+
+  @Test
+  public void testShouldNotSkipAuthWhenNullTokenProvided() {
+    assertFalse(abstractKeycloakFilter.shouldSkipAuthentication(request, null));
+  }
+
+  @Test
+  public void testShouldNotSkipAuthWhenProvidedTokenIsNotMachine() {
+    assertFalse(abstractKeycloakFilter.shouldSkipAuthentication(request, "testToken"));
+  }
+
+  @Test
+  public void testAuthIsNotNeededWhenMachineTokenProvided() throws Exception {
+    assertTrue(abstractKeycloakFilter.shouldSkipAuthentication(request, machineToken));
+  }
+
+  static class TestLoginFilter extends AbstractKeycloakFilter {
+    @Override
+    public void doFilter(
+        ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+        throws IOException, ServletException {}
+  }
+}

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/test/java/org/eclipse/che/multiuser/keycloak/server/KeycloakEnvironmentInitalizationFilterTest.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/test/java/org/eclipse/che/multiuser/keycloak/server/KeycloakEnvironmentInitalizationFilterTest.java
@@ -10,9 +10,11 @@
  */
 package org.eclipse.che.multiuser.keycloak.server;
 
+import static io.jsonwebtoken.SignatureAlgorithm.RS512;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -20,9 +22,14 @@ import static org.mockito.Mockito.when;
 import static org.testng.AssertJUnit.assertEquals;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.impl.DefaultClaims;
 import io.jsonwebtoken.impl.DefaultHeader;
 import io.jsonwebtoken.impl.DefaultJwt;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
 import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.FilterChain;
@@ -36,6 +43,8 @@ import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.commons.subject.SubjectImpl;
 import org.eclipse.che.multiuser.api.permission.server.AuthorizedSubject;
 import org.eclipse.che.multiuser.api.permission.server.PermissionChecker;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManager;
+import org.eclipse.che.multiuser.machine.authentication.shared.Constants;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -47,6 +56,7 @@ import org.testng.annotations.Test;
 @Listeners(value = {MockitoTestNGListener.class})
 public class KeycloakEnvironmentInitalizationFilterTest {
 
+  @Mock private SignatureKeyManager keyManager;
   @Mock private KeycloakUserManager userManager;
   @Mock private RequestTokenExtractor tokenExtractor;
   @Mock private PermissionChecker permissionChecker;
@@ -66,14 +76,26 @@ public class KeycloakEnvironmentInitalizationFilterTest {
     EnvironmentContext.setCurrent(context);
     filter =
         new KeycloakEnvironmentInitalizationFilter(userManager, tokenExtractor, permissionChecker);
+    filter.signatureKeyManager = keyManager;
+    final KeyPair kp = new KeyPair(mock(PublicKey.class), mock(PrivateKey.class));
+    when(keyManager.getKeyPair()).thenReturn(kp);
   }
 
   @Test
   public void shouldSkipRequestsWithMachineTokens() throws Exception {
-
-    EnvironmentContext context = EnvironmentContext.getCurrent();
-    // given
-    when(tokenExtractor.getToken(any(HttpServletRequest.class))).thenReturn("machine123123token");
+    final KeyPairGenerator kpg = KeyPairGenerator.getInstance("RSA");
+    kpg.initialize(1024);
+    final KeyPair keyPair = kpg.generateKeyPair();
+    when(keyManager.getKeyPair()).thenReturn(keyPair);
+    final Map<String, Object> header = new HashMap<>();
+    header.put("kind", Constants.MACHINE_TOKEN_KIND);
+    final String token =
+        Jwts.builder()
+            .setPayload("payload")
+            .setHeader(header)
+            .signWith(RS512, keyPair.getPrivate())
+            .compact();
+    when(tokenExtractor.getToken(any(HttpServletRequest.class))).thenReturn(token);
 
     // when
     filter.doFilter(request, response, chain);
@@ -81,7 +103,6 @@ public class KeycloakEnvironmentInitalizationFilterTest {
     // then
     verify(chain).doFilter(eq(request), eq(response));
     verifyNoMoreInteractions(userManager);
-    verifyNoMoreInteractions(context);
   }
 
   @Test

--- a/multiuser/machine-auth/che-multiuser-machine-authentication-agent/pom.xml
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-agent/pom.xml
@@ -25,8 +25,16 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>
@@ -46,15 +54,15 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-user-shared</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-auth</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.everrest</groupId>

--- a/multiuser/machine-auth/che-multiuser-machine-authentication-agent/src/main/java/org/eclipse/che/multiuser/machine/authentication/agent/MachineLoginFilter.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-agent/src/main/java/org/eclipse/che/multiuser/machine/authentication/agent/MachineLoginFilter.java
@@ -11,8 +11,22 @@
 package org.eclipse.che.multiuser.machine.authentication.agent;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.MACHINE_TOKEN_KIND;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.USER_ID_CLAIM;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.USER_NAME_CLAIM;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.WORKSPACE_ID_CLAIM;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import java.io.IOException;
+import java.security.PublicKey;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -25,10 +39,6 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import org.eclipse.che.api.core.ApiException;
-import org.eclipse.che.api.core.UnauthorizedException;
-import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
-import org.eclipse.che.api.user.shared.dto.UserDto;
 import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
@@ -42,18 +52,19 @@ import org.eclipse.che.commons.subject.SubjectImpl;
 @Singleton
 public class MachineLoginFilter implements Filter {
 
-  private final String apiEndpoint;
-  private final HttpJsonRequestFactory requestFactory;
+  private final PublicKey publicKey;
   private final RequestTokenExtractor tokenExtractor;
+
+  private final String workspaceId;
 
   @Inject
   public MachineLoginFilter(
-      @Named("che.api") String apiEndpoint,
-      HttpJsonRequestFactory requestFactory,
+      @Named("env.CHE_WORKSPACE_ID") String workspaceId,
+      @Named("signature.public.key") PublicKey publicKey,
       RequestTokenExtractor tokenExtractor) {
-    this.apiEndpoint = apiEndpoint;
-    this.requestFactory = requestFactory;
     this.tokenExtractor = tokenExtractor;
+    this.publicKey = publicKey;
+    this.workspaceId = workspaceId;
   }
 
   @Override
@@ -64,48 +75,72 @@ public class MachineLoginFilter implements Filter {
       throws IOException, ServletException {
     final HttpServletRequest httpRequest = (HttpServletRequest) request;
     final HttpSession session = httpRequest.getSession(false);
-    if (session != null && session.getAttribute("principal") != null) {
+
+    // sets subject from session
+    final Subject sessionSubject;
+    if (session != null && (sessionSubject = (Subject) session.getAttribute("principal")) != null) {
       try {
-        EnvironmentContext.getCurrent().setSubject((Subject) session.getAttribute("principal"));
+        EnvironmentContext.getCurrent().setSubject(sessionSubject);
         chain.doFilter(request, response);
         return;
       } finally {
         EnvironmentContext.reset();
       }
     }
-    final String machineToken = tokenExtractor.getToken(httpRequest);
-    if (isNullOrEmpty(machineToken)) {
-      ((HttpServletResponse) response)
-          .sendError(
-              HttpServletResponse.SC_UNAUTHORIZED,
-              "Authentication on machine failed, token is missed");
+
+    // retrieves a token from a request and verify it
+    final String token = tokenExtractor.getToken(httpRequest);
+    if (isNullOrEmpty(token)) {
+      sendErr(response, SC_UNAUTHORIZED, "Authentication on machine failed, token is missed.");
       return;
     }
+
+    // checks token signature and workspace identifier if ok then sets subject into the context
     try {
-      final UserDto userDescriptor =
-          requestFactory
-              .fromUrl(apiEndpoint + "/user/")
-              .useGetMethod()
-              .setAuthorizationHeader(machineToken)
-              .request()
-              .asDto(UserDto.class);
-      final Subject machineUser =
-          new SubjectImpl(userDescriptor.getName(), userDescriptor.getId(), machineToken, false);
-      EnvironmentContext.getCurrent().setSubject(machineUser);
-      final HttpSession httpSession = httpRequest.getSession(true);
-      httpSession.setAttribute("principal", machineUser);
-      chain.doFilter(request, response);
-    } catch (UnauthorizedException nfEx) {
-      ((HttpServletResponse) response)
-          .sendError(
-              HttpServletResponse.SC_UNAUTHORIZED,
-              "Authentication on machine failed, token " + machineToken + " is invalid");
-    } catch (ApiException apiEx) {
-      ((HttpServletResponse) response)
-          .sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, apiEx.getMessage());
-    } finally {
-      EnvironmentContext.reset();
+      final Jws<Claims> jwt = Jwts.parser().setSigningKey(publicKey).parseClaimsJws(token);
+      final Claims claims = jwt.getBody();
+      if (!isValidToken(jwt)) {
+        sendErr(
+            response, SC_UNAUTHORIZED, "Authentication on machine failed, invalid token provided.");
+        return;
+      }
+
+      try {
+        final SubjectImpl subject =
+            new SubjectImpl(
+                claims.get(USER_NAME_CLAIM, String.class),
+                claims.get(USER_ID_CLAIM, String.class),
+                token,
+                false);
+        EnvironmentContext.getCurrent().setSubject(subject);
+        final HttpSession httpSession = httpRequest.getSession(true);
+        httpSession.setAttribute("principal", subject);
+        chain.doFilter(request, response);
+      } finally {
+        EnvironmentContext.reset();
+      }
+    } catch (ExpiredJwtException
+        | UnsupportedJwtException
+        | MalformedJwtException
+        | SignatureException
+        | IllegalArgumentException ex) {
+      sendErr(
+          response,
+          SC_UNAUTHORIZED,
+          format("Authentication on machine failed cause: '%s'", ex.getMessage()));
     }
+  }
+
+  /** Checks whether given JWT token is valid */
+  private boolean isValidToken(Jws<Claims> jwt) {
+    return MACHINE_TOKEN_KIND.equals(jwt.getHeader().get("kind"))
+        && workspaceId.equals(jwt.getBody().get(WORKSPACE_ID_CLAIM, String.class));
+  }
+
+  /** Sets given error code with err message into give response. */
+  private static void sendErr(ServletResponse res, int errCode, String msg) throws IOException {
+    final HttpServletResponse response = (HttpServletResponse) res;
+    response.sendError(errCode, msg);
   }
 
   @Override

--- a/multiuser/machine-auth/che-multiuser-machine-authentication-agent/src/test/java/org/eclipse/che/multiuser/machine/authentication/agent/MachineLoginFilterTest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-agent/src/test/java/org/eclipse/che/multiuser/machine/authentication/agent/MachineLoginFilterTest.java
@@ -10,157 +10,177 @@
  */
 package org.eclipse.che.multiuser.machine.authentication.agent;
 
+import static io.jsonwebtoken.SignatureAlgorithm.RS512;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.MACHINE_TOKEN_KIND;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
+import com.google.gson.Gson;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.HashMap;
+import java.util.Map;
 import javax.servlet.FilterChain;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import javax.ws.rs.core.HttpHeaders;
-import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.UnauthorizedException;
-import org.eclipse.che.api.core.rest.HttpJsonRequest;
-import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
-import org.eclipse.che.api.core.rest.HttpJsonResponse;
-import org.eclipse.che.api.user.shared.dto.UserDto;
-import org.eclipse.che.commons.auth.token.HeaderRequestTokenExtractor;
 import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
-import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.commons.subject.SubjectImpl;
-import org.eclipse.che.commons.test.mockito.answer.SelfReturningAnswer;
+import org.eclipse.che.multiuser.machine.authentication.shared.Constants;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
-/** @author Anton Korneta */
+/**
+ * Tests {@link MachineLoginFilter}.
+ *
+ * @author Anton Korneta
+ */
 @Listeners(MockitoTestNGListener.class)
 public class MachineLoginFilterTest {
-  private static final String API_ENDPOINT = "http://localhost:8080/api";
-  private static final String MACHINE_TOKEN = "machineToken";
-  private static final String USERNAME = "fakeName";
-  private static final String USER_ID = "12";
 
-  @Mock HttpJsonRequestFactory requestFactoryMock;
-  @Mock HttpServletResponse servletResponseMock;
-  @Mock FilterChain chainMock;
-  @Mock HttpSession sessionMock;
-  @Mock UserDto userMock;
-  @Mock HttpJsonResponse jsonResponseMock;
+  private static final int KEY_SIZE = 1024;
 
-  RequestTokenExtractor requestTokenExtractor;
-  HttpJsonRequest httpJsonRequestMock;
-  Subject machineSubject;
+  private static final Gson GSON = new Gson();
 
-  MachineLoginFilter machineLoginFilter;
+  private static final String SIGNATURE_ALGORITHM = "RSA";
+  private static final String WORKSPACE_ID = "workspace31";
+  private static final String PRINCIPAL = "principal";
+  private static final String USER_ID = "test_user31";
+  private static final String USER_NAME = "test_user";
+
+  private static final Map<String, Object> HEADER = new HashMap<>();
+  private static final Map<String, Object> CLAIMS = new HashMap<>(2);
+
+  static {
+    HEADER.put("kind", MACHINE_TOKEN_KIND);
+    CLAIMS.put(Constants.WORKSPACE_ID_CLAIM, WORKSPACE_ID);
+    CLAIMS.put(Constants.USER_ID_CLAIM, USER_ID);
+    CLAIMS.put(Constants.USER_NAME_CLAIM, USER_NAME);
+    CLAIMS.put(Claims.ID, "8312-213-1we31");
+  }
+
+  @Mock private RequestTokenExtractor tokenExtractorMock;
+  @Mock private FilterChain chainMock;
+  @Mock private HttpSession sessionMock;
+  @Mock private HttpServletResponse responseMock;
+
+  private MachineLoginFilter machineLoginFilter;
+
+  private String machineToken;
+  private KeyPair keyPair;
+  private Subject subject;
 
   @BeforeMethod
   public void setUp() throws Exception {
-    requestTokenExtractor = new HeaderRequestTokenExtractor();
+    final KeyPairGenerator kpg = KeyPairGenerator.getInstance(SIGNATURE_ALGORITHM);
+    kpg.initialize(KEY_SIZE);
+    keyPair = kpg.generateKeyPair();
+    machineToken =
+        Jwts.builder()
+            .setClaims(CLAIMS)
+            .setHeader(HEADER)
+            .signWith(RS512, keyPair.getPrivate())
+            .compact();
     machineLoginFilter =
-        new MachineLoginFilter(API_ENDPOINT, requestFactoryMock, requestTokenExtractor);
-    httpJsonRequestMock = mock(HttpJsonRequest.class, new SelfReturningAnswer());
-    EnvironmentContext.reset();
-    when(requestFactoryMock.fromUrl(anyString())).thenReturn(httpJsonRequestMock);
-    when(httpJsonRequestMock.request()).thenReturn(jsonResponseMock);
-    when(httpJsonRequestMock.useGetMethod().setAuthorizationHeader(anyString()))
-        .thenReturn(httpJsonRequestMock);
-    when(userMock.getName()).thenReturn(USERNAME);
-    when(userMock.getId()).thenReturn(USER_ID);
-    machineSubject = new SubjectImpl(USERNAME, USER_ID, MACHINE_TOKEN, false);
+        spy(new MachineLoginFilter(WORKSPACE_ID, keyPair.getPublic(), tokenExtractorMock));
+
+    subject = new SubjectImpl(USER_NAME, USER_ID, machineToken, false);
+    when(tokenExtractorMock.getToken(any(HttpServletRequest.class))).thenReturn(machineToken);
   }
 
   @Test
-  public void shouldProcessingRequestThenCreateHttpSessionAndPutUserIntoHttpSession()
-      throws Exception {
-    // token service response mocking
-    when(jsonResponseMock.asDto(UserDto.class)).thenReturn(userMock);
-    // mocking for setting the principal in http session
-    doNothing().when(sessionMock).setAttribute(anyString(), any());
+  public void testProcessRequestWithSubjectFromSession() throws Exception {
+    when(sessionMock.getAttribute(PRINCIPAL)).thenReturn(subject);
 
-    machineLoginFilter.doFilter(
-        getRequestMock(null, MACHINE_TOKEN), servletResponseMock, chainMock);
+    machineLoginFilter.doFilter(getRequestMock(sessionMock, machineToken), responseMock, chainMock);
 
-    verify(sessionMock).setAttribute("principal", machineSubject);
+    verify(sessionMock).getAttribute(PRINCIPAL);
+    verifyZeroInteractions(tokenExtractorMock);
   }
 
   @Test
-  public void shouldProcessingRequestWithValidQueryParameterAndPutUserIntoHttpSession()
-      throws Exception {
-    // token service response mocking
-    when(jsonResponseMock.asDto(UserDto.class)).thenReturn(userMock);
-    // mocking for setting the principal in http session
-    doNothing().when(sessionMock).setAttribute(anyString(), any());
-    final HttpServletRequest requestMock = getRequestMock(null, MACHINE_TOKEN);
-    when(requestMock.getQueryString()).thenReturn("token=" + MACHINE_TOKEN);
+  public void testSetErrorInResponseWhenNullTokenProvided() throws Exception {
+    when(tokenExtractorMock.getToken(any(HttpServletRequest.class))).thenReturn(null);
 
-    machineLoginFilter.doFilter(requestMock, servletResponseMock, chainMock);
+    machineLoginFilter.doFilter(getRequestMock(null, machineToken), responseMock, chainMock);
 
-    verify(sessionMock).setAttribute("principal", machineSubject);
+    verify(tokenExtractorMock).getToken(any(HttpServletRequest.class));
+    verify(responseMock)
+        .sendError(SC_UNAUTHORIZED, "Authentication on machine failed, token is missed.");
   }
 
   @Test
-  public void shouldProcessingRequestWithAliveSessionAndConfiguredPrincipal() throws Exception {
-    // mocking of session principal
-    final Subject subject = new SubjectImpl(USERNAME, USER_ID, MACHINE_TOKEN, false);
-    when(sessionMock.getAttribute("principal")).thenReturn(subject);
-    final HttpServletRequest requestMock = getRequestMock(sessionMock, MACHINE_TOKEN);
-    machineLoginFilter.doFilter(requestMock, servletResponseMock, chainMock);
+  public void testProcessRequestWithValidTokenAndCreateSession() throws Exception {
+    machineLoginFilter.doFilter(getRequestMock(null, machineToken), responseMock, chainMock);
 
-    verify(chainMock).doFilter(requestMock, servletResponseMock);
+    verify(tokenExtractorMock).getToken(any(HttpServletRequest.class));
+    verify(sessionMock).setAttribute(PRINCIPAL, subject);
+    verifyZeroInteractions(responseMock);
   }
 
   @Test
-  public void shouldNotProcessingRequestWithEmptyTokenAndShowUnauthorisedServletResponse()
-      throws Exception {
-    // put empty token into request
-    machineLoginFilter.doFilter(getRequestMock(null, null), servletResponseMock, chainMock);
+  public void testSetErrorInResponseWhenInvalidTokenProvided() throws Exception {
+    final String invalidToken = "invalid_token";
+    when(tokenExtractorMock.getToken(any(HttpServletRequest.class))).thenReturn(invalidToken);
 
-    verify(servletResponseMock)
+    machineLoginFilter.doFilter(getRequestMock(null, invalidToken), responseMock, chainMock);
+
+    verify(tokenExtractorMock).getToken(any(HttpServletRequest.class));
+    verify(responseMock)
         .sendError(
-            HttpServletResponse.SC_UNAUTHORIZED,
-            "Authentication on machine failed, token is missed");
+            eq(SC_UNAUTHORIZED),
+            argThat(s -> s.startsWith("Authentication on machine failed cause:")));
   }
 
   @Test
-  public void shouldNotProcessingRequestWhenApiExceptionOccurs() throws Exception {
-    final String apiExMsg = "panic!";
-    // token service response mocking
-    when(jsonResponseMock.asDto(UserDto.class)).thenReturn(userMock);
-    // mocking for setting the principal in http session
-    doNothing().when(sessionMock).setAttribute(anyString(), any());
-    when(httpJsonRequestMock.request()).thenThrow(new ServerException(apiExMsg));
+  public void testSetErrorInResponseWhenNonMachineTokenProvided() throws Exception {
+    final String differentToken =
+        Jwts.builder()
+            .setPayload(GSON.toJson(subject))
+            .setHeader(new HashMap<>())
+            .signWith(RS512, keyPair.getPrivate())
+            .compact();
+    when(tokenExtractorMock.getToken(any(HttpServletRequest.class))).thenReturn(differentToken);
 
-    machineLoginFilter.doFilter(
-        getRequestMock(null, MACHINE_TOKEN), servletResponseMock, chainMock);
+    machineLoginFilter.doFilter(getRequestMock(null, differentToken), responseMock, chainMock);
 
-    verify(servletResponseMock).sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, apiExMsg);
+    verify(tokenExtractorMock).getToken(any(HttpServletRequest.class));
+    verify(responseMock)
+        .sendError(SC_UNAUTHORIZED, "Authentication on machine failed, invalid token provided.");
   }
 
   @Test
-  public void shouldNotProcessingRequestWithInvalidTokenAndShowUnauthorisedServletResponse()
-      throws Exception {
-    // token service response mocking
-    when(jsonResponseMock.asDto(UserDto.class)).thenReturn(userMock);
-    // mocking for setting the principal in http session
-    doNothing().when(sessionMock).setAttribute(anyString(), any());
-    when(httpJsonRequestMock.request())
-        .thenThrow(new UnauthorizedException("Token " + MACHINE_TOKEN + " Not found"));
+  public void testSetErrorInResponseWhenTokenIsNotRelatedToThisWorkspace() throws Exception {
+    final Map<String, Object> headers = new HashMap<>();
+    headers.put("kind", MACHINE_TOKEN_KIND);
+    headers.put("workspace", "workspace73");
+    final String differentToken =
+        Jwts.builder()
+            .setPayload(GSON.toJson(subject))
+            .setHeader(headers)
+            .signWith(RS512, keyPair.getPrivate())
+            .compact();
+    when(tokenExtractorMock.getToken(any(HttpServletRequest.class))).thenReturn(differentToken);
 
-    machineLoginFilter.doFilter(
-        getRequestMock(null, MACHINE_TOKEN), servletResponseMock, chainMock);
+    machineLoginFilter.doFilter(getRequestMock(null, differentToken), responseMock, chainMock);
 
-    verify(servletResponseMock)
-        .sendError(
-            HttpServletResponse.SC_UNAUTHORIZED,
-            "Authentication on machine failed, token " + MACHINE_TOKEN + " is invalid");
+    verify(tokenExtractorMock).getToken(any(HttpServletRequest.class));
+    verify(responseMock)
+        .sendError(SC_UNAUTHORIZED, "Authentication on machine failed, invalid token provided.");
   }
 
   // if the session is null it means that there will be created new one

--- a/multiuser/machine-auth/che-multiuser-machine-authentication-shared/src/main/java/org/eclipse/che/multiuser/machine/authentication/shared/Constants.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-shared/src/main/java/org/eclipse/che/multiuser/machine/authentication/shared/Constants.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.shared;
+
+/** @author Anton Korneta */
+public class Constants {
+
+  public static final String USER_ID_CLAIM = "uid";
+  public static final String USER_NAME_CLAIM = "uname";
+  public static final String WORKSPACE_ID_CLAIM = "wsid";
+
+  public static final String MACHINE_TOKEN_KIND = "machine_token";
+
+  public static final String SIGNATURE_ALGORITHM_ENV = "CHE_MACHINE_AUTH_SIGNATURE__ALGORITHM";
+  public static final String SIGNATURE_PUBLIC_KEY_ENV = "CHE_MACHINE_AUTH_SIGNATURE__PUBLIC__KEY";
+
+  private Constants() {}
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/pom.xml
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/pom.xml
@@ -38,6 +38,22 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-persist</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
@@ -71,11 +87,19 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-auth</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-db</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
@@ -86,18 +110,21 @@
             <artifactId>che-multiuser-machine-authentication-shared</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.multiuser</groupId>
-            <artifactId>che-multiuser-api-permission</artifactId>
-            <scope>provided</scope>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.multiuser</groupId>
-            <artifactId>che-multiuser-permission-workspace</artifactId>
-            <scope>provided</scope>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -107,17 +134,27 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-test</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-db</artifactId>
+            <artifactId>che-core-db-vendor-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-sql-schema</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
-            <artifactId>javax.persistence</artifactId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -216,6 +253,23 @@
                         <version>${project.version}</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <!-- Create the test jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/spi/tck/*.*</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthModule.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthModule.java
@@ -11,7 +11,15 @@
 package org.eclipse.che.multiuser.machine.authentication.server;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.multibindings.Multibinder;
+import com.google.inject.name.Names;
+import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureAlgorithmEnvProvider;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManager;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignaturePublicKeyEnvProvider;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.jpa.JpaSignatureKeyDao;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.spi.SignatureKeyDao;
 
 /**
  * Machine auth module.
@@ -25,5 +33,14 @@ public class MachineAuthModule extends AbstractModule {
     bind(MachineSessionInvalidator.class).asEagerSingleton();
 
     bind(MachineTokenProvider.class).to(MachineTokenProviderImpl.class);
+
+    bind(SignatureKeyManager.class);
+    bind(SignatureKeyDao.class).to(JpaSignatureKeyDao.class);
+    final Multibinder<EnvVarProvider> envVarProviders =
+        Multibinder.newSetBinder(binder(), EnvVarProvider.class);
+    envVarProviders.addBinding().to(SignaturePublicKeyEnvProvider.class);
+    envVarProviders.addBinding().to(SignatureAlgorithmEnvProvider.class);
+    bindConstant().annotatedWith(Names.named("che.auth.signature_key_size")).to(2048);
+    bindConstant().annotatedWith(Names.named("che.auth.signature_key_algorithm")).to("RSA");
   }
 }

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineLoginFilter.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineLoginFilter.java
@@ -10,8 +10,19 @@
  */
 package org.eclipse.che.multiuser.machine.authentication.server;
 
-import static com.google.common.base.Strings.nullToEmpty;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static javax.servlet.http.HttpServletResponse.SC_UNAUTHORIZED;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.MACHINE_TOKEN_KIND;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.USER_ID_CLAIM;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import java.io.IOException;
 import java.security.Principal;
 import javax.inject.Inject;
@@ -24,9 +35,9 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.model.user.User;
 import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
 import org.eclipse.che.commons.env.EnvironmentContext;
@@ -34,52 +45,99 @@ import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.commons.subject.SubjectImpl;
 import org.eclipse.che.multiuser.api.permission.server.AuthorizedSubject;
 import org.eclipse.che.multiuser.api.permission.server.PermissionChecker;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManager;
 
-/** @author Max Shaposhnik (mshaposhnik@codenvy.com) */
+/**
+ * Handles requests that comes from machines with specific machine token.
+ *
+ * @author Max Shaposhnik (mshaposhnik@codenvy.com)
+ * @author Anton Korneta
+ */
 @Singleton
 public class MachineLoginFilter implements Filter {
 
-  @Inject private RequestTokenExtractor tokenExtractor;
+  private final RequestTokenExtractor tokenExtractor;
+  private final UserManager userManager;
+  private final SignatureKeyManager keyManager;
+  private final PermissionChecker permissionChecker;
 
-  @Inject private MachineTokenRegistry machineTokenRegistry;
-
-  @Inject private UserManager userManager;
-
-  @Inject private PermissionChecker permissionChecker;
+  @Inject
+  public MachineLoginFilter(
+      RequestTokenExtractor tokenExtractor,
+      UserManager userManager,
+      SignatureKeyManager keyManager,
+      PermissionChecker permissionChecker) {
+    this.tokenExtractor = tokenExtractor;
+    this.userManager = userManager;
+    this.keyManager = keyManager;
+    this.permissionChecker = permissionChecker;
+  }
 
   @Override
   public void init(FilterConfig filterConfig) throws ServletException {}
 
   @Override
-  public void doFilter(
-      ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
-    final HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
-    if (!nullToEmpty(tokenExtractor.getToken(httpRequest)).startsWith("machine")) {
-      filterChain.doFilter(servletRequest, servletResponse);
+    final HttpServletRequest httpRequest = (HttpServletRequest) request;
+    final String token = tokenExtractor.getToken(httpRequest);
+
+    if (isNullOrEmpty(token)) {
+      chain.doFilter(request, response);
       return;
-    } else {
-      String tokenString;
-      User user;
-      try {
-        tokenString = tokenExtractor.getToken(httpRequest);
-        String userId = machineTokenRegistry.getUserId(tokenString);
-        user = userManager.getById(userId);
-      } catch (NotFoundException | ServerException e) {
-        throw new ServletException("Cannot find user by machine token.");
+    }
+
+    // check token signature and verify is this token machine or not
+    try {
+      final Jws<Claims> jwt =
+          Jwts.parser().setSigningKey(keyManager.getKeyPair().getPublic()).parseClaimsJws(token);
+      final Claims claims = jwt.getBody();
+
+      if (!isMachineToken(jwt)) {
+        chain.doFilter(request, response);
+        return;
       }
 
-      final Subject subject =
-          new AuthorizedSubject(
-              new SubjectImpl(user.getName(), user.getId(), tokenString, false), permissionChecker);
-
       try {
-        EnvironmentContext.getCurrent().setSubject(subject);
-        filterChain.doFilter(addUserInRequest(httpRequest, subject), servletResponse);
+        final String userId = claims.get(USER_ID_CLAIM, String.class);
+        // check if user with such id exists
+        final String userName = userManager.getById(userId).getName();
+        final Subject authorizedSubject =
+            new AuthorizedSubject(
+                new SubjectImpl(userName, userId, token, false), permissionChecker);
+        EnvironmentContext.getCurrent().setSubject(authorizedSubject);
+        chain.doFilter(addUserInRequest(httpRequest, authorizedSubject), response);
+      } catch (NotFoundException ex) {
+        sendErr(
+            response,
+            SC_UNAUTHORIZED,
+            "Authentication with machine token failed because user for this token no longer exist.");
+      } catch (ServerException ex) {
+        sendErr(
+            response,
+            SC_UNAUTHORIZED,
+            format("Authentication with machine token failed cause: %s", ex.getMessage()));
       } finally {
         EnvironmentContext.reset();
       }
+    } catch (UnsupportedJwtException
+        | MalformedJwtException
+        | SignatureException
+        | ExpiredJwtException ex) {
+      // signature check failed
+      chain.doFilter(request, response);
     }
+  }
+
+  /** Checks whether given token from a machine. */
+  private boolean isMachineToken(Jws<Claims> jwt) {
+    return MACHINE_TOKEN_KIND.equals(jwt.getHeader().get("kind"));
+  }
+
+  /** Sets given error code with err message into give response. */
+  private static void sendErr(ServletResponse res, int errCode, String msg) throws IOException {
+    final HttpServletResponse response = (HttpServletResponse) res;
+    response.sendError(errCode, msg);
   }
 
   private HttpServletRequest addUserInRequest(

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureAlgorithmEnvProvider.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureAlgorithmEnvProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.multiuser.machine.authentication.shared.Constants;
+
+/**
+ * Provides signature algorithm into machine environment.
+ *
+ * @author Anton Korneta
+ */
+public class SignatureAlgorithmEnvProvider implements EnvVarProvider {
+
+  private final String algorithm;
+
+  @Inject
+  public SignatureAlgorithmEnvProvider(
+      @Named("che.auth.signature_key_algorithm") String algorithm) {
+    this.algorithm = algorithm;
+  }
+
+  @Override
+  public Pair<String, String> get(RuntimeIdentity runtimeIdentity) {
+    return Pair.of(Constants.SIGNATURE_ALGORITHM_ENV, algorithm);
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureKey.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureKey.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Defines signature key interface.
+ *
+ * @author Anton Korneta
+ */
+@Beta
+public interface SignatureKey {
+
+  /** Returns algorithm of this signature key. */
+  String getAlgorithm();
+
+  /** Returns encoding format of this signature key. */
+  String getFormat();
+
+  /** Returns encoded value of this signature key. */
+  byte[] getEncoded();
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureKeyManager.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureKeyManager.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature;
+
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
+
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.EncodedKeySpec;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Iterator;
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.core.db.DBInitializer;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyPairImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.spi.SignatureKeyDao;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages signature keys.
+ *
+ * @author Anton Korneta
+ */
+@Beta
+@Singleton
+public class SignatureKeyManager {
+
+  public static final String PKCS_8 = "PKCS#8";
+  public static final String X_509 = "X.509";
+
+  private static final Logger LOG = LoggerFactory.getLogger(SignatureKeyManager.class);
+
+  private final int keySize;
+
+  private final String algorithm;
+  private final SignatureKeyDao signatureKeyDao;
+
+  @Inject
+  @SuppressWarnings("unused")
+  private DBInitializer dbInitializer;
+
+  private KeyPair cachedPair;
+
+  @Inject
+  public SignatureKeyManager(
+      @Named("che.auth.signature_key_size") int keySize,
+      @Named("che.auth.signature_key_algorithm") String algorithm,
+      SignatureKeyDao signatureKeyDao) {
+    this.keySize = keySize;
+    this.algorithm = algorithm;
+    this.signatureKeyDao = signatureKeyDao;
+  }
+
+  /** Returns cached instance of {@link KeyPair} or null when failed to load key pair. */
+  @Nullable
+  public KeyPair getKeyPair() {
+    if (cachedPair == null) {
+      loadKeyPair();
+    }
+    return cachedPair;
+  }
+
+  /** Loads signature key pair if no existing keys found then stores a newly generated key pair. */
+  @PostConstruct
+  @VisibleForTesting
+  void loadKeyPair() {
+    try {
+      final Iterator<SignatureKeyPairImpl> it = signatureKeyDao.getAll(1, 0).getItems().iterator();
+      if (it.hasNext()) {
+        cachedPair = toJavaKeyPair(it.next());
+        return;
+      }
+    } catch (ServerException ex) {
+      LOG.error("Failed to load signature keys. Cause: {}", ex.getMessage());
+      return;
+    }
+
+    try {
+      cachedPair = toJavaKeyPair(signatureKeyDao.create(generateKeyPair()));
+    } catch (ConflictException | ServerException ex) {
+      LOG.error("Failed to store signature keys. Cause: {}", ex.getMessage());
+    }
+  }
+
+  @VisibleForTesting
+  SignatureKeyPairImpl generateKeyPair() throws ServerException {
+    final KeyPairGenerator kpg;
+    try {
+      kpg = KeyPairGenerator.getInstance(algorithm);
+    } catch (NoSuchAlgorithmException ex) {
+      throw new ServerException(ex.getMessage(), ex);
+    }
+    kpg.initialize(keySize);
+    final KeyPair pair = kpg.generateKeyPair();
+    final SignatureKeyPairImpl kp =
+        new SignatureKeyPairImpl(generate("signatureKey", 16), pair.getPublic(), pair.getPrivate());
+    LOG.info("Generated signature key pair with id {} and algorithm {}.", kp.getId(), algorithm);
+    return kp;
+  }
+
+  /** Converts {@link SignatureKeyPair} to {@link KeyPair}. */
+  public static KeyPair toJavaKeyPair(SignatureKeyPair keyPair) throws ServerException {
+    try {
+      final PrivateKey privateKey =
+          KeyFactory.getInstance(keyPair.getPrivateKey().getAlgorithm())
+              .generatePrivate(getKeySpec(keyPair.getPrivateKey()));
+      final PublicKey publicKey =
+          KeyFactory.getInstance(keyPair.getPublicKey().getAlgorithm())
+              .generatePublic(getKeySpec(keyPair.getPublicKey()));
+      return new KeyPair(publicKey, privateKey);
+    } catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+      LOG.error("Failed to convert signature key pair to Java keys. Cause: {}", ex.getMessage());
+      throw new ServerException("Failed to convert signature key pair to Java keys.");
+    }
+  }
+
+  /** Returns key spec by key format and encoded data. */
+  private static EncodedKeySpec getKeySpec(SignatureKey key) {
+    switch (key.getFormat()) {
+      case PKCS_8:
+        return new PKCS8EncodedKeySpec(key.getEncoded());
+      case X_509:
+        return new X509EncodedKeySpec(key.getEncoded());
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unsupported key spec '%s' for signature keys", key.getFormat()));
+    }
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureKeyPair.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureKeyPair.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Represents signature key pair with public and private part.
+ *
+ * @see SignatureKey
+ * @author Anton Korneta
+ */
+@Beta
+public interface SignatureKeyPair {
+
+  /** Returns unique identifier for this sign key pair. */
+  String getId();
+
+  /** Returns public part for this sign key pair. */
+  SignatureKey getPublicKey();
+
+  /** Returns private part for this sign key pair. */
+  SignatureKey getPrivateKey();
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignaturePublicKeyEnvProvider.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignaturePublicKeyEnvProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature;
+
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.SIGNATURE_PUBLIC_KEY_ENV;
+
+import java.util.Base64;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
+import org.eclipse.che.commons.lang.Pair;
+
+/**
+ * Provides a public part of a signature key into machine environment.
+ *
+ * @author Anton Korneta
+ */
+public class SignaturePublicKeyEnvProvider implements EnvVarProvider {
+
+  private final SignatureKeyManager keyManager;
+
+  @Inject
+  public SignaturePublicKeyEnvProvider(SignatureKeyManager keyManager) {
+    this.keyManager = keyManager;
+  }
+
+  @Override
+  public Pair<String, String> get(RuntimeIdentity runtimeIdentity) {
+    return Pair.of(
+        SIGNATURE_PUBLIC_KEY_ENV,
+        new String(Base64.getEncoder().encode(keyManager.getKeyPair().getPublic().getEncoded())));
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/jpa/JpaSignatureKeyDao.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/jpa/JpaSignatureKeyDao.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature.jpa;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+import com.google.inject.persist.Transactional;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.persistence.EntityManager;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.Page;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.core.db.jpa.DuplicateKeyException;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyPairImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.spi.SignatureKeyDao;
+
+/**
+ * JPA based implementation of {@link SignatureKeyDao}.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class JpaSignatureKeyDao implements SignatureKeyDao {
+
+  private final Provider<EntityManager> managerProvider;
+
+  @Inject
+  public JpaSignatureKeyDao(Provider<EntityManager> managerProvider) {
+    this.managerProvider = managerProvider;
+  }
+
+  @Override
+  public SignatureKeyPairImpl create(SignatureKeyPairImpl keyPair)
+      throws ConflictException, ServerException {
+    requireNonNull(keyPair, "Required non-null key pair");
+    try {
+      doCreate(keyPair);
+    } catch (DuplicateKeyException dkEx) {
+      throw new ConflictException(
+          format("Signature key pair with id '%s' already exists", keyPair.getId()));
+    } catch (RuntimeException ex) {
+      throw new ServerException(ex.getMessage(), ex);
+    }
+    return new SignatureKeyPairImpl(keyPair);
+  }
+
+  @Transactional
+  protected void doCreate(SignatureKeyPairImpl key) {
+    final EntityManager manager = managerProvider.get();
+    manager.persist(key);
+    manager.flush();
+  }
+
+  @Override
+  public void remove(String id) throws ServerException {
+    requireNonNull(id, "Required non-null key pair");
+    try {
+      doRemove(id);
+    } catch (RuntimeException ex) {
+      throw new ServerException(ex.getMessage(), ex);
+    }
+  }
+
+  @Transactional
+  protected void doRemove(String id) {
+    final SignatureKeyPairImpl keyPair = managerProvider.get().find(SignatureKeyPairImpl.class, id);
+    if (keyPair != null) {
+      final EntityManager manager = managerProvider.get();
+      manager.remove(keyPair);
+      manager.flush();
+    }
+  }
+
+  @Override
+  @Transactional
+  public Page<SignatureKeyPairImpl> getAll(int maxItems, long skipCount) throws ServerException {
+    checkArgument(maxItems >= 0, "The number of items to return can't be negative.");
+    checkArgument(
+        skipCount >= 0,
+        "The number of items to skip can't be negative or greater than " + Integer.MAX_VALUE);
+    try {
+      final EntityManager manager = managerProvider.get();
+      final List<SignatureKeyPairImpl> list =
+          manager
+              .createNamedQuery("SignKeyPair.getAll", SignatureKeyPairImpl.class)
+              .setMaxResults(maxItems)
+              .setFirstResult((int) skipCount)
+              .getResultList()
+              .stream()
+              .map(SignatureKeyPairImpl::new)
+              .collect(toList());
+      final long count =
+          manager.createNamedQuery("SignKeyPair.getAllCount", Long.class).getSingleResult();
+      return new Page<>(list, skipCount, maxItems, count);
+    } catch (RuntimeException ex) {
+      throw new ServerException(ex.getMessage(), ex);
+    }
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/model/impl/SignatureKeyImpl.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/model/impl/SignatureKeyImpl.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl;
+
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKey;
+
+/** @author Anton Korneta */
+@Entity(name = "SignKey")
+@Table(name = "che_sign_key")
+public class SignatureKeyImpl implements SignatureKey {
+
+  @Id
+  @GeneratedValue
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "algorithm")
+  private String algorithm;
+
+  @Column(name = "encoding_format")
+  private String format;
+
+  @Column(name = "encoded_value")
+  private byte[] encoded;
+
+  public SignatureKeyImpl() {}
+
+  public SignatureKeyImpl(Key publicKey) {
+    this(publicKey.getEncoded(), publicKey.getAlgorithm(), publicKey.getFormat());
+  }
+
+  public SignatureKeyImpl(byte[] encoded, String algorithm, String format) {
+    this.encoded = encoded;
+    this.algorithm = algorithm;
+    this.format = format;
+  }
+
+  @Override
+  public String getAlgorithm() {
+    return algorithm;
+  }
+
+  @Override
+  public String getFormat() {
+    return format;
+  }
+
+  @Override
+  public byte[] getEncoded() {
+    return encoded;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof SignatureKeyImpl)) {
+      return false;
+    }
+    final SignatureKeyImpl that = (SignatureKeyImpl) obj;
+    return Objects.equals(id, that.id)
+        && Objects.equals(algorithm, that.algorithm)
+        && Objects.equals(format, that.format)
+        && Arrays.equals(encoded, that.encoded);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 31 * hash + Objects.hashCode(id);
+    hash = 31 * hash + Objects.hashCode(algorithm);
+    hash = 31 * hash + Objects.hashCode(format);
+    hash = 31 * hash + Arrays.hashCode(encoded);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "SignatureKeyImpl{"
+        + "id="
+        + id
+        + ", algorithm='"
+        + algorithm
+        + '\''
+        + ", format='"
+        + format
+        + '\''
+        + ", encoded="
+        + Arrays.toString(encoded)
+        + '}';
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/model/impl/SignatureKeyPairImpl.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/model/impl/SignatureKeyPairImpl.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl;
+
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.util.Objects;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyPair;
+
+/** @author Anton Korneta */
+@Entity(name = "SignKeyPair")
+@Table(name = "che_sign_key_pair")
+@NamedQueries({
+  @NamedQuery(name = "SignKeyPair.getAll", query = "SELECT kp FROM SignKeyPair kp"),
+  @NamedQuery(name = "SignKeyPair.getAllCount", query = "SELECT COUNT(kp) FROM SignKeyPair kp")
+})
+public class SignatureKeyPairImpl implements SignatureKeyPair {
+
+  @Id
+  @Column(name = "id")
+  private String id;
+
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "public_key")
+  private SignatureKeyImpl publicKey;
+
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "private_key")
+  private SignatureKeyImpl privateKey;
+
+  public SignatureKeyPairImpl() {}
+
+  public SignatureKeyPairImpl(SignatureKeyPairImpl keyPair) {
+    this(keyPair.getId(), keyPair.getPublicKey(), keyPair.getPrivateKey());
+  }
+
+  public SignatureKeyPairImpl(String id, PublicKey publicKey, PrivateKey privateKey) {
+    this(id, new SignatureKeyImpl(publicKey), new SignatureKeyImpl(privateKey));
+  }
+
+  public SignatureKeyPairImpl(String id, SignatureKeyImpl publicKey, SignatureKeyImpl privateKey) {
+    this.id = id;
+    this.publicKey = publicKey;
+    this.privateKey = privateKey;
+  }
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  @Override
+  public SignatureKeyImpl getPublicKey() {
+    return publicKey;
+  }
+
+  public void setPublicKey(SignatureKeyImpl publicKey) {
+    this.publicKey = publicKey;
+  }
+
+  @Override
+  public SignatureKeyImpl getPrivateKey() {
+    return privateKey;
+  }
+
+  public void setPrivateKey(SignatureKeyImpl privateKey) {
+    this.privateKey = privateKey;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof SignatureKeyPairImpl)) {
+      return false;
+    }
+    final SignatureKeyPairImpl that = (SignatureKeyPairImpl) obj;
+    return Objects.equals(id, that.id)
+        && Objects.equals(publicKey, that.publicKey)
+        && Objects.equals(privateKey, that.privateKey);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 31 * hash + Objects.hashCode(id);
+    hash = 31 * hash + Objects.hashCode(publicKey);
+    hash = 31 * hash + Objects.hashCode(privateKey);
+    return hash;
+  }
+
+  @Override
+  public String toString() {
+    return "SignatureKeyPairImpl{"
+        + "id='"
+        + id
+        + '\''
+        + ", publicKey="
+        + publicKey
+        + ", privateKey="
+        + privateKey
+        + '}';
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/spi/SignatureKeyDao.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/signature/spi/SignatureKeyDao.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature.spi;
+
+import com.google.common.annotations.Beta;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.Page;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyPairImpl;
+
+/**
+ * Defines data access object for {@link SignatureKeyPairImpl}.
+ *
+ * @author Anton Korneta
+ */
+@Beta
+public interface SignatureKeyDao {
+
+  /**
+   * Creates signature key pair.
+   *
+   * @param keyPair signature key pair to create
+   * @throws ConflictException when signature key pair with given id already exists
+   * @throws ServerException when any errors occur while creating signature key pair
+   */
+  SignatureKeyPairImpl create(SignatureKeyPairImpl keyPair)
+      throws ConflictException, ServerException;
+
+  /**
+   * Removes signature key pair with given id.
+   *
+   * @param id signature key identifier
+   * @throws ServerException when any errors occur while removing signature key pair
+   */
+  void remove(String id) throws ServerException;
+
+  /**
+   * Returns all the signature key pairs.
+   *
+   * @param skipCount the number of signature key pairs to skip
+   * @param maxItems the maximum number of signature key pairs to return
+   * @return list of signature key pairs or an empty list when no keys were found
+   * @throws ServerException when any errors occur while fetching the key pairs
+   * @throws IllegalArgumentException when {@code maxItems} or {@code skipCount} is negative
+   */
+  Page<SignatureKeyPairImpl> getAll(int maxItems, long skipCount) throws ServerException;
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/MachineLoginFilterTest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/MachineLoginFilterTest.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server;
+
+import static io.jsonwebtoken.SignatureAlgorithm.RS512;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.MACHINE_TOKEN_KIND;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.user.User;
+import org.eclipse.che.api.user.server.UserManager;
+import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.multiuser.api.permission.server.PermissionChecker;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManager;
+import org.eclipse.che.multiuser.machine.authentication.shared.Constants;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link MachineLoginFilter}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class MachineLoginFilterTest {
+
+  private static final int KEY_SIZE = 1024;
+
+  private static final String REQUEST_SCHEME = "https";
+  private static final String SIGNATURE_ALGORITHM = "RSA";
+  private static final String WORKSPACE_ID = "workspace31";
+
+  private static final Subject SUBJECT =
+      new SubjectImpl("test_user", "test_user31", "userToken", false);
+
+  private static final Map<String, Object> HEADER = new HashMap<>();
+  private static final Claims CLAIMS = Jwts.claims();
+
+  static {
+    HEADER.put("kind", MACHINE_TOKEN_KIND);
+    CLAIMS.put(Constants.WORKSPACE_ID_CLAIM, WORKSPACE_ID);
+    CLAIMS.put(Constants.USER_ID_CLAIM, SUBJECT.getUserId());
+    CLAIMS.put(Constants.USER_NAME_CLAIM, SUBJECT.getUserName());
+    CLAIMS.put(Claims.ID, "84123-132-fn31");
+  }
+
+  @Mock private UserManager userManagerMock;
+  @Mock private RequestTokenExtractor tokenExtractorMock;
+  @Mock private SignatureKeyManager keyManagerMock;
+  @Mock private PermissionChecker permissionCheckerMock;
+  @Mock private FilterChain chainMock;
+  @Mock private HttpSession sessionMock;
+  @Mock private HttpServletResponse responseMock;
+
+  private MachineLoginFilter machineLoginFilter;
+
+  @BeforeMethod
+  private void setUp() throws Exception {
+    final User userMock = mock(User.class);
+    final KeyPairGenerator kpg = KeyPairGenerator.getInstance(SIGNATURE_ALGORITHM);
+    kpg.initialize(KEY_SIZE);
+    final KeyPair keyPair = kpg.generateKeyPair();
+    final String token =
+        Jwts.builder()
+            .setClaims(CLAIMS)
+            .setHeader(HEADER)
+            .signWith(RS512, keyPair.getPrivate())
+            .compact();
+    machineLoginFilter =
+        new MachineLoginFilter(
+            tokenExtractorMock, userManagerMock, keyManagerMock, permissionCheckerMock);
+
+    when(tokenExtractorMock.getToken(any(HttpServletRequest.class))).thenReturn(token);
+    when(keyManagerMock.getKeyPair()).thenReturn(keyPair);
+
+    when(userMock.getName()).thenReturn(SUBJECT.getUserName());
+    when(userManagerMock.getById(SUBJECT.getUserId())).thenReturn(userMock);
+  }
+
+  @Test
+  public void testProcessRequestWithValidToken() throws Exception {
+    machineLoginFilter.doFilter(getRequestMock(), responseMock, chainMock);
+
+    verify(keyManagerMock).getKeyPair();
+    verify(userManagerMock).getById(anyString());
+    verifyZeroInteractions(responseMock);
+  }
+
+  @Test
+  public void testProceedRequestWhenSignatureCheckIsFailed() throws Exception {
+    final String tokenWithInvalidSignature = "keycloak_token";
+    final HttpServletRequest requestMock = getRequestMock();
+    when(tokenExtractorMock.getToken(any(HttpServletRequest.class)))
+        .thenReturn(tokenWithInvalidSignature);
+
+    machineLoginFilter.doFilter(requestMock, responseMock, chainMock);
+
+    verify(tokenExtractorMock).getToken(any(HttpServletRequest.class));
+    verify(keyManagerMock).getKeyPair();
+    verify(chainMock).doFilter(requestMock, responseMock);
+    verifyZeroInteractions(userManagerMock);
+    verifyZeroInteractions(responseMock);
+  }
+
+  @Test
+  public void testProceedRequestWhenEmptyTokenProvided() throws Exception {
+    final HttpServletRequest requestMock = getRequestMock();
+    when(tokenExtractorMock.getToken(any(HttpServletRequest.class))).thenReturn(null);
+
+    machineLoginFilter.doFilter(requestMock, responseMock, chainMock);
+
+    verify(tokenExtractorMock).getToken(any(HttpServletRequest.class));
+    verify(chainMock).doFilter(requestMock, responseMock);
+    verifyZeroInteractions(keyManagerMock);
+    verifyZeroInteractions(userManagerMock);
+    verifyZeroInteractions(responseMock);
+  }
+
+  @Test
+  public void testSetErrorInResponseWhenNoUserFoundForProvidedToken() throws Exception {
+    when(userManagerMock.getById(anyString())).thenThrow(new NotFoundException("User not found"));
+
+    machineLoginFilter.doFilter(getRequestMock(), responseMock, chainMock);
+
+    verify(keyManagerMock).getKeyPair();
+    verify(userManagerMock).getById(anyString());
+    verify(responseMock)
+        .sendError(
+            401,
+            "Authentication with machine token failed because user for this token no longer exist.");
+  }
+
+  @Test
+  public void testSetErrorInResponseWhenUnableToGetUserForProvidedToken() throws Exception {
+    when(userManagerMock.getById(anyString())).thenThrow(new ServerException("err"));
+
+    machineLoginFilter.doFilter(getRequestMock(), responseMock, chainMock);
+
+    verify(keyManagerMock).getKeyPair();
+    verify(userManagerMock).getById(anyString());
+    verify(responseMock)
+        .sendError(
+            eq(401), argThat(s -> s.startsWith("Authentication with machine token failed cause:")));
+  }
+
+  private HttpServletRequest getRequestMock() {
+    final HttpServletRequest request = mock(HttpServletRequest.class);
+    when(request.getSession(true)).thenReturn(sessionMock);
+    when(request.getScheme()).thenReturn(REQUEST_SCHEME);
+    return request;
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenRegistryTest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenRegistryTest.java
@@ -10,40 +10,121 @@
  */
 package org.eclipse.che.multiuser.machine.authentication.server;
 
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.USER_ID_CLAIM;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.USER_NAME_CLAIM;
+import static org.eclipse.che.multiuser.machine.authentication.shared.Constants.WORKSPACE_ID_CLAIM;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
 import java.util.HashMap;
 import java.util.Map;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.model.user.User;
+import org.eclipse.che.api.user.server.UserManager;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManager;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
  * Tests for {@link MachineTokenRegistry}.
  *
  * @author Yevhenii Voevodin
+ * @author Anton Korneta
  */
+@Listeners(MockitoTestNGListener.class)
 public class MachineTokenRegistryTest {
+
+  private MachineTokenRegistry tokenRegistry;
+
+  private static final int KEY_SIZE = 1024;
+  private static final String SIGNATURE_ALGORITHM = "RSA";
+  private static final String USER_ID = "user13";
+  private static final String USER_NAME = "testUser";
+  private static final String WORKSPACE_ID = "workspace31";
+
+  @Mock private SignatureKeyManager signatureKeyManager;
+  @Mock private UserManager userManager;
+
+  private KeyPair keyPair;
+
+  @BeforeMethod
+  private void setUp() throws Exception {
+    tokenRegistry = new MachineTokenRegistry(signatureKeyManager, userManager);
+    final KeyPairGenerator kpg = KeyPairGenerator.getInstance(SIGNATURE_ALGORITHM);
+    kpg.initialize(KEY_SIZE);
+    keyPair = kpg.generateKeyPair();
+
+    mockUser(USER_ID, USER_NAME);
+    when(signatureKeyManager.getKeyPair()).thenReturn(keyPair);
+  }
+
+  @Test
+  public void testCreatesNewTokenWhenNoPreviouslyCreatedFound() throws Exception {
+    final String generatedToken = tokenRegistry.getOrCreateToken(USER_ID, WORKSPACE_ID);
+
+    final Claims claims =
+        Jwts.parser().setSigningKey(keyPair.getPublic()).parseClaimsJws(generatedToken).getBody();
+
+    final SubjectImpl subject =
+        new SubjectImpl(
+            claims.get(USER_NAME_CLAIM, String.class),
+            claims.get(USER_ID_CLAIM, String.class),
+            null,
+            false);
+    assertEquals(subject.getUserId(), USER_ID);
+    assertEquals(subject.getUserName(), USER_NAME);
+    assertEquals(claims.get(WORKSPACE_ID_CLAIM, String.class), WORKSPACE_ID);
+    verify(userManager).getById(USER_ID);
+    verify(signatureKeyManager).getKeyPair();
+    assertNotNull(generatedToken);
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testThrowsIllegalStateExceptionWhenTryToGetTokenForNonExistingUser()
+      throws Exception {
+    when(userManager.getById(anyString())).thenThrow(new NotFoundException("User not found"));
+
+    tokenRegistry.getOrCreateToken(USER_ID, WORKSPACE_ID);
+  }
 
   @Test
   public void removeTokensShouldReturnUserToTokenMap() throws Exception {
-    final MachineTokenRegistry registry = new MachineTokenRegistry();
-
     final Map<String, String> userToToken = new HashMap<>();
-    userToToken.put("user1", registry.getOrCreateToken("user1", "workspace123"));
-    userToToken.put("user2", registry.getOrCreateToken("user2", "workspace123"));
-    userToToken.put("user3", registry.getOrCreateToken("user3", "workspace123"));
-    final String tokenNotToRemove = registry.getOrCreateToken("user1", "workspace234");
+    final String user1 = "user1";
+    final String user2 = "user2";
+    final String workspace1 = "workspace123";
+    final String workspace2 = "workspace234";
+    mockUser(user1, user1);
+    mockUser(user2, user2);
+    userToToken.put(user1, tokenRegistry.getOrCreateToken(user1, workspace1));
+    userToToken.put(user2, tokenRegistry.getOrCreateToken(user2, workspace1));
+    final String tokenNotToRemove = tokenRegistry.getOrCreateToken(user1, workspace2);
 
-    final Map<String, String> removedTokens = registry.removeTokens("workspace123");
+    final Map<String, String> removedTokens = tokenRegistry.removeTokens(workspace1);
 
     assertEquals(removedTokens, userToToken);
+    assertEquals(tokenRegistry.getOrCreateToken(user1, workspace2), tokenNotToRemove);
+    assertNotEquals(tokenRegistry.getOrCreateToken(user1, workspace1), removedTokens.get(user1));
+    assertNotEquals(tokenRegistry.getOrCreateToken(user2, workspace1), removedTokens.get(user2));
+  }
 
-    assertEquals(registry.getOrCreateToken("user1", "workspace234"), tokenNotToRemove);
-    assertFalse(
-        registry.getOrCreateToken("user1", "workspace123").equals(userToToken.get("user1")));
-    assertFalse(
-        registry.getOrCreateToken("user2", "workspace123").equals(userToToken.get("user2")));
-    assertFalse(
-        registry.getOrCreateToken("user2", "workspace123").equals(userToToken.get("user3")));
+  private void mockUser(String userId, String userName) throws Exception {
+    final User userMock = mock(User.class);
+    when(userMock.getId()).thenReturn(userId);
+    when(userMock.getName()).thenReturn(userName);
+    when(userManager.getById(userId)).thenReturn(userMock);
   }
 }

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureKeyManagerTest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/signature/SignatureKeyManagerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import java.security.Key;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import org.eclipse.che.api.core.Page;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyPairImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.spi.SignatureKeyDao;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link SignatureKeyManager}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(MockitoTestNGListener.class)
+public class SignatureKeyManagerTest {
+
+  private static final int KEY_SIZE = 512;
+  private static final String ALGORITHM = "RSA";
+
+  @Mock SignatureKeyDao signatureKeyDao;
+
+  private KeyPairGenerator kpg;
+  private SignatureKeyManager signatureKeyManager;
+
+  @BeforeMethod
+  public void createEntities() throws Exception {
+    kpg = KeyPairGenerator.getInstance(ALGORITHM);
+    kpg.initialize(KEY_SIZE);
+    signatureKeyManager = new SignatureKeyManager(KEY_SIZE, ALGORITHM, signatureKeyDao);
+  }
+
+  @Test
+  public void testLoadSignatureKeys() throws Exception {
+    final SignatureKeyPairImpl kp = newKeyPair("id_" + 1);
+    when(signatureKeyDao.getAll(anyInt(), anyLong()))
+        .thenReturn(new Page<>(singleton(kp), 0, 1, 1));
+
+    signatureKeyManager.loadKeyPair();
+
+    final KeyPair cachedPair = signatureKeyManager.getKeyPair();
+    assertNotNull(cachedPair);
+    assertKeys(cachedPair.getPublic(), kp.getPublicKey());
+    assertKeys(cachedPair.getPrivate(), kp.getPrivateKey());
+  }
+
+  @Test
+  public void testTriesToLoadKeysOnGettingKeyPairAndNoCachedKeyPair() throws Exception {
+    when(signatureKeyDao.getAll(anyInt(), anyLong()))
+        .thenThrow(new ServerException("unexpected end of stack"));
+
+    signatureKeyManager.getKeyPair();
+
+    verify(signatureKeyDao).getAll(anyInt(), anyLong());
+  }
+
+  @Test
+  public void testGeneratesNewKeyPairWhenNoExistingKeyPairFound() throws Exception {
+    doReturn(new Page<>(emptyList(), 0, 1, 0)).when(signatureKeyDao).getAll(anyInt(), anyLong());
+    when(signatureKeyDao.create(any(SignatureKeyPairImpl.class)))
+        .thenAnswer((Answer<SignatureKeyPairImpl>) invoke -> invoke.getArgument(0));
+
+    final KeyPair cachedPair = signatureKeyManager.getKeyPair();
+
+    verify(signatureKeyDao).getAll(anyInt(), anyLong());
+    verify(signatureKeyDao).create(any(SignatureKeyPairImpl.class));
+    assertNotNull(cachedPair);
+  }
+
+  @Test
+  public void testReturnNullKeyPairWhenFailedToLoadAndGenerateKeys() throws Exception {
+    doReturn(new Page<>(emptyList(), 0, 1, 0)).when(signatureKeyDao).getAll(anyInt(), anyLong());
+    when(signatureKeyDao.create(any(SignatureKeyPairImpl.class)))
+        .thenThrow(new ServerException("unexpected end of stack"));
+
+    final KeyPair cachedPair = signatureKeyManager.getKeyPair();
+
+    verify(signatureKeyDao).getAll(anyInt(), anyLong());
+    verify(signatureKeyDao).create(any(SignatureKeyPairImpl.class));
+    assertNull(cachedPair);
+  }
+
+  @Test
+  public void testReturnNullKeyPairWhenAlgorithmIsNotSupported() throws Exception {
+    final SignatureKeyImpl publicKey = new SignatureKeyImpl(new byte[] {}, "ECDH", "PKCS#15");
+    final SignatureKeyImpl privateKey = new SignatureKeyImpl(new byte[] {}, "ECDH", "PKCS#3");
+    final SignatureKeyPairImpl kp = new SignatureKeyPairImpl("id_" + 1, publicKey, privateKey);
+    doReturn(new Page<>(singleton(kp), 0, 1, 1)).when(signatureKeyDao).getAll(anyInt(), anyLong());
+
+    final KeyPair cachedPair = signatureKeyManager.getKeyPair();
+
+    verify(signatureKeyDao).getAll(anyInt(), anyLong());
+    assertNull(cachedPair);
+  }
+
+  private SignatureKeyPairImpl newKeyPair(String id) {
+    final KeyPair pair = kpg.generateKeyPair();
+    return new SignatureKeyPairImpl(id, pair.getPublic(), pair.getPrivate());
+  }
+
+  private static void assertKeys(Key key, SignatureKey signatureKey) {
+    assertEquals(key.getAlgorithm(), signatureKey.getAlgorithm());
+    assertEquals(key.getEncoded(), signatureKey.getEncoded());
+    assertEquals(key.getFormat(), signatureKey.getFormat());
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/signature/jpa/SignatureKeyTckModule.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/signature/jpa/SignatureKeyTckModule.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature.jpa;
+
+import com.google.inject.TypeLiteral;
+import org.eclipse.che.commons.test.db.H2DBTestServer;
+import org.eclipse.che.commons.test.db.H2JpaCleaner;
+import org.eclipse.che.commons.test.db.PersistTestModuleBuilder;
+import org.eclipse.che.commons.test.tck.TckModule;
+import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
+import org.eclipse.che.commons.test.tck.repository.JpaTckRepository;
+import org.eclipse.che.commons.test.tck.repository.TckRepository;
+import org.eclipse.che.core.db.DBInitializer;
+import org.eclipse.che.core.db.h2.jpa.eclipselink.H2ExceptionHandler;
+import org.eclipse.che.core.db.schema.SchemaInitializer;
+import org.eclipse.che.core.db.schema.impl.flyway.FlywaySchemaInitializer;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyPairImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.spi.SignatureKeyDao;
+
+/** @author Anton Korneta */
+public class SignatureKeyTckModule extends TckModule {
+
+  @Override
+  protected void configure() {
+    H2DBTestServer server = H2DBTestServer.startDefault();
+    install(
+        new PersistTestModuleBuilder()
+            .setDriver("org.h2.Driver")
+            .runningOn(server)
+            .addEntityClasses(SignatureKeyImpl.class, SignatureKeyPairImpl.class)
+            .setExceptionHandler(H2ExceptionHandler.class)
+            .build());
+
+    bind(DBInitializer.class).asEagerSingleton();
+    bind(SchemaInitializer.class)
+        .toInstance(new FlywaySchemaInitializer(server.getDataSource(), "che-schema"));
+    bind(TckResourcesCleaner.class).toInstance(new H2JpaCleaner(server));
+
+    bind(SignatureKeyDao.class).to(JpaSignatureKeyDao.class);
+    bind(new TypeLiteral<TckRepository<SignatureKeyPairImpl>>() {})
+        .toInstance(new JpaTckRepository<>(SignatureKeyPairImpl.class));
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/signature/spi/tck/SignatureKeyDaoTest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/signature/spi/tck/SignatureKeyDaoTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server.signature.spi.tck;
+
+import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.HashSet;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.Page;
+import org.eclipse.che.commons.test.tck.TckListener;
+import org.eclipse.che.commons.test.tck.repository.TckRepository;
+import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyPairImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.spi.SignatureKeyDao;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link SignatureKeyDao}.
+ *
+ * @author Anton Korneta
+ */
+@Listeners(TckListener.class)
+@Test(suiteName = SignatureKeyDaoTest.SUITE_NAME)
+public class SignatureKeyDaoTest {
+
+  public static final String SUITE_NAME = "SignatureKeyDaoTck";
+  public static final String ALGORITHM = "RSA";
+  public static final int KEY_SIZE = 512;
+
+  private static final int COUNT_KEY_PAIRS = 5;
+
+  @Inject private TckRepository<SignatureKeyPairImpl> signatureKeyRepo;
+  @Inject private SignatureKeyDao dao;
+
+  private SignatureKeyPairImpl[] storedKeyPairs;
+  private KeyPairGenerator kpg;
+
+  @AfterMethod
+  public void removeEntities() throws TckRepositoryException {
+    signatureKeyRepo.removeAll();
+  }
+
+  @BeforeMethod
+  public void createEntities() throws Exception {
+    storedKeyPairs = new SignatureKeyPairImpl[COUNT_KEY_PAIRS];
+    kpg = KeyPairGenerator.getInstance(ALGORITHM);
+    kpg.initialize(KEY_SIZE);
+    for (int i = 0; i < COUNT_KEY_PAIRS; i++) {
+      storedKeyPairs[i] = newKeyPair("id_" + i);
+    }
+    signatureKeyRepo.createAll(
+        Stream.of(storedKeyPairs).map(SignatureKeyPairImpl::new).collect(toList()));
+  }
+
+  @Test
+  public void testGetsAllKeys() throws Exception {
+    final Page<SignatureKeyPairImpl> foundKeys = dao.getAll(COUNT_KEY_PAIRS, 0);
+
+    assertEquals(new HashSet<>(foundKeys.getItems()), new HashSet<>(asList(storedKeyPairs)));
+    assertEquals(foundKeys.getTotalItemsCount(), COUNT_KEY_PAIRS);
+    assertEquals(foundKeys.getItems().size(), COUNT_KEY_PAIRS);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testThrowsIllegalArgumentExceptionWhenMaxItemsIsNegative() throws Exception {
+    dao.getAll(-1, 0);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testThrowsIllegalArgumentExceptionWhenSkipCountIsNegative() throws Exception {
+    dao.getAll(1, -1);
+  }
+
+  @Test(expectedExceptions = ConflictException.class)
+  public void throwsConflictExceptionWhenCreatingSignatureKeyPair() throws Exception {
+    final SignatureKeyPairImpl signKeyPair = newKeyPair(storedKeyPairs[0].getId());
+
+    dao.create(signKeyPair);
+  }
+
+  @Test
+  public void testCreatesSignatureKeyPair() throws Exception {
+    final SignatureKeyPairImpl signKeyPair = newKeyPair("id_" + 10);
+
+    dao.create(signKeyPair);
+
+    final Page<SignatureKeyPairImpl> keys = dao.getAll(COUNT_KEY_PAIRS + 1, 0);
+    assertTrue(keys.getItems().contains(signKeyPair));
+    assertEquals(keys.getTotalItemsCount(), COUNT_KEY_PAIRS + 1);
+  }
+
+  @Test
+  public void testRemovesSignatureKeyPair() throws Exception {
+    final SignatureKeyPairImpl toRemove = storedKeyPairs[0];
+
+    dao.remove(toRemove.getId());
+
+    final Page<SignatureKeyPairImpl> keys = dao.getAll(COUNT_KEY_PAIRS, 0);
+    assertFalse(keys.getItems().contains(toRemove));
+    assertEquals(keys.getTotalItemsCount(), COUNT_KEY_PAIRS - 1);
+  }
+
+  private SignatureKeyPairImpl newKeyPair(String id) {
+    final KeyPair pair = kpg.generateKeyPair();
+    return new SignatureKeyPairImpl(id, pair.getPublic(), pair.getPrivate());
+  }
+}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/resources/META-INF/services/org.eclipse.che.commons.test.tck.TckModule
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/resources/META-INF/services/org.eclipse.che.commons.test.tck.TckModule
@@ -1,0 +1,1 @@
+org.eclipse.che.multiuser.machine.authentication.server.signature.jpa.SignatureKeyTckModule

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/resources/logback-test.xml
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/resources/logback-test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<configuration>
+
+    <appender name="stdout" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="stdout"/>
+    </root>
+
+</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -964,6 +964,12 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.multiuser</groupId>
+                <artifactId>che-multiuser-machine-authentication</artifactId>
+                <version>${che.version}</version>
+                <classifier>tests</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.multiuser</groupId>
                 <artifactId>che-multiuser-machine-authentication-agent</artifactId>
                 <version>${che.version}</version>
             </dependency>

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentModule.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentModule.java
@@ -13,6 +13,8 @@ package org.eclipse.che.wsagent.server;
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
 import java.net.URI;
+import java.security.PublicKey;
+import org.eclipse.che.MachinePublicKeyProvider;
 import org.eclipse.che.MachineTokenProvider;
 import org.eclipse.che.UriApiEndpointProvider;
 import org.eclipse.che.inject.DynaModule;
@@ -36,5 +38,9 @@ public class CheWsAgentModule extends AbstractModule {
     bind(String.class)
         .annotatedWith(Names.named("wsagent.endpoint"))
         .toProvider(WsAgentURLProvider.class);
+
+    bind(PublicKey.class)
+        .annotatedWith(Names.named("signature.public.key"))
+        .toProvider(MachinePublicKeyProvider.class);
   }
 }

--- a/wsagent/wsagent-local/src/main/java/org/eclipse/che/MachinePublicKeyProvider.java
+++ b/wsagent/wsagent-local/src/main/java/org/eclipse/che/MachinePublicKeyProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che;
+
+import com.google.inject.Provider;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * Provides instance of {@link PublicKey} created from environment.
+ *
+ * @author Anton Korneta
+ */
+public class MachinePublicKeyProvider implements Provider<PublicKey> {
+
+  private final String publicKey;
+  private final String algorithm;
+
+  @Inject
+  public MachinePublicKeyProvider(
+      @Named("env.CHE_MACHINE_AUTH_SIGNATURE__ALGORITHM") String alg,
+      @Named("env.CHE_MACHINE_AUTH_SIGNATURE__PUBLIC__KEY") String key) {
+    this.publicKey = key;
+    this.algorithm = alg;
+  }
+
+  @Override
+  public PublicKey get() {
+    try {
+      return KeyFactory.getInstance(algorithm)
+          .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(publicKey)));
+    } catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+      throw new IllegalStateException(ex.getCause());
+    }
+  }
+}

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.4.0/2__add_signature_key.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.4.0/2__add_signature_key.sql
@@ -1,0 +1,35 @@
+--
+-- Copyright (c) 2012-2017 Red Hat, Inc.
+-- All rights reserved. This program and the accompanying materials
+-- are made available under the terms of the Eclipse Public License v1.0
+-- which accompanies this distribution, and is available at
+-- http://www.eclipse.org/legal/epl-v10.html
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+-- Signature key ---------------------------------------------------------------------
+CREATE TABLE che_sign_key (
+    id                    BIGINT       NOT NULL,
+    algorithm             VARCHAR(255) NOT NULL,
+    encoding_format       VARCHAR(255) NOT NULL,
+    encoded_value         BLOB         NOT NULL,
+
+    PRIMARY KEY (id)
+);
+
+-- Signature key pair ----------------------------------------------------------------
+CREATE TABLE che_sign_key_pair (
+    id                  VARCHAR(255) NOT NULL,
+    public_key          BIGINT       NOT NULL,
+    private_key         BIGINT       NOT NULL,
+
+    PRIMARY KEY (id)
+);
+--constraints
+ALTER TABLE che_sign_key_pair ADD CONSTRAINT fk_sign_public_key_id FOREIGN KEY (public_key) REFERENCES che_sign_key (id);
+ALTER TABLE che_sign_key_pair ADD CONSTRAINT fk_sign_private_key_id FOREIGN KEY (private_key) REFERENCES che_sign_key (id);
+--indexes
+CREATE INDEX index_sign_public_key_id ON che_sign_key_pair (public_key);
+CREATE INDEX index_sign_private_key_id ON che_sign_key_pair (private_key);

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.4.0/postgresql/2__add_signature_key.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.4.0/postgresql/2__add_signature_key.sql
@@ -1,0 +1,35 @@
+--
+-- Copyright (c) 2012-2017 Red Hat, Inc.
+-- All rights reserved. This program and the accompanying materials
+-- are made available under the terms of the Eclipse Public License v1.0
+-- which accompanies this distribution, and is available at
+-- http://www.eclipse.org/legal/epl-v10.html
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+-- Signature key ---------------------------------------------------------------------
+CREATE TABLE che_sign_key (
+    id                    BIGINT       NOT NULL,
+    algorithm             VARCHAR(255) NOT NULL,
+    encoding_format       VARCHAR(255) NOT NULL,
+    encoded_value         BYTEA        NOT NULL,
+
+    PRIMARY KEY (id)
+);
+
+-- Signature key pair ----------------------------------------------------------------
+CREATE TABLE che_sign_key_pair (
+    id                  VARCHAR(255) NOT NULL,
+    public_key          BIGINT       NOT NULL,
+    private_key         BIGINT       NOT NULL,
+
+    PRIMARY KEY (id)
+);
+--constraints
+ALTER TABLE che_sign_key_pair ADD CONSTRAINT fk_sign_public_key_id FOREIGN KEY (public_key) REFERENCES che_sign_key (id);
+ALTER TABLE che_sign_key_pair ADD CONSTRAINT fk_sign_private_key_id FOREIGN KEY (private_key) REFERENCES che_sign_key (id);
+--indexes
+CREATE INDEX index_sign_public_key_id ON che_sign_key_pair (public_key);
+CREATE INDEX index_sign_private_key_id ON che_sign_key_pair (private_key);

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -45,6 +45,11 @@
             <classifier>tests</classifier>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication</artifactId>
+            <classifier>tests</classifier>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
@@ -160,6 +165,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
             <scope>test</scope>
@@ -242,7 +252,8 @@
                                         che-core-api-user,
                                         che-core-api-ssh,
                                         che-core-api-workspace,
-                                        che-core-api-installer</includeArtifactIds>
+                                        che-core-api-installer,
+                                        che-multiuser-machine-authentication</includeArtifactIds>
                                     <includeScope>test</includeScope>
                                     <includeClassifiers>tests</includeClassifiers>
                                 </configuration>

--- a/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
+++ b/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
@@ -71,6 +71,10 @@ import org.eclipse.che.core.db.DBInitializer;
 import org.eclipse.che.core.db.postgresql.jpa.eclipselink.PostgreSqlExceptionHandler;
 import org.eclipse.che.core.db.schema.SchemaInitializer;
 import org.eclipse.che.core.db.schema.impl.flyway.FlywaySchemaInitializer;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.jpa.JpaSignatureKeyDao;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.model.impl.SignatureKeyPairImpl;
+import org.eclipse.che.multiuser.machine.authentication.server.signature.spi.SignatureKeyDao;
 import org.eclipse.che.security.PasswordEncryptor;
 import org.eclipse.che.security.SHA512PasswordEncryptor;
 import org.postgresql.Driver;
@@ -122,7 +126,9 @@ public class PostgreSqlTckModule extends TckModule {
                 InstallerImpl.class,
                 InstallerServerConfigImpl.class,
                 WorkspaceExpiration.class,
-                VolumeImpl.class)
+                VolumeImpl.class,
+                SignatureKeyImpl.class,
+                SignatureKeyPairImpl.class)
             .addEntityClass(
                 "org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl$Attribute")
             .build());
@@ -176,6 +182,11 @@ public class PostgreSqlTckModule extends TckModule {
     bind(InstallerDao.class).to(JpaInstallerDao.class);
     bind(new TypeLiteral<TckRepository<InstallerImpl>>() {})
         .toInstance(new JpaTckRepository<>(InstallerImpl.class));
+
+    // sign keys
+    bind(SignatureKeyDao.class).to(JpaSignatureKeyDao.class);
+    bind(new TypeLiteral<TckRepository<SignatureKeyPairImpl>>() {})
+        .toInstance(new JpaTckRepository<>(SignatureKeyPairImpl.class));
   }
 
   private static void waitConnectionIsEstablished(String dbUrl, String dbUser, String dbPassword) {


### PR DESCRIPTION
### What does this PR do?
Replaces machine tokens with JWT tokens.
Rewrites `MachineLoginFilter` agents/server in accordance to token changes.
Rewrite go agents auth mechanism to use JWT.
Adds signature keys manager, dao (generation of signature keys performs once on tomcat startup).
Verification flow for agents changed, so now they do not need to request ws-master to verify tokens.

Simplified interaction flow described in sequence diagram below:
![machine auth 2](https://user-images.githubusercontent.com/12269156/37208949-01e106b2-23ac-11e8-9a78-5ea9d9c8cab6.png)

New tokens will be signed by `RSASSA-PKCS-v1_5` using `SHA-512` and for the initial stage, it won't be configurable. 
JWT will contain following data:
```json
#Header
{
  "alg": "RS512",
  "kind": "machine_token"
}
# Payload
{
  "wsid": "workspacekrh99xjenek3h571",
  "uid": "b07e3a58-ed50-4a6e-be17-fcf49ff8b242",
  "uname": "john",
  "jti": "06c73349-2242-45f8-a94c-722e081bb6fd"
}
# Signature
{}
```

### What issues does this PR fix or reference?
#7785 
#9028
#### Release Notes
n/a