### PR TITLE
Add missing service terminations

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -216,9 +216,17 @@ public class WsMasterModule extends AbstractModule {
 
     // system components
     install(new SystemModule());
-    Multibinder.newSetBinder(binder(), ServiceTermination.class)
+    Multibinder<ServiceTermination> terminationMultiBinder =
+        Multibinder.newSetBinder(binder(), ServiceTermination.class);
+    terminationMultiBinder
         .addBinding()
         .to(org.eclipse.che.api.workspace.server.WorkspaceServiceTermination.class);
+    terminationMultiBinder
+        .addBinding()
+        .to(org.eclipse.che.api.system.server.CronThreadPullTermination.class);
+    terminationMultiBinder
+        .addBinding()
+        .to(org.eclipse.che.api.workspace.server.hc.probe.ProbeSchedulerTermination.class);
 
     final Map<String, String> persistenceProperties = new HashMap<>();
     persistenceProperties.put(PersistenceUnitProperties.TARGET_SERVER, "None");

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -332,8 +332,10 @@ public class KubernetesInternalRuntime<
               getContext().getIdentity(), machineName, MachineStatus.FAILED);
         } catch (InfrastructureException e) {
           LOG.error(
-              "Unable to update status of the machine '%s:%s'. Cause: %s",
-              getContext().getIdentity().getWorkspaceId(), machineName, e.getMessage());
+              "Unable to update status of the machine '{}:{}'. Cause: {}",
+              getContext().getIdentity().getWorkspaceId(),
+              machineName,
+              e.getMessage());
         }
         eventPublisher.sendFailedEvent(machineName, ex.getMessage(), getContext().getIdentity());
       }
@@ -366,8 +368,10 @@ public class KubernetesInternalRuntime<
             getContext().getIdentity(), machineName, MachineStatus.RUNNING);
       } catch (InfrastructureException e) {
         LOG.error(
-            "Unable to update status of the machine '%s:%s'. Cause: %s",
-            getContext().getIdentity().getWorkspaceId(), machineName, e.getMessage());
+            "Unable to update status of the machine '{}:{}'. Cause: {}",
+            getContext().getIdentity().getWorkspaceId(),
+            machineName,
+            e.getMessage());
       }
       eventPublisher.sendRunningEvent(machineName, getContext().getIdentity());
     };
@@ -574,8 +578,11 @@ public class KubernetesInternalRuntime<
         eventPublisher.sendServerRunningEvent(machineName, serverRef, url, identity);
       } catch (InfrastructureException e) {
         LOG.error(
-            "Unable to update status of the server '%s:%s:%s'. Cause: %s",
-            identity.getWorkspaceId(), machineName, serverRef, e.getMessage());
+            "Unable to update status of the server '{}:{}:{}'. Cause: {}",
+            identity.getWorkspaceId(),
+            machineName,
+            serverRef,
+            e.getMessage());
       }
     }
   }
@@ -608,8 +615,11 @@ public class KubernetesInternalRuntime<
         }
       } catch (InfrastructureException e) {
         LOG.error(
-            "Unable to update status of the server '%s:%s:%s'. Cause: %s",
-            identity.getWorkspaceId(), machineName, serverName, e.getMessage());
+            "Unable to update status of the server '{}:{}:{}'. Cause: {}",
+            identity.getWorkspaceId(),
+            machineName,
+            serverName,
+            e.getMessage());
       }
     }
   }

