### PR TITLE
Add exec with error output processing

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesMachine.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesMachine.java
@@ -14,6 +14,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
@@ -100,6 +101,21 @@ public class KubernetesMachine implements Machine {
           "Server with provided reference " + serverRef + " is missed");
     }
     server.setStatus(status);
+  }
+
+  /**
+   * Executes command in this machine.
+   *
+   * @param outputConsumer command output consumer that accepts stream and output message
+   * @param command command to execute
+   * @throws InfrastructureException when exec timeout is reached
+   * @throws InfrastructureException when {@link Thread} is interrupted while command executing
+   * @throws InfrastructureException when command error stream is not empty
+   * @throws InfrastructureException when any other exception occurs
+   */
+  public void exec(BiConsumer<String, String> outputConsumer, String... command)
+      throws InfrastructureException {
+    namespace.pods().exec(podName, containerName, EXEC_TIMEOUT_MIN, command, outputConsumer);
   }
 
   public void exec(String... command) throws InfrastructureException {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/bootstrap/AbstractBootstrapper.java
@@ -137,7 +137,10 @@ public abstract class AbstractBootstrapper {
     try {
       doBootstrapAsync(installerEndpoint, outputEndpoint);
     } catch (InfrastructureException ex) {
-      finishEventFuture.completeExceptionally(ex);
+      finishEventFuture.completeExceptionally(
+          new InfrastructureException(
+              "Bootstrapping of machine " + machineName + " failed. Cause: " + ex.getMessage(),
+              ex));
     }
     return bootstrapFuture;
   }


### PR DESCRIPTION
### What does this PR do?
Adds bootstrapper command error stream processing, in cases when error stream is not empty, stops the bootstrapping and propagates appropriate logs.

### What issues does this PR fix or reference?
fixes #9180 