### PR TITLE
Fixed removing of PVCs when OpenShift project name is predefined

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -39,6 +39,14 @@ public class KubernetesNamespaceFactory {
   }
 
   /**
+   * Returns true if namespace is predefined for all workspaces or false if each workspace will be
+   * provided with a new namespace.
+   */
+  public boolean isPredefined() {
+    return isNullOrEmpty(namespaceName);
+  }
+
+  /**
    * Creates a Kubernetes namespace for the specified workspace.
    *
    * <p>The namespace name will be chosen according to a configuration, and it will be prepared

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPersistentVolumeClaims.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPersistentVolumeClaims.java
@@ -16,6 +16,7 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
@@ -28,6 +29,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastruct
  * @author Sergii Leshchenko
  */
 public class KubernetesPersistentVolumeClaims {
+
   private final String namespace;
   private final String workspaceId;
   private final KubernetesClientFactory clientFactory;
@@ -113,6 +115,25 @@ public class KubernetesPersistentVolumeClaims {
       if (!existing.contains(pvc.getMetadata().getName())) {
         create(pvc);
       }
+    }
+  }
+
+  /**
+   * Removes all PVCs which have the specified labels.
+   *
+   * @param labels labels to filter PVCs
+   * @throws InfrastructureException when any error occurs while removing
+   */
+  public void delete(Map<String, String> labels) throws InfrastructureException {
+    try {
+      clientFactory
+          .create(workspaceId)
+          .persistentVolumeClaims()
+          .inNamespace(namespace)
+          .withLabels(labels)
+          .delete();
+    } catch (KubernetesClientException e) {
+      throw new KubernetesInfrastructureException(e);
     }
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleanerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleanerTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -24,6 +25,7 @@ import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -39,32 +41,43 @@ import org.testng.annotations.Test;
 public class WorkspacePVCCleanerTest {
 
   private static final String WORKSPACE_ID = "workspace132";
-  private static final String NAMESPACE_NAME = "che";
 
   @Mock private WorkspaceVolumesStrategy pvcStrategy;
   @Mock private EventService eventService;
+  @Mock private KubernetesNamespaceFactory namespaceFactory;
 
   private WorkspacePVCCleaner workspacePVCCleaner;
 
   @BeforeMethod
   public void setUp() {
-    workspacePVCCleaner = new WorkspacePVCCleaner(true, NAMESPACE_NAME, pvcStrategy);
+    when(namespaceFactory.isPredefined()).thenReturn(false);
+    workspacePVCCleaner = new WorkspacePVCCleaner(true, namespaceFactory, pvcStrategy);
   }
 
   @Test
   public void testDoNotSubscribesCleanerWhenPVCDisabled() {
-    workspacePVCCleaner = spy(new WorkspacePVCCleaner(false, NAMESPACE_NAME, pvcStrategy));
+    workspacePVCCleaner = spy(new WorkspacePVCCleaner(false, namespaceFactory, pvcStrategy));
 
     workspacePVCCleaner.subscribe(eventService);
 
-    verify(eventService, never()).subscribe(any());
+    verify(eventService, never()).subscribe(any(), eq(WorkspaceRemovedEvent.class));
+  }
+
+  @Test
+  public void testDoNotSubscribesCleanerWhenPVCEnabledAndNamespaceIsPredefined() {
+    when(namespaceFactory.isPredefined()).thenReturn(true);
+    workspacePVCCleaner = spy(new WorkspacePVCCleaner(false, namespaceFactory, pvcStrategy));
+
+    workspacePVCCleaner.subscribe(eventService);
+
+    verify(eventService, never()).subscribe(any(), eq(WorkspaceRemovedEvent.class));
   }
 
   @Test
   public void testSubscribesDeleteKubernetesOnWorkspaceRemove() throws Exception {
     workspacePVCCleaner.subscribe(eventService);
 
-    verify(eventService).subscribe(any(EventSubscriber.class));
+    verify(eventService).subscribe(any(), eq(WorkspaceRemovedEvent.class));
   }
 
   @Test
@@ -81,7 +94,7 @@ public class WorkspacePVCCleanerTest {
               return invocationOnMock;
             })
         .when(eventService)
-        .subscribe(any());
+        .subscribe(any(), eq(WorkspaceRemovedEvent.class));
 
     workspacePVCCleaner.subscribe(eventService);
 
@@ -102,7 +115,7 @@ public class WorkspacePVCCleanerTest {
               return invocationOnMock;
             })
         .when(eventService)
-        .subscribe(any());
+        .subscribe(any(), eq(WorkspaceRemovedEvent.class));
     doThrow(InfrastructureException.class).when(pvcStrategy).cleanup(WORKSPACE_ID);
 
     workspacePVCCleaner.subscribe(eventService);


### PR DESCRIPTION
### What does this PR do?
The bug appeared on OpenShift infrastructure because of `che.infra.kubernetes.namespace` configuration property. It is used by few components which are bound for both Kubernetes and OpenShift infrastructure. But OpenShift infrastructure introduces a new property called `che.infra.openshift.project` and ignore old one. So components used non-configured property, it was a reason why WorkspacePVCCleaner doesn't subscribe to WorkspaceRemoved events.

This PR introduces changes to avoiding injection of `che.infra.kubernetes.namespace` configuration property. Instead of it, components should use other components like KubernetesNamespaceFactory, KubernetesNamespace, which are overridden by OpenShift infrastructure (OpenShiftProjectFactory, OpenShiftProject).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9431

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A


#### Docs PR
N/A