### PR TITLE
generate workspace dto impls in same package

### DIFF
--- a/wsmaster/che-core-api-workspace-shared/pom.xml
+++ b/wsmaster/che-core-api-workspace-shared/pom.xml
@@ -77,7 +77,7 @@
                         <package>org.eclipse.che.api.workspace.shared.dto</package>
                     </dtoPackages>
                     <outputDirectory>${dto-generator-out-directory}</outputDirectory>
-                    <genClassName>org.eclipse.che.api.workspace.server.dto.DtoServerImpls</genClassName>
+                    <genClassName>org.eclipse.che.api.workspace.shared.dto.DtoServerImpls</genClassName>
                     <impl>server</impl>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Generate implementations of ``che-core-api-workspace-shared`` DTOs in same package for allow simpler use externally.