### PR TITLE
Do not throw Exception when not project item is found in root

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/fs/server/impl/SimpleFsDtoConverter.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/fs/server/impl/SimpleFsDtoConverter.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.api.fs.server.impl;
 
-import static org.eclipse.che.api.fs.server.WsPathUtils.isRoot;
 import static org.eclipse.che.api.fs.server.WsPathUtils.nameOf;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
@@ -55,15 +54,7 @@ public class SimpleFsDtoConverter implements FsDtoConverter {
       length = null;
     }
 
-    RegisteredProject project;
-    if (isRoot(wsPath)) {
-      project = null;
-    } else {
-      project =
-          projectManager
-              .getClosest(wsPath)
-              .orElseThrow(() -> new NotFoundException("Can't find project for item " + wsPath));
-    }
+    RegisteredProject project = projectManager.getClosest(wsPath).orElse(null);
 
     String type;
     if (projectManager.isRegistered(wsPath)) {


### PR DESCRIPTION
### What does this PR do?
We store some settings for workspace in .che folder at the same level as the projects
So, we should not throw Exception when not project item is found in root

### What issues does this PR fix or reference?
#9192 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>