### PR TITLE
Do not redirect to UD requests intended to be for the API

### DIFF
--- a/assembly/assembly-ide-war/src/main/java/org/eclipse/che/ApiAccessRejectionFilter.java
+++ b/assembly/assembly-ide-war/src/main/java/org/eclipse/che/ApiAccessRejectionFilter.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+import javax.inject.Singleton;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Returns internal server error when request is supposed to be handled by API war. Situation occurs
+ * when API war failed to start and all requests to it handled by ROOT war.
+ *
+ * @author Alexander Garagatyi
+ */
+@Singleton
+public class ApiAccessRejectionFilter implements Filter {
+  public static final String ERROR_MESSAGE = "Internal server occurs. API is not accessible";
+
+  private static final byte[] ERROR_MESSAGE_IN_BYTES = ERROR_MESSAGE.getBytes();
+  private static final Pattern API_PATTERN = Pattern.compile("^/api(/.*)?$");
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    HttpServletRequest req = (HttpServletRequest) request;
+    HttpServletResponse resp = (HttpServletResponse) response;
+
+    if (API_PATTERN.matcher(req.getRequestURI()).matches()) {
+      resp.setStatus(500);
+      resp.getOutputStream().write(ERROR_MESSAGE_IN_BYTES);
+      return;
+    }
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {}
+
+  @Override
+  public void destroy() {}
+}

--- a/assembly/assembly-ide-war/src/main/java/org/eclipse/che/ApiAccessRejectionFilter.java
+++ b/assembly/assembly-ide-war/src/main/java/org/eclipse/che/ApiAccessRejectionFilter.java
@@ -11,7 +11,6 @@
 package org.eclipse.che;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
 import javax.inject.Singleton;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -19,12 +18,11 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
  * Returns internal server error when request is supposed to be handled by API war. Situation occurs
- * when API war failed to start and all requests to it handled by ROOT war.
+ * when API war failed to start and all requests to it are handled by ROOT war.
  *
  * @author Alexander Garagatyi
  */
