### PR TITLE
Fix installers version confusing by displaying only the latest version

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.html
@@ -25,7 +25,7 @@
       <!-- Agents list  -->
       <che-list class="machine-agents-list" flex
                 ng-if="machineAgentsController.agentsList && machineAgentsController.agentsList.length > 0">
-        <div class="machine-agents-item"
+        <div class="machine-agents-item" ng-if="agentItem.isLatest || agentItem.isEnabled"
              ng-repeat="agentItem in machineAgentsController.agentsList | orderBy:[machineAgentsController.agentOrderBy, '-version' ]">
           <che-list-item flex>
             <div flex="100"


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
There is need to avoid confusing users by ability to switch installer's version. Dealt to display only the latest one.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8092

No installers duplication:
![screenshot from 2018-05-21 14-31-42](https://user-images.githubusercontent.com/1611939/40305594-cc9c6b54-5d03-11e8-824a-02971f4d29a7.png)
 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A


#### Docs PR
N/A
