### PR TITLE
Adding `-Dvertx.disableDnsResolver=true` to vert.x run / debug commands

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2244,7 +2244,7 @@
           "goal": "Build"
         }
       }, {
-        "commandLine": "scl enable rh-maven33 'mvn compile vertx:run -f ${current.project.path}'",
+        "commandLine": "scl enable rh-maven33 'mvn compile vertx:run -f ${current.project.path} -Dvertx.disableDnsResolver=true'",
         "name": "run",
         "type": "custom",
         "attributes": {
@@ -2252,7 +2252,7 @@
           "goal": "Run"
         }
       }, {
-        "commandLine": "scl enable rh-maven33 'mvn compile vertx:debug -f ${current.project.path}'",
+        "commandLine": "scl enable rh-maven33 'mvn compile vertx:debug -f ${current.project.path} -Dvertx.disableDnsResolver=true'",
         "name": "debug",
         "type": "custom",
         "attributes": {


### PR DESCRIPTION

### What does this PR do?
Adding -Dvertx.disableDnsResolver=true to vert.x run / debug commands


### What issues does this PR fix or reference?
osio issue - https://github.com/openshiftio/openshift.io/issues/3428
rh-che PR - https://github.com/redhat-developer/rh-che/pull/662

<!-- #### Changelog -->
Adding -Dvertx.disableDnsResolver=true to vert.x run / debug commands



#### Release Notes
Adding -Dvertx.disableDnsResolver=true to vert.x run / debug commands


#### Docs PR
N/A
