### PR TITLE
Fixed wrong logger output

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -143,7 +143,7 @@ public class PVCSubPathHelper {
       pods.create(pod);
       final Pod finished = pods.wait(podName, WAIT_POD_TIMEOUT_MIN, POD_PREDICATE::apply);
       if (POD_PHASE_FAILED.equals(finished.getStatus().getPhase())) {
-        LOG.error("Job command '%s' execution is failed.", Arrays.toString(command));
+        LOG.error("Job command '{}' execution is failed.", Arrays.toString(command));
       }
     } catch (InfrastructureException ex) {
       LOG.error(


### PR DESCRIPTION
### What does this PR do?
Fixed wrong logger output
instead of 
```2018-05-11 19:59:12,584[er-ThreadPool-1]  [ERROR] [e.c.w.i.k.n.p.PVCSubPathHelper 146]  - Job command '%s' execution is failed```

should be 

```2018-05-11 19:59:12,584[er-ThreadPool-1]  [ERROR] [e.c.w.i.k.n.p.PVCSubPathHelper 146]  - Job command 'some command' execution is failed```


### What issues does this PR fix or reference?
n/a


#### Release Notes
Fixed wrong logger output


#### Docs PR
n/a
