### PR TITLE
Fix Eclipse Che deployment on OCP

### DIFF
--- a/deploy/openshift/ocp.sh
+++ b/deploy/openshift/ocp.sh
@@ -151,7 +151,7 @@ deploy_che_to_ocp() {
   if [ "${DEPLOY_CHE}" == "true" ];then
     echo "Logging in to OpenShift cluster..."
     $OC_BINARY login -u "${OPENSHIFT_USERNAME}" -p "${OPENSHIFT_PASSWORD}" > /dev/null
-    ./deploy_che.sh
+    ${BASE_DIR}/deploy_che.sh
   fi
 }
 


### PR DESCRIPTION
### What does this PR do?
It fixes Eclipse Che on OCP deployment error:
```
[OCP] wait for ocp full boot...
Logging in to OpenShift cluster...
/home/codenvy/workspace/che-pullrequests-test-ocp/deploy/openshift/ocp.sh: line 154: ./deploy_che.sh: No such file or directory
Error response from daemon: No such container: sh
```

### What issues does this PR fix or reference?
#9625