### PR TITLE
Fix File Watcher exclude feature

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/filewatcher/FileWatcherExcludesOperation.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/filewatcher/FileWatcherExcludesOperation.java
@@ -26,6 +26,7 @@ import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.ide.api.WindowActionEvent;
 import org.eclipse.che.ide.api.WindowActionHandler;
+import org.eclipse.che.ide.api.workspace.WorkspaceReadyEvent;
 
 /**
  * Tracks and allows to manage the file watcher exclude patterns for tracking creation, modification
@@ -52,7 +53,7 @@ public class FileWatcherExcludesOperation implements WindowActionHandler {
     this.promises = promises;
     this.requestTransmitter = requestTransmitter;
     eventBus.addHandler(WindowActionEvent.TYPE, this);
-    subscribe();
+    eventBus.addHandler(WorkspaceReadyEvent.getType(), event -> subscribe());
   }
 
   @Inject


### PR DESCRIPTION
### What does this PR do?
Subscribe on File Watcher operation messages on WorkspaceReadyEvent
We get the event at start/restart workspace, refresh page, open page when workspace is running, so it should fix cases when we don't subscribe on corresponding server events.

### What issues does this PR fix or reference?
#6487 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
