### PR TITLE
Disable PVC creation for che-multiuser master

### DIFF
--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
 {{- end }}
+{{- if not .Values.global.multiuser }}
       - name: fmp-volume-permission
         image: busybox
         command: ["chmod", "777", "/data"]
@@ -42,6 +43,7 @@ spec:
               "mountPath": "/data",
               "name": "che-data-volume"
         }]
+{{- end }}
       containers:
       - env:
         - name: CHE_DOMAIN
@@ -233,9 +235,15 @@ spec:
             memory: 600Mi
           requests:
             memory: 256Mi
+{{- if not .Values.global.multiuser }}
         volumeMounts:
         - mountPath: /data
           name: che-data-volume
+      volumes:
+      - name: che-data-volume
+        persistentVolumeClaim:
+          claimName: che-data-volume
+{{- end }}
 {{- if .Values.registry }}
 {{- if and .Values.registry.password .Values.registry.username }}
       imagePullSecrets:
@@ -243,7 +251,3 @@ spec:
 {{- end }}
 {{- end }}
       serviceAccountName: che
-      volumes:
-      - name: che-data-volume
-        persistentVolumeClaim:
-          claimName: che-data-volume

--- a/deploy/kubernetes/helm/che/templates/pvc.yaml
+++ b/deploy/kubernetes/helm/che/templates/pvc.yaml
@@ -5,6 +5,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 
+{{- if not .Values.global.multiuser }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -17,3 +18,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
+{{- end }}

--- a/deploy/openshift/che-openshift.yml
+++ b/deploy/openshift/che-openshift.yml
@@ -2,18 +2,7 @@
 apiVersion: v1
 kind: List
 items:
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    labels:
-      app: che
-    name: che-data-volume
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 1Gi
+#CHE_MASTER_PVC
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -77,12 +66,9 @@ items:
             requests:
               memory: 256Mi
           volumeMounts:
-          - mountPath: /data
-            name: che-data-volume
+          #CHE_MASTER_VOLUME_MOUNTS
         serviceAccountName: che
         volumes:
-        - name: che-data-volume
-          persistentVolumeClaim:
-            claimName: che-data-volume
+        #CHE_MASTER_VOLUMES
     triggers:
     - type: ConfigChange

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -246,10 +246,6 @@ init() {
 
   [ -z "$CHE_DATABASE" ] && export CHE_DATABASE=${CHE_DATA}/storage
   [ -z "$CHE_TEMPLATE_STORAGE" ] && export CHE_TEMPLATE_STORAGE=${CHE_DATA}/templates
-  [ -z "$CHE_WORKSPACE_AGENT_DEV" ] && export CHE_WORKSPACE_AGENT_DEV=${CHE_DATA_HOST}/lib/ws-agent.tar.gz
-  [ -z "$CHE_WORKSPACE_TERMINAL__LINUX__AMD64" ] && export CHE_WORKSPACE_TERMINAL__LINUX__AMD64=${CHE_DATA_HOST}/lib/linux_amd64/terminal
-  [ -z "$CHE_WORKSPACE_TERMINAL__LINUX__ARM7" ] && export CHE_WORKSPACE_TERMINAL__LINUX__ARM7=${CHE_DATA_HOST}/lib/linux_arm7/terminal
-  [ -z "$CHE_WORKSPACE_EXEC__LINUX__AMD64" ] && export CHE_WORKSPACE_EXEC__LINUX__AMD64=${CHE_DATA_HOST}/lib/linux_amd64/exec
 
   perform_database_migration
 
@@ -264,10 +260,8 @@ init() {
   [ -z "$CHE_WORKSPACE_STORAGE" ] && export CHE_WORKSPACE_STORAGE="${CHE_DATA_HOST}/workspaces"
   [ -z "$CHE_WORKSPACE_STORAGE_CREATE_FOLDERS" ] && export CHE_WORKSPACE_STORAGE_CREATE_FOLDERS=false
 
-  # Move files from /lib to /lib-copy.  This puts files onto the host.
-  rm -rf ${CHE_DATA}/lib/*
-  mkdir -p ${CHE_DATA}/lib  
-  cp -rf ${CHE_HOME}/lib/* "${CHE_DATA}"/lib
+  #Recursively removes the legacy che-data/lib folder with agents inside(will be removed in future versions)
+  rm -rf ${CHE_DATA}/lib
 
   # Cleanup no longer in use stacks folder, accordance to a new loading policy.
   if [[ -d "${CHE_DATA}"/stacks ]];then

--- a/dockerfiles/init/modules/che/templates/che.env.erb
+++ b/dockerfiles/init/modules/che/templates/che.env.erb
@@ -51,9 +51,6 @@ CHE_LOGS_DIR=/logs
 CHE_WORKSPACE_LOGS=/logs/machines
 CHE_TEMPLATE_STORAGE=/data/templates
 
-CHE_WORKSPACE_TERMINAL__LINUX__AMD64=<%= scope.lookupvar('che::che_instance') %>/data/lib/linux_amd64/terminal
-CHE_WORKSPACE_TERMINAL__LINUX__ARM7=<%= scope.lookupvar('che::che_instance') %>/data/lib/linux_arm7/terminal
-CHE_WORKSPACE_AGENT_DEV=<%= scope.lookupvar('che::che_instance') %>/data/lib/ws-agent.tar.gz
 
 <% if ! @che_http_proxy.empty? or ! @che_https_proxy.empty? -%>
 JAVA_HTTP_PROXY_SET=-Dhttp.proxySet=true


### PR DESCRIPTION
### What does this PR do?
Removes backup of che-home/lib folder.
Disables che-data PVC creation for che-muliuser deployed on Kubernetes/OpenShift.

The motivation for these changes is that we want to be able to run simultaneously two Che masters and more. To achieve that we need to avoid usage of shared PV between these instances, because in the cases when PVs does not support RWX mode we will get an issue with deploying of Che on different nodes.
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9040
