### PR TITLE
Added an ability to schedule servers checkers for STARTING K8s/OS runtime

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfrastructure.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfrastructure.java
@@ -16,7 +16,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
@@ -66,8 +65,7 @@ public class KubernetesInfrastructure extends RuntimeInfrastructure {
 
   @Override
   protected KubernetesRuntimeContext internalPrepare(
-      RuntimeIdentity id, InternalEnvironment environment)
-      throws ValidationException, InfrastructureException {
+      RuntimeIdentity id, InternalEnvironment environment) throws InfrastructureException {
     final KubernetesEnvironment kubernetesEnvironment = asKubernetesEnv(environment);
 
     k8sEnvProvisioner.provision(kubernetesEnvironment, id);
@@ -76,7 +74,7 @@ public class KubernetesInfrastructure extends RuntimeInfrastructure {
   }
 
   private KubernetesEnvironment asKubernetesEnv(InternalEnvironment source)
-      throws ValidationException, InfrastructureException {
+      throws InfrastructureException {
     if (source instanceof KubernetesEnvironment) {
       return (KubernetesEnvironment) source;
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesRuntimeContext.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesRuntimeContext.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.ValidationException;
-import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
@@ -81,9 +80,7 @@ public class KubernetesRuntimeContext<T extends KubernetesEnvironment> extends R
             namespaceFactory.create(workspaceId, runtimeState.getNamespace()),
             getEnvironment().getWarnings());
 
-    if (runtime.getStatus() == WorkspaceStatus.RUNNING) {
-      runtime.startServersCheckers();
-    }
+    runtime.scheduleServersCheckers();
 
     return runtime;
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -31,6 +31,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -593,6 +594,53 @@ public class KubernetesInternalRuntimeTest {
 
     // then
     assertFalse(runtimeStatesCache.get(internalRuntime.getContext().getIdentity()).isPresent());
+  }
+
+  @Test
+  public void shouldScheduleServerCheckersForRunningRuntime() throws Exception {
+    // given
+    runtimeStatesCache.putIfAbsent(
+        new KubernetesRuntimeState(
+            internalRuntime.getContext().getIdentity(), "test", WorkspaceStatus.RUNNING));
+
+    // when
+    internalRuntime.scheduleServersCheckers();
+
+    // then
+    verify(probesScheduler).schedule(any(), any());
+  }
+
+  @Test
+  public void shouldScheduleServerCheckersForStartingRuntime() throws Exception {
+    // given
+    runtimeStatesCache.putIfAbsent(
+        new KubernetesRuntimeState(
+            internalRuntime.getContext().getIdentity(), "test", WorkspaceStatus.STARTING));
+
+    // when
+    internalRuntime.scheduleServersCheckers();
+
+    // then
+    verify(probesScheduler).schedule(any(), any(), any());
+  }
+
+  @Test(dataProvider = "nonStartingRunningStatuses")
+  public void shouldNotScheduleServerCheckersIfRuntimeIsNotStartingOrRunning(WorkspaceStatus status)
+      throws Exception {
+    // given
+    runtimeStatesCache.putIfAbsent(
+        new KubernetesRuntimeState(internalRuntime.getContext().getIdentity(), "test", status));
+
+    // when
+    internalRuntime.scheduleServersCheckers();
+
+    // then
+    verifyZeroInteractions(probesScheduler);
+  }
+
+  @DataProvider(name = "nonStartingRunningStatuses")
+  public Object[][] nonStartingRunningStatuses() {
+    return new Object[][] {{WorkspaceStatus.STOPPED}, {WorkspaceStatus.STOPPING}};
   }
 
   private static MachineStatusEvent newEvent(String machineName, MachineStatus status) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.ValidationException;
-import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
@@ -74,9 +73,7 @@ public class OpenShiftRuntimeContext extends KubernetesRuntimeContext<OpenShiftE
             projectFactory.create(workspaceId, runtimeState.getNamespace()),
             getEnvironment().getWarnings());
 
-    if (runtime.getStatus() == WorkspaceStatus.RUNNING) {
-      runtime.startServersCheckers();
-    }
+    runtime.scheduleServersCheckers();
 
     return runtime;
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactory.java
@@ -64,9 +64,20 @@ public class WorkspaceProbesFactory {
    */
   public WorkspaceProbes getProbes(RuntimeIdentity runtimeId, Runtime runtime)
       throws InfrastructureException {
+    return getProbes(runtimeId, runtime.getMachines());
+  }
+
+  /**
+   * Get {@link WorkspaceProbes} for servers of the specified machines
+   *
+   * @throws InfrastructureException when the operation fails
+   */
+  public WorkspaceProbes getProbes(
+      RuntimeIdentity runtimeId, Map<String, ? extends Machine> machines)
+      throws InfrastructureException {
     List<ProbeFactory> factories = new ArrayList<>();
     try {
-      for (Entry<String, ? extends Machine> entry : runtime.getMachines().entrySet()) {
+      for (Entry<String, ? extends Machine> entry : machines.entrySet()) {
         fillProbes(runtimeId, entry.getKey(), factories, entry.getValue().getServers());
       }
     } catch (MalformedURLException e) {


### PR DESCRIPTION
### What does this PR do?
Adds an ability to schedule servers checkers for STARTING K8s/OS runtime.

So, K8s/OS infrastructure is able to schedule servers checkers for recovered STARTING workspaces.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9502

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A
