### PR TITLE
Fix contribute part displaying at project selection

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/PartStack.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/PartStack.java
@@ -104,8 +104,21 @@ public interface PartStack extends Presenter {
   /** Shows the part stack. */
   void show();
 
-  /** Hides the part stack. */
+  /**
+   * Hides the Part Stack. Use {@link #hide(boolean)} when hiding of the Part Stack is caused by
+   * user action
+   */
   void hide();
+
+  /**
+   * Hides the Part Stack.
+   *
+   * @param isUserInteraction pass {@code true} when hiding of the Part Stack is caused by user
+   *     action (user clicked 'Hide' button, for example) or {@code false} otherwise
+   */
+  default void hide(boolean isUserInteraction) {
+    hide();
+  }
 
   /** Maximizes the part stack. */
   void maximize();

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/PartStackStateChangedEvent.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/parts/PartStackStateChangedEvent.java
@@ -29,13 +29,33 @@ public class PartStackStateChangedEvent extends GwtEvent<PartStackStateChangedEv
   public static final GwtEvent.Type<Handler> TYPE = new GwtEvent.Type<Handler>();
 
   private PartStack partStack;
+  private boolean isUserInteraction;
 
   public PartStackStateChangedEvent(PartStack partStack) {
+    this(partStack, false);
+  }
+
+  /**
+   * Creates event to notify Part Stack state is changed.
+   *
+   * @param isUserInteraction pass {@code true} when hiding of the Part Stack is caused by user
+   *     action (user clicked 'Hide' button, for example) or {@code false} otherwise
+   */
+  public PartStackStateChangedEvent(PartStack partStack, boolean isUserInteraction) {
     this.partStack = partStack;
+    this.isUserInteraction = isUserInteraction;
   }
 
   public PartStack getPartStack() {
     return partStack;
+  }
+
+  /**
+   * Returns {@code true} when hiding of the Part Stack is caused by user action (user clicked
+   * 'Hide' button, for example) or {@code false} otherwise
+   */
+  public boolean isUserInteraction() {
+    return isUserInteraction;
   }
 
   @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/HidePartAction.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/actions/common/HidePartAction.java
@@ -50,7 +50,7 @@ public class HidePartAction extends BaseAction implements ActivePartChangedHandl
 
   @Override
   public void actionPerformed(ActionEvent e) {
-    activePartStack.hide();
+    activePartStack.hide(true);
   }
 
   @Override

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/PartStackPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/PartStackPresenter.java
@@ -238,15 +238,7 @@ public class PartStackPresenter
       workBenchPartController.setHidden(false);
     }
 
-    // Notify the part stack state has been changed.
-    Scheduler.get()
-        .scheduleDeferred(
-            new Scheduler.ScheduledCommand() {
-              @Override
-              public void execute() {
-                eventBus.fireEvent(new PartStackStateChangedEvent(PartStackPresenter.this));
-              }
-            });
+    notifyPartStackStateChanged();
 
     selectActiveTab(tab);
   }
@@ -321,7 +313,7 @@ public class PartStackPresenter
 
   @Override
   public void onHide() {
-    hide();
+    hide(true);
   }
 
   @Override
@@ -350,15 +342,7 @@ public class PartStackPresenter
       delegate.onMaximize(this);
     }
 
-    // Notify the part stack state has been changed.
-    Scheduler.get()
-        .scheduleDeferred(
-            new Scheduler.ScheduledCommand() {
-              @Override
-              public void execute() {
-                eventBus.fireEvent(new PartStackStateChangedEvent(PartStackPresenter.this));
-              }
-            });
+    notifyPartStackStateChanged();
   }
 
   @Override
@@ -388,15 +372,7 @@ public class PartStackPresenter
     activeTab = null;
     activePart = null;
 
-    // Notify the part stack state has been changed.
-    Scheduler.get()
-        .scheduleDeferred(
-            new Scheduler.ScheduledCommand() {
-              @Override
-              public void execute() {
-                eventBus.fireEvent(new PartStackStateChangedEvent(PartStackPresenter.this));
-              }
-            });
+    notifyPartStackStateChanged();
   }
 
   @Override
