### PR TITLE
Provide configuration property to be able to set docker image build timeout

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -275,6 +275,9 @@ che.infra.docker.bootstrapper.server_check_period_sec=3
 # in parallel on workspace startups.
 che.infra.docker.max_pull_threads=10
 
+# Time(in seconds) that limits the docker build process.
+# The default value is 8 minutes, after which the build will be considered as failed.
+che.infra.docker.build_timeout_sec=480
 
 # Single port mode
 che.single.port=false

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -253,6 +253,9 @@ CHE_SINGLE_PORT=false
 # This variable is automatically overridden in single port mode.
 #CHE_INFRA_DOCKER_URL__REWRITER=DEFAULT
 
+# Time(in seconds) that limits the docker build process.
+# The default value is 8 minutes, after which the build will be considered as failed.
+# CHE_INFRA_DOCKER_BUILD__TIMEOUT__SEC=480
 
 ########################################################################################
 #####                                                                              #####


### PR DESCRIPTION
### What does this PR do?
Provides configuration property which allows setting a limitation for docker image build timeout.
property:
`che.infra.docker.build_timeout_sec`
default value(experimental):
`480 seconds`

### What issues does this PR fix or reference?
#9130 
