### PR TITLE
Fixed removal of remote subscriptions in manager

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionManager.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionManager.java
@@ -13,7 +13,6 @@ package org.eclipse.che.api.core.notification;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.BiPredicate;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
@@ -73,11 +72,7 @@ public class RemoteSubscriptionManager {
 
   private void consumeUnSubscriptionRequest(
       String endpointId, EventSubscription eventSubscription) {
-    remoteSubscriptionStorage
-        .getByMethod(eventSubscription.getMethod())
-        .removeIf(
-            remoteSubscriptionContext ->
-                Objects.equals(remoteSubscriptionContext.getEndpointId(), endpointId));
+    remoteSubscriptionStorage.removeSubscription(eventSubscription.getMethod(), endpointId);
   }
 
   private <T> void transmit(String endpointId, String method, T event) {

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionStorage.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionStorage.java
@@ -20,7 +20,9 @@ import java.util.Set;
 public interface RemoteSubscriptionStorage {
 
   /**
-   * Returns all active subscriptions for the given method
+   * Returns all active subscriptions for the given method. It is recommended to use for read-only
+   * operations because it is not guaranteed that all storage implementations will reflect changes
+   * of this set.
    *
    * @param method Method name
    * @return active subscriptions to this method

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionStorage.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionStorage.java
@@ -20,9 +20,8 @@ import java.util.Set;
 public interface RemoteSubscriptionStorage {
 
   /**
-   * Returns all active subscriptions for the given method. It is recommended to use for read-only
-   * operations because it is not guaranteed that all storage implementations will reflect changes
-   * of this set.
+   * Returns all active subscriptions for the given method. It is recommended for implementations to
+   * return copy of the stored set, so this method should not be used for modifying operations.
    *
    * @param method Method name
    * @return active subscriptions to this method

--- a/multiuser/api/che-multiuser-api-remote-subscription/src/main/java/org/eclipse/che/multiuser/api/subscription/DistributedRemoteSubscriptionStorage.java
+++ b/multiuser/api/che-multiuser-api-remote-subscription/src/main/java/org/eclipse/che/multiuser/api/subscription/DistributedRemoteSubscriptionStorage.java
@@ -82,11 +82,18 @@ public class DistributedRemoteSubscriptionStorage implements RemoteSubscriptionS
     lock.lock();
     try {
       Set<RemoteSubscriptionContext> existing =
-          subscriptions.getOrDefault(method, Collections.emptySet());
+          subscriptions.get(method);
+      if (existing == null) {
+        return;
+      }
       existing.removeIf(
           remoteSubscriptionContext ->
               Objects.equals(remoteSubscriptionContext.getEndpointId(), endpointId));
-      subscriptions.put(method, existing);
+      if (existing.isEmpty()) {
+        subscriptions.remove(method);
+      } else {
+        subscriptions.put(method, existing);
+      }
     } finally {
       lock.unlock();
     }


### PR DESCRIPTION
### What does this PR do?
- Fixes removal of remote subscriptions in manager. It should be done via removeSubscription() method since storage may not reflect changes in undelying set;
- Fixes remote storage to prevent unmodifiable set to be stored;




#### Docs PR
N/A