### PR TITLE
Selenium: check that the IDE is loaded before switching to IDE application frame

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
@@ -323,9 +323,9 @@ public class SeleniumWebDriver
   }
 
   public void switchFromDashboardIframeToIde(int timeout) {
-    new WebDriverWait(this, timeout)
-        .until(visibilityOfElementLocated(By.id("ide-application-iframe")));
-    new WebDriverWait(this, ATTACHING_ELEM_TO_DOM_SEC)
+    wait(timeout).until(visibilityOfElementLocated(By.id("ide-application-iframe")));
+
+    wait(ATTACHING_ELEM_TO_DOM_SEC)
         .until(
             (ExpectedCondition<Boolean>)
                 driver ->
@@ -333,8 +333,8 @@ public class SeleniumWebDriver
                             .executeScript("return angular.element('body').scope().showIDE"))
                         .toString()
                         .equals("true"));
-    new WebDriverWait(this, timeout)
-        .until(frameToBeAvailableAndSwitchToIt(By.id("ide-application-iframe")));
+
+    wait(timeout).until(frameToBeAvailableAndSwitchToIt(By.id("ide-application-iframe")));
   }
 
   public WebDriverWait wait(int timeOutInSeconds) {

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
@@ -11,8 +11,11 @@
 package org.eclipse.che.selenium.core;
 
 import static java.lang.String.format;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ATTACHING_ELEM_TO_DOM_SEC;
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
+import static org.openqa.selenium.support.ui.ExpectedConditions.frameToBeAvailableAndSwitchToIt;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -45,7 +48,6 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.ExpectedCondition;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -317,13 +319,22 @@ public class SeleniumWebDriver
   }
 
   public void switchFromDashboardIframeToIde() {
-    new WebDriverWait(this, LOADER_TIMEOUT_SEC * 6)
-        .until(ExpectedConditions.frameToBeAvailableAndSwitchToIt(By.id("ide-application-iframe")));
+    switchFromDashboardIframeToIde(APPLICATION_START_TIMEOUT_SEC);
   }
 
   public void switchFromDashboardIframeToIde(int timeout) {
     new WebDriverWait(this, timeout)
-        .until(ExpectedConditions.frameToBeAvailableAndSwitchToIt(By.id("ide-application-iframe")));
+        .until(visibilityOfElementLocated(By.id("ide-application-iframe")));
+    new WebDriverWait(this, ATTACHING_ELEM_TO_DOM_SEC)
+        .until(
+            (ExpectedCondition<Boolean>)
+                driver ->
+                    (((JavascriptExecutor) driver)
+                            .executeScript("return angular.element('body').scope().showIDE"))
+                        .toString()
+                        .equals("true"));
+    new WebDriverWait(this, timeout)
+        .until(frameToBeAvailableAndSwitchToIt(By.id("ide-application-iframe")));
   }
 
   public WebDriverWait wait(int timeOutInSeconds) {


### PR DESCRIPTION
### What does this PR do?
This PR adds to **switchFromDashboardIframeToIde** method checking that the **IDE** is loaded before switching to IDE application frame.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9100
