### PR TITLE
[#8040]: Fix Git credentials by creating ~/.ssh in case it is missing

### DIFF
--- a/agents/git-credentials/src/main/resources/installers/1.0.0/org.eclipse.che.git.script.sh
+++ b/agents/git-credentials/src/main/resources/installers/1.0.0/org.eclipse.che.git.script.sh
@@ -10,6 +10,7 @@
 #
 
 SCRIPT_FILE=~/.ssh/git.sh
+mkdir -p ~/.ssh
 
 token=$(if [ "$CHE_MACHINE_TOKEN" != "dummy_token" ]; then echo "$CHE_MACHINE_TOKEN"; fi)
 che_host=$(cat /etc/hosts | grep che-host | awk '{print $1;}')


### PR DESCRIPTION
Signed-off-by: Jens Reimann <jreimann@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fix issue #8040 by ensuring that the parent directory exists.

### What issues does this PR fix or reference?

This fixes issue #8040 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
