### PR TITLE
Fix workspace loader which should pass its query strings to the underlying alternate IDE

### DIFF
--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -315,13 +315,13 @@ export class WorkspaceLoader {
                 for (let serverId in servers) {
                     let attributes = servers[serverId].attributes;
                     if (attributes['type'] === 'ide') {
-                        this.openURL(servers[serverId].url);
+                        this.openURL(servers[serverId].url + this.getQueryString());
                         return;
                     }
                 }
             }
 
-            this.openURL(workspace.links.ide);
+            this.openURL(workspace.links.ide + this.getQueryString());
         });
     }
 

--- a/workspace-loader/test/test.spec.ts
+++ b/workspace-loader/test/test.spec.ts
@@ -171,6 +171,36 @@ describe('Workspace Loader', () => {
         });
     });
 
+    describe('must open preconfigured IDE with query parameters', () => {
+        let ideURL = "ide URL"
+        let workspaceLoader;
+
+        beforeEach((done) => {
+            let loader = new Loader();
+            workspaceLoader = new WorkspaceLoader(loader);
+
+            spyOn(workspaceLoader, 'getWorkspaceKey').and.returnValue("foo/bar");
+            spyOn(workspaceLoader, 'getQueryString').and.returnValue("?param=value");
+
+            spyOn(workspaceLoader, 'getWorkspace').and.callFake(() => {
+                return new Promise((resolve) => {
+                    fakeWorkspaceConfig.status = 'RUNNING';
+                    fakeWorkspaceConfig.runtime = {machines: {ide: {servers: {server1: {attributes: {type: "ide"}, url: ideURL}}}}}
+                    resolve(fakeWorkspaceConfig);
+                    done();
+                });
+            });
+
+            spyOn(workspaceLoader, "openIDE").and.callThrough();
+            spyOn(workspaceLoader, "openURL");
+            workspaceLoader.load();
+        });
+
+        it('must be called', () => {
+            expect(workspaceLoader.openURL).toHaveBeenCalledWith(ideURL + "?param=value");
+        });
+    });
+
     describe('must handle workspace when it has IDE server', () => {
         let workspaceLoader;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When starting a Che factory with an alternate IDE, workspace loader should pass its query string to the underlying ide url. This is done for the legacy gwt ide but not preconfigured IDE such as Theia.
This PR is fixing it.

![workspace 1_119](https://user-images.githubusercontent.com/650571/38567940-ac3bff14-3ce7-11e8-85d4-633477e3bc6e.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9221

