### PR TITLE
Add missing maven-server binaries for Che-in-Che deployment

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
+++ b/assembly/assembly-wsmaster-war/src/main/resources/che-in-che.json
@@ -92,7 +92,7 @@
           }
         },
         {
-          "commandLine": "cd /home/user/tomcat8/bin && export SERVER_PORT=8080 && export JPDA_ADDRESS=9000 && ./catalina.sh jpda run",
+          "commandLine": "cp -r /home/user/che/ws-agent/maven-server /home/user/tomcat8 && cd /home/user/tomcat8/bin && export SERVER_PORT=8080 && export JPDA_ADDRESS=9000 && ./catalina.sh jpda run",
           "name": "Tomcat8-IDE Start",
           "type": "custom",
           "attributes": {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Tomcat that is used for developing Che-in-Che cannot launch ws-agent war, because it relies on presence of maven-server binaries. Proposed solution is to copy them from Workpace's ws-agent Tomcat during it's startup (executing the "Tomcat8-IDE Start" command).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9425
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
