### PR TITLE
che #9376 Setting default postgres image for 'deploy_postgres_only.sh' instead of failing if 'IMAGE_POSTGRES' env var is not set

### DIFF
--- a/deploy/openshift/multi-user/deploy_postgres_only.sh
+++ b/deploy/openshift/multi-user/deploy_postgres_only.sh
@@ -6,8 +6,7 @@
 # http://www.eclipse.org/legal/epl-v10.html
 #
 
-if [ -z "${IMAGE_POSTGRES+x}" ]; then echo "[CHE] **ERROR**Env var IMAGE_POSTGRES is unset. You need to set it to continue. Aborting"; exit 1; fi
-
+IMAGE_POSTGRES=${IMAGE_POSTGRES:-"eclipse/che-postgres:nightly"}
 COMMAND_DIR=$(dirname "$0")
 export CHE_EPHEMERAL=${CHE_EPHEMERAL:-false}
 


### PR DESCRIPTION
### What does this PR do?
Setting default postgres image for 'deploy_postgres_only.sh' instead of failing if 'IMAGE_POSTGRES' env var is not set

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9376

#### Release Notes
Setting default postgres image for 'deploy_postgres_only.sh' instead of failing if 'IMAGE_POSTGRES' env var is not set

#### Docs PR
N/A
