### PR TITLE
Added an error when keycloak container is not found

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/KeycloakAdminConsoleClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/KeycloakAdminConsoleClient.java
@@ -81,6 +81,11 @@ public class KeycloakAdminConsoleClient {
             processAgent.execute("echo $(docker ps | grep che_keycloak | cut -d ' ' -f1)");
         break;
     }
+
+    if (keycloakContainerId.trim().isEmpty()) {
+      throw new RuntimeException(
+          "Keycloak container is not found. Make sure that correct value is set for `CHE_INFRASTRUCTURE`.");
+    }
   }
 
   public TestUserImpl createUser(RemovableUserProvider testUserProvider) throws IOException {


### PR DESCRIPTION
### What does this PR do?
Adds an error when keycloak container is not found. Earlier when `CHE_INFRASTRUCTURE` was not set correctly then selenium tests failed with error `no such container sh -c` because of invalid constructed commands like `docker exec -i sh -c` where container id is missed.

### What issues does this PR fix or reference?
--

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A