### PR TITLE
Selenium: wait for Project Explorer after starting IDE in tests from refactor.types package

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/GenericsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/GenericsTest.java
@@ -10,27 +10,28 @@
  */
 package org.eclipse.che.selenium.refactor.types;
 
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
+import static org.testng.Assert.assertEquals;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
-import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
-import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,10 +41,9 @@ import org.testng.annotations.Test;
  * @author Musienko Maxim
  */
 public class GenericsTest {
-  private static final String NAME_OF_PROJECT =
-      NameGenerator.generate(GenericsTest.class.getSimpleName(), 2);
+  private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
-      NAME_OF_PROJECT + "/src/main/java/renametype";
+      PROJECT_NAME + "/src/main/java/renametype";
 
   private String pathToCurrentPackage;
   private String contentFromInA;
@@ -52,10 +52,8 @@ public class GenericsTest {
   @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
   @Inject private Refactor refactorPanel;
-  @Inject private Consoles consoles;
   @Inject private Menu menu;
   @Inject private AskDialog askDialog;
   @Inject private TestProjectServiceClient testProjectServiceClient;
@@ -66,27 +64,23 @@ public class GenericsTest {
     testProjectServiceClient.importProject(
         workspace.getId(),
         Paths.get(resource.toURI()),
-        NAME_OF_PROJECT,
+        PROJECT_NAME,
         ProjectTemplates.MAVEN_SIMPLE);
     ide.open(workspace);
   }
 
   @Test
   public void testGenerics2() throws Exception {
-    projectExplorer.waitVisibleItem(NAME_OF_PROJECT);
+    projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
 
-    loader.waitOnClosed();
     setFieldsForTest("testGenerics2");
     projectExplorer.scrollAndSelectItem(pathToCurrentPackage + "/A.java");
     projectExplorer.openItemByPath(pathToCurrentPackage + "/A.java");
-    Assert.assertEquals(editor.getVisibleTextFromEditor(), contentFromInA);
+    assertEquals(editor.getVisibleTextFromEditor(), contentFromInA);
     editor.waitTextIntoEditor(contentFromInA);
     projectExplorer.waitAndSelectItem(pathToCurrentPackage + "/A.java");
-    menu.runCommand(
-        TestMenuCommandsConstants.Assistant.ASSISTANT,
-        TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING,
-        TestMenuCommandsConstants.Assistant.Refactoring.RENAME);
+    menu.runCommand(ASSISTANT, REFACTORING, RENAME);
 
     refactorPanel.typeAndWaitNewName("B.java");
     refactorPanel.sendKeysIntoField(Keys.ARROW_LEFT.toString());
@@ -97,7 +91,7 @@ public class GenericsTest {
         "Found potential matches. Please review changes on the preview page.");
     askDialog.waitFormToClose();
     projectExplorer.waitItem(pathToCurrentPackage + "/B.java");
-    Assert.assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
+    assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
     editor.waitTextIntoEditor(contentFromOutB);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/GenericsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/GenericsTest.java
@@ -71,6 +71,7 @@ public class GenericsTest {
 
   @Test
   public void testGenerics2() throws Exception {
+    projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/IllegalTypeNameTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/IllegalTypeNameTest.java
@@ -62,6 +62,7 @@ public class IllegalTypeNameTest {
 
   @Test
   public void illegalTypeName4() throws Exception {
+    projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/IllegalTypeNameTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/IllegalTypeNameTest.java
@@ -10,13 +10,15 @@
  */
 package org.eclipse.che.selenium.refactor.types;
 
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.testng.Assert.assertEquals;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -24,7 +26,6 @@ import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -34,10 +35,9 @@ import org.testng.annotations.Test;
  * @author Musienko Maxim
  */
 public class IllegalTypeNameTest {
-  private static final String NAME_OF_PROJECT =
-      NameGenerator.generate(IllegalTypeNameTest.class.getSimpleName(), 2);
+  private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
-      NAME_OF_PROJECT + "/src/main/java/renametype";
+      PROJECT_NAME + "/src/main/java/renametype";
 
   private String pathToCurrentPackage;
   private String contentFromInA;
@@ -55,21 +55,22 @@ public class IllegalTypeNameTest {
     testProjectServiceClient.importProject(
         workspace.getId(),
         Paths.get(resource.toURI()),
-        NAME_OF_PROJECT,
+        PROJECT_NAME,
         ProjectTemplates.MAVEN_SIMPLE);
     ide.open(workspace);
   }
 
   @Test
   public void illegalTypeName4() throws Exception {
-    projectExplorer.waitVisibleItem(NAME_OF_PROJECT);
+    projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
-    projectExplorer.scrollToItemByPath(NAME_OF_PROJECT + "/pom.xml");
+
+    projectExplorer.scrollToItemByPath(PROJECT_NAME + "/pom.xml");
     loader.waitOnClosed();
     setFieldsForTest("testIllegalTypeName4");
     projectExplorer.openItemByPath(pathToCurrentPackage + "/A.java");
     editor.waitActive();
-    Assert.assertEquals(editor.getVisibleTextFromEditor(), contentFromInA);
+    assertEquals(editor.getVisibleTextFromEditor(), contentFromInA);
     editor.waitTextIntoEditor(contentFromInA);
     projectExplorer.waitAndSelectItemByName("A.java");
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -10,6 +10,10 @@
  */
 package org.eclipse.che.selenium.refactor.types;
 
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
 import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
@@ -21,9 +25,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
-import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
@@ -46,10 +48,9 @@ import org.testng.annotations.Test;
 /** @author Musienko Maxim */
 public class RenameTypeTest {
   private static final Logger LOG = LoggerFactory.getLogger(RenameTypeTest.class);
-  private static final String NAME_OF_PROJECT =
-      NameGenerator.generate(RenameTypeTest.class.getSimpleName(), 2);
+  private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
-      NAME_OF_PROJECT + "/src/main/java/renametype";
+      PROJECT_NAME + "/src/main/java/renametype";
 
   private String pathToCurrentPackage;
   private String contentFromInA;
@@ -72,13 +73,13 @@ public class RenameTypeTest {
     testProjectServiceClient.importProject(
         workspace.getId(),
         Paths.get(resource.toURI()),
-        NAME_OF_PROJECT,
+        PROJECT_NAME,
         ProjectTemplates.MAVEN_SIMPLE);
+
     ide.open(workspace);
-    projectExplorer.waitVisibleItem(NAME_OF_PROJECT);
+    projectExplorer.waitItem(PROJECT_NAME);
     consoles.closeProcessesArea();
     projectExplorer.quickExpandWithJavaScript();
-    loader.waitOnClosed();
   }
 
   @BeforeMethod
@@ -180,10 +181,7 @@ public class RenameTypeTest {
     projectExplorer.openItemByPath(pathToCurrentPackage + "/A.java");
     editor.waitTextIntoEditor(contentFromInA);
     projectExplorer.waitAndSelectItem(pathToCurrentPackage + "/A.java");
-    menu.runCommand(
-        TestMenuCommandsConstants.Assistant.ASSISTANT,
-        TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING,
-        TestMenuCommandsConstants.Assistant.Refactoring.RENAME);
+    menu.runCommand(ASSISTANT, REFACTORING, RENAME);
 
     refactorPanel.typeAndWaitNewName("B.java");
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -77,6 +77,7 @@ public class RenameTypeTest {
         ProjectTemplates.MAVEN_SIMPLE);
 
     ide.open(workspace);
+    projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     consoles.closeProcessesArea();
     projectExplorer.quickExpandWithJavaScript();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestAnnotationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestAnnotationsTest.java
@@ -14,13 +14,15 @@ import static java.lang.String.format;
 import static java.nio.charset.Charset.forName;
 import static java.nio.file.Files.readAllLines;
 import static java.nio.file.Paths.get;
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
 
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
 import java.net.URL;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
-import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
@@ -36,10 +38,9 @@ import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
 public class TestAnnotationsTest {
-  private static final String NAME_OF_PROJECT =
-      NameGenerator.generate(TestAnnotationsTest.class.getSimpleName(), 4);
+  private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
-      NAME_OF_PROJECT + "/src/main/java/renametype";
+      PROJECT_NAME + "/src/main/java/renametype";
 
   private String pathToCurrentPackage;
   private String contentFromInA;
@@ -59,24 +60,21 @@ public class TestAnnotationsTest {
   public void setup() throws Exception {
     URL resource = TestAnnotationsTest.this.getClass().getResource("/projects/RenameType");
     testProjectServiceClient.importProject(
-        workspace.getId(), get(resource.toURI()), NAME_OF_PROJECT, ProjectTemplates.MAVEN_SIMPLE);
+        workspace.getId(), get(resource.toURI()), PROJECT_NAME, ProjectTemplates.MAVEN_SIMPLE);
 
     ide.open(workspace);
   }
 
   @Test
   public void testAnnotation1() throws Exception {
-    projectExplorer.waitVisibleItem(NAME_OF_PROJECT);
+    projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
-    loader.waitOnClosed();
+
     setFieldsForTest("testAnnotation1");
     projectExplorer.openItemByPath(pathToCurrentPackage + "/A.java");
     editor.waitTextIntoEditor(contentFromInA);
     projectExplorer.waitAndSelectItem(pathToCurrentPackage + "/A.java");
-    menu.runCommand(
-        TestMenuCommandsConstants.Assistant.ASSISTANT,
-        TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING,
-        TestMenuCommandsConstants.Assistant.Refactoring.RENAME);
+    menu.runCommand(ASSISTANT, REFACTORING, RENAME);
 
     refactorPanel.typeAndWaitNewName("B.java");
     try {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestAnnotationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestAnnotationsTest.java
@@ -67,6 +67,7 @@ public class TestAnnotationsTest {
 
   @Test
   public void testAnnotation1() throws Exception {
+    projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestEnumerationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestEnumerationsTest.java
@@ -10,47 +10,45 @@
  */
 package org.eclipse.che.selenium.refactor.types;
 
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
+import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
+import static org.testng.Assert.assertEquals;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
-import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
 public class TestEnumerationsTest {
-  private static final String NAME_OF_PROJECT =
-      NameGenerator.generate(TestEnumerationsTest.class.getSimpleName(), 2);
+  private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
-      NAME_OF_PROJECT + "/src/main/java/renametype";
+      PROJECT_NAME + "/src/main/java/renametype";
 
   private String pathToCurrentPackage;
   private String contentFromInA;
   private String contentFromOutB;
 
   @Inject private TestWorkspace workspace;
-  @Inject private DefaultTestUser defaultTestUser;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
   @Inject private Refactor refactorPanel;
   @Inject private Consoles consoles;
@@ -64,25 +62,22 @@ public class TestEnumerationsTest {
     testProjectServiceClient.importProject(
         workspace.getId(),
         Paths.get(resource.toURI()),
-        NAME_OF_PROJECT,
+        PROJECT_NAME,
         ProjectTemplates.MAVEN_SIMPLE);
     ide.open(workspace);
   }
 
   @Test
   public void testEnum1() throws Exception {
-    projectExplorer.waitVisibleItem(NAME_OF_PROJECT);
+    projectExplorer.waitItem(PROJECT_NAME);
     consoles.closeProcessesArea();
     projectExplorer.quickExpandWithJavaScript();
-    loader.waitOnClosed();
+
     setFieldsForTest("testEnum1");
     projectExplorer.openItemByPath(pathToCurrentPackage + "/A.java");
     editor.waitTextIntoEditor(contentFromInA);
     projectExplorer.waitAndSelectItem(pathToCurrentPackage + "/A.java");
-    menu.runCommand(
-        TestMenuCommandsConstants.Assistant.ASSISTANT,
-        TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING,
-        TestMenuCommandsConstants.Assistant.Refactoring.RENAME);
+    menu.runCommand(ASSISTANT, REFACTORING, RENAME);
 
     refactorPanel.typeAndWaitNewName("B.java");
     refactorPanel.sendKeysIntoField(Keys.ARROW_LEFT.toString());
@@ -91,7 +86,7 @@ public class TestEnumerationsTest {
     askDialog.clickOkBtn();
     askDialog.waitFormToClose();
     projectExplorer.waitItem(pathToCurrentPackage + "/B.java");
-    Assert.assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
+    assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
     editor.waitTextIntoEditor(contentFromOutB);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestEnumerationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestEnumerationsTest.java
@@ -69,6 +69,7 @@ public class TestEnumerationsTest {
 
   @Test
   public void testEnum1() throws Exception {
+    projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     consoles.closeProcessesArea();
     projectExplorer.quickExpandWithJavaScript();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestFailTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestFailTest.java
@@ -10,14 +10,14 @@
  */
 package org.eclipse.che.selenium.refactor.types;
 
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
+
 import com.google.inject.Inject;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.nio.file.Paths;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
@@ -40,17 +40,15 @@ import org.testng.annotations.Test;
 /** @author Musienko Maxim */
 public class TestFailTest {
   private static final Logger LOG = LoggerFactory.getLogger(TestEnumerationsTest.class);
-  private static final String NAME_OF_PROJECT =
-      NameGenerator.generate(TestFailTest.class.getSimpleName(), 3);
+  private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
-      NAME_OF_PROJECT + "/src/main/java/renametype";
+      PROJECT_NAME + "/src/main/java/renametype";
 
   private String renameItem = "B.java";
   private String pathToCurrentPackage;
   private Services services;
 
   @Inject private TestWorkspace workspace;
-  @Inject private DefaultTestUser defaultTestUser;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
@@ -70,14 +68,14 @@ public class TestFailTest {
     testProjectServiceClient.importProject(
         workspace.getId(),
         Paths.get(resource.toURI()),
-        NAME_OF_PROJECT,
+        PROJECT_NAME,
         ProjectTemplates.MAVEN_SIMPLE);
 
     ide.open(workspace);
-    projectExplorer.waitVisibleItem(NAME_OF_PROJECT);
+
+    projectExplorer.waitItem(PROJECT_NAME);
     consoles.closeProcessesArea();
     projectExplorer.quickExpandWithJavaScript();
-    loader.waitOnClosed();
   }
 
   @BeforeMethod

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestFailTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestFailTest.java
@@ -73,6 +73,7 @@ public class TestFailTest {
 
     ide.open(workspace);
 
+    projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     consoles.closeProcessesArea();
     projectExplorer.quickExpandWithJavaScript();


### PR DESCRIPTION
### What does this PR do?
- Wait for **Project Explorer** to be visible after opening **IDE**.
- Remove unused code.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9623