@@ -33,20 +31,13 @@ public class ApiAccessRejectionFilter implements Filter {
   public static final String ERROR_MESSAGE = "Internal server occurs. API is not accessible";
 
   private static final byte[] ERROR_MESSAGE_IN_BYTES = ERROR_MESSAGE.getBytes();
-  private static final Pattern API_PATTERN = Pattern.compile("^/api(/.*)?$");
 
   @Override
   public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
       throws IOException, ServletException {
-    HttpServletRequest req = (HttpServletRequest) request;
     HttpServletResponse resp = (HttpServletResponse) response;
-
-    if (API_PATTERN.matcher(req.getRequestURI()).matches()) {
-      resp.setStatus(500);
-      resp.getOutputStream().write(ERROR_MESSAGE_IN_BYTES);
-      return;
-    }
-    chain.doFilter(request, response);
+    resp.setStatus(500);
+    resp.getOutputStream().write(ERROR_MESSAGE_IN_BYTES);
   }
 
   @Override

--- a/assembly/assembly-ide-war/src/main/java/org/eclipse/che/DashboardModule.java
+++ b/assembly/assembly-ide-war/src/main/java/org/eclipse/che/DashboardModule.java
@@ -17,6 +17,7 @@ import org.eclipse.che.inject.DynaModule;
 public class DashboardModule extends ServletModule {
   @Override
   protected void configureServlets() {
+    filter("/*").through(ApiAccessRejectionFilter.class);
     filter("/*").through(DashboardRedirectionFilter.class);
   }
 }

--- a/assembly/assembly-ide-war/src/main/java/org/eclipse/che/DashboardModule.java
+++ b/assembly/assembly-ide-war/src/main/java/org/eclipse/che/DashboardModule.java
@@ -17,7 +17,7 @@ import org.eclipse.che.inject.DynaModule;
 public class DashboardModule extends ServletModule {
   @Override
   protected void configureServlets() {
-    filter("/*").through(ApiAccessRejectionFilter.class);
+    filter("/api", "/api/*").through(ApiAccessRejectionFilter.class);
     filter("/*").through(DashboardRedirectionFilter.class);
   }
 }

--- a/assembly/assembly-ide-war/src/test/java/org/eclipse/che/ApiAccessRejectionFilterTest.java
+++ b/assembly/assembly-ide-war/src/test/java/org/eclipse/che/ApiAccessRejectionFilterTest.java
@@ -10,23 +10,18 @@
  */
 package org.eclipse.che;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -43,11 +38,9 @@ public class ApiAccessRejectionFilterTest {
 
   @InjectMocks private ApiAccessRejectionFilter filter;
 
-  @Test(dataProvider = "apiPathProvider")
-  public void shouldReturnErrorOnRequestsToApi(String path) throws Exception {
+  @Test
+  public void shouldReturnError() throws Exception {
     // given
-    when(request.getMethod()).thenReturn("GET");
-    when(request.getRequestURI()).thenReturn(path);
     when(response.getOutputStream()).thenReturn(outputStream);
 
     // when
@@ -57,34 +50,5 @@ public class ApiAccessRejectionFilterTest {
     verifyZeroInteractions(chain);
     verify(response).setStatus(500);
     verify(outputStream).write(eq(ApiAccessRejectionFilter.ERROR_MESSAGE.getBytes()));
-  }
-
-  @DataProvider(name = "apiPathProvider")
-  public static Object[][] apiPathProvider() {
-    return new Object[][] {
-      {"/api"}, {"/api/"}, {"/api/workspace"}, {"/api/workspace/"}, {"/api/system/state"},
-    };
-  }
-
-  @Test(dataProvider = "nonApiPathProvider")
-  public void shouldSkipNonApiRequests(String path) throws Exception {
-    // given
-    when(request.getMethod()).thenReturn("GET");
-    when(request.getRequestURI()).thenReturn(path);
-
-    // when
-    filter.doFilter(request, response, chain);
-
-    // then
-    verify(chain).doFilter(any(ServletRequest.class), any(ServletResponse.class));
-    verifyZeroInteractions(response);
-    verifyNoMoreInteractions(chain);
-  }
-
-  @DataProvider(name = "nonApiPathProvider")
-  public Object[][] nonApiPathProvider() {
-    return new Object[][] {
-      {"/ws-id/"}, {"/wsname"}, {"/dashboard"}, {"/dashboard/"}, {"/"}, {""},
-    };
   }
 }

--- a/assembly/assembly-ide-war/src/test/java/org/eclipse/che/ApiAccessRejectionFilterTest.java
+++ b/assembly/assembly-ide-war/src/test/java/org/eclipse/che/ApiAccessRejectionFilterTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Alexander Garagatyi */
+@Listeners(value = {MockitoTestNGListener.class})
+public class ApiAccessRejectionFilterTest {
+  @Mock private FilterChain chain;
+
+  @Mock private HttpServletRequest request;
+
+  @Mock private HttpServletResponse response;
+
+  @Mock private ServletOutputStream outputStream;
+
+  @InjectMocks private ApiAccessRejectionFilter filter;
+
+  @Test(dataProvider = "apiPathProvider")
+  public void shouldReturnErrorOnRequestsToApi(String path) throws Exception {
+    // given
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getRequestURI()).thenReturn(path);
+    when(response.getOutputStream()).thenReturn(outputStream);
+
+    // when
+    filter.doFilter(request, response, chain);
+
+    // then
+    verifyZeroInteractions(chain);
+    verify(response).setStatus(500);
+    verify(outputStream).write(eq(ApiAccessRejectionFilter.ERROR_MESSAGE.getBytes()));
+  }
+
+  @DataProvider(name = "apiPathProvider")
+  public static Object[][] apiPathProvider() {
+    return new Object[][] {
+      {"/api"}, {"/api/"}, {"/api/workspace"}, {"/api/workspace/"}, {"/api/system/state"},
+    };
+  }
+
+  @Test(dataProvider = "nonApiPathProvider")
+  public void shouldSkipNonApiRequests(String path) throws Exception {
+    // given
+    when(request.getMethod()).thenReturn("GET");
+    when(request.getRequestURI()).thenReturn(path);
+
+    // when
+    filter.doFilter(request, response, chain);
+
+    // then
+    verify(chain).doFilter(any(ServletRequest.class), any(ServletResponse.class));
+    verifyZeroInteractions(response);
+    verifyNoMoreInteractions(chain);
+  }
+
+  @DataProvider(name = "nonApiPathProvider")
+  public Object[][] nonApiPathProvider() {
+    return new Object[][] {
+      {"/ws-id/"}, {"/wsname"}, {"/dashboard"}, {"/dashboard/"}, {"/"}, {""},
+    };
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Add a filter to prevent redirection of API requests to UD page.  The situation appears when API war deployment fails and all the `/api/` requests are handled by ROOT war.

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/8646, https://github.com/redhat-developer/rh-che/issues/592
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Fix liveness checks when API war deployment fails.


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
