### PR TITLE
Introduce logger REST API to manage log level at runtime

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -266,6 +266,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-permission-logger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-permission-resource</artifactId>
         </dependency>
         <dependency>

--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -150,6 +150,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-logger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-project-templates</artifactId>
         </dependency>
         <dependency>

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -138,6 +138,7 @@ public class WsMasterModule extends AbstractModule {
     bind(org.eclipse.che.api.workspace.server.WorkspaceService.class);
     install(new FactoryModuleBuilder().build(ServersCheckerFactory.class));
     install(new FactoryModuleBuilder().build(ExecAgentClientFactory.class));
+    bind(org.eclipse.che.api.logger.LoggerService.class);
 
     Multibinder<InternalEnvironmentProvisioner> internalEnvironmentProvisioners =
         Multibinder.newSetBinder(binder(), InternalEnvironmentProvisioner.class);
@@ -264,7 +265,6 @@ public class WsMasterModule extends AbstractModule {
     bind(org.eclipse.che.security.oauth.shared.OAuthTokenProvider.class)
         .to(org.eclipse.che.security.oauth.OAuthAuthenticatorTokenProvider.class);
     bind(org.eclipse.che.security.oauth.OAuthAuthenticationService.class);
-    bind(org.eclipse.che.api.logger.LoggerService.class);
 
   }
 
@@ -288,6 +288,8 @@ public class WsMasterModule extends AbstractModule {
     binder.addBinding().toInstance(UserServicePermissionsFilter.MANAGE_USERS_ACTION);
     bind(org.eclipse.che.multiuser.permission.user.UserProfileServicePermissionsFilter.class);
     bind(org.eclipse.che.multiuser.permission.user.UserServicePermissionsFilter.class);
+    bind(org.eclipse.che.multiuser.permission.logger.LoggerServicePermissionsFilter.class);
+
 
     bind(org.eclipse.che.multiuser.permission.factory.FactoryPermissionsFilter.class);
     bind(

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -264,6 +264,8 @@ public class WsMasterModule extends AbstractModule {
     bind(org.eclipse.che.security.oauth.shared.OAuthTokenProvider.class)
         .to(org.eclipse.che.security.oauth.OAuthAuthenticatorTokenProvider.class);
     bind(org.eclipse.che.security.oauth.OAuthAuthenticationService.class);
+    bind(org.eclipse.che.api.logger.LoggerService.class);
+
   }
 
   private void configureMultiUserMode() {

--- a/multiuser/permission/che-multiuser-permission-logger/pom.xml
+++ b/multiuser/permission/che-multiuser-permission-logger/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-multiuser-permission</artifactId>
+        <groupId>org.eclipse.che.multiuser</groupId>
+        <version>6.3.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-multiuser-permission-logger</artifactId>
+    <name>Che Multiuser :: Logger Permissions</name>
+    <properties>
+        <findbugs.failonerror>false</findbugs.failonerror>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-dto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-logger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-api-permission</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-json</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockitong</groupId>
+            <artifactId>mockitong</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- compiler inlines constants, so it is impossible to find reference on dependency -->
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <ignoredDependencies>
+                                <ignoreDependenvy>org.eclipse.che.multiuser:che-multiuser-api-permission</ignoreDependenvy>
+                            </ignoredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/multiuser/permission/che-multiuser-permission-logger/pom.xml
+++ b/multiuser/permission/che-multiuser-permission-logger/pom.xml
@@ -58,16 +58,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>

--- a/multiuser/permission/che-multiuser-permission-logger/src/main/java/org/eclipse/che/multiuser/permission/logger/LoggerServicePermissionsFilter.java
+++ b/multiuser/permission/che-multiuser-permission-logger/src/main/java/org/eclipse/che/multiuser/permission/logger/LoggerServicePermissionsFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.logger;
+
+import javax.ws.rs.Path;
+import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.everrest.CheMethodInvokerFilter;
+import org.eclipse.che.multiuser.api.permission.server.SystemDomain;
+import org.everrest.core.Filter;
+import org.everrest.core.resource.GenericResourceMethod;
+
+/**
+ * Filter that covers calls to {@link org.eclipse.che.api.logger.LoggerService} with authorization
+ *
+ * @author Florent Benoit
+ */
+@Filter
+@Path("/logger{path:.*}")
+public class LoggerServicePermissionsFilter extends CheMethodInvokerFilter {
+
+  @Override
+  protected void filter(GenericResourceMethod resource, Object[] args) throws ApiException {
+    switch (resource.getMethod().getName()) {
+      case "getLoggerByName":
+      case "getLoggers":
+      case "updateLogger":
+      case "createLogger":
+        EnvironmentContext.getCurrent()
+            .getSubject()
+            .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+        break;
+      default:
+        throw new ForbiddenException("The user does not have permission to perform this operation");
+    }
+  }
+}

--- a/multiuser/permission/che-multiuser-permission-logger/src/test/java/org/eclipse/che/multiuser/permission/user/LoggerServicePermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-logger/src/test/java/org/eclipse/che/multiuser/permission/user/LoggerServicePermissionsFilterTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.user;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
+import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.testng.Assert.assertEquals;
+
+import com.jayway.restassured.response.Response;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.rest.ApiExceptionMapper;
+import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
+import org.eclipse.che.api.logger.LoggerService;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.multiuser.api.permission.server.SystemDomain;
+import org.eclipse.che.multiuser.permission.logger.LoggerServicePermissionsFilter;
+import org.everrest.assured.EverrestJetty;
+import org.everrest.core.Filter;
+import org.everrest.core.GenericContainerRequest;
+import org.everrest.core.RequestFilter;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link org.eclipse.che.multiuser.permission.logger.LoggerServicePermissionsFilter}
+ *
+ * @author Florent Benoit
+ */
+@Listeners(value = {EverrestJetty.class, MockitoTestNGListener.class})
+public class LoggerServicePermissionsFilterTest {
+  @SuppressWarnings("unused")
+  private static final ApiExceptionMapper MAPPER = new ApiExceptionMapper();
+
+  @SuppressWarnings("unused")
+  private static final EnvironmentFilter FILTER = new EnvironmentFilter();
+
+  LoggerServicePermissionsFilter permissionsFilter;
+
+  @Mock private static Subject subject;
+
+  @Mock LoggerService service;
+
+  @BeforeMethod
+  public void setUp() {
+    permissionsFilter = new LoggerServicePermissionsFilter();
+  }
+
+  @Test
+  public void shouldCheckPermissionsOnGetLoggers() throws Exception {
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger");
+
+    assertEquals(response.getStatusCode(), 200);
+    verify(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenUserDoesNotHavePermissionsToGetLoggers() throws Exception {
+    doThrow(new ForbiddenException("User is not authorized"))
+        .when(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger");
+
+    assertEquals(response.getStatusCode(), 403);
+    assertEquals(unwrapError(response), "User is not authorized");
+    verify(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+    verifyZeroInteractions(service);
+  }
+
+  @Test
+  public void shouldCheckPermissionsOnGetLogger() throws Exception {
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger/FOO");
+
+    assertEquals(response.getStatusCode(), 204);
+    verify(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenUserDoesNotHavePermissionsToGetLogger() throws Exception {
+    doThrow(new ForbiddenException("User is not authorized"))
+        .when(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger/FOO");
+
+    assertEquals(response.getStatusCode(), 403);
+    assertEquals(unwrapError(response), "User is not authorized");
+    verify(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+    verifyZeroInteractions(service);
+  }
+
+  @Test
+  public void shouldCheckPermissionsOnUpdateLogger() throws Exception {
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .when()
+            .put(SECURE_PATH + "/logger/FOO");
+
+    assertEquals(response.getStatusCode(), 204);
+    verify(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenUserDoesNotHavePermissionsToUpdateLogger() throws Exception {
+    doThrow(new ForbiddenException("User is not authorized"))
+        .when(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .when()
+            .put(SECURE_PATH + "/logger/FOO");
+
+    assertEquals(response.getStatusCode(), 403);
+    assertEquals(unwrapError(response), "User is not authorized");
+    verify(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+    verifyZeroInteractions(service);
+  }
+
+  @Test
+  public void shouldCheckPermissionsOnCreateLogger() throws Exception {
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .when()
+            .post(SECURE_PATH + "/logger/FOO");
+
+    assertEquals(response.getStatusCode(), 204);
+    verify(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+  }
+
+  @Test
+  public void shouldThrowExceptionWhenUserDoesNotHavePermissionsToCreateLogger() throws Exception {
+    doThrow(new ForbiddenException("User is not authorized"))
+        .when(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .when()
+            .post(SECURE_PATH + "/logger/FOO");
+
+    assertEquals(response.getStatusCode(), 403);
+    assertEquals(unwrapError(response), "User is not authorized");
+    verify(subject)
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+    verifyZeroInteractions(service);
+  }
+
+  private static String unwrapError(Response response) {
+    return unwrapDto(response, ServiceError.class).getMessage();
+  }
+
+  private static <T> T unwrapDto(Response response, Class<T> dtoClass) {
+    return DtoFactory.getInstance().createDtoFromJson(response.body().print(), dtoClass);
+  }
+
+  @Filter
+  public static class EnvironmentFilter implements RequestFilter {
+    public void doFilter(GenericContainerRequest request) {
+      EnvironmentContext.getCurrent().setSubject(subject);
+    }
+  }
+}

--- a/multiuser/permission/pom.xml
+++ b/multiuser/permission/pom.xml
@@ -29,5 +29,6 @@
         <module>che-multiuser-permission-system</module>
         <module>che-multiuser-permission-installer</module>
         <module>che-multiuser-permission-resource</module>
+        <module>che-multiuser-permission-logger</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -985,6 +985,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.multiuser</groupId>
+                <artifactId>che-multiuser-permission-logger</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.multiuser</groupId>
                 <artifactId>che-multiuser-permission-resource</artifactId>
                 <version>${che.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -414,6 +414,16 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-logger</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-logger-shared</artifactId>
+                <version>${che.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.che.core</groupId>
                 <artifactId>che-core-api-model</artifactId>
                 <version>${che.version}</version>
             </dependency>

--- a/wsmaster/che-core-api-logger-shared/pom.xml
+++ b/wsmaster/che-core-api-logger-shared/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-master-parent</artifactId>
+        <groupId>org.eclipse.che.core</groupId>
+        <version>6.3.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-core-api-logger-shared</artifactId>
+    <packaging>jar</packaging>
+    <name>Che Core :: API :: Logger :: Shared</name>
+    <properties>
+        <dto-generator-out-directory>${project.build.directory}/generated-sources/dto/</dto-generator-out-directory>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-dto</artifactId>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-dto-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>generate-server-dto</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <dtoPackages>
+                                <package>org.eclipse.che.api.logger.shared.dto</package>
+                            </dtoPackages>
+                            <outputDirectory>${dto-generator-out-directory}</outputDirectory>
+                            <genClassName>org.eclipse.che.api.logger.server.dto.DtoServerImpls</genClassName>
+                            <impl>server</impl>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.eclipse.che.core</groupId>
+                        <artifactId>che-core-api-logger-shared</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>pre-compile</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${dto-generator-out-directory}/META-INF</directory>
+                                    <targetPath>META-INF</targetPath>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${dto-generator-out-directory}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/wsmaster/che-core-api-logger-shared/src/main/java/org/eclipse/che/api/logger/shared/dto/LoggerDto.java
+++ b/wsmaster/che-core-api-logger-shared/src/main/java/org/eclipse/che/api/logger/shared/dto/LoggerDto.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.logger.shared.dto;
+
+import org.eclipse.che.dto.shared.DTO;
+
+@DTO
+public interface LoggerDto {
+
+  public String getName();
+
+  public void setName(String name);
+
+  public LoggerDto withName(String name);
+
+  public String getLevel();
+
+  public void setLevel(String level);
+
+  public LoggerDto withLevel(String level);
+}

--- a/wsmaster/che-core-api-logger/pom.xml
+++ b/wsmaster/che-core-api-logger/pom.xml
@@ -54,34 +54,9 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-persist</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.websocket</groupId>
-            <artifactId>javax.websocket-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-db</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.jayway.restassured</groupId>
@@ -90,27 +65,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-ssh</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-db-vendor-h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-sql-schema</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>org.eclipse.persistence.jpa</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -121,11 +76,6 @@
         <dependency>
             <groupId>org.everrest</groupId>
             <artifactId>everrest-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.flywaydb</groupId>
-            <artifactId>flyway-core</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Mock testing -->

--- a/wsmaster/che-core-api-logger/pom.xml
+++ b/wsmaster/che-core-api-logger/pom.xml
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-master-parent</artifactId>
+        <groupId>org.eclipse.che.core</groupId>
+        <version>6.3.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>che-core-api-logger</artifactId>
+    <packaging>jar</packaging>
+    <name>Che Core :: API :: Logger</name>
+    <properties>
+        <findbugs.failonerror>false</findbugs.failonerror>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-dto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-logger-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-persist</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.websocket</groupId>
+            <artifactId>javax.websocket-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-db</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-db-vendor-h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-sql-schema</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.jpa</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Mock testing -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Mock testing of REST services -->
+        <dependency>
+            <groupId>org.mockitong</groupId>
+            <artifactId>mockitong</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/wsmaster/che-core-api-logger/src/main/java/org/eclipse/che/api/logger/LoggerService.java
+++ b/wsmaster/che-core-api-logger/src/main/java/org/eclipse/che/api/logger/LoggerService.java
@@ -24,12 +24,14 @@ import io.swagger.annotations.ApiResponses;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.rest.Service;
 import org.eclipse.che.api.logger.shared.dto.LoggerDto;
@@ -68,13 +70,21 @@ public class LoggerService extends Service {
   @ApiResponses({
     @ApiResponse(code = 200, message = "The loggers successfully fetched"),
   })
-  public List<LoggerDto> getLoggers() {
+  public List<LoggerDto> getLoggers(
+      @ApiParam("The number of the items to skip") @DefaultValue("0") @QueryParam("skipCount")
+          Integer skipCount,
+      @ApiParam("The limit of the items in the response, default is 30")
+          @DefaultValue("30")
+          @QueryParam("maxItems")
+          Integer maxItems) {
     LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
 
     return loggerContext
         .getLoggerList()
         .stream()
         .filter(log -> log.getLevel() != null || log.iteratorForAppenders().hasNext())
+        .skip(skipCount)
+        .limit(maxItems)
         .map(this::asDto)
         .collect(Collectors.toList());
   }

--- a/wsmaster/che-core-api-logger/src/main/java/org/eclipse/che/api/logger/LoggerService.java
+++ b/wsmaster/che-core-api-logger/src/main/java/org/eclipse/che/api/logger/LoggerService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.logger;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.rest.Service;
+import org.eclipse.che.api.logger.shared.dto.LoggerDto;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Defines Logger REST API. It allows to manage the loggers (with log level) dynamically.
+ *
+ * @author Florent Benoit
+ */
+@Api(value = "/logger", description = "Logger REST API")
+@Path("/logger")
+public class LoggerService extends Service {
+
+  @GET
+  @Path("/{name}")
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(value = "Get the logger level for the given logger")
+  @ApiResponses({
+    @ApiResponse(code = 200, message = "The response contains requested logger entity"),
+    @ApiResponse(code = 404, message = "The logger with specified name does not exist")
+  })
+  public LoggerDto getLoggerByName(@ApiParam(value = "logger name") @PathParam("name") String name)
+      throws NotFoundException {
+    return asDto(getLogger(name));
+  }
+
+  @GET
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(
+    value = "Get loggers which are configured",
+    notes = "This operation can be performed only by authorized user",
+    response = LoggerDto.class,
+    responseContainer = "List"
+  )
+  @ApiResponses({
+    @ApiResponse(code = 200, message = "The loggers successfully fetched"),
+  })
+  public List<LoggerDto> getLoggers() {
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+    return loggerContext
+        .getLoggerList()
+        .stream()
+        .filter(log -> log.getLevel() != null || log.iteratorForAppenders().hasNext())
+        .map(this::asDto)
+        .collect(Collectors.toList());
+  }
+
+  protected LoggerDto asDto(final Logger log) {
+    return newDto(LoggerDto.class).withName(log.getName()).withLevel(log.getLevel().levelStr);
+  }
+
+  @PUT
+  @Path("/{name}")
+  @Consumes(APPLICATION_JSON)
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(value = "Update the logger level")
+  @ApiResponses({
+    @ApiResponse(code = 200, message = "The logger successfully updated"),
+  })
+  public LoggerDto updateLogger(
+      @ApiParam(value = "logger name") @PathParam("name") String name, LoggerDto update)
+      throws NotFoundException {
+    Logger logger = getLogger(name);
+    logger.setLevel(Level.toLevel(update.getLevel()));
+    return asDto(logger);
+  }
+
+  @POST
+  @Path("/{name}")
+  @Consumes(APPLICATION_JSON)
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(value = "Create a new logger level")
+  @ApiResponses({
+    @ApiResponse(code = 200, message = "The logger successfully created"),
+  })
+  public LoggerDto createLogger(
+      @ApiParam(value = "logger name") @PathParam("name") String name, LoggerDto createdLogger)
+      throws NotFoundException {
+    Logger logger = getLogger(name, false);
+    logger.setLevel(Level.toLevel(createdLogger.getLevel()));
+    return asDto(logger);
+  }
+
+  /** Check if given logger exists */
+  protected Logger getLogger(String name) throws NotFoundException {
+    return getLogger(name, true);
+  }
+
+  /**
+   * Gets a logger, if checkLevel is true and if logger has no level defined it will return a
+   * NameNotFound exception
+   */
+  protected Logger getLogger(String name, boolean checkLevel) throws NotFoundException {
+    LoggerContext loggerContext = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+    Logger log = loggerContext.getLogger(name);
+    if (checkLevel && log.getLevel() == null) {
+      throw new NotFoundException("The logger with name " + name + " is not existing.");
+    }
+    return log;
+  }
+}

--- a/wsmaster/che-core-api-logger/src/test/java/org/eclipse/che/api/logger/LoggerServiceTest.java
+++ b/wsmaster/che-core-api-logger/src/test/java/org/eclipse/che/api/logger/LoggerServiceTest.java
@@ -129,7 +129,7 @@ public class LoggerServiceTest {
 
     assertEquals(response.getStatusCode(), 200);
 
-    List<LoggerDto> loggers = this.loggerService.getLoggers();
+    List<LoggerDto> loggers = this.loggerService.getLoggers(0, 30);
     assertTrue(loggers.contains(toCreateLoggerDto));
   }
 
@@ -149,8 +149,36 @@ public class LoggerServiceTest {
 
     assertEquals(response.getStatusCode(), 200);
 
-    List<LoggerDto> loggers = this.loggerService.getLoggers();
+    List<LoggerDto> loggers = this.loggerService.getLoggers(0, 30);
     assertTrue(loggers.contains(toUpdateLoggerDto));
+  }
+
+  @Test(dependsOnMethods = "shouldCreateLogger")
+  public void shouldGetLoggerPaginateSkip() {
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger/?skipCount=100");
+
+    assertEquals(response.getStatusCode(), 200);
+    List<LoggerDto> loggers = unwrapDtoList(response, LoggerDto.class);
+    assertEquals(loggers.size(), 0);
+  }
+
+  @Test(dependsOnMethods = "shouldCreateLogger")
+  public void shouldGetLoggerPaginateLimit() {
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger/?maxItems=1");
+
+    assertEquals(response.getStatusCode(), 200);
+    List<LoggerDto> loggers = unwrapDtoList(response, LoggerDto.class);
+    assertEquals(loggers.size(), 1);
   }
 
   private static <T> List<T> unwrapDtoList(Response response, Class<T> dtoClass) {

--- a/wsmaster/che-core-api-logger/src/test/java/org/eclipse/che/api/logger/LoggerServiceTest.java
+++ b/wsmaster/che-core-api-logger/src/test/java/org/eclipse/che/api/logger/LoggerServiceTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.logger;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
+import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.jayway.restassured.response.Response;
+import java.util.List;
+import org.eclipse.che.api.core.rest.ApiExceptionMapper;
+import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
+import org.eclipse.che.api.logger.shared.dto.LoggerDto;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.everrest.assured.EverrestJetty;
+import org.everrest.core.Filter;
+import org.everrest.core.GenericContainerRequest;
+import org.everrest.core.RequestFilter;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link org.eclipse.che.api.logger.LoggerService}.
+ *
+ * @author Florent Benoit
+ */
+@Listeners(value = {EverrestJetty.class, MockitoTestNGListener.class})
+public class LoggerServiceTest {
+
+  @SuppressWarnings("unused")
+  private static final ApiExceptionMapper MAPPER = new ApiExceptionMapper();
+
+  private static final String NAMESPACE = "user";
+  private static final String USER_ID = "user123";
+  private static final String LOGGER_NAME = "org.eclipse.che.api-sample-logger";
+
+  @SuppressWarnings("unused")
+  private static final EnvironmentFilter FILTER = new EnvironmentFilter();
+
+  private LoggerService loggerService;
+
+  @BeforeMethod
+  public void setup() {
+    loggerService = new LoggerService();
+  }
+
+  @Test
+  public void shouldGetLogger() {
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger/ROOT");
+
+    assertEquals(response.getStatusCode(), 200);
+    LoggerDto remoteLoggerDto =
+        DtoFactory.getInstance().createDtoFromJson(response.body().print(), LoggerDto.class);
+    assertNotNull(remoteLoggerDto);
+    assertEquals(remoteLoggerDto.getName(), "ROOT");
+    assertEquals(remoteLoggerDto.getLevel(), "DEBUG");
+  }
+
+  @Test
+  public void shouldGetNotFoundExceptionOnUnknownLogger() {
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger/unknown");
+
+    assertEquals(response.getStatusCode(), 404);
+    assertEquals(
+        DtoFactory.getInstance()
+            .createDtoFromJson(response.body().print(), ServiceError.class)
+            .getMessage(),
+        "The logger with name unknown is not existing.");
+  }
+
+  @Test
+  public void shouldGetLoggers() throws Exception {
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/logger");
+
+    assertEquals(response.getStatusCode(), 200);
+    List<LoggerDto> loggers = unwrapDtoList(response, LoggerDto.class);
+    LoggerDto rootLoggerDto = newDto(LoggerDto.class).withName("ROOT").withLevel("DEBUG");
+    assertTrue(loggers.contains(rootLoggerDto));
+  }
+
+  @Test
+  public void shouldCreateLogger() throws Exception {
+
+    LoggerDto toCreateLoggerDto = newDto(LoggerDto.class).withName(LOGGER_NAME).withLevel("INFO");
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .body(toCreateLoggerDto)
+            .when()
+            .post(SECURE_PATH + "/logger/" + LOGGER_NAME);
+
+    assertEquals(response.getStatusCode(), 200);
+
+    List<LoggerDto> loggers = this.loggerService.getLoggers();
+    assertTrue(loggers.contains(toCreateLoggerDto));
+  }
+
+  @Test(dependsOnMethods = "shouldCreateLogger")
+  public void shouldUpdateLogger() throws Exception {
+
+    LoggerDto toUpdateLoggerDto = newDto(LoggerDto.class).withName(LOGGER_NAME).withLevel("DEBUG");
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .body(toUpdateLoggerDto)
+            .when()
+            .put(SECURE_PATH + "/logger/" + LOGGER_NAME);
+
+    assertEquals(response.getStatusCode(), 200);
+
+    List<LoggerDto> loggers = this.loggerService.getLoggers();
+    assertTrue(loggers.contains(toUpdateLoggerDto));
+  }
+
+  private static <T> List<T> unwrapDtoList(Response response, Class<T> dtoClass) {
+    return DtoFactory.getInstance().createListDtoFromJson(response.body().print(), dtoClass);
+  }
+
+  @Filter
+  public static class EnvironmentFilter implements RequestFilter {
+    @Override
+    public void doFilter(GenericContainerRequest request) {
+      EnvironmentContext.getCurrent()
+          .setSubject(new SubjectImpl(NAMESPACE, USER_ID, "token", false));
+    }
+  }
+}

--- a/wsmaster/pom.xml
+++ b/wsmaster/pom.xml
@@ -44,5 +44,7 @@
         <module>integration-tests</module>
         <module>che-core-api-system</module>
         <module>che-core-api-system-shared</module>
+        <module>che-core-api-logger-shared</module>
+        <module>che-core-api-logger</module>
     </modules>
 </project>


### PR DESCRIPTION
### What does this PR do?

following this previous comment https://github.com/eclipse/che/issues/8997#issuecomment-370127156

with this Rest API, it's possible to create new logger with log level, list all loggers defined with loglevel, change level on a given logger, etc

On multi-user, `System#MANAGE_SYSTEM` permission is required.

Change-Id: I1c105aca33cc88f90270ade4d792d3a75191740a
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8997
