### PR TITLE
docker-compose: stop exposing postgres to external

### DIFF
--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -121,8 +121,8 @@ services:
       - '<%= scope.lookupvar('che::che_instance') -%>/config/postgres/init-che-user.sh:/var/lib/pgsql/init-che-user.sh'
       - '<%= scope.lookupvar('che::che_instance') -%>/config/postgres/init-che-user-and-run.sh:/var/lib/pgsql/init-che-user-and-run.sh'
 <% if scope.lookupvar('che::che_single_port') == 'false' -%>
-    ports:
-      - '5432:5432'
+    expose:
+      - '5432'
 <% end -%>
     restart: always
     healthcheck:

--- a/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
+++ b/dockerfiles/init/modules/compose/templates/docker-compose.yml.erb
@@ -123,6 +123,10 @@ services:
 <% if scope.lookupvar('che::che_single_port') == 'false' -%>
     expose:
       - '5432'
+<% if scope.lookupvar('che::che_env') == 'development' -%>
+    ports:
+      - '5432:5432'
+<% end -%>
 <% end -%>
     restart: always
     healthcheck:


### PR DESCRIPTION
<!-- HOLY SHIT -->
<!-- HOW DID YOU EVEN LET THIS HAPPEN!? -->

### What does this PR do?

Fixes the vulnerable-by-default configuration.

Having 5432 binded on 0.0.0.0 is **_nasty_**.

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

Security: fix postgres being exposed by default