### PR TITLE
Rework organization-related tests to be executed in multi-thread mode

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestOrganizationServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestOrganizationServiceClient.java
@@ -14,8 +14,8 @@ import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
-import com.google.inject.Inject;
-import com.google.inject.Singleton;
+import com.google.inject.assistedinject.Assisted;
+import com.google.inject.assistedinject.AssistedInject;
 import java.util.List;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
@@ -23,22 +23,31 @@ import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.multiuser.api.permission.shared.dto.PermissionsDto;
 import org.eclipse.che.multiuser.organization.shared.dto.OrganizationDto;
 import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
+import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactoryCreator;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** This util is handling the requests to Organization API. */
-@Singleton
 public class TestOrganizationServiceClient {
   private static final Logger LOG = LoggerFactory.getLogger(TestOrganizationServiceClient.class);
 
   private final String apiEndpoint;
   private final HttpJsonRequestFactory requestFactory;
 
-  @Inject
   public TestOrganizationServiceClient(
       TestApiEndpointUrlProvider apiEndpointUrlProvider, HttpJsonRequestFactory requestFactory) {
     this.apiEndpoint = apiEndpointUrlProvider.get().toString();
     this.requestFactory = requestFactory;
+  }
+
+  @AssistedInject
+  public TestOrganizationServiceClient(
+      TestApiEndpointUrlProvider apiEndpointUrlProvider,
+      TestUserHttpJsonRequestFactoryCreator testUserHttpJsonRequestFactoryCreator,
+      @Assisted TestUser testUser) {
+    this.apiEndpoint = apiEndpointUrlProvider.get().toString();
+    this.requestFactory = testUserHttpJsonRequestFactoryCreator.create(testUser);
   }
 
   public List<OrganizationDto> getAll() throws Exception {

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestOrganizationServiceClientFactory.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestOrganizationServiceClientFactory.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.client;
+
+import com.google.inject.assistedinject.Assisted;
+import org.eclipse.che.selenium.core.user.TestUser;
+
+/** @author Dmytro Nochevnov */
+public interface TestOrganizationServiceClientFactory {
+  TestOrganizationServiceClient create(@Assisted TestUser testUser);
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumMultiUserModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumMultiUserModule.java
@@ -12,20 +12,18 @@ package org.eclipse.che.selenium.core;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Key;
-import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
-import com.google.inject.name.Named;
+import org.eclipse.che.selenium.core.client.CheTestDefaultOrganizationServiceClient;
 import org.eclipse.che.selenium.core.client.CheTestMachineServiceClient;
 import org.eclipse.che.selenium.core.client.KeycloakTestAuthServiceClient;
 import org.eclipse.che.selenium.core.client.TestAuthServiceClient;
 import org.eclipse.che.selenium.core.client.TestMachineServiceClient;
 import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.TestOrganizationServiceClientFactory;
 import org.eclipse.che.selenium.core.provider.AdminTestUserProvider;
 import org.eclipse.che.selenium.core.provider.DefaultTestUserProvider;
-import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
 import org.eclipse.che.selenium.core.provider.TestUserProvider;
-import org.eclipse.che.selenium.core.requestfactory.CheTestAdminHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
 import org.eclipse.che.selenium.core.user.MultiUserCheAdminTestUserProvider;
 import org.eclipse.che.selenium.core.user.MultiUserCheDefaultTestUserProvider;
@@ -50,6 +48,8 @@ public class CheSeleniumMultiUserModule extends AbstractModule {
     bind(AdminTestUser.class).toProvider(AdminTestUserProvider.class);
     bind(AdminTestUserProvider.class).to(MultiUserCheAdminTestUserProvider.class);
 
+    bind(TestOrganizationServiceClient.class).to(CheTestDefaultOrganizationServiceClient.class);
+
     install(
         new FactoryModuleBuilder()
             .build(Key.get(new TypeLiteral<TestUserFactory<AdminTestUser>>() {}.getType())));
@@ -57,13 +57,7 @@ public class CheSeleniumMultiUserModule extends AbstractModule {
     install(
         new FactoryModuleBuilder()
             .build(Key.get(new TypeLiteral<TestUserFactory<TestUserImpl>>() {}.getType())));
-  }
 
-  @Provides
-  @Named(CheSeleniumSuiteModule.ADMIN)
-  public TestOrganizationServiceClient getAdminOrganizationServiceClient(
-      TestApiEndpointUrlProvider apiEndpointUrlProvider,
-      CheTestAdminHttpJsonRequestFactory requestFactory) {
-    return new TestOrganizationServiceClient(apiEndpointUrlProvider, requestFactory);
+    install(new FactoryModuleBuilder().build(TestOrganizationServiceClientFactory.class));
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
@@ -46,7 +46,7 @@ import org.eclipse.che.selenium.core.provider.TestDashboardUrlProvider;
 import org.eclipse.che.selenium.core.provider.TestIdeUrlProvider;
 import org.eclipse.che.selenium.core.provider.TestOfflineToAccessTokenExchangeApiEndpointUrlProvider;
 import org.eclipse.che.selenium.core.provider.TestWorkspaceAgentApiEndpointUrlProvider;
-import org.eclipse.che.selenium.core.requestfactory.CheTestDefaultUserHttpJsonRequestFactory;
+import org.eclipse.che.selenium.core.requestfactory.CheTestDefaultHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactoryCreator;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
@@ -66,7 +66,6 @@ import org.eclipse.che.selenium.pageobject.PageObjectsInjectorImpl;
  */
 public class CheSeleniumSuiteModule extends AbstractModule {
 
-  public static final String ADMIN = "admin";
   public static final String AUXILIARY = "auxiliary";
   public static final String DOCKER_INFRASTRUCTURE = "docker";
   public static final String OPENSHIFT_INFRASTRUCTURE = "openshift";
@@ -87,7 +86,7 @@ public class CheSeleniumSuiteModule extends AbstractModule {
     bind(TestUserServiceClient.class).to(CheTestUserServiceClient.class);
 
     bind(HttpJsonRequestFactory.class).to(TestUserHttpJsonRequestFactory.class);
-    bind(TestUserHttpJsonRequestFactory.class).to(CheTestDefaultUserHttpJsonRequestFactory.class);
+    bind(TestUserHttpJsonRequestFactory.class).to(CheTestDefaultHttpJsonRequestFactory.class);
 
     bind(TestApiEndpointUrlProvider.class).to(CheTestApiEndpointUrlProvider.class);
     bind(TestIdeUrlProvider.class).to(CheTestIdeUrlProvider.class);

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestAdminOrganizationServiceClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestAdminOrganizationServiceClient.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.client;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
+import org.eclipse.che.selenium.core.requestfactory.CheTestAdminHttpJsonRequestFactory;
+
+/** This util is handling the requests to Organization API as admin. */
+@Singleton
+public class CheTestAdminOrganizationServiceClient extends TestOrganizationServiceClient {
+
+  @Inject
+  public CheTestAdminOrganizationServiceClient(
+      TestApiEndpointUrlProvider apiEndpointUrlProvider,
+      CheTestAdminHttpJsonRequestFactory adminRequestFactory) {
+    super(apiEndpointUrlProvider, adminRequestFactory);
+  }
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestDefaultOrganizationServiceClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/CheTestDefaultOrganizationServiceClient.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.client;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
+import org.eclipse.che.selenium.core.requestfactory.CheTestDefaultHttpJsonRequestFactory;
+
+/** This util is handling the requests to Organization API as default user. */
+@Singleton
+public class CheTestDefaultOrganizationServiceClient extends TestOrganizationServiceClient {
+
+  @Inject
+  public CheTestDefaultOrganizationServiceClient(
+      TestApiEndpointUrlProvider apiEndpointUrlProvider,
+      CheTestDefaultHttpJsonRequestFactory defaultRequestFactory) {
+    super(apiEndpointUrlProvider, defaultRequestFactory);
+  }
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/requestfactory/CheTestDefaultHttpJsonRequestFactory.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/requestfactory/CheTestDefaultHttpJsonRequestFactory.java
@@ -11,14 +11,16 @@
 package org.eclipse.che.selenium.core.requestfactory;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.client.TestAuthServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 
 /** @author Anton Korneta */
-public class CheTestDefaultUserHttpJsonRequestFactory extends TestUserHttpJsonRequestFactory {
+@Singleton
+public class CheTestDefaultHttpJsonRequestFactory extends TestUserHttpJsonRequestFactory {
 
   @Inject
-  public CheTestDefaultUserHttpJsonRequestFactory(
+  public CheTestDefaultHttpJsonRequestFactory(
       TestAuthServiceClient authServiceClient, DefaultTestUser defaultTestUser) {
     super(authServiceClient, defaultTestUser);
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
@@ -40,15 +40,12 @@ import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
 import org.openqa.selenium.support.ui.Wait;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** @author Andrey Chizhikov */
 @Singleton
 public class Swagger {
 
   private final SeleniumWebDriver seleniumWebDriver;
-  private static final Logger LOG = LoggerFactory.getLogger(SeleniumWebDriver.class);
 
   @Inject
   public Swagger(SeleniumWebDriver seleniumWebDriver) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -13,6 +13,7 @@ package org.eclipse.che.selenium.pageobject.dashboard;
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
@@ -197,7 +198,8 @@ public class NewWorkspace {
   }
 
   public void waitToolbar() {
-    new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC)
+    // we need increased timeout here to prevent error on Eclipse Che on OCP
+    new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC)
         .until(visibilityOfElementLocated(By.id(Locators.TOOLBAR_TITLE_ID)));
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/account/Account.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/account/Account.java
@@ -67,6 +67,11 @@ public class Account {
   }
 
   @Override
+  public int hashCode() {
+    return Objects.hash(login, email, firstName, lastName);
+  }
+
+  @Override
   public String toString() {
     return format(
         "%s{login=%s, email=%s, firstName=%s, lastName=%s}",

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
@@ -20,8 +20,7 @@ import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
-import org.eclipse.che.selenium.core.user.AdminTestUser;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.CheMultiuserAdminDashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
@@ -63,11 +62,11 @@ public class AddWorkspaceToOrganizationTest {
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;
 
-  @Inject private AdminTestUser adminTestUser;
+  @Inject private TestUser adminTestUser;
 
   @Inject private NewWorkspace newWorkspace;
   @Inject private Workspaces workspaces;
-  @Inject private DefaultTestUser testUser;
+  @Inject private TestUser testUser;
 
   @BeforeClass
   public void setUp() throws Exception {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
@@ -61,11 +61,10 @@ public class AddWorkspaceToOrganizationTest {
   @Inject private WorkspaceDetails workspaceDetails;
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;
-
-  @Inject private TestUser adminTestUser;
-
   @Inject private NewWorkspace newWorkspace;
   @Inject private Workspaces workspaces;
+
+  @Inject private TestUser adminTestUser;
   @Inject private TestUser testUser;
 
   @BeforeClass

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfParentOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfParentOrganizationTest.java
@@ -49,7 +49,6 @@ public class AdminOfParentOrganizationTest {
   private TestOrganizationServiceClient userTestOrganizationServiceClient;
 
   @Inject private TestOrganizationServiceClientFactory userOrganizationServiceClientFactory;
-
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfParentOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfParentOrganizationTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.selenium.dashboard.organization;
 
-import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.ADMIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 import static org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage.OrganizationListHeader.ACTIONS;
 import static org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage.OrganizationListHeader.AVAILABLE_RAM;
@@ -23,13 +22,15 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import java.util.ArrayList;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.TestOrganizationServiceClientFactory;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
+import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactoryCreator;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.CheMultiuserAdminDashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage;
@@ -45,18 +46,17 @@ import org.testng.annotations.Test;
 @Test(groups = {TestGroup.MULTIUSER})
 public class AdminOfParentOrganizationTest {
   private int initialOrgCount;
+  private TestOrganizationServiceClient userTestOrganizationServiceClient;
 
-  @Inject
-  @Named(ADMIN)
-  private TestOrganizationServiceClient adminTestOrganizationServiceClient;
-
-  @Inject private TestOrganizationServiceClient userTestOrganizationServiceClient;
+  @Inject private TestOrganizationServiceClientFactory userOrganizationServiceClientFactory;
 
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;
   @Inject private CheMultiuserAdminDashboard dashboard;
-  @Inject private DefaultTestUser testUser;
+  @Inject private TestUser testUser;
+  @Inject private TestApiEndpointUrlProvider apiEndpointUrlProvider;
+  @Inject private TestUserHttpJsonRequestFactoryCreator testUserHttpJsonRequestFactoryCreator;
 
   @InjectTestOrganization(prefix = "parentOrg")
   private TestOrganization parentOrg;
@@ -66,6 +66,8 @@ public class AdminOfParentOrganizationTest {
 
   @BeforeClass
   public void setUp() throws Exception {
+    userTestOrganizationServiceClient = userOrganizationServiceClientFactory.create(testUser);
+
     parentOrg.addAdmin(testUser.getId());
     childOrg.addMember(testUser.getId());
     initialOrgCount = userTestOrganizationServiceClient.getAll().size();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfSubOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfSubOrganizationTest.java
@@ -25,9 +25,10 @@ import com.google.inject.Inject;
 import java.util.ArrayList;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.TestOrganizationServiceClientFactory;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.CheMultiuserAdminDashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage;
@@ -43,6 +44,7 @@ import org.testng.annotations.Test;
 @Test(groups = {TestGroup.MULTIUSER})
 public class AdminOfSubOrganizationTest {
   private int initialOrgNumber;
+  private TestOrganizationServiceClient testOrganizationServiceClient;
 
   @InjectTestOrganization(prefix = "parentOrg")
   private TestOrganization parentOrg;
@@ -50,19 +52,20 @@ public class AdminOfSubOrganizationTest {
   @InjectTestOrganization(parentPrefix = "parentOrg")
   private TestOrganization childOrg;
 
-  @Inject private TestOrganizationServiceClient userTestOrganizationServiceClient;
-
+  @Inject private TestOrganizationServiceClientFactory testOrganizationServiceClientFactory;
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;
   @Inject private CheMultiuserAdminDashboard dashboard;
-  @Inject private DefaultTestUser testUser;
+  @Inject private TestUser testUser;
 
   @BeforeClass
   public void setUp() throws Exception {
+    testOrganizationServiceClient = testOrganizationServiceClientFactory.create(testUser);
+
     parentOrg.addMember(testUser.getId());
     childOrg.addAdmin(testUser.getId());
-    initialOrgNumber = userTestOrganizationServiceClient.getAll().size();
+    initialOrgNumber = testOrganizationServiceClient.getAll().size();
 
     dashboard.open(testUser.getName(), testUser.getPassword());
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/CreateOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/CreateOrganizationTest.java
@@ -11,16 +11,14 @@
 package org.eclipse.che.selenium.dashboard.organization;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.ADMIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 import static org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage.OrganizationListHeader.NAME;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
@@ -43,9 +41,7 @@ public class CreateOrganizationTest {
 
   private int initialOrgNumber;
 
-  @Inject
-  @Named(ADMIN)
-  private TestOrganizationServiceClient testOrganizationServiceClient;
+  @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
 
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
@@ -58,14 +54,14 @@ public class CreateOrganizationTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    initialOrgNumber = testOrganizationServiceClient.getAllRoot().size();
+    initialOrgNumber = adminOrganizationServiceClient.getAllRoot().size();
     dashboard.open(adminTestUser.getName(), adminTestUser.getPassword());
   }
 
   @AfterClass
   public void tearDown() throws Exception {
-    testOrganizationServiceClient.deleteByName(CHILD_ORG_NAME);
-    testOrganizationServiceClient.deleteByName(PARENT_ORG_NAME);
+    adminOrganizationServiceClient.deleteByName(CHILD_ORG_NAME);
+    adminOrganizationServiceClient.deleteByName(PARENT_ORG_NAME);
   }
 
   public void testCreateOrganization() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/CreateRootOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/CreateRootOrganizationTest.java
@@ -35,21 +35,18 @@ import org.testng.annotations.Test;
  * @author Ann Shumilova
  */
 @Test(groups = {TestGroup.MULTIUSER})
-public class CreateOrganizationTest {
+public class CreateRootOrganizationTest {
   private static final String PARENT_ORG_NAME = generate("parent-", 4);
   private static final String CHILD_ORG_NAME = generate("child-", 4);
 
   private int initialOrgNumber;
 
   @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
-
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private AddOrganization addOrganization;
   @Inject private NavigationBar navigationBar;
-
   @Inject private AdminTestUser adminTestUser;
-
   @Inject private Dashboard dashboard;
 
   @BeforeClass

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationByBulkTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationByBulkTest.java
@@ -44,11 +44,8 @@ public class DeleteOrganizationByBulkTest {
   @InjectTestOrganization private TestOrganization org2;
 
   @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
-
   @Inject private OrganizationListPage organizationListPage;
-
   @Inject private AdminTestUser adminTestUser;
-
   @Inject private NavigationBar navigationBar;
   @Inject private ConfirmDialog confirmDialog;
   @Inject private Dashboard dashboard;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationByBulkTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationByBulkTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.selenium.dashboard.organization;
 
-import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.ADMIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 import static org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage.OrganizationListHeader.NAME;
 import static org.testng.Assert.assertEquals;
@@ -18,9 +17,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
@@ -45,9 +43,7 @@ public class DeleteOrganizationByBulkTest {
   @InjectTestOrganization private TestOrganization org1;
   @InjectTestOrganization private TestOrganization org2;
 
-  @Inject
-  @Named(ADMIN)
-  private TestOrganizationServiceClient testOrganizationServiceClient;
+  @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
 
   @Inject private OrganizationListPage organizationListPage;
 
@@ -59,7 +55,7 @@ public class DeleteOrganizationByBulkTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    initialOrgNumber = testOrganizationServiceClient.getAllRoot().size();
+    initialOrgNumber = adminOrganizationServiceClient.getAllRoot().size();
     dashboard.open(adminTestUser.getName(), adminTestUser.getPassword());
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationInListTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationInListTest.java
@@ -44,13 +44,10 @@ public class DeleteOrganizationInListTest {
   @InjectTestOrganization private TestOrganization org4;
 
   @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
-
   @Inject private OrganizationListPage organizationListPage;
   @Inject private NavigationBar navigationBar;
   @Inject private ConfirmDialog confirmDialog;
-
   @Inject private AdminTestUser adminTestUser;
-
   @Inject private Dashboard dashboard;
 
   @BeforeClass

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationInListTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationInListTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.selenium.dashboard.organization;
 
-import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.ADMIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 import static org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage.OrganizationListHeader.NAME;
 import static org.testng.Assert.assertEquals;
@@ -18,9 +17,8 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
@@ -45,9 +43,7 @@ public class DeleteOrganizationInListTest {
   @InjectTestOrganization private TestOrganization org3;
   @InjectTestOrganization private TestOrganization org4;
 
-  @Inject
-  @Named(ADMIN)
-  private TestOrganizationServiceClient testOrganizationServiceClient;
+  @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
 
   @Inject private OrganizationListPage organizationListPage;
   @Inject private NavigationBar navigationBar;
@@ -59,7 +55,7 @@ public class DeleteOrganizationInListTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    initialOrgNumber = testOrganizationServiceClient.getAllRoot().size();
+    initialOrgNumber = adminOrganizationServiceClient.getAllRoot().size();
     dashboard.open(adminTestUser.getName(), adminTestUser.getPassword());
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationTest.java
@@ -10,14 +10,14 @@
  */
 package org.eclipse.che.selenium.dashboard.organization;
 
-import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.ADMIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 import static org.testng.Assert.assertEquals;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.eclipse.che.selenium.core.TestGroup;
+import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
 import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.TestOrganizationServiceClientFactory;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
@@ -37,6 +37,7 @@ import org.testng.annotations.Test;
 @Test(groups = {TestGroup.MULTIUSER})
 public class DeleteOrganizationTest {
   private int initialOrgNumber;
+  private TestOrganizationServiceClient testOrganizationServiceClient;
 
   @InjectTestOrganization(prefix = "parentOrg")
   private TestOrganization parentOrg;
@@ -44,11 +45,9 @@ public class DeleteOrganizationTest {
   @InjectTestOrganization(parentPrefix = "parentOrg")
   private TestOrganization childOrg;
 
-  @Inject
-  @Named(ADMIN)
-  private TestOrganizationServiceClient adminTestOrganizationServiceClient;
+  @Inject private CheTestAdminOrganizationServiceClient adminTestOrganizationServiceClient;
 
-  @Inject private TestOrganizationServiceClient userTestOrganizationServiceClient;
+  @Inject private TestOrganizationServiceClientFactory testOrganizationServiceClientFactory;
 
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
@@ -59,9 +58,11 @@ public class DeleteOrganizationTest {
 
   @BeforeClass
   public void setUp() throws Exception {
+    testOrganizationServiceClient = testOrganizationServiceClientFactory.create(testUser);
+
     parentOrg.addAdmin(testUser.getId());
     childOrg.addAdmin(testUser.getId());
-    initialOrgNumber = userTestOrganizationServiceClient.getAll().size();
+    initialOrgNumber = testOrganizationServiceClient.getAll().size();
 
     dashboard.open(testUser.getName(), testUser.getPassword());
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationTest.java
@@ -15,7 +15,6 @@ import static org.testng.Assert.assertEquals;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
 import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
 import org.eclipse.che.selenium.core.client.TestOrganizationServiceClientFactory;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
@@ -45,10 +44,7 @@ public class DeleteOrganizationTest {
   @InjectTestOrganization(parentPrefix = "parentOrg")
   private TestOrganization childOrg;
 
-  @Inject private CheTestAdminOrganizationServiceClient adminTestOrganizationServiceClient;
-
   @Inject private TestOrganizationServiceClientFactory testOrganizationServiceClientFactory;
-
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/FilterOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/FilterOrganizationTest.java
@@ -18,10 +18,11 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.TestOrganizationServiceClientFactory;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
-import org.eclipse.che.selenium.core.user.AdminTestUser;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.organization.AddOrganization;
@@ -40,24 +41,28 @@ public class FilterOrganizationTest {
   private static final String WRONG_ORG_NAME = generate("wrong-org-", 7);
 
   private int initialOrgNumber;
+  private TestOrganizationServiceClient organizationServiceClient;
 
   @InjectTestOrganization private TestOrganization organization;
 
-  @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
+  @Inject private TestOrganizationServiceClientFactory organizationServiceClientFactory;
 
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private AddOrganization addOrganization;
   @Inject private NavigationBar navigationBar;
 
-  @Inject private AdminTestUser adminTestUser;
+  @Inject private TestUser testUser;
 
   @Inject private Dashboard dashboard;
 
   @BeforeClass
   public void setUp() throws Exception {
-    initialOrgNumber = adminOrganizationServiceClient.getAllRoot().size();
-    dashboard.open(adminTestUser.getName(), adminTestUser.getPassword());
+    organizationServiceClient = organizationServiceClientFactory.create(testUser);
+
+    organization.addMember(testUser.getId());
+    initialOrgNumber = organizationServiceClient.getAll().size();
+    dashboard.open(testUser.getName(), testUser.getPassword());
   }
 
   public void testOrganizationListFiler() {
@@ -68,7 +73,9 @@ public class FilterOrganizationTest {
     organizationListPage.waitForOrganizationsList();
     assertEquals(navigationBar.getMenuCounterValue(ORGANIZATIONS), initialOrgNumber);
     assertEquals(organizationListPage.getOrganizationListItemCount(), initialOrgNumber);
-    assertTrue(organizationListPage.getValues(NAME).contains(organization.getName()));
+    assertTrue(
+        organizationListPage.getValues(NAME).contains(organization.getName()),
+        "Organization list consisted of " + organizationListPage.getValues(NAME));
 
     // Tests filter the organization by full organization name
     organizationListPage.typeInSearchInput(organization.getName());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/FilterOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/FilterOrganizationTest.java
@@ -11,16 +11,14 @@
 package org.eclipse.che.selenium.dashboard.organization;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.ADMIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 import static org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage.OrganizationListHeader.NAME;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
@@ -45,9 +43,7 @@ public class FilterOrganizationTest {
 
   @InjectTestOrganization private TestOrganization organization;
 
-  @Inject
-  @Named(ADMIN)
-  private TestOrganizationServiceClient testOrganizationServiceClient;
+  @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
 
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
@@ -60,7 +56,7 @@ public class FilterOrganizationTest {
 
   @BeforeClass
   public void setUp() throws Exception {
-    initialOrgNumber = testOrganizationServiceClient.getAllRoot().size();
+    initialOrgNumber = adminOrganizationServiceClient.getAllRoot().size();
     dashboard.open(adminTestUser.getName(), adminTestUser.getPassword());
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/MemberOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/MemberOrganizationTest.java
@@ -25,9 +25,10 @@ import com.google.inject.Inject;
 import java.util.ArrayList;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.TestOrganizationServiceClientFactory;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage;
@@ -43,6 +44,7 @@ import org.testng.annotations.Test;
 @Test(groups = {TestGroup.MULTIUSER})
 public class MemberOrganizationTest {
   private int initialOrgNumber;
+  private TestOrganizationServiceClient testOrganizationServiceClient;
 
   @InjectTestOrganization(prefix = "parentOrg")
   private TestOrganization parentOrg;
@@ -50,16 +52,17 @@ public class MemberOrganizationTest {
   @InjectTestOrganization(parentPrefix = "parentOrg")
   private TestOrganization childOrg;
 
-  @Inject private TestOrganizationServiceClient testOrganizationServiceClient;
-
+  @Inject private TestOrganizationServiceClientFactory testOrganizationServiceClientFactory;
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;
   @Inject private Dashboard dashboard;
-  @Inject private DefaultTestUser testUser;
+  @Inject private TestUser testUser;
 
   @BeforeClass
   public void setUp() throws Exception {
+    testOrganizationServiceClient = testOrganizationServiceClientFactory.create(testUser);
+
     parentOrg.addMember(testUser.getId());
     childOrg.addMember(testUser.getId());
     initialOrgNumber = testOrganizationServiceClient.getAll().size();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/OrganizationMembersTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/OrganizationMembersTest.java
@@ -39,7 +39,6 @@ public class OrganizationMembersTest {
   @InjectTestOrganization private TestOrganization organization;
 
   @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
-
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;
@@ -48,7 +47,6 @@ public class OrganizationMembersTest {
   @Inject private Loader loader;
   @Inject private Dashboard dashboard;
   @Inject private TestUser testUser;
-
   @Inject private AdminTestUser adminTestUser;
 
   @BeforeClass

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/OrganizationMembersTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/OrganizationMembersTest.java
@@ -11,17 +11,15 @@
 package org.eclipse.che.selenium.dashboard.organization;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.ADMIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
@@ -40,9 +38,7 @@ public class OrganizationMembersTest {
 
   @InjectTestOrganization private TestOrganization organization;
 
-  @Inject
-  @Named(ADMIN)
-  private TestOrganizationServiceClient testOrganizationServiceClient;
+  @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
 
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
@@ -51,7 +47,7 @@ public class OrganizationMembersTest {
   @Inject private AddMember addMember;
   @Inject private Loader loader;
   @Inject private Dashboard dashboard;
-  @Inject private DefaultTestUser testUser;
+  @Inject private TestUser testUser;
 
   @Inject private AdminTestUser adminTestUser;
 
@@ -63,7 +59,7 @@ public class OrganizationMembersTest {
 
   @AfterClass
   public void tearDown() throws Exception {
-    testOrganizationServiceClient.deleteByName(NEW_ORG_NAME);
+    adminOrganizationServiceClient.deleteByName(NEW_ORG_NAME);
   }
 
   public void testOperationsWithMembersInExistsOrganization() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/RenameOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/RenameOrganizationTest.java
@@ -21,8 +21,7 @@ import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
-import org.eclipse.che.selenium.core.user.AdminTestUser;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.EditMode;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
@@ -58,9 +57,7 @@ public class RenameOrganizationTest {
   @Inject private NavigationBar navigationBar;
   @Inject private EditMode editMode;
   @Inject private Dashboard dashboard;
-  @Inject private DefaultTestUser testUser;
-
-  @Inject private AdminTestUser adminTestUser;
+  @Inject private TestUser testUser;
 
   @BeforeClass
   public void setUp() throws Exception {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/ShareWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/ShareWorkspaceTest.java
@@ -22,7 +22,7 @@ import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.CheMultiuserAdminDashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
@@ -55,7 +55,7 @@ public class ShareWorkspaceTest {
 
   @Inject private NewWorkspace newWorkspace;
   @Inject private Workspaces workspaces;
-  @Inject private DefaultTestUser testUser;
+  @Inject private TestUser testUser;
   @Inject private WorkspaceShare workspaceShare;
 
   @BeforeClass

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/SystemAdminOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/SystemAdminOrganizationTest.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.che.selenium.dashboard.organization;
 
-import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.ADMIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuItem.ORGANIZATIONS;
 import static org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage.OrganizationListHeader.ACTIONS;
 import static org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage.OrganizationListHeader.AVAILABLE_RAM;
@@ -23,10 +22,9 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import java.util.ArrayList;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.CheTestAdminOrganizationServiceClient;
 import org.eclipse.che.selenium.core.organization.InjectTestOrganization;
 import org.eclipse.che.selenium.core.organization.TestOrganization;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
@@ -52,21 +50,18 @@ public class SystemAdminOrganizationTest {
   @InjectTestOrganization(parentPrefix = "parentOrg")
   private TestOrganization childOrg;
 
-  @Inject
-  @Named(ADMIN)
-  private TestOrganizationServiceClient testOrganizationServiceClient;
+  @Inject private CheTestAdminOrganizationServiceClient adminOrganizationServiceClient;
 
   @Inject private OrganizationListPage organizationListPage;
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;
   @Inject private CheMultiuserAdminDashboard dashboard;
-
   @Inject private AdminTestUser adminTestUser;
 
   @BeforeClass
   public void setUp() throws Exception {
     parentOrg.addAdmin(adminTestUser.getId());
-    initialRootOrgNumber = testOrganizationServiceClient.getAllRoot().size();
+    initialRootOrgNumber = adminOrganizationServiceClient.getAllRoot().size();
 
     dashboard.open(adminTestUser.getName(), adminTestUser.getPassword());
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/SystemAdminOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/SystemAdminOrganizationTest.java
@@ -56,14 +56,14 @@ public class SystemAdminOrganizationTest {
   @Inject private OrganizationPage organizationPage;
   @Inject private NavigationBar navigationBar;
   @Inject private CheMultiuserAdminDashboard dashboard;
-  @Inject private AdminTestUser adminTestUser;
+  @Inject private AdminTestUser systemAdmin;
 
   @BeforeClass
   public void setUp() throws Exception {
-    parentOrg.addAdmin(adminTestUser.getId());
+    parentOrg.addAdmin(systemAdmin.getId());
     initialRootOrgNumber = adminOrganizationServiceClient.getAllRoot().size();
 
-    dashboard.open(adminTestUser.getName(), adminTestUser.getPassword());
+    dashboard.open(systemAdmin.getName(), systemAdmin.getPassword());
   }
 
   public void testOrganizationListComponents() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/UserEmptyOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/UserEmptyOrganizationTest.java
@@ -36,12 +36,12 @@ public class UserEmptyOrganizationTest {
   @Inject private NavigationBar navigationBar;
   @Inject private Dashboard dashboard;
 
-  @Inject private TestOrganizationServiceClient testOrganizationServiceClient;
+  @Inject private TestOrganizationServiceClient defaultUserOrganizationServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
     assertTrue(
-        testOrganizationServiceClient.getAll().isEmpty(),
+        defaultUserOrganizationServiceClient.getAll().isEmpty(),
         "This test requires empty organization list inside the default user account.");
     dashboard.open();
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/UserEmptyOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/UserEmptyOrganizationTest.java
@@ -18,6 +18,8 @@ import static org.testng.Assert.assertTrue;
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestOrganizationServiceClient;
+import org.eclipse.che.selenium.core.client.TestOrganizationServiceClientFactory;
+import org.eclipse.che.selenium.core.user.TestUser;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationListPage;
@@ -32,18 +34,24 @@ import org.testng.annotations.Test;
 @Test(groups = {TestGroup.MULTIUSER})
 public class UserEmptyOrganizationTest {
 
+  private TestOrganizationServiceClient organizationServiceClient;
+
   @Inject private OrganizationListPage organizationListPage;
   @Inject private NavigationBar navigationBar;
   @Inject private Dashboard dashboard;
 
-  @Inject private TestOrganizationServiceClient defaultUserOrganizationServiceClient;
+  @Inject private TestOrganizationServiceClientFactory organizationServiceClientFactory;
+
+  @Inject TestUser testUser;
 
   @BeforeClass
   public void setUp() throws Exception {
+    organizationServiceClient = organizationServiceClientFactory.create(testUser);
+
     assertTrue(
-        defaultUserOrganizationServiceClient.getAll().isEmpty(),
+        organizationServiceClient.getAll().isEmpty(),
         "This test requires empty organization list inside the default user account.");
-    dashboard.open();
+    dashboard.open(testUser.getName(), testUser.getPassword());
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -43,20 +43,10 @@
             </method-selector>
         </method-selectors>
         <classes>
-            <class name="org.eclipse.che.selenium.dashboard.organization.UserEmptyOrganizationTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfParentOrganizationTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfSubOrganizationTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.CreateOrganizationTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.CreateRootOrganizationTest"/>
             <class name="org.eclipse.che.selenium.dashboard.organization.DeleteOrganizationByBulkTest"/>
             <class name="org.eclipse.che.selenium.dashboard.organization.DeleteOrganizationInListTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.DeleteOrganizationTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.FilterOrganizationTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.MemberOrganizationTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.OrganizationMembersTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.RenameOrganizationTest"/>
             <class name="org.eclipse.che.selenium.dashboard.organization.SystemAdminOrganizationTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.AddWorkspaceToOrganizationTest"/>
-            <class name="org.eclipse.che.selenium.dashboard.organization.ShareWorkspaceTest"/>
             <class name="org.eclipse.che.selenium.git.AuthorizeOnGithubFromDashboardTest"/>
             <class name="org.eclipse.che.selenium.git.AuthorizeOnGithubFromPreferencesTest"/>
             <class name="org.eclipse.che.selenium.git.CheckoutToRemoteBranchTest"/>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -60,6 +60,16 @@
           <class name="org.eclipse.che.selenium.dashboard.WorkspacesListTest"/>
           <class name="org.eclipse.che.selenium.dashboard.CreateFactoryTest"/>
           <class name="org.eclipse.che.selenium.dashboard.FactoriesListTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.UserEmptyOrganizationTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfParentOrganizationTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfSubOrganizationTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.DeleteOrganizationTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.FilterOrganizationTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.MemberOrganizationTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.OrganizationMembersTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.RenameOrganizationTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.AddWorkspaceToOrganizationTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.organization.ShareWorkspaceTest"/>
           <class name="org.eclipse.che.selenium.debugger.ChangeVariableWithEvaluatingTest"/>
           <class name="org.eclipse.che.selenium.debugger.CheckBreakPointStateTest"/>
           <class name="org.eclipse.che.selenium.debugger.CppProjectDebuggingTest"/>


### PR DESCRIPTION
### What does this PR do?
It fixes next organization selenium tests to be able to be executed in multi-thread mode:
- UserEmptyOrganizationTest
- AdminOfParentOrganizationTest
- AdminOfSubOrganizationTest
- DeleteOrganizationTest
- FilterOrganizationTest
- MemberOrganizationTest
- OrganizationMembersTest
- RenameOrganizationTest
- AddWorkspaceToOrganizationTest
- ShareWorkspaceTest

### What issues does this PR fix or reference?
#9019 