### PR TITLE
Don't publish ProjectCreatedEvent on importing arbitrary zipped resources

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/ProjectServiceApi.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/ProjectServiceApi.java
@@ -517,8 +517,6 @@ public class ProjectServiceApi {
 
     fsManager.unzip(wsPath, zip, skipFirstLevel);
 
-    eventService.publish(new ProjectCreatedEvent(wsPath));
-
     return Response.created(
             serviceContext
                 .getBaseUriBuilder()


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR removes publishing `ProjectCreatedEvent` to `EventService` after importing zipped data through the Project API. Since `importZip` method is intended to [import arbitrary zipped resources](https://github.com/eclipse/che/blob/70b87d7560e5ee80db86689764b53d749c165b53/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/ProjectService.java#L514).

### What issues does this PR fix or reference?
fixes #8759 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
