### PR TITLE
Provide configuration property to be able to set docker image build timeout

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/codenvy/che.properties
@@ -290,6 +290,10 @@ che.docker.tcp_connection_read_timeout_ms=600000
 # to determine swap size. To disable swap set to 0.
 che.docker.swap=-1
 
+# Time(in seconds) that limits the docker build process.
+# The default value is 8 minutes, after which the build will be considered as failed.
+che.docker.build_timeout_sec=480
+
 ### INTERNAL
 # Remove locations where internal message bus events should be propagated to.
 # For debugging - set to retrieve internal events from external clients.

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -388,6 +388,9 @@ CHE_SINGLE_PORT=false
 #     periodically.
 #CHE_DOCKER_CLEANUP__PERIOD__MIN=60
 
+# Time(in seconds) that limits the docker build process.
+# The default value is 8 minutes, after which the build will be considered as failed.
+# CHE_DOCKER_BUILD__TIMEOUT__SEC=480
 
 
 ########################################################################################

--- a/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/main/java/org/eclipse/che/plugin/docker/client/DockerConnector.java
@@ -12,6 +12,7 @@ package org.eclipse.che.plugin.docker.client;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.net.UrlEscapers.urlPathSegmentEscaper;
+import static java.lang.String.format;
 import static javax.ws.rs.core.Response.Status.CREATED;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
 import static javax.ws.rs.core.Response.Status.NOT_MODIFIED;
@@ -43,7 +44,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.core.MediaType;
 import org.eclipse.che.api.core.util.FileCleaner;
@@ -135,6 +139,7 @@ public class DockerConnector {
           .setFieldNamingPolicy(FieldNamingPolicy.UPPER_CAMEL_CASE)
           .create();
 
+  private final long imageBuildTimeoutSec;
   private final URI dockerDaemonUri;
   private final DockerRegistryAuthResolver authResolver;
   private final ExecutorService executor;
@@ -144,10 +149,12 @@ public class DockerConnector {
 
   @Inject
   public DockerConnector(
+      @Named("che.docker.build_timeout_sec") long imageBuildTimeoutSec,
       DockerConnectorConfiguration connectorConfiguration,
       DockerConnectionFactory connectionFactory,
       DockerRegistryAuthResolver authResolver,
       DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider) {
+    this.imageBuildTimeoutSec = imageBuildTimeoutSec;
     this.dockerDaemonUri = connectorConfiguration.getDockerDaemonUri();
     this.connectionFactory = connectionFactory;
     this.authResolver = authResolver;
@@ -909,7 +916,7 @@ public class DockerConnector {
                       "Docker image build failed. Image id not found in build output.", 500);
                 });
 
-        return imageIdFuture.get();
+        return imageIdFuture.get(imageBuildTimeoutSec, TimeUnit.SECONDS);
       } catch (ExecutionException e) {
         // unwrap exception thrown by task with .getCause()
         if (e.getCause() instanceof ImageNotFoundException) {
@@ -920,6 +927,9 @@ public class DockerConnector {
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new DockerException("Docker image build was interrupted", 500);
+      } catch (TimeoutException ex) {
+        throw new DockerException(
+            format("Docker image build exceed timeout %s seconds.", imageBuildTimeoutSec), 500);
       }
     }
   }

