### PR TITLE
Add supervisor into Theia image to reap zombie processes

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -9,13 +9,14 @@
 
 FROM node:8-alpine
 # build dependencies requireed to compile a custom Theia
-RUN apk add --no-cache make gcc g++ python git openssh bash
+RUN apk add --no-cache make gcc g++ python git openssh bash supervisor
 WORKDIR /home/theia
 # build Theia with all extensions to persist yarn cache in the image and
 # have default Theia build in the workspace in case no plugins are requested
 ADD https://raw.githubusercontent.com/theia-ide/theia-apps/master/theia-full-docker/latest.package.json /home/theia/package.json
 ADD theia-default-package.json /home/default/theia/package.json
 ADD src/add-native-plugins.js /home/default
+ADD supervisord.conf /etc/
 RUN node /home/default/add-native-plugins.js \
     che-theia-ssh-extension:https://github.com/eclipse/che-theia-ssh-plugin.git \
     && rm /home/default/add-native-plugins.js
@@ -31,4 +32,4 @@ EXPOSE 3000
 ARG GITHUB_TOKEN
 ENV USE_LOCAL_GIT=true \
     GITHUB_TOKEN=${GITHUB_TOKEN}
-ENTRYPOINT ["node", "/theia_launcher/theia_launcher.js"]
+ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisord.conf"]

--- a/dockerfiles/theia/supervisord.conf
+++ b/dockerfiles/theia/supervisord.conf
@@ -1,0 +1,6 @@
+[supervisord]
+
+[program:theia]
+command=node /theia_launcher/theia_launcher.js
+stopasgroup=true
+killasgroup=true


### PR DESCRIPTION
### What does this PR do?
Adds supervisor into Theia docker image. This is done because we need to reap zombie processes inside container.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9212
https://github.com/theia-demo-plugins/wiptheia/pull/10