### PR TITLE
Selenium: Restore order of the test methods launch in the "ContextMenuEditorTest" selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
@@ -167,7 +167,7 @@ public class ContextMenuEditorTest {
     editor.waitContextMenuIsNotPresent();
   }
 
-  @Test
+  @Test(priority = 1)
   public void checkUndoRedo() {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.scrollToItemByPath(
@@ -193,7 +193,7 @@ public class ContextMenuEditorTest {
     editor.waitContextMenuIsNotPresent();
   }
 
-  @Test
+  @Test(priority = 2)
   public void checkClose() {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.scrollToItemByPath(
@@ -209,7 +209,7 @@ public class ContextMenuEditorTest {
     editor.waitTabIsNotPresent("AppController");
   }
 
-  @Test
+  @Test(priority = 3)
   public void checkQuickDocumentation() {
     projectExplorer.waitItem(PROJECT_NAME_2);
     projectExplorer.openItemByPath(
@@ -226,7 +226,7 @@ public class ContextMenuEditorTest {
     editor.waitJavaDocPopUpClosed();
   }
 
-  @Test
+  @Test(priority = 4)
   public void checkQuickFix() {
     projectExplorer.waitItem(PROJECT_NAME_2);
     projectExplorer.openItemByPath(
@@ -247,7 +247,7 @@ public class ContextMenuEditorTest {
     editor.typeTextIntoEditor(Keys.ENTER.toString());
   }
 
-  @Test
+  @Test(priority = 5)
   public void checkOpenDeclaration() {
     projectExplorer.waitItem(PROJECT_NAME_2);
     projectExplorer.openItemByPath(
@@ -261,7 +261,7 @@ public class ContextMenuEditorTest {
     editor.closeFileByNameWithSaving("ModelAndView");
   }
 
-  @Test
+  @Test(priority = 6)
   public void checkRefactoring() {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.openItemByPath(PROJECT_NAME + "/src/main/java/com/example/Test1.java");
@@ -292,7 +292,7 @@ public class ContextMenuEditorTest {
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/Zclass.java");
   }
 
-  @Test
+  @Test(priority = 7)
   public void checkNaviFileStructure() {
     projectExplorer.waitItem(PROJECT_NAME_2);
     projectExplorer.openItemByPath(
@@ -315,7 +315,7 @@ public class ContextMenuEditorTest {
     editor.waitSpecifiedValueForLineAndChar(25, 25);
   }
 
-  @Test
+  @Test(priority = 8)
   public void checkFind() {
     projectExplorer.waitItem(PROJECT_NAME_2);
     projectExplorer.openItemByPath(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Restore order of the test methods launch in the "ContextMenuEditorTest" selenium test

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
