### PR TITLE
Send request with activity on ws-agent in a separate thread

### DIFF
--- a/wsagent/che-core-workspace-activity-server/src/main/java/org/eclipse/che/workspace/activity/WorkspaceActivityNotifier.java
+++ b/wsagent/che-core-workspace-activity-server/src/main/java/org/eclipse/che/workspace/activity/WorkspaceActivityNotifier.java
@@ -53,9 +53,14 @@ public class WorkspaceActivityNotifier {
   /**
    * Notify workspace master about activity in this workspace.
    *
-   * <p>After last notification, any consecutive activities that come within specific amount of time
-   * - {@code threshold}, will not notify immediately, but trigger notification in scheduler method
-   * {@link WorkspaceActivityNotifier#scheduleActivityNotification}
+   * <p>There is a {@code threshold} that limits request sending frequency - if no activity has
+   * occurred within the duration of threshold, then the request will be sent immediately (in a
+   * separate thread, to prevent it's possible long execution from blocking of the Tomcat thread,
+   * from which it may be called).
+   *
+   * <p>In case there was any recent activity within threshold time, any consecutive activities will
+   * not send request immediately, but trigger it's sending in scheduler method {@link
+   * WorkspaceActivityNotifier#scheduleActivityNotification}
    */
   public void onActivity() {
     long currentTime = System.currentTimeMillis();

--- a/wsagent/che-core-workspace-activity-server/src/main/java/org/eclipse/che/workspace/activity/WorkspaceActivityNotifier.java
+++ b/wsagent/che-core-workspace-activity-server/src/main/java/org/eclipse/che/workspace/activity/WorkspaceActivityNotifier.java
@@ -75,10 +75,17 @@ public class WorkspaceActivityNotifier {
   }
 
   private void notifyActivity() {
-    try {
-      httpJsonRequestFactory.fromUrl(apiEndpoint + "/activity/" + wsId).usePutMethod().request();
-    } catch (Exception e) {
-      LOG.error("Cannot notify master about workspace " + wsId + " activity", e);
-    }
+    new Thread(
+            () -> {
+              try {
+                httpJsonRequestFactory
+                    .fromUrl(apiEndpoint + "/activity/" + wsId)
+                    .usePutMethod()
+                    .request();
+              } catch (Exception e) {
+                LOG.error("Cannot notify master about workspace " + wsId + " activity", e);
+              }
+            })
+        .start();
   }
 }

--- a/wsagent/che-core-workspace-activity-server/src/main/java/org/eclipse/che/workspace/activity/WorkspaceActivityNotifier.java
+++ b/wsagent/che-core-workspace-activity-server/src/main/java/org/eclipse/che/workspace/activity/WorkspaceActivityNotifier.java
@@ -62,7 +62,10 @@ public class WorkspaceActivityNotifier {
     if (currentTime < (lastUpdateTime + threshold)) {
       activeDuringThreshold.set(true);
     } else {
-      notifyActivity();
+      Thread activityRequestThread = new Thread(this::notifyActivity);
+      activityRequestThread.setDaemon(true);
+      activityRequestThread.start();
+
       lastUpdateTime = currentTime;
     }
   }
@@ -75,17 +78,10 @@ public class WorkspaceActivityNotifier {
   }
 
   private void notifyActivity() {
-    new Thread(
-            () -> {
-              try {
-                httpJsonRequestFactory
-                    .fromUrl(apiEndpoint + "/activity/" + wsId)
-                    .usePutMethod()
-                    .request();
-              } catch (Exception e) {
-                LOG.error("Cannot notify master about workspace " + wsId + " activity", e);
-              }
-            })
-        .start();
+    try {
+      httpJsonRequestFactory.fromUrl(apiEndpoint + "/activity/" + wsId).usePutMethod().request();
+    } catch (Exception e) {
+      LOG.error("Cannot notify master about workspace " + wsId + " activity", e);
+    }
   }
 }

--- a/wsagent/che-core-workspace-activity-server/src/main/java/org/eclipse/che/workspace/activity/WorkspaceActivityNotifier.java
+++ b/wsagent/che-core-workspace-activity-server/src/main/java/org/eclipse/che/workspace/activity/WorkspaceActivityNotifier.java
@@ -68,6 +68,7 @@ public class WorkspaceActivityNotifier {
       activeDuringThreshold.set(true);
     } else {
       Thread activityRequestThread = new Thread(this::notifyActivity);
+      activityRequestThread.setName("WorkspaceActivityRequestThread");
       activityRequestThread.setDaemon(true);
       activityRequestThread.start();
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
On WS-Agent, sending requests will be performed in separate threads, to prevent blocking the tomcat thread if request takes too long to complete.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9126

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
