### PR TITLE
CHE-9428: fix kubernetes infra after a merge of not checked PR

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -335,6 +335,12 @@ che.infra.kubernetes.password=
 che.infra.kubernetes.oauth_token=
 che.infra.kubernetes.trust_certs=
 
+# Defines the way how servers are exposed to the world in k8s infra.
+# List of  strategies implemented in Che: default-host, multi-host, single-host
+che.infra.kubernetes.server_strategy=default-host
+# Used to generate domain for a server in a workspace
+che.infra.kubernetes.ingress.domain=unspecified-ingress-domain
+
 # Defines Kubernetes namespace in which all workspaces will be created.
 # If not set, every workspace will be created in a new namespace, where namespace = workspace id
 #

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -339,7 +339,7 @@ che.infra.kubernetes.trust_certs=
 # List of  strategies implemented in Che: default-host, multi-host, single-host
 che.infra.kubernetes.server_strategy=default-host
 # Used to generate domain for a server in a workspace in case property `che.infra.kubernetes.server_strategy` is set to `multi-host`
-che.infra.kubernetes.ingress.domain=unspecified-ingress-domain
+che.infra.kubernetes.ingress.domain=
 
 # Defines Kubernetes namespace in which all workspaces will be created.
 # If not set, every workspace will be created in a new namespace, where namespace = workspace id

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -338,7 +338,7 @@ che.infra.kubernetes.trust_certs=
 # Defines the way how servers are exposed to the world in k8s infra.
 # List of  strategies implemented in Che: default-host, multi-host, single-host
 che.infra.kubernetes.server_strategy=default-host
-# Used to generate domain for a server in a workspace
+# Used to generate domain for a server in a workspace in case property `che.infra.kubernetes.server_strategy` is set to `multi-host`
 che.infra.kubernetes.ingress.domain=unspecified-ingress-domain
 
 # Defines Kubernetes namespace in which all workspaces will be created.

--- a/deploy/kubernetes/kubectl/che-kubernetes.yaml
+++ b/deploy/kubernetes/kubectl/che-kubernetes.yaml
@@ -70,6 +70,8 @@ items:
     CHE_WORKSPACE_AUTO_START: "false"
     CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"nginx.ingress.kubernetes.io/rewrite-target": "/","nginx.ingress.kubernetes.io/ssl-redirect": "false","nginx.ingress.kubernetes.io/proxy-connect-timeout": "3600","nginx.ingress.kubernetes.io/proxy-read-timeout": "3600"}'
     CHE_LOGS_APPENDERS_IMPL: "plaintext"
+    CHE_INFRA_KUBERNETES_INGRESS_DOMAIN: "192.168.99.101.nip.io"
+    CHE_INFRA_KUBERNETES_SERVER__STRATEGY: "default-host"
 - apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
@@ -257,6 +259,16 @@ items:
             valueFrom:
               configMapKeyRef:
                 key: CHE_LOGS_APPENDERS_IMPL
