### PR TITLE
CHE-9542: Disable unrecoverable k8s events handling

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -428,7 +428,10 @@ public class KubernetesInternalRuntime<
     // namespace.pods().watch(new AbnormalStopHandler());
     namespace.pods().watchContainers(new MachineLogsPublisher());
     if (!Strings.isNullOrEmpty(unrecoverableEvents)) {
-      namespace.pods().watchContainers(new UnrecoverableEventHanler());
+      // The handler for unrecoverable events is disabled because it has a bug that prevents start
+      // of workspaces after previous workspace start failure.
+      // See https://github.com/eclipse/che/issues/9542
+      // namespace.pods().watchContainers(new UnrecoverableEventHanler());
     }
 
     final KubernetesServerResolver serverResolver =

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -272,7 +272,7 @@ public class KubernetesInternalRuntimeTest {
     verify(pods).create(any());
     verify(ingresses).create(any());
     verify(services).create(any());
-    verify(namespace.pods(), times(2)).watchContainers(any());
+    // verify(namespace.pods(), times(2)).watchContainers(any());
     verify(bootstrapper, times(2)).bootstrapAsync();
     verify(eventService, times(4)).publish(any());
     verifyOrderedEventsChains(


### PR DESCRIPTION
### What does this PR do?
Disable handling of unrecoverable events because they prevent the start of workspaces in certain cases after a workspace failed to start. See https://github.com/eclipse/che/issues/9542

### What issues does this PR fix or reference?
Workarounds #9542 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