@@ -406,6 +382,11 @@ public class PartStackPresenter
 
   @Override
   public void hide() {
+    hide(false);
+  }
+
+  @Override
+  public void hide(boolean isUserAction) {
     // Update the view state.
     view.setMaximized(false);
 
@@ -435,15 +416,7 @@ public class PartStackPresenter
     activeTab = null;
     activePart = null;
 
-    // Notify the part stack state has been changed.
-    Scheduler.get()
-        .scheduleDeferred(
-            new Scheduler.ScheduledCommand() {
-              @Override
-              public void execute() {
-                eventBus.fireEvent(new PartStackStateChangedEvent(PartStackPresenter.this));
-              }
-            });
+    notifyPartStackStateChanged(isUserAction);
   }
 
   @Override
@@ -459,15 +432,7 @@ public class PartStackPresenter
       delegate.onRestore(this);
     }
 
-    // Notify the part stack state has been changed.
-    Scheduler.get()
-        .scheduleDeferred(
-            new Scheduler.ScheduledCommand() {
-              @Override
-              public void execute() {
-                eventBus.fireEvent(new PartStackStateChangedEvent(PartStackPresenter.this));
-              }
-            });
+    notifyPartStackStateChanged();
 
     if (activePart != null) {
       activePart.onOpen();
@@ -519,15 +484,7 @@ public class PartStackPresenter
       activeTab.select();
     }
 
-    // Notify the part stack state has been changed.
-    Scheduler.get()
-        .scheduleDeferred(
-            new Scheduler.ScheduledCommand() {
-              @Override
-              public void execute() {
-                eventBus.fireEvent(new PartStackStateChangedEvent(PartStackPresenter.this));
-              }
-            });
+    notifyPartStackStateChanged();
   }
 
   /** {@inheritDoc} */
@@ -555,6 +512,25 @@ public class PartStackPresenter
   @Override
   public void onPartStackMenu(int mouseX, int mouseY) {
     partMenu.show(mouseX, mouseY);
+  }
+
+  /** Notify the Part Stack state has been changed. */
+  private void notifyPartStackStateChanged() {
+    notifyPartStackStateChanged(false);
+  }
+
+  /**
+   * Notify the Part Stack state has been changed.
+   *
+   * @param isUserInteraction pass {@code true} when hiding of the Part Stack is caused by user
+   *     action (user clicked 'Hide' button, for example) or {@code false} otherwise
+   */
+  private void notifyPartStackStateChanged(boolean isUserInteraction) {
+    Scheduler.get()
+        .scheduleDeferred(
+            () ->
+                eventBus.fireEvent(
+                    new PartStackStateChangedEvent(PartStackPresenter.this, isUserInteraction)));
   }
 
   /** Handles PartStack actions */

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/statepersistance/AppStateManager.java
@@ -149,10 +149,22 @@ public class AppStateManager {
             stateComponentRegistry.get().getComponentById(key);
         if (stateComponent.isPresent()) {
           StateComponent component = stateComponent.get();
-          Log.debug(getClass(), "Restore state for the component ID: " + component.getId());
+          String componentId = component.getId();
+          Log.debug(getClass(), "Restore state for the component ID: " + componentId);
           sequentialRestore =
               sequentialRestore.thenPromise(
-                  ignored -> component.loadState(appState.getObject(key)));
+                  ignored ->
+                      component
+                          .loadState(appState.getObject(key))
+                          .catchError(
+                              arg -> {
+                                String error =
+                                    "Error is happened at restoring state for the component "
+                                        + componentId
+                                        + ": "
+                                        + arg.getMessage();
+                                Log.error(getClass(), error);
+                              }));
         }
       }
       return sequentialRestore;

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/pom.xml
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/pom.xml
@@ -31,10 +31,6 @@
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>
-            <artifactId>gwt-elemental</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.gwt</groupId>
             <artifactId>gwt-user</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributeMessages.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributeMessages.java
@@ -278,4 +278,19 @@ public interface ContributeMessages extends Messages {
 
   @Key("action.switch.contribute.part.displaying.description")
   String switchContributePartDisplayingDescription();
+
+  /*
+   * Contribute part preferences
+   */
+  @Key("contribute.preferences.title")
+  String contributePreferencesTitle();
+
+  @Key("contribute.preferences.category")
+  String contributePreferencesCategory();
+
+  @Key("contribute.preferences.activateByProjectSelectionLabel")
+  String contributePreferencesActivateByProjectSelectionLabel();
+
+  @Key("contribute.preferences.notification.activatePart.text")
+  String contributePreferencesNotificationActivatePartText();
 }

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/actions/ContributePartDisplayingModeAction.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/actions/ContributePartDisplayingModeAction.java
@@ -23,6 +23,7 @@ import org.eclipse.che.ide.api.action.ActionEvent;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.ide.api.parts.PartStack;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.plugin.pullrequest.client.ContributeMessages;
 import org.eclipse.che.plugin.pullrequest.client.ContributeResources;
