### PR TITLE
Port org.slf4j.helpers.Util.java to the slf4j GWT logger

### DIFF
--- a/ide/gwt-logger/src/main/super/org/slf4j/helpers/Util.java
+++ b/ide/gwt-logger/src/main/super/org/slf4j/helpers/Util.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2004-2011 QOS.ch
+ * All rights reserved.
+ *
+ * Permission is hereby granted, free  of charge, to any person obtaining
+ * a  copy  of this  software  and  associated  documentation files  (the
+ * "Software"), to  deal in  the Software without  restriction, including
+ * without limitation  the rights to  use, copy, modify,  merge, publish,
+ * distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ * permit persons to whom the Software  is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The  above  copyright  notice  and  this permission  notice  shall  be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ * EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ * MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+package org.slf4j.helpers;
+
+/**
+ *
+ * Note:
+ * Taken form org.slf4j.helpers.
+ * Class doesn't nothing, contains empty methods.
+ * Adding only for porting slf4j logger to the GWT app
+ *
+ *
+ * An internal utility class.
+ *
+ *
+ *
+ * @author Alexander Dorokhine
+ * @author Ceki G&uuml;lc&uuml;
+ */
+public final class Util {
+
+
+  private Util() {
+  }
+
+  public static String safeGetSystemProperty(String key) {
+    return "";
+  }
+
+  public static boolean safeGetBooleanSystemProperty(String key) {
+    return false;
+  }
+
+  public static Class<?> getCallingClass() {
+    return null;
+  }
+
+  static final public void report(String msg, Throwable t) {
+  }
+
+  static final public void report(String msg) {
+  }
+}

--- a/ide/gwt-logger/src/main/super/org/slf4j/helpers/Util.java
+++ b/ide/gwt-logger/src/main/super/org/slf4j/helpers/Util.java
@@ -28,7 +28,7 @@ package org.slf4j.helpers;
  *
  * Note:
  * Taken form org.slf4j.helpers.
- * Class doesn't nothing, contains empty methods.
+ * Class does nothing, contains empty methods
  * Adding only for porting slf4j logger to the GWT app
  *
  *


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

### What does this PR do?
Taken form org.slf4j.helpers.
Class does nothing, contains empty methods.
Adding only for porting slf4j logger to the GWT app

