### PR TITLE
Add an ability to try Workspace.Next features

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -482,3 +482,10 @@ che.singleport.wildcard_domain.port=NULL
 
 # Enable single port custom DNS without inserting the IP
 che.singleport.wildcard_domain.ipless=false
+
+### Experimental properties
+# Next properties are subject to changes and removal, so do not rely on them in a stable Che assembly
+
+# Workspace.Next feature API endpoint. Should be a valid HTTP URL that includes protocol, port etc.
+# In case Workspace.Next is not needed value 'NULL' should be used
+che.workspace.feature.api=NULL

--- a/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/StringArrayConverter.java
+++ b/core/commons/che-core-commons-inject/src/main/java/org/eclipse/che/inject/StringArrayConverter.java
@@ -18,7 +18,14 @@ import com.google.inject.matcher.Matchers;
 import com.google.inject.spi.TypeConverter;
 import java.util.regex.Pattern;
 
-/** @author andrew00x */
+/**
+ * Converts injected string value to an array of strings if such an array is requested by injection.
+ *
+ * <p>Entries of the array should be separated by a comma sign. Spaces around entries are trimmed.
+ * Supports injection from property files, environment variables and Java system properties.
+ *
+ * @author andrew00x
+ */
 public class StringArrayConverter extends AbstractModule implements TypeConverter {
   private static final Pattern PATTERN = Pattern.compile(" *, *");
 

--- a/deploy/kubernetes/kubectl/Deploy Che.md
+++ b/deploy/kubernetes/kubectl/Deploy Che.md
@@ -33,3 +33,7 @@ and clean redeploy of Che.
 - Create namespace `che`: `kubectl create namespace che`
 - Deploy Che: `kubectl --namespace=che apply -f che-kubernetes.yaml`
 - Check Che pod status until it become `Running`: `kubectl get --namespace=che pods`
+
+### Workspace Next:
+There is a file `wsnext/feature-api.yaml` which contains kubesrv service needed to test Workspace Next on kubernetes infrastructure.
+To use it call `kubectl apply --namespace=che -f wsnext/feature-api.yaml` and Che will be able to use Workspace Next flow.

--- a/deploy/kubernetes/kubectl/che-kubernetes.yaml
+++ b/deploy/kubernetes/kubectl/che-kubernetes.yaml
@@ -72,6 +72,7 @@ items:
     CHE_LOGS_APPENDERS_IMPL: "plaintext"
     CHE_INFRA_KUBERNETES_INGRESS_DOMAIN: "192.168.99.100.nip.io"
     CHE_INFRA_KUBERNETES_SERVER__STRATEGY: "default-host"
+    CHE_WORKSPACE_FEATURE_API: "http://feature-api-service:3000"
 - apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
@@ -269,6 +270,11 @@ items:
             valueFrom:
               configMapKeyRef:
                 key: CHE_INFRA_KUBERNETES_SERVER__STRATEGY
+                name: che
+          - name: CHE_WORKSPACE_FEATURE_API
+            valueFrom:
+              configMapKeyRef:
+                key: CHE_WORKSPACE_FEATURE_API
                 name: che
           image: eclipse/che-server:nightly
           imagePullPolicy: Always

--- a/deploy/kubernetes/kubectl/che-kubernetes.yaml
+++ b/deploy/kubernetes/kubectl/che-kubernetes.yaml
@@ -70,7 +70,7 @@ items:
     CHE_WORKSPACE_AUTO_START: "false"
     CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"nginx.ingress.kubernetes.io/rewrite-target": "/","nginx.ingress.kubernetes.io/ssl-redirect": "false","nginx.ingress.kubernetes.io/proxy-connect-timeout": "3600","nginx.ingress.kubernetes.io/proxy-read-timeout": "3600"}'
     CHE_LOGS_APPENDERS_IMPL: "plaintext"
-    CHE_INFRA_KUBERNETES_INGRESS_DOMAIN: "192.168.99.101.nip.io"
+    CHE_INFRA_KUBERNETES_INGRESS_DOMAIN: "192.168.99.100.nip.io"
     CHE_INFRA_KUBERNETES_SERVER__STRATEGY: "default-host"
 - apiVersion: extensions/v1beta1
   kind: Ingress