@@ -66,8 +67,9 @@ public class ContributePartDisplayingModeAction extends AbstractPerspectiveActio
   public void actionPerformed(ActionEvent e) {
     ContributePartPresenter contributePartPresenter = contributePartPresenterProvider.get();
     PartPresenter activePart = workspaceAgent.getActivePart();
-    if (activePart != null && activePart instanceof ContributePartPresenter) {
-      workspaceAgent.hidePart(contributePartPresenter);
+    if (activePart instanceof ContributePartPresenter) {
+      PartStack toolingPartStack = workspaceAgent.getPartStack(TOOLING);
+      toolingPartStack.hide(true);
 
       EditorPartPresenter activeEditor = editorAgent.getActiveEditor();
       if (activeEditor != null) {

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/inject/PullRequestGinModule.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/inject/PullRequestGinModule.java
@@ -12,12 +12,15 @@ package org.eclipse.che.plugin.pullrequest.client.inject;
 
 import com.google.gwt.inject.client.AbstractGinModule;
 import com.google.gwt.inject.client.assistedinject.GinFactoryModuleBuilder;
+import com.google.gwt.inject.client.multibindings.GinMultibinder;
 import javax.inject.Singleton;
 import org.eclipse.che.ide.api.extension.ExtensionGinModule;
+import org.eclipse.che.ide.api.preferences.PreferencePagePresenter;
 import org.eclipse.che.plugin.pullrequest.client.dialogs.commit.CommitView;
 import org.eclipse.che.plugin.pullrequest.client.dialogs.commit.CommitViewImpl;
 import org.eclipse.che.plugin.pullrequest.client.parts.contribute.ContributePartView;
 import org.eclipse.che.plugin.pullrequest.client.parts.contribute.ContributePartViewImpl;
+import org.eclipse.che.plugin.pullrequest.client.preference.ContributePreferencePresenter;
 import org.eclipse.che.plugin.pullrequest.client.steps.AddForkRemoteStepFactory;
 import org.eclipse.che.plugin.pullrequest.client.steps.PushBranchOnForkStep;
 import org.eclipse.che.plugin.pullrequest.client.steps.PushBranchStepFactory;
@@ -43,5 +46,8 @@ public class PullRequestGinModule extends AbstractGinModule {
     install(new GinFactoryModuleBuilder().build(WaitForkOnRemoteStepFactory.class));
     install(new GinFactoryModuleBuilder().build(PushBranchStepFactory.class));
     install(new GinFactoryModuleBuilder().build(AddForkRemoteStepFactory.class));
+    GinMultibinder.newSetBinder(binder(), PreferencePagePresenter.class)
+        .addBinding()
+        .to(ContributePreferencePresenter.class);
   }
 }

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/preference/ContributePreferencePresenter.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/preference/ContributePreferencePresenter.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.pullrequest.client.preference;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.String.valueOf;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
+import static org.eclipse.che.ide.api.parts.PartStack.State.HIDDEN;
+import static org.eclipse.che.ide.api.parts.PartStackType.TOOLING;
+
+import com.google.gwt.user.client.ui.AcceptsOneWidget;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.web.bindery.event.shared.EventBus;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.parts.PartStack;
+import org.eclipse.che.ide.api.parts.PartStackStateChangedEvent;
+import org.eclipse.che.ide.api.parts.WorkspaceAgent;
+import org.eclipse.che.ide.api.preferences.AbstractPreferencePagePresenter;
+import org.eclipse.che.ide.api.preferences.PreferencesManager;
+import org.eclipse.che.ide.bootstrap.BasicIDEInitializedEvent;
+import org.eclipse.che.plugin.pullrequest.client.ContributeMessages;
+
+/**
+ * Preference page presenter for the Contribute Part.
+ *
+ * @author Roman Nikitenko
+ */
+@Singleton
+public class ContributePreferencePresenter extends AbstractPreferencePagePresenter
+    implements ContributePreferenceView.ActionDelegate, PartStackStateChangedEvent.Handler {
+  public static final String ACTIVATE_BY_PROJECT_SELECTION =
+      "git.contribute.activate.projectSelection";
+
+  private ContributePreferenceView view;
+  private ContributeMessages localizationConstants;
+  private PreferencesManager preferencesManager;
+
+  private PartStack toolingPartStack;
+  private NotificationManager notificationManager;
+  private boolean isActivateByProjectSelection;
+
+  @Inject
+  public ContributePreferencePresenter(
+      EventBus eventBus,
+      WorkspaceAgent workspaceAgent,
+      ContributePreferenceView view,
+      ContributeMessages localizationConstants,
+      PreferencesManager preferencesManager,
+      NotificationManager notificationManager) {
+    super(
+        localizationConstants.contributePreferencesTitle(),
+        localizationConstants.contributePreferencesCategory());
+
+    this.view = view;
+    this.localizationConstants = localizationConstants;
+    this.preferencesManager = preferencesManager;
+    this.toolingPartStack = workspaceAgent.getPartStack(TOOLING);
+    this.notificationManager = notificationManager;
+
+    view.setDelegate(this);
+    eventBus.addHandler(PartStackStateChangedEvent.TYPE, this);
+    eventBus.addHandler(BasicIDEInitializedEvent.TYPE, e -> init());
+  }
+
+  private void init() {
+    String preference = preferencesManager.getValue(ACTIVATE_BY_PROJECT_SELECTION);
+    if (isNullOrEmpty(preference)) {
+      preference = "true";
+      preferencesManager.setValue(ACTIVATE_BY_PROJECT_SELECTION, preference);
+    }
+
+    isActivateByProjectSelection = parseBoolean(preference);
+  }
+
+  @Override
+  public boolean isDirty() {
+    String preference = preferencesManager.getValue(ACTIVATE_BY_PROJECT_SELECTION);
+    boolean storedValue = isNullOrEmpty(preference) || parseBoolean(preference);
+
+    return isActivateByProjectSelection != storedValue;
+  }
+
+  @Override
+  public void go(AcceptsOneWidget container) {
+    container.setWidget(view);
+
+    view.setActivateByProjectSelection(isActivateByProjectSelection);
+  }
+
+  @Override
+  public void storeChanges() {
+    preferencesManager.setValue(
+        ACTIVATE_BY_PROJECT_SELECTION, valueOf(isActivateByProjectSelection));
+  }
+
+  @Override
+  public void revertChanges() {
+    boolean storedValue = parseBoolean(preferencesManager.getValue(ACTIVATE_BY_PROJECT_SELECTION));
+
+    isActivateByProjectSelection = storedValue;
+    view.setActivateByProjectSelection(storedValue);
+  }
+
+  @Override
+  public void onActivateByProjectSelectionChanged(boolean isActivated) {
+    isActivateByProjectSelection = isActivated;
+    delegate.onDirtyChanged();
+  }
+
+  @Override
+  public void onPartStackStateChanged(PartStackStateChangedEvent event) {
+    if (!isActivateByProjectSelection || !event.isUserInteraction()) {
+      return;
+    }
+
+    if (toolingPartStack != null
+        && toolingPartStack.equals(event.getPartStack())
+        && toolingPartStack.getPartStackState() == HIDDEN) {
+      isActivateByProjectSelection = false;
+      view.setActivateByProjectSelection(false);
+
+      preferencesManager.setValue(ACTIVATE_BY_PROJECT_SELECTION, "false");
+      preferencesManager.flushPreferences();
+      notificationManager.notify(
+          "",
+          localizationConstants.contributePreferencesNotificationActivatePartText(),
+          SUCCESS,
+          EMERGE_MODE);
+    }
+  }
+}

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/preference/ContributePreferenceView.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/preference/ContributePreferenceView.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.pullrequest.client.preference;
+
+import com.google.inject.ImplementedBy;
+import org.eclipse.che.ide.api.mvp.View;
+
+/**
+ * View interface for the Contribute Part preference page.
+ *
+ * @author Roman Nikitenko
+ */
+@ImplementedBy(ContributePreferenceViewImpl.class)
+public interface ContributePreferenceView extends View<ContributePreferenceView.ActionDelegate> {
+
+  /** Sets 'Activate by project selection' property */
+  void setActivateByProjectSelection(boolean isActivate);
+
+  interface ActionDelegate {
+    /** 'Activate by project selection' property is being changed */
+    void onActivateByProjectSelectionChanged(boolean isActivated);
+  }
+}

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/preference/ContributePreferenceViewImpl.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/preference/ContributePreferenceViewImpl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.pullrequest.client.preference;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.uibinder.client.UiBinder;
+import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.ui.CheckBox;
+import com.google.gwt.user.client.ui.FlowPanel;
+import com.google.gwt.user.client.ui.Widget;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/** @author Roman Nikitenko */
+@Singleton
+public class ContributePreferenceViewImpl implements ContributePreferenceView {
+  private static ContributePreferenceViewImplUiBinder ourUiBinder =
+      GWT.create(ContributePreferenceViewImplUiBinder.class);
+
+  @UiField CheckBox activateByProjectSelection;
+  private ActionDelegate delegate;
+  private final FlowPanel rootElement;
+
+  @Inject
+  public ContributePreferenceViewImpl() {
+    rootElement = ourUiBinder.createAndBindUi(this);
+  }
+
+  @UiHandler("activateByProjectSelection")
+  void handleActivateByProjectSelection(ValueChangeEvent<Boolean> event) {
+    delegate.onActivateByProjectSelectionChanged(event.getValue());
+  }
+
+  @Override
+  public void setActivateByProjectSelection(boolean isActivate) {
+    activateByProjectSelection.setValue(isActivate);
+  }
+
+  @Override
+  public void setDelegate(ActionDelegate delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Widget asWidget() {
+    return rootElement;
+  }
+
+  interface ContributePreferenceViewImplUiBinder
+      extends UiBinder<FlowPanel, ContributePreferenceViewImpl> {}
+}

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/preference/ContributePreferenceViewImpl.ui.xml
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/preference/ContributePreferenceViewImpl.ui.xml
@@ -1,0 +1,37 @@
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
+             xmlns:g='urn:import:com.google.gwt.user.client.ui'>
+
+    <ui:with type="org.eclipse.che.plugin.pullrequest.client.ContributeMessages" field="localizationConstants"/>
+    <ui:style>
+        .main {
+        width: 100%;
+        height: 25px;
+        margin-top: 5px;
+        margin-left: 5px;
+        }
+        .leftAlign {
+        float: left;
+        }
+        .rightAlign {
+        float: right;
+        }
+    </ui:style>
+
+    <g:FlowPanel addStyleNames="{style.main}">
+        <g:Label text="{localizationConstants.contributePreferencesActivateByProjectSelectionLabel}" addStyleNames="{style.leftAlign}"/>
+        <g:CheckBox ui:field="activateByProjectSelection" debugId="preferences-git-contribute-activateByProjectSelection" addStyleNames="{style.rightAlign}"/>
+    </g:FlowPanel>
+
+</ui:UiBinder>

--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/resources/org/eclipse/che/plugin/pullrequest/client/ContributeMessages.properties
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/resources/org/eclipse/che/plugin/pullrequest/client/ContributeMessages.properties
@@ -161,3 +161,11 @@ failed.to.apply.vcs.mixin=Failed to apply mixin to project: {0}. Cause: {1}
 #
 action.switch.contribute.part.displaying.title=Contribute
 action.switch.contribute.part.displaying.description=Switch Contribute part displaying mode
+
+#
+# Contribute Part Preferences
+#
+contribute.preferences.title=Contribute
+contribute.preferences.category=Git
+contribute.preferences.activateByProjectSelectionLabel=Activate Contribute Panel by clicking on a project
+contribute.preferences.notification.activatePart.text=To activate Contribute Panel by clicking on a project go to Profile -> Preferences -> Git -> Contribute


### PR DESCRIPTION
### What does this PR do?
- Fix bug related to restore IDE state when one of the components can not be restored correctly
- Add Preferences page for Contribute Part
- Control the Contribute Part displaying corresponding to preference property.

Preference property "Activate Contribute Panel by clicking on a project" defined as "true" by default - so we show the Contribute Part at project selection, but once it is closed - the preference property gets "false" value and it must stay closed.  

User can display the panel:
- change the preference property to "true" and select a project
- using Panel selector
- from menu Assistant ---> Tool Windows ---> Contribute action
- by hot key

Preference property value is changed automatically to "false":
- user clicks "Hide" button of the Tooling Part Stack panel 
- user hit "Options --> Hide" action of the Tooling Part Stack panel
- user hit action from menu Assistant --> Tool Windows --> Contribute when Contribute Part is active

To inform user how change preference property notification is displayed:
 
![notification](https://user-images.githubusercontent.com/5676062/40551034-825fbb4c-6044-11e8-8a62-d89416be4030.png)


### What issues does this PR fix or reference?
#9484  

![contrpart](https://user-images.githubusercontent.com/5676062/40550939-36961b20-6044-11e8-847c-1f440f54d902.png)
