### PR TITLE
Changed absolute paths to relative paths for zipped content

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/fs/server/impl/ZipArchiver.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/fs/server/impl/ZipArchiver.java
@@ -64,12 +64,7 @@ class ZipArchiver {
 
       try (FileOutputStream fos = new FileOutputStream(outFile);
           ZipOutputStream zos = new ZipOutputStream(fos)) {
-        Path parent = fsPath.getParent();
-        if (root.startsWith(parent)) {
-          zip(root, inFile, zos);
-        } else {
-          zip(parent, inFile, zos);
-        }
+        zip(fsPath, inFile, zos);
       }
 
       return newInputStream(outFile.toPath());

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/fs/server/impl/ZipArchiver.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/fs/server/impl/ZipArchiver.java
@@ -23,24 +23,35 @@ import java.nio.file.Path;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.io.IOUtils;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.fs.server.PathTransformer;
+import org.eclipse.che.api.fs.server.WsPathUtils;
 
 @Singleton
 class ZipArchiver {
 
-  private static void zip(File zipInFile, String fileName, ZipOutputStream zos) throws IOException {
+  private final Path root;
+
+  @Inject
+  ZipArchiver(PathTransformer pathTransformer) {
+    this.root = pathTransformer.transform(WsPathUtils.ROOT);
+  }
+
+  private static void zip(Path zipRoot, File zipInFile, ZipOutputStream zos) throws IOException {
     if (zipInFile.isDirectory()) {
       File[] files = zipInFile.listFiles();
       for (File file : files == null ? new File[0] : files) {
-        zip(file, file.getAbsolutePath(), zos);
+        zip(zipRoot, file, zos);
       }
       return;
     }
 
     try (FileInputStream fis = new FileInputStream(zipInFile); ) {
-      ZipEntry zipEntry = new ZipEntry(fileName);
+      String zipEntryName = zipRoot.relativize(zipInFile.toPath()).toString();
+      ZipEntry zipEntry = new ZipEntry(zipEntryName);
       zos.putNextEntry(zipEntry);
       IOUtils.copy(fis, zos);
     }
@@ -53,7 +64,12 @@ class ZipArchiver {
 
       try (FileOutputStream fos = new FileOutputStream(outFile);
           ZipOutputStream zos = new ZipOutputStream(fos)) {
-        zip(inFile, inFile.getName(), zos);
+        Path parent = fsPath.getParent();
+        if (root.startsWith(parent)) {
+          zip(root, inFile, zos);
+        } else {
+          zip(parent, inFile, zos);
+        }
       }
 
       return newInputStream(outFile.toPath());


### PR DESCRIPTION
Relative issue: https://github.com/eclipse/che/issues/9397

Changed absolute paths to relative paths for zipped content