### PR TITLE
Notify other browsers when project is created in one session

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -1183,6 +1183,9 @@ public interface CoreLocalizationConstant extends Messages {
   @Key("messages.machine.not.found")
   String machineNotFound(String machineId);
 
+  @Key("message.projectCreated")
+  String projectCreated(String projectName);
+
   @Key("ssh.connect.info")
   String sshConnectInfo(
       String machineName,

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -277,6 +277,7 @@ messages.noOpenedProject=No opened project
 messages.startingMachine=Starting machine \"{0}\"
 messages.startingOperation=Starting {0}
 messages.machine.not.found=Machine {0} not found
+message.projectCreated=Project {0} created
 
 ############### Buttons ###############################
 ok = OK


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds an ability to notify the use in different browser window about project creation by notification balloon.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#2428 

#### Release Notes
N/A

#### Docs PR
N/A