### PR TITLE
hide "Users" menu item in left navbar when keycloack is used

### DIFF
--- a/dashboard/src/app/navbar/navbar.controller.ts
+++ b/dashboard/src/app/navbar/navbar.controller.ts
@@ -59,6 +59,7 @@ export class CheNavBarController {
   private cheKeycloak: CheKeycloak;
   private cheService: CheService;
   private isPermissionServiceAvailable: boolean;
+  private isKeycloackPresent: boolean;
 
   /**
    * Default constructor
@@ -81,6 +82,8 @@ export class CheNavBarController {
     this.chePermissions = chePermissions;
     this.cheKeycloak = cheKeycloak;
     this.cheService = cheService;
+
+    this.isKeycloackPresent = this.cheKeycloak.isPresent();
 
     this.profile = cheAPI.getProfile().getProfile();
 

--- a/dashboard/src/app/navbar/navbar.html
+++ b/dashboard/src/app/navbar/navbar.html
@@ -98,7 +98,8 @@
             <span>Administration</span>
           </div>
           <md-list layout="column">
-            <md-list-item flex class="navbar-subsection-item"
+            <md-list-item ng-hide="navbarController.isKeycloackPresent"
+                          flex class="navbar-subsection-item"
                           ng-if="navbarController.userServices.hasAdminUserService">
               <md-button nav-bar-selected flex che-reload-href
                          href="{{navbarController.menuItemUrl.usermanagement}}"

--- a/dashboard/src/app/navbar/navbar.html
+++ b/dashboard/src/app/navbar/navbar.html
@@ -98,9 +98,8 @@
             <span>Administration</span>
           </div>
           <md-list layout="column">
-            <md-list-item ng-hide="navbarController.isKeycloackPresent"
-                          flex class="navbar-subsection-item"
-                          ng-if="navbarController.userServices.hasAdminUserService">
+            <md-list-item flex class="navbar-subsection-item"
+                          ng-if="navbarController.isKeycloackPresent === false && navbarController.userServices.hasAdminUserService">
               <md-button nav-bar-selected flex che-reload-href
                          href="{{navbarController.menuItemUrl.usermanagement}}"
                          layout-align="left">


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Since we do not have an ability to manage users in multi-user mode with KeyCloack authentication enabled, the menu item "Users" should be hidden from navbar of Dashboard in that case. 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix