### PR TITLE
Selenium: not check Workspace API installer changeability in WorkspaceDetailsSingleMachineTest test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceInstallers.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceInstallers.java
@@ -76,17 +76,6 @@ public class WorkspaceInstallers {
     return Boolean.parseBoolean(state);
   }
 
-  public Boolean isInstallerStateNotChangeable(String installerName) {
-    String state =
-        new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-            .until(
-                ExpectedConditions.visibilityOfElementLocated(
-                    By.xpath(format(Locators.INSTALLER_STATE, installerName))))
-            .getAttribute("aria-disabled");
-
-    return Boolean.parseBoolean(state);
-  }
-
   public String getInstallerDescription(String installerName) {
     return new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
         .until(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/WorkspaceDetailsSingleMachineTest.java
@@ -129,7 +129,6 @@ public class WorkspaceDetailsSingleMachineTest {
   @Test
   public void checkWorkingWithInstallers() {
     workspaceDetails.selectTabInWorkspaceMenu(INSTALLERS);
-    assertTrue(workspaceInstallers.isInstallerStateNotChangeable("Workspace API"));
 
     // check all needed installers in dev-machine exist
     workspaceMachines.selectMachine("Workspace Installers", "dev-machine");


### PR DESCRIPTION
### What does this PR do?
This PR removes checking that **Workspace API** installer is not changeable because for now all installer can be disabled.

![selection_225](https://user-images.githubusercontent.com/7760565/38410979-b153bf7a-398e-11e8-8d21-11ac2c2f1d6c.png)
