### PR TITLE
Fix injection of default user in selenium tests of SingleUser Che

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestAuthServiceClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestAuthServiceClient.java
@@ -12,6 +12,7 @@ package org.eclipse.che.selenium.core.client;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import org.eclipse.che.api.core.rest.DefaultHttpJsonRequestFactory;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,8 @@ public class CheTestAuthServiceClient implements TestAuthServiceClient {
   private final HttpJsonRequestFactory requestFactory;
 
   @Inject
-  public CheTestAuthServiceClient(String apiEndpoint, HttpJsonRequestFactory requestFactory) {
+  public CheTestAuthServiceClient(
+      String apiEndpoint, DefaultHttpJsonRequestFactory requestFactory) {
     this.apiEndpoint = apiEndpoint;
     this.requestFactory = requestFactory;
   }


### PR DESCRIPTION
### What does this PR do?
It fixes error of selenium tests execution on [Single User Eclipse Che](https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-ocp/218/consoleText):
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-failsafe-plugin:2.20.1:verify (default) on project che-selenium-test: There are test failures.
[ERROR] 
[ERROR] Please refer to /home/codenvy/workspace/che-integration-tests-master-ocp/selenium/che-selenium-test/target/failsafe-reports for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date]-jvmRun[N].dump, [date].dumpstream and [date]-jvmRun[N].dumpstream.
[ERROR] org.apache.maven.surefire.booter.SurefireBooterForkException: There was an error in the forked process
[ERROR] Unable to create injector, see the following errors:
[ERROR] 
[ERROR] 1) Tried proxying org.eclipse.che.selenium.core.user.DefaultTestUser to support a circular dependency, but it is not an interface.
[ERROR] at org.eclipse.che.selenium.core.user.SingleUserCheDefaultTestUserProvider.class(SingleUserCheDefaultTestUserProvider.java:26)
[ERROR] while locating org.eclipse.che.selenium.core.user.SingleUserCheDefaultTestUserProvider
[ERROR] while locating org.eclipse.che.selenium.core.provider.DefaultTestUserProvider
[ERROR] while locating org.eclipse.che.selenium.core.user.DefaultTestUser
[ERROR] for the 2nd parameter of org.eclipse.che.selenium.core.requestfactory.CheTestDefaultUserHttpJsonRequestFactory.<init>(CheTestDefaultUserHttpJsonRequestFactory.java:23)
[ERROR] while locating org.eclipse.che.selenium.core.requestfactory.CheTestDefaultUserHttpJsonRequestFactory
[ERROR] while locating org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactory
[ERROR] while locating org.eclipse.che.api.core.rest.HttpJsonRequestFactory
[ERROR] for the 2nd parameter of org.eclipse.che.selenium.core.client.CheTestAuthServiceClient.<init>(CheTestAuthServiceClient.java:29)
[ERROR] at org.eclipse.che.selenium.core.client.CheTestAuthServiceClient.class(CheTestAuthServiceClient.java:23)
[ERROR] while locating org.eclipse.che.selenium.core.client.CheTestAuthServiceClient
[ERROR] while locating org.eclipse.che.selenium.core.client.TestAuthServiceClient
[ERROR] for the 2nd parameter of org.eclipse.che.selenium.core.user.DefaultTestUser.<init>(DefaultTestUser.java:41)
[ERROR] while locating org.eclipse.che.selenium.core.user.DefaultTestUser annotated with @com.google.inject.internal.UniqueAnnotations$Internal(value=1)
[ERROR] at org.eclipse.che.selenium.core.user.SingleUserCheDefaultTestUserProvider.<init>(SingleUserCheDefaultTestUserProvider.java:34)
[ERROR] at org.eclipse.che.selenium.core.user.SingleUserCheDefaultTestUserProvider.class(SingleUserCheDefaultTestUserProvider.java:26)
[ERROR] while locating org.eclipse.che.selenium.core.user.SingleUserCheDefaultTestUserProvider
[ERROR] while locating org.eclipse.che.selenium.core.provider.DefaultTestUserProvider
[ERROR] while locating org.eclipse.che.selenium.core.user.DefaultTestUser
[ERROR] for the 4th parameter of org.eclipse.che.selenium.core.workspace.TestWorkspaceProviderImpl.<init>(TestWorkspaceProviderImpl.java:62)
[ERROR] at org.eclipse.che.selenium.core.workspace.TestWorkspaceProviderImpl.class(TestWorkspaceProviderImpl.java:41)
[ERROR] while locating org.eclipse.che.selenium.core.workspace.TestWorkspaceProviderImpl
[ERROR] at org.eclipse.che.selenium.core.CheSeleniumSuiteModule.configure(CheSeleniumSuiteModule.java:100)
[ERROR] while locating org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider
```

### What issues does this PR fix or reference?
#9277 