### PR TITLE
CHE-9067: Fix bug with git colors in editor tabs

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/plugins/EditorTabsColorizer.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/plugins/EditorTabsColorizer.java
@@ -19,6 +19,8 @@ import static org.eclipse.che.ide.ext.git.client.GitUtil.getRootPath;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import org.eclipse.che.api.git.shared.FileChangedEventDto;
+import org.eclipse.che.api.git.shared.RepositoryDeletedEventDto;
+import org.eclipse.che.api.git.shared.RepositoryInitializedEventDto;
 import org.eclipse.che.api.git.shared.Status;
 import org.eclipse.che.api.git.shared.StatusChangedEventDto;
 import org.eclipse.che.ide.api.editor.EditorAgent;
@@ -102,5 +104,37 @@ public class EditorTabsColorizer implements GitEventsSubscriber {
                 tab.setTitleColor(NOT_MODIFIED.getColor());
               }
             });
+  }
+
+  @Override
+  public void onGitRepositoryDeleted(
+      String endpointId, RepositoryDeletedEventDto repositoryDeletedEventDto) {
+    editorAgentProvider
+        .get()
+        .getOpenedEditors()
+        .stream()
+        .filter(editor -> editor instanceof HasVcsChangeMarkerRender)
+        .forEach(
+            editor ->
+                multiPartStackProvider
+                    .get()
+                    .getTabByPart(editor)
+                    .setTitleColor(NOT_MODIFIED.getColor()));
+  }
+
+  @Override
+  public void onGitRepositoryInitialized(
+      String endpointId, RepositoryInitializedEventDto gitRepositoryInitializedEventDto) {
+    editorAgentProvider
+        .get()
+        .getOpenedEditors()
+        .stream()
+        .filter(editor -> editor instanceof HasVcsChangeMarkerRender)
+        .forEach(
+            editor ->
+                multiPartStackProvider
+                    .get()
+                    .getTabByPart(editor)
+                    .setTitleColor(UNTRACKED.getColor()));
   }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/plugins/ProjectExplorerTreeColorizer.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/plugins/ProjectExplorerTreeColorizer.java
@@ -10,25 +10,22 @@
  */
 package org.eclipse.che.ide.ext.git.client.plugins;
 
-import static org.eclipse.che.ide.api.vcs.VcsStatus.ADDED;
-import static org.eclipse.che.ide.api.vcs.VcsStatus.MODIFIED;
-import static org.eclipse.che.ide.api.vcs.VcsStatus.NOT_MODIFIED;
-import static org.eclipse.che.ide.api.vcs.VcsStatus.UNTRACKED;
 import static org.eclipse.che.ide.ext.git.client.GitUtil.getRootPath;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
 import org.eclipse.che.api.git.shared.FileChangedEventDto;
-import org.eclipse.che.api.git.shared.Status;
 import org.eclipse.che.api.git.shared.StatusChangedEventDto;
-import org.eclipse.che.ide.api.resources.File;
-import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType;
+import org.eclipse.che.api.project.shared.dto.event.ProjectTreeStateUpdateDto;
 import org.eclipse.che.ide.api.vcs.VcsStatus;
+import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.ext.git.client.GitEventSubscribable;
 import org.eclipse.che.ide.ext.git.client.GitEventsSubscriber;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.resource.Path;
+import org.eclipse.che.ide.resources.ProjectTreeChangeHandler;
 import org.eclipse.che.ide.resources.tree.FileNode;
 import org.eclipse.che.ide.ui.smartTree.Tree;
 
