### PR TITLE
Send initialized event, after initialization

### DIFF
--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerInitializer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerInitializer.java
@@ -66,12 +66,12 @@ class LanguageServerInitializer {
 
   @Inject
   public LanguageServerInitializer(
-          ServerCapabilitiesAccumulator serverCapabilitiesAccumulator,
-          RegistryContainer registryContainer,
-          FindId findId,
-          EventService eventService,
-          CheLanguageClientFactory cheLanguageClientFactory,
-          InitializeParamsProvider initializeParamsProvider) {
+      ServerCapabilitiesAccumulator serverCapabilitiesAccumulator,
+      RegistryContainer registryContainer,
+      FindId findId,
+      EventService eventService,
+      CheLanguageClientFactory cheLanguageClientFactory,
+      InitializeParamsProvider initializeParamsProvider) {
     this.executor = newCachedThreadPool(getFactory());
 
     this.eventService = eventService;
@@ -90,10 +90,10 @@ class LanguageServerInitializer {
 
   private static ThreadFactory getFactory() {
     return new ThreadFactoryBuilder()
-            .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
-            .setNameFormat(LanguageServerInitializer.class.getSimpleName())
-            .setDaemon(true)
-            .build();
+        .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
+        .setNameFormat(LanguageServerInitializer.class.getSimpleName())
+        .setDaemon(true)
+        .build();
   }
 
   /**
@@ -108,40 +108,40 @@ class LanguageServerInitializer {
    */
   CompletableFuture<ServerCapabilities> initialize(String wsPath) {
     return supplyAsync(
-            () -> {
-              LOG.info("Started language servers initialization, file path '{}'", wsPath);
+        () -> {
+          LOG.info("Started language servers initialization, file path '{}'", wsPath);
 
-              Set<ServerCapabilities> serverCapabilitiesSet =
-                      findId
-                              .byPath(wsPath)
-                              .stream()
-                              .map(this::initializeIOStreams)
-                              .filter(Objects::nonNull)
-                              .map(this::createServerInstance)
-                              .filter(Objects::nonNull)
-                              .map(this::initializeServerInstance)
-                              .filter(Objects::nonNull)
-                              .map(this::initialized)
-                              .filter(Objects::nonNull)
-                              .map(serverCapabilitiesRegistry::getOrNull)
-                              .filter(Objects::nonNull)
-                              .collect(toSet());
+          Set<ServerCapabilities> serverCapabilitiesSet =
+              findId
+                  .byPath(wsPath)
+                  .stream()
+                  .map(this::initializeIOStreams)
+                  .filter(Objects::nonNull)
+                  .map(this::createServerInstance)
+                  .filter(Objects::nonNull)
+                  .map(this::initializeServerInstance)
+                  .filter(Objects::nonNull)
+                  .map(this::initialized)
+                  .filter(Objects::nonNull)
+                  .map(serverCapabilitiesRegistry::getOrNull)
+                  .filter(Objects::nonNull)
+                  .collect(toSet());
 
-              LOG.info("Finished language servers initialization, file path '{}'", wsPath);
+          LOG.info("Finished language servers initialization, file path '{}'", wsPath);
 
-              LOG.debug("Calculating number of initialized servers and accumulating capabilities");
-              if (serverCapabilitiesSet.isEmpty()) {
-                String message = String.format("Could not initialize any server for '%s'", wsPath);
-                LOG.error(message);
-                LanguageServerException cause = new LanguageServerException(message);
-                throw new CompletionException(cause);
-              } else {
-                return serverCapabilitiesSet
-                        .stream()
-                        .reduce(new ServerCapabilities(), serverCapabilitiesAccumulator);
-              }
-            },
-            executor);
+          LOG.debug("Calculating number of initialized servers and accumulating capabilities");
+          if (serverCapabilitiesSet.isEmpty()) {
+            String message = String.format("Could not initialize any server for '%s'", wsPath);
+            LOG.error(message);
+            LanguageServerException cause = new LanguageServerException(message);
+            throw new CompletionException(cause);
+          } else {
+            return serverCapabilitiesSet
+                .stream()
+                .reduce(new ServerCapabilities(), serverCapabilitiesAccumulator);
+          }
+        },
+        executor);
   }
 
   private String initialized(String id) {
@@ -223,10 +223,10 @@ class LanguageServerInitializer {
         LanguageServer languageServer = languageServerRegistry.get(id);
         InitializeParams initializeParams = initializeParamsProvider.get(id);
         InitializeResult initializeResult =
-                languageServer.initialize(initializeParams).get(30, SECONDS);
+            languageServer.initialize(initializeParams).get(30, SECONDS);
 
         LanguageServerInitializedEvent event =
-                new LanguageServerInitializedEvent(id, languageServer);
+            new LanguageServerInitializedEvent(id, languageServer);
         eventService.publish(event);
         LOG.debug("Published a corresponding event: {}", event);
 
@@ -236,9 +236,9 @@ class LanguageServerInitializer {
         return serverCapabilitiesRegistry.add(id, initializeResult.getCapabilities());
       }
     } catch (LanguageServerException
-            | InterruptedException
-            | ExecutionException
-            | TimeoutException e) {
+        | InterruptedException
+        | ExecutionException
+        | TimeoutException e) {
       LOG.error("Can't initialize language server for '{}'", id, e);
     }
 

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerInitializer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerInitializer.java
@@ -32,6 +32,7 @@ import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.slf4j.Logger;
@@ -65,12 +66,12 @@ class LanguageServerInitializer {
 
   @Inject
   public LanguageServerInitializer(
-      ServerCapabilitiesAccumulator serverCapabilitiesAccumulator,
-      RegistryContainer registryContainer,
-      FindId findId,
-      EventService eventService,
-      CheLanguageClientFactory cheLanguageClientFactory,
-      InitializeParamsProvider initializeParamsProvider) {
+          ServerCapabilitiesAccumulator serverCapabilitiesAccumulator,
+          RegistryContainer registryContainer,
+          FindId findId,
+          EventService eventService,
+          CheLanguageClientFactory cheLanguageClientFactory,
+          InitializeParamsProvider initializeParamsProvider) {
     this.executor = newCachedThreadPool(getFactory());
 
     this.eventService = eventService;
@@ -89,10 +90,10 @@ class LanguageServerInitializer {
 
   private static ThreadFactory getFactory() {
     return new ThreadFactoryBuilder()
-        .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
-        .setNameFormat(LanguageServerInitializer.class.getSimpleName())
-        .setDaemon(true)
-        .build();
+            .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
+            .setNameFormat(LanguageServerInitializer.class.getSimpleName())
+            .setDaemon(true)
+            .build();
   }
 
   /**
@@ -107,38 +108,54 @@ class LanguageServerInitializer {
    */
   CompletableFuture<ServerCapabilities> initialize(String wsPath) {
     return supplyAsync(
-        () -> {
-          LOG.info("Started language servers initialization, file path '{}'", wsPath);
+            () -> {
+              LOG.info("Started language servers initialization, file path '{}'", wsPath);
 
-          Set<ServerCapabilities> serverCapabilitiesSet =
-              findId
-                  .byPath(wsPath)
-                  .stream()
-                  .map(this::initializeIOStreams)
-                  .filter(Objects::nonNull)
-                  .map(this::createServerInstance)
-                  .filter(Objects::nonNull)
-                  .map(this::initializeServerInstance)
-                  .filter(Objects::nonNull)
-                  .map(serverCapabilitiesRegistry::getOrNull)
-                  .filter(Objects::nonNull)
-                  .collect(toSet());
+              Set<ServerCapabilities> serverCapabilitiesSet =
+                      findId
+                              .byPath(wsPath)
+                              .stream()
+                              .map(this::initializeIOStreams)
+                              .filter(Objects::nonNull)
+                              .map(this::createServerInstance)
+                              .filter(Objects::nonNull)
+                              .map(this::initializeServerInstance)
+                              .filter(Objects::nonNull)
+                              .map(this::initialized)
+                              .filter(Objects::nonNull)
+                              .map(serverCapabilitiesRegistry::getOrNull)
+                              .filter(Objects::nonNull)
+                              .collect(toSet());
 
-          LOG.info("Finished language servers initialization, file path '{}'", wsPath);
+              LOG.info("Finished language servers initialization, file path '{}'", wsPath);
 
-          LOG.debug("Calculating number of initialized servers and accumulating capabilities");
-          if (serverCapabilitiesSet.isEmpty()) {
-            String message = String.format("Could not initialize any server for '%s'", wsPath);
-            LOG.error(message);
-            LanguageServerException cause = new LanguageServerException(message);
-            throw new CompletionException(cause);
-          } else {
-            return serverCapabilitiesSet
-                .stream()
-                .reduce(new ServerCapabilities(), serverCapabilitiesAccumulator);
-          }
-        },
-        executor);
+              LOG.debug("Calculating number of initialized servers and accumulating capabilities");
+              if (serverCapabilitiesSet.isEmpty()) {
+                String message = String.format("Could not initialize any server for '%s'", wsPath);
+                LOG.error(message);
+                LanguageServerException cause = new LanguageServerException(message);
+                throw new CompletionException(cause);
+              } else {
+                return serverCapabilitiesSet
+                        .stream()
+                        .reduce(new ServerCapabilities(), serverCapabilitiesAccumulator);
+              }
+            },
+            executor);
+  }
+
+  private String initialized(String id) {
+    try {
+      LOG.debug("Send Initialized message to the server '{}': started", id);
+      synchronized (idRegistry.get(id)) {
+        languageServerRegistry.get(id).initialized(new InitializedParams());
+        LOG.debug("Initializing of IO streams for server '{}': finished", id);
+        return id;
+      }
+    } catch (LanguageServerException e) {
+      LOG.error("Can't initialize IO streams for '{}'", id, e);
+    }
+    return null;
   }
 
   private String initializeIOStreams(String id) {
@@ -206,10 +223,10 @@ class LanguageServerInitializer {
         LanguageServer languageServer = languageServerRegistry.get(id);
         InitializeParams initializeParams = initializeParamsProvider.get(id);
         InitializeResult initializeResult =
-            languageServer.initialize(initializeParams).get(30, SECONDS);
+                languageServer.initialize(initializeParams).get(30, SECONDS);
 
         LanguageServerInitializedEvent event =
-            new LanguageServerInitializedEvent(id, languageServer);
+                new LanguageServerInitializedEvent(id, languageServer);
         eventService.publish(event);
         LOG.debug("Published a corresponding event: {}", event);
 
@@ -219,9 +236,9 @@ class LanguageServerInitializer {
         return serverCapabilitiesRegistry.add(id, initializeResult.getCapabilities());
       }
     } catch (LanguageServerException
-        | InterruptedException
-        | ExecutionException
-        | TimeoutException e) {
+            | InterruptedException
+            | ExecutionException
+            | TimeoutException e) {
       LOG.error("Can't initialize language server for '{}'", id, e);
     }
 

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerInitializer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerInitializer.java
@@ -121,8 +121,6 @@ class LanguageServerInitializer {
                   .filter(Objects::nonNull)
                   .map(this::initializeServerInstance)
                   .filter(Objects::nonNull)
-                  .map(this::initialized)
-                  .filter(Objects::nonNull)
                   .map(serverCapabilitiesRegistry::getOrNull)
                   .filter(Objects::nonNull)
                   .collect(toSet());
@@ -144,19 +142,6 @@ class LanguageServerInitializer {
         executor);
   }
 
-  private String initialized(String id) {
-    try {
-      LOG.debug("Send Initialized message to the server '{}': started", id);
-      synchronized (idRegistry.get(id)) {
-        languageServerRegistry.get(id).initialized(new InitializedParams());
-        LOG.debug("Initializing of IO streams for server '{}': finished", id);
-        return id;
-      }
-    } catch (LanguageServerException e) {
-      LOG.error("Can't initialize IO streams for '{}'", id, e);
-    }
-    return null;
-  }
 
   private String initializeIOStreams(String id) {
     try {
@@ -233,6 +218,7 @@ class LanguageServerInitializer {
         LOG.debug("Initializing of a language server instance for server '{}': finished", id);
 
         LOG.info("Initialized language server '{}'", id);
+        languageServer.initialized(new InitializedParams());//send initialized message, some LS required it
         return serverCapabilitiesRegistry.add(id, initializeResult.getCapabilities());
       }
     } catch (LanguageServerException


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfonov@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
According to the specification client must send `initialized` message jaust after getting server capabilities. Looks like not all LS support this method we met this problem with LS's what we got from VS Code. Like GoLang ang C# 

### What issues does this PR fix or reference?
#9351


