### PR TITLE
Fix GitHub optional properties binding to selenium tests

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestGitHubKeyUploader.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestGitHubKeyUploader.java
@@ -29,11 +29,11 @@ public class TestGitHubKeyUploader {
 
   @Inject private TestSshServiceClient testSshServiceClient;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -156,7 +156,7 @@ public abstract class SeleniumTestHandler
 
   private void revokeGithubOauthToken() {
     // do not revoke if github tests are not being executed
-    if (excludedGroups == null || excludedGroups.contains(TestGroup.GITHUB)) {
+    if (excludedGroups != null && excludedGroups.contains(TestGroup.GITHUB)) {
       return;
     }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -122,15 +122,15 @@ public abstract class SeleniumTestHandler
   @Named("sys.driver.version")
   private String webDriverVersion;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 
-  @Inject(optional = true)
+  @Inject
   @Named("sys.excludedGroups")
   private String excludedGroups;
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.core;
 
+import static com.google.inject.name.Names.named;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.utils.PlatformUtils.isMac;
@@ -19,7 +20,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Named;
-import com.google.inject.name.Names;
 import java.io.IOException;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.action.ActionsFactory;
@@ -76,9 +76,7 @@ public class CheSeleniumSuiteModule extends AbstractModule {
   @Override
   public void configure() {
     TestConfiguration config = new SeleniumTestConfiguration();
-    config
-        .getMap()
-        .forEach((key, value) -> bindConstant().annotatedWith(Names.named(key)).to(value));
+    config.getMap().forEach((key, value) -> bindConstant().annotatedWith(named(key)).to(value));
 
     bind(TestUser.class).to(CheDefaultTestUser.class);
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestOfflineToAccessTokenExchangeApiEndpointUrlProvider.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/provider/CheTestOfflineToAccessTokenExchangeApiEndpointUrlProvider.java
@@ -20,7 +20,7 @@ import javax.inject.Named;
 @Singleton
 public class CheTestOfflineToAccessTokenExchangeApiEndpointUrlProvider
     implements TestOfflineToAccessTokenExchangeApiEndpointUrlProvider {
-  @Inject(optional = true)
+  @Inject
   @Named("che.offline.to.access.token.exchange.endpoint")
   private String offlineToAccessTokenExchangeApiEndpointUrl;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
@@ -42,11 +42,11 @@ public class ImportProjectFromGitHubTest {
   private String projectName;
   private String ideWin;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithMultiModuleTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithMultiModuleTest.java
@@ -40,7 +40,7 @@ public class CheckFactoryWithMultiModuleTest {
   @Inject private Dashboard dashboard;
   @Inject private PullRequestPanel pullRequestPanel;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithSparseCheckoutTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithSparseCheckoutTest.java
@@ -38,7 +38,7 @@ public class CheckFactoryWithSparseCheckoutTest {
   @Inject private Dashboard dashboard;
   @Inject private PullRequestPanel pullRequestPanel;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithKeepDirectoryTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithKeepDirectoryTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 @Test(groups = TestGroup.GITHUB)
 public class DirectUrlFactoryWithKeepDirectoryTest {
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolderTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolderTest.java
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 public class DirectUrlFactoryWithRootFolderTest {
   private static final String EXPECTED_PROJECT = "quickstart";
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
 
 @Test(groups = TestGroup.GITHUB)
 public class DirectUrlFactoryWithSpecificBranchTest {
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AddFilesToIndexTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AddFilesToIndexTest.java
@@ -75,11 +75,11 @@ public class AddFilesToIndexTest {
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AmendCommitTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AmendCommitTest.java
@@ -51,11 +51,11 @@ public class AmendCommitTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromDashboardTest.java
@@ -39,11 +39,11 @@ public class AuthorizeOnGithubFromDashboardTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(AuthorizeOnGithubFromDashboardTest.class);
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromImportTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromImportTest.java
@@ -50,11 +50,11 @@ public class AuthorizeOnGithubFromImportTest {
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromPreferencesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromPreferencesTest.java
@@ -49,11 +49,11 @@ public class AuthorizeOnGithubFromPreferencesTest {
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/BranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/BranchTest.java
@@ -79,7 +79,7 @@ public class BranchTest {
   @Inject private Ide ide;
   @Inject private TestUser user;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CheckoutReferenceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CheckoutReferenceTest.java
@@ -48,11 +48,11 @@ public class CheckoutReferenceTest {
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CheckoutToRemoteBranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CheckoutToRemoteBranchTest.java
@@ -60,7 +60,7 @@ public class CheckoutToRemoteBranchTest {
   @Inject private TestUser productUser;
   @Inject private TestGitHubRepository testRepo;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesByMultiSelectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesByMultiSelectTest.java
@@ -84,11 +84,11 @@ public class CommitFilesByMultiSelectTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesTest.java
@@ -65,7 +65,7 @@ public class CommitFilesTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CreateAndDeleteLocalBranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CreateAndDeleteLocalBranchTest.java
@@ -43,7 +43,7 @@ public class CreateAndDeleteLocalBranchTest {
   @Inject private Ide ide;
   @Inject private TestUser user;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/FetchAndMergeRemoteBranchIntoLocalTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/FetchAndMergeRemoteBranchIntoLocalTest.java
@@ -45,7 +45,7 @@ public class FetchAndMergeRemoteBranchIntoLocalTest {
   @Inject private TestUser productUser;
   @Inject private TestGitHubRepository testRepo;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitChangeMarkersTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitChangeMarkersTest.java
@@ -43,11 +43,11 @@ public class GitChangeMarkersTest {
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitColorsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitColorsTest.java
@@ -49,7 +49,7 @@ public class GitColorsTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitCompareTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitCompareTest.java
@@ -47,7 +47,7 @@ public class GitCompareTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPanelTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPanelTest.java
@@ -64,7 +64,7 @@ public class GitPanelTest {
   private static final String JAVA_SPRING_DELETED_FILE_NAME = "spring-servlet.xml";
   private static final String JAVA_SPRING_ADDED_FILE_NAME = "test.java";
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullConflictTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullConflictTest.java
@@ -69,7 +69,7 @@ public class GitPullConflictTest {
   @Inject private TestUser productUser;
   @Inject private TestGitHubRepository testRepo;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullTest.java
@@ -42,7 +42,7 @@ public class GitPullTest {
   @Inject private TestUser productUser;
   @Inject private TestGitHubRepository testRepo;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportProjectIntoSpecifiedBranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportProjectIntoSpecifiedBranchTest.java
@@ -43,11 +43,11 @@ public class ImportProjectIntoSpecifiedBranchTest {
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportRecursiveSubmoduleTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportRecursiveSubmoduleTest.java
@@ -40,11 +40,11 @@ public class ImportRecursiveSubmoduleTest {
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/InitializeAndDeleteLocalRepositoryTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/InitializeAndDeleteLocalRepositoryTest.java
@@ -52,7 +52,7 @@ public class InitializeAndDeleteLocalRepositoryTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/KeepDirectoryGitImportTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/KeepDirectoryGitImportTest.java
@@ -59,11 +59,11 @@ public class KeepDirectoryGitImportTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PullRequestPluginTest.java
@@ -68,11 +68,11 @@ public class PullRequestPluginTest {
   private static final String COMMENT = generate("Comment: ", 8);
   private static final String PATH_TO_README_FILE = FIRST_PROJECT_NAME + "/README.md";
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PushChangeNotUpdatedRepoTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PushChangeNotUpdatedRepoTest.java
@@ -51,11 +51,11 @@ public class PushChangeNotUpdatedRepoTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PushingChangesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/PushingChangesTest.java
@@ -60,11 +60,11 @@ public class PushingChangesTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/RevertCommitTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/RevertCommitTest.java
@@ -52,11 +52,11 @@ public class RevertCommitTest {
   @Inject private Ide ide;
   @Inject private TestUser productUser;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.username")
   private String gitHubUsername;
 
-  @Inject(optional = true)
+  @Inject
   @Named("github.password")
   private String gitHubPassword;
 

--- a/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
+++ b/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
@@ -19,3 +19,12 @@ che.workspace.activity_check_scheduler_period_s=60
 
 # Workspace default size
 workspace.default_memory_gb=2
+
+# Github credentials
+github.username=
+github.password=
+github.auxiliary.username=
+github.auxiliary.password=
+
+# authentication properties
+che.offline.to.access.token.exchange.endpoint=


### PR DESCRIPTION
### What does this PR do?
It fixes error of injection of _auxiliary github test user_ credentials into the selenium tests which can be optional:
```
[ERROR] 1) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=github.auxiliary.password) was bound.
[ERROR]   while locating java.lang.String annotated with @com.google.inject.name.Named(value=github.auxiliary.password)
[ERROR]     for the 2nd parameter of org.eclipse.che.selenium.core.CheSeleniumSuiteModule.getTestGitHubRepository(CheSeleniumSuiteModule.java:161)
[ERROR]   at org.eclipse.che.selenium.core.CheSeleniumSuiteModule.getTestGitHubRepository(CheSeleniumSuiteModule.java:161)
[ERROR] 
[ERROR] 2) No implementation for java.lang.String annotated with @com.google.inject.name.Named(value=github.auxiliary.password) was bound.
[ERROR]   at org.eclipse.che.selenium.core.CheSeleniumSuiteModule.getTestGitHubRepository(CheSeleniumSuiteModule.java:161)
```

It also gets rid of optional injection at all by setting default values within the **selenium.properties** file, and fixes check up on exclusion of github tests as well.

### What issues does this PR fix or reference?
#9338