### PR TITLE
make KC configuration before CHE start in case of deploy to OS

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -433,6 +433,7 @@ oc apply -f -
 if [[ "${CHE_MULTIUSER}" == "true" ]] && [[ "${COMMAND}" == "deploy" ]]; then
     if [ "${CHE_DEDICATED_KEYCLOAK}" == "true" ]; then
         "${BASE_DIR}"/multi-user/deploy_postgres_and_keycloak.sh
+        "${BASE_DIR}"/multi-user/configure_keycloak.sh
     else
         "${BASE_DIR}"/multi-user/deploy_postgres_only.sh
     fi
@@ -535,10 +536,6 @@ fi
 
 if [ "${WAIT_FOR_CHE}" == "true" ]; then
   wait_until_che_is_available
-fi
-
-if [ "${CHE_DEDICATED_KEYCLOAK}" == "true" ]; then
-"${BASE_DIR}"/multi-user/configure_keycloak.sh
 fi
 
 che_route=$(oc get route che -o jsonpath='{.spec.host}')


### PR DESCRIPTION
make KC configuration before CHE start
with changes introduced in https://github.com/eclipse/che/pull/8650 CHE calling KC during start-up
while deploy script performed KC configuration AFTER CHE pod is fully deployed. So CHE was failed to start because KC was not ready on it's start and due to another bug fixed by https://github.com/eclipse/che/pull/9168 CHE liveness probe didn't work properly and CHE pod in failed state was treated as healthy
needed for: https://github.com/eclipse/che/pull/8650
