### PR TITLE
che #9542 Processing only the events that happened after `watchContainers` initialization

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -656,7 +656,6 @@ public class KubernetesInternalRuntime<
   public class UnrecoverableEventHanler implements ContainerEventHandler {
     private List<String> events;
     private Map<String, Pod> workspacePods;
-    private Date handlerInitialization;
 
     public UnrecoverableEventHanler(Map<String, Pod> workspacePods) {
       this.events =
@@ -664,7 +663,6 @@ public class KubernetesInternalRuntime<
               ? Collections.EMPTY_LIST
               : Arrays.asList(unrecoverableEvents.split(","));
       this.workspacePods = workspacePods;
-      this.handlerInitialization = new Date();
     }
 
     /*
@@ -673,9 +671,7 @@ public class KubernetesInternalRuntime<
      */
     @Override
     public void handle(ContainerEvent event) {
-      if (isWorkspaceEvent(event)
-          && happenedAfterHandlerInitialization(event)
-          && isUnrecoverable(event)) {
+      if (isWorkspaceEvent(event) && isUnrecoverable(event)) {
         String reason = event.getReason();
         String message = event.getMessage();
         String workspaceId = getContext().getIdentity().getWorkspaceId();
@@ -703,16 +699,6 @@ public class KubernetesInternalRuntime<
     private boolean isWorkspaceEvent(ContainerEvent event) {
       String podName = event.getPodName();
       return workspacePods.containsKey(podName);
-    }
-
-    /**
-     * Returns true if 'lastTimestamp' of the event is *after* the time of the handler
-     * initialization
-     */
-    private boolean happenedAfterHandlerInitialization(ContainerEvent event) {
-      String eventLastTimestamp = event.getLastTimestamp();
-      Date eventLastTimestampDate = convertEventTimestampToDate(eventLastTimestamp);
-      return eventLastTimestampDate != null && eventLastTimestampDate.after(handlerInitialization);
     }
 
     private Date convertEventTimestampToDate(String timestamp) {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -278,7 +278,7 @@ public class KubernetesInternalRuntimeTest {
     verify(pods).create(any());
     verify(ingresses).create(any());
     verify(services).create(any());
-    // verify(namespace.pods(), times(2)).watchContainers(any());
+    verify(namespace.pods(), times(2)).watchContainers(any());
     verify(bootstrapper, times(2)).bootstrapAsync();
     verify(eventService, times(4)).publish(any());
     verifyOrderedEventsChains(
@@ -511,23 +511,6 @@ public class KubernetesInternalRuntimeTest {
             getCurrentTimestampWithOneHourShiftAhead());
     unrecoverableEventHanler.handle(regularEvent);
     // 'internalStop' is NOT expected to be called and namespace cleanup will not be triggered
-    verify(namespace, never()).cleanUp();
-  }
-
-  @Test
-  public void testHandleUnrecoverableEventWhichHappenedInPast() throws Exception {
-    final UnrecoverableEventHanler unrecoverableEventHanler =
-        internalRuntime.new UnrecoverableEventHanler(k8sEnv.getPods());
-    final ContainerEvent regularEvent =
-        mockContainerEvent(
-            WORKSPACE_POD_NAME,
-            "Pulling",
-            "pulling image",
-            EVENT_CREATION_TIMESTAMP,
-            EVENT_LAST_TIMESTAMP_IN_PAST);
-    unrecoverableEventHanler.handle(regularEvent);
-    // 'internalStop' is NOT expected to be called since unrecoverable event had happened in the
-    // past. Namespace cleanup will not be triggered
     verify(namespace, never()).cleanUp();
   }
 


### PR DESCRIPTION
### What does this PR do?
Processing only the events that happened after `watchContainers` initialization

### What issues does this PR fix or reference?
Adressing comment in PR review - https://github.com/eclipse/che/pull/9703#pullrequestreview-121052243

#### Release Notes
N/A

#### Docs PR
N/A
