### PR TITLE
Revert "Use workspace limit idle timeout value in WorkspaceActivityManager (#9342)"

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -106,6 +106,12 @@ che.workspace.hosts=NULL
 
 che.installer.registry.remote=NULL
 
+# Idle Timeout
+#     The system will suspend the workspace if the end user is idle for
+#     this amount of time. Idleness is determined by the length of time that a user has
+#     not interacted with the workspace. Leaving a browser window open counts as idleness time.
+che.workspace.agent.dev.inactive_stop_timeout_ms=3600000
+#
 # Period of inactive workspaces suspend job execution.
 che.workspace.activity_check_scheduler_period_s=60
 #

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che_aliases.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che_aliases.properties
@@ -33,6 +33,3 @@ che.infra.kubernetes.tls_enabled=che.infra.openshift.tls_enabled
 
 che.infra.docker.daemon_url=docker.client.daemon_url
 che.infra.docker.certificates_folder=docker.client.certificates_folder
-
-# old name of property has been removed due to https://github.com/eclipse/che/issues/8951
-che.limits.workspace.idle.timeout=che.workspace.agent.dev.inactive_stop_timeout_ms

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -146,6 +146,14 @@
 #   Default java command line options to be added to JVM that run maven server.
 #CHE_WORKSPACE_MAVEN__SERVER__JAVA__OPTIONS=XX:MaxRAM=128m -XX:MaxRAMFraction=1 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom
 
+
+# Workspace Idle timeout
+#   The length of time after which workspaces will be automatically stopped, if no activity
+#   has been detected on them. Currently, keyboard and mouse interactions in IDE, as well as HTTP
+#   requests to ws-agent count as activity. Set "0" to disable automatic stop of inactive workspaces.
+#   Default to the value of this property in che.properties (3600000)
+#CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS=0
+
 ########################################################################################
 #####                                                                              #####
 #####                    NETWORKING FOR CHE ON DOCKER                              #####
@@ -654,7 +662,7 @@ CHE_SINGLE_PORT=false
 #     suspend the workspace and then stopping it. Idleness is the
 #     length of time that the user has not interacted with the workspace, meaning that
 #     one of our agents has not received interaction. Leaving a browser window open
-#     counts toward idleness. Value is provided in milliseconds.
+#     counts toward idleness.
 #CHE_LIMITS_WORKSPACE_IDLE_TIMEOUT=-1
 
 #     The maximum amount of RAM that a user can allocate to a workspace when they

--- a/wsmaster/che-core-api-workspace-activity/pom.xml
+++ b/wsmaster/che-core-api-workspace-activity/pom.xml
@@ -87,14 +87,6 @@
             <artifactId>che-core-db</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.multiuser</groupId>
-            <artifactId>che-multiuser-api-resource</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.multiuser</groupId>
-            <artifactId>che-multiuser-api-resource-shared</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.persistence</groupId>
             <artifactId>javax.persistence</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManager.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManager.java
@@ -14,14 +14,10 @@ import static java.util.Collections.emptyMap;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STOPPED_BY;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.List;
-import java.util.Optional;
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.eclipse.che.account.api.AccountManager;
-import org.eclipse.che.account.shared.model.Account;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
@@ -29,12 +25,8 @@ import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
-import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
 import org.eclipse.che.commons.schedule.ScheduleDelay;
