### PR TITLE
Allow to use NULL in JDBC env vars

### DIFF
--- a/core/che-core-db-vendor-h2/src/main/java/org/eclipse/che/core/db/h2/H2SQLJndiDataSourceFactory.java
+++ b/core/che-core-db-vendor-h2/src/main/java/org/eclipse/che/core/db/h2/H2SQLJndiDataSourceFactory.java
@@ -31,12 +31,20 @@ public class H2SQLJndiDataSourceFactory extends JNDIDataSourceFactory {
 
   public H2SQLJndiDataSourceFactory() throws Exception {
     super(
-        firstNonNull(System.getenv("CHE_JDBC_USERNAME"), DEFAULT_USERNAME),
-        firstNonNull(System.getenv("CHE_JDBC_PASSWORD"), DEFAULT_PASSWORD),
-        firstNonNull(System.getenv("CHE_JDBC_URL"), DEFAULT_URL),
-        firstNonNull(System.getenv("CHE_JDBC_DRIVER__CLASS__NAME"), DEFAULT_DRIVER__CLASS__NAME),
-        firstNonNull(System.getenv("CHE_JDBC_MAX__TOTAL"), DEFAULT_MAX__TOTAL),
-        firstNonNull(System.getenv("CHE_JDBC_MAX__IDLE"), DEFAULT_MAX__IDLE),
-        firstNonNull(System.getenv("CHE_JDBC_MAX__WAIT__MILLIS"), DEFAULT_MAX__WAIT__MILLIS));
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_USERNAME")), DEFAULT_USERNAME),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_PASSWORD")), DEFAULT_PASSWORD),
+        firstNonNull(nullStringToNullReference(System.getenv("CHE_JDBC_URL")), DEFAULT_URL),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_DRIVER__CLASS__NAME")),
+            DEFAULT_DRIVER__CLASS__NAME),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_MAX__TOTAL")), DEFAULT_MAX__TOTAL),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_MAX__IDLE")), DEFAULT_MAX__IDLE),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_MAX__WAIT__MILLIS")),
+            DEFAULT_MAX__WAIT__MILLIS));
   }
 }

--- a/core/che-core-db-vendor-postgresql/src/main/java/org/eclipse/che/core/db/postgresql/PostgreSQLJndiDataSourceFactory.java
+++ b/core/che-core-db-vendor-postgresql/src/main/java/org/eclipse/che/core/db/postgresql/PostgreSQLJndiDataSourceFactory.java
@@ -31,12 +31,20 @@ public class PostgreSQLJndiDataSourceFactory extends JNDIDataSourceFactory {
 
   public PostgreSQLJndiDataSourceFactory() throws Exception {
     super(
-        firstNonNull(System.getenv("CHE_JDBC_USERNAME"), DEFAULT_USERNAME),
-        firstNonNull(System.getenv("CHE_JDBC_PASSWORD"), DEFAULT_PASSWORD),
-        firstNonNull(System.getenv("CHE_JDBC_URL"), DEFAULT_URL),
-        firstNonNull(System.getenv("CHE_JDBC_DRIVER__CLASS__NAME"), DEFAULT_DRIVER__CLASS__NAME),
-        firstNonNull(System.getenv("CHE_JDBC_MAX__TOTAL"), DEFAULT_MAX__TOTAL),
-        firstNonNull(System.getenv("CHE_JDBC_MAX__IDLE"), DEFAULT_MAX__IDLE),
-        firstNonNull(System.getenv("CHE_JDBC_MAX__WAIT__MILLIS"), DEFAULT_MAX__WAIT__MILLIS));
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_USERNAME")), DEFAULT_USERNAME),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_PASSWORD")), DEFAULT_PASSWORD),
+        firstNonNull(nullStringToNullReference(System.getenv("CHE_JDBC_URL")), DEFAULT_URL),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_DRIVER__CLASS__NAME")),
+            DEFAULT_DRIVER__CLASS__NAME),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_MAX__TOTAL")), DEFAULT_MAX__TOTAL),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_MAX__IDLE")), DEFAULT_MAX__IDLE),
+        firstNonNull(
+            nullStringToNullReference(System.getenv("CHE_JDBC_MAX__WAIT__MILLIS")),
+            DEFAULT_MAX__WAIT__MILLIS));
   }
 }

--- a/core/che-core-db/src/main/java/org/eclipse/che/core/db/JNDIDataSourceFactory.java
+++ b/core/che-core-db/src/main/java/org/eclipse/che/core/db/JNDIDataSourceFactory.java
@@ -60,4 +60,16 @@ public abstract class JNDIDataSourceFactory implements ObjectFactory {
         "This={} obj={} name={} Context={} environment={}", this, obj, name, nameCtx, environment);
     return dataSource;
   }
+
+  /**
+   * Util method to convert string {@code "NULL"} to null reference. Allows to set string {@code
+   * "NULL"} as a value of the property instead of making sure it is unset as it is done in {@link
+   * org.eclipse.che.inject.CheBootstrap}
+   *
+   * @param value value to transform if needed
+   * @return null or passed value
+   */
+  protected static String nullStringToNullReference(String value) {
+    return "NULL".equals(value) ? null : value;
+  }
 }

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -546,6 +546,7 @@ CHE_INFRA_OPENSHIFT_TLS_ENABLED=false
 #CHE_MULTIUSER=false
 #
 # Postgres config
+# Value NULL is treated in the same way as when environment variable is unset
 #CHE_JDBC_USERNAME=pgche
 #CHE_JDBC_PASSWORD=pgchepassword
 #CHE_JDBC_DATABASE=dbche


### PR DESCRIPTION
### What does this PR do?
Allows to use NULL as a value of JDBC config to simplify usage of
environment variables for JDBC settings in k8s/Openshift
deployment files. NULL is treated as unset variable.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
