### PR TITLE
Fix error of selenium tests when admin credentials is incorrect

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestAuthServiceClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestAuthServiceClient.java
@@ -12,7 +12,6 @@ package org.eclipse.che.selenium.core.client;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
-import org.eclipse.che.api.core.rest.DefaultHttpJsonRequestFactory;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,8 +26,7 @@ public class CheTestAuthServiceClient implements TestAuthServiceClient {
   private final HttpJsonRequestFactory requestFactory;
 
   @Inject
-  public CheTestAuthServiceClient(
-      String apiEndpoint, DefaultHttpJsonRequestFactory requestFactory) {
+  public CheTestAuthServiceClient(String apiEndpoint, HttpJsonRequestFactory requestFactory) {
     this.apiEndpoint = apiEndpoint;
     this.requestFactory = requestFactory;
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/KeycloakAdminConsoleClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/KeycloakAdminConsoleClient.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Singleton;
+import org.eclipse.che.selenium.core.provider.AdminTestUserProvider;
 import org.eclipse.che.selenium.core.provider.RemovableUserProvider;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
@@ -44,7 +45,7 @@ public class KeycloakAdminConsoleClient {
       Pattern.compile("^.*Created new user with id '(.*)'.*$", Pattern.DOTALL);
 
   // we need to inject AdminTestUser separately to avoid circular dependency error
-  @Inject private AdminTestUser adminTestUser;
+  @Inject private AdminTestUserProvider adminTestUserProvider;
 
   private final DockerUtil dockerUtil;
   private final TestUserFactory<DefaultTestUser> defaultTestUserFactory;
@@ -123,7 +124,7 @@ public class KeycloakAdminConsoleClient {
     String authPartOfCommand =
         format(
             "--no-config --server http://localhost:8080/auth --user %s --password %s --realm master",
-            adminTestUser.getName(), adminTestUser.getPassword());
+            adminTestUserProvider.get().getName(), adminTestUserProvider.get().getPassword());
 
     String createUserCommand =
         format(
@@ -210,8 +211,8 @@ public class KeycloakAdminConsoleClient {
             keycloakContainerId,
             userId,
             username,
-            adminTestUser.getName(),
-            adminTestUser.getPassword());
+            adminTestUserProvider.get().getName(),
+            adminTestUserProvider.get().getPassword());
 
     processAgent.execute(commandToDeleteUser);
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/user/MultiUserCheAdminTestUserProvider.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/user/MultiUserCheAdminTestUserProvider.java
@@ -31,28 +31,43 @@ public class MultiUserCheAdminTestUserProvider implements AdminTestUserProvider 
   private static final Logger LOG =
       LoggerFactory.getLogger(MultiUserCheDefaultTestUserProvider.class);
 
-  private final AdminTestUser adminTestUser;
+  private AdminTestUser adminTestUser;
+
+  @Inject private TestUserFactory<AdminTestUser> adminTestUserFactory;
+  @Inject private KeycloakAdminConsoleClient keycloakAdminConsoleClient;
 
   @Inject
-  public MultiUserCheAdminTestUserProvider(
-      TestUserFactory<AdminTestUser> adminTestUserFactory,
-      KeycloakAdminConsoleClient keycloakAdminConsoleClient,
-      @Named("che.admin.name") String name,
-      @Named("che.admin.email") String email,
-      @Named("che.admin.password") String password,
-      @Named("che.admin.offline_token") String offlineToken) {
-    if (email == null || email.trim().isEmpty() || password == null || password.trim().isEmpty()) {
-      throw new IllegalStateException("Admin test user credentials are unknown");
-    }
+  @Named("che.admin.name")
+  private String name;
 
-    adminTestUser = adminTestUserFactory.create(name, email, password, offlineToken, this);
-    keycloakAdminConsoleClient.setupAdmin(adminTestUser);
+  @Inject
+  @Named("che.admin.email")
+  private String email;
 
-    LOG.info("User name='{}', id='{}' is being used as admin", name, adminTestUser.getId());
-  }
+  @Inject
+  @Named("che.admin.password")
+  private String password;
+
+  @Inject
+  @Named("che.admin.offline_token")
+  private String offlineToken;
 
   @Override
   public AdminTestUser get() {
+    if (adminTestUser == null) {
+      if (email == null
+          || email.trim().isEmpty()
+          || password == null
+          || password.trim().isEmpty()) {
+        throw new IllegalStateException("Admin test user credentials are unknown");
+      }
+
+      adminTestUser = adminTestUserFactory.create(name, email, password, offlineToken, this);
+      keycloakAdminConsoleClient.setupAdmin(adminTestUser);
+
+      LOG.info("User name='{}', id='{}' is being used as admin", name, adminTestUser.getId());
+    }
+
     return adminTestUser;
   }
 


### PR DESCRIPTION
### What does this PR do?
It fixes code which injects admin test user so that it doesn't fail all tests execution at the initialization step in case of admin credentials is incorrect.

### What issues does this PR fix or reference?
#9454 