### PR TITLE
Add processing of runtime exceptions during JWT tokens validation

### DIFF
--- a/multiuser/api/che-multiuser-api-remote-subscription/src/main/java/org/eclipse/che/multiuser/api/subscription/DistributedRemoteSubscriptionStorage.java
+++ b/multiuser/api/che-multiuser-api-remote-subscription/src/main/java/org/eclipse/che/multiuser/api/subscription/DistributedRemoteSubscriptionStorage.java
@@ -81,8 +81,7 @@ public class DistributedRemoteSubscriptionStorage implements RemoteSubscriptionS
     Lock lock = lockService.getLock(method);
     lock.lock();
     try {
-      Set<RemoteSubscriptionContext> existing =
-          subscriptions.get(method);
+      Set<RemoteSubscriptionContext> existing = subscriptions.get(method);
       if (existing == null) {
         return;
       }


### PR DESCRIPTION
### What does this PR do?
Adds processing of runtime exceptions during JWT tokens validation.
It solves the following issues:
- setting correct 403 response code instead of 500;
- added response message to notify a client about error reason;
- don't log an error in case of invalid JWT token.

### What issues does this PR fix or reference?
- 

#### Release Notes
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
