### PR TITLE
Support set-up Theia extension version.

### DIFF
--- a/dockerfiles/theia/src/main.js
+++ b/dockerfiles/theia/src/main.js
@@ -31,6 +31,13 @@ else {
         theiaConfig = defaultConfig;
         let dep = theiaConfig.dependencies;
         for (let d of pluginList) {
+            if (d.indexOf(":") > -1) {
+                let newDep = d.split(":");
+                let depName = newDep[0].trim();
+                let depVersion = newDep[1].trim();
+                dep[depName] = depVersion;
+                continue;
+            }
             if (!dep.hasOwnProperty(d)) {
                 dep[d] = "latest";
             }
@@ -39,7 +46,7 @@ else {
         handlePromise(callYarn().then(callBuild).then(callRun));
     } else {
         const defaultTheia = `/home/default/theia`;
-        cp.execSync(`cp -r ${defaultTheia}/* ${theiaRoot}`);
+        cp.execSync(`cp -r ${defaultTheia}/\* ${theiaRoot}`);
         handlePromise(callRun());
     }
 

--- a/dockerfiles/theia/src/main.js
+++ b/dockerfiles/theia/src/main.js
@@ -31,6 +31,7 @@ else {
         theiaConfig = defaultConfig;
         let dep = theiaConfig.dependencies;
         for (let d of pluginList) {
+            // check if plugin has a version using format pluginName:versionNumber
             if (d.indexOf(":") > -1) {
                 let newDep = d.split(":");
                 let depName = newDep[0].trim();


### PR DESCRIPTION
### What does this PR do?
Support set-up Theia extension version. If you need apply your Theia extension with specified version to the  Theia workspace, you can apply environment variable to Theia machine in format:  
 
`"THEIA_PLUGINS": "@theia/go : 3.7.0, @theia/python"`

### What issues does this PR fix or reference?
It's useful for local testing Theia extensions inside Eclipse CHE. See more: https://docs.google.com/document/d/1s3vBBbeJL4Jas89dNBMMC5ERlPIvyBjZz4vnF1ZlAE8/edit

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
