### PR TITLE
Fix move sign key binding to auth module

### DIFF
--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentModule.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentModule.java
@@ -13,8 +13,6 @@ package org.eclipse.che.wsagent.server;
 import com.google.inject.AbstractModule;
 import com.google.inject.name.Names;
 import java.net.URI;
-import java.security.PublicKey;
-import org.eclipse.che.MachinePublicKeyProvider;
 import org.eclipse.che.MachineTokenProvider;
 import org.eclipse.che.UriApiEndpointProvider;
 import org.eclipse.che.inject.DynaModule;
@@ -39,10 +37,6 @@ public class CheWsAgentModule extends AbstractModule {
     bind(String.class)
         .annotatedWith(Names.named("wsagent.endpoint"))
         .toProvider(WsAgentURLProvider.class);
-
-    bind(PublicKey.class)
-        .annotatedWith(Names.named("signature.public.key"))
-        .toProvider(MachinePublicKeyProvider.class);
 
     bind(AppStateService.class);
   }

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentAuthModule.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/WsAgentAuthModule.java
@@ -11,6 +11,9 @@
 package org.eclipse.che.wsagent.server;
 
 import com.google.inject.AbstractModule;
+import com.google.inject.name.Names;
+import java.security.PublicKey;
+import org.eclipse.che.MachinePublicKeyProvider;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.commons.auth.token.ChainedTokenExtractor;
 import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
@@ -29,5 +32,8 @@ public class WsAgentAuthModule extends AbstractModule {
   private void configureMultiUserMode() {
     bind(HttpJsonRequestFactory.class).to(AgentHttpJsonRequestFactory.class);
     bind(RequestTokenExtractor.class).to(ChainedTokenExtractor.class);
+    bind(PublicKey.class)
+        .annotatedWith(Names.named("signature.public.key"))
+        .toProvider(MachinePublicKeyProvider.class);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Fixes ws-agent bindings for single Che assembly.
cause of merge: https://github.com/eclipse/che/pull/9016