### PR TITLE
Change the name of test project for better readability

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.selenium.refactor.types;
 import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -44,10 +43,10 @@ import org.testng.annotations.Test;
 /** @author Musienko Maxim */
 public class RenameTypeTest {
   private static final Logger LOG = LoggerFactory.getLogger(RenameTypeTest.class);
-  private static final String nameOfProject =
-      NameGenerator.generate(RenameTypeTest.class.getName(), 2);
+  private static final String NAME_OF_PROJECT =
+      NameGenerator.generate(RenameTypeTest.class.getSimpleName(), 2);
   private static final String pathToPackageInChePrefix =
-      nameOfProject + "/src" + "/main" + "/java" + "/renametype";
+      NAME_OF_PROJECT + "/src" + "/main" + "/java" + "/renametype";
 
   private String pathToCurrentPackage;
   private String contentFromInA;
@@ -70,17 +69,17 @@ public class RenameTypeTest {
     testProjectServiceClient.importProject(
         workspace.getId(),
         Paths.get(resource.toURI()),
-        nameOfProject,
+        NAME_OF_PROJECT,
         ProjectTemplates.MAVEN_SIMPLE);
     ide.open(workspace);
-    projectExplorer.waitVisibleItem(nameOfProject);
+    projectExplorer.waitVisibleItem(NAME_OF_PROJECT);
     consoles.closeProcessesArea();
     projectExplorer.quickExpandWithJavaScript();
     loader.waitOnClosed();
   }
 
   @BeforeMethod
-  public void setCurrentFieldForTest(Method method) throws IOException {
+  public void setCurrentFieldForTest(Method method) {
     try {
       setFieldsForTest(method.getName());
     } catch (Exception e) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -42,10 +42,10 @@ import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
 public class RenameTypeTest {
-  private static final Logger LOG = LoggerFactory.getLogger(RenameTypeTest.class);
-  private static final String NAME_OF_PROJECT =
+  private static final Logger LOG                           = LoggerFactory.getLogger(RenameTypeTest.class);
+  private static final String NAME_OF_PROJECT               =
       NameGenerator.generate(RenameTypeTest.class.getSimpleName(), 2);
-  private static final String pathToPackageInChePrefix =
+  private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
       NAME_OF_PROJECT + "/src/main/java/renametype";
 
   private String pathToCurrentPackage;
@@ -151,7 +151,7 @@ public class RenameTypeTest {
   }
 
   private void setFieldsForTest(String nameCurrentTest) throws Exception {
-    pathToCurrentPackage = pathToPackageInChePrefix + "/" + nameCurrentTest;
+    pathToCurrentPackage = PATH_TO_PACKAGE_IN_CHE_PREFIX + "/" + nameCurrentTest;
 
     URL resourcesInA =
         getClass()

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -46,7 +46,7 @@ public class RenameTypeTest {
   private static final String NAME_OF_PROJECT =
       NameGenerator.generate(RenameTypeTest.class.getSimpleName(), 2);
   private static final String pathToPackageInChePrefix =
-      NAME_OF_PROJECT + "/src" + "/main" + "/java" + "/renametype";
+      NAME_OF_PROJECT + "/src/main/java/renametype";
 
   private String pathToCurrentPackage;
   private String contentFromInA;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -13,7 +13,9 @@ package org.eclipse.che.selenium.refactor.types;
 import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
+import java.io.IOException;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
@@ -33,6 +35,7 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -42,8 +45,8 @@ import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
 public class RenameTypeTest {
-  private static final Logger LOG                           = LoggerFactory.getLogger(RenameTypeTest.class);
-  private static final String NAME_OF_PROJECT               =
+  private static final Logger LOG = LoggerFactory.getLogger(RenameTypeTest.class);
+  private static final String NAME_OF_PROJECT =
       NameGenerator.generate(RenameTypeTest.class.getSimpleName(), 2);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
       NAME_OF_PROJECT + "/src/main/java/renametype";
@@ -79,12 +82,8 @@ public class RenameTypeTest {
   }
 
   @BeforeMethod
-  public void setCurrentFieldForTest(Method method) {
-    try {
-      setFieldsForTest(method.getName());
-    } catch (Exception e) {
-      LOG.error(e.getLocalizedMessage(), e);
-    }
+  public void setCurrentFieldForTest(Method method) throws IOException, URISyntaxException {
+    setFieldsForTest(method.getName());
   }
 
   @AfterMethod
@@ -95,7 +94,7 @@ public class RenameTypeTest {
         refactorPanel.clickCancelButtonRefactorForm();
       }
       editor.closeAllTabs();
-    } catch (Exception e) {
+    } catch (WebDriverException e) {
       LOG.error(e.getLocalizedMessage(), e);
     }
   }
@@ -150,7 +149,7 @@ public class RenameTypeTest {
     testCase();
   }
 
-  private void setFieldsForTest(String nameCurrentTest) throws Exception {
+  private void setFieldsForTest(String nameCurrentTest) throws URISyntaxException, IOException {
     pathToCurrentPackage = PATH_TO_PACKAGE_IN_CHE_PREFIX + "/" + nameCurrentTest;
 
     URL resourcesInA =
@@ -166,7 +165,7 @@ public class RenameTypeTest {
     contentFromOutB = getTextFromFile(resourcesOutA);
   }
 
-  private String getTextFromFile(URL url) throws Exception {
+  private String getTextFromFile(URL url) throws URISyntaxException, IOException {
     String result = "";
     List<String> listWithAllLines =
         Files.readAllLines(Paths.get(url.toURI()), Charset.forName("UTF-8"));


### PR DESCRIPTION
### What does this PR do?
The name of test project gets a FQN of the class. This looks strange in the test. 
**See screenshot:**
![ugly_name](https://user-images.githubusercontent.com/1640058/38139147-d6171648-3436-11e8-9a6e-87bfee6636ab.png)
The PR fix it. The name will be build from simple name of the class + 2 random symbols
