### PR TITLE
Include workspace activity times into cascade removals;

### DIFF
--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -16,7 +16,6 @@ import com.google.inject.persist.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -108,11 +107,6 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
     @PostConstruct
     public void subscribe() {
       eventService.subscribe(this, BeforeWorkspaceRemovedEvent.class);
-    }
-
-    @PreDestroy
-    public void unsubscribe() {
-      eventService.unsubscribe(this, BeforeWorkspaceRemovedEvent.class);
     }
 
     @Override

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -99,7 +99,7 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
   }
 
   @Singleton
-  public static class RemoveExpirationsBeforeWorkspaceRemovedEventSubscriber
+  public static class RemoveExpirationBeforeWorkspaceRemovedEventSubscriber
       extends CascadeEventSubscriber<BeforeWorkspaceRemovedEvent> {
 
     @Inject private EventService eventService;

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/inject/WorkspaceActivityModule.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/inject/WorkspaceActivityModule.java
@@ -12,6 +12,7 @@ package org.eclipse.che.api.workspace.activity.inject;
 
 import com.google.inject.AbstractModule;
 import org.eclipse.che.api.workspace.activity.JpaWorkspaceActivityDao;
+import org.eclipse.che.api.workspace.activity.JpaWorkspaceActivityDao.RemoveExpirationBeforeWorkspaceRemovedEventSubscriber;
 import org.eclipse.che.api.workspace.activity.WorkspaceActivityDao;
 import org.eclipse.che.api.workspace.activity.WorkspaceActivityManager;
 import org.eclipse.che.api.workspace.activity.WorkspaceActivityService;
@@ -23,7 +24,7 @@ public class WorkspaceActivityModule extends AbstractModule {
     bind(WorkspaceActivityService.class);
     bind(WorkspaceActivityManager.class);
     bind(WorkspaceActivityDao.class).to(JpaWorkspaceActivityDao.class);
-    bind(JpaWorkspaceActivityDao.RemoveExpirationsBeforeWorkspaceRemovedEventSubscriber.class)
+    bind(RemoveExpirationBeforeWorkspaceRemovedEventSubscriber.class)
         .asEagerSingleton();
   }
 }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/inject/WorkspaceActivityModule.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/inject/WorkspaceActivityModule.java
@@ -24,7 +24,6 @@ public class WorkspaceActivityModule extends AbstractModule {
     bind(WorkspaceActivityService.class);
     bind(WorkspaceActivityManager.class);
     bind(WorkspaceActivityDao.class).to(JpaWorkspaceActivityDao.class);
-    bind(RemoveExpirationBeforeWorkspaceRemovedEventSubscriber.class)
-        .asEagerSingleton();
+    bind(RemoveExpirationBeforeWorkspaceRemovedEventSubscriber.class).asEagerSingleton();
   }
 }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/inject/WorkspaceActivityModule.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/inject/WorkspaceActivityModule.java
@@ -23,5 +23,7 @@ public class WorkspaceActivityModule extends AbstractModule {
     bind(WorkspaceActivityService.class);
     bind(WorkspaceActivityManager.class);
     bind(WorkspaceActivityDao.class).to(JpaWorkspaceActivityDao.class);
+    bind(JpaWorkspaceActivityDao.RemoveExpirationsBeforeWorkspaceRemovedEventSubscriber.class)
+        .asEagerSingleton();
   }
 }

--- a/wsmaster/integration-tests/cascade-removal/pom.xml
+++ b/wsmaster/integration-tests/cascade-removal/pom.xml
@@ -98,6 +98,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace-activity</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace-shared</artifactId>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
### What does this PR do?
Fixes bug when it is impossible to remove workspace which have last activity time by adding `BeforeWorkspaceRemovedEvent` listener.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9599

#### Release Notes
N/A


#### Docs PR
N/A