### PR TITLE
Issue 8721 - Update Libraries, etc. based on JDT notifications #8721

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/node/ProjectClasspathChangedEvent.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/project/node/ProjectClasspathChangedEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.project.node;
+
+import com.google.gwt.event.shared.EventHandler;
+import com.google.gwt.event.shared.GwtEvent;
+
+/** @author V. Rubezhny */
+public class ProjectClasspathChangedEvent
+    extends GwtEvent<ProjectClasspathChangedEvent.ProjectClasspathChangedHandler> {
+
+  private String projectPath;
+
+  public interface ProjectClasspathChangedHandler extends EventHandler {
+    void onProjectClasspathChanged(ProjectClasspathChangedEvent event);
+  }
+
+  private static Type<ProjectClasspathChangedHandler> TYPE;
+
+  public static Type<ProjectClasspathChangedHandler> getType() {
+    if (TYPE == null) {
+      TYPE = new Type<>();
+    }
+    return TYPE;
+  }
+
+  public ProjectClasspathChangedEvent(String projectPath) {
+    this.projectPath = projectPath;
+  }
+
+  public String getProject() {
+    return projectPath;
+  }
+
+  @Override
+  public Type<ProjectClasspathChangedHandler> getAssociatedType() {
+    return TYPE;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  protected void dispatch(ProjectClasspathChangedHandler handler) {
+    handler.onProjectClasspathChanged(this);
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/library/LibrariesNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/tree/library/LibrariesNode.java
@@ -28,6 +28,8 @@ import org.eclipse.che.ide.dto.DtoFactory;
 import org.eclipse.che.ide.ext.java.client.JavaResources;
 import org.eclipse.che.ide.ext.java.client.service.JavaLanguageExtensionServiceClient;
 import org.eclipse.che.ide.ext.java.client.tree.JavaNodeFactory;
+import org.eclipse.che.ide.project.node.ProjectClasspathChangedEvent;
+import org.eclipse.che.ide.project.node.ProjectClasspathChangedEvent.ProjectClasspathChangedHandler;
 import org.eclipse.che.ide.project.node.SyntheticNode;
 import org.eclipse.che.ide.project.node.SyntheticNodeUpdateEvent;
 import org.eclipse.che.ide.resource.Path;
@@ -39,7 +41,8 @@ import org.eclipse.che.jdt.ls.extension.api.dto.Jar;
 
 /** @author Vlad Zhukovskiy */
 @Beta
-public class LibrariesNode extends SyntheticNode<Path> implements ResourceChangedHandler {
+public class LibrariesNode extends SyntheticNode<Path>
+    implements ResourceChangedHandler, ProjectClasspathChangedHandler {
 
   private final JavaNodeFactory nodeFactory;
   private DtoFactory dtoFactory;
@@ -64,6 +67,7 @@ public class LibrariesNode extends SyntheticNode<Path> implements ResourceChange
     this.eventBus = eventBus;
 
     eventBus.addHandler(ResourceChangedEvent.getType(), this);
+    eventBus.addHandler(ProjectClasspathChangedEvent.getType(), this);
   }
 
   @Override
@@ -107,6 +111,15 @@ public class LibrariesNode extends SyntheticNode<Path> implements ResourceChange
     final ResourceDelta delta = event.getDelta();
 
     if (delta.getKind() == UPDATED && delta.getResource().getLocation().equals(getData())) {
+      eventBus.fireEvent(new SyntheticNodeUpdateEvent(LibrariesNode.this));
+    }
+  }
+
+  @Override
+  public void onProjectClasspathChanged(ProjectClasspathChangedEvent event) {
+    final Path project = new Path(event.getProject());
+
+    if (getProject().equals(project)) {
       eventBus.fireEvent(new SyntheticNodeUpdateEvent(LibrariesNode.this));
     }
   }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
@@ -61,6 +61,12 @@ public final class Constants {
   public static final String VALIDATE_RENAMED_NAME = "java/validateRenamedName";
   public static final String GET_LINKED_MODEL = "java/getLinkedModel";
 
+  public static final String EXECUTE_CLIENT_COMMAND = "workspace/executeClientCommand";
+  public static final String EXECUTE_CLIENT_COMMAND_UNSUBSCRIBE =
+      "workspace/executeClientCommand/unsubscribe";
+  public static final String EXECUTE_CLIENT_COMMAND_SUBSCRIBE =
+      "workspace/executeClientCommand/subscribe";
+
   private Constants() {
     throw new UnsupportedOperationException("Unused constructor.");
   }

--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/ExecuteClientCommandJsonRpcTransmitter.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/ExecuteClientCommandJsonRpcTransmitter.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.java.languageserver;
+
+import static org.eclipse.che.ide.ext.java.shared.Constants.EXECUTE_CLIENT_COMMAND;
+import static org.eclipse.che.ide.ext.java.shared.Constants.EXECUTE_CLIENT_COMMAND_SUBSCRIBE;
+import static org.eclipse.che.ide.ext.java.shared.Constants.EXECUTE_CLIENT_COMMAND_UNSUBSCRIBE;
+
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArraySet;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.languageserver.server.dto.DtoServerImpls;
+import org.eclipse.che.api.languageserver.server.dto.DtoServerImpls.ExecuteCommandParamsDto;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+
+/** Transmits 'workspace/executeClientCommand' over the JSON-RPC */
+@Singleton
+public class ExecuteClientCommandJsonRpcTransmitter {
+  private final Set<String> endpointIds = new CopyOnWriteArraySet<>();
+
+  private final RequestTransmitter requestTransmitter;
+
+  @Inject
+  public ExecuteClientCommandJsonRpcTransmitter(RequestTransmitter requestTransmitter) {
+    this.requestTransmitter = requestTransmitter;
+  }
+
+  @Inject
+  private void subscribe(EventService eventService, RequestTransmitter requestTransmitter) {
+    eventService.subscribe(
+        event ->
+            endpointIds.forEach(
+                endpointId ->
+                    requestTransmitter
+                        .newRequest()
+                        .endpointId(endpointId)
+                        .methodName(EXECUTE_CLIENT_COMMAND)
+                        .paramsAsDto(new ExecuteCommandParamsDto(event))
+                        .sendAndSkipResult()),
+        ExecuteCommandParams.class);
+  }
+
+  @Inject
+  private void configureSubscribeHandler(RequestHandlerConfigurator requestHandler) {
+    requestHandler
+        .newConfiguration()
+        .methodName(EXECUTE_CLIENT_COMMAND_SUBSCRIBE)
+        .noParams()
+        .noResult()
+        .withConsumer(endpointIds::add);
+  }
+
+  @Inject
+  private void configureUnSubscribeHandler(RequestHandlerConfigurator requestHandler) {
+    requestHandler
+        .newConfiguration()
+        .methodName(EXECUTE_CLIENT_COMMAND_UNSUBSCRIBE)
+        .noParams()
+        .noResult()
+        .withConsumer(endpointIds::remove);
+  }
+
+  public CompletableFuture<Object> executeClientCommand(ExecuteCommandParams requestParams) {
+    ExecuteCommandParamsDto paramsDto =
+        (ExecuteCommandParamsDto) DtoServerImpls.makeDto(requestParams);
+
+    CompletableFuture<Object> result = new CompletableFuture<>();
+    for (String endpointId : endpointIds) {
+      requestTransmitter
+          .newRequest()
+          .endpointId(endpointId)
+          .methodName(EXECUTE_CLIENT_COMMAND)
+          .paramsAsDto(paramsDto)
+          .sendAndSkipResult();
+    }
+    result.complete(null);
+    return result;
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageClient.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageClient.java
@@ -10,7 +10,10 @@
  */
 package org.eclipse.che.plugin.java.languageserver;
 
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 
 public interface JavaLanguageClient {
   /**
@@ -28,4 +31,7 @@ public interface JavaLanguageClient {
    */
   @JsonNotification("language/progressReport")
   void sendProgressReport(ProgressReport report);
+
+  @JsonRequest("workspace/executeClientCommand")
+  CompletableFuture<Object> executeClientCommand(ExecuteCommandParams params);
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
@@ -39,6 +39,7 @@ import org.eclipse.che.plugin.languageserver.ide.navigation.symbol.GoToSymbolAct
 import org.eclipse.che.plugin.languageserver.ide.navigation.workspace.FindSymbolAction;
 import org.eclipse.che.plugin.languageserver.ide.registry.LanguageServerRegistry;
 import org.eclipse.che.plugin.languageserver.ide.rename.LSRenameAction;
+import org.eclipse.che.plugin.languageserver.ide.service.ExecuteClientCommandReceiver;
 import org.eclipse.che.plugin.languageserver.ide.service.PublishDiagnosticsReceiver;
 import org.eclipse.che.plugin.languageserver.ide.service.ShowMessageJsonRpcReceiver;
 import org.eclipse.che.plugin.languageserver.ide.service.TextDocumentServiceClient;
@@ -60,7 +61,8 @@ public class LanguageServerExtension {
       EventBus eventBus,
       AppContext appContext,
       ShowMessageJsonRpcReceiver showMessageJsonRpcReceiver,
-      PublishDiagnosticsReceiver publishDiagnosticsReceiver) {
+      PublishDiagnosticsReceiver publishDiagnosticsReceiver,
+      ExecuteClientCommandReceiver executeClientCommandReceiver) {
     eventBus.addHandler(
         WsAgentServerRunningEvent.TYPE,
         e -> {
@@ -68,6 +70,7 @@ public class LanguageServerExtension {
           languageDescriptionInitializer.initialize();
           showMessageJsonRpcReceiver.subscribe();
           publishDiagnosticsReceiver.subscribe();
+          executeClientCommandReceiver.subscribe();
         });
 
     if (appContext.getWorkspace().getStatus() == RUNNING) {
@@ -75,6 +78,7 @@ public class LanguageServerExtension {
       languageDescriptionInitializer.initialize();
       showMessageJsonRpcReceiver.subscribe();
       publishDiagnosticsReceiver.subscribe();
+      executeClientCommandReceiver.subscribe();
     }
   }
 

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
@@ -24,6 +24,7 @@ import org.eclipse.che.plugin.languageserver.ide.editor.quickassist.LanguageServ
 import org.eclipse.che.plugin.languageserver.ide.editor.signature.LanguageServerSignatureHelpFactory;
 import org.eclipse.che.plugin.languageserver.ide.location.OpenLocationPresenterFactory;
 import org.eclipse.che.plugin.languageserver.ide.rename.node.RenameNodeFactory;
+import org.eclipse.che.plugin.languageserver.ide.service.ExecuteClientCommandReceiver;
 import org.eclipse.che.plugin.languageserver.ide.service.PublishDiagnosticsReceiver;
 import org.eclipse.che.plugin.languageserver.ide.service.ShowMessageJsonRpcReceiver;
 
@@ -48,6 +49,7 @@ public class LanguageServerGinModule extends AbstractGinModule {
 
     bind(PublishDiagnosticsReceiver.class).asEagerSingleton();
     bind(ShowMessageJsonRpcReceiver.class).asEagerSingleton();
+    bind(ExecuteClientCommandReceiver.class).asEagerSingleton();
 
     GinMultibinder.newSetBinder(binder(), LanguageDescription.class);
   }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ExecuteClientCommandProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ExecuteClientCommandProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.languageserver.ide.service;
+
+import com.google.gwt.json.client.JSONString;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+import org.eclipse.che.ide.project.node.ProjectClasspathChangedEvent;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+
+/**
+ * A processor for incoming <code>workspace/ClasspathChanged</code> notifications sent by a language
+ * server.
+ *
+ * @author V. Rubezhny
+ */
+@Singleton
+public class ExecuteClientCommandProcessor {
+  private static final String CLIENT_UPDATE_PROJECTS_CLASSPATH =
+      "che.jdt.ls.extension.workspace.clientUpdateProjectsClasspath";
+
+  private EventBus eventBus;
+
+  @Inject
+  public ExecuteClientCommandProcessor(EventBus eventBus) {
+    this.eventBus = eventBus;
+  }
+
+  public void execute(ExecuteCommandParams params) {
+    if (CLIENT_UPDATE_PROJECTS_CLASSPATH.equals(params.getCommand())) {
+      for (Object project : params.getArguments()) {
+        eventBus.fireEvent(new ProjectClasspathChangedEvent(stringValue(project)));
+      }
+    }
+  }
+
+  private String stringValue(Object value) {
+    return value instanceof JSONString ? ((JSONString) value).stringValue() : String.valueOf(value);
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ExecuteClientCommandReceiver.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ExecuteClientCommandReceiver.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.languageserver.ide.service;
+
+import static org.eclipse.che.ide.api.jsonrpc.Constants.WS_AGENT_JSON_RPC_ENDPOINT_ID;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+
+/**
+ * Subscribes and receives JSON-RPC messages related to ClassPath Notification
+ * 'workspace/executeClientCommand' events
+ */
+@Singleton
+public class ExecuteClientCommandReceiver {
+  public static final String EXECUTE_CLIENT_COMMAND = "workspace/executeClientCommand";
+  public static final String EXECUTE_CLIENT_COMMAND_SUBSCRIBE =
+      "workspace/executeClientCommand/subscribe";
+  private final RequestTransmitter transmitter;
+
+  @Inject
+  public ExecuteClientCommandReceiver(RequestTransmitter transmitter) {
+    this.transmitter = transmitter;
+  }
+
+  public void subscribe() {
+    subscribe(transmitter);
+  }
+
+  @Inject
+  private void configureReceiver(
+      Provider<ExecuteClientCommandProcessor> provider, RequestHandlerConfigurator configurator) {
+    configurator
+        .newConfiguration()
+        .methodName(EXECUTE_CLIENT_COMMAND)
+        .paramsAsDto(ExecuteCommandParams.class)
+        .noResult()
+        .withConsumer(params -> provider.get().execute(params));
+  }
+
+  private void subscribe(RequestTransmitter transmitter) {
+    transmitter
+        .newRequest()
+        .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
+        .methodName(EXECUTE_CLIENT_COMMAND_SUBSCRIBE)
+        .noParams()
+        .sendAndSkipResult();
+  }
+}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The fix adds a listener for 'che.jdt.ls.extension.workspace.clientUpdateProjectsClasspath" events and updates an according "External Libraries" node in Project Explorer.

### What issues does this PR fix or reference?

Fixes #8721 
Depends on https://github.com/eclipse/che-ls-jdt/pull/44

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
![ls8721](https://user-images.githubusercontent.com/620781/39756831-3de3e4d8-52cb-11e8-9e63-0327bc026867.gif)

Project Explorer tree now listens for the "Update Classpath" events of che-jdt-ls and updates "External Libraries" node of java project that is indicated in the event data. 

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
