### PR TITLE
Set editor scroll position when editor is focused

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/EditorPartPresenter.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/EditorPartPresenter.java
@@ -37,6 +37,9 @@ public interface EditorPartPresenter extends PartPresenter {
   /** The property id for editor input changed. */
   int PROP_INPUT = 0x102;
 
+  /** The property id for state when editor has got focus. */
+  int PROP_FOCUSED = 0x103;
+
   /**
    * Initializes this editor with the given input.
    *

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditor.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/texteditor/TextEditor.java
@@ -138,6 +138,13 @@ public interface TextEditor extends EditorPartPresenter {
   int getCursorOffset();
 
   /**
+   * Used to determine editor vertical scroll position
+   *
+   * @return the top visible line when editor is focused or cached value otherwise
+   */
+  int getTopLine();
+
+  /**
    * Returns the top visible line. Used to determine editor vertical scroll position
    *
    * @return the top visible line

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -215,6 +215,7 @@ public class OrionEditorPresenter extends AbstractEditorPresenter
   /** The editor's error state. */
   private EditorState errorState;
 
+  private int topLine;
   private boolean delayedFocus;
   private boolean isFocused;
   private BreakpointRenderer breakpointRenderer;
@@ -781,6 +782,11 @@ public class OrionEditorPresenter extends AbstractEditorPresenter
   }
 
   @Override
+  public int getTopLine() {
+    return isFocused ? getTopVisibleLine() : topLine;
+  }
+
+  @Override
   public int getTopVisibleLine() {
     return editorWidget.getTopVisibleLine();
   }
@@ -888,6 +894,7 @@ public class OrionEditorPresenter extends AbstractEditorPresenter
   public void editorLostFocus() {
     this.editorView.updateInfoPanelUnfocused(this.document.getLineCount());
     this.isFocused = false;
+    this.topLine = getTopVisibleLine();
     if (isDirty() && autoSaveMode.isActivated()) {
       doSave();
     }
@@ -896,7 +903,9 @@ public class OrionEditorPresenter extends AbstractEditorPresenter
   @Override
   public void editorGotFocus() {
     this.isFocused = true;
-    this.editorView.updateInfoPanelPosition(this.document.getCursorPosition());
+
+    Scheduler.get().scheduleDeferred(() -> firePropertyChange(PROP_FOCUSED));
+    editorView.updateInfoPanelPosition(this.document.getCursorPosition());
   }
 
   @Override


### PR DESCRIPTION
### What does this PR do?
Set editor scroll position when editor is focused at restoring IDE state
Fix case related to saving wrong value of a top line for not focused editors at storing app state 

### What issues does this PR fix or reference?
#9456 
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
