### PR TITLE
 Add DB termination component on application shutdown

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -69,6 +69,7 @@ import org.eclipse.che.api.workspace.server.stack.StackLoader;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
 import org.eclipse.che.commons.auth.token.ChainedTokenExtractor;
 import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
+import org.eclipse.che.core.db.DBTermination;
 import org.eclipse.che.core.db.schema.SchemaInitializer;
 import org.eclipse.che.inject.DynaModule;
 import org.eclipse.che.mail.template.ST.STTemplateProcessorImpl;
@@ -227,6 +228,7 @@ public class WsMasterModule extends AbstractModule {
     terminationMultiBinder
         .addBinding()
         .to(org.eclipse.che.api.workspace.server.hc.probe.ProbeSchedulerTermination.class);
+    bind(DBTermination.class);
 
     final Map<String, String> persistenceProperties = new HashMap<>();
     persistenceProperties.put(PersistenceUnitProperties.TARGET_SERVER, "None");

--- a/core/che-core-db/pom.xml
+++ b/core/che-core-db/pom.xml
@@ -54,6 +54,10 @@
             <artifactId>org.eclipse.persistence.core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>org.eclipse.persistence.extension</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>

--- a/core/che-core-db/src/main/java/org/eclipse/che/core/db/DBTermination.java
+++ b/core/che-core-db/src/main/java/org/eclipse/che/core/db/DBTermination.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.core.db;
+
+import com.google.inject.Inject;
+import com.google.inject.persist.PersistService;
+import java.lang.reflect.Field;
+import javax.inject.Singleton;
+import javax.persistence.EntityManagerFactory;
+import org.eclipse.persistence.internal.sessions.AbstractSession;
+import org.eclipse.persistence.internal.sessions.coordination.jgroups.JGroupsRemoteConnection;
+import org.eclipse.persistence.sessions.coordination.CommandManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stops {@link PersistService} when a system is ready to shutdown.
+ *
+ * @author Anton Korneta
+ */
+@Singleton
+public class DBTermination {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DBTermination.class);
+
+  private final PersistService persistService;
+  private final EntityManagerFactory emFactory;
+
+  @Inject
+  public DBTermination(PersistService persistService, EntityManagerFactory emFactory) {
+    this.persistService = persistService;
+    this.emFactory = emFactory;
+  }
+
+  /** Stops {@link PersistService}. Any DB operations are impossible after that. */
+  public void terminate() {
+    try {
+      LOG.info("Stopping persistence service.");
+      fixJChannelClosing(emFactory);
+      persistService.stop();
+    } catch (RuntimeException ex) {
+      LOG.error("Failed to stop persistent service. Cause: " + ex.getMessage());
+    }
+  }
+
+  /**
+   * This method is hack that changes value of {@link JGroupsRemoteConnection#isLocal} to false.
+   * This is needed to close the JGroups EclipseLinkCommandChannel and as result gracefully stop of
+   * the system.<br>
+   * For more details see {@link JGroupsRemoteConnection#closeInternal()}
+   */
+  private void fixJChannelClosing(EntityManagerFactory emFactory) {
+    try {
+      final AbstractSession session = emFactory.unwrap(AbstractSession.class);
+      CommandManager commandManager = session.getCommandManager();
+      if (commandManager == null) {
+        // not cluster mode
+        return;
+      }
+      final JGroupsRemoteConnection conn =
+          (JGroupsRemoteConnection) commandManager.getTransportManager().getConnectionToLocalHost();
+      final Field isLocal = conn.getClass().getDeclaredField("isLocal");
+      isLocal.setAccessible(true);
+      isLocal.set(conn, false);
+    } catch (IllegalAccessException | NoSuchFieldException ex) {
+      LOG.error(
+          "Failed to change JGroupsRemoteConnection#isLocal this may prevent the graceful stop of "
+              + "the system because EclipseLinkCommandChannel won't be closed. Cause: "
+              + ex.getMessage());
+    }
+  }
+}

--- a/wsmaster/che-core-api-system/pom.xml
+++ b/wsmaster/che-core-api-system/pom.xml
@@ -86,6 +86,10 @@
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-schedule</artifactId>
         </dependency>
+          <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-db</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -103,6 +107,11 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.persistence</groupId>
+            <artifactId>javax.persistence</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/SystemManager.java
+++ b/wsmaster/che-core-api-system/src/main/java/org/eclipse/che/api/system/server/SystemManager.java
@@ -30,6 +30,7 @@ import org.eclipse.che.api.system.shared.SystemStatus;
 import org.eclipse.che.api.system.shared.event.SystemStatusChangedEvent;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
+import org.eclipse.che.core.db.DBTermination;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,13 +47,16 @@ public class SystemManager {
   private final AtomicReference<SystemStatus> statusRef;
   private final EventService eventService;
   private final ServiceTerminator terminator;
+  private final DBTermination dbTermination;
 
   private final CountDownLatch shutdownLatch = new CountDownLatch(1);
 
   @Inject
-  public SystemManager(ServiceTerminator terminator, EventService eventService) {
+  public SystemManager(
+      ServiceTerminator terminator, DBTermination dbTermination, EventService eventService) {
     this.terminator = terminator;
     this.eventService = eventService;
+    this.dbTermination = dbTermination;
     this.statusRef = new AtomicReference<>(RUNNING);
   }
 
@@ -152,6 +156,7 @@ public class SystemManager {
       shutdownLatch.await();
     } else {
       doSuspendServices();
+      dbTermination.terminate();
     }
   }
 }

--- a/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/SystemManagerTest.java
+++ b/wsmaster/che-core-api-system/src/test/java/org/eclipse/che/api/system/server/SystemManagerTest.java
@@ -14,6 +14,7 @@ import static org.eclipse.che.api.system.shared.SystemStatus.PREPARING_TO_SHUTDO
 import static org.eclipse.che.api.system.shared.SystemStatus.READY_TO_SHUTDOWN;
 import static org.eclipse.che.api.system.shared.SystemStatus.RUNNING;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import java.util.Iterator;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.system.shared.dto.SystemStatusChangedEventDto;
+import org.eclipse.che.core.db.DBTermination;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -44,6 +46,8 @@ public class SystemManagerTest {
 
   @Mock private EventService eventService;
 
+  @Mock private DBTermination dbTermination;
+
   @Captor private ArgumentCaptor<SystemStatusChangedEventDto> eventsCaptor;
 
   private SystemManager systemManager;
@@ -51,7 +55,7 @@ public class SystemManagerTest {
   @BeforeMethod
   public void init() {
     MockitoAnnotations.initMocks(this);
-    systemManager = new SystemManager(terminator, eventService);
+    systemManager = new SystemManager(terminator, dbTermination, eventService);
   }
 
   @Test
@@ -92,6 +96,11 @@ public class SystemManagerTest {
     systemManager.shutdown();
 
     verifySuspendCompleted();
+    verifyDBTerminated();
+  }
+
+  private void verifyDBTerminated() {
+    verify(dbTermination, atLeastOnce()).terminate();
   }
 
   private void verifyShutdownCompleted() throws InterruptedException {


### PR DESCRIPTION
### What does this PR do?
 Adds DB termination component which stops persistence service and optionally network cache coordination service  on application shutdown.




### What issues does this PR fix or reference?

### Release Notes
### Docs PR
