### PR TITLE
CHE-9095: Improve Theia build stability on plugin list changes

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -9,7 +9,7 @@
 
 FROM node:8-alpine
 # build dependencies requireed to compile a custom Theia
-RUN apk add --no-cache make gcc g++ python git openssh bash rsync
+RUN apk add --no-cache make gcc g++ python git openssh bash
 WORKDIR /home/theia
 # build Theia with all extensions to persist yarn cache in the image and
 # have default Theia build in the workspace in case no plugins are requested
@@ -20,9 +20,7 @@ RUN yarn && \
     rm -rf * && \
     cd /home/default/theia && \
     yarn && \
-    yarn theia build && \
-    ln -sf /home/default/theia/node_modules /home/theia/node_modules && \
-    ln -sf /home/default/theia/yarn.lock /home/theia/yarn.lock
+    yarn theia build
 ADD src/main.js /theia_launcher/theia_launcher.js
 RUN mkdir -p /home/default/time && touch /home/default/time/$(date +"%T")
 EXPOSE 3000

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -22,7 +22,6 @@ RUN yarn && \
     yarn && \
     yarn theia build
 ADD src/main.js /theia_launcher/theia_launcher.js
-RUN mkdir -p /home/default/time && touch /home/default/time/$(date +"%T")
 EXPOSE 3000
 ARG GITHUB_TOKEN
 ENV USE_LOCAL_GIT=true \

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -15,7 +15,6 @@ WORKDIR /home/theia
 # have default Theia build in the workspace in case no plugins are requested
 ADD https://raw.githubusercontent.com/theia-ide/theia-apps/master/theia-full-docker/latest.package.json /home/theia/package.json
 ADD theia-default-package.json /home/default/theia/package.json
-ADD src/main.js /theia_launcher/theia_launcher.js
 RUN yarn && \
     yarn theia build && \
     rm -rf * && \
@@ -24,6 +23,8 @@ RUN yarn && \
     yarn theia build && \
     ln -sf /home/default/theia/node_modules /home/theia/node_modules && \
     ln -sf /home/default/theia/yarn.lock /home/theia/yarn.lock
+ADD src/main.js /theia_launcher/theia_launcher.js
+RUN mkdir -p /home/default/time && touch /home/default/time/$(date +"%T")
 EXPOSE 3000
 ARG GITHUB_TOKEN
 ENV USE_LOCAL_GIT=true \

--- a/dockerfiles/theia/src/main.js
+++ b/dockerfiles/theia/src/main.js
@@ -22,7 +22,7 @@ prepareTheia();
 function prepareTheia() {
     process.chdir(theiaRoot);
 
-    const extraPlagins = getExtraTheiaPlugins();
+    const extraPlugins = getExtraTheiaPlugins();
     let currentPlugins = getTheiaPlugins();
     let newPlugins = getDefaultTheiaPlugins();
 
@@ -31,8 +31,8 @@ function prepareTheia() {
         currentPlugins = getTheiaPlugins();
     }
 
-    for (let pluginName in extraPlagins) {
-        newPlugins[pluginName] = extraPlagins[pluginName];
+    for (let pluginName in extraPlugins) {
+        newPlugins[pluginName] = extraPlugins[pluginName];
     }
 
     if (!isPluginsEqual(currentPlugins, newPlugins)) {


### PR DESCRIPTION
### What does this PR do?
Adds support for Theia native plugins from filesystem
Adds support for Theia native plugins which is hosted in git repository
Improves build stability. Skips Invalid plugins (where possible).

### Plugin format
To set custom Theia plugins one should list them in `THEIA_PLUGINS` environment variable, each plugin should be separated by `,`. For example: `THEIA_PLUGINS=@theia/go,@theia/python`

Plugin versions are supported and could be specified after `:`. Example: `plugin-name:5.6.7`

 - if a plugin is native Theia plugin, name and optionally version should be specified. For example: `@theia/python:0.3.7`
- If a plugin is located on local file system (useful for developing and testing purposes), one should specify absolute path to the plugin folder itself (not parent folder with `lerna.json`) instead of version. Example: `plugin-name:/path/my-plugin`
- If a plugin is located in git repository, the following format should be used: 
`plugin-name:git://github.com/username/plugin-repository`
Note, field `name` in plugin's `package.json` should be the same as `plugin-name` at the beggining of plugin defining.

### What issues does this PR fix or reference?
Partially fixes https://github.com/eclipse/che/issues/9095