### PR TITLE
Added starting servers checkers after recovering only for RUNNING workspaces

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesRuntimeContext.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesRuntimeContext.java
@@ -81,10 +81,10 @@ public class KubernetesRuntimeContext<T extends KubernetesEnvironment> extends R
             namespaceFactory.create(workspaceId, runtimeState.getNamespace()),
             getEnvironment().getWarnings());
 
-    if (runtime.getStatus() != WorkspaceStatus.RUNNING
-        || runtime.getStatus() != WorkspaceStatus.STOPPED) {
+    if (runtime.getStatus() == WorkspaceStatus.RUNNING) {
       runtime.startServersCheckers();
     }
+
     return runtime;
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesMachinesCacheTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesMachinesCacheTest.java
@@ -205,6 +205,20 @@ public class KubernetesMachinesCacheTest {
     assertEquals(fetchedServer.getStatus(), ServerStatus.RUNNING);
   }
 
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp = "Server with name 'non-existing' was not found"
+  )
+  public void shouldThrowExceptionWhenServerWasNotFoundOnStatusUpdating() throws Exception {
+    // given
+    RuntimeId runtimeId = runtimeStates[0].getRuntimeId();
+    KubernetesMachineImpl machine = machines[0];
+
+    // when
+    machineCache.updateServerStatus(
+        runtimeId, machine.getName(), "non-existing", ServerStatus.RUNNING);
+  }
+
   @Test
   public void shouldUpdateMachineStatus() throws Exception {
     // given

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
@@ -74,10 +74,10 @@ public class OpenShiftRuntimeContext extends KubernetesRuntimeContext<OpenShiftE
             projectFactory.create(workspaceId, runtimeState.getNamespace()),
             getEnvironment().getWarnings());
 
-    if (runtime.getStatus() != WorkspaceStatus.RUNNING
-        || runtime.getStatus() != WorkspaceStatus.STOPPED) {
+    if (runtime.getStatus() == WorkspaceStatus.RUNNING) {
       runtime.startServersCheckers();
     }
+
     return runtime;
   }
 }


### PR DESCRIPTION
### What does this PR do?
Added starting servers checkers after recovering only for RUNNING workspaces.
Also, it contains separated commit with fixing Transactions and NPE issues in K8s runtimes caches.

### What issues does this PR fix or reference?
Partially fixes https://github.com/eclipse/che/issues/9453

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A