### PR TITLE
CHE-8675: fix reconnection to a WebSocket entrypoint

### DIFF
--- a/dashboard/src/components/api/json-rpc/che-json-rpc-api.factory.ts
+++ b/dashboard/src/components/api/json-rpc/che-json-rpc-api.factory.ts
@@ -20,20 +20,26 @@ import {WebsocketClient} from './websocket-client';
  */
 export class CheJsonRpcApi {
 
-  static $inject = ['$q', '$websocket', '$log'];
+  static $inject = ['$q', '$websocket', '$log', '$timeout'];
 
   private $q: ng.IQService;
   private $websocket: any;
   private $log: ng.ILogService;
   private jsonRpcApiConnection: Map<string, CheJsonRpcMasterApi>;
 
+  private $timeout: ng.ITimeoutService;
+
   /**
    * Default constructor that is using resource
    */
-  constructor($q: ng.IQService, $websocket: any, $log: ng.ILogService) {
+  constructor($q: ng.IQService,
+              $websocket: any,
+              $log: ng.ILogService,
+              $timeout: ng.ITimeoutService) {
     this.$q = $q;
     this.$websocket = $websocket;
     this.$log = $log;
+    this.$timeout = $timeout;
     this.jsonRpcApiConnection = new Map<string, CheJsonRpcMasterApi>();
   }
 
@@ -42,7 +48,7 @@ export class CheJsonRpcApi {
      return this.jsonRpcApiConnection.get(entrypoint);
    } else {
      let websocketClient = new WebsocketClient(this.$websocket, this.$q);
-     let cheJsonRpcMasterApi: CheJsonRpcMasterApi = new CheJsonRpcMasterApi(websocketClient, entrypoint);
+     let cheJsonRpcMasterApi: CheJsonRpcMasterApi = new CheJsonRpcMasterApi(websocketClient, entrypoint, this.$log, this.$timeout);
      this.jsonRpcApiConnection.set(entrypoint, cheJsonRpcMasterApi);
      return cheJsonRpcMasterApi;
    }

--- a/dashboard/src/components/api/json-rpc/che-json-rpc-master-api.ts
+++ b/dashboard/src/components/api/json-rpc/che-json-rpc-master-api.ts
@@ -60,7 +60,9 @@ export class CheJsonRpcMasterApi {
   }
 
   onConnectionOpen(): void {
-    this.$log.log('WebSocket connection is opened.');
+    if (this.reconnectionAttemptNumber !== 0) {
+      this.$log.log('WebSocket connection is opened.');
+    }
     this.reconnectionAttemptNumber = 0;
   }
 

--- a/dashboard/src/components/api/json-rpc/json-rpc-client.ts
+++ b/dashboard/src/components/api/json-rpc/json-rpc-client.ts
@@ -12,15 +12,15 @@
 
 const JSON_RPC_VERSION: string = '2.0';
 
+/* tslint:disable */
+export type communicationClientEvent = 'close' | 'error' | 'open' | 'response';
+/* tslint:enable */
+
 /**
  * Interface for communication between two entrypoints.
  * The implementation can be through websocket or http protocol.
  */
 export interface ICommunicationClient {
-  /**
-   * Process responses.
-   */
-  onResponse: Function;
   /**
    * Performs connections.
    *
@@ -31,6 +31,17 @@ export interface ICommunicationClient {
    * Close the connection.
    */
   disconnect(): void;
+  /**
+   * Adds listener on client event.
+   */
+  addListener(event: communicationClientEvent, handler: Function): void;
+  /**
+   * Removes listener.
+   *
+   * @param {communicationClientEvent} event
+   * @param {Function} handler
+   */
+  removeListener(event: communicationClientEvent, handler: Function): void;
   /**
    * Send pointed data.
    *
@@ -94,9 +105,9 @@ export class JsonRpcClient {
     this.pendingRequests = new Map<string, ng.IDeferred<any>>();
     this.notificationHandlers = new Map<string, Array<Function>>();
 
-    this.client.onResponse = (message: any): void => {
+    this.client.addListener('response', (message: any) => {
       this.processResponse(message);
-    };
+    });
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds the ability to handle the 'close' event of JSON-RPC client and tries to re-connect the client if the previous connection fails.

### What issues does this PR fix or reference?
fix https://github.com/eclipse/che/issues/8675

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix