### PR TITLE
[kubernetes] set PROXY_ADDRESS_FORWARDING in keycloak deployment when tls is enabled

### DIFF
--- a/deploy/kubernetes/helm/che/charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/charts/che-keycloak/templates/deployment.yaml
@@ -52,6 +52,8 @@ spec:
         - name: PROTOCOL
 {{- if .Values.global.tls.enabled }}
           value: "https"
+        - name: PROXY_ADDRESS_FORWARDING
+          value: "true"
 {{- else }}
           value: "http"
 {{- end }}


### PR DESCRIPTION
### What does this PR do?

set the environment varibale PROXY_ADDRESS_FORWARDING to TRUE in keycloak deployment yaml when tls is enabled

### What issues does this PR fix or reference?

#9429 and #9674 