--- a/deploy/kubernetes/kubectl/wsnext/feature-api.yaml
+++ b/deploy/kubernetes/kubectl/wsnext/feature-api.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: feature-api
+    name: feature-api-service
+  spec:
+    ports:
+    - name: feature-api
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+    selector:
+      app: feature-api
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    labels:
+      app: feature-api
+    name: feature-api
+  data:
+    CHE_REGISTRY_UPDATE_INTERVAL: "60"
+    CHE_REGISTRY_GITHUB_URL: "https://github.com/garagatyi/che-registry.git"
+- apiVersion: extensions/v1beta1
+  kind: Ingress
+  metadata:
+    name: feature-api-ingress
+    annotations:
+      nginx.ingress.kubernetes.io/rewrite-target: /
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600"
+  spec:
+    rules:
+    - host: feature.192.168.99.100.nip.io
+      http:
+        paths:
+        - backend:
+            serviceName: feature-api-service
+            servicePort: 3000
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: feature-api
+    name: feature-api
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      matchLabels:
+        app: feature-api
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: feature-api
+      spec:
+        containers:
+        - env:
+          - name: CHE_REGISTRY_UPDATE_INTERVAL
+            valueFrom:
+              configMapKeyRef:
+                key: CHE_REGISTRY_UPDATE_INTERVAL
+                name: feature-api
+          - name: CHE_REGISTRY_GITHUB_URL
+            valueFrom:
+              configMapKeyRef:
+                key: CHE_REGISTRY_GITHUB_URL
+                name: feature-api
+          image: garagatyi/kubesrv:latest
+          imagePullPolicy: Always
+          name: feature-api
+          ports:
+          - containerPort: 3000
+            name: feature-api
+          resources:
+            limits:
+              memory: 600Mi
+            requests:
+              memory: 256Mi

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -28,6 +28,7 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentF
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiExternalEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiInternalEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
+import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextApplier;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
@@ -53,6 +54,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.ExternalServer
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.IngressAnnotationsProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.MultiHostIngressExternalServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.SingleHostIngressExternalServerExposer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsnext.KubernetesWorkspaceNextApplier;
 
 /** @author Sergii Leshchenko */
 public class KubernetesInfraModule extends AbstractModule {
@@ -116,5 +118,9 @@ public class KubernetesInfraModule extends AbstractModule {
 
     bind(KubernetesRuntimeStateCache.class).to(JpaKubernetesRuntimeStateCache.class);
     bind(KubernetesMachineCache.class).to(JpaKubernetesMachineCache.class);
+
+    MapBinder<String, WorkspaceNextApplier> wsNext =
+        MapBinder.newMapBinder(binder(), String.class, WorkspaceNextApplier.class);
+    wsNext.addBinding(KubernetesEnvironment.TYPE).to(KubernetesWorkspaceNextApplier.class);
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsnext/KubernetesWorkspaceNextApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsnext/KubernetesWorkspaceNextApplier.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.wsnext;
+
+import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+
+import com.google.common.annotations.Beta;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Quantity;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextApplier;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
+import org.eclipse.che.api.workspace.server.wsnext.model.Container;
+import org.eclipse.che.api.workspace.server.wsnext.model.EnvVar;
+import org.eclipse.che.api.workspace.server.wsnext.model.ResourceRequirements;
+import org.eclipse.che.api.workspace.server.wsnext.model.Server;
+import org.eclipse.che.api.workspace.server.wsnext.model.Volume;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
+
+/**
+ * Applies Workspace.Next configuration to a kubernetes internal runtime object.
+ *
+ * @author Oleksander Garagatyi
+ */
+@Beta
+public class KubernetesWorkspaceNextApplier implements WorkspaceNextApplier {
+
+  private final String defaultMachineMemorySizeAttribute;
+
+  @Inject
+  public KubernetesWorkspaceNextApplier(
+      @Named("che.workspace.default_memory_mb") long defaultMachineMemorySizeMB) {
+    this.defaultMachineMemorySizeAttribute =
+        String.valueOf(defaultMachineMemorySizeMB * 1024 * 1024);
+  }
+
+  @Override
+  public void apply(InternalEnvironment internalEnvironment, Collection<CheService> cheServices)
+      throws InfrastructureException {
+    if (cheServices.isEmpty()) {
+      return;
+    }
+    KubernetesEnvironment kubernetesEnvironment = (KubernetesEnvironment) internalEnvironment;
+    Map<String, Pod> pods = kubernetesEnvironment.getPods();
+    if (pods.size() != 1) {
+      throw new InfrastructureException(
+          "Workspace.Next configuration can be applied to a workspace with one pod only");
+    }
+    Pod pod = pods.values().iterator().next();
+    for (CheService cheService : cheServices) {
+      for (Container container : cheService.getSpec().getContainers()) {
+        io.fabric8.kubernetes.api.model.Container k8sContainer =
+            addContainer(pod, container.getImage(), container.getEnv(), container.getResources());
+
+        String machineName = Names.machineName(pod, k8sContainer);
+
+        InternalMachineConfig machineConfig =
+            addMachine(
+                kubernetesEnvironment, machineName, container.getServers(), container.getVolumes());
+
+        normalizeMemory(k8sContainer, machineConfig);
+      }
+    }
+  }
+
+  private io.fabric8.kubernetes.api.model.Container addContainer(
+      Pod toolingPod, String image, List<EnvVar> env, ResourceRequirements resources) {
+    io.fabric8.kubernetes.api.model.Container container =
+        new ContainerBuilder()
+            .withImage(image)
+            .withName(Names.generateName("tooling"))
+            .withEnv(toK8sEnv(env))
+            .withResources(toK8sResources(resources))
+            .build();
+    toolingPod.getSpec().getContainers().add(container);
+    return container;
+  }
+
+  private io.fabric8.kubernetes.api.model.ResourceRequirements toK8sResources(
+      ResourceRequirements resources) {
+    io.fabric8.kubernetes.api.model.ResourceRequirements result =
+        new io.fabric8.kubernetes.api.model.ResourceRequirements();
+    String memory = resources.getRequests().get("memory");
+    if (memory != null) {
+      result.setRequests(singletonMap("memory", new Quantity(memory)));
+    }
+    return result;
+  }
+
+  private InternalMachineConfig addMachine(
+      KubernetesEnvironment kubernetesEnvironment,
+      String machineName,
+      List<Server> servers,
+      List<Volume> volumes) {
+
+    InternalMachineConfig machineConfig =
+        new InternalMachineConfig(
+            null, toWorkspaceServers(servers), null, null, toWorkspaceVolumes(volumes));
+    kubernetesEnvironment.getMachines().put(machineName, machineConfig);
+
+    return machineConfig;
+  }
+
+  private void normalizeMemory(
+      io.fabric8.kubernetes.api.model.Container container, InternalMachineConfig machineConfig) {
+    long ramLimit = Containers.getRamLimit(container);
+    Map<String, String> attributes = machineConfig.getAttributes();
+    if (ramLimit > 0) {
+      attributes.put(MEMORY_LIMIT_ATTRIBUTE, String.valueOf(ramLimit));
+    } else {
+      attributes.put(MEMORY_LIMIT_ATTRIBUTE, defaultMachineMemorySizeAttribute);
+    }
+  }
+
+  private Map<String, ? extends org.eclipse.che.api.core.model.workspace.config.Volume>
+      toWorkspaceVolumes(List<Volume> volumes) {
+    Map<String, VolumeImpl> result = new HashMap<>();
+
+    for (Volume volume : volumes) {
+      result.put(volume.getName(), new VolumeImpl().withPath(volume.getMountPath()));
+    }
+    return result;
+  }
+
+  private Map<String, ? extends ServerConfig> toWorkspaceServers(List<Server> servers) {
+    HashMap<String, ServerConfigImpl> result = new HashMap<>();
+    for (Server server : servers) {
+      result.put(
+          server.getName(),
+          normalizeServer(
+              new ServerConfigImpl(
+                  server.getPort().toString(),
+                  server.getProtocol(),
+                  null,
+                  server.getAttributes())));
+    }
+    return result;
+  }
+
+  private List<io.fabric8.kubernetes.api.model.EnvVar> toK8sEnv(List<EnvVar> env) {
+    List<io.fabric8.kubernetes.api.model.EnvVar> result = new ArrayList<>();
+
+    for (EnvVar envVar : env) {
+      result.add(
+          new io.fabric8.kubernetes.api.model.EnvVar(envVar.getName(), envVar.getValue(), null));
+    }
+
+    return result;
+  }
+
+  private ServerConfigImpl normalizeServer(ServerConfigImpl serverConfig) {
+    String port = serverConfig.getPort();
+    if (port != null && !port.contains("/")) {
+      serverConfig.setPort(port + "/tcp");
+    }
+    return serverConfig;
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsnext/KubernetesWorkspaceNextApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsnext/KubernetesWorkspaceNextApplierTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.wsnext;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Quantity;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheServiceSpec;
+import org.eclipse.che.api.workspace.server.wsnext.model.EnvVar;
+import org.eclipse.che.api.workspace.server.wsnext.model.ResourceRequirements;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Alexander Garagatyi */
+@Listeners(MockitoTestNGListener.class)
+public class KubernetesWorkspaceNextApplierTest {
+  private static final String TEST_IMAGE = "testImage/test:test";
+  private static final String ENV_VAR = "PLUGINS_ENV_VAR";
+  private static final String ENV_VAR_VALUE = "PLUGINS_ENV_VAR_VALUE";
+  private static final String MEMORY_KEY = "memory";
+  private static final String MEMORY_VALUE = "100Mi";
+  private static final String POD_NAME = "pod12";
+  private static final Map<String, String> RESOURCES_REQUEST =
+      ImmutableMap.of(MEMORY_KEY, MEMORY_VALUE);
+
+  @Mock Pod pod;
+  @Mock PodSpec podSpec;
+  @Mock ObjectMeta meta;
+  @Mock KubernetesEnvironment internalEnvironment;
+
+  KubernetesWorkspaceNextApplier applier;
+  List<Container> containers;
+  Map<String, InternalMachineConfig> machines;
+
+  @BeforeMethod
+  public void setUp() {
+    applier = new KubernetesWorkspaceNextApplier(200);
+    machines = new HashMap<>();
+    containers = new ArrayList<>();
+
+    when(internalEnvironment.getPods()).thenReturn(of(POD_NAME, pod));
+    when(pod.getSpec()).thenReturn(podSpec);
+    when(podSpec.getContainers()).thenReturn(containers);
+    when(pod.getMetadata()).thenReturn(meta);
+    when(meta.getName()).thenReturn(POD_NAME);
+    when(internalEnvironment.getMachines()).thenReturn(machines);
+  }
+
+  @Test
+  public void doesNothingIfServicesListIsEmpty() throws Exception {
+    applier.apply(internalEnvironment, emptyList());
+
+    verifyZeroInteractions(internalEnvironment);
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp =
+        "Workspace.Next configuration can be applied to a workspace with one pod only"
+  )
+  public void throwsExceptionWhenTheNumberOfPodsIsNot1() throws Exception {
+    when(internalEnvironment.getPods()).thenReturn(of("pod1", pod, "pod2", pod));
+
+    applier.apply(internalEnvironment, singletonList(testService()));
+  }
+
+  @Test
+  public void addToolingContainerToAPod() throws Exception {
+    applier.apply(internalEnvironment, singletonList(testService()));
+
+    assertEquals(containers.size(), 1);
+    Container toolingContainer = containers.get(0);
+    verifyContainer(toolingContainer);
+  }
+
+  @Test
+  public void canAddMultipleToolingContainersToAPodFromOneService() throws Exception {
+    applier.apply(internalEnvironment, singletonList(testServiceWith2Containers()));
+
+    assertEquals(containers.size(), 2);
+    for (Container container : containers) {
+      verifyContainer(container);
+    }
+  }
+
+  @Test
+  public void canAddMultipleToolingContainersToAPodFromSeveralServices() throws Exception {
+    applier.apply(internalEnvironment, ImmutableList.of(testService(), testService()));
+
+    assertEquals(containers.size(), 2);
+    for (Container container : containers) {
+      verifyContainer(container);
+    }
+  }
+
+  private CheService testService() {
+    CheService service = new CheService();
+    CheServiceSpec cheServiceSpec = new CheServiceSpec();
+    cheServiceSpec.setContainers(singletonList(testContainer()));
+    service.setSpec(cheServiceSpec);
+    return service;
+  }
+
+  private CheService testServiceWith2Containers() {
+    CheService service = new CheService();
+    CheServiceSpec cheServiceSpec = new CheServiceSpec();
+    cheServiceSpec.setContainers(Arrays.asList(testContainer(), testContainer()));
+    service.setSpec(cheServiceSpec);
+    return service;
+  }
+
+  private org.eclipse.che.api.workspace.server.wsnext.model.Container testContainer() {
+    org.eclipse.che.api.workspace.server.wsnext.model.Container cheContainer =
+        new org.eclipse.che.api.workspace.server.wsnext.model.Container();
+    cheContainer.setImage(TEST_IMAGE);
+    cheContainer.setEnv(singletonList(new EnvVar().name(ENV_VAR).value(ENV_VAR_VALUE)));
+    cheContainer.setResources(new ResourceRequirements().requests(RESOURCES_REQUEST));
+    return cheContainer;
+  }
+
+  private void verifyContainer(Container toolingContainer) {
+    assertEquals(toolingContainer.getImage(), TEST_IMAGE);
+    assertEquals(
+        toolingContainer.getEnv(),
+        singletonList(new io.fabric8.kubernetes.api.model.EnvVar(ENV_VAR, ENV_VAR_VALUE, null)));
+    io.fabric8.kubernetes.api.model.ResourceRequirements resourceRequirements =
+        new io.fabric8.kubernetes.api.model.ResourceRequirements();
+    resourceRequirements.setLimits(emptyMap());
+    resourceRequirements.setRequests(singletonMap(MEMORY_KEY, new Quantity(MEMORY_VALUE)));
+    assertEquals(toolingContainer.getResources(), resourceRequirements);
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
@@ -14,6 +14,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.fabric8.kubernetes.client.utils.Utils.isNotNullOrEmpty;
 
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
@@ -22,7 +23,6 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
 import io.fabric8.openshift.client.internal.OpenShiftOAuthInterceptor;
-import java.io.IOException;
 import java.net.URL;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -36,8 +36,6 @@ import okhttp3.Response;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * @author Sergii Leshchenko
@@ -53,8 +51,6 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
 
   private static final String BEFORE_TOKEN = "access_token=";
   private static final String AFTER_TOKEN = "&expires";
-
-  private static final Logger LOG = LoggerFactory.getLogger(OpenShiftClientFactory.class);
 
   private final OpenShiftClientConfigFactory configBuilder;
 
@@ -83,128 +79,6 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
         maxIdleConnections,
         connectionPoolKeepAlive);
     this.configBuilder = configBuilder;
-  }
-
-  protected Config buildDefaultConfig(
-      String masterUrl, String username, String password, String oauthToken, Boolean doTrustCerts) {
-    OpenShiftConfigBuilder configBuilder = new OpenShiftConfigBuilder();
-    if (!isNullOrEmpty(masterUrl)) {
-      configBuilder.withMasterUrl(masterUrl);
-    }
-
-    if (!isNullOrEmpty(username)) {
-      configBuilder.withUsername(username);
-    }
-
-    if (!isNullOrEmpty(password)) {
-      configBuilder.withPassword(password);
-    }
-
-    if (!isNullOrEmpty(oauthToken)) {
-      configBuilder.withOauthToken(oauthToken);
-    }
-
-    if (doTrustCerts != null) {
-      configBuilder.withTrustCerts(doTrustCerts);
-    }
-
-    Config theConfig = configBuilder.build();
-    return theConfig;
-  }
-
-  /**
-   * Builds the Openshift {@link Config} object based on a default {@link Config} object and an
-   * optional workspace Id.
-   *
-   * <p>This method overrides the one in the Kubernetes infrastructure to introduce an additional
-   * extension level by delegating to an {@link OpenShiftClientConfigFactory}
-   */
-  @Override
-  protected Config buildConfig(Config defaultConfig, @Nullable String workspaceId)
-      throws InfrastructureException {
-    return configBuilder.buildConfig(defaultConfig, workspaceId);
-  }
-
-  protected Interceptor buildKubernetesInterceptor(Config config) {
-    final String oauthToken;
-    if (Utils.isNotNullOrEmpty(config.getUsername())
-        && Utils.isNotNullOrEmpty(config.getPassword())) {
-      synchronized (getHttpClient()) {
-        try {
-          OkHttpClient.Builder builder = getHttpClient().newBuilder();
-          builder.interceptors().clear();
-          OkHttpClient clone = builder.build();
-
-          String credential =
-              Credentials.basic(config.getUsername(), new String(config.getPassword()));
-          URL url = new URL(URLUtils.join(config.getMasterUrl(), AUTHORIZE_PATH));
-          Response response =
-              clone
-                  .newCall(
-                      new Request.Builder()
-                          .get()
-                          .url(url)
-                          .header(AUTHORIZATION, credential)
-                          .build())
-                  .execute();
-
-          response.body().close();
-          response = response.priorResponse() != null ? response.priorResponse() : response;
-          response = response.networkResponse() != null ? response.networkResponse() : response;
-          String token = response.header(LOCATION);
-          if (token == null || token.isEmpty()) {
-            throw new KubernetesClientException(
-                "Unexpected response ("
-                    + response.code()
-                    + " "
-                    + response.message()
-                    + "), to the authorization request. Missing header:["
-                    + LOCATION
-                    + "]!");
-          }
-          token = token.substring(token.indexOf(BEFORE_TOKEN) + BEFORE_TOKEN.length());
-          token = token.substring(0, token.indexOf(AFTER_TOKEN));
-          oauthToken = token;
-        } catch (Exception e) {
-          throw KubernetesClientException.launderThrowable(e);
-        }
-      }
-    } else if (Utils.isNotNullOrEmpty(config.getOauthToken())) {
-      oauthToken = config.getOauthToken();
-    } else {
-      oauthToken = null;
-    }
-
-    return new Interceptor() {
-      @Override
-      public Response intercept(Chain chain) throws IOException {
-        Request request = chain.request();
-        if (isNotNullOrEmpty(oauthToken)) {
-          Request authReq =
-              chain
-                  .request()
-                  .newBuilder()
-                  .addHeader("Authorization", "Bearer " + oauthToken)
-                  .build();
-          return chain.proceed(authReq);
-        }
-        return chain.proceed(request);
-      }
-    };
-  }
-
-  private OpenShiftClient createOC(Config config) throws InfrastructureException {
-    OkHttpClient clientHttpClient =
-        getHttpClient().newBuilder().authenticator(Authenticator.NONE).build();
-    OkHttpClient.Builder builder = clientHttpClient.newBuilder();
-    builder.interceptors().clear();
-    clientHttpClient =
-        builder
-            .addInterceptor(
-                new OpenShiftOAuthInterceptor(clientHttpClient, OpenShiftConfig.wrap(config)))
-            .build();
-
-    return new UnclosableOpenShiftClient(clientHttpClient, config);
   }
 
   /**
@@ -240,6 +114,123 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
    */
   public OpenShiftClient createOC() throws InfrastructureException {
     return createOC(buildConfig(getDefaultConfig(), null));
+  }
+
+  @Override
+  protected Config buildDefaultConfig(
+      String masterUrl, String username, String password, String oauthToken, Boolean doTrustCerts) {
+    OpenShiftConfigBuilder configBuilder = new OpenShiftConfigBuilder();
+    if (!isNullOrEmpty(masterUrl)) {
+      configBuilder.withMasterUrl(masterUrl);
+    }
+
+    if (!isNullOrEmpty(username)) {
+      configBuilder.withUsername(username);
+    }
+
+    if (!isNullOrEmpty(password)) {
+      configBuilder.withPassword(password);
+    }
+
+    if (!isNullOrEmpty(oauthToken)) {
+      configBuilder.withOauthToken(oauthToken);
+    }
+
+    if (doTrustCerts != null) {
+      configBuilder.withTrustCerts(doTrustCerts);
+    }
+
+    return configBuilder.build();
+  }
+
+  /**
+   * Builds the Openshift {@link Config} object based on a provided {@link Config} object and an
+   * optional workspace ID.
+   *
+   * <p>This method overrides the one in the Kubernetes infrastructure to introduce an additional
+   * extension level by delegating to an {@link OpenShiftClientConfigFactory}
+   */
+  @Override
+  protected Config buildConfig(Config config, @Nullable String workspaceId)
+      throws InfrastructureException {
+    return configBuilder.buildConfig(config, workspaceId);
+  }
+
+  @Override
+  protected Interceptor buildKubernetesInterceptor(Config config) {
+    final String oauthToken;
+    if (Utils.isNotNullOrEmpty(config.getUsername())
+        && Utils.isNotNullOrEmpty(config.getPassword())) {
+      synchronized (getHttpClient()) {
+        try {
+          OkHttpClient.Builder builder = getHttpClient().newBuilder();
+          builder.interceptors().clear();
+          OkHttpClient clone = builder.build();
+
+          String credential = Credentials.basic(config.getUsername(), config.getPassword());
+          URL url = new URL(URLUtils.join(config.getMasterUrl(), AUTHORIZE_PATH));
+          Response response =
+              clone
+                  .newCall(
+                      new Request.Builder()
+                          .get()
+                          .url(url)
+                          .header(AUTHORIZATION, credential)
+                          .build())
+                  .execute();
+
+          // False positive warn: according to javadocs response.body() returns non-null value
+          // if called after Call.execute()
+          response.body().close();
+          response = response.priorResponse() != null ? response.priorResponse() : response;
+          response = response.networkResponse() != null ? response.networkResponse() : response;
+          String token = response.header(LOCATION);
+          if (token == null || token.isEmpty()) {
+            throw new KubernetesClientException(
+                "Unexpected response ("
+                    + response.code()
+                    + " "
+                    + response.message()
+                    + "), to the authorization request. Missing header:["
+                    + LOCATION
+                    + "]!");
+          }
+          token = token.substring(token.indexOf(BEFORE_TOKEN) + BEFORE_TOKEN.length());
+          token = token.substring(0, token.indexOf(AFTER_TOKEN));
+          oauthToken = token;
+        } catch (Exception e) {
+          throw KubernetesClientException.launderThrowable(e);
+        }
+      }
+    } else if (Utils.isNotNullOrEmpty(config.getOauthToken())) {
+      oauthToken = config.getOauthToken();
+    } else {
+      oauthToken = null;
+    }
+
+    return chain -> {
+      Request request = chain.request();
+      if (isNotNullOrEmpty(oauthToken)) {
+        Request authReq =
+            chain.request().newBuilder().addHeader("Authorization", "Bearer " + oauthToken).build();
+        return chain.proceed(authReq);
+      }
+      return chain.proceed(request);
+    };
+  }
+
+  private OpenShiftClient createOC(Config config) {
+    OkHttpClient clientHttpClient =
+        getHttpClient().newBuilder().authenticator(Authenticator.NONE).build();
+    OkHttpClient.Builder builder = clientHttpClient.newBuilder();
+    builder.interceptors().clear();
+    clientHttpClient =
+        builder
+            .addInterceptor(
+                new OpenShiftOAuthInterceptor(clientHttpClient, OpenShiftConfig.wrap(config)))
+            .build();
+
+    return new UnclosableOpenShiftClient(clientHttpClient, config);
   }
 
   /** Decorates the {@link DefaultOpenShiftClient} so that it can not be closed from the outside. */

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
-import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
@@ -18,6 +18,7 @@ import io.fabric8.openshift.api.model.Route;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Warning;
@@ -44,13 +45,13 @@ import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftServer
 public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShiftRuntimeContext> {
 
   private final OpenShiftProject project;
-  private final String unrecoverableEvents;
+  private final Set<String> unrecoverableEvents;
 
   @Inject
   public OpenShiftInternalRuntime(
       @Named("che.infra.kubernetes.workspace_start_timeout_min") int workspaceStartTimeout,
       @Named("che.infra.kubernetes.ingress_start_timeout_min") int ingressStartTimeout,
-      @Named("che.infra.kubernetes.workspace_unrecoverable_events") String unrecoverableEvents,
+      @Named("che.infra.kubernetes.workspace_unrecoverable_events") String[] unrecoverableEvents,
       NoOpURLRewriter urlRewriter,
       KubernetesBootstrapperFactory bootstrapperFactory,
       ServersCheckerFactory serverCheckerFactory,
@@ -82,7 +83,7 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
         project,
         warnings);
     this.project = project;
-    this.unrecoverableEvents = unrecoverableEvents;
+    this.unrecoverableEvents = ImmutableSet.copyOf(unrecoverableEvents);
   }
 
   @Override
@@ -101,9 +102,9 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
     // project.pods().watch(new AbnormalStopHandler());
 
     project.pods().watchContainers(new MachineLogsPublisher());
-    if (!Strings.isNullOrEmpty(unrecoverableEvents)) {
+    if (!unrecoverableEvents.isEmpty()) {
       Map<String, Pod> pods = getContext().getEnvironment().getPods();
-      project.pods().watchContainers(new UnrecoverableEventHanler(pods));
+      project.pods().watchContainers(new UnrecoverableEventHandler(pods));
     }
 
     doStartMachine(new OpenShiftServerResolver(createdServices, createdRoutes));

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -102,9 +102,9 @@ public class OpenShiftInternalRuntimeTest {
   private static final String ROUTE_HOST = "localhost";
   private static final String M1_NAME = POD_NAME + '/' + CONTAINER_NAME_1;
   private static final String M2_NAME = POD_NAME + '/' + CONTAINER_NAME_2;
-  private static final String EMPTY_UNRECOVERABLE_EVENTS = "";
-  private static final String UNRECOVERABLE_EVENTS =
-      "Failed Mount,Failed Scheduling,Failed to pull image";
+  private static final String[] EMPTY_UNRECOVERABLE_EVENTS = new String[0];
+  private static final String[] UNRECOVERABLE_EVENTS =
+      new String[] {"Failed Mount", "Failed Scheduling", "Failed to pull image"};
 
   private static final RuntimeIdentity IDENTITY =
       new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");

--- a/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
+++ b/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
@@ -82,6 +82,7 @@ import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.StackDao;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
+import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextApplier;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.subject.SubjectImpl;
@@ -253,6 +254,10 @@ public class JpaEntitiesCascadeRemovalTest {
                 Multibinder.newSetBinder(binder(), ResourceLockKeyProvider.class);
                 Multibinder.newSetBinder(binder(), ResourceUsageTracker.class);
                 MapBinder.newMapBinder(binder(), String.class, AvailableResourcesProvider.class);
+                bind(String.class)
+                    .annotatedWith(Names.named("che.workspace.feature.api"))
+                    .toInstance("");
+                MapBinder.newMapBinder(binder(), String.class, WorkspaceNextApplier.class);
                 Multibinder.newSetBinder(binder(), ResourceType.class)
                     .addBinding()
                     .to(RamResourceType.class);

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -69,6 +69,17 @@ public final class Constants {
    */
   public static final String ERROR_MESSAGE_ATTRIBUTE_NAME = "errorMessage";
   /**
+   * Contains Workspace.Next features list that should be added to a workspace. Should be set/read
+   * from {@link Workspace#getAttributes}.
+   *
+   * <p>Value is comma separated list of features in a format: '< feature1Name >/< feature1Version
+   * >,< feature2Name >/< feature2Version >' <br>
+   * Spaces around commas are trimmed. <br>
+   * This is beta constant that is subject to change or removal. Example of the attribute value:
+   * 'org.eclipse.che.feature1/0.0.1, com.redhat.enterpriseFeature1/1.0.0'
+   */
+  public static final String WORKSPACE_NEXT_FEATURES = "features";
+  /**
    * Describes workspace runtimes which perform start/stop of this workspace. Should be set/read
    * from {@link Workspace#getAttributes}
    */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -65,6 +66,9 @@ import org.eclipse.che.api.workspace.server.spi.RuntimeStartInterruptedException
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
+import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextApplier;
+import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextObjectsRetriever;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
 import org.eclipse.che.api.workspace.shared.dto.event.RuntimeStatusEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.WorkspaceStatusEvent;
 import org.eclipse.che.commons.env.EnvironmentContext;
@@ -100,6 +104,8 @@ public class WorkspaceRuntimes {
   private final ProbeScheduler probeScheduler;
   // Unique identifier for this workspace runtimes
   private final String workspaceRuntimesId;
+  private final Map<String, WorkspaceNextApplier> workspaceNextAppliers;
+  private final WorkspaceNextObjectsRetriever workspaceNextObjectsRetriever;
 
   @VisibleForTesting
   WorkspaceRuntimes(
@@ -112,7 +118,9 @@ public class WorkspaceRuntimes {
       @SuppressWarnings("unused") DBInitializer ignored,
       ProbeScheduler probeScheduler,
       WorkspaceStatusCache statuses,
-      WorkspaceLockService lockService) {
+      WorkspaceLockService lockService,
+      Map<String, WorkspaceNextApplier> workspaceNextAppliers,
+      WorkspaceNextObjectsRetriever workspaceNextObjectsRetriever) {
     this(
         eventService,
         envFactories,
@@ -122,7 +130,9 @@ public class WorkspaceRuntimes {
         ignored,
         probeScheduler,
         statuses,
-        lockService);
+        lockService,
+        workspaceNextAppliers,
+        workspaceNextObjectsRetriever);
     this.runtimes = runtimes;
   }
 
@@ -136,7 +146,9 @@ public class WorkspaceRuntimes {
       @SuppressWarnings("unused") DBInitializer ignored,
       ProbeScheduler probeScheduler,
       WorkspaceStatusCache statuses,
-      WorkspaceLockService lockService) {
+      WorkspaceLockService lockService,
+      Map<String, WorkspaceNextApplier> workspaceNextAppliers,
+      WorkspaceNextObjectsRetriever workspaceNextObjectsRetriever) {
     this.probeScheduler = probeScheduler;
     this.runtimes = new ConcurrentHashMap<>();
     this.statuses = statuses;
@@ -147,6 +159,8 @@ public class WorkspaceRuntimes {
     this.infrastructure = infra;
     this.environmentFactories = ImmutableMap.copyOf(envFactories);
     this.lockService = lockService;
+    this.workspaceNextAppliers = ImmutableMap.copyOf(workspaceNextAppliers);
+    this.workspaceNextObjectsRetriever = workspaceNextObjectsRetriever;
     LOG.info("Configured factories for environments: '{}'", envFactories.keySet());
     LOG.info("Registered infrastructure '{}'", infra.getName());
     SetView<String> notSupportedByInfra =
@@ -172,7 +186,7 @@ public class WorkspaceRuntimes {
       throw new NotFoundException("Infrastructure not found for type: " + type);
     }
     // try to create internal environment to check if the specified environment is valid
-    createInternalEnvironment(environment);
+    createInternalEnvironment(environment, null);
   }
 
   /**
@@ -296,7 +310,8 @@ public class WorkspaceRuntimes {
     final String ownerId = EnvironmentContext.getCurrent().getSubject().getUserId();
     final RuntimeIdentity runtimeId = new RuntimeIdentityImpl(workspaceId, envName, ownerId);
     try {
-      InternalEnvironment internalEnv = createInternalEnvironment(environment);
+      InternalEnvironment internalEnv =
+          createInternalEnvironment(environment, workspace.getAttributes());
       RuntimeContext runtimeContext = infrastructure.prepare(runtimeId, internalEnv);
       InternalRuntime runtime = runtimeContext.getRuntime();
 
@@ -570,7 +585,8 @@ public class WorkspaceRuntimes {
 
     InternalRuntime runtime;
     try {
-      InternalEnvironment internalEnv = createInternalEnvironment(environment);
+      InternalEnvironment internalEnv =
+          createInternalEnvironment(environment, workspace.getAttributes());
       runtime = infra.prepare(identity, internalEnv).getRuntime();
 
       try (Unlocker ignored = lockService.writeLock(workspace.getId())) {
@@ -723,7 +739,8 @@ public class WorkspaceRuntimes {
     return environmentFactories.keySet();
   }
 
-  private InternalEnvironment createInternalEnvironment(Environment environment)
+  private InternalEnvironment createInternalEnvironment(
+      Environment environment, Map<String, String> workspaceAttributes)
       throws InfrastructureException, ValidationException, NotFoundException {
     String recipeType = environment.getRecipe().getType();
     InternalEnvironmentFactory factory = environmentFactories.get(recipeType);
@@ -731,7 +748,28 @@ public class WorkspaceRuntimes {
       throw new NotFoundException(
           format("InternalEnvironmentFactory is not configured for recipe type: '%s'", recipeType));
     }
-    return factory.create(environment);
+    InternalEnvironment internalEnvironment = factory.create(environment);
+
+    applyWorkspaceNext(internalEnvironment, workspaceAttributes, recipeType);
+
+    return internalEnvironment;
+  }
+
+  private void applyWorkspaceNext(
+      InternalEnvironment internalEnvironment,
+      Map<String, String> workspaceAttributes,
+      String recipeType)
+      throws InfrastructureException {
+    Collection<CheService> cheServices = workspaceNextObjectsRetriever.get(workspaceAttributes);
+    if (cheServices.isEmpty()) {
+      return;
+    }
+    WorkspaceNextApplier wsNext = workspaceNextAppliers.get(recipeType);
+    if (wsNext == null) {
+      throw new InfrastructureException(
+          "Workspace.Next features are not supported for recipe type " + recipeType);
+    }
+    wsNext.apply(internalEnvironment, cheServices);
   }
 
   private String sessionUserNameOr(String nameIfNoUser) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalMachineConfig.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalMachineConfig.java
@@ -18,7 +18,6 @@ import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.installer.server.model.impl.InstallerImpl;
 import org.eclipse.che.api.installer.shared.model.Installer;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 
 /**
  * Machine Config to use inside infrastructure.
@@ -52,8 +51,7 @@ public class InternalMachineConfig {
       Map<String, ? extends ServerConfig> servers,
       Map<String, String> env,
       Map<String, String> attributes,
-      Map<String, ? extends Volume> volumes)
-      throws InfrastructureException {
+      Map<String, ? extends Volume> volumes) {
     this();
     if (servers != null) {
       this.servers.putAll(servers);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/WorkspaceNextApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/WorkspaceNextApplier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext;
+
+import com.google.common.annotations.Beta;
+import java.util.Collection;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
+
+/**
+ * Applies Workspace.Next configuration to an internal runtime object that represents workspace
+ * runtime configuration on an infrastructure level.
+ *
+ * @author Oleksander Garagatyi
+ */
+@Beta
+public interface WorkspaceNextApplier {
+
+  /**
+   * Applies Workspace.Next configuration to internal environment.
+   *
+   * @param internalEnvironment infrastructure specific representation of workspace runtime
+   *     environment
+   * @param cheServices Workspace.Next configuration to apply to {@code internalEnvironment}
+   * @throws InfrastructureException when applying Workspace.Next objects fails
+   */
+  void apply(InternalEnvironment internalEnvironment, Collection<CheService> cheServices)
+      throws InfrastructureException;
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/WorkspaceNextObjectsRetriever.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/WorkspaceNextObjectsRetriever.java
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static java.util.Collections.emptyList;
+
+import com.google.common.annotations.Beta;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.io.CharStreams;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriBuilderException;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheFeature;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheServiceParameter;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheServiceReference;
+import org.eclipse.che.api.workspace.server.wsnext.model.Container;
+import org.eclipse.che.api.workspace.server.wsnext.model.EnvVar;
+import org.eclipse.che.api.workspace.shared.Constants;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.commons.lang.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Fetches Workspace.Next objects corresponding to attributes of a workspace.
+ *
+ * @author Oleksander Garagatyi
+ */
+@Beta
+public class WorkspaceNextObjectsRetriever {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WorkspaceNextObjectsRetriever.class);
+  private static final Pattern PARAMETER_ENV_VAR_VALUE = Pattern.compile("^\\$\\{.+}$");
+  private static final String FEATURE_OBJECT_ERROR = "Feature '%s/%s' configuration is invalid. %s";
+  private static final String SERVICE_OBJECT_ERROR = "Service '%s/%s' configuration is invalid. %s";
+
+  protected static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+  private final UriBuilder featureApi;
+
+  @Inject
+  public WorkspaceNextObjectsRetriever(
+      @Nullable @Named("che.workspace.feature.api") String featureApi) {
+    if (featureApi == null) {
+      LOG.info(
+          "Workspace.Next is disabled - Feature API endpoint property 'che.workspace.feature.api' is not configured");
+      this.featureApi = null;
+    } else {
+      this.featureApi = UriBuilder.fromUri(featureApi);
+    }
+  }
+
+  /**
+   * Gets Workspace.Next features list from provided workspace attributes, fetches corresponding
+   * objects from Feature API and returns list of {@link CheService} needed to provide features
+   * functionality in a workspace.
+   *
+   * <p>This method resolves feature dependencies and parameters, so returned list of {@code
+   * CheServices} is ready to be applied to a workspace runtime.
+   *
+   * @param attributes workspace attributes
+   * @throws InfrastructureException when features list contains invalid entries or Workspace.Next
+   *     objects retrieval from Feature API fails
+   */
+  public Collection<CheService> get(Map<String, String> attributes) throws InfrastructureException {
+    if (featureApi == null || attributes == null || attributes.isEmpty()) {
+      return emptyList();
+    }
+    String featuresAttribute = attributes.get(Constants.WORKSPACE_NEXT_FEATURES);
+    if (isNullOrEmpty(featuresAttribute)) {
+      return emptyList();
+    }
+    String[] features = featuresAttribute.split(" *, *");
+    if (features.length == 0) {
+      return emptyList();
+    }
+
+    Collection<Pair<String, String>> featuresNameVersion = parseFeatures(features);
+
+    return toServices(getFeatures(featuresNameVersion));
+  }
+
+  private Collection<Pair<String, String>> parseFeatures(String[] features)
+      throws InfrastructureException {
+    Map<String, Pair<String, String>> featuresNameVersion = new HashMap<>();
+    for (String feature : features) {
+      String[] featureAndVersion = feature.split("/");
+      if (featureAndVersion.length != 2
+          || featureAndVersion[0].isEmpty()
+          || featureAndVersion[1].isEmpty()) {
+        throw new InfrastructureException(
+            "Features format is illegal. Problematic feature entry:" + feature);
+      }
+      String key = featureAndVersion[0] + '/' + featureAndVersion[1];
+      if (featuresNameVersion.containsKey(key)) {
+        throw new InfrastructureException(
+            format("Invalid Workspace.Next configuration: feature %s is duplicated", key));
+      }
+      featuresNameVersion.put(key, Pair.of(featureAndVersion[0], featureAndVersion[1]));
+    }
+    return featuresNameVersion.values();
+  }
+
+  private Collection<CheFeature> getFeatures(Collection<Pair<String, String>> featureAndVersion)
+      throws InfrastructureException {
+    List<CheFeature> features = new ArrayList<>();
+    for (Pair<String, String> nameVersion : featureAndVersion) {
+      features.add(getFeature(nameVersion.first, nameVersion.second));
+    }
+
+    return features;
+  }
+
+  private CheFeature getFeature(String featureName, String featureVersion)
+      throws InfrastructureException {
+    try {
+      URI getFeatureURI =
+          featureApi.clone().path("feature").path(featureName).path(featureVersion).build();
+
+      CheFeature feature = getBody(getFeatureURI, CheFeature.class);
+      validateFeature(feature, featureName, featureVersion);
+      return feature;
+    } catch (IllegalArgumentException | UriBuilderException e) {
+      throw new InternalInfrastructureException(
+          format("Feature %s/%s retrieval failed", featureName, featureVersion));
+    } catch (IOException e) {
+      throw new InfrastructureException(
+          format(
+              "Error occurred on retrieval of feature %s. Error: %s",
+              featureName + '/' + featureVersion, e.getMessage()));
+    }
+  }
+
+  private Collection<CheService> toServices(Collection<CheFeature> features)
+      throws InfrastructureException {
+    Collection<CheService> services = getServices(features);
+    Map<String, List<String>> parameters = getServicesParameters(features);
+
+    for (CheService service : services) {
+      String serviceName = service.getMetadata().getName();
+      String serviceVersion = service.getSpec().getVersion();
+      String serviceKey = serviceName + '/' + serviceVersion;
+
+      // for now we match whole env variable value against '${<parameter name>}'
+      service
+          .getSpec()
+          .getContainers()
+          .stream()
+          .flatMap(container -> container.getEnv().stream())
+          .filter(this::isParameter)
+          .forEach(
+              envVar -> {
+                String parameterKey = serviceKey + '/' + envVar.getValue();
+                List<String> remove = parameters.remove(parameterKey);
+                String envVarValue;
+                if (remove != null) {
+                  envVarValue = String.join(",", remove);
+                } else {
+                  envVarValue = "";
+                }
+                envVar.setValue(envVarValue);
+              });
+    }
+
+    if (!parameters.isEmpty()) {
+      throw new InfrastructureException(
+          "Parameters not supported by services found: " + parameters.keySet());
+    }
+
+    return services;
+  }
+
+  private Collection<CheService> getServices(Collection<CheFeature> features)
+      throws InfrastructureException {
+    Map<String, CheService> services = new HashMap<>();
+    for (CheFeature feature : features) {
+      for (CheServiceReference serviceReference : feature.getSpec().getServices()) {
+        String serviceName = serviceReference.getName();
+        String serviceVersion = serviceReference.getVersion();
+        String key = serviceName + '/' + serviceVersion;
+        if (!services.containsKey(key)) {
+          CheService service = getService(serviceName, serviceVersion);
+          services.put(key, service);
+        }
+      }
+    }
+    return services.values();
+  }
+
+  private boolean isParameter(EnvVar envVar) {
+    return PARAMETER_ENV_VAR_VALUE.matcher(envVar.getValue()).matches();
+  }
+
+  /**
+   * Returns map where key is concatenation of service name, version and parameter name separated by
+   * slash symbol. < serviceName/serviceVersion/${parameter} > to < parameterValue >
+   */
+  private Map<String, List<String>> getServicesParameters(Collection<CheFeature> features) {
+    Map<String, List<String>> parameters = new HashMap<>();
+    for (CheFeature feature : features) {
+      for (CheServiceReference serviceReference : feature.getSpec().getServices()) {
+        if (serviceReference.getParameters().isEmpty()) {
+          continue;
+        }
+
+        String serviceName = serviceReference.getName();
+        String serviceVersion = serviceReference.getVersion();
+
+        for (CheServiceParameter cheServiceParameter : serviceReference.getParameters()) {
+          // add dollar sign and curly brackets because parameter is easier to find with these signs
+          // in the map keys
+          String parameterKey =
+              serviceName + "/" + serviceVersion + "/${" + cheServiceParameter.getName() + "}";
+          List<String> cheServiceParameters =
+              parameters.computeIfAbsent(parameterKey, key -> new ArrayList<>());
+          cheServiceParameters.add(cheServiceParameter.getValue());
+        }
+      }
+    }
+    return parameters;
+  }
+
+  private CheService getService(String serviceName, String serviceVersion)
+      throws InfrastructureException {
+    try {
+      URI getServiceURI =
+          featureApi.clone().path("service").path(serviceName).path(serviceVersion).build();
+
+      CheService service = getBody(getServiceURI, CheService.class);
+      validateService(service, serviceName, serviceVersion);
+      return service;
+    } catch (IllegalArgumentException | UriBuilderException e) {
+      throw new InternalInfrastructureException(
+          format("Service %s/%s retrieval failed", serviceName, serviceVersion));
+    } catch (IOException e) {
+      throw new InfrastructureException(
+          format(
+              "Error occurred on retrieval of service %s. Error: %s",
+              serviceName + '/' + serviceVersion, e.getMessage()));
+    }
+  }
+
+  private void validateFeature(CheFeature feature, String name, String version)
+      throws InfrastructureException {
+    requireNotNull(
+        feature.getMetadata(), FEATURE_OBJECT_ERROR, name, version, "Metadata is missing.");
+    requireNotNullNorEmpty(
+        feature.getMetadata().getName(), FEATURE_OBJECT_ERROR, name, version, "Name is missing.");
+    requireNotNull(feature.getSpec(), FEATURE_OBJECT_ERROR, name, version, "Spec is missing.");
+    requireNotNullNorEmpty(
+        feature.getSpec().getVersion(), FEATURE_OBJECT_ERROR, name, version, "Version is missing.");
+    requireNotNullNorEmpty(
+        feature.getSpec().getServices(),
+        FEATURE_OBJECT_ERROR,
+        name,
+        version,
+        "Services are missing.");
+    for (CheServiceReference serviceReference : feature.getSpec().getServices()) {
+      requireNotNull(
+          serviceReference, FEATURE_OBJECT_ERROR, name, version, "A service is missing.");
+      requireNotNullNorEmpty(
+          serviceReference.getVersion(),
+          FEATURE_OBJECT_ERROR,
+          name,
+          version,
+          "Service version is missing.");
+      requireNotNullNorEmpty(
+          serviceReference.getName(),
+          FEATURE_OBJECT_ERROR,
+          name,
+          version,
+          "Service name is missing.");
+    }
+  }
+
+  private void validateService(CheService service, String name, String version)
+      throws InfrastructureException {
+    requireNotNull(
+        service.getMetadata(), SERVICE_OBJECT_ERROR, name, version, "Metadata is missing.");
+    requireNotNullNorEmpty(
+        service.getMetadata().getName(), SERVICE_OBJECT_ERROR, name, version, "Name is missing.");
+    requireEqual(
+        name,
+        service.getMetadata().getName(),
+        "Service name in feature and Service objects didn't match. Service object seems broken.");
+    requireNotNull(service.getSpec(), SERVICE_OBJECT_ERROR, name, version, "Spec is missing.");
+    requireNotNullNorEmpty(
+        service.getSpec().getVersion(), SERVICE_OBJECT_ERROR, name, version, "Version is missing.");
+    requireEqual(
+        version,
+        service.getSpec().getVersion(),
+        "Service version in feature and Service objects didn't match. Service object seems broken.");
+    requireNotNullNorEmpty(
+        service.getSpec().getContainers(),
+        SERVICE_OBJECT_ERROR,
+        name,
+        version,
+        "Containers are missing.");
+    for (Container container : service.getSpec().getContainers()) {
+      requireNotNull(container, SERVICE_OBJECT_ERROR, name, version, "A container is missing.");
+      requireNotNullNorEmpty(
+          container.getImage(), SERVICE_OBJECT_ERROR, name, version, "Container image is missing.");
+    }
+  }
+
+  @VisibleForTesting
+  protected <T> T getBody(URI uri, Class<T> clas) throws IOException {
+    HttpURLConnection httpURLConnection = null;
+    try {
+      httpURLConnection = (HttpURLConnection) uri.toURL().openConnection();
+
+      int responseCode = httpURLConnection.getResponseCode();
+      if (responseCode != 200) {
+        throw new IOException(
+            format(
+                "Can't get object by URI '%s'. Error: %s",
+                uri.toString(), getError(httpURLConnection)));
+      }
+
+      return parseResponseStreamAndClose(httpURLConnection.getInputStream(), clas);
+    } finally {
+      if (httpURLConnection != null) {
+        httpURLConnection.disconnect();
+      }
+    }
+  }
+
+  private String getError(HttpURLConnection httpURLConnection) throws IOException {
+    try (InputStreamReader isr = new InputStreamReader(httpURLConnection.getInputStream())) {
+      return CharStreams.toString(isr);
+    }
+  }
+
+  protected <T> T parseResponseStreamAndClose(InputStream inputStream, Class<T> clazz)
+      throws IOException {
+    try (InputStreamReader reader = new InputStreamReader(inputStream)) {
+      T objectFromJson = GSON.fromJson(reader, clazz);
+      if (objectFromJson == null) {
+        throw new IOException(
+            "Internal server error. Unexpected response body received from Feature API.");
+      }
+      return objectFromJson;
+    } catch (JsonParseException e) {
+      throw new IOException(e.getLocalizedMessage(), e);
+    }
+  }
+
+  private void requireNotNullNorEmpty(String s, String error, String... errorArgs)
+      throws InfrastructureException {
+    if (s == null || s.isEmpty()) {
+      throw new InfrastructureException(format(error, (Object[]) errorArgs));
+    }
+  }
+
+  private void requireNotNullNorEmpty(Collection objects, String error, String... errorArgs)
+      throws InfrastructureException {
+    if (objects == null || objects.isEmpty()) {
+      throw new InfrastructureException(format(error, (Object[]) errorArgs));
+    }
+  }
+
+  private void requireNotNull(Object object, String error, String... errorArgs)
+      throws InfrastructureException {
+    if (object == null) {
+      throw new InfrastructureException(format(error, (Object[]) errorArgs));
+    }
+  }
+
+  private void requireEqual(String version, String version1, String error, String... errorArgs)
+      throws InfrastructureException {
+    if (!version.equals(version1)) {
+      throw new InfrastructureException(format(error, (Object[]) errorArgs));
+    }
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheFeature.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheFeature.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.Objects;
+
+public class CheFeature extends TypeMeta {
+
+  private ObjectMeta metadata = null;
+  private CheFeatureSpec spec = null;
+
+  /** */
+  public CheFeature metadata(ObjectMeta metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  public ObjectMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(ObjectMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  /** */
+  public CheFeature spec(CheFeatureSpec spec) {
+    this.spec = spec;
+    return this;
+  }
+
+  public CheFeatureSpec getSpec() {
+    return spec;
+  }
+
+  public void setSpec(CheFeatureSpec spec) {
+    this.spec = spec;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CheFeature cheFeature = (CheFeature) o;
+    return Objects.equals(metadata, cheFeature.metadata) && Objects.equals(spec, cheFeature.spec);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metadata, spec);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CheFeature {\n");
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    spec: ").append(toIndentedString(spec)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheFeatureSpec.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheFeatureSpec.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class CheFeatureSpec {
+
+  private String version = null;
+  private List<CheServiceReference> services = new ArrayList<CheServiceReference>();
+
+  /** */
+  public CheFeatureSpec version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  /** */
+  public CheFeatureSpec services(List<CheServiceReference> services) {
+    this.services = services;
+    return this;
+  }
+
+  public List<CheServiceReference> getServices() {
+    return services;
+  }
+
+  public void setServices(List<CheServiceReference> services) {
+    this.services = services;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CheFeatureSpec cheFeatureSpec = (CheFeatureSpec) o;
+    return Objects.equals(version, cheFeatureSpec.version)
+        && Objects.equals(services, cheFeatureSpec.services);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, services);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CheFeatureSpec {\n");
+
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
+    sb.append("    services: ").append(toIndentedString(services)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheService.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.Objects;
+
+public class CheService extends TypeMeta {
+
+  private ObjectMeta metadata = null;
+  private CheServiceSpec spec = null;
+
+  /** */
+  public CheService metadata(ObjectMeta metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  public ObjectMeta getMetadata() {
+    return metadata;
+  }
+
+  public void setMetadata(ObjectMeta metadata) {
+    this.metadata = metadata;
+  }
+
+  /** */
+  public CheService spec(CheServiceSpec spec) {
+    this.spec = spec;
+    return this;
+  }
+
+  public CheServiceSpec getSpec() {
+    return spec;
+  }
+
+  public void setSpec(CheServiceSpec spec) {
+    this.spec = spec;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CheService cheService = (CheService) o;
+    return Objects.equals(metadata, cheService.metadata) && Objects.equals(spec, cheService.spec);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(metadata, spec);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CheService {\n");
+    sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+    sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
+    sb.append("    spec: ").append(toIndentedString(spec)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheServiceParameter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheServiceParameter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.Objects;
+
+public class CheServiceParameter {
+
+  private String name = null;
+  private String value = null;
+
+  /** */
+  public CheServiceParameter name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /** */
+  public CheServiceParameter value(String value) {
+    this.value = value;
+    return this;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CheServiceParameter cheServiceParameter = (CheServiceParameter) o;
+    return Objects.equals(name, cheServiceParameter.name)
+        && Objects.equals(value, cheServiceParameter.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CheServiceParameter {\n");
+
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    value: ").append(toIndentedString(value)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheServiceReference.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheServiceReference.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class CheServiceReference {
+
+  private String name = null;
+  private String version = null;
+  private List<CheServiceParameter> parameters = new ArrayList<CheServiceParameter>();
+
+  /** */
+  public CheServiceReference name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /** */
+  public CheServiceReference version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  /** */
+  public CheServiceReference parameters(List<CheServiceParameter> parameters) {
+    this.parameters = parameters;
+    return this;
+  }
+
+  public List<CheServiceParameter> getParameters() {
+    return parameters;
+  }
+
+  public void setParameters(List<CheServiceParameter> parameters) {
+    this.parameters = parameters;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CheServiceReference cheServiceReference = (CheServiceReference) o;
+    return Objects.equals(name, cheServiceReference.name)
+        && Objects.equals(version, cheServiceReference.version)
+        && Objects.equals(parameters, cheServiceReference.parameters);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, version, parameters);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CheServiceReference {\n");
+
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
+    sb.append("    parameters: ").append(toIndentedString(parameters)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheServiceSpec.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheServiceSpec.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class CheServiceSpec {
+
+  private String version = null;
+  private List<Container> containers = new ArrayList<Container>();
+
+  /** */
+  public CheServiceSpec version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  /** */
+  public CheServiceSpec containers(List<Container> containers) {
+    this.containers = containers;
+    return this;
+  }
+
+  public List<Container> getContainers() {
+    return containers;
+  }
+
+  public void setContainers(List<Container> containers) {
+    this.containers = containers;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CheServiceSpec cheServiceSpec = (CheServiceSpec) o;
+    return Objects.equals(version, cheServiceSpec.version)
+        && Objects.equals(containers, cheServiceSpec.containers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(version, containers);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CheServiceSpec {\n");
+
+    sb.append("    version: ").append(toIndentedString(version)).append("\n");
+    sb.append("    containers: ").append(toIndentedString(containers)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/Command.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/Command.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Command {
+
+  private String name = null;
+  private String workingDir = null;
+  private List<String> command = new ArrayList<String>();
+
+  /** */
+  public Command name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /** */
+  public Command workingDir(String workingDir) {
+    this.workingDir = workingDir;
+    return this;
+  }
+
+  public String getWorkingDir() {
+    return workingDir;
+  }
+
+  public void setWorkingDir(String workingDir) {
+    this.workingDir = workingDir;
+  }
+
+  /** */
+  public Command command(List<String> command) {
+    this.command = command;
+    return this;
+  }
+
+  public List<String> getCommand() {
+    return command;
+  }
+
+  public void setCommand(List<String> command) {
+    this.command = command;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Command command = (Command) o;
+    return Objects.equals(name, command.name)
+        && Objects.equals(workingDir, command.workingDir)
+        && Objects.equals(command, command.command);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, workingDir, command);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Command {\n");
+
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    workingDir: ").append(toIndentedString(workingDir)).append("\n");
+    sb.append("    command: ").append(toIndentedString(command)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/Container.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/Container.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class Container {
+
+  private String image = null;
+  private List<EnvVar> env = new ArrayList<EnvVar>();
+  private ResourceRequirements resources = null;
+  private List<Command> commands = new ArrayList<Command>();
+  private List<Server> servers = new ArrayList<Server>();
+  private List<Volume> volumes = new ArrayList<Volume>();
+
+  /** */
+  public Container image(String image) {
+    this.image = image;
+    return this;
+  }
+
+  public String getImage() {
+    return image;
+  }
+
+  public void setImage(String image) {
+    this.image = image;
+  }
+
+  /** List of environment variables to set in the container. Cannot be updated. */
+  public Container env(List<EnvVar> env) {
+    this.env = env;
+    return this;
+  }
+
+  public List<EnvVar> getEnv() {
+    return env;
+  }
+
+  public void setEnv(List<EnvVar> env) {
+    this.env = env;
+  }
+
+  /** */
+  public Container resources(ResourceRequirements resources) {
+    this.resources = resources;
+    return this;
+  }
+
+  public ResourceRequirements getResources() {
+    return resources;
+  }
+
+  public void setResources(ResourceRequirements resources) {
+    this.resources = resources;
+  }
+
+  /** List of container commands */
+  public Container commands(List<Command> commands) {
+    this.commands = commands;
+    return this;
+  }
+
+  public List<Command> getCommands() {
+    return commands;
+  }
+
+  public void setCommands(List<Command> commands) {
+    this.commands = commands;
+  }
+
+  /** List of container servers */
+  public Container servers(List<Server> servers) {
+    this.servers = servers;
+    return this;
+  }
+
+  public List<Server> getServers() {
+    return servers;
+  }
+
+  public void setServers(List<Server> servers) {
+    this.servers = servers;
+  }
+
+  /** List of container volumes */
+  public Container volumes(List<Volume> volumes) {
+    this.volumes = volumes;
+    return this;
+  }
+
+  public List<Volume> getVolumes() {
+    return volumes;
+  }
+
+  public void setVolumes(List<Volume> volumes) {
+    this.volumes = volumes;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Container container = (Container) o;
+    return Objects.equals(image, container.image)
+        && Objects.equals(env, container.env)
+        && Objects.equals(resources, container.resources)
+        && Objects.equals(commands, container.commands)
+        && Objects.equals(servers, container.servers)
+        && Objects.equals(volumes, container.volumes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(image, env, resources, commands, servers, volumes);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Container {\n");
+
+    sb.append("    image: ").append(toIndentedString(image)).append("\n");
+    sb.append("    env: ").append(toIndentedString(env)).append("\n");
+    sb.append("    resources: ").append(toIndentedString(resources)).append("\n");
+    sb.append("    commands: ").append(toIndentedString(commands)).append("\n");
+    sb.append("    servers: ").append(toIndentedString(servers)).append("\n");
+    sb.append("    volumes: ").append(toIndentedString(volumes)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/EnvVar.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/EnvVar.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.Objects;
+
+/** EnvVar represents an environment variable present in a Container. */
+public class EnvVar {
+
+  private String name = null;
+  private String value = null;
+
+  /** Name of the environment variable. Must be a C_IDENTIFIER. */
+  public EnvVar name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Variable references $(VAR_NAME) are expanded using the previous defined environment variables
+   * in the container and any service environment variables. If a variable cannot be resolved, the
+   * reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a
+   * double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether
+   * the variable exists or not. Defaults to \&quot;\&quot;.
+   */
+  public EnvVar value(String value) {
+    this.value = value;
+    return this;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(String value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EnvVar envVar = (EnvVar) o;
+    return Objects.equals(name, envVar.name) && Objects.equals(value, envVar.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, value);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class EnvVar {\n");
+
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    value: ").append(toIndentedString(value)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/ObjectMeta.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/ObjectMeta.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class ObjectMeta {
+
+  private String name = null;
+  private Map<String, String> labels = new HashMap<String, String>();
+
+  /** Object name. Name must be unique. */
+  public ObjectMeta name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /**
+   * Map of string keys and values that can be used to organize and categorize (scope and select)
+   * objects. May match selectors of replication controllers and services. More info:
+   * http://kubernetes.io/docs/user-guide/labels
+   */
+  public ObjectMeta labels(Map<String, String> labels) {
+    this.labels = labels;
+    return this;
+  }
+
+  public Map<String, String> getLabels() {
+    return labels;
+  }
+
+  public void setLabels(Map<String, String> labels) {
+    this.labels = labels;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ObjectMeta objectMeta = (ObjectMeta) o;
+    return Objects.equals(name, objectMeta.name) && Objects.equals(labels, objectMeta.labels);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, labels);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ObjectMeta {\n");
+
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    labels: ").append(toIndentedString(labels)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/ResourceRequirements.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/ResourceRequirements.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/** Compute Resources required by this container. Cannot be updated. More */
+public class ResourceRequirements {
+
+  private Map<String, String> requests = new HashMap<String, String>();
+
+  /**
+   * Requests describes the minimum amount of compute resources required. If Requests is omitted for
+   * a container, it defaults to Limits if that is explicitly specified, otherwise to an
+   * implementation-defined value.
+   */
+  public ResourceRequirements requests(Map<String, String> requests) {
+    this.requests = requests;
+    return this;
+  }
+
+  public Map<String, String> getRequests() {
+    return requests;
+  }
+
+  public void setRequests(Map<String, String> requests) {
+    this.requests = requests;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ResourceRequirements resourceRequirements = (ResourceRequirements) o;
+    return Objects.equals(requests, resourceRequirements.requests);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(requests);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class ResourceRequirements {\n");
+
+    sb.append("    requests: ").append(toIndentedString(requests)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/Server.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/Server.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class Server {
+
+  private String name = null;
+  private Integer port = null;
+  private String protocol = null;
+  private Map<String, String> attributes = new HashMap<String, String>();
+
+  /** */
+  public Server name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /** */
+  public Server port(Integer port) {
+    this.port = port;
+    return this;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  public void setPort(Integer port) {
+    this.port = port;
+  }
+
+  /** */
+  public Server protocol(String protocol) {
+    this.protocol = protocol;
+    return this;
+  }
+
+  public String getProtocol() {
+    return protocol;
+  }
+
+  public void setProtocol(String protocol) {
+    this.protocol = protocol;
+  }
+
+  /** */
+  public Server attributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+    return this;
+  }
+
+  public Map<String, String> getAttributes() {
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Server server = (Server) o;
+    return Objects.equals(name, server.name)
+        && Objects.equals(port, server.port)
+        && Objects.equals(protocol, server.protocol)
+        && Objects.equals(attributes, server.attributes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, port, protocol, attributes);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Server {\n");
+
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    port: ").append(toIndentedString(port)).append("\n");
+    sb.append("    protocol: ").append(toIndentedString(protocol)).append("\n");
+    sb.append("    attributes: ").append(toIndentedString(attributes)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/TypeMeta.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/TypeMeta.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.Objects;
+
+public class TypeMeta {
+
+  private String kind = null;
+  private String apiVersion = null;
+
+  /** Kind is a string value representing the REST resource this object represents. */
+  public TypeMeta kind(String kind) {
+    this.kind = kind;
+    return this;
+  }
+
+  public String getKind() {
+    return kind;
+  }
+
+  public void setKind(String kind) {
+    this.kind = kind;
+  }
+
+  /** APIVersion defines the versioned schema of this representation of an object */
+  public TypeMeta apiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+    return this;
+  }
+
+  public String getApiVersion() {
+    return apiVersion;
+  }
+
+  public void setApiVersion(String apiVersion) {
+    this.apiVersion = apiVersion;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TypeMeta typeMeta = (TypeMeta) o;
+    return Objects.equals(kind, typeMeta.kind) && Objects.equals(apiVersion, typeMeta.apiVersion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(kind, apiVersion);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class TypeMeta {\n");
+
+    sb.append("    kind: ").append(toIndentedString(kind)).append("\n");
+    sb.append("    apiVersion: ").append(toIndentedString(apiVersion)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/Volume.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/Volume.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.Objects;
+
+public class Volume {
+
+  private String name = null;
+  private String mountPath = null;
+
+  /** */
+  public Volume name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  /** mountPath of the volume in running container */
+  public Volume mountPath(String path) {
+    this.mountPath = path;
+    return this;
+  }
+
+  public String getMountPath() {
+    return mountPath;
+  }
+
+  public void setMountPath(String mountPath) {
+    this.mountPath = mountPath;
+  }
+
+  @Override
+  public boolean equals(java.lang.Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Volume volume = (Volume) o;
+    return Objects.equals(name, volume.name) && Objects.equals(mountPath, volume.mountPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, mountPath);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Volume {\n");
+
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    mountPath: ").append(toIndentedString(mountPath)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces (except the first line).
+   */
+  private String toIndentedString(java.lang.Object o) {
+    if (o == null) {
+      return "null";
+    }
+    return o.toString().replace("\n", "\n    ");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -62,6 +62,7 @@ import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
+import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextObjectsRetriever;
 import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
 import org.eclipse.che.api.workspace.shared.dto.event.RuntimeStatusEvent;
 import org.eclipse.che.core.db.DBInitializer;
@@ -93,6 +94,8 @@ public class WorkspaceRuntimesTest {
 
   @Mock private WorkspaceStatusCache statuses;
 
+  @Mock private WorkspaceNextObjectsRetriever workspaceNextObjectsRetriever;
+
   private RuntimeInfrastructure infrastructure;
 
   @Mock private InternalEnvironmentFactory<InternalEnvironment> testEnvFactory;
@@ -113,7 +116,9 @@ public class WorkspaceRuntimesTest {
             dbInitializer,
             probeScheduler,
             statuses,
-            lockService);
+            lockService,
+            emptyMap(),
+            workspaceNextObjectsRetriever);
   }
 
   @Test
@@ -202,7 +207,9 @@ public class WorkspaceRuntimesTest {
             dbInitializer,
             probeScheduler,
             statuses,
-            lockService);
+            lockService,
+            emptyMap(),
+            workspaceNextObjectsRetriever);
     localRuntimes.init();
     RuntimeIdentityDto identity =
         DtoFactory.newDto(RuntimeIdentityDto.class)
@@ -261,7 +268,9 @@ public class WorkspaceRuntimesTest {
             dbInitializer,
             probeScheduler,
             statuses,
-            lockService);
+            lockService,
+            emptyMap(),
+            workspaceNextObjectsRetriever);
 
     // when
     localRuntimes.injectRuntime(workspace);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/wsnext/WorkspaceNextObjectsRetrieverTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/wsnext/WorkspaceNextObjectsRetrieverTest.java
@@ -1,0 +1,662 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_NEXT_FEATURES;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheFeature;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheFeatureSpec;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheServiceParameter;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheServiceReference;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheServiceSpec;
+import org.eclipse.che.api.workspace.server.wsnext.model.Container;
+import org.eclipse.che.api.workspace.server.wsnext.model.EnvVar;
+import org.eclipse.che.api.workspace.server.wsnext.model.ObjectMeta;
+import org.eclipse.che.api.workspace.server.wsnext.model.ResourceRequirements;
+import org.eclipse.che.api.workspace.server.wsnext.model.Server;
+import org.eclipse.che.api.workspace.server.wsnext.model.Volume;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Alexander Garagatyi */
+@Listeners(MockitoTestNGListener.class)
+public class WorkspaceNextObjectsRetrieverTest {
+
+  private static final String TEST_FEATURE_NAME = "org.eclipse.che.example-plugin1";
+  private static final String TEST_FEATURE_2_NAME = "org.eclipse.che.example-plugin2";
+  private static final String TEST_FEATURE_VERSION = "1.0.2";
+  private static final String TEST_FEATURE_2_VERSION = "0.0.16";
+  private static final String TEST_SERVICE = "my-service";
+  private static final String TEST_SERVICE_2 = "my-test-service-2";
+  private static final String TEST_SERVICE_VERSION = "0.0.0";
+  private static final String TEST_SERVICE_VERSION_2 = "1.0.0-SNAPSHOT";
+  private static final String TEST_SERVICE_ENV_NAME = "MY_ENV";
+  private static final String TEST_SERVICE_ENV_NAME_2 = "MY_ENV_2";
+  private static final String TEST_SERVICE_ENV_NAME_3 = "MY_ENV_3";
+  private static final String TEST_SERVICE_ENV_VALUE = "MY_VALUE";
+  private static final String TEST_SERVICE_PARAM_NAME = "MY_PARAMETER_1";
+  private static final String TEST_SERVICE_PARAM_2_NAME = "TEST_PARAM_2";
+  private static final String TEST_SERVICE_PARAM_PLACEHOLDER = "${" + TEST_SERVICE_PARAM_NAME + "}";
+  private static final String TEST_SERVICE_PARAM_2_PLACEHOLDER =
+      "${" + TEST_SERVICE_PARAM_2_NAME + "}";
+  private static final String TEST_SERVICE_PARAM_VALUE = "http://github.com/plugin1";
+  private static final String TEST_SERVICE_PARAM_VALUE_2 = "http://github.com/plugin2";
+  private static final String TEST_SERVICE_IMAGE = "test/image:tag";
+  private static final String TEST_SERVER_NAME = "serv1";
+  private static final int TEST_SERVER_PORT = 9090;
+  private static final String TEST_SERVER_PROTOCOL = "https";
+  private static final Map<String, String> TEST_SERVER_ATTRIBUTES = ImmutableMap.of("type", "ide");
+  private static final String TEST_VOLUME_NAME = "vol1";
+  private static final String TEST_VOLUME_PATH = "/vol1/test";
+  private static final String API_ENDPOINT = "http://localhost:3000";
+  private static final Map<String, String> SINGLE_FEATURE_ATTRIBUTES =
+      singletonMap(WORKSPACE_NEXT_FEATURES, TEST_FEATURE_NAME + "/" + TEST_FEATURE_VERSION);
+
+  WorkspaceNextObjectsRetriever retriever;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    retriever = spy(new WorkspaceNextObjectsRetriever(API_ENDPOINT));
+  }
+
+  @Test
+  public void doesNothingWhenFeatureApiIsNotSet() throws Exception {
+    retriever = new WorkspaceNextObjectsRetriever(null);
+
+    Collection<CheService> services = retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+
+    assertTrue(services.isEmpty());
+  }
+
+  @Test
+  public void doesNothingWhenAttributesAreEmpty() throws Exception {
+    Collection<CheService> services = retriever.get(emptyMap());
+
+    assertTrue(services.isEmpty());
+  }
+
+  @Test
+  public void doesNothingWhenAttributesAreNull() throws Exception {
+    Collection<CheService> services = retriever.get(null);
+
+    assertTrue(services.isEmpty());
+  }
+
+  @Test
+  public void doesNothingWhenThereIsNoFeaturesAttribute() throws Exception {
+    Collection<CheService> services = retriever.get(singletonMap("not_feature_attribute", "value"));
+
+    assertTrue(services.isEmpty());
+  }
+
+  @Test
+  public void doesNothingWhenFeaturesAttributeIsEmpty() throws Exception {
+    Collection<CheService> services = retriever.get(singletonMap(WORKSPACE_NEXT_FEATURES, ""));
+
+    assertTrue(services.isEmpty());
+  }
+
+  @Test(
+    dataProvider = "incorrectFeatures",
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp = "Features format is illegal. Problematic feature entry:.*"
+  )
+  public void throwsExceptionWhenFeatureEntryIsIncorrect(String featuresAttributeValue)
+      throws Exception {
+    retriever.get(singletonMap(WORKSPACE_NEXT_FEATURES, featuresAttributeValue));
+  }
+
+  @DataProvider(name = "incorrectFeatures")
+  public static Object[][] incorrectFeatures() {
+    return new Object[][] {
+      {"feature1"},
+      {"feature1/"},
+      {"/version1"},
+      {"/"},
+      {"feature1:version1"},
+      {"/feature1/version1"},
+      {"/feature1/version1/"},
+      {"feature1//version1"},
+      {"feature1//version1,"},
+      {",feature1//version1"},
+      {"feature1/version1,feature2//version2"},
+      {"feature1/version1,/feature2/version2"},
+      {"feature1/version1,feature2:version2"},
+    };
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp =
+        "Invalid Workspace.Next configuration: feature .* is duplicated"
+  )
+  public void throwsExceptionWhenFeatureIsDuplicated() throws Exception {
+    retriever.get(singletonMap(WORKSPACE_NEXT_FEATURES, "feature1/version1,feature1/version1"));
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp = "Error occurred on retrieval of feature .*. Error: test error"
+  )
+  public void throwsExceptionWhenFeatureRetrievalFails() throws Exception {
+    doThrow(new IOException("test error"))
+        .when(retriever)
+        .getBody(any(URI.class), eq(CheFeature.class));
+
+    retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp = "Error occurred on retrieval of service .*. Error: test error"
+  )
+  public void throwsExceptionWhenServiceRetrievalFails() throws Exception {
+    CheFeature cheFeature = testFeature();
+    doReturn(cheFeature).when(retriever).getBody(any(URI.class), eq(CheFeature.class));
+    doThrow(new IOException("test error"))
+        .when(retriever)
+        .getBody(any(URI.class), eq(CheService.class));
+
+    retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp =
+        "Service '.*/.*' configuration is invalid. Version is missing."
+  )
+  public void throwExceptionIfServiceVersionIsNull() throws Exception {
+    CheFeature cheFeature = testFeature();
+    CheService service = testService();
+    service.getSpec().setVersion(null);
+    doReturn(cheFeature).when(retriever).getBody(any(URI.class), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+
+    retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp =
+        "Service '.*/.*' configuration is invalid. Version is missing."
+  )
+  public void throwExceptionIfServiceVersionIsEmpty() throws Exception {
+    CheFeature cheFeature = testFeature();
+    CheService service = testService();
+    service.getSpec().setVersion("");
+    doReturn(cheFeature).when(retriever).getBody(any(URI.class), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+
+    retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp = "Service '.*/.*' configuration is invalid. Name is missing."
+  )
+  public void throwExceptionIfServiceNameIsNull() throws Exception {
+    CheFeature cheFeature = testFeature();
+    CheService service = testService();
+    service.getMetadata().setName(null);
+    doReturn(cheFeature).when(retriever).getBody(any(URI.class), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+
+    retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp = "Service '.*/.*' configuration is invalid. Name is missing."
+  )
+  public void throwExceptionIfServiceNameIsEmpty() throws Exception {
+    CheFeature cheFeature = testFeature();
+    CheService service = testService();
+    service.getMetadata().setName("");
+    doReturn(cheFeature).when(retriever).getBody(any(URI.class), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+
+    retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+  }
+
+  @Test(
+    expectedExceptions = InfrastructureException.class,
+    expectedExceptionsMessageRegExp =
+        "Parameters not supported by services found: .*" + TEST_SERVICE_PARAM_NAME + ".*"
+  )
+  public void throwExceptionIfValueForServiceParameterNotFound() throws Exception {
+    CheFeature cheFeature =
+        testFeature(
+            TEST_SERVICE, TEST_SERVICE_VERSION, TEST_SERVICE_PARAM_NAME, TEST_SERVICE_PARAM_VALUE);
+    CheService service = testServiceWithEnv(TEST_SERVICE_ENV_NAME, TEST_SERVICE_ENV_VALUE);
+    doReturn(cheFeature).when(retriever).getBody(any(URI.class), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+
+    retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+  }
+
+  @Test
+  public void testFeaturesWithoutParameters() throws Exception {
+    CheFeature cheFeature = testFeature();
+    CheService service = testService();
+    doReturn(cheFeature).when(retriever).getBody(any(URI.class), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+
+    Collection<CheService> services = retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+
+    assertEquals(services, singletonList(expectedService()));
+  }
+
+  @Test
+  public void testFeaturesWithParameter() throws Exception {
+    CheFeature cheFeature =
+        testFeature(
+            TEST_SERVICE, TEST_SERVICE_VERSION, TEST_SERVICE_PARAM_NAME, TEST_SERVICE_PARAM_VALUE);
+    CheService service = testServiceWithEnv(TEST_SERVICE_ENV_NAME, TEST_SERVICE_PARAM_PLACEHOLDER);
+    doReturn(cheFeature).when(retriever).getBody(any(URI.class), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+
+    Collection<CheService> services = retriever.get(SINGLE_FEATURE_ATTRIBUTES);
+
+    assertEquals(
+        services,
+        singletonList(expectedServiceWithEnv(TEST_SERVICE_ENV_NAME, TEST_SERVICE_PARAM_VALUE)));
+  }
+
+  @Test
+  public void testFeaturesWithTheSameServicesAndTheSameParameters() throws Exception {
+    Map<String, String> featuresAttributes =
+        featuresAttribute(
+            TEST_FEATURE_NAME, TEST_FEATURE_VERSION, TEST_FEATURE_2_NAME, TEST_FEATURE_2_VERSION);
+    CheFeature feature1 =
+        testFeature(
+            TEST_SERVICE, TEST_SERVICE_VERSION, TEST_SERVICE_PARAM_NAME, TEST_SERVICE_PARAM_VALUE);
+    CheFeature feature2 =
+        testFeature(
+            TEST_SERVICE,
+            TEST_SERVICE_VERSION,
+            TEST_SERVICE_PARAM_NAME,
+            TEST_SERVICE_PARAM_VALUE_2);
+    CheService service =
+        testServiceWithEnv(TEST_SERVICE_ENV_NAME_2, TEST_SERVICE_PARAM_PLACEHOLDER);
+    doReturn(feature1)
+        .when(retriever)
+        .getBody(eq(getFeatureURI(TEST_FEATURE_NAME, TEST_FEATURE_VERSION)), eq(CheFeature.class));
+    doReturn(feature2)
+        .when(retriever)
+        .getBody(
+            eq(getFeatureURI(TEST_FEATURE_2_NAME, TEST_FEATURE_2_VERSION)), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+
+    Collection<CheService> services = retriever.get(featuresAttributes);
+
+    // we don't know the order of values in env var from feature, so we have to match it separately
+    // - can't assert whole object
+    assertEquals(services.size(), 1);
+    CheService actualService = services.iterator().next();
+    assertEquals(actualService.getSpec().getContainers().size(), 1);
+    List<EnvVar> envVars = actualService.getSpec().getContainers().iterator().next().getEnv();
+    envVars
+        .stream()
+        .filter(envVar -> envVar.getName().equals(TEST_SERVICE_ENV_NAME_2))
+        .forEach(
+            envVar -> {
+              assertEqualsNoOrder(
+                  envVar.getValue().split(","),
+                  new String[] {TEST_SERVICE_PARAM_VALUE_2, TEST_SERVICE_PARAM_VALUE});
+            });
+  }
+
+  @Test
+  public void testFeaturesWithTheSameServicesButDifferentParameters() throws Exception {
+    Map<String, String> featuresAttributes =
+        featuresAttribute(
+            TEST_FEATURE_NAME, TEST_FEATURE_VERSION, TEST_FEATURE_2_NAME, TEST_FEATURE_2_VERSION);
+    CheFeature feature1 =
+        testFeature(
+            TEST_SERVICE, TEST_SERVICE_VERSION, TEST_SERVICE_PARAM_NAME, TEST_SERVICE_PARAM_VALUE);
+    CheFeature feature2 =
+        testFeature(
+            TEST_SERVICE,
+            TEST_SERVICE_VERSION,
+            TEST_SERVICE_PARAM_2_NAME,
+            TEST_SERVICE_PARAM_VALUE_2);
+    CheService service =
+        testService(
+            TEST_SERVICE_ENV_NAME_2,
+            TEST_SERVICE_PARAM_PLACEHOLDER,
+            TEST_SERVICE_ENV_NAME_3,
+            TEST_SERVICE_PARAM_2_PLACEHOLDER);
+    doReturn(feature1)
+        .when(retriever)
+        .getBody(eq(getFeatureURI(TEST_FEATURE_NAME, TEST_FEATURE_VERSION)), eq(CheFeature.class));
+    doReturn(feature2)
+        .when(retriever)
+        .getBody(
+            eq(getFeatureURI(TEST_FEATURE_2_NAME, TEST_FEATURE_2_VERSION)), eq(CheFeature.class));
+    doReturn(service).when(retriever).getBody(any(URI.class), eq(CheService.class));
+    CheService expectedService =
+        expectedServiceWithEnv(
+            TEST_SERVICE_ENV_NAME_2,
+            TEST_SERVICE_PARAM_VALUE,
+            TEST_SERVICE_ENV_NAME_3,
+            TEST_SERVICE_PARAM_VALUE_2);
+
+    Collection<CheService> services = retriever.get(featuresAttributes);
+
+    assertEquals(services, singletonList(expectedService));
+  }
+
+  @Test
+  public void testFeaturesWithDifferentServicesButTheSameParameter() throws Exception {
+    Map<String, String> featuresAttributes =
+        featuresAttribute(
+            TEST_FEATURE_NAME, TEST_FEATURE_VERSION, TEST_FEATURE_2_NAME, TEST_FEATURE_2_VERSION);
+    CheFeature feature1 =
+        testFeature(
+            TEST_SERVICE, TEST_SERVICE_VERSION, TEST_SERVICE_PARAM_NAME, TEST_SERVICE_PARAM_VALUE);
+    CheFeature feature2 =
+        testFeature(
+            TEST_SERVICE_2,
+            TEST_SERVICE_VERSION_2,
+            TEST_SERVICE_PARAM_NAME,
+            TEST_SERVICE_PARAM_VALUE);
+    CheService service1 =
+        testServiceWithSpecifiedServiceAndEnv(
+            TEST_SERVICE,
+            TEST_SERVICE_VERSION,
+            TEST_SERVICE_ENV_NAME_2,
+            TEST_SERVICE_PARAM_PLACEHOLDER);
+    CheService service2 =
+        testServiceWithSpecifiedServiceAndEnv(
+            TEST_SERVICE_2,
+            TEST_SERVICE_VERSION_2,
+            TEST_SERVICE_ENV_NAME_3,
+            TEST_SERVICE_PARAM_PLACEHOLDER);
+    doReturn(feature1)
+        .when(retriever)
+        .getBody(eq(getFeatureURI(TEST_FEATURE_NAME, TEST_FEATURE_VERSION)), eq(CheFeature.class));
+    doReturn(feature2)
+        .when(retriever)
+        .getBody(
+            eq(getFeatureURI(TEST_FEATURE_2_NAME, TEST_FEATURE_2_VERSION)), eq(CheFeature.class));
+    doReturn(service1)
+        .when(retriever)
+        .getBody(eq(getServiceURI(TEST_SERVICE, TEST_SERVICE_VERSION)), eq(CheService.class));
+    doReturn(service2)
+        .when(retriever)
+        .getBody(eq(getServiceURI(TEST_SERVICE_2, TEST_SERVICE_VERSION_2)), eq(CheService.class));
+    CheService expectedService1 =
+        expectedServiceWithSpecifiedServiceAndEnv(
+            TEST_SERVICE, TEST_SERVICE_VERSION, TEST_SERVICE_ENV_NAME_2, TEST_SERVICE_PARAM_VALUE);
+    CheService expectedService2 =
+        expectedServiceWithSpecifiedServiceAndEnv(
+            TEST_SERVICE_2,
+            TEST_SERVICE_VERSION_2,
+            TEST_SERVICE_ENV_NAME_3,
+            TEST_SERVICE_PARAM_VALUE);
+
+    Collection<CheService> services = retriever.get(featuresAttributes);
+
+    assertEquals(services, Arrays.asList(expectedService1, expectedService2));
+  }
+
+  @Test
+  public void testFeaturesWithDifferentServicesAndDifferentParameters() throws Exception {
+    Map<String, String> featuresAttributes =
+        featuresAttribute(
+            TEST_FEATURE_NAME, TEST_FEATURE_VERSION, TEST_FEATURE_2_NAME, TEST_FEATURE_2_VERSION);
+    CheFeature feature1 =
+        testFeature(
+            TEST_SERVICE, TEST_SERVICE_VERSION, TEST_SERVICE_PARAM_NAME, TEST_SERVICE_PARAM_VALUE);
+    CheFeature feature2 =
+        testFeature(
+            TEST_SERVICE_2,
+            TEST_SERVICE_VERSION_2,
+            TEST_SERVICE_PARAM_2_NAME,
+            TEST_SERVICE_PARAM_VALUE_2);
+    CheService service1 =
+        testServiceWithSpecifiedServiceAndEnv(
+            TEST_SERVICE,
+            TEST_SERVICE_VERSION,
+            TEST_SERVICE_ENV_NAME_2,
+            TEST_SERVICE_PARAM_PLACEHOLDER);
+    CheService service2 =
+        testServiceWithSpecifiedServiceAndEnv(
+            TEST_SERVICE_2,
+            TEST_SERVICE_VERSION_2,
+            TEST_SERVICE_ENV_NAME_3,
+            TEST_SERVICE_PARAM_2_PLACEHOLDER);
+    doReturn(feature1)
+        .when(retriever)
+        .getBody(eq(getFeatureURI(TEST_FEATURE_NAME, TEST_FEATURE_VERSION)), eq(CheFeature.class));
+    doReturn(feature2)
+        .when(retriever)
+        .getBody(
+            eq(getFeatureURI(TEST_FEATURE_2_NAME, TEST_FEATURE_2_VERSION)), eq(CheFeature.class));
+    doReturn(service1)
+        .when(retriever)
+        .getBody(eq(getServiceURI(TEST_SERVICE, TEST_SERVICE_VERSION)), eq(CheService.class));
+    doReturn(service2)
+        .when(retriever)
+        .getBody(eq(getServiceURI(TEST_SERVICE_2, TEST_SERVICE_VERSION_2)), eq(CheService.class));
+    CheService expectedService1 =
+        expectedServiceWithSpecifiedServiceAndEnv(
+            TEST_SERVICE, TEST_SERVICE_VERSION, TEST_SERVICE_ENV_NAME_2, TEST_SERVICE_PARAM_VALUE);
+    CheService expectedService2 =
+        expectedServiceWithSpecifiedServiceAndEnv(
+            TEST_SERVICE_2,
+            TEST_SERVICE_VERSION_2,
+            TEST_SERVICE_ENV_NAME_3,
+            TEST_SERVICE_PARAM_VALUE_2);
+
+    Collection<CheService> services = retriever.get(featuresAttributes);
+
+    assertEquals(services, Arrays.asList(expectedService1, expectedService2));
+  }
+
+  private CheService expectedService() {
+    return expectedService(TEST_SERVICE, TEST_SERVICE_VERSION);
+  }
+
+  private CheService expectedService(String serviceName, String serviceVersion) {
+    CheService expectedService = new CheService();
+    expectedService.setMetadata(new ObjectMeta().name(serviceName));
+    CheServiceSpec expectedServiceSpec = new CheServiceSpec();
+    Container expectedContainer = new Container();
+    expectedContainer.setEnv(
+        new ArrayList<>(
+            singletonList(new EnvVar().name(TEST_SERVICE_ENV_NAME).value(TEST_SERVICE_ENV_VALUE))));
+    expectedContainer.setImage(TEST_SERVICE_IMAGE);
+    expectedContainer.setVolumes(
+        singletonList(new Volume().name(TEST_VOLUME_NAME).mountPath(TEST_VOLUME_PATH)));
+    expectedContainer.setServers(
+        singletonList(
+            new Server()
+                .name(TEST_SERVER_NAME)
+                .port(TEST_SERVER_PORT)
+                .protocol(TEST_SERVER_PROTOCOL)
+                .attributes(TEST_SERVER_ATTRIBUTES)));
+    expectedContainer.setResources(new ResourceRequirements());
+    expectedServiceSpec.setContainers(singletonList(expectedContainer));
+    expectedServiceSpec.setVersion(serviceVersion);
+    expectedService.setSpec(expectedServiceSpec);
+    return expectedService;
+  }
+
+  private CheService expectedServiceWithEnv(String envName, String envValue) {
+    CheService service = expectedService();
+    service
+        .getSpec()
+        .getContainers()
+        .get(0)
+        .getEnv()
+        .add(new EnvVar().name(envName).value(envValue));
+    return service;
+  }
+
+  private CheService expectedServiceWithSpecifiedServiceAndEnv(
+      String serviceName, String serviceVersion, String envName, String envValue) {
+    CheService service = expectedService(serviceName, serviceVersion);
+    service
+        .getSpec()
+        .getContainers()
+        .get(0)
+        .getEnv()
+        .add(new EnvVar().name(envName).value(envValue));
+    return service;
+  }
+
+  private CheService expectedServiceWithEnv(
+      String envName, String envValue, String envName2, String envValue2) {
+    CheService service = expectedService();
+    service
+        .getSpec()
+        .getContainers()
+        .get(0)
+        .getEnv()
+        .add(new EnvVar().name(envName).value(envValue));
+    service
+        .getSpec()
+        .getContainers()
+        .get(0)
+        .getEnv()
+        .add(new EnvVar().name(envName2).value(envValue2));
+    return service;
+  }
+
+  private static CheFeature testFeature() {
+    CheFeature cheFeature = new CheFeature();
+    CheFeatureSpec cheFeatureSpec = new CheFeatureSpec();
+    CheServiceReference theiaServiceReference = new CheServiceReference();
+    theiaServiceReference.setName(TEST_SERVICE);
+    theiaServiceReference.setVersion(TEST_SERVICE_VERSION);
+    theiaServiceReference.setParameters(new ArrayList<>());
+    cheFeatureSpec.setServices(new ArrayList<>(singletonList(theiaServiceReference)));
+    cheFeatureSpec.setVersion(TEST_FEATURE_VERSION);
+    cheFeature.setSpec(cheFeatureSpec);
+    cheFeature.setMetadata(new ObjectMeta().name(TEST_FEATURE_NAME));
+    return cheFeature;
+  }
+
+  private static CheFeature testFeature(
+      String serviceName, String serviceVersion, String paramName, String paramValue) {
+    CheServiceReference theiaServiceReference = new CheServiceReference();
+    theiaServiceReference.setName(serviceName);
+    theiaServiceReference.setVersion(serviceVersion);
+    theiaServiceReference.setParameters(
+        new ArrayList<>(
+            singletonList(new CheServiceParameter().name(paramName).value(paramValue))));
+    CheFeature feature = testFeature();
+    feature.getSpec().getServices().add(theiaServiceReference);
+    return feature;
+  }
+
+  private static CheService testService() {
+    return testService(TEST_SERVICE, TEST_SERVICE_VERSION);
+  }
+
+  private static CheService testService(String serviceName, String serviceVersion) {
+    CheService service = new CheService();
+    CheServiceSpec cheServiceSpec = new CheServiceSpec();
+    Container container = new Container();
+    container.setCommands(emptyList());
+    container.setEnv(
+        new ArrayList<>(
+            ImmutableList.of(
+                new EnvVar().name(TEST_SERVICE_ENV_NAME).value(TEST_SERVICE_ENV_VALUE))));
+    container.setImage(TEST_SERVICE_IMAGE);
+    container.setResources(new ResourceRequirements());
+    container.setServers(
+        singletonList(
+            new Server()
+                .name(TEST_SERVER_NAME)
+                .port(TEST_SERVER_PORT)
+                .protocol(TEST_SERVER_PROTOCOL)
+                .attributes(TEST_SERVER_ATTRIBUTES)));
+    container.setVolumes(
+        singletonList(new Volume().name(TEST_VOLUME_NAME).mountPath(TEST_VOLUME_PATH)));
+    cheServiceSpec.setContainers(singletonList(container));
+    cheServiceSpec.setVersion(serviceVersion);
+    service.setSpec(cheServiceSpec);
+    service.setMetadata(new ObjectMeta().name(serviceName));
+    return service;
+  }
+
+  private static CheService testServiceWithEnv(String envVarName, String envVarValue) {
+    CheService service = testService();
+    for (Container container : service.getSpec().getContainers()) {
+      container.getEnv().add(new EnvVar().name(envVarName).value(envVarValue));
+    }
+    return service;
+  }
+
+  private CheService testServiceWithSpecifiedServiceAndEnv(
+      String serviceName, String serviceVersion, String envVarName, String envVarValue) {
+    CheService service = testService(serviceName, serviceVersion);
+    for (Container container : service.getSpec().getContainers()) {
+      container.getEnv().add(new EnvVar().name(envVarName).value(envVarValue));
+    }
+    return service;
+  }
+
+  private CheService testService(
+      String envVarName, String envVarValue, String envVarName2, String envVarValue2) {
+    CheService service = testService();
+    for (Container container : service.getSpec().getContainers()) {
+      container.getEnv().add(new EnvVar().name(envVarName).value(envVarValue));
+      container.getEnv().add(new EnvVar().name(envVarName2).value(envVarValue2));
+    }
+    return service;
+  }
+
+  private URI getFeatureURI(String featureName, String featureVersion) throws URISyntaxException {
+    return new URI(API_ENDPOINT + "/feature/" + featureName + '/' + featureVersion);
+  }
+
+  private URI getServiceURI(String testService, String testServiceVersion)
+      throws URISyntaxException {
+    return new URI(API_ENDPOINT + "/service/" + testService + '/' + testServiceVersion);
+  }
+
+  private Map<String, String> featuresAttribute(
+      String feature1Name, String feature1Version, String feature2Name, String feature2Version) {
+    return ImmutableMap.of(
+        WORKSPACE_NEXT_FEATURES,
+        feature1Name + "/" + feature1Version + "," + feature2Name + "/" + feature2Version);
+  }
+}

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.core.db.jpa;
 
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.eclipse.che.core.db.jpa.TestObjectsFactory.createAccount;
 import static org.eclipse.che.core.db.jpa.TestObjectsFactory.createPreferences;
@@ -33,7 +34,6 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Stage;
 import com.google.inject.name.Names;
-import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import javax.annotation.PostConstruct;
@@ -209,14 +209,16 @@ public class CascadeRemovalTest {
                     spy(
                         new WorkspaceRuntimes(
                             mock(EventService.class),
-                            Collections.emptyMap(),
+                            emptyMap(),
                             infra,
                             mock(WorkspaceSharedPool.class),
                             mock(WorkspaceDao.class),
                             mock(DBInitializer.class),
                             mock(ProbeScheduler.class),
                             new DefaultWorkspaceStatusCache(),
-                            new DefaultWorkspaceLockService()));
+                            new DefaultWorkspaceLockService(),
+                            emptyMap(),
+                            null));
                 when(wR.hasRuntime(anyString())).thenReturn(false);
                 bind(WorkspaceRuntimes.class).toInstance(wR);
                 bind(AccountManager.class);


### PR DESCRIPTION
This PR is designed to be reviewed in a commit by commit manner. 

It is in WIP state because not all the unit tests are finished. 
### What does this PR do?
Add an ability to try Workspace.Next features. 
To try it out user needs to add an attribute to a workspace with name `features` and a list of features as a value.
An example of value: `"org.eclipse.che.che-theia-hello/0.0.1,org.eclipse.che.che-theia-ssh/0.0.1"`
This PR contains code to use Workspace.Next with the kubernetes recipe only. 
Support of other recipes should be added additionally. 
### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
