### PR TITLE
Selenium: remove info about known issues from dashboard and miscellaneous packages

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
@@ -14,7 +14,6 @@ import static org.eclipse.che.selenium.core.constant.TestStacksConstants.JAVA;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.GITHUB;
-import static org.testng.Assert.fail;
 import static org.testng.AssertJUnit.assertTrue;
 
 import com.google.inject.Inject;
@@ -30,7 +29,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -107,13 +105,7 @@ public class ImportProjectFromGitHubTest {
     projectSourcePage.clickOnConnectGithubAccountButton();
     seleniumWebDriver.switchToNoneCurrentWindow(ideWin);
 
-    try {
-      projectSourcePage.waitAuthorizationPageOpened();
-    } catch (TimeoutException ex) {
-      // Remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/8250");
-    }
-
+    projectSourcePage.waitAuthorizationPageOpened();
     projectSourcePage.typeLogin(gitHubUsername);
     projectSourcePage.typePassword(gitHubPassword);
     projectSourcePage.clickOnSignInButton();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
@@ -15,7 +15,6 @@ import static org.eclipse.che.selenium.core.constant.TestStacksConstants.JAVA;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
@@ -30,7 +29,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationLi
 import org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationPage;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
-import org.openqa.selenium.TimeoutException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -112,12 +110,7 @@ public class AddWorkspaceToOrganizationTest {
     // check that the Namespace link in workspace details correct
     checkNamespaceLink(org1.getName(), WORKSPACE_FOR_ADMIN_1);
     checkNamespaceLink(org2.getName(), WORKSPACE_FOR_ADMIN_2);
-    try {
-      checkNamespaceLink(suborgForAdminName, WORKSPACE_FOR_ADMIN_3);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7925");
-    }
+    checkNamespaceLink(suborgForAdminName, WORKSPACE_FOR_ADMIN_3);
   }
 
   @Test(priority = 1)
@@ -149,13 +142,7 @@ public class AddWorkspaceToOrganizationTest {
 
     // check that the Namespace link in workspace details correct
     checkNamespaceLink(org2.getName(), WORKSPACE_FOR_MEMBER_1);
-
-    try {
-      checkNamespaceLink(suborgForMemberName, WORKSPACE_FOR_MEMBER_2);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/7925");
-    }
+    checkNamespaceLink(suborgForMemberName, WORKSPACE_FOR_MEMBER_2);
   }
 
   private void createWorkspace(String organizationName, String workspaceName) {
@@ -169,26 +156,14 @@ public class AddWorkspaceToOrganizationTest {
     newWorkspace.selectStack(JAVA.getId());
     newWorkspace.typeWorkspaceName(workspaceName);
     newWorkspace.clickOnCreateButtonAndEditWorkspace();
-
-    try {
-      workspaceDetails.waitToolbarTitleName(workspaceName);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/8497");
-    }
+    workspaceDetails.waitToolbarTitleName(workspaceName);
   }
 
   private void checkNamespaceLink(String organizationName, String workspaceName) {
     dashboard.selectWorkspacesItemOnDashboard();
     workspaces.selectWorkspaceItemName(workspaceName);
     workspaceDetails.waitToolbarTitleName(workspaceName);
-
-    try {
-      Assert.assertEquals(workspaceDetails.getOrganizationName(), organizationName);
-    } catch (AssertionError ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/8776");
-    }
+    Assert.assertEquals(workspaceDetails.getOrganizationName(), organizationName);
 
     workspaceDetails.clickOnOpenOrganizationButton();
     organizationPage.waitOrganizationTitle(organizationName);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/RenameOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/RenameOrganizationTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.che.selenium.pageobject.dashboard.organization.Organiz
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
@@ -129,13 +128,7 @@ public class RenameOrganizationTest {
     organizationPage.clickBackButton();
     organizationListPage.waitForOrganizationsList();
 
-    try {
-      assertTrue(organizationListPage.getValues(NAME).contains(newChildOrgQualifiedName));
-    } catch (AssertionError ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/8668");
-    }
-
+    assertTrue(organizationListPage.getValues(NAME).contains(newChildOrgQualifiedName));
     assertTrue(organizationListPage.getValues(NAME).contains(NEW_PARENT_ORG_NAME));
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureBaseOperationTest.java
@@ -14,7 +14,6 @@ import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FILE_STRUCTURE;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -27,7 +26,6 @@ import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -110,14 +108,7 @@ public class FileStructureBaseOperationTest {
     fileStructure.waitExpectedTextInFileStructure(CLASS_MEMBERS_1);
     fileStructure.waitExpectedTextIsNotPresentInFileStructure(INHERITED_MEMBERS);
     fileStructure.launchFileStructureFormByKeyboard();
-
-    try {
-      fileStructure.waitExpectedTextInFileStructure(CLASS_MEMBERS_2);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/8509");
-    }
-
+    fileStructure.waitExpectedTextInFileStructure(CLASS_MEMBERS_2);
     fileStructure.waitExpectedTextInFileStructure(INHERITED_MEMBERS);
     fileStructure.launchFileStructureFormByKeyboard();
     fileStructure.waitExpectedTextInFileStructure(CLASS_MEMBERS_1);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ResolveDependencyAfterRecreateProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ResolveDependencyAfterRecreateProjectTest.java
@@ -17,7 +17,6 @@ import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextM
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.eclipse.che.selenium.pageobject.Wizard.SamplesName.WEB_JAVA_SPRING;
 import static org.eclipse.che.selenium.pageobject.Wizard.TypeProject.MAVEN;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -29,7 +28,6 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Wizard;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -78,13 +76,7 @@ public class ResolveDependencyAfterRecreateProjectTest {
     projectExplorer.waitItem(PROJECT_NAME2);
     projectExplorer.waitAndSelectItemByName(PROJECT_NAME2);
     projectExplorer.expandPathInProjectExplorer(PROJECT_NAME2 + PATH_TO_EXPAND);
-
-    try {
-      projectExplorer.openItemByPath(PROJECT_NAME2 + PATH_TO_FILE);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/8791");
-    }
+    projectExplorer.openItemByPath(PROJECT_NAME2 + PATH_TO_FILE);
 
     editor.waitActive();
     editor.waitAllMarkersInvisibility(ERROR);


### PR DESCRIPTION
### What does this PR do?
This PR removes info about resolved #8250, #7925, #8497, #8776, #8668, #8509, #8791 issues in selenium tests from **dashboard** and **miscellaneous** packages.