### PR TITLE
Fix go stack version.

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -658,7 +658,7 @@
     "id": "go-default",
     "creator": "ide",
     "name": "Go",
-    "description": "Default Go Stack with Go 1.6.2",
+    "description": "Default Go Stack with Go 1.8.3",
     "scope": "general",
     "tags": [
       "Ubuntu",
@@ -671,7 +671,7 @@
       },
       {
         "name": "Go",
-        "version": "1.6.2"
+        "version": "1.8.3"
       }
     ],
     "workspaceConfig": {


### PR DESCRIPTION
### What does this PR do?
Fix outdated info for go version inside golang stack. Go installed inside stack is newer https://github.com/eclipse/che-dockerfiles/blob/master/recipes/ubuntu_go/Dockerfile#L8

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>


