### PR TITLE
Fix bootstrapping fast failed when URL is invalid

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
@@ -150,7 +150,7 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
     exec(
         outputConsumer,
         "curl",
-        "-sSo",
+        "-fsSo",
         BOOTSTRAPPER_DIR + BOOTSTRAPPER_FILE,
         bootstrapperBinaryUrl);
     exec(outputConsumer, "chmod", "+x", BOOTSTRAPPER_DIR + BOOTSTRAPPER_FILE);


### PR DESCRIPTION
### What does this PR do?
Adds `-f` flag to `curl` while bootstrapping agents, so if HTTP error occurs on downloading binaries then workspace start will fail.