-import org.eclipse.che.multiuser.resource.api.type.TimeoutResourceType;
-import org.eclipse.che.multiuser.resource.api.usage.ResourceManager;
-import org.eclipse.che.multiuser.resource.model.Resource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,12 +48,10 @@ public class WorkspaceActivityManager {
 
   private static final String ACTIVITY_CHECKER = "activity-checker";
 
-  private final long defaultTimeout;
+  private final long timeout;
   private final WorkspaceActivityDao activityDao;
   private final EventService eventService;
   private final EventSubscriber<?> workspaceEventsSubscriber;
-  private final AccountManager accountManager;
-  private final ResourceManager resourceManager;
 
   protected final WorkspaceManager workspaceManager;
 
@@ -69,16 +59,12 @@ public class WorkspaceActivityManager {
   public WorkspaceActivityManager(
       WorkspaceManager workspaceManager,
       WorkspaceActivityDao activityDao,
-      AccountManager accountManager,
-      ResourceManager resourceManager,
       EventService eventService,
-      @Named("che.limits.workspace.idle.timeout") long timeout) {
+      @Named("che.workspace.agent.dev.inactive_stop_timeout_ms") long timeout) {
+    this.timeout = timeout > 0 ? timeout : -1;
     this.workspaceManager = workspaceManager;
     this.eventService = eventService;
     this.activityDao = activityDao;
-    this.accountManager = accountManager;
-    this.resourceManager = resourceManager;
-    this.defaultTimeout = timeout;
     this.workspaceEventsSubscriber =
         new EventSubscriber<WorkspaceStatusEvent>() {
           @Override
@@ -118,31 +104,12 @@ public class WorkspaceActivityManager {
    * @param activityTime moment in which the activity occurred
    */
   public void update(String wsId, long activityTime) {
-    try {
-      long timeout = getIdleTimeout(wsId);
-      if (timeout > 0) {
+    if (timeout > 0) {
+      try {
         activityDao.setExpiration(new WorkspaceExpiration(wsId, activityTime + timeout));
+      } catch (ServerException e) {
+        LOG.error(e.getLocalizedMessage(), e);
       }
-    } catch (NotFoundException | ServerException e) {
-      LOG.error(e.getLocalizedMessage(), e);
-    }
-  }
-
-  private long getIdleTimeout(String wsId) throws NotFoundException, ServerException {
-    WorkspaceImpl workspace = workspaceManager.getWorkspace(wsId);
-    Account account = accountManager.getByName(workspace.getNamespace());
-    List<? extends Resource> availableResources =
-        resourceManager.getAvailableResources(account.getId());
-    Optional<? extends Resource> timeoutOpt =
-        availableResources
-            .stream()
-            .filter(resource -> TimeoutResourceType.ID.equals(resource.getType()))
-            .findAny();
-
-    if (timeoutOpt.isPresent()) {
-      return timeoutOpt.get().getAmount() * 60 * 1000;
-    } else {
-      return defaultTimeout;
     }
   }
 

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManagerTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManagerTest.java
@@ -10,10 +10,8 @@
  */
 package org.eclipse.che.api.workspace.activity;
 
-import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,9 +26,6 @@ import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
 import org.eclipse.che.dto.server.DtoFactory;
-import org.eclipse.che.multiuser.resource.api.type.TimeoutResourceType;
-import org.eclipse.che.multiuser.resource.api.usage.ResourceManager;
-import org.eclipse.che.multiuser.resource.spi.impl.ResourceImpl;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -53,7 +48,6 @@ public class WorkspaceActivityManagerTest {
   @Mock private Account account;
   @Mock private WorkspaceImpl workspace;
   @Mock private WorkspaceActivityDao workspaceActivityDao;
-  @Mock private ResourceManager resourceManager;
 
   @Mock private EventService eventService;
 
@@ -63,12 +57,7 @@ public class WorkspaceActivityManagerTest {
   private void setUp() throws Exception {
     activityManager =
         new WorkspaceActivityManager(
-            workspaceManager,
-            workspaceActivityDao,
-            accountManager,
-            resourceManager,
-            eventService,
-            EXPIRE_PERIOD_MS);
+            workspaceManager, workspaceActivityDao, eventService, EXPIRE_PERIOD_MS);
 
     when(account.getName()).thenReturn("accountName");
     when(account.getId()).thenReturn("account123");
@@ -76,21 +65,11 @@ public class WorkspaceActivityManagerTest {
 
     when(workspaceManager.getWorkspace(anyString())).thenReturn(workspace);
     when(workspace.getNamespace()).thenReturn("accountName");
-
-    doReturn(
-            singletonList(
-                new ResourceImpl(
-                    TimeoutResourceType.ID,
-                    EXPIRE_PERIOD_MS / 60 / 1000,
-                    TimeoutResourceType.UNIT)))
-        .when(resourceManager)
-        .getAvailableResources(anyString());
   }
 
   @Test
   public void shouldAddNewActiveWorkspace() throws Exception {
     final String wsId = "testWsId";
-    final String wsName = "testWsName";
     final long activityTime = 1000L;
 
     activityManager.update(wsId, activityTime);


### PR DESCRIPTION
This reverts commit f85c0a299b71c5109aefe79d6cb4c560edc5c3e9.

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Reverting https://github.com/eclipse/che/pull/9342 PR, as it breaks single-user Che.

PR will be reworked and tested in accordance to single and multi user Che.
### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
