### PR TITLE
Selenium: Delete the 'try/catch' from selenium tests in the 'opendeclaration' package

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0093Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0093Test.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.selenium.opendeclaration;
 
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.WARNING;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -24,9 +23,6 @@ import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -36,8 +32,6 @@ import org.testng.annotations.Test;
  */
 public class Eclipse0093Test {
 
-  private static final String PATH_TO_PACKAGE_PREFIX = "/src/main/java/org/eclipse/qa/examples/";
-  private static final Logger LOG = LoggerFactory.getLogger(Eclipse0093Test.class);
   private static final String PROJECT_NAME =
       NameGenerator.generate(Eclipse0093Test.class.getSimpleName(), 4);
 
@@ -61,42 +55,10 @@ public class Eclipse0093Test {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.expandPathInProjectExplorerAndOpenFile(
         PROJECT_NAME + "/src/main/java/org.eclipse.qa.examples", "Test.java");
-    waitMarkerInPosition();
+    editor.waitMarkerInPosition(WARNING, 12);
     editor.goToCursorPositionVisible(17, 26);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("MyEnum");
     editor.waitSpecifiedValueForLineAndChar(14, 3);
-  }
-
-  private void waitMarkerInPosition() throws Exception {
-    try {
-      editor.waitMarkerInPosition(WARNING, 12);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      logExternalLibraries();
-      logProjectTypeChecking();
-      logProjectLanguageChecking();
-      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
-    }
-  }
-
-  private void logExternalLibraries() throws Exception {
-    testProjectServiceClient
-        .getExternalLibraries(ws.getId(), PROJECT_NAME)
-        .forEach(library -> LOG.info("project external library:  {}", library));
-  }
-
-  private void logProjectTypeChecking() throws Exception {
-    LOG.info(
-        "Project type of the {} project is \"maven\" - {}",
-        PROJECT_NAME,
-        testProjectServiceClient.checkProjectType(ws.getId(), PROJECT_NAME, "maven"));
-  }
-
-  private void logProjectLanguageChecking() throws Exception {
-    LOG.info(
-        "Project language of the {} project is \"java\" - {}",
-        PROJECT_NAME,
-        testProjectServiceClient.checkProjectLanguage(ws.getId(), PROJECT_NAME, "java"));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0115Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0115Test.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.selenium.opendeclaration;
 
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.WARNING;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -24,9 +23,6 @@ import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -36,8 +32,6 @@ import org.testng.annotations.Test;
  */
 public class Eclipse0115Test {
 
-  private static final String PATH_TO_PACKAGE_PREFIX = "/src/main/java/org/eclipse/qa/examples/";
-  private static final Logger LOG = LoggerFactory.getLogger(Eclipse0115Test.class);
   private static final String PROJECT_NAME =
       NameGenerator.generate(Eclipse0115Test.class.getSimpleName(), 4);
 
@@ -61,42 +55,9 @@ public class Eclipse0115Test {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.expandPathInProjectExplorerAndOpenFile(
         PROJECT_NAME + "/src/main/java/org.eclipse.qa.examples", "X.java");
-    waitMarkerInPosition();
+    editor.waitMarkerInPosition(WARNING, 14);
     editor.goToCursorPositionVisible(32, 14);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitSpecifiedValueForLineAndChar(35, 24);
-  }
-
-  private void waitMarkerInPosition() throws Exception {
-    try {
-      editor.waitMarkerInPosition(WARNING, 14);
-    } catch (TimeoutException ex) {
-      logExternalLibraries();
-      logProjectTypeChecking();
-      logProjectLanguageChecking();
-
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
-    }
-  }
-
-  private void logExternalLibraries() throws Exception {
-    testProjectServiceClient
-        .getExternalLibraries(ws.getId(), PROJECT_NAME)
-        .forEach(library -> LOG.info("project external library:  {}", library));
-  }
-
-  private void logProjectTypeChecking() throws Exception {
-    LOG.info(
-        "Project type of the {} project is \"maven\" - {}",
-        PROJECT_NAME,
-        testProjectServiceClient.checkProjectType(ws.getId(), PROJECT_NAME, "maven"));
-  }
-
-  private void logProjectLanguageChecking() throws Exception {
-    LOG.info(
-        "Project language of the {} project is \"java\" - {}",
-        PROJECT_NAME,
-        testProjectServiceClient.checkProjectLanguage(ws.getId(), PROJECT_NAME, "java"));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0120Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0120Test.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 public class Eclipse0120Test {
   private static final String PROJECT_NAME = NameGenerator.generate("Eclipse0120Test-", 4);
   private static final String PATH_TO_EXPAND =
-      String.format("%s/%s", PROJECT_NAME, "src/main/java/org.eclipse.qa.examples");
+      PROJECT_NAME + "/src/main/java/org.eclipse.qa.examples";
 
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0120Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0120Test.java
@@ -29,9 +29,9 @@ import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev */
 public class Eclipse0120Test {
-  private static final String PATH_TO_PACKAGE_PREFIX = "/src/main/java/org/eclipse/qa/examples/";
-  private static final String PROJECT_NAME =
-      NameGenerator.generate(Eclipse0120Test.class.getSimpleName(), 4);
+  private static final String PROJECT_NAME = NameGenerator.generate("Eclipse0120Test-", 4);
+  private static final String PATH_TO_EXPAND =
+      String.format("%s/%s", PROJECT_NAME, "src/main/java/org.eclipse.qa.examples");
 
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
@@ -52,8 +52,7 @@ public class Eclipse0120Test {
   public void test0120() throws Exception {
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
-    projectExplorer.quickExpandWithJavaScript();
-    projectExplorer.openItemByPath(PROJECT_NAME + PATH_TO_PACKAGE_PREFIX + "Test.java");
+    projectExplorer.expandPathInProjectExplorerAndOpenFile(PATH_TO_EXPAND, "Test.java");
     editor.waitActive();
     editor.waitMarkerInPosition(WARNING, 16);
     editor.goToCursorPositionVisible(16, 42);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0121Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0121Test.java
@@ -10,8 +10,6 @@
  */
 package org.eclipse.che.selenium.opendeclaration;
 
-import static org.testng.Assert.fail;
-
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -23,9 +21,6 @@ import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,7 +30,6 @@ import org.testng.annotations.Test;
  */
 public class Eclipse0121Test {
 
-  private static final Logger LOG = LoggerFactory.getLogger(Eclipse0121Test.class);
   private static final String PROJECT_NAME =
       NameGenerator.generate(Eclipse0121Test.class.getSimpleName(), 4);
   private static final String PATH_FOR_EXPAND =
@@ -63,38 +57,7 @@ public class Eclipse0121Test {
     editor.waitActive();
     editor.goToCursorPositionVisible(15, 43);
     editor.typeTextIntoEditor(Keys.F4.toString());
-
-    try {
-      editor.waitTabIsPresent("Collections");
-    } catch (TimeoutException ex) {
-      logExternalLibraries();
-      logProjectTypeChecking();
-      logProjectLanguageChecking();
-
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7161", ex);
-    }
-
+    editor.waitTabIsPresent("Collections");
     editor.waitSpecifiedValueForLineAndChar(14, 35);
-  }
-
-  private void logExternalLibraries() throws Exception {
-    testProjectServiceClient
-        .getExternalLibraries(ws.getId(), PROJECT_NAME)
-        .forEach(library -> LOG.info("project external library:  {}", library));
-  }
-
-  private void logProjectTypeChecking() throws Exception {
-    LOG.info(
-        "Project type of the {} project is \"maven\" - {}",
-        PROJECT_NAME,
-        testProjectServiceClient.checkProjectType(ws.getId(), PROJECT_NAME, "maven"));
-  }
-
-  private void logProjectLanguageChecking() throws Exception {
-    LOG.info(
-        "Project language of the {} project is \"java\" - {}",
-        PROJECT_NAME,
-        testProjectServiceClient.checkProjectLanguage(ws.getId(), PROJECT_NAME, "java"));
   }
 }


### PR DESCRIPTION
### What does this PR do?
* Delete the 'try/catch' blocks from tests related to resolve and close issue #7161
* Replace the 'quickExpandWithJavaScript()' method on the native clicks to expand the project tree in the 'Eclipse0120Test'
* Related selenium tests: _Eclipse0093Test_, _Eclipse0115Test_, _Eclipse0121Test_; _Eclipse0120Test_

### What issues does this PR fix or reference?
#9057, #9058