--- a/wsmaster/che-core-api-system/pom.xml
+++ b/wsmaster/che-core-api-system/pom.xml
@@ -83,6 +83,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-schedule</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/CronThreadPullTermination.java
+++ b/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/CronThreadPullTermination.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.system.server;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.Collections;
+import java.util.Set;
+import org.eclipse.che.commons.schedule.executor.ThreadPullLauncher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Terminates {@link ThreadPullLauncher}.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class CronThreadPullTermination implements ServiceTermination {
+  private static final Logger LOG = LoggerFactory.getLogger(CronThreadPullTermination.class);
+
+  public static final String SERVICE_NAME = "CronJobService";
+
+  private final ThreadPullLauncher launcher;
+
+  @Inject
+  public CronThreadPullTermination(ThreadPullLauncher launcher) {
+    this.launcher = launcher;
+  }
+
+  @Override
+  public void terminate() throws InterruptedException {
+    suspend();
+  }
+
+  @Override
+  public void suspend() throws InterruptedException {
+    try {
+      launcher.shutdown();
+    } catch (RuntimeException ex) {
+      LOG.error("Failed to stop cron job thread pool. Cause: " + ex.getMessage());
+    }
+  }
+
+  @Override
+  public String getServiceName() {
+    return SERVICE_NAME;
+  }
+
+  @Override
+  public Set<String> getDependencies() {
+    return Collections.emptySet();
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/TemporaryWorkspaceRemover.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/TemporaryWorkspaceRemover.java
@@ -14,7 +14,6 @@ import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.Pages;
@@ -49,7 +48,6 @@ public class TemporaryWorkspaceRemover {
     }
   }
 
-  @PreDestroy
   void shutdown() {
     try {
       removeTemporaryWs();

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTermination.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTermination.java
@@ -27,6 +27,7 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.system.server.CronThreadPullTermination;
 import org.eclipse.che.api.system.server.ServiceTermination;
 import org.eclipse.che.api.system.shared.event.service.SystemServiceItemStoppedEvent;
 import org.eclipse.che.api.system.shared.event.service.SystemServiceItemSuspendedEvent;
@@ -83,7 +84,7 @@ public class WorkspaceServiceTermination implements ServiceTermination {
 
   @Override
   public Set<String> getDependencies() {
-    return Collections.emptySet();
+    return Collections.singleton(CronThreadPullTermination.SERVICE_NAME);
   }
 
   /**

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTermination.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTermination.java
@@ -62,6 +62,7 @@ public class WorkspaceServiceTermination implements ServiceTermination {
   private final WorkspaceRuntimes runtimes;
   private final RuntimeInfrastructure runtimeInfrastructure;
   private final EventService eventService;
+  private final TemporaryWorkspaceRemover workspaceRemover;
 
   @Inject
   public WorkspaceServiceTermination(
@@ -69,12 +70,14 @@ public class WorkspaceServiceTermination implements ServiceTermination {
       WorkspaceSharedPool sharedPool,
       WorkspaceRuntimes runtimes,
       RuntimeInfrastructure runtimeInfrastructure,
-      EventService eventService) {
+      EventService eventService,
+      TemporaryWorkspaceRemover workspaceRemover) {
     this.manager = manager;
     this.sharedPool = sharedPool;
     this.runtimes = runtimes;
     this.runtimeInfrastructure = runtimeInfrastructure;
     this.eventService = eventService;
+    this.workspaceRemover = workspaceRemover;
   }
 
   @Override
@@ -105,6 +108,10 @@ public class WorkspaceServiceTermination implements ServiceTermination {
     } finally {
       eventService.unsubscribe(propagator);
     }
+    try {
+      workspaceRemover.shutdown();
+    } catch (Exception ignored) {
+    }
   }
 
   /**
@@ -129,6 +136,10 @@ public class WorkspaceServiceTermination implements ServiceTermination {
       sharedPool.shutdown();
     } finally {
       eventService.unsubscribe(propagator);
+    }
+    try {
+      workspaceRemover.shutdown();
+    } catch (Exception ignored) {
     }
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/ProbeSchedulerTermination.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/ProbeSchedulerTermination.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.hc.probe;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Singleton;
+import java.util.Set;
+import javax.inject.Inject;
+import org.eclipse.che.api.system.server.ServiceTermination;
+import org.eclipse.che.api.workspace.server.WorkspaceServiceTermination;
+
+/**
+ * Terminates {@link ProbeScheduler}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class ProbeSchedulerTermination implements ServiceTermination {
+  public static final String SERVICE_NAME = "ProbeScheduler";
+
+  private final ProbeScheduler probeScheduler;
+
+  @Inject
+  public ProbeSchedulerTermination(ProbeScheduler probeScheduler) {
+    this.probeScheduler = probeScheduler;
+  }
+
+  @Override
+  public void terminate() {
+    probeScheduler.shutdown();
+  }
+
+  @Override
+  public String getServiceName() {
+    return SERVICE_NAME;
+  }
+
+  @Override
+  public Set<String> getDependencies() {
+    return ImmutableSet.of(WorkspaceServiceTermination.SERVICE_NAME);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Add service terminations for CronThreadPull and ProbeScheduller.

Move removing of the temporary workspaces from @PreDestroy phase to WorkspaceTerminationService. It is needed to make sure that temporary workspaces will be stopped before removing.

Minor change: fix logging of errors which may occur during server status updating.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9415


#### Release Notes
N/A

#### Docs PR
N/A