### PR TITLE
Add logging of Kubernetes/OpenShift unrecoverable events

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -105,7 +105,7 @@ case $key in
         exit 1
     ;;
     *)
-    echo "You've passed wrong arg."
+    echo "You've passed wrong arg '$key'."
     echo -e "$HELP"
     exit 1
     ;;

--- a/deploy/openshift/ocp.sh
+++ b/deploy/openshift/ocp.sh
@@ -286,7 +286,7 @@ parse_args() {
                exit 1
            ;;
            *)
-               echo "You've passed wrong arg."
+               echo "You've passed wrong arg '$i'."
                echo -e "$HELP"
                exit 1
            ;;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -628,19 +628,20 @@ public class KubernetesInternalRuntime<
         String reason = event.getReason();
         String message = event.getMessage();
         String podName = event.getPodName();
+        String workspaceId = getContext().getIdentity().getWorkspaceId();
+        LOG.error(
+            "Unrecoverable event occurred during workspace '{}' startup: {}, {}, {}",
+            workspaceId,
+            reason,
+            message,
+            podName);
         try {
           internalStop(emptyMap());
         } catch (InfrastructureException e) {
-          String workspaceId = getContext().getIdentity().getWorkspaceId();
-          LOG.error(
-              "Unrecoverable event occured during workspace '{}' startup: {}, {}, {}",
-              workspaceId,
-              reason,
-              message,
-              podName);
+          LOG.error("Error occurred during runtime '{}' stopping. {}", workspaceId, e.getMessage());
         } finally {
           eventPublisher.sendRuntimeStoppedEvent(
-              format("Unrecoverable event occured: '%s', '%s', '%s'", reason, message, podName),
+              format("Unrecoverable event occurred: '%s', '%s', '%s'", reason, message, podName),
               getContext().getIdentity());
         }
       }


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is adding logging of Kubernetes/OpenShift unrecoverable events. It should help while workspace starts failings investigations.

Also, it contains a minor deploy_che.sh script changes with adding a name of an unknown argument in error message. 

### What issues does this PR fix or reference?
-


#### Release Notes
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
