### PR TITLE
Improve abstract InternalRuntime to be more flexible for recovery functionality

### DIFF
--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerInternalRuntime.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Warning;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -180,7 +181,7 @@ public class DockerInternalRuntime extends InternalRuntime<DockerRuntimeContext>
       WorkspaceProbesFactory probesFactory,
       ParallelDockerImagesBuilderFactory imagesBuilderFactory,
       int bootstrappingTimeoutMinutes) {
-    super(context, urlRewriter, warnings, running);
+    super(context, urlRewriter, warnings, running ? WorkspaceStatus.RUNNING : null);
     this.networks = networks;
     this.containerStarter = machineStarter;
     this.eventService = eventService;

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeConsistencyChecker.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeConsistencyChecker.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 
@@ -21,7 +22,7 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfi
 @Singleton
 class RuntimeConsistencyChecker {
   void check(InternalEnvironment environment, DockerInternalRuntime runtime)
-      throws ValidationException {
+      throws ValidationException, InfrastructureException {
     Map<String, InternalMachineConfig> configs = environment.getMachines();
     Map<String, ? extends Machine> machines = runtime.getMachines();
     if (configs.size() != machines.size()) {

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeConsistencyCheckerTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/RuntimeConsistencyCheckerTest.java
@@ -28,7 +28,7 @@ public class RuntimeConsistencyCheckerTest {
 
   @Test(dataProvider = "consistentRuntimesProvider")
   public void consistentRuntimes(InternalEnvironment environment, DockerInternalRuntime runtime)
-      throws ValidationException {
+      throws Exception {
     new RuntimeConsistencyChecker().check(environment, runtime);
   }
 
@@ -37,19 +37,19 @@ public class RuntimeConsistencyCheckerTest {
     expectedExceptions = ValidationException.class
   )
   public void inconsistentRuntimes(InternalEnvironment environment, DockerInternalRuntime runtime)
-      throws ValidationException {
+      throws Exception {
     new RuntimeConsistencyChecker().check(environment, runtime);
   }
 
   @DataProvider
-  private static Object[][] consistentRuntimesProvider() {
+  private static Object[][] consistentRuntimesProvider() throws Exception {
     return new Object[][] {
       {environment("a", "b"), runtime("b", "a")}, {environment("b", "a"), runtime("b", "a")}
     };
   }
 
   @DataProvider
-  private static Object[][] inconsistentRuntimesProvider() {
+  private static Object[][] inconsistentRuntimesProvider() throws Exception {
     return new Object[][] {
       {environment("a", "b"), runtime("a")},
       {environment("a", "b"), runtime("a", "c")},
@@ -71,7 +71,7 @@ public class RuntimeConsistencyCheckerTest {
     return environment;
   }
 
-  private static DockerInternalRuntime runtime(String... names) {
+  private static DockerInternalRuntime runtime(String... names) throws Exception {
     Map<String, DockerMachine> machines = new HashMap<>();
     for (String name : names) {
       machines.put(name, mock(DockerMachine.class));

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -109,7 +109,7 @@ public class KubernetesInternalRuntime<
       @Assisted T context,
       @Assisted KubernetesNamespace namespace,
       @Assisted List<Warning> warnings) {
-    super(context, urlRewriter, warnings, false);
+    super(context, urlRewriter, warnings);
     this.bootstrapperFactory = bootstrapperFactory;
     this.serverCheckerFactory = serverCheckerFactory;
     this.volumesStrategy = volumesStrategy;

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -164,8 +164,6 @@ public class WorkspaceManager {
   /**
    * Gets list of workspaces which user can read
    *
-   * <p>
-   *
    * <p>Returned workspaces have either {@link WorkspaceStatus#STOPPED} status or status defined by
    * their runtime instances(if those exist).
    *
@@ -175,7 +173,7 @@ public class WorkspaceManager {
    * @return the list of workspaces or empty list if user can't read any workspace
    * @throws NullPointerException when {@code user} is null
    * @throws ServerException when any server error occurs while getting workspaces with {@link
-   *     WorkspaceDao#getWorkspaces(String)}
+   *     WorkspaceDao#getWorkspaces(String, int, long)}
    */
   public Page<WorkspaceImpl> getWorkspaces(
       String user, boolean includeRuntimes, int maxItems, long skipCount) throws ServerException {
@@ -201,7 +199,7 @@ public class WorkspaceManager {
    * @return the list of workspaces or empty list if no matches
    * @throws NullPointerException when {@code namespace} is null
    * @throws ServerException when any server error occurs while getting workspaces with {@link
-   *     WorkspaceDao#getByNamespace(String)}
+   *     WorkspaceDao#getByNamespace(String, int, long)}
    */
   public Page<WorkspaceImpl> getByNamespace(
       String namespace, boolean includeRuntimes, int maxItems, long skipCount)

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -144,16 +144,25 @@ public class WorkspaceRuntimes {
    *
    * @param workspace the workspace to inject runtime into
    */
-  public void injectRuntime(WorkspaceImpl workspace) {
+  public void injectRuntime(WorkspaceImpl workspace) throws ServerException {
     RuntimeState runtimeState = runtimes.get(workspace.getId());
     if (runtimeState != null) {
-      workspace.setRuntime(new RuntimeImpl(runtimeState.runtime));
+      try {
+        workspace.setRuntime(asRuntime(runtimeState));
+      } catch (InfrastructureException e) {
+        throw new ServerException(
+            "Error occurred while runtime state inspection. " + e.getMessage());
+      }
       workspace.setStatus(runtimeState.status);
     } else {
       workspace.setStatus(STOPPED);
     }
   }
 
+  private RuntimeImpl asRuntime(RuntimeState runtimeState) throws InfrastructureException {
+    InternalRuntime<?> runtime = runtimeState.runtime;
+    return new RuntimeImpl(runtime.getActiveEnv(), runtime.getMachines(), runtime.getOwner());
+  }
   /**
    * Gets workspace status by its identifier.
    *

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -461,9 +461,11 @@ public class WorkspaceRuntimes {
     }
 
     InternalRuntime runtime;
+    WorkspaceStatus status;
     try {
       InternalEnvironment internalEnv = createInternalEnvironment(environment);
       runtime = infra.prepare(identity, internalEnv).getRuntime();
+      status = runtime.getStatus();
     } catch (InfrastructureException | ValidationException | NotFoundException x) {
       LOG.error(
           "Couldn't recover runtime '{}:{}'. Error: {}",
@@ -474,7 +476,7 @@ public class WorkspaceRuntimes {
     }
 
     RuntimeState prev =
-        runtimes.putIfAbsent(identity.getWorkspaceId(), new RuntimeState(runtime, RUNNING));
+        runtimes.putIfAbsent(identity.getWorkspaceId(), new RuntimeState(runtime, status));
     if (prev == null) {
       LOG.info(
           "Successfully recovered workspace runtime '{}'",

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/RuntimeImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/RuntimeImpl.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.eclipse.che.api.core.model.workspace.Runtime;
+import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 
 /**
@@ -34,6 +35,17 @@ public class RuntimeImpl implements Runtime {
     this.activeEnv = activeEnv;
     this.machines = machines;
     this.owner = owner;
+  }
+
+  public RuntimeImpl(
+      String activeEnv,
+      Map<String, ? extends Machine> machines,
+      String owner,
+      List<? extends Warning> warnings) {
+    this.activeEnv = activeEnv;
+    this.machines = machines;
+    this.owner = owner;
+    this.warnings = warnings.stream().map(WarningImpl::new).collect(Collectors.toList());
   }
 
   public RuntimeImpl(Runtime runtime) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerImpl.java
@@ -25,6 +25,16 @@ public class ServerImpl implements Server {
 
   public ServerImpl() {}
 
+  public ServerImpl(String url, ServerStatus status, Map<String, String> attributes) {
+    this.url = url;
+    this.status = status;
+    if (attributes != null) {
+      this.attributes = new HashMap<>(attributes);
+    } else {
+      this.attributes = new HashMap<>();
+    }
+  }
+
   public ServerImpl(Server server) {
     this.url = server.getUrl();
     this.status = server.getStatus();

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
-import org.eclipse.che.api.core.model.workspace.Runtime;
 import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
@@ -27,6 +26,7 @@ import org.eclipse.che.api.workspace.server.URLRewriter;
 import org.eclipse.che.api.workspace.server.model.impl.MachineImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /**
  * Implementation of concrete Runtime
@@ -38,19 +38,29 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
   private final T context;
   private final URLRewriter urlRewriter;
   private final List<Warning> warnings;
-  private WorkspaceStatus status;
+  protected WorkspaceStatus status;
 
-  public InternalRuntime(
-      T context, URLRewriter urlRewriter, List<Warning> warnings, boolean running) {
+  public InternalRuntime(T context, URLRewriter urlRewriter, List<Warning> warnings) {
     this.context = context;
     this.urlRewriter = urlRewriter;
     this.warnings = new CopyOnWriteArrayList<>();
     if (warnings != null) {
       this.warnings.addAll(warnings);
     }
-    if (running) {
-      status = WorkspaceStatus.RUNNING;
+  }
+
+  public InternalRuntime(
+      T context,
+      URLRewriter urlRewriter,
+      List<Warning> warnings,
+      @Nullable WorkspaceStatus status) {
+    this.context = context;
+    this.urlRewriter = urlRewriter;
+    this.warnings = new CopyOnWriteArrayList<>();
+    if (warnings != null) {
+      this.warnings.addAll(warnings);
     }
+    this.status = status;
   }
 
   @Override
@@ -91,6 +101,15 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
   protected abstract Map<String, ? extends Machine> getInternalMachines();
 
   /**
+   * Returns runtime status.
+   *
+   * @throws InfrastructureException when any error occurs
+   */
+  public WorkspaceStatus getStatus() throws InfrastructureException {
+    return status == null ? WorkspaceStatus.STOPPED : status;
+  }
+
+  /**
    * Starts Runtime. In practice this method launching supposed to take unpredictable long time so
    * normally it should be launched in separated thread
    *
@@ -102,12 +121,14 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
    * @throws InfrastructureException when any other error occurs
    */
   public void start(Map<String, String> startOptions) throws InfrastructureException {
-    if (this.status != null) {
-      throw new StateException("Runtime already started");
+    markStarting();
+    try {
+      internalStart(startOptions);
+      markRunning();
+    } catch (InfrastructureException e) {
+      markStopped();
+      throw e;
     }
-    status = WorkspaceStatus.STARTING;
-    internalStart(startOptions);
-    status = WorkspaceStatus.RUNNING;
   }
 
   /**
@@ -129,20 +150,16 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
    * WorkspaceStatus#STARTING}.
    *
    * @param stopOptions options of workspace that may used in environment stop
-   * @throws StateException when the context can't be stopped because otherwise it would be in
+   * @throws StateException when the runtime can't be stopped because otherwise it would be in
    *     inconsistent status (e.g. stop(interrupt) might not be allowed during start)
    * @throws InfrastructureException when any other error occurs
    */
   public final void stop(Map<String, String> stopOptions) throws InfrastructureException {
-    if (status != WorkspaceStatus.RUNNING && status != WorkspaceStatus.STARTING) {
-      throw new StateException("The environment must be running or starting");
-    }
-    status = WorkspaceStatus.STOPPING;
-
+    markStopping();
     try {
       internalStop(stopOptions);
     } finally {
-      status = WorkspaceStatus.STOPPED;
+      markStopped();
     }
   }
 
@@ -201,5 +218,62 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
     }
 
     return outgoing;
+  }
+
+  /**
+   * Marks runtime as {@link WorkspaceStatus#STARTING STARTING}.
+   *
+   * <p>Note that this method must be overridden if runtime implementation stores status itself.
+   *
+   * @throws StateException when the runtime was already marked as STARTING
+   * @throws StateException when the runtime was already marked as STARTING
+   * @throws InfrastructureException when any other exception occurs
+   */
+  protected void markStarting() throws InfrastructureException {
+    if (status != null) {
+      throw new StateException("Runtime already started");
+    }
+    this.status = WorkspaceStatus.STARTING;
+  }
+
+  /**
+   * Marks runtime as {@link WorkspaceStatus#RUNNING RUNNING}.
+   *
+   * <p>Note that this method must be overridden if runtime implementation stores status itself.
+   *
+   * @throws InfrastructureException when any exception occurs
+   */
+  protected void markRunning() throws InfrastructureException {
+    this.status = WorkspaceStatus.RUNNING;
+  }
+
+  /**
+   * Marks runtime as {@link WorkspaceStatus#STOPPING STOPPING}.
+   *
+   * <p>Note that this method must be overridden if runtime implementation stores status itself.
+   * Also this method must be overridden if runtime implementation doesn't support start
+   * interruption.
+   *
+   * @throws StateException when the runtime is not RUNNING or STARTING
+   * @throws StateException when the runtime is STARTING and implementation doesn't support start
+   *     interruption
+   * @throws InfrastructureException when any exception occurs
+   */
+  protected void markStopping() throws InfrastructureException {
+    if (status != WorkspaceStatus.RUNNING && status != WorkspaceStatus.STARTING) {
+      throw new StateException("The environment must be running or starting");
+    }
+    status = WorkspaceStatus.STOPPING;
+  }
+
+  /**
+   * Marks runtime as {@link WorkspaceStatus#STOPPED STOPPED}.
+   *
+   * <p>Note that this method must be overridden if runtime implementation stores status itself.
+   *
+   * @throws InfrastructureException when any exception occurs
+   */
+  protected void markStopped() throws InfrastructureException {
+    status = WorkspaceStatus.STOPPED;
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -29,17 +29,22 @@ import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 
 /**
- * Implementation of concrete Runtime
+ * Implementation of concrete Runtime.
  *
  * @author gazarenkov
  */
-public abstract class InternalRuntime<T extends RuntimeContext> implements Runtime {
+public abstract class InternalRuntime<T extends RuntimeContext> {
 
   private final T context;
   private final URLRewriter urlRewriter;
   private final List<Warning> warnings;
   protected WorkspaceStatus status;
 
+  /**
+   * @param context prepared context for runtime starting
+   * @param urlRewriter url rewriter
+   * @param warnings warning that occurred while context preparing
+   */
   public InternalRuntime(T context, URLRewriter urlRewriter, List<Warning> warnings) {
     this.context = context;
     this.urlRewriter = urlRewriter;
@@ -49,6 +54,13 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
     }
   }
 
+  /**
+   * @param context prepared context for runtime starting
+   * @param urlRewriter url rewriter
+   * @param warnings warning that occurred while context preparing
+   * @param status status of the runtime, or null if {@link #start(Map)} and {@link #stop(Map)} were
+   *     not invoked yet
+   */
   public InternalRuntime(
       T context,
       URLRewriter urlRewriter,
@@ -63,23 +75,27 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
     this.status = status;
   }
 
-  @Override
+  /** Returns name of the active environment. */
   public String getActiveEnv() {
     return context.getIdentity().getEnvName();
   }
 
-  @Override
+  /** Returns identifier of user who started a runtime. */
   public String getOwner() {
     return context.getIdentity().getOwnerId();
   }
 
-  @Override
+  /** Returns identifier of user who started a runtime. */
   public List<? extends Warning> getWarnings() {
     return warnings;
   }
 
-  @Override
-  public Map<String, ? extends Machine> getMachines() {
+  /**
+   * Returns map of machine name to machine instance entries.
+   *
+   * @throws InfrastructureException when any error occurs
+   */
+  public Map<String, ? extends Machine> getMachines() throws InfrastructureException {
     return getInternalMachines()
         .entrySet()
         .stream()
@@ -96,9 +112,12 @@ public abstract class InternalRuntime<T extends RuntimeContext> implements Runti
   /**
    * Returns map of machine name to machine instance entries.
    *
-   * <p>Implementation should not return null
+   * <p>Implementation must not return null
+   *
+   * @throws InfrastructureException when any error occurs
    */
-  protected abstract Map<String, ? extends Machine> getInternalMachines();
+  protected abstract Map<String, ? extends Machine> getInternalMachines()
+      throws InfrastructureException;
 
   /**
    * Returns runtime status.

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.Warning;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
@@ -633,7 +634,7 @@ public class InternalRuntimeTest {
           new TestRuntimeContext(null, new RuntimeIdentityImpl("ws", "env", "id"), null),
           urlRewriter,
           emptyList(),
-          running);
+          running ? WorkspaceStatus.RUNNING : null);
     }
 
     @Override


### PR DESCRIPTION
### What does this PR do?
Improve abstract InternalRuntime to be more flexible for recovery functionality. It includes:

- Add an ability to store status by an implementation of InternalRuntime. It allows infrastructure provide an actual status after runtime recovery. Also, it adds an ability to deny stopping of STARTING workspaces if it is not implemented like in Kubernetes/OpenShift infrastructures.
Unfortunately, denying stop of STARTING workspace will not work correctly. Here is a registered bug for that https://github.com/eclipse/che/issues/9354.

- Add an ability to throw InfrastructureException by InternalRuntimes#getMachines method. It is needed because Runtime may store machines information in storage that may throw some exceptions (like database as storage may throw connection related exceptions).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5919
It's needed for OpenShift recovery functionality changes https://github.com/eclipse/che/pull/9301

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
