### PR TITLE
CHE-9716: Use the fixed version of Theia in eclipse/che-theia image

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -8,28 +8,31 @@
 #   Red Hat, Inc. - initial API and implementation
 
 FROM node:8-alpine
+
+ARG GITHUB_TOKEN
+ARG THEIA_VERSION
+ENV USE_LOCAL_GIT=true \
+    GITHUB_TOKEN=${GITHUB_TOKEN}
+
 # build dependencies requireed to compile a custom Theia
-RUN apk add --no-cache make gcc g++ python git openssh bash supervisor
+RUN apk add --no-cache make gcc g++ python git openssh bash supervisor jq
 WORKDIR /home/theia
 # build Theia with all extensions to persist yarn cache in the image and
 # have default Theia build in the workspace in case no plugins are requested
-ADD https://raw.githubusercontent.com/theia-ide/theia-apps/master/theia-full-docker/latest.package.json /home/theia/package.json
+ADD https://raw.githubusercontent.com/theia-ide/theia/v${THEIA_VERSION}/examples/browser/package.json /home/theia/package.json
 ADD theia-default-package.json /home/default/theia/package.json
-ADD src/add-extensions.js /home/default
+ADD versions.sh /home/default/versions.sh
+RUN cd /home/default && ./versions.sh
+
 ADD supervisord.conf /etc/
-RUN node /home/default/add-extensions.js \
-    che-theia-ssh-extension:https://github.com/eclipse/che-theia-ssh-plugin.git \
-    && rm /home/default/add-extensions.js
 RUN cd /home/theia && \
     yarn && \
-    yarn theia build && \
+    yarn theia build --mode development && \
     rm -rf * && \
     cd /home/default/theia && \
     yarn && \
     yarn theia build
 ADD src/main.js /theia_launcher/theia_launcher.js
 EXPOSE 3000
-ARG GITHUB_TOKEN
-ENV USE_LOCAL_GIT=true \
-    GITHUB_TOKEN=${GITHUB_TOKEN}
+
 ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisord.conf"]

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -14,6 +14,8 @@ ARG THEIA_VERSION
 ENV USE_LOCAL_GIT=true \
     GITHUB_TOKEN=${GITHUB_TOKEN}
 
+RUN if [ -z "${THEIA_VERSION}" ]; then echo -e '\033[0;31m' Set up build argument 'THEIA_VERSION' '\033[0m'; exit 1; fi
+
 # build dependencies requireed to compile a custom Theia
 RUN apk add --no-cache make gcc g++ python git openssh bash supervisor jq
 WORKDIR /home/theia

--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -1,0 +1,15 @@
+# How to Build Theia Image
+
+## Build image manually
+Example:
+docker build -t eclipse/che-theia:nightly --build-arg GITHUB_TOKEN={your token} build-arg THEIA_VERSION=0.3.10 .
+
+## Theia version
+
+There's a default Theia version set in the script. This version is then injected in all package.jsons.
+You can override `THEIA_VERSION` by exporting the env before running the script
+
+## GITHUB_TOKEN
+
+Once of Theia dependencies calls GitHub API during build to download binaries. It may happen that GitHub API rate limit is exceeded.
+As a result build fails. It may not happen at all. If it happens, obtain GitHub API token

--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -2,7 +2,7 @@
 
 ## Build image manually
 Example:
-docker build -t eclipse/che-theia:nightly --build-arg GITHUB_TOKEN={your token} build-arg THEIA_VERSION=0.3.10 .
+docker build -t eclipse/che-theia:nightly --build-arg GITHUB_TOKEN={your token} --build-arg THEIA_VERSION=0.3.10 .
 
 ## Theia version
 

--- a/dockerfiles/theia/src/add-extensions.js
+++ b/dockerfiles/theia/src/add-extensions.js
@@ -23,6 +23,7 @@ givenExtensions.shift();
 givenExtensions.shift();
 
 if (givenExtensions.length > 0) {
+    cp.execSync(mkdir -p ${EXTENSIONS_DIR});
     addExtensions(parseExtensions(givenExtensions));
 }
 

--- a/dockerfiles/theia/supervisord.conf
+++ b/dockerfiles/theia/supervisord.conf
@@ -4,3 +4,9 @@
 command=node /theia_launcher/theia_launcher.js
 stopasgroup=true
 killasgroup=true
+
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/dockerfiles/theia/theia-default-package.json
+++ b/dockerfiles/theia/theia-default-package.json
@@ -9,7 +9,8 @@
         "@theia/git": "latest",
         "@theia/file-search": "latest",
         "@theia/markers": "latest",
-        "@theia/extension-manager": "latest"
+        "@theia/extension-manager": "latest",
+        "@theia/messages": "latest"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/dockerfiles/theia/versions.sh
+++ b/dockerfiles/theia/versions.sh
@@ -9,7 +9,11 @@
 #   Red Hat, Inc. - initial API and implementation
 set -e
 
-THEIA_VERSION="0.3.10"
+if [ -z "${THEIA_VERSION}" ]; then
+    echo '\033[0;31m Set up 'THEIA_VERSION' argument, please \033[0m';
+    exit 1;
+fi
+
 LATEST_VERSION="latest"
 PACKAGE_JSON_PATH="/home/default/theia/package.json"
 
@@ -26,4 +30,4 @@ for i in ${PACKAGES_FULL[@]}; do
 done
 
 # edit dev dependency version
-sed -i "s#\"@theia/cli\": \"latest\"#\"@theia/cli\": \"${THEIA_VERSION}\"#g" ${PACKAGE_JSON_PATH}
+sed -i "s#\"@theia/cli\": \"$LATEST_VERSION\"#\"@theia/cli\": \"${THEIA_VERSION}\"#g" ${PACKAGE_JSON_PATH}

--- a/dockerfiles/theia/versions.sh
+++ b/dockerfiles/theia/versions.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright (c) 2018 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+set -e
+
+THEIA_VERSION="0.3.10"
+LATEST_VERSION="latest"
+PACKAGE_JSON_PATH="/home/default/theia/package.json"
+
+# modify  package json files according to provided THEIA_VERSION. Check if included packages are available before running sed
+PACKAGES_FULL=$(cat ${PACKAGE_JSON_PATH} | jq -r '.dependencies | keys | .[]')
+for i in ${PACKAGES_FULL[@]}; do
+    PACKAGE=$(npm show ${i}@${THEIA_VERSION})
+    if [ -z "${PACKAGE}" ]; then
+      echo "${i} package with version ${THEIA_VERSION} not found. Using latest"
+    else
+      echo "Found ${i} package with version ${THEIA_VERSION}"
+      sed -i "s#\"${i}\": \"latest\"#\"${i}\": \"${THEIA_VERSION}\"#g" ${PACKAGE_JSON_PATH}
+    fi
+done
+
+# edit dev dependency version
+sed -i "s#\"@theia/cli\": \"latest\"#\"@theia/cli\": \"${THEIA_VERSION}\"#g" ${PACKAGE_JSON_PATH}


### PR DESCRIPTION
### What does this PR do?
Fix displaying logs theia-launcher as supervisor child process.
Use the fixed version of Theia in eclipse/che-theia image, code proposed by @eivantsov https://github.com/eclipse/che-dockerfiles/pull/183 .
Don't rebuild browser-app and electron-app for extensions uploaded from github to speed up Theia stack launch.
Apply `@theia/messages`  extension to default package json.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9716

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
