### PR TITLE
Fix letter display of workspace name

### DIFF
--- a/dashboard/src/components/attribute/clip-the-middle/che-clip-the-middle.styl
+++ b/dashboard/src/components/attribute/clip-the-middle/che-clip-the-middle.styl
@@ -6,9 +6,7 @@
   .che-clip-the-middle-start
     flex 1 1 inherit
     text-overflow ellipsis !important
-    overflow hidden
     white-space nowrap
-    padding-right 1px
 
   .che-clip-the-middle-end
     flex 1 0 auto

--- a/dashboard/src/components/attribute/clip-the-middle/che-clip-the-middle.styl
+++ b/dashboard/src/components/attribute/clip-the-middle/che-clip-the-middle.styl
@@ -8,6 +8,7 @@
     text-overflow ellipsis !important
     overflow hidden
     white-space nowrap
+    padding-right 1px
 
   .che-clip-the-middle-end
     flex 1 0 auto


### PR DESCRIPTION
Last letter of che-clip-the-middle-start will now be whole visible.

### What does this PR do?
The span including the first part of workspace name has now set padding-right to 1px to not cut the letter in italics. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9664