### PR TITLE
che-9234: fix diagnostics by reworking websocket usage to jsonrpc

### DIFF
--- a/dashboard/src/app/diagnostics/diagnostics.controller.ts
+++ b/dashboard/src/app/diagnostics/diagnostics.controller.ts
@@ -12,7 +12,6 @@
 import {DiagnosticsWebsocketWsMaster} from './test/diagnostics-websocket-wsmaster.factory';
 import {DiagnosticCallback} from './diagnostic-callback';
 import {DiagnosticsWorkspaceStartCheck} from './test/diagnostics-workspace-start-check.factory';
-import {CheWebsocket} from '../../components/api/che-websocket.factory';
 import {DiagnosticsRunningWorkspaceCheck} from './test/diagnostics-workspace-check-workspace.factory';
 import {DiagnosticPart} from './diagnostic-part';
 import {DiagnosticPartState} from './diagnostic-part-state';
@@ -26,7 +25,7 @@ import {CheBranding} from '../../components/branding/che-branding.factory';
  */
 export class DiagnosticsController {
 
-  static $inject = ['$log', '$q', 'lodash', '$timeout', 'diagnosticsWebsocketWsMaster', 'cheWebsocket', 'cheBranding', 'diagnosticsRunningWorkspaceCheck', 'diagnosticsWorkspaceStartCheck'];
+  static $inject = ['$log', '$q', 'lodash', '$timeout', 'diagnosticsWebsocketWsMaster', 'cheBranding', 'diagnosticsRunningWorkspaceCheck', 'diagnosticsWorkspaceStartCheck'];
 
   /**
    * Promise service handling.
@@ -52,11 +51,6 @@ export class DiagnosticsController {
    * Instance of checker for workspace
    */
   private diagnosticsWorkspaceStartCheck: DiagnosticsWorkspaceStartCheck;
-
-  /**
-   * Websocket library.
-   */
-  private cheWebsocket: CheWebsocket;
 
   /**
    * Angular timeout service.
@@ -124,7 +118,6 @@ export class DiagnosticsController {
   constructor($log: ng.ILogService, $q: ng.IQService, lodash: any,
               $timeout: ng.ITimeoutService,
               diagnosticsWebsocketWsMaster: DiagnosticsWebsocketWsMaster,
-              cheWebsocket: CheWebsocket,
               cheBranding: CheBranding,
               diagnosticsRunningWorkspaceCheck: DiagnosticsRunningWorkspaceCheck,
               diagnosticsWorkspaceStartCheck: DiagnosticsWorkspaceStartCheck) {
@@ -136,7 +129,6 @@ export class DiagnosticsController {
     this.diagnosticsWorkspaceStartCheck = diagnosticsWorkspaceStartCheck;
     this.diagnosticsRunningWorkspaceCheck = diagnosticsRunningWorkspaceCheck;
     this.parts = new Array<DiagnosticPart>();
-    this.cheWebsocket = cheWebsocket;
     this.sharedMap = new Map<string, any>();
     this.cheBranding = cheBranding;
     this.isLogDisplayed = false;
@@ -222,7 +214,7 @@ export class DiagnosticsController {
    * @returns {DiagnosticCallback} the newly callback
    */
   public newItem(text: string, diagnosticPart: DiagnosticPart): DiagnosticCallback {
-    let callback: DiagnosticCallback = new DiagnosticCallback(this.$q, this.cheWebsocket, this.$timeout, text, this.sharedMap, this, diagnosticPart);
+    let callback: DiagnosticCallback = new DiagnosticCallback(this.$q, this.$timeout, text, this.sharedMap, this, diagnosticPart);
     diagnosticPart.addCallback(callback);
     return callback;
   }

--- a/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
+++ b/dashboard/src/app/diagnostics/test/diagnostics-workspace-start-check.factory.ts
@@ -227,6 +227,7 @@ export class DiagnosticsWorkspaceStartCheck {
               let workspace = this.cheWorkspace.getWorkspaceById(workspaceId);
               diagnosticCallback.shared('workspace', workspace);
               diagnosticCallback.shared('machineToken', workspace.runtime.machineToken);
+              diagnosticCallback.shared('clientId', this.cheJsonRpcMasterApi.getClientId());
               diagnosticCallback.success('Starting workspace OK');
             });
           });

--- a/dashboard/src/components/api/json-rpc/che-json-rpc-api.factory.ts
+++ b/dashboard/src/components/api/json-rpc/che-json-rpc-api.factory.ts
@@ -12,6 +12,7 @@
 
 import {CheJsonRpcMasterApi} from './che-json-rpc-master-api';
 import {WebsocketClient} from './websocket-client';
+import {CheJsonRpcWsagentApi} from './che-json-rpc-wsagent-api';
 
 /**
  * This class manages the api connection through JSON RPC.
@@ -26,7 +27,6 @@ export class CheJsonRpcApi {
   private $websocket: any;
   private $log: ng.ILogService;
   private jsonRpcApiConnection: Map<string, CheJsonRpcMasterApi>;
-
   private $timeout: ng.ITimeoutService;
 
   /**
@@ -53,4 +53,11 @@ export class CheJsonRpcApi {
      return cheJsonRpcMasterApi;
    }
   }
+
+  getJsonRpcWsagentApi(entrypoint: string): CheJsonRpcWsagentApi {
+    let websocketClient = new WebsocketClient(this.$websocket, this.$q);
+    let cheJsonRpcWsagentApi: CheJsonRpcWsagentApi = new CheJsonRpcWsagentApi(websocketClient);
+    return cheJsonRpcWsagentApi;
+  }
+
 }

--- a/dashboard/src/components/api/json-rpc/websocket-client.ts
+++ b/dashboard/src/components/api/json-rpc/websocket-client.ts
@@ -42,11 +42,9 @@ export class WebsocketClient implements ICommunicationClient {
 
     this.websocketStream.onOpen(() => {
       const event: communicationClientEvent = 'open';
-      if (!this.handlers[event] || this.handlers[event].length === 0) {
-        return;
+      if (this.handlers[event] && this.handlers[event].length === 0) {
+        this.handlers[event].forEach((handler: Function) => handler() );
       }
-
-      this.handlers[event].forEach((handler: Function) => handler() );
 
       deferred.resolve();
     });


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes the diagnostics feature by reworking usage of everest websocket to JSON RPC one. 
Also as far as heartbeat is not implemented - used fetching client id instead. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9234

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A