@@ -42,12 +39,18 @@ import org.eclipse.che.ide.ui.smartTree.Tree;
 public class ProjectExplorerTreeColorizer implements GitEventsSubscriber {
 
   private final Provider<ProjectExplorerPresenter> projectExplorerPresenterProvider;
+  private final ProjectTreeChangeHandler treeChangeHandler;
+  private final DtoFactory dtoFactory;
 
   @Inject
   public ProjectExplorerTreeColorizer(
       GitEventSubscribable subscribeToGitEvents,
-      Provider<ProjectExplorerPresenter> projectExplorerPresenterProvider) {
+      Provider<ProjectExplorerPresenter> projectExplorerPresenterProvider,
+      ProjectTreeChangeHandler treeChangeHandler,
+      DtoFactory dtoFactory) {
     this.projectExplorerPresenterProvider = projectExplorerPresenterProvider;
+    this.treeChangeHandler = treeChangeHandler;
+    this.dtoFactory = dtoFactory;
 
     subscribeToGitEvents.addSubscriber(this);
   }
@@ -78,7 +81,6 @@ public class ProjectExplorerTreeColorizer implements GitEventsSubscriber {
   @Override
   public void onGitStatusChanged(String endpointId, StatusChangedEventDto statusChangedEventDto) {
     Tree tree = projectExplorerPresenterProvider.get().getTree();
-    Status status = statusChangedEventDto.getStatus();
     tree.getNodeStorage()
         .getAll()
         .stream()
@@ -89,27 +91,11 @@ public class ProjectExplorerTreeColorizer implements GitEventsSubscriber {
                         .getProjectName()
                         .equals(getRootPath(((FileNode) node).getData().getLocation())))
         .forEach(
-            node -> {
-              Resource resource = ((FileNode) node).getData();
-              File file = resource.asFile();
-              String nodeLocation = resource.getLocation().removeFirstSegments(1).toString();
-
-              VcsStatus newVcsStatus;
-              if (status.getUntracked().contains(nodeLocation)) {
-                newVcsStatus = UNTRACKED;
-              } else if (status.getModified().contains(nodeLocation)
-                  || status.getChanged().contains(nodeLocation)) {
-                newVcsStatus = MODIFIED;
-              } else if (status.getAdded().contains(nodeLocation)) {
-                newVcsStatus = ADDED;
-              } else {
-                newVcsStatus = NOT_MODIFIED;
-              }
-
-              if (file.getVcsStatus() != newVcsStatus) {
-                file.setVcsStatus(newVcsStatus);
-                tree.refresh(node);
-              }
-            });
+            node ->
+                treeChangeHandler.handleFileChange(
+                    dtoFactory
+                        .createDto(ProjectTreeStateUpdateDto.class)
+                        .withPath(((FileNode) node).getData().getLocation().toString())
+                        .withType(FileWatcherEventType.MODIFIED)));
   }
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/plugins/ProjectExplorerTreeColorizer.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/plugins/ProjectExplorerTreeColorizer.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.git.shared.FileChangedEventDto;
 import org.eclipse.che.api.git.shared.StatusChangedEventDto;
 import org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType;
 import org.eclipse.che.api.project.shared.dto.event.ProjectTreeStateUpdateDto;
+import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.vcs.VcsStatus;
 import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.ext.git.client.GitEventSubscribable;
@@ -27,6 +28,7 @@ import org.eclipse.che.ide.part.explorer.project.ProjectExplorerPresenter;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.resources.ProjectTreeChangeHandler;
 import org.eclipse.che.ide.resources.tree.FileNode;
+import org.eclipse.che.ide.resources.tree.ResourceNode;
 import org.eclipse.che.ide.ui.smartTree.Tree;
 
 /**
@@ -90,12 +92,16 @@ public class ProjectExplorerTreeColorizer implements GitEventsSubscriber {
                     && statusChangedEventDto
                         .getProjectName()
                         .equals(getRootPath(((FileNode) node).getData().getLocation())))
+        .map(node -> (FileNode) node)
+        .map(ResourceNode::getData)
+        .map(Resource::getLocation)
+        .map(Path::toString)
         .forEach(
-            node ->
+            location ->
                 treeChangeHandler.handleFileChange(
                     dtoFactory
                         .createDto(ProjectTreeStateUpdateDto.class)
-                        .withPath(((FileNode) node).getData().getLocation().toString())
+                        .withPath(location)
                         .withType(FileWatcherEventType.MODIFIED)));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitColorsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitColorsTest.java
@@ -20,7 +20,6 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.G
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Project.New.FILE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Project.New.NEW;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Project.PROJECT;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -38,7 +37,6 @@ import org.eclipse.che.selenium.pageobject.*;
 import org.eclipse.che.selenium.pageobject.git.Git;
 import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -103,12 +101,7 @@ public class GitColorsTest {
     // Check file to be in default color
     projectExplorer.openItemByPath(PROJECT_NAME + "/README.md");
     projectExplorer.waitDefaultColorNode(PROJECT_NAME + "/README.md");
-    try {
-      editor.waitDefaultColorTab("README.md");
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/9067");
-    }
+    editor.waitDefaultColorTab("README.md");
 
     // Remove file from index
     menu.runCommand(GIT, REMOVE_FROM_INDEX);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix bug: Opened editor has not actual tab color if the file was opened after commit.

### What issues does this PR fix or reference?
#9067 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A