### PR TITLE
Change way of storing IDE state data

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/statepersistance/AppStateServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/statepersistance/AppStateServiceClient.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.api.statepersistance;
+
+import elemental.json.JsonFactory;
+import org.eclipse.che.api.promises.client.Promise;
+
+/**
+ * Service allows to get or persist IDE state for current user.
+ *
+ * @author Roman Nikitenko
+ */
+public interface AppStateServiceClient {
+
+  /**
+   * Get saved IDE state for current workspace in JSON format. Use {@link JsonFactory#parse(String)}
+   * to get corresponding object. Note: it is expected that saved IDE state object is valid, so any
+   * validations are not performed.
+   */
+  Promise<String> getState();
+
+  /**
+   * Save IDE state for current workspace.
+   *
+   * @param state IDE state in JSON format.
+   */
+  Promise<Void> saveState(String state);
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/statepersistance/AppStateServiceClient.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/statepersistance/AppStateServiceClient.java
@@ -14,18 +14,18 @@ import elemental.json.JsonFactory;
 import org.eclipse.che.api.promises.client.Promise;
 
 /**
- * Service allows to get or persist IDE state for current user.
+ * Service allows to load or persist IDE state for current user.
  *
  * @author Roman Nikitenko
  */
 public interface AppStateServiceClient {
 
   /**
-   * Get saved IDE state for current workspace in JSON format. Use {@link JsonFactory#parse(String)}
-   * to get corresponding object. Note: it is expected that saved IDE state object is valid, so any
-   * validations are not performed.
+   * Load saved IDE state for current workspace in JSON format. Use {@link
+   * JsonFactory#parse(String)} to get corresponding object. Note: it is expected that saved IDE
+   * state object is valid, so any validations are not performed.
    */
-  Promise<String> getState();
+  Promise<String> loadState();
 
   /**
    * Save IDE state for current workspace.

--- a/ide/che-core-ide-app/pom.xml
+++ b/ide/che-core-ide-app/pom.xml
@@ -184,6 +184,10 @@
             <artifactId>che-terminal-client</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-dev</artifactId>
             <scope>provided</scope>

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/DefaultIdeInitializationStrategy.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/DefaultIdeInitializationStrategy.java
@@ -34,7 +34,6 @@ import org.eclipse.che.ide.context.AppContextImpl;
 import org.eclipse.che.ide.context.BrowserAddress;
 import org.eclipse.che.ide.core.StandardComponentInitializer;
 import org.eclipse.che.ide.preferences.StyleInjector;
-import org.eclipse.che.ide.statepersistance.AppStateManager;
 import org.eclipse.che.ide.theme.ThemeAgentImpl;
 import org.eclipse.che.ide.ui.dialogs.DialogFactory;
 import org.eclipse.che.ide.workspace.WorkspacePresenter;
@@ -60,7 +59,6 @@ class DefaultIdeInitializationStrategy implements IdeInitializationStrategy {
   protected final ThemeAgent themeAgent;
   protected final StyleInjector styleInjector;
   protected final Provider<StandardComponentInitializer> standardComponentsInitializerProvider;
-  protected final AppStateManager appStateManager;
   protected final Provider<WorkspacePresenter> workspacePresenterProvider;
   protected final EventBus eventBus;
   protected final DialogFactory dialogFactory;
@@ -74,7 +72,6 @@ class DefaultIdeInitializationStrategy implements IdeInitializationStrategy {
       ThemeAgent themeAgent,
       StyleInjector styleInjector,
       Provider<StandardComponentInitializer> standardComponentsInitializerProvider,
-      AppStateManager appStateManager,
       Provider<WorkspacePresenter> workspacePresenterProvider,
       EventBus eventBus,
       DialogFactory dialogFactory) {
@@ -85,7 +82,6 @@ class DefaultIdeInitializationStrategy implements IdeInitializationStrategy {
     this.themeAgent = themeAgent;
     this.styleInjector = styleInjector;
     this.standardComponentsInitializerProvider = standardComponentsInitializerProvider;
-    this.appStateManager = appStateManager;
     this.workspacePresenterProvider = workspacePresenterProvider;
     this.eventBus = eventBus;
     this.dialogFactory = dialogFactory;
@@ -149,7 +145,6 @@ class DefaultIdeInitializationStrategy implements IdeInitializationStrategy {
   private Operation<Void> showUI() {
     return aVoid -> {
       standardComponentsInitializerProvider.get().initialize();
-      appStateManager.readStateFromPreferences();
       showRootPresenter();
 
       // Bind browser's window events

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/FactoryIdeInitializationStrategy.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/bootstrap/FactoryIdeInitializationStrategy.java
@@ -33,7 +33,6 @@ import org.eclipse.che.ide.context.AppContextImpl;
 import org.eclipse.che.ide.context.BrowserAddress;
 import org.eclipse.che.ide.core.StandardComponentInitializer;
 import org.eclipse.che.ide.preferences.StyleInjector;
-import org.eclipse.che.ide.statepersistance.AppStateManager;
 import org.eclipse.che.ide.ui.dialogs.DialogFactory;
 import org.eclipse.che.ide.workspace.WorkspacePresenter;
 import org.eclipse.che.ide.workspace.WorkspaceServiceClient;
@@ -57,7 +56,6 @@ class FactoryIdeInitializationStrategy extends DefaultIdeInitializationStrategy 
       ThemeAgent themeAgent,
       StyleInjector styleInjector,
       Provider<StandardComponentInitializer> standardComponentsInitializerProvider,
-      AppStateManager appStateManager,
       Provider<WorkspacePresenter> workspacePresenterProvider,
       EventBus eventBus,
       QueryParameters queryParameters,
@@ -71,7 +69,6 @@ class FactoryIdeInitializationStrategy extends DefaultIdeInitializationStrategy 
         themeAgent,
         styleInjector,
         standardComponentsInitializerProvider,
-        appStateManager,
         workspacePresenterProvider,
         eventBus,
         dialogFactory);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateBackCompatibility.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateBackCompatibility.java
@@ -31,10 +31,9 @@ import org.eclipse.che.ide.util.loging.Log;
  */
 @Singleton
 public class AppStateBackCompatibility {
-
-  private JsonFactory jsonFactory;
-  private final PreferencesManager preferencesManager;
   private final AppContext appContext;
+  private final JsonFactory jsonFactory;
+  private final PreferencesManager preferencesManager;
 
   @Inject
   public AppStateBackCompatibility(
@@ -93,8 +92,7 @@ public class AppStateBackCompatibility {
    * preferences
    */
   private Promise<Void> writeToPreferences(JsonObject state) {
-    final String json = state.toJson();
-    preferencesManager.setValue(APP_STATE, json);
+    preferencesManager.setValue(APP_STATE, state.toJson());
     return preferencesManager
         .flushPreferences()
         .catchError(

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateBackCompatibility.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateBackCompatibility.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.statepersistance;
+
+import static org.eclipse.che.ide.statepersistance.AppStateConstants.APP_STATE;
+import static org.eclipse.che.ide.statepersistance.AppStateConstants.WORKSPACE;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import elemental.json.JsonFactory;
+import elemental.json.JsonObject;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.preferences.PreferencesManager;
+import org.eclipse.che.ide.util.loging.Log;
+
+/**
+ * User preferences was used to storage serialized IDE state. The class provides back compatibility
+ * and allows to get IDE state from preferences and clean up them.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class AppStateBackCompatibility {
+
+  private JsonFactory jsonFactory;
+  private final PreferencesManager preferencesManager;
+  private final AppContext appContext;
+
+  @Inject
+  public AppStateBackCompatibility(
+      AppContext appContext, JsonFactory jsonFactory, PreferencesManager preferencesManager) {
+    this.appContext = appContext;
+    this.jsonFactory = jsonFactory;
+    this.preferencesManager = preferencesManager;
+  }
+
+  /**
+   * Allows to get IDE state for current workspace from user preferences.
+   *
+   * @return IDE state of current workspace or {@code null} when this one is not found
+   */
+  @Nullable
+  JsonObject getAppState() {
+    JsonObject allWsState = getAllWorkspacesState();
+    if (allWsState == null) {
+      return null;
+    }
+
+    String wsId = appContext.getWorkspace().getId();
+    JsonObject workspaceSettings = allWsState.getObject(wsId);
+
+    return workspaceSettings != null ? workspaceSettings.get(WORKSPACE) : null;
+  }
+
+  /**
+   * Allows to get states for all workspaces from user preferences.
+   *
+   * @return app states of all workspaces for current user or {@code null} when these ones are not
+   *     found
+   */
+  @Nullable
+  JsonObject getAllWorkspacesState() {
+    try {
+      String json = preferencesManager.getValue(APP_STATE);
+      return jsonFactory.parse(json);
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  /** Allows to remove IDE state for current workspace from user preferences */
+  void removeAppState() {
+    JsonObject allWsState = getAllWorkspacesState();
+    if (allWsState != null) {
+      String wsId = appContext.getWorkspace().getId();
+      allWsState.remove(wsId);
+      writeToPreferences(allWsState);
+    }
+  }
+
+  /**
+   * Provide ability to write to preferences state for all workspaces. It's used to clean up user
+   * preferences
+   */
+  private Promise<Void> writeToPreferences(JsonObject state) {
+    final String json = state.toJson();
+    preferencesManager.setValue(APP_STATE, json);
+    return preferencesManager
+        .flushPreferences()
+        .catchError(
+            error -> {
+              Log.error(
+                  AppStateBackCompatibility.class,
+                  "Failed to store app's state to user's preferences: " + error.getMessage());
+            });
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateBackwardCompatibility.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateBackwardCompatibility.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.statepersistance;
 
 import static org.eclipse.che.ide.statepersistance.AppStateConstants.APP_STATE;
 import static org.eclipse.che.ide.statepersistance.AppStateConstants.WORKSPACE;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -21,7 +22,7 @@ import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.preferences.PreferencesManager;
-import org.eclipse.che.ide.util.loging.Log;
+import org.slf4j.Logger;
 
 /**
  * User preferences was used to storage serialized IDE state. The class provides back compatibility
@@ -30,13 +31,15 @@ import org.eclipse.che.ide.util.loging.Log;
  * @author Roman Nikitenko
  */
 @Singleton
-public class AppStateBackCompatibility {
+public class AppStateBackwardCompatibility {
+  private static final Logger LOG = getLogger(AppStateBackwardCompatibility.class);
+
   private final AppContext appContext;
   private final JsonFactory jsonFactory;
   private final PreferencesManager preferencesManager;
 
   @Inject
-  public AppStateBackCompatibility(
+  public AppStateBackwardCompatibility(
       AppContext appContext, JsonFactory jsonFactory, PreferencesManager preferencesManager) {
     this.appContext = appContext;
     this.jsonFactory = jsonFactory;
@@ -97,9 +100,8 @@ public class AppStateBackCompatibility {
         .flushPreferences()
         .catchError(
             error -> {
-              Log.error(
-                  AppStateBackCompatibility.class,
-                  "Failed to store app's state to user's preferences: " + error.getMessage());
+              LOG.error(
+                  "Failed to store app's state to user's preferences: {}", error.getMessage());
             });
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateConstants.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateConstants.java
@@ -11,13 +11,14 @@
 package org.eclipse.che.ide.statepersistance;
 
 /**
- * Constants for the mappings in user preferences to store/restore app state.
+ * Constants for the mappings to store/restore app state.
  *
  * @author Roman Nikitenko
  */
 public final class AppStateConstants {
 
   public static final String APP_STATE = "IdeAppStates";
+  public static final String WORKSPACE = "workspace";
   public static final String PERSPECTIVES = "perspectives";
   public static final String PART_STACKS = "PART_STACKS";
   public static final String PART_STACK_STATE = "STATE";

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
@@ -10,143 +10,105 @@
  */
 package org.eclipse.che.ide.statepersistance;
 
-import static org.eclipse.che.ide.statepersistance.AppStateConstants.APP_STATE;
 import static org.eclipse.che.ide.statepersistance.AppStateConstants.PART_STACKS;
 import static org.eclipse.che.ide.statepersistance.AppStateConstants.PERSPECTIVES;
+import static org.eclipse.che.ide.statepersistance.AppStateConstants.WORKSPACE;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.gwt.user.client.Timer;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import com.google.web.bindery.event.shared.EventBus;
 import elemental.json.Json;
 import elemental.json.JsonException;
 import elemental.json.JsonFactory;
 import elemental.json.JsonObject;
 import java.util.Optional;
-import org.eclipse.che.api.core.model.workspace.Workspace;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
-import org.eclipse.che.api.promises.client.callback.AsyncPromiseHelper;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.ide.DelayedTask;
-import org.eclipse.che.ide.api.WindowActionEvent;
-import org.eclipse.che.ide.api.WindowActionHandler;
-import org.eclipse.che.ide.api.app.AppContext;
-import org.eclipse.che.ide.api.parts.PartStackStateChangedEvent;
 import org.eclipse.che.ide.api.parts.PartStackType;
 import org.eclipse.che.ide.api.parts.PerspectiveManager;
-import org.eclipse.che.ide.api.preferences.PreferencesManager;
+import org.eclipse.che.ide.api.statepersistance.AppStateServiceClient;
 import org.eclipse.che.ide.api.statepersistance.StateComponent;
-import org.eclipse.che.ide.api.workspace.WorkspaceReadyEvent;
 import org.eclipse.che.ide.util.loging.Log;
 
 /**
- * Responsible for persisting and restoring IDE state across sessions. Uses user preferences as
- * storage for serialized state.
+ * Responsible for collecting, persisting and restoring IDE state.
  *
  * @author Artem Zatsarynnyi
  * @author Yevhen Vydolob
  * @author Vlad Zhukovskyi
+ * @author Roman Nikitenko
  */
 @Singleton
 public class AppStateManager {
-
-  /** The name of the property for the mappings in user preferences. */
-  public static final String PREFERENCE_PROPERTY_NAME = "IdeAppStates";
-
-  private static final String WORKSPACE = "workspace";
-
   private final Provider<PerspectiveManager> perspectiveManagerProvider;
   private final Provider<StateComponentRegistry> stateComponentRegistry;
 
-  private final PreferencesManager preferencesManager;
   private final JsonFactory jsonFactory;
   private final PromiseProvider promises;
-  private EventBus eventBus;
-  private final AppContext appContext;
-  private JsonObject allWsState;
-  private final DelayedTask persistWorkspaceStateTask =
-      new DelayedTask() {
-        @Override
-        public void onExecute() {
-          persistWorkspaceState();
-        }
-      };
+  private final AppStateServiceClient appStateService;
+
+  private JsonObject appState;
 
   @Inject
   public AppStateManager(
       Provider<PerspectiveManager> perspectiveManagerProvider,
       Provider<StateComponentRegistry> stateComponentRegistryProvider,
-      PreferencesManager preferencesManager,
       JsonFactory jsonFactory,
       PromiseProvider promises,
-      EventBus eventBus,
-      AppContext appContext) {
+      AppStateServiceClient appStateService) {
     this.perspectiveManagerProvider = perspectiveManagerProvider;
     this.stateComponentRegistry = stateComponentRegistryProvider;
-    this.preferencesManager = preferencesManager;
     this.jsonFactory = jsonFactory;
     this.promises = promises;
-    this.eventBus = eventBus;
-    this.appContext = appContext;
-
-    eventBus.addHandler(WorkspaceReadyEvent.getType(), this::onWorkspaceReady);
-
-    eventBus.addHandler(
-        WindowActionEvent.TYPE,
-        new WindowActionHandler() {
-          @Override
-          public void onWindowClosing(WindowActionEvent event) {
-            Workspace workspace = appContext.getWorkspace();
-            if (workspace != null) {
-              persistWorkspaceState();
-            }
-          }
-
-          @Override
-          public void onWindowClosed(WindowActionEvent event) {}
-        });
+    this.appStateService = appStateService;
   }
 
-  public void readStateFromPreferences() {
-    final String json = preferencesManager.getValue(APP_STATE);
-    if (json == null) {
-      allWsState = jsonFactory.createObject();
+  /**
+   * Allows to get saved IDE state for current workspace from server side. Creates 'clear' state
+   * when state for current workspace is not found.
+   */
+  public Promise<Void> readState() {
+    return appStateService
+        .getState()
+        .thenPromise(
+            (Function<String, Promise<Void>>)
+                state -> {
+                  try {
+                    appState = jsonFactory.parse(state);
+                  } catch (Exception e) {
+                    // create 'clear' state if any deserializing error occurred
+                    appState = jsonFactory.createObject();
+                  }
+                  return null;
+                })
+        .catchError(
+            error -> {
+              appState = jsonFactory.createObject();
+            });
+  }
+
+  /** Collects current IDE state {@link #collectAppStateData()} and saves on server side. */
+  public Promise<Void> persistState() {
+    JsonObject newAppState = collectAppStateData();
+    if (appState == null || !appState.toJson().equals(newAppState.toJson())) {
+      appState = newAppState;
+      return appStateService.saveState(newAppState.toJson());
     } else {
-      try {
-        allWsState = jsonFactory.parse(json);
-      } catch (Exception e) {
-        // create 'clear' state if any deserializing error occurred
-        allWsState = jsonFactory.createObject();
-      }
+      return promises.resolve(null);
     }
   }
 
   /**
-   * Gets cached state for given {@code partStackType}. Use {@link #readStateFromPreferences()}
-   * first to get not cached state
+   * Gets cached state for given {@code partStackType}. Use {@link #readState()} first to get not
+   * cached state
    */
   @Nullable
   public JsonObject getStateFor(PartStackType partStackType) {
-    String workspaceId = appContext.getWorkspace().getId();
-    if (!allWsState.hasKey(workspaceId)) {
-      return null;
-    }
-
-    JsonObject preferences = allWsState.getObject(workspaceId);
-    if (!preferences.hasKey(WORKSPACE)) {
-      return null;
-    }
-
-    JsonObject workspace = preferences.getObject(WORKSPACE);
-    if (!workspace.hasKey(WORKSPACE)) {
-      return null;
-    }
-
-    JsonObject workspaceState = workspace.getObject(WORKSPACE);
-    if (!workspaceState.hasKey(PERSPECTIVES)) {
+    JsonObject workspaceState = appState.getObject(WORKSPACE);
+    if (workspaceState == null || !workspaceState.hasKey(PERSPECTIVES)) {
       return null;
     }
 
@@ -169,107 +131,52 @@ public class AppStateManager {
     return partStacks.getObject(partStackType.name());
   }
 
-  private Promise<Void> restoreWorkspaceStateWithDelay() {
-    return AsyncPromiseHelper.createFromAsyncRequest(
-        callback ->
-            new Timer() {
-              @Override
-              public void run() {
-                restoreWorkspaceState()
-                    .then(
-                        arg -> {
-                          callback.onSuccess(null);
-                        })
-                    .catchError(
-                        arg -> {
-                          callback.onFailure(arg.getCause());
-                        });
-              }
-            }.schedule(1000));
+  /** Restores given IDE state for {@link StateComponent}s. */
+  Promise<Void> restoreState(JsonObject updatedState) {
+    appState = updatedState;
+    return restoreState();
   }
 
-  @VisibleForTesting
-  Promise<Void> restoreWorkspaceState() {
-    final String wsId = appContext.getWorkspace().getId();
-
-    if (allWsState.hasKey(wsId)) {
-      return restoreState(allWsState.getObject(wsId));
-    }
-    return promises.resolve(null);
-  }
-
-  private Promise<Void> restoreState(JsonObject settings) {
+  /**
+   * Restores cached state for {@link StateComponent}s. Use {@link #readState()} first to restore
+   * not cached state or {@link #restoreState(JsonObject)}
+   */
+  Promise<Void> restoreState() {
     try {
-      if (settings.hasKey(WORKSPACE)) {
-        JsonObject workspace = settings.getObject(WORKSPACE);
-        Promise<Void> sequentialRestore = promises.resolve(null);
-        for (String key : workspace.keys()) {
-          Optional<StateComponent> stateComponent =
-              stateComponentRegistry.get().getComponentById(key);
-          if (stateComponent.isPresent()) {
-            StateComponent component = stateComponent.get();
-            Log.debug(getClass(), "Restore state for the component ID: " + component.getId());
-            sequentialRestore =
-                sequentialRestore.thenPromise(
-                    ignored -> component.loadState(workspace.getObject(key)));
-          }
+      Promise<Void> sequentialRestore = promises.resolve(null);
+      for (String key : appState.keys()) {
+        Optional<StateComponent> stateComponent =
+            stateComponentRegistry.get().getComponentById(key);
+        if (stateComponent.isPresent()) {
+          StateComponent component = stateComponent.get();
+          Log.debug(getClass(), "Restore state for the component ID: " + component.getId());
+          sequentialRestore =
+              sequentialRestore.thenPromise(
+                  ignored -> component.loadState(appState.getObject(key)));
         }
-        return sequentialRestore;
       }
+      return sequentialRestore;
     } catch (JsonException e) {
       Log.error(getClass(), e);
     }
     return promises.resolve(null);
   }
 
-  public Promise<Void> persistWorkspaceState() {
-    String wsId = appContext.getWorkspace().getId();
-    JsonObject settings = Json.createObject();
-    JsonObject workspace = Json.createObject();
-    settings.put(WORKSPACE, workspace);
-
+  /**
+   * Allows to collect current state of {@link StateComponent}s. Creates 'clear' state when {@link
+   * StateComponentRegistry} is empty or some errors are occurred at collecting current state.
+   */
+  @NotNull
+  JsonObject collectAppStateData() {
+    JsonObject newAppState = Json.createObject();
     for (StateComponent entry : stateComponentRegistry.get().getComponents()) {
       try {
         Log.debug(getClass(), "Persist state for the component ID: " + entry.getId());
-        workspace.put(entry.getId(), entry.getState());
+        newAppState.put(entry.getId(), entry.getState());
       } catch (Exception e) {
         Log.error(getClass(), e);
       }
     }
-    JsonObject oldSettings = allWsState.getObject(wsId);
-    if (oldSettings == null || !oldSettings.toJson().equals(settings.toJson())) {
-      allWsState.put(wsId, settings);
-      return writeStateToPreferences(allWsState);
-    } else {
-      return promises.resolve(null);
-    }
-  }
-
-  private Promise<Void> writeStateToPreferences(JsonObject state) {
-    final String json = state.toJson();
-    preferencesManager.setValue(APP_STATE, json);
-    return preferencesManager
-        .flushPreferences()
-        .catchError(
-            error -> {
-              Log.error(
-                  AppStateManager.class,
-                  "Failed to store app's state to user's preferences: " + error.getMessage());
-            });
-  }
-
-  @Deprecated
-  public boolean hasStateForWorkspace(String wsId) {
-    return allWsState.hasKey(wsId);
-  }
-
-  private void onWorkspaceReady(WorkspaceReadyEvent workspaceReadyEvent) {
-    // delay is required because we need to wait some time while different components initialized
-    restoreWorkspaceStateWithDelay()
-        .then(
-            ignored -> {
-              eventBus.addHandler(
-                  PartStackStateChangedEvent.TYPE, event -> persistWorkspaceStateTask.delay(500));
-            });
+    return newAppState;
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
@@ -67,12 +67,12 @@ public class AppStateManager {
   }
 
   /**
-   * Allows to get saved IDE state for current workspace from server side. Creates 'clear' state
+   * Allows to load saved IDE state for current workspace from server side. Creates 'clear' state
    * when state for current workspace is not found.
    */
   public Promise<Void> readState() {
     return appStateService
-        .getState()
+        .loadState()
         .thenPromise(
             (Function<String, Promise<Void>>)
                 state -> {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateServiceClientImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateServiceClientImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.statepersistance;
+
+import static org.eclipse.che.ide.MimeType.APPLICATION_JSON;
+import static org.eclipse.che.ide.rest.HTTPHeader.ACCEPT;
+import static org.eclipse.che.ide.rest.HTTPHeader.CONTENT_TYPE;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.statepersistance.AppStateServiceClient;
+import org.eclipse.che.ide.rest.AsyncRequestFactory;
+import org.eclipse.che.ide.rest.StringUnmarshaller;
+
+/** @author Roman Nikitenko */
+@Singleton
+public class AppStateServiceClientImpl implements AppStateServiceClient {
+  private static final String PREFIX = "/app/state";
+
+  private AppContext appContext;
+  private AsyncRequestFactory asyncRequestFactory;
+
+  @Inject
+  public AppStateServiceClientImpl(AppContext appContext, AsyncRequestFactory asyncRequestFactory) {
+    this.appContext = appContext;
+    this.asyncRequestFactory = asyncRequestFactory;
+  }
+
+  @Override
+  public Promise<String> getState() {
+    String userId = appContext.getCurrentUser().getId();
+    String url = appContext.getWsAgentServerApiEndpoint() + PREFIX + "?userId=" + userId;
+    return asyncRequestFactory
+        .createGetRequest(url)
+        .header(ACCEPT, APPLICATION_JSON)
+        .send(new StringUnmarshaller());
+  }
+
+  @Override
+  public Promise<Void> saveState(String state) {
+    String userId = appContext.getCurrentUser().getId();
+    String url =
+        appContext.getWsAgentServerApiEndpoint() + PREFIX + "/update/" + "?userId=" + userId;
+
+    return asyncRequestFactory
+        .createPostRequest(url, state)
+        .header(CONTENT_TYPE, APPLICATION_JSON)
+        .send();
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateServiceClientImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateServiceClientImpl.java
@@ -37,7 +37,7 @@ public class AppStateServiceClientImpl implements AppStateServiceClient {
   }
 
   @Override
-  public Promise<String> getState() {
+  public Promise<String> loadState() {
     String userId = appContext.getCurrentUser().getId();
     String url = appContext.getWsAgentServerApiEndpoint() + PREFIX + "?userId=" + userId;
     return asyncRequestFactory

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateSyncWriter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateSyncWriter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.statepersistance;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import elemental.json.JsonObject;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.statepersistance.AppStateServiceClient;
+
+/**
+ * Provides ability to save IDE state synchronously. It is strongly encouraged to use {@link
+ * AppStateServiceClient} instead.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class AppStateSyncWriter {
+  private static final String UPDATE_STATE = "/app/state/update";
+
+  private final AppContext appContext;
+
+  @Inject
+  public AppStateSyncWriter(AppContext appContext) {
+    this.appContext = appContext;
+  }
+
+  /**
+   * Save IDE state synchronously. Note: Consider using {@link
+   * AppStateServiceClient#saveState(String)} instead.
+   *
+   * @param appState IDE state to save
+   */
+  void saveState(JsonObject appState) {
+    String userId = appContext.getCurrentUser().getId();
+    String url = appContext.getWsAgentServerApiEndpoint() + UPDATE_STATE + "?userId=" + userId;
+    String machineToken = appContext.getWorkspace().getRuntime().getMachineToken();
+
+    sendSyncRequest(url, machineToken, appState.toJson());
+  }
+
+  private native void sendSyncRequest(String url, String machineToken, String json) /*-{
+              try {
+                    var request = new XMLHttpRequest();
+                    request.open("POST", url, false);
+                    request.setRequestHeader("Content-Type", "application/json");
+                    request.setRequestHeader("Authorization", machineToken);
+                    request.send(json);
+                } catch (e) {
+                    console.error(e);
+                }
+    }-*/;
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateTracker.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateTracker.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.statepersistance;
+
+import static elemental.events.Event.BLUR;
+import static org.eclipse.che.ide.util.dom.Elements.getWindow;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+import com.google.web.bindery.event.shared.HandlerRegistration;
+import elemental.events.EventRemover;
+import elemental.json.JsonObject;
+import org.eclipse.che.ide.DelayedTask;
+import org.eclipse.che.ide.api.WindowActionEvent;
+import org.eclipse.che.ide.api.WindowActionHandler;
+import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.api.parts.PartStackStateChangedEvent;
+import org.eclipse.che.ide.api.workspace.WorkspaceReadyEvent;
+import org.eclipse.che.ide.api.workspace.event.WorkspaceStoppingEvent;
+
+/**
+ * Contains handlers to track app state and persist/restore IDE state across sessions.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class AppStateTracker
+    implements WindowActionHandler,
+        PartStackStateChangedEvent.Handler,
+        WorkspaceStoppingEvent.Handler {
+
+  private EventBus eventBus;
+  private AppContext appContext;
+  private AppStateSyncWriter appStateSyncWriter;
+  private AppStateManager appStateManager;
+  private AppStateBackCompatibility appStateBackCompatibility;
+
+  private EventRemover blurEventRemover;
+  private HandlerRegistration windowEventsRemover;
+  private HandlerRegistration partStackStateEventRemover;
+  private HandlerRegistration workspaceStoppingEventRemover;
+
+  private final DelayedTask restoreStateTask =
+      new DelayedTask() {
+        @Override
+        public void onExecute() {
+          restoreState();
+        }
+      };
+
+  private final DelayedTask persistStateTask =
+      new DelayedTask() {
+        @Override
+        public void onExecute() {
+          appStateManager.persistState();
+        }
+      };
+
+  @Inject
+  public AppStateTracker(
+      EventBus eventBus,
+      AppContext appContext,
+      AppStateSyncWriter appStateSyncWriter,
+      AppStateManager appStateManager,
+      AppStateBackCompatibility appStateBackCompatibility) {
+    this.eventBus = eventBus;
+    this.appContext = appContext;
+    this.appStateSyncWriter = appStateSyncWriter;
+    this.appStateManager = appStateManager;
+    this.appStateBackCompatibility = appStateBackCompatibility;
+
+    eventBus.addHandler(WorkspaceReadyEvent.getType(), this::onWorkspaceReady);
+  }
+
+  private void onWorkspaceReady(WorkspaceReadyEvent event) {
+    // delay is required because we need to wait some time while different components initialized
+    restoreStateTask.delay(1_000);
+  }
+
+  @Override
+  public void onWorkspaceStopping(WorkspaceStoppingEvent event) {
+    cleanUpHandlers();
+  }
+
+  @Override
+  public void onWindowClosing(WindowActionEvent event) {
+    if (appContext.getWorkspace() == null) {
+      return;
+    }
+
+    JsonObject appState = appStateManager.collectAppStateData();
+    if (appState.keys().length > 0) {
+      appStateSyncWriter.saveState(appState);
+    }
+  }
+
+  @Override
+  public void onPartStackStateChanged(PartStackStateChangedEvent event) {
+    persistStateTask.delay(500);
+  }
+
+  private void restoreState() {
+    JsonObject appStateFromPreferences = appStateBackCompatibility.getAppState();
+    if (appStateFromPreferences != null) {
+      appStateManager
+          .restoreState(appStateFromPreferences)
+          .then(
+              arg -> {
+                addHandlers();
+              });
+
+      appStateBackCompatibility.removeAppState();
+    } else {
+      appStateManager
+          .readState()
+          .then(
+              arg -> {
+                appStateManager
+                    .restoreState()
+                    .then(
+                        aVoid -> {
+                          addHandlers();
+                        });
+              });
+    }
+  }
+
+  private void addHandlers() {
+    cleanUpHandlers();
+
+    partStackStateEventRemover = eventBus.addHandler(PartStackStateChangedEvent.TYPE, this);
+    blurEventRemover = getWindow().addEventListener(BLUR, evt -> appStateManager.persistState());
+    windowEventsRemover = eventBus.addHandler(WindowActionEvent.TYPE, this);
+    workspaceStoppingEventRemover = eventBus.addHandler(WorkspaceStoppingEvent.TYPE, this);
+  }
+
+  private void cleanUpHandlers() {
+    if (partStackStateEventRemover != null) {
+      partStackStateEventRemover.removeHandler();
+    }
+
+    if (blurEventRemover != null) {
+      blurEventRemover.remove();
+    }
+
+    if (windowEventsRemover != null) {
+      windowEventsRemover.removeHandler();
+    }
+
+    if (workspaceStoppingEventRemover != null) {
+      workspaceStoppingEventRemover.removeHandler();
+    }
+  }
+
+  @Override
+  public void onWindowClosed(WindowActionEvent event) {}
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateTracker.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateTracker.java
@@ -42,7 +42,7 @@ public class AppStateTracker
   private AppContext appContext;
   private AppStateSyncWriter appStateSyncWriter;
   private AppStateManager appStateManager;
-  private AppStateBackCompatibility appStateBackCompatibility;
+  private AppStateBackwardCompatibility appStateBackwardCompatibility;
 
   private EventRemover blurEventRemover;
   private HandlerRegistration windowEventsRemover;
@@ -71,12 +71,12 @@ public class AppStateTracker
       AppContext appContext,
       AppStateSyncWriter appStateSyncWriter,
       AppStateManager appStateManager,
-      AppStateBackCompatibility appStateBackCompatibility) {
+      AppStateBackwardCompatibility appStateBackwardCompatibility) {
     this.eventBus = eventBus;
     this.appContext = appContext;
     this.appStateSyncWriter = appStateSyncWriter;
     this.appStateManager = appStateManager;
-    this.appStateBackCompatibility = appStateBackCompatibility;
+    this.appStateBackwardCompatibility = appStateBackwardCompatibility;
 
     eventBus.addHandler(WorkspaceReadyEvent.getType(), this::onWorkspaceReady);
   }
@@ -109,7 +109,7 @@ public class AppStateTracker
   }
 
   private void restoreState() {
-    JsonObject appStateFromPreferences = appStateBackCompatibility.getAppState();
+    JsonObject appStateFromPreferences = appStateBackwardCompatibility.getAppState();
     if (appStateFromPreferences != null) {
       appStateManager
           .restoreState(appStateFromPreferences)
@@ -118,7 +118,7 @@ public class AppStateTracker
                 addHandlers();
               });
 
-      appStateBackCompatibility.removeAppState();
+      appStateBackwardCompatibility.removeAppState();
     } else {
       appStateManager
           .readState()

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/PersistenceApiModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/PersistenceApiModule.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.statepersistance;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.multibindings.GinMultibinder;
+import org.eclipse.che.ide.api.statepersistance.AppStateServiceClient;
 import org.eclipse.che.ide.api.statepersistance.StateComponent;
 import org.eclipse.che.ide.editor.EditorAgentImpl;
 import org.eclipse.che.ide.part.explorer.project.ProjectExplorerStateComponent;
@@ -22,7 +23,9 @@ public class PersistenceApiModule extends AbstractGinModule {
 
   @Override
   protected void configure() {
+    bind(AppStateTracker.class).asEagerSingleton();
     bind(AppStateManager.class).asEagerSingleton();
+    bind(AppStateServiceClient.class).to(AppStateServiceClientImpl.class);
 
     GinMultibinder<StateComponent> stateComponents =
         GinMultibinder.newSetBinder(binder(), StateComponent.class);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/StopWorkspaceAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/StopWorkspaceAction.java
@@ -20,6 +20,7 @@ import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.action.AbstractPerspectiveAction;
 import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.statepersistance.AppStateManager;
 
 /**
  * The class contains business logic to stop workspace.
@@ -28,6 +29,7 @@ import org.eclipse.che.ide.api.app.AppContext;
  */
 public class StopWorkspaceAction extends AbstractPerspectiveAction {
 
+  private AppStateManager appStateManager;
   private final CurrentWorkspaceManager workspaceManager;
   private final AppContext appContext;
 
@@ -35,9 +37,11 @@ public class StopWorkspaceAction extends AbstractPerspectiveAction {
   public StopWorkspaceAction(
       CoreLocalizationConstant locale,
       AppContext appContext,
+      AppStateManager appStateManager,
       CurrentWorkspaceManager workspaceManager) {
     super(singletonList(PROJECT_PERSPECTIVE_ID), locale.stopWsTitle(), locale.stopWsDescription());
     this.appContext = appContext;
+    this.appStateManager = appStateManager;
     this.workspaceManager = workspaceManager;
   }
 
@@ -51,7 +55,11 @@ public class StopWorkspaceAction extends AbstractPerspectiveAction {
   @Override
   public void actionPerformed(ActionEvent event) {
     checkNotNull(appContext.getWorkspace().getId(), "Workspace id should not be null");
-
-    workspaceManager.stopWorkspace();
+    appStateManager
+        .persistState()
+        .then(
+            arg -> {
+              workspaceManager.stopWorkspace();
+            });
   }
 }

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/statepersistance/AppStateManagerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/statepersistance/AppStateManagerTest.java
@@ -10,18 +10,16 @@
  */
 package org.eclipse.che.ide.statepersistance;
 
-import static org.eclipse.che.ide.statepersistance.AppStateConstants.APP_STATE;
 import static org.fest.assertions.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.gwtmockito.GwtMockitoTestRunner;
 import com.google.inject.Provider;
-import com.google.web.bindery.event.shared.EventBus;
 import elemental.json.Json;
 import elemental.json.JsonFactory;
 import elemental.json.JsonObject;
@@ -31,11 +29,9 @@ import java.util.Optional;
 import org.eclipse.che.api.promises.client.Function;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
-import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.parts.PerspectiveManager;
-import org.eclipse.che.ide.api.preferences.PreferencesManager;
+import org.eclipse.che.ide.api.statepersistance.AppStateServiceClient;
 import org.eclipse.che.ide.api.statepersistance.StateComponent;
-import org.eclipse.che.ide.api.workspace.model.WorkspaceImpl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,7 +49,8 @@ import org.mockito.Mock;
 @RunWith(GwtMockitoTestRunner.class)
 public class AppStateManagerTest {
 
-  private static final String WS_ID = "ws_id";
+  private static final String COMPONENT_ONE_ID = "component1";
+  private static final String COMPONENT_TWO_ID = "component2";
 
   @Mock private StateComponentRegistry stateComponentRegistry;
   @Mock private Provider<StateComponentRegistry> stateComponentRegistryProvider;
@@ -63,28 +60,23 @@ public class AppStateManagerTest {
   @Mock private Provider<StateComponent> component1Provider;
   @Mock private Provider<StateComponent> component2Provider;
   @Mock private Promise<Void> promise;
-  @Mock private PreferencesManager preferencesManager;
+  @Mock private Promise<String> getStatePromise;
   @Mock private JsonFactory jsonFactory;
-  @Mock private EventBus eventBus;
-  @Mock private AppContext appContext;
-  @Mock private JsonObject pref;
+  @Mock private AppStateServiceClient appStateService;
   @Mock private PromiseProvider promiseProvider;
 
   @Mock private Promise<Void> sequentialRestore;
 
   @Captor private ArgumentCaptor<Function<Void, Promise<Void>>> sequentialRestoreThenFunction;
 
-  @Captor private ArgumentCaptor<String> preferenceArgumentCaptor;
-
-  @Captor private ArgumentCaptor<String> jsonArgumentCaptor;
+  @Captor private ArgumentCaptor<String> saveStateArgumentCaptor;
 
   private AppStateManager appStateManager;
 
   @Before
   public void setUp() {
-    WorkspaceImpl workspace = mock(WorkspaceImpl.class);
-    when(workspace.getId()).thenReturn(WS_ID);
-    when(appContext.getWorkspace()).thenReturn(workspace);
+    when(appStateService.getState()).thenReturn(getStatePromise);
+    when(getStatePromise.thenPromise((Function<String, Promise<Void>>) any())).thenReturn(promise);
 
     List<StateComponent> components = new ArrayList<>();
     components.add(component1);
@@ -97,89 +89,71 @@ public class AppStateManagerTest {
     when(component1Provider.get()).thenReturn(component1);
     when(component2Provider.get()).thenReturn(component2);
 
-    when(component1.getId()).thenReturn("component1");
-    when(component2.getId()).thenReturn("component2");
-    when(preferencesManager.flushPreferences()).thenReturn(promise);
-    when(preferencesManager.getValue(APP_STATE)).thenReturn("");
-    when(jsonFactory.parse(anyString())).thenReturn(pref = Json.createObject());
+    when(component1.getId()).thenReturn(COMPONENT_ONE_ID);
+    when(component2.getId()).thenReturn(COMPONENT_TWO_ID);
+    when(jsonFactory.parse(anyString())).thenReturn(Json.createObject());
     appStateManager =
         new AppStateManager(
             perspectiveManagerProvider,
             stateComponentRegistryProvider,
-            preferencesManager,
             jsonFactory,
             promiseProvider,
-            eventBus,
-            appContext);
-    appStateManager.readStateFromPreferences();
+            appStateService);
+    appStateManager.readState();
   }
 
   @Test
-  public void shouldStoreStateInPreferences() throws Exception {
-    appStateManager.persistWorkspaceState();
-    verify(preferencesManager).flushPreferences();
+  public void shouldStoreState() throws Exception {
+    appStateManager.persistState();
+
+    verify(appStateService).saveState(saveStateArgumentCaptor.capture());
+    assertThat(saveStateArgumentCaptor.getValue()).isNotNull();
   }
 
   @Test
   public void shouldCallGetStateOnStateComponent() throws Exception {
-    appStateManager.persistWorkspaceState();
+    appStateManager.persistState();
     verify(component1, atLeastOnce()).getState();
     verify(component2, atLeastOnce()).getState();
   }
 
   @Test
-  public void shouldStoreStateByWsId() throws Exception {
-    appStateManager.persistWorkspaceState();
-    verify(preferencesManager)
-        .setValue(preferenceArgumentCaptor.capture(), jsonArgumentCaptor.capture());
-    assertThat(preferenceArgumentCaptor.getValue()).isNotNull();
-    assertThat(preferenceArgumentCaptor.getValue()).isNotNull();
-    JsonObject object = Json.parse(jsonArgumentCaptor.getValue());
-    assertThat(object.hasKey(WS_ID)).isTrue();
-  }
-
-  @Test
   public void shouldSaveStateInFile() throws Exception {
-    JsonObject object = Json.createObject();
-    object.put("key1", "value1");
-    when(component1.getState()).thenReturn(object);
+    JsonObject firstComponentState = Json.createObject();
+    firstComponentState.put("key1", "value1");
+    when(component1.getState()).thenReturn(firstComponentState);
 
-    appStateManager.persistWorkspaceState();
+    JsonObject secondComponentState = Json.createObject();
+    secondComponentState.put("key2", "value2");
+    when(component2.getState()).thenReturn(secondComponentState);
+
+    appStateManager.persistState();
 
     verify(component1).getState();
-    verify(preferencesManager).setValue(anyString(), jsonArgumentCaptor.capture());
-    assertThat(jsonArgumentCaptor.getValue()).isNotNull().isNotEmpty();
+    verify(component2).getState();
+    verify(appStateService).saveState(saveStateArgumentCaptor.capture());
 
-    String value = jsonArgumentCaptor.getValue();
-    JsonObject jsonObject = Json.parse(value).getObject(WS_ID);
-    JsonObject workspace = jsonObject.getObject("workspace");
-    assertThat(workspace).isNotNull();
+    String json = saveStateArgumentCaptor.getValue();
+    assertThat(json).isNotNull();
+    JsonObject appState = Json.parse(json);
+    assertThat(appState).isNotNull();
 
-    JsonObject jsonObject1 = workspace.getObject("component1");
-    assertThat(jsonObject1.jsEquals(object)).isTrue();
-  }
+    JsonObject jsonObject1 = appState.getObject(COMPONENT_ONE_ID);
+    assertThat(jsonObject1.jsEquals(firstComponentState)).isTrue();
 
-  @Test
-  public void restoreShouldReadFromPreferences() throws Exception {
-    pref.put(WS_ID, Json.createObject());
-    appStateManager.restoreWorkspaceState();
-
-    verify(preferencesManager).getValue(APP_STATE);
+    JsonObject jsonObject2 = appState.getObject(COMPONENT_TWO_ID);
+    assertThat(jsonObject2.jsEquals(secondComponentState)).isTrue();
   }
 
   @Test
   public void restoreShouldCallLoadState() throws Exception {
-    JsonObject ws = Json.createObject();
-    pref.put(WS_ID, ws);
-    JsonObject workspace = Json.createObject();
-    ws.put("workspace", workspace);
-    JsonObject comp1 = Json.createObject();
-    workspace.put("component1", comp1);
-    comp1.put("key1", "value1");
-
+    JsonObject appState = Json.createObject();
+    JsonObject firstComponent = Json.createObject();
+    appState.put("component1", firstComponent);
+    firstComponent.put("key1", "value1");
     when(promiseProvider.resolve(nullable(Void.class))).thenReturn(sequentialRestore);
 
-    appStateManager.restoreWorkspaceState();
+    appStateManager.restoreState(appState);
 
     verify(sequentialRestore).thenPromise(sequentialRestoreThenFunction.capture());
     sequentialRestoreThenFunction.getValue().apply(null);

--- a/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/statepersistance/AppStateManagerTest.java
+++ b/ide/che-core-ide-app/src/test/java/org/eclipse/che/ide/statepersistance/AppStateManagerTest.java
@@ -75,7 +75,7 @@ public class AppStateManagerTest {
 
   @Before
   public void setUp() {
-    when(appStateService.getState()).thenReturn(getStatePromise);
+    when(appStateService.loadState()).thenReturn(getStatePromise);
     when(getStatePromise.thenPromise((Function<String, Promise<Void>>) any())).thenReturn(promise);
 
     List<StateComponent> components = new ArrayList<>();

--- a/wsagent/che-wsagent-core/pom.xml
+++ b/wsagent/che-wsagent-core/pom.xml
@@ -39,12 +39,20 @@
             <artifactId>guice-servlet</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>net.logstash.logback</groupId>
@@ -74,6 +82,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-project</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-project-shared</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
@@ -154,6 +166,31 @@
             <groupId>javax.websocket</groupId>
             <artifactId>javax.websocket-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockitong</groupId>
+            <artifactId>mockitong</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentModule.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentModule.java
@@ -18,6 +18,7 @@ import org.eclipse.che.MachinePublicKeyProvider;
 import org.eclipse.che.MachineTokenProvider;
 import org.eclipse.che.UriApiEndpointProvider;
 import org.eclipse.che.inject.DynaModule;
+import org.eclipse.che.wsagent.server.appstate.AppStateService;
 
 /**
  * Configuration of Che ws agent core part that can be different in different assembly.
@@ -42,5 +43,7 @@ public class CheWsAgentModule extends AbstractModule {
     bind(PublicKey.class)
         .annotatedWith(Names.named("signature.public.key"))
         .toProvider(MachinePublicKeyProvider.class);
+
+    bind(AppStateService.class);
   }
 }

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateManager.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateManager.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.wsagent.server.appstate;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static org.eclipse.che.api.fs.server.WsPathUtils.absolutize;
+import static org.eclipse.che.api.fs.server.WsPathUtils.resolve;
+import static org.eclipse.che.api.project.shared.Constants.CHE_DIR;
+
+import com.google.inject.Inject;
+import javax.validation.constraints.NotNull;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.fs.server.FsManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Allows to get or persist serialized IDE state by user identifier. It is expected that incoming
+ * IDE state object is valid, so the manager doesn't perform any validations.
+ *
+ * @author Roman Nikitenko
+ */
+public class AppStateManager {
+  private static final Logger LOG = LoggerFactory.getLogger(AppStateManager.class);
+
+  private static final String USER_DIR_PREFIX = "user_";
+  private static final String APP_STATE_HOLDER = "appState";
+
+  private FsManager fsManager;
+
+  @Inject
+  public AppStateManager(FsManager fsManager) {
+    this.fsManager = fsManager;
+  }
+
+  /**
+   * Get saved IDE state of current workspace for given user in JSON format. Note: it is expected
+   * that saved IDE state object is valid, so any validations are not performed. Empty string will
+   * be returned when IDE state is not found.
+   *
+   * @param userId user identifier
+   * @return saved IDE state of current workspace for given user in JSON format
+   * @throws ValidationException when user identifier is {@code null} or empty
+   * @throws ServerException when any server error occurs
+   */
+  public String getAppState(String userId) throws ValidationException, ServerException {
+    checkUserIdentifier(userId);
+
+    String appStateHolderPath = getAppStateHolderPath(userId);
+    try {
+      if (fsManager.existsAsFile(appStateHolderPath)) {
+        return fsManager.readAsString(appStateHolderPath);
+      }
+    } catch (NotFoundException | ConflictException e) {
+      LOG.error("Can not get app state for user %s, the reason is: %s", userId, e.getCause());
+      throw new ServerException("Can not save app state for user " + userId);
+    }
+    return "";
+  }
+
+  /**
+   * Save IDE state of current workspace for given user. Note: it is expected that incoming IDE
+   * state object is valid, so any validations are not performed.
+   *
+   * @param userId user identifier
+   * @param json IDE state in JSON format
+   * @throws ValidationException when user identifier is {@code null} or empty
+   * @throws ServerException when any server error occurs
+   */
+  public void saveState(String userId, String json) throws ValidationException, ServerException {
+    checkUserIdentifier(userId);
+
+    String appStateHolderPath = getAppStateHolderPath(userId);
+    try {
+      if (fsManager.existsAsFile(appStateHolderPath)) {
+        fsManager.update(appStateHolderPath, json);
+      } else {
+        fsManager.createFile(appStateHolderPath, json, false, true);
+      }
+    } catch (NotFoundException | ConflictException e) {
+      LOG.error("Can not save app state for user %s, the reason is: %s", userId, e.getCause());
+      throw new ServerException("Can not save app state for user " + userId);
+    }
+  }
+
+  /**
+   * Checks user identifier is not {@code null} or empty.
+   *
+   * @param userId user identifier
+   * @throws ValidationException when user identifier is {@code null} or empty.
+   */
+  private static void checkUserIdentifier(String userId) throws ValidationException {
+    if (isNullOrEmpty(userId)) {
+      throw new ValidationException("User ID should be defined");
+    }
+  }
+
+  private String getAppStateHolderPath(@NotNull String userId) {
+    String userDir = USER_DIR_PREFIX + userId;
+    return resolve(absolutize(CHE_DIR), format("%s/%s", userDir, APP_STATE_HOLDER));
+  }
+}

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateManager.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateManager.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Allows to get or persist serialized IDE state by user identifier. It is expected that incoming
+ * Allows to load or persist serialized IDE state by user identifier. It is expected that incoming
  * IDE state object is valid, so the manager doesn't perform any validations.
  *
  * @author Roman Nikitenko
@@ -46,7 +46,7 @@ public class AppStateManager {
   }
 
   /**
-   * Get saved IDE state of current workspace for given user in JSON format. Note: it is expected
+   * Load saved IDE state of current workspace for given user in JSON format. Note: it is expected
    * that saved IDE state object is valid, so any validations are not performed. Empty string will
    * be returned when IDE state is not found.
    *
@@ -55,7 +55,7 @@ public class AppStateManager {
    * @throws ValidationException when user identifier is {@code null} or empty
    * @throws ServerException when any server error occurs
    */
-  public String getAppState(String userId) throws ValidationException, ServerException {
+  public String loadAppState(String userId) throws ValidationException, ServerException {
     checkUserIdentifier(userId);
 
     String appStateHolderPath = getAppStateHolderPath(userId);
@@ -64,8 +64,8 @@ public class AppStateManager {
         return fsManager.readAsString(appStateHolderPath);
       }
     } catch (NotFoundException | ConflictException e) {
-      LOG.error("Can not get app state for user %s, the reason is: %s", userId, e.getCause());
-      throw new ServerException("Can not save app state for user " + userId);
+      LOG.error("Can not load app state for user %s, the reason is: %s", userId, e.getCause());
+      throw new ServerException("Can not load app state for user " + userId);
     }
     return "";
   }

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateService.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateService.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.wsagent.server.appstate;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import com.google.inject.Inject;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.rest.annotations.Required;
+
+/**
+ * Service allows to get or persist serialized IDE state by user identifier.
+ *
+ * @author Roman Nikitenko
+ */
+@Path("app/state")
+public class AppStateService {
+  private AppStateManager appStateManager;
+
+  @Inject
+  public AppStateService(AppStateManager appStateManager) {
+    this.appStateManager = appStateManager;
+  }
+
+  @GET
+  @Consumes(APPLICATION_JSON)
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(
+    value = "Get saved serialized IDE state of current workspace by user identifier",
+    notes =
+        "It is expected that saved IDE state object is valid, so any validations are not performed. Empty string will be returned when IDE state is not found."
+  )
+  @ApiResponses({
+    @ApiResponse(code = 200, message = "OK"),
+    @ApiResponse(code = 400, message = "User ID should be defined"),
+    @ApiResponse(code = 500, message = "Server error")
+  })
+  public String getAppState(
+      @ApiParam(value = "User identifier") @Required @QueryParam("userId") String userId)
+      throws ServerException, BadRequestException {
+    try {
+      return appStateManager.getAppState(userId);
+    } catch (ValidationException e) {
+      throw new BadRequestException(e.getMessage());
+    }
+  }
+
+  @POST
+  @Path("update")
+  @Consumes(APPLICATION_JSON)
+  @ApiOperation(
+    value = "Save serialized IDE state of current workspace for given user",
+    notes =
+        "It is expected that incoming IDE state object is valid, so any validations are not performed."
+  )
+  @ApiResponses({
+    @ApiResponse(code = 200, message = "OK"),
+    @ApiResponse(code = 400, message = "User ID should be defined"),
+    @ApiResponse(code = 500, message = "Server error")
+  })
+  public void saveState(
+      @ApiParam(value = "User identifier") @Required @QueryParam("userId") String userId,
+      @ApiParam(value = "Serialized IDE state") String json)
+      throws ServerException, BadRequestException {
+    try {
+      appStateManager.saveState(userId, json);
+    } catch (ValidationException e) {
+      throw new BadRequestException(e.getMessage());
+    }
+  }
+}

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateService.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateService.java
@@ -48,7 +48,8 @@ public class AppStateService {
   @ApiOperation(
     value = "Get saved serialized IDE state of current workspace by user identifier",
     notes =
-        "It is expected that saved IDE state object is valid, so any validations are not performed. Empty string will be returned when IDE state is not found."
+        "It is expected that saved IDE state object is valid, so any validations are not performed. "
+            + "Empty string will be returned when IDE state is not found."
   )
   @ApiResponses({
     @ApiResponse(code = 200, message = "OK"),

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateService.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/appstate/AppStateService.java
@@ -46,7 +46,7 @@ public class AppStateService {
   @Consumes(APPLICATION_JSON)
   @Produces(APPLICATION_JSON)
   @ApiOperation(
-    value = "Get saved serialized IDE state of current workspace by user identifier",
+    value = "Load saved serialized IDE state of current workspace by user identifier",
     notes =
         "It is expected that saved IDE state object is valid, so any validations are not performed. "
             + "Empty string will be returned when IDE state is not found."
@@ -56,11 +56,11 @@ public class AppStateService {
     @ApiResponse(code = 400, message = "User ID should be defined"),
     @ApiResponse(code = 500, message = "Server error")
   })
-  public String getAppState(
+  public String loadAppState(
       @ApiParam(value = "User identifier") @Required @QueryParam("userId") String userId)
       throws ServerException, BadRequestException {
     try {
-      return appStateManager.getAppState(userId);
+      return appStateManager.loadAppState(userId);
     } catch (ValidationException e) {
       throw new BadRequestException(e.getMessage());
     }

--- a/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateManagerTest.java
+++ b/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateManagerTest.java
@@ -39,7 +39,6 @@ public class AppStateManagerTest {
       "{\"projectExplorer\":{\"revealPath\":[\"/spring\"],\"showHiddenFiles\":false}}";
 
   @Mock private FsManager fsManager;
-
   @InjectMocks private AppStateManager appStateManager;
 
   @Test(expectedExceptions = ValidationException.class)

--- a/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateManagerTest.java
+++ b/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateManagerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.wsagent.server.appstate;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.fs.server.FsManager;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link AppStateManager}
+ *
+ * @author Roman Nikitenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class AppStateManagerTest {
+
+  private static final String USER_ID = "userId";
+  private static final String APP_STATE =
+      "{\"projectExplorer\":{\"revealPath\":[\"/spring\"],\"showHiddenFiles\":false}}";
+
+  @Mock private FsManager fsManager;
+
+  @InjectMocks private AppStateManager appStateManager;
+
+  @Test(expectedExceptions = ValidationException.class)
+  public void shouldThrowExceptionAtGettingAppState() throws Exception {
+    // user id is not valid
+    appStateManager.getAppState("");
+  }
+
+  @Test
+  public void shouldReadState() throws Exception {
+    when(fsManager.existsAsFile(anyString())).thenReturn(true);
+
+    appStateManager.getAppState(USER_ID);
+
+    verify(fsManager).existsAsFile(anyString());
+    verify(fsManager).readAsString(anyString());
+  }
+
+  @Test
+  public void shouldReturnEmptyStringWhenStateNotFound() throws Exception {
+    when(fsManager.existsAsFile(anyString())).thenReturn(false);
+
+    String appState = appStateManager.getAppState(USER_ID);
+
+    verify(fsManager).existsAsFile(anyString());
+    verify(fsManager, never()).readAsString(anyString());
+    assertEquals(appState, "");
+  }
+
+  @Test
+  public void shouldSaveState() throws Exception {
+    when(fsManager.existsAsFile(anyString())).thenReturn(true);
+
+    appStateManager.saveState(USER_ID, APP_STATE);
+
+    verify(fsManager, never()).createFile(anyString(), anyBoolean(), anyBoolean());
+    verify(fsManager).update(anyString(), eq(APP_STATE));
+  }
+
+  @Test
+  public void shouldCreateFileWithPatents() throws Exception {
+    when(fsManager.existsAsFile(anyString())).thenReturn(false);
+
+    appStateManager.saveState(USER_ID, APP_STATE);
+
+    verify(fsManager, never()).update(anyString(), eq(APP_STATE));
+    verify(fsManager).createFile(anyString(), eq(APP_STATE), eq(false), eq(true));
+  }
+
+  @Test(expectedExceptions = ValidationException.class)
+  public void shouldThrowExceptionAtSavingAppState() throws Exception {
+    // user id is not valid
+    appStateManager.saveState("", APP_STATE);
+  }
+}

--- a/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateManagerTest.java
+++ b/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateManagerTest.java
@@ -44,14 +44,14 @@ public class AppStateManagerTest {
   @Test(expectedExceptions = ValidationException.class)
   public void shouldThrowExceptionAtGettingAppState() throws Exception {
     // user id is not valid
-    appStateManager.getAppState("");
+    appStateManager.loadAppState("");
   }
 
   @Test
   public void shouldReadState() throws Exception {
     when(fsManager.existsAsFile(anyString())).thenReturn(true);
 
-    appStateManager.getAppState(USER_ID);
+    appStateManager.loadAppState(USER_ID);
 
     verify(fsManager).existsAsFile(anyString());
     verify(fsManager).readAsString(anyString());
@@ -61,7 +61,7 @@ public class AppStateManagerTest {
   public void shouldReturnEmptyStringWhenStateNotFound() throws Exception {
     when(fsManager.existsAsFile(anyString())).thenReturn(false);
 
-    String appState = appStateManager.getAppState(USER_ID);
+    String appState = appStateManager.loadAppState(USER_ID);
 
     verify(fsManager).existsAsFile(anyString());
     verify(fsManager, never()).readAsString(anyString());

--- a/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateServiceTest.java
+++ b/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateServiceTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.wsagent.server.appstate;
+
+import static com.jayway.restassured.RestAssured.given;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
+import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.jayway.restassured.response.Response;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.rest.ApiExceptionMapper;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.everrest.assured.EverrestJetty;
+import org.everrest.core.Filter;
+import org.everrest.core.GenericContainerRequest;
+import org.everrest.core.RequestFilter;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link AppStateService}.
+ *
+ * @author Roman Nikitenko
+ */
+@Listeners({EverrestJetty.class, MockitoTestNGListener.class})
+public class AppStateServiceTest {
+
+  private static final String USER_ID = "userId";
+  private static final String APP_STATE =
+      "{\"projectExplorer\":{\"revealPath\":[\"/spring\"],\"showHiddenFiles\":false}}";
+  private static final String EXCEPTION_MESSAGE = "User ID should be defined";
+
+  @SuppressWarnings("unused")
+  private static final ApiExceptionMapper MAPPER = new ApiExceptionMapper();
+
+  @SuppressWarnings("unused")
+  private static final EnvironmentFilter FILTER = new EnvironmentFilter();
+
+  private static final Subject SUBJECT = new SubjectImpl("user", USER_ID, "token", false);
+
+  @Captor private ArgumentCaptor<String> stateCaptor;
+
+  @Mock(answer = Answers.RETURNS_MOCKS)
+  private AppStateManager appStateManager;
+
+  @InjectMocks private AppStateService appStateService;
+
+  @Test
+  public void shouldGetAppState() throws Exception {
+    when(appStateManager.getAppState(USER_ID)).thenReturn(APP_STATE);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .when()
+            .queryParam("userId", USER_ID)
+            .get(SECURE_PATH + "/app/state");
+
+    assertEquals(response.getStatusCode(), 200);
+    assertEquals(response.getBody().print(), APP_STATE);
+  }
+
+  @Test
+  public void shouldThrowBadRequestAtGettingAppState() throws Exception {
+    when(appStateManager.getAppState("")).thenThrow(new ValidationException(EXCEPTION_MESSAGE));
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .when()
+            .queryParam("userId", "")
+            .get(SECURE_PATH + "/app/state");
+
+    assertEquals(response.getStatusCode(), 400);
+  }
+
+  @Test
+  public void shouldSaveAppState() throws Exception {
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .when()
+            .queryParam("userId", USER_ID)
+            .body(APP_STATE)
+            .post(SECURE_PATH + "/app/state/update");
+
+    verify(appStateManager).saveState(eq(USER_ID), stateCaptor.capture());
+
+    assertEquals(stateCaptor.getValue(), APP_STATE);
+    assertEquals(response.getStatusCode(), 204);
+  }
+
+  @Test
+  public void shouldThrowBadRequestAtSavingAppState() throws Exception {
+    doThrow(new ValidationException(EXCEPTION_MESSAGE))
+        .when(appStateManager)
+        .saveState("", APP_STATE);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .when()
+            .queryParam("userId", "")
+            .body(APP_STATE)
+            .post(SECURE_PATH + "/app/state/update");
+
+    assertEquals(response.getStatusCode(), 400);
+  }
+
+  @Filter
+  public static class EnvironmentFilter implements RequestFilter {
+    public void doFilter(GenericContainerRequest request) {
+      EnvironmentContext.getCurrent().setSubject(SUBJECT);
+    }
+  }
+}

--- a/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateServiceTest.java
+++ b/wsagent/che-wsagent-core/src/test/java/org/eclipse/che/wsagent/server/appstate/AppStateServiceTest.java
@@ -69,7 +69,7 @@ public class AppStateServiceTest {
 
   @Test
   public void shouldGetAppState() throws Exception {
-    when(appStateManager.getAppState(USER_ID)).thenReturn(APP_STATE);
+    when(appStateManager.loadAppState(USER_ID)).thenReturn(APP_STATE);
 
     final Response response =
         given()
@@ -86,7 +86,7 @@ public class AppStateServiceTest {
 
   @Test
   public void shouldThrowBadRequestAtGettingAppState() throws Exception {
-    when(appStateManager.getAppState("")).thenThrow(new ValidationException(EXCEPTION_MESSAGE));
+    when(appStateManager.loadAppState("")).thenThrow(new ValidationException(EXCEPTION_MESSAGE));
 
     final Response response =
         given()


### PR DESCRIPTION
### What does this PR do?
User preferences was used to storage serialized IDE state. The PR change way of storing IDE state data 
 and provides back compatibility: allows to get IDE state from preferences and clean up them.

So, the new behavior is:
1. We try to read IDE state from user preferences and remove this one from preferences
2. Use root '.che' directory to storage IDE state for current workspace and current user (for example, /.che/user_userID/appState)

### What issues does this PR fix or reference?
#7551 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