+                name: che
+          - name: CHE_INFRA_KUBERNETES_INGRESS_DOMAIN
+            valueFrom:
+              configMapKeyRef:
+                key: CHE_INFRA_KUBERNETES_INGRESS_DOMAIN
+                name: che
+          - name: CHE_INFRA_KUBERNETES_SERVER__STRATEGY
+            valueFrom:
+              configMapKeyRef:
+                key: CHE_INFRA_KUBERNETES_SERVER__STRATEGY
                 name: che
           image: eclipse/che-server:nightly
           imagePullPolicy: Always

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
@@ -41,7 +41,7 @@ public class KubernetesEnvironmentProvisioner {
   private final boolean pvcEnabled;
   private final WorkspaceVolumesStrategy volumesStrategy;
   private final UniqueNamesProvisioner<KubernetesEnvironment> uniqueNamesProvisioner;
-  private final ServersConverter serversConverter;
+  private final ServersConverter<KubernetesEnvironment> serversConverter;
   private final EnvVarsConverter envVarsConverter;
   private final RestartPolicyRewriter restartPolicyRewriter;
   private final RamLimitProvisioner ramLimitProvisioner;
@@ -55,7 +55,7 @@ public class KubernetesEnvironmentProvisioner {
   public KubernetesEnvironmentProvisioner(
       @Named("che.infra.kubernetes.pvc.enabled") boolean pvcEnabled,
       UniqueNamesProvisioner<KubernetesEnvironment> uniqueNamesProvisioner,
-      ServersConverter serversConverter,
+      ServersConverter<KubernetesEnvironment> serversConverter,
       EnvVarsConverter envVarsConverter,
       RestartPolicyRewriter restartPolicyRewriter,
       WorkspaceVolumesStrategy volumesStrategy,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -43,6 +43,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.Workspa
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesCheApiEnvVarProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.LogsRootEnvVariableProvider;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.ServersConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.DefaultHostIngressExternalServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.ExternalServerExposerStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.ExternalServerExposerStrategyProvider;
@@ -77,8 +78,11 @@ public class KubernetesInfraModule extends AbstractModule {
     volumesStrategies.addBinding(UNIQUE_STRATEGY).to(UniqueWorkspacePVCStrategy.class);
     bind(WorkspaceVolumesStrategy.class).toProvider(WorkspaceVolumeStrategyProvider.class);
 
-    MapBinder<String, ExternalServerExposerStrategy> ingressStrategies =
-        MapBinder.newMapBinder(binder(), String.class, ExternalServerExposerStrategy.class);
+    MapBinder<String, ExternalServerExposerStrategy<KubernetesEnvironment>> ingressStrategies =
+        MapBinder.newMapBinder(
+            binder(),
+            new TypeLiteral<String>() {},
+            new TypeLiteral<ExternalServerExposerStrategy<KubernetesEnvironment>>() {});
     ingressStrategies
         .addBinding(MULTI_HOST_STRATEGY)
         .to(MultiHostIngressExternalServerExposer.class);
@@ -88,8 +92,11 @@ public class KubernetesInfraModule extends AbstractModule {
     ingressStrategies
         .addBinding(DEFAULT_HOST_STRATEGY)
         .to(DefaultHostIngressExternalServerExposer.class);
-    bind(ExternalServerExposerStrategy.class)
-        .toProvider(ExternalServerExposerStrategyProvider.class);
+    bind(new TypeLiteral<ExternalServerExposerStrategy<KubernetesEnvironment>>() {})
+        .toProvider(
+            new TypeLiteral<ExternalServerExposerStrategyProvider<KubernetesEnvironment>>() {});
+
+    bind(ServersConverter.class).to(new TypeLiteral<ServersConverter<KubernetesEnvironment>>() {});
 
     Multibinder<EnvVarProvider> envVarProviders =
         Multibinder.newSetBinder(binder(), EnvVarProvider.class);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/ExternalServerExposerStrategyProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/ExternalServerExposerStrategyProvider.java
@@ -18,6 +18,7 @@ import javax.inject.Named;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import org.eclipse.che.inject.ConfigurationException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
 /**
  * Provides implementation of {@link ExternalServerExposerStrategy} for configured value.
@@ -25,16 +26,16 @@ import org.eclipse.che.inject.ConfigurationException;
  * @author Guy Daich
  */
 @Singleton
-public class ExternalServerExposerStrategyProvider
-    implements Provider<ExternalServerExposerStrategy> {
+public class ExternalServerExposerStrategyProvider<T extends KubernetesEnvironment>
+    implements Provider<ExternalServerExposerStrategy<T>> {
 
-  private final ExternalServerExposerStrategy externalServerExposerStrategy;
+  private final ExternalServerExposerStrategy<T> externalServerExposerStrategy;
 
   @Inject
   public ExternalServerExposerStrategyProvider(
       @Named("che.infra.kubernetes.server_strategy") String strategy,
-      Map<String, ExternalServerExposerStrategy> strategies) {
-    final ExternalServerExposerStrategy externalServerExposerStrategy = strategies.get(strategy);
+      Map<String, ExternalServerExposerStrategy<T>> strategies) {
+    final ExternalServerExposerStrategy<T> externalServerExposerStrategy = strategies.get(strategy);
     if (externalServerExposerStrategy != null) {
       this.externalServerExposerStrategy = externalServerExposerStrategy;
     } else {
@@ -44,7 +45,7 @@ public class ExternalServerExposerStrategyProvider
   }
 
   @Override
-  public ExternalServerExposerStrategy get() {
+  public ExternalServerExposerStrategy<T> get() {
     return externalServerExposerStrategy;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/ExternalServerExposerStrategyProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/ExternalServerExposerStrategyProvider.java
@@ -29,11 +29,13 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 public class ExternalServerExposerStrategyProvider<T extends KubernetesEnvironment>
     implements Provider<ExternalServerExposerStrategy<T>> {
 
+  public static final String STRATEGY_PROPERTY = "che.infra.kubernetes.server_strategy";
+
   private final ExternalServerExposerStrategy<T> externalServerExposerStrategy;
 
   @Inject
   public ExternalServerExposerStrategyProvider(
-      @Named("che.infra.kubernetes.server_strategy") String strategy,
+      @Named(STRATEGY_PROPERTY) String strategy,
       Map<String, ExternalServerExposerStrategy<T>> strategies) {
     final ExternalServerExposerStrategy<T> externalServerExposerStrategy = strategies.get(strategy);
     if (externalServerExposerStrategy != null) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/SingleHostIngressExternalServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/SingleHostIngressExternalServerExposer.java
@@ -18,7 +18,7 @@ import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 
 /**
- * Provides a path-based strategy for exposing service ports outside the cluster using Ingress
+ * Provides a path-based strategy for exposing service ports outside the cluster using Ingress.
  * Ingresses will be created with a common host name for all workspaces.
  *
  * <p>This strategy uses different Ingress path entries <br>

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/MultiHostIngressExternalServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/MultiHostIngressExternalServerExposerTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.KubernetesServerExposer.SERVER_PREFIX;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.MultiHostIngressExternalServerExposer.MULTI_HOST_STRATEGY;
 import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
@@ -60,7 +61,8 @@ public class MultiHostIngressExternalServerExposerTest {
 
     kubernetesEnvironment =
         KubernetesEnvironment.builder().setPods(ImmutableMap.of("pod", pod)).build();
-    externalServerExposer = new MultiHostIngressExternalServerExposer(emptyMap(), DOMAIN);
+    externalServerExposer =
+        new MultiHostIngressExternalServerExposer(emptyMap(), DOMAIN, MULTI_HOST_STRATEGY);
   }
 
   @Test

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -42,7 +42,7 @@ public class OpenShiftEnvironmentProvisioner {
   private final WorkspaceVolumesStrategy volumesStrategy;
   private final UniqueNamesProvisioner<OpenShiftEnvironment> uniqueNamesProvisioner;
   private final RouteTlsProvisioner routeTlsProvisioner;
-  private final ServersConverter serversConverter;
+  private final ServersConverter<OpenShiftEnvironment> serversConverter;
   private final EnvVarsConverter envVarsConverter;
   private final RestartPolicyRewriter restartPolicyRewriter;
   private final RamLimitProvisioner ramLimitProvisioner;
@@ -55,7 +55,7 @@ public class OpenShiftEnvironmentProvisioner {
       @Named("che.infra.kubernetes.pvc.enabled") boolean pvcEnabled,
       OpenShiftUniqueNamesProvisioner uniqueNamesProvisioner,
       RouteTlsProvisioner routeTlsProvisioner,
-      ServersConverter serversConverter,
+      ServersConverter<OpenShiftEnvironment> serversConverter,
       EnvVarsConverter envVarsConverter,
       RestartPolicyRewriter restartPolicyRewriter,
       WorkspaceVolumesStrategy volumesStrategy,


### PR DESCRIPTION
### What does this PR do?
Fix kubernetes infra after a merge of not checked PR.
Set correct bindings of generics, fix generics;
Add missing properties in che.properties and kubectl deployment.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
