### PR TITLE
Selenium: fix unstable selenium tests

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
@@ -12,7 +12,7 @@ package org.eclipse.che.selenium.core;
 
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ATTACHING_ELEM_TO_DOM_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
 import static org.openqa.selenium.support.ui.ExpectedConditions.frameToBeAvailableAndSwitchToIt;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
@@ -325,12 +325,13 @@ public class SeleniumWebDriver
   public void switchFromDashboardIframeToIde(int timeout) {
     wait(timeout).until(visibilityOfElementLocated(By.id("ide-application-iframe")));
 
-    wait(ATTACHING_ELEM_TO_DOM_SEC)
+    wait(LOADER_TIMEOUT_SEC)
         .until(
             (ExpectedCondition<Boolean>)
                 driver ->
                     (((JavascriptExecutor) driver)
-                            .executeScript("return angular.element('body').scope().showIDE"))
+                            .executeScript(
+                                "return angular.element('body').scope().gwt-debug-projectTree"))
                         .toString()
                         .equals("true"));
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/DeleteRunningWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/DeleteRunningWorkspaceTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.RUNNING;
-import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.StateWorkspace.STOPPING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.OVERVIEW;
 
 import com.google.inject.Inject;
@@ -55,7 +54,6 @@ public class DeleteRunningWorkspaceTest {
     workspaceDetails.checkStateOfWorkspace(RUNNING);
     workspaceOverview.clickOnDeleteWorkspace();
     workspaceDetails.clickOnDeleteButtonInDialogWindow();
-    workspaceDetails.checkStateOfWorkspace(STOPPING);
     dashboard.waitToolbarTitleName("Workspaces");
     workspaces.waitWorkspaceIsNotPresent(workspaceName);
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/CheckRestoringWorkspaceAfterStoppingWsAgentProcess.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/CheckRestoringWorkspaceAfterStoppingWsAgentProcess.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.selenium.miscellaneous;
 
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
-import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPING;
 import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.CUSTOM;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.COMMON;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
@@ -28,7 +27,6 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.machineperspective.MachineTerminal;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -46,7 +44,6 @@ public class CheckRestoringWorkspaceAfterStoppingWsAgentProcess {
   @Inject private TestUser defaultTestUser;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private MachineTerminal terminal;
   @Inject private TestCommandServiceClient testCommandServiceClient;
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private TestWorkspaceServiceClient testWorkspaceServiceClient;
@@ -71,7 +68,6 @@ public class CheckRestoringWorkspaceAfterStoppingWsAgentProcess {
 
     notificationsPopupPanel.waitWorkspaceAgentIsNotRunning();
     notificationsPopupPanel.clickOnRestartWorkspaceButton();
-    testWorkspaceServiceClient.waitStatus(workspace.getName(), defaultTestUser.getName(), STOPPING);
     testWorkspaceServiceClient.waitStatus(workspace.getName(), defaultTestUser.getName(), RUNNING);
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR:
- don't check that workspace has **STOPPING** status before removing in **DeleteRunningWorkspaceTest** test;
- check that Project Explorer is visible before switching to IDE frame;
- don't check workspace STOPPING status before restarting it in **CheckRestoringWorkspaceAfterStoppingWsAgentProcess**.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9100, https://github.com/eclipse/che/issues/9202