### PR TITLE
Selenium: remove info about #9100 issue from ProjectExplorer page object

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -255,6 +255,8 @@ public class ProjectExplorer {
       if (seleniumWebDriverHelper.isVisible(By.id("ide-loader-progress-bar"))) {
         fail("Known issue https://github.com/eclipse/che/issues/8468", ex);
       }
+
+      throw ex;
     }
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -255,8 +255,6 @@ public class ProjectExplorer {
       if (seleniumWebDriverHelper.isVisible(By.id("ide-loader-progress-bar"))) {
         fail("Known issue https://github.com/eclipse/che/issues/8468", ex);
       }
-
-      fail("Known issue https://github.com/eclipse/che/issues/9100", ex);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR removes info about resolved #9100 issue from **ProjectExplorer** page object.
