### PR TITLE
Update cached children when external file event is coming

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -846,13 +846,9 @@ public final class ResourceManager {
       return getRemoteResources(container, DEPTH_ONE, true);
     }
 
-    final Optional<Resource[]> optChildren = store.get(container.getLocation());
+    Promise<Void> promise = loadAndRegisterResources(container.getLocation());
 
-    if (optChildren.isPresent()) {
-      return promises.resolve(optChildren.get());
-    } else {
-      return promises.resolve(NO_RESOURCES);
-    }
+    return promise.thenPromise(ignored -> promises.resolve(store.get(container.getLocation()).or(NO_RESOURCES)));
   }
 
   private Promise<Optional<Resource>> doFindResource(Path path) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/impl/ResourceManager.java
@@ -848,7 +848,8 @@ public final class ResourceManager {
 
     Promise<Void> promise = loadAndRegisterResources(container.getLocation());
 
-    return promise.thenPromise(ignored -> promises.resolve(store.get(container.getLocation()).or(NO_RESOURCES)));
+    return promise.thenPromise(
+        ignored -> promises.resolve(store.get(container.getLocation()).or(NO_RESOURCES)));
   }
 
   private Promise<Optional<Resource>> doFindResource(Path path) {


### PR DESCRIPTION
### What does this PR do?
This changes proposal fixes the problem when folder didn't consume external file changes event when it collapsed on the UI. So before folder expand it checks if on server new items appears.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#9026 

#### Release Notes
N/A

#### Docs PR
N/A