--- a/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-docker-client/src/test/java/org/eclipse/che/plugin/docker/client/DockerConnectorTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.FieldNamingPolicy;
@@ -170,6 +171,7 @@ public class DockerConnectorTest {
   private static final byte[] DOCKER_RESPONSE_BYTES = DOCKER_RESPONSE.getBytes();
 
   private static final int CONTAINER_EXIT_CODE = 0;
+  private static final int IMAGE_BUILD_TIMEOUT = 300;
 
   @Mock private DockerConnectorConfiguration dockerConnectorConfiguration;
   @Mock private DockerConnectionFactory dockerConnectionFactory;
@@ -201,12 +203,7 @@ public class DockerConnectorTest {
     when(dockerApiVersionPathPrefixProvider.get()).thenReturn(API_VERSION_PREFIX);
 
     dockerConnector =
-        spy(
-            new DockerConnector(
-                dockerConnectorConfiguration,
-                dockerConnectionFactory,
-                authManager,
-                dockerApiVersionPathPrefixProvider));
+        dockerConnector = newConnectorSpy(IMAGE_BUILD_TIMEOUT, dockerApiVersionPathPrefixProvider);
 
     inputStream = spy(new ByteArrayInputStream(ERROR_MESSAGE.getBytes()));
     when(dockerResponse.getInputStream()).thenReturn(inputStream);
@@ -237,13 +234,7 @@ public class DockerConnectorTest {
       throws IOException, JsonParseException {
     String apiVersion = "/v1.18";
     when(dockerApiVersionPathPrefixProvider.get()).thenReturn(apiVersion);
-    dockerConnector =
-        spy(
-            new DockerConnector(
-                dockerConnectorConfiguration,
-                dockerConnectionFactory,
-                authManager,
-                dockerApiVersionPathPrefixProvider));
+    dockerConnector = newConnectorSpy(IMAGE_BUILD_TIMEOUT, dockerApiVersionPathPrefixProvider);
     SystemInfo systemInfo = mock(SystemInfo.class);
     doReturn(systemInfo)
         .when(dockerConnector)
@@ -1336,6 +1327,34 @@ public class DockerConnectorTest {
     verify(dockerResponse).getInputStream();
   }
 
+  @Test(
+    expectedExceptions = DockerException.class,
+    expectedExceptionsMessageRegExp = "Docker image build exceed timeout .* seconds."
+  )
+  public void testThrowsDockerExceptionWhenImageBuildExceedTimeout() throws Exception {
+    dockerConnector = newConnectorSpy(0, dockerApiVersionPathPrefixProvider);
+    final AuthConfigs authConfigs =
+        DtoFactory.newDto(AuthConfigs.class)
+            .withConfigs(ImmutableMap.of("auth", DtoFactory.newDto(AuthConfig.class)));
+
+    final BuildImageParams buildImageParams =
+        BuildImageParams.create(dockerfile).withAuthConfigs(authConfigs);
+    final InputStream slowStream =
+        new InputStream() {
+          @Override
+          public int read() {
+            try {
+              Thread.sleep(373);
+            } catch (Exception ignored) {
+            }
+            return 43;
+          }
+        };
+    doReturn(slowStream).when(dockerResponse).getInputStream();
+
+    dockerConnector.buildImage(buildImageParams, progressMonitor);
+  }
+
   @Test
   public void shouldCallRemoveImageWithParametersObject() throws IOException {
     RemoveImageParams removeImageParams = RemoveImageParams.create(IMAGE);
@@ -2233,5 +2252,16 @@ public class DockerConnectorTest {
                     new NewIpamConfig()
                         .withIPv4Address("ipv4_address")
                         .withIPv6Address("ipv6_address")));
+  }
+
+  private DockerConnector newConnectorSpy(
+      int buildTimeout, DockerApiVersionPathPrefixProvider dockerApiVersionPathPrefixProvider) {
+    return spy(
+        new DockerConnector(
+            buildTimeout,
+            dockerConnectorConfiguration,
+            dockerConnectionFactory,
+            authManager,
+            dockerApiVersionPathPrefixProvider));
   }
 }

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/main/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnector.java
@@ -270,9 +270,11 @@ public class OpenShiftConnector extends DockerConnector {
       @Nullable @Named("che.openshift.workspace.memory.request") String cheWorkspaceMemoryRequest,
       @Nullable @Named("che.openshift.workspace.memory.override") String cheWorkspaceMemoryLimit,
       @Named("che.openshift.secure.routes") boolean secureRoutes,
-      @Named("che.openshift.precreate.workspace.dirs") boolean createWorkspaceDirs) {
+      @Named("che.openshift.precreate.workspace.dirs") boolean createWorkspaceDirs,
+      @Named("che.docker.build_timeout_sec") long imageBuildTimeoutSec) {
 
     super(
+        imageBuildTimeoutSec,
         connectorConfiguration,
         connectionFactory,
         authResolver,

--- a/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
+++ b/plugins/plugin-docker/che-plugin-openshift-client/src/test/java/org/eclipse/che/plugin/openshift/client/OpenShiftConnectorTest.java
@@ -62,6 +62,8 @@ public class OpenShiftConnectorTest {
   @Mock private OpenShiftDeploymentCleaner openShiftDeploymentCleaner;
   @Mock private WorkspaceSubjectRegistry workspaceSubjectRegistry;
 
+  private static final int IMAGE_BUILD_TIMEOUT = 300;
+
   private OpenShiftConnector openShiftConnector;
 
   @BeforeMethod
@@ -92,7 +94,8 @@ public class OpenShiftConnectorTest {
             CHE_WORKSPACE_CPU_LIMIT,
             null,
             SECURE_ROUTES,
-            CREATE_WORKSPACE_DIRS);
+            CREATE_WORKSPACE_DIRS,
+            IMAGE_BUILD_TIMEOUT);
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Provides configuration property which allows setting a limitation for docker image build timeout.
property:
`che.infra.docker.build_timeout_sec`
default value(experimental):
`480 seconds`

### What issues does this PR fix or reference?
#9130 
