### PR TITLE
Correct handle of input events in navigate to file dialogue

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/navigation/NavigateToFileView.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/navigation/NavigateToFileView.java
@@ -34,7 +34,7 @@ public interface NavigateToFileView extends View<NavigateToFileView.ActionDelega
      *
      * @param fileName file name
      */
-    void onFileNameChanged(String fileName);
+    void onFileNameChanged();
 
     /**
      * Is called when file is selected.
@@ -56,6 +56,13 @@ public interface NavigateToFileView extends View<NavigateToFileView.ActionDelega
    * @param items items of suggestions
    */
   void showItems(List<SearchResultDto> items);
+
+  /**
+   * Set the file name input field enabled or disabled.
+   *
+   * @param enabled {@code true} if field has to be enabled, otherwise {@code false}
+   */
+  void setFileNameTextBoxEnabled(boolean enabled);
 
   /** Returns entered file name. */
   String getFileName();


### PR DESCRIPTION
### What does this PR do?
This changes proposal provides changes to correct handling input events in _Navigate to file_ dialogue. At first keyDown events where replaced by keyUp events, because it could cause incorrect construction of search request when user search a file with a single character.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#8293 


#### Release Notes
N/A

#### Docs PR
N/A
