### PR TITLE
Added an ability to interrupt the start of a Kubernetes/OpenShift runtime

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/ReplicationModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/ReplicationModule.java
@@ -19,6 +19,7 @@ import org.eclipse.che.api.system.server.ServiceTermination;
 import org.eclipse.che.api.workspace.server.WorkspaceLockService;
 import org.eclipse.che.api.workspace.server.WorkspaceStatusCache;
 import org.eclipse.che.multiuser.api.distributed.JGroupsServiceTermination;
+import org.eclipse.che.multiuser.api.distributed.WorkspaceStopPropagator;
 import org.eclipse.che.multiuser.api.distributed.subscription.DistributedRemoteSubscriptionStorage;
 import org.eclipse.persistence.config.CacheCoordinationProtocol;
 import org.eclipse.persistence.config.PersistenceUnitProperties;
@@ -53,5 +54,7 @@ public class ReplicationModule extends AbstractModule {
     Multibinder.newSetBinder(binder(), ServiceTermination.class)
         .addBinding()
         .to(JGroupsServiceTermination.class);
+
+    bind(WorkspaceStopPropagator.class).asEagerSingleton();
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -72,6 +72,7 @@ public class KubernetesInfraModule extends AbstractModule {
 
     install(new FactoryModuleBuilder().build(KubernetesRuntimeFactory.class));
     install(new FactoryModuleBuilder().build(KubernetesBootstrapperFactory.class));
+    install(new FactoryModuleBuilder().build(StartSynchronizerFactory.class));
     bind(WorkspacePVCCleaner.class).asEagerSingleton();
     bind(RemoveNamespaceOnWorkspaceRemove.class).asEagerSingleton();
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -336,7 +336,11 @@ public class KubernetesInternalRuntime<
         bootstrapperFuture =
             bootstrapperFactory
                 .create(
-                    getContext().getIdentity(), machineConfig.getInstallers(), machine, namespace)
+                    getContext().getIdentity(),
+                    machineConfig.getInstallers(),
+                    machine,
+                    namespace,
+                    startSynchronizer)
                 .bootstrapAsync();
         toCancelFutures.add(bootstrapperFuture);
       } else {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -730,17 +730,12 @@ public class KubernetesInternalRuntime<
             reason,
             message,
             event.getPodName());
-        try {
-          internalStop(emptyMap());
-        } catch (InfrastructureException e) {
-          LOG.error("Error occurred during runtime '{}' stopping. {}", workspaceId, e.getMessage());
-        } finally {
-          eventPublisher.sendRuntimeStoppedEvent(
-              format(
-                  "Unrecoverable event occurred: '%s', '%s', '%s'",
-                  reason, message, event.getPodName()),
-              getContext().getIdentity());
-        }
+
+        startSynchronizer.completeExceptionally(
+            new InfrastructureException(
+                format(
+                    "Unrecoverable event occurred: '%s', '%s', '%s'",
+                    reason, message, event.getPodName())));
       }
     }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/StartSynchronizer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/StartSynchronizer.java
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import com.google.inject.assistedinject.Assisted;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.core.notification.EventSubscriber;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.RuntimeStartInterruptedException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.event.KubernetesRuntimeStoppedEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.event.KubernetesRuntimeStoppingEvent;
+
+/**
+ * Controls the runtime start flow and helps to cancel it.
+ *
+ * <p>The runtime start with cancellation using the Start Synchronizer might look like:
+ *
+ * <pre>
+ * ...
+ *   public void startRuntime() {
+ *     startSynchronizer.setStartThread();
+ *     try {
+ *       startMachines();
+ *       startSynchronizer.checkFailure();
+ *
+ *       // ...
+ *
+ *       waitMachines()
+ *         .then(startSynchronizer.checkFailure())
+ *         .then(bootstrapAsync())
+ *         .then(startSynchronizer.checkFailure())
+ *         .then(checkServers)
+ *         // ...
+ *
+ *       startSynchronizer.complete();
+ *     } catch (Exception ex) {
+ *       startSynchronizer.completeExceptionally(ex);
+ *       throw ex;
+ *     }
+ *   }
+ * ...
+ * </pre>
+ *
+ * <p>At the same time stopping might look like:
+ *
+ * <pre>
+ * ...
+ *   public void stopRuntime() {
+ *     if (startSynchronizer.interrupt()) {
+ *       try {
+ *         if (startSynchronizer.awaitInterruption(30)) {
+ *           // runtime is interrupted correctly
+ *         } else {
+ *           // runtime is not interrupted correctly in time
+ *           // need to forcibly stop it and clean up used resources
+ *         }
+ *       } catch (RuntimeStartInterruptedException ex) {
+ *         // normal stop
+ *       } catch (InterruptedException ex) {
+ *         Thread.currentThread().interrupt();
+ *         ...
+ *       }
+ *     }
+ *   }
+ * ...
+ * </pre>
+ *
+ * <p>Note that class is designed to work in clustered mode. For this purpose it listens to {@link
+ * KubernetesRuntimeStoppedEvent} and {@link KubernetesRuntimeStoppingEvent} events. So, if Che
+ * Server is run in clustered mode then the described events must be published via {@link
+ * EventService} otherwise start interruption won't work correctly.
+ *
+ * @author Sergii Leshchenko
+ */
+public class StartSynchronizer {
+
+  private final RuntimeIdentity runtimeId;
+  private final EventService eventService;
+
+  // future that holds error that occurs during runtime start
+  // failure must be completed with null value when start is finished without any exception
+  private final CompletableFuture<Void> startFailure;
+
+  // latch that indicates whether start is completed or not
+  private CountDownLatch completionLatch;
+
+  // thread which is performing start
+  // it may be nullable when start is performing on another Che Server instance
+  private Thread startThread;
+
+  // flag that indicates whether start is in progress or not
+  private boolean isStarting;
+
+  private final RuntimeStartInterrupter runtimeStartInterrupter;
+  private final RuntimeStopWatcher runtimeStopWatcher;
+
+  @Inject
+  public StartSynchronizer(EventService eventService, @Assisted RuntimeIdentity runtimeId) {
+    this.eventService = eventService;
+    this.startFailure = new CompletableFuture<>();
+    this.completionLatch = new CountDownLatch(0);
+    this.runtimeId = runtimeId;
+    this.runtimeStartInterrupter = new RuntimeStartInterrupter();
+    this.runtimeStopWatcher = new RuntimeStopWatcher();
+    this.isStarting = false;
+  }
+
+  /** Registers a runtime start. */
+  public synchronized void start() {
+    if (!isStarting) {
+      isStarting = true;
+      completionLatch = new CountDownLatch(1);
+      eventService.subscribe(runtimeStartInterrupter, KubernetesRuntimeStoppingEvent.class);
+      eventService.subscribe(
+          event -> completionLatch.countDown(), KubernetesRuntimeStoppedEvent.class);
+    }
+  }
+
+  /**
+   * Sets {@link Thread#currentThread()} as a {@link #startThread}.
+   *
+   * @throws InternalInfrastructureException when {@link #startThread} is already set.
+   */
+  public synchronized void setStartThread() throws InternalInfrastructureException {
+    if (startThread != null) {
+      throw new InternalInfrastructureException("Runtime is already started");
+    }
+    startThread = Thread.currentThread();
+  }
+
+  /**
+   * Registers start completion.
+   *
+   * <p>It also releases {@link #awaitInterruption(long, TimeUnit)}.
+   *
+   * @throws RuntimeStartInterruptedException when start was interrupted
+   * @throws InfrastructureException when any other exception occurs during start
+   */
+  public synchronized void complete() throws InfrastructureException {
+    completionLatch.countDown();
+    startThread = null;
+    isStarting = false;
+    eventService.unsubscribe(runtimeStartInterrupter);
+    eventService.unsubscribe(runtimeStopWatcher);
+
+    // try to complete start failure holder and
+    // rethrow original exception if it is already completed exceptionally
+    if (!startFailure.complete(null) && startFailure.isCompletedExceptionally()) {
+      try {
+        // future is already completed.
+        startFailure.getNow(null);
+      } catch (CompletionException e) {
+        rethrowCause(e);
+      }
+    }
+  }
+
+  /**
+   * Registers exception that occurs during runtime start.
+   *
+   * <p>Note that only first exception will be saved.
+   *
+   * <p>It also releases {@link #awaitInterruption(long, TimeUnit)}.
+   */
+  public synchronized void completeExceptionally(Exception ex) {
+    startFailure.completeExceptionally(ex);
+
+    completionLatch.countDown();
+    startThread = null;
+    isStarting = false;
+    eventService.unsubscribe(runtimeStartInterrupter);
+    eventService.unsubscribe(runtimeStopWatcher);
+  }
+
+  /**
+   * Checks if start is failed.
+   *
+   * <p>If yes then original exception will be rethrown.
+   *
+   * @throws RuntimeStartInterruptedException when start was interrupted
+   * @throws InfrastructureException when any other exception occurs during start
+   */
+  public void checkFailure() throws InfrastructureException {
+    try {
+      startFailure.getNow(null);
+      // no exception hasn't occurred yet
+    } catch (CompletionException e) {
+      rethrowCause(e);
+    }
+  }
+
+  /** Returns future that holds error that occurs during runtime start */
+  public CompletableFuture<Void> getStartFailure() {
+    return startFailure;
+  }
+
+  /**
+   * Interrupts workspace start if it is in progress and is not interrupted yet
+   *
+   * @return true if workspace start is interrupted, false otherwise
+   */
+  public synchronized boolean interrupt() {
+    if (!isStarting) {
+      return false;
+    }
+    startFailure.completeExceptionally(new RuntimeStartInterruptedException(runtimeId));
+
+    if (startThread != null) {
+      startThread.interrupt();
+      // set to not to interrupt twice
+      startThread = null;
+    }
+
+    return true;
+  }
+
+  /**
+   * Awaits until workspace start process will be completed.
+   *
+   * <p>Returns true is interruption is completed. Or returns false when interruption wasn't
+   * received or processed by start thread and workspace is STARTING or STOPPING. So it's needed to
+   * stop a runtime and clean up used resources.
+   *
+   * @throws InterruptedException if the current thread is interrupted while waiting
+   */
+  public boolean awaitInterruption(long timeout, TimeUnit unit) throws InterruptedException {
+    boolean isCompleted = completionLatch.await(timeout, unit);
+
+    if (isCompleted) {
+      // check start failure
+      try {
+        startFailure.get();
+      } catch (ExecutionException e) {
+        // start is interrupted or failed. Resources are freed
+        return true;
+      }
+    }
+    // runtime start is still in progress
+    return false;
+  }
+
+  /** Returns true if start is completed, false otherwise. */
+  public boolean isCompleted() {
+    return completionLatch.getCount() == 0;
+  }
+
+  /** Returns start failure exception if occurred otherwise null will be returned. */
+  public InfrastructureException getStartFailureNow() {
+    try {
+      startFailure.getNow(null);
+      return null;
+    } catch (CompletionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof InfrastructureException) {
+        return (InfrastructureException) cause;
+      } else {
+        return new InternalInfrastructureException(cause.getMessage(), cause);
+      }
+    }
+  }
+
+  private void rethrowCause(Throwable e) throws InfrastructureException {
+    try {
+      throw e.getCause();
+    } catch (InfrastructureException ex) {
+      throw ex;
+    } catch (Throwable ex) {
+      throw new InternalInfrastructureException(ex.getMessage(), ex);
+    }
+  }
+
+  /**
+   * Listens {@link KubernetesRuntimeStoppingEvent} and interrupts workspace start when workspace
+   * become {@link WorkspaceStatus#STOPPING}.
+   */
+  private class RuntimeStartInterrupter implements EventSubscriber<KubernetesRuntimeStoppingEvent> {
+    @Override
+    public void onEvent(KubernetesRuntimeStoppingEvent event) {
+      if (event.getWorkspaceId().equals(runtimeId.getWorkspaceId())) {
+        interrupt();
+      }
+    }
+  }
+
+  /**
+   * Listens {@link KubernetesRuntimeStoppedEvent} and realises {@link #completionLatch} when
+   * workspace become {@link WorkspaceStatus#STOPPED}.
+   */
+  private class RuntimeStopWatcher implements EventSubscriber<KubernetesRuntimeStoppedEvent> {
+    @Override
+    public void onEvent(KubernetesRuntimeStoppedEvent event) {
+      if (event.getWorkspaceId().equals(runtimeId.getWorkspaceId())) {
+        try {
+          // try to complete start it if is not completed yet
+          complete();
+        } catch (InfrastructureException ignored) {
+        }
+      }
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/StartSynchronizerFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/StartSynchronizerFactory.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+
+/** @author Sergii Leshchenko */
+public interface StartSynchronizerFactory {
+  StartSynchronizer create(RuntimeIdentity runtimeIdentity);
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapperFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapperFactory.java
@@ -14,6 +14,7 @@ import com.google.inject.assistedinject.Assisted;
 import java.util.List;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.installer.shared.model.Installer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesMachineImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 
@@ -23,5 +24,6 @@ public interface KubernetesBootstrapperFactory {
       @Assisted RuntimeIdentity runtimeIdentity,
       @Assisted List<? extends Installer> agents,
       @Assisted KubernetesMachineImpl kubernetesMachine,
-      @Assisted KubernetesNamespace namespace);
+      @Assisted KubernetesNamespace namespace,
+      @Assisted StartSynchronizer startSynchronizer);
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/event/KubernetesRuntimeStoppedEvent.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/event/KubernetesRuntimeStoppedEvent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.event;
+
+import java.util.Objects;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
+
+/**
+ * Should published via {@link EventService} when workspace becomes {@link WorkspaceStatus#STOPPED}.
+ *
+ * <p>Note that is not published by default. It is needed for {@link StartSynchronizer} to
+ * synchronize state in cluster mode.
+ *
+ * @author Sergii Leshchenko
+ */
+public class KubernetesRuntimeStoppedEvent {
+
+  private final String workspaceId;
+
+  public KubernetesRuntimeStoppedEvent(String workspaceId) {
+    this.workspaceId = workspaceId;
+  }
+
+  public String getWorkspaceId() {
+    return workspaceId;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof KubernetesRuntimeStoppedEvent)) {
+      return false;
+    }
+    final KubernetesRuntimeStoppedEvent that = (KubernetesRuntimeStoppedEvent) obj;
+    return Objects.equals(workspaceId, that.workspaceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(workspaceId);
+  }
+
+  @Override
+  public String toString() {
+    return "KubernetesRuntimeStoppedEvent{" + "workspaceId='" + workspaceId + '\'' + '}';
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/event/KubernetesRuntimeStoppingEvent.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/event/KubernetesRuntimeStoppingEvent.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.event;
+
+import java.util.Objects;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
+
+/**
+ * Should published via {@link EventService} when workspace becomes {@link
+ * WorkspaceStatus#STOPPING}.
+ *
+ * <p>Note that is not published by default. It is needed for {@link StartSynchronizer} to
+ * synchronize state in cluster mode.
+ *
+ * @author Sergii Leshchenko
+ */
+public class KubernetesRuntimeStoppingEvent {
+
+  private final String workspaceId;
+
+  public KubernetesRuntimeStoppingEvent(String workspaceId) {
+    this.workspaceId = workspaceId;
+  }
+
+  public String getWorkspaceId() {
+    return workspaceId;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof KubernetesRuntimeStoppingEvent)) {
+      return false;
+    }
+    final KubernetesRuntimeStoppingEvent that = (KubernetesRuntimeStoppingEvent) obj;
+    return Objects.equals(workspaceId, that.workspaceId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(workspaceId);
+  }
+
+  @Override
+  public String toString() {
+    return "KubernetesRuntimeStoppingEvent{" + "workspaceId='" + workspaceId + '\'' + '}';
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -244,7 +244,8 @@ public class KubernetesInternalRuntimeTest {
     when(namespace.services()).thenReturn(services);
     when(namespace.ingresses()).thenReturn(ingresses);
     when(namespace.pods()).thenReturn(pods);
-    when(bootstrapperFactory.create(any(), anyList(), any(), any())).thenReturn(bootstrapper);
+    when(bootstrapperFactory.create(any(), anyList(), any(), any(), any()))
+        .thenReturn(bootstrapper);
     doReturn(
             ImmutableMap.of(
                 M1_NAME,

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -341,7 +341,7 @@ public class KubernetesInternalRuntimeTest {
       verify(namespace, never()).ingresses();
       throw rethrow;
     } finally {
-      verify(namespace.pods(), times(1)).stopWatch();
+      verify(namespace.pods(), times(2)).stopWatch();
     }
   }
 
@@ -383,7 +383,7 @@ public class KubernetesInternalRuntimeTest {
       verify(namespace, never()).ingresses();
       throw rethrow;
     } finally {
-      verify(namespace.pods(), times(1)).stopWatch();
+      verify(namespace.pods(), times(2)).stopWatch();
     }
   }
 
@@ -469,8 +469,8 @@ public class KubernetesInternalRuntimeTest {
             EVENT_CREATION_TIMESTAMP,
             getCurrentTimestampWithOneHourShiftAhead());
     unrecoverableEventHandler.handle(unrecoverableEvent);
-    // 'internalStop' expected to be called which triggers namespace cleanup
-    verify(namespace).cleanUp();
+
+    verify(startSynchronizer).completeExceptionally(any(InfrastructureException.class));
   }
 
   @Test
@@ -487,8 +487,8 @@ public class KubernetesInternalRuntimeTest {
             EVENT_CREATION_TIMESTAMP,
             getCurrentTimestampWithOneHourShiftAhead());
     unrecoverableEventHandler.handle(unrecoverableEvent);
-    // 'internalStop' expected to be called which triggers namespace cleanup
-    verify(namespace).cleanUp();
+
+    verify(startSynchronizer).completeExceptionally(any(InfrastructureException.class));
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -90,6 +91,7 @@ import org.eclipse.che.api.workspace.server.hc.probe.WorkspaceProbesFactory;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.RuntimeStartInterruptedException;
 import org.eclipse.che.api.workspace.server.spi.StateException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.shared.dto.event.MachineLogEvent;
@@ -156,8 +158,10 @@ public class KubernetesInternalRuntimeTest {
   private static final RuntimeIdentity IDENTITY =
       new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");
 
-  @Mock private KubernetesRuntimeContext<KubernetesEnvironment> context;
   @Mock private EventService eventService;
+  @Mock private StartSynchronizerFactory startSynchronizerFactory;
+  private StartSynchronizer startSynchronizer;
+  @Mock private KubernetesRuntimeContext<KubernetesEnvironment> context;
   @Mock private ServersCheckerFactory serverCheckerFactory;
   @Mock private ServersChecker serversChecker;
   @Mock private KubernetesBootstrapperFactory bootstrapperFactory;
@@ -190,6 +194,9 @@ public class KubernetesInternalRuntimeTest {
     runtimeStatesCache = new MapBasedRuntimeStateCache();
     machinesCache = new MapBasedMachinesCache();
 
+    startSynchronizer = spy(new StartSynchronizer(eventService, IDENTITY));
+    when(startSynchronizerFactory.create(any())).thenReturn(startSynchronizer);
+
     internalRuntime =
         new KubernetesInternalRuntime<>(
             13,
@@ -205,6 +212,7 @@ public class KubernetesInternalRuntimeTest {
             new KubernetesSharedPool(),
             runtimeStatesCache,
             machinesCache,
+            startSynchronizerFactory,
             context,
             namespace,
             emptyList());
@@ -224,6 +232,7 @@ public class KubernetesInternalRuntimeTest {
             new KubernetesSharedPool(),
             runtimeStatesCache,
             machinesCache,
+            startSynchronizerFactory,
             context,
             namespace,
             emptyList());
@@ -378,8 +387,10 @@ public class KubernetesInternalRuntimeTest {
   }
 
   @Test(
-    expectedExceptions = InfrastructureException.class,
-    expectedExceptionsMessageRegExp = "Kubernetes environment start was interrupted"
+    expectedExceptions = RuntimeStartInterruptedException.class,
+    expectedExceptionsMessageRegExp =
+        "Runtime start for identity 'workspace: workspace123, "
+            + "environment: env1, ownerId: id1' is interrupted"
   )
   public void throwsInfrastructureExceptionWhenMachinesWaitingIsInterrupted() throws Exception {
     final Thread thread = Thread.currentThread();
@@ -616,7 +627,7 @@ public class KubernetesInternalRuntimeTest {
 
   @Test(
     expectedExceptions = StateException.class,
-    expectedExceptionsMessageRegExp = "The environment must be running",
+    expectedExceptionsMessageRegExp = "The environment must be running or starting",
     dataProvider = "nonRunningStatuses"
   )
   public void shouldThrowExceptionWhenTryToMakeNonRunningNorStartingRuntimeAsStopping(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/StartSynchronizerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/StartSynchronizerTest.java
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.RuntimeStartInterruptedException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.event.KubernetesRuntimeStoppedEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.event.KubernetesRuntimeStoppingEvent;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link StartSynchronizer}
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class StartSynchronizerTest {
+  @Mock private EventService eventService;
+  private RuntimeIdentityImpl runtimeId;
+
+  private StartSynchronizer startSynchronizer;
+
+  @BeforeMethod
+  public void setUp() {
+    runtimeId = new RuntimeIdentityImpl("workspace123", "envName", "ownerId");
+    startSynchronizer = new StartSynchronizer(eventService, runtimeId);
+  }
+
+  @Test
+  public void testSuccessfulStartCompletion() throws Exception {
+    // given
+    startSynchronizer.setStartThread();
+
+    // when
+    startSynchronizer.complete();
+
+    // then
+    assertTrue(startSynchronizer.isCompleted());
+    assertTrue(startSynchronizer.getStartFailure().isDone());
+    assertFalse(startSynchronizer.getStartFailure().isCompletedExceptionally());
+  }
+
+  @Test
+  public void testFailureStartCompletion() throws Exception {
+    // given
+    startSynchronizer.setStartThread();
+    RuntimeStartInterruptedException expected = new RuntimeStartInterruptedException(runtimeId);
+
+    // when
+    startSynchronizer.completeExceptionally(expected);
+
+    // then
+    assertTrue(startSynchronizer.isCompleted());
+    assertTrue(startSynchronizer.getStartFailure().isCompletedExceptionally());
+    try {
+      startSynchronizer.getStartFailure().getNow(null);
+      fail("Start failure is empty");
+    } catch (CompletionException actual) {
+      assertEquals(actual.getCause(), expected);
+    }
+  }
+
+  @Test(expectedExceptions = RuntimeStartInterruptedException.class)
+  public void shouldThrowExceptionOnCheckingFailureIfStartIsCompletedExceptionally()
+      throws Exception {
+    // given
+    startSynchronizer.start();
+    RuntimeStartInterruptedException expected = new RuntimeStartInterruptedException(runtimeId);
+    startSynchronizer.completeExceptionally(expected);
+
+    // when
+    startSynchronizer.checkFailure();
+  }
+
+  @Test
+  public void shouldNotThrowExceptionOnCheckingFailureIfStartIsNotCompleted() throws Exception {
+    // given
+    startSynchronizer.start();
+
+    // when
+    startSynchronizer.checkFailure();
+  }
+
+  @Test
+  public void shouldNotThrowExceptionOnCheckingFailureIfStartIsCompleted() throws Exception {
+    // given
+    startSynchronizer.start();
+    startSynchronizer.complete();
+
+    // when
+    startSynchronizer.checkFailure();
+  }
+
+  @Test
+  public void shouldInterruptStartThread() throws Exception {
+    // given
+    startSynchronizer.start();
+    startSynchronizer.setStartThread();
+
+    // when
+    startSynchronizer.interrupt();
+
+    // then
+    assertTrue(Thread.interrupted());
+  }
+
+  @Test(
+    expectedExceptions = InternalInfrastructureException.class,
+    expectedExceptionsMessageRegExp = "Runtime is already started"
+  )
+  public void shouldNotSetStartThreadIfItIsAlreadySet() throws Exception {
+    // given
+    startSynchronizer.setStartThread();
+
+    // when
+    startSynchronizer.setStartThread();
+  }
+
+  @Test
+  public void shouldNotInterruptThreadIfItWasNotSet() {
+    // given
+    startSynchronizer.start();
+
+    // when
+    startSynchronizer.interrupt();
+
+    // then
+    assertFalse(Thread.interrupted());
+  }
+
+  @Test
+  public void shouldSubscribeOnRuntimeStoppingAndStoppedEventsWhenStartIsCalled() {
+    // when
+    startSynchronizer.start();
+
+    // then
+    verify(eventService).subscribe(any(), eq(KubernetesRuntimeStoppingEvent.class));
+    verify(eventService).subscribe(any(), eq(KubernetesRuntimeStoppedEvent.class));
+  }
+
+  @Test(expectedExceptions = RuntimeStartInterruptedException.class)
+  public void shouldInterruptStartWhenStoppingEventIsPublished() throws Exception {
+    // given
+    EventService eventService = new EventService();
+    StartSynchronizer localStartSynchronizer = new StartSynchronizer(eventService, runtimeId);
+    localStartSynchronizer.start();
+
+    // when
+    eventService.publish(new KubernetesRuntimeStoppingEvent("workspace123"));
+
+    // then
+    localStartSynchronizer.checkFailure();
+  }
+
+  @Test
+  public void shouldCompleteStartWhenStoppedEventIsPublished() {
+    // given
+    EventService eventService = new EventService();
+    StartSynchronizer localStartSynchronizer = new StartSynchronizer(eventService, runtimeId);
+    localStartSynchronizer.start();
+
+    // when
+    eventService.publish(new KubernetesRuntimeStoppedEvent("workspace123"));
+
+    // then
+    assertTrue(localStartSynchronizer.isCompleted());
+  }
+
+  @Test(expectedExceptions = RuntimeStartInterruptedException.class)
+  public void shouldRethrowOriginalExceptionIfStartCompletedExceptionallyOnCompletion()
+      throws Exception {
+    // given
+    startSynchronizer.completeExceptionally(new RuntimeStartInterruptedException(runtimeId));
+
+    // when
+    startSynchronizer.complete();
+  }
+
+  @Test
+  public void shouldAwaitTerminationWhenItIsCompleted() throws Exception {
+    // given
+    startSynchronizer.complete();
+
+    // when
+    boolean isInterrupted = startSynchronizer.awaitInterruption(1, TimeUnit.SECONDS);
+
+    // then
+    assertFalse(isInterrupted);
+  }
+
+  @Test
+  public void shouldAwaitTerminationWhenItIsCompletedExceptionally() throws Exception {
+    // given
+    startSynchronizer.completeExceptionally(new RuntimeStartInterruptedException(runtimeId));
+
+    // when
+    boolean isInterrupted = startSynchronizer.awaitInterruption(1, TimeUnit.SECONDS);
+
+    // then
+    assertTrue(isInterrupted);
+  }
+
+  @Test
+  public void shouldReturnFalseOnAwaitingTerminationWhenItIsNotCompletedInTime() throws Exception {
+    // given
+    startSynchronizer.start();
+
+    // when
+    boolean isInterrupted = startSynchronizer.awaitInterruption(10, TimeUnit.MILLISECONDS);
+
+    // then
+    assertFalse(isInterrupted);
+  }
+
+  @Test
+  public void shouldNotInterruptStartIfItIsNotStarted() {
+    // when
+    boolean isInterrupted = startSynchronizer.interrupt();
+
+    // then
+    assertFalse(isInterrupted);
+  }
+
+  @Test
+  public void shouldWrapExceptionIntoInternalExcWhenItIsCompletedWithNonInfraException() {
+    // given
+    RuntimeException toThrow = new RuntimeException("test exception");
+    startSynchronizer.completeExceptionally(toThrow);
+
+    // when
+    InfrastructureException startFailure = startSynchronizer.getStartFailureNow();
+
+    // then
+    assertTrue(startFailure instanceof InternalInfrastructureException);
+    assertEquals(startFailure.getCause(), toThrow);
+  }
+
+  @Test
+  public void shouldReturnStartFailureWhenItIsCompletedExceptionally() {
+    // given
+    InfrastructureException toThrow = new RuntimeStartInterruptedException(runtimeId);
+    startSynchronizer.completeExceptionally(toThrow);
+
+    // when
+    InfrastructureException startFailure = startSynchronizer.getStartFailureNow();
+
+    // then
+    assertTrue(startFailure instanceof RuntimeStartInterruptedException);
+    assertEquals(startFailure, toThrow);
+  }
+
+  @Test
+  public void shouldReturnNullOnGettingStartFailureWhenItIsNotCompletedExceptionally()
+      throws Exception {
+    // given
+    startSynchronizer.complete();
+
+    // when
+    InfrastructureException startFailure = startSynchronizer.getStartFailureNow();
+
+    // then
+    assertNull(startFailure);
+  }
+
+  @Test
+  public void shouldReturnStartFailureWhenItIsNotCompletedYet() {
+    // when
+    InfrastructureException startFailure = startSynchronizer.getStartFailureNow();
+
+    // then
+    assertNull(startFailure);
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -27,6 +27,7 @@ import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientTermination;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
@@ -65,6 +66,7 @@ public class OpenShiftInfraModule extends AbstractModule {
 
     install(new FactoryModuleBuilder().build(OpenShiftRuntimeContextFactory.class));
     install(new FactoryModuleBuilder().build(OpenShiftRuntimeFactory.class));
+    install(new FactoryModuleBuilder().build(StartSynchronizerFactory.class));
 
     install(new FactoryModuleBuilder().build(KubernetesBootstrapperFactory.class));
     bind(WorkspacePVCCleaner.class).asEagerSingleton();

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -28,6 +28,7 @@ import org.eclipse.che.api.workspace.server.hc.probe.ProbeScheduler;
 import org.eclipse.che.api.workspace.server.hc.probe.WorkspaceProbesFactory;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
@@ -62,6 +63,7 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
       KubernetesSharedPool sharedPool,
       KubernetesRuntimeStateCache runtimesStatusesCache,
       KubernetesMachineCache machinesCache,
+      StartSynchronizerFactory startSynchronizerFactory,
       @Assisted OpenShiftRuntimeContext context,
       @Assisted OpenShiftProject project,
       @Assisted List<Warning> warnings) {
@@ -79,6 +81,7 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
         sharedPool,
         runtimesStatusesCache,
         machinesCache,
+        startSynchronizerFactory,
         context,
         project,
         warnings);

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -63,6 +63,8 @@ import org.eclipse.che.api.workspace.server.hc.probe.WorkspaceProbesFactory;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapper;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
@@ -109,6 +111,9 @@ public class OpenShiftInternalRuntimeTest {
   private static final RuntimeIdentity IDENTITY =
       new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");
 
+  @Mock private StartSynchronizerFactory startSynchronizerFactory;
+  @Mock private StartSynchronizer startSynchronizer;
+
   @Mock private OpenShiftRuntimeContext context;
   @Mock private EventService eventService;
   @Mock private ServersCheckerFactory serverCheckerFactory;
@@ -137,6 +142,9 @@ public class OpenShiftInternalRuntimeTest {
   @BeforeMethod
   public void setup() throws Exception {
     MockitoAnnotations.initMocks(this);
+
+    when(startSynchronizerFactory.create(any())).thenReturn(startSynchronizer);
+
     internalRuntime =
         new OpenShiftInternalRuntime(
             13,
@@ -152,6 +160,7 @@ public class OpenShiftInternalRuntimeTest {
             mock(KubernetesSharedPool.class),
             runtimeStateCache,
             machinesCache,
+            startSynchronizerFactory,
             context,
             project,
             emptyList());
@@ -171,6 +180,7 @@ public class OpenShiftInternalRuntimeTest {
             mock(KubernetesSharedPool.class),
             runtimeStateCache,
             machinesCache,
+            startSynchronizerFactory,
             context,
             project,
             emptyList());

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -192,7 +192,8 @@ public class OpenShiftInternalRuntimeTest {
     when(project.services()).thenReturn(services);
     when(project.routes()).thenReturn(routes);
     when(project.pods()).thenReturn(pods);
-    when(bootstrapperFactory.create(any(), anyList(), any(), any())).thenReturn(bootstrapper);
+    when(bootstrapperFactory.create(any(), anyList(), any(), any(), any()))
+        .thenReturn(bootstrapper);
     doReturn(
             ImmutableMap.of(
                 M1_NAME,

--- a/multiuser/api/che-multiuser-api-jgroups/pom.xml
+++ b/multiuser/api/che-multiuser-api-jgroups/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.infrastructure</groupId>
+            <artifactId>infrastructure-kubernetes</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
         </dependency>

--- a/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/WorkspaceStopPropagator.java
+++ b/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/WorkspaceStopPropagator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.api.distributed;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.multiuser.api.distributed.cache.JGroupsWorkspaceStatusCache;
+import org.eclipse.che.multiuser.api.distributed.cache.StatusChangeListener;
+import org.eclipse.che.workspace.infrastructure.kubernetes.event.KubernetesRuntimeStoppedEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.event.KubernetesRuntimeStoppingEvent;
+
+/**
+ * Propagate workspace status changes.
+ *
+ * <p>It's needed to synchronize interrupt/stop operations between Che Servers instances. There can
+ * be two Che Servers in case of Rolling Update.
+ *
+ * @author Sergii Leshchenko
+ * @see org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer
+ */
+@Singleton
+public class WorkspaceStopPropagator implements StatusChangeListener {
+
+  private final EventService eventService;
+
+  @Inject
+  public WorkspaceStopPropagator(
+      EventService eventService, JGroupsWorkspaceStatusCache statusCache) {
+    this.eventService = eventService;
+    statusCache.subscribe(this);
+  }
+
+  @Override
+  public void statusChanged(String workspaceId, WorkspaceStatus status) {
+    switch (status) {
+      case STOPPING:
+        // is supposed to notify start synchronizer that workspace is stopping
+        // so, if runtime is starting then start will be interrupted
+        eventService.publish(new KubernetesRuntimeStoppingEvent(workspaceId));
+        break;
+      case STOPPED:
+        // is supposed to notify start synchronizer that workspace is stopped
+        // so, if runtime start was interrupting then interruption will be considered as finished
+        eventService.publish(new KubernetesRuntimeStoppedEvent(workspaceId));
+        break;
+      default:
+        // there is no needed to publish other statuses
+    }
+  }
+}

--- a/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/cache/JGroupsWorkspaceStatusCache.java
+++ b/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/cache/JGroupsWorkspaceStatusCache.java
@@ -80,6 +80,26 @@ public class JGroupsWorkspaceStatusCache implements WorkspaceStatusCache {
     return new HashMap<>(delegate);
   }
 
+  /**
+   * Subscribes status changes listener.
+   *
+   * @param listener listener instance that will receive status changed events
+   */
+  public void subscribe(StatusChangeListener listener) {
+    delegate.addNotifier(
+        new ReplicatedMapNotificationAdapter() {
+          @Override
+          public void entrySet(Object workspaceId, Object workspaceStatus) {
+            listener.statusChanged((String) workspaceId, (WorkspaceStatus) workspaceStatus);
+          }
+
+          @Override
+          public void entryRemoved(Object workspaceId) {
+            listener.statusChanged((String) workspaceId, WorkspaceStatus.STOPPED);
+          }
+        });
+  }
+
   /** Stops workspace status cache. */
   public void shutdown() {
     try {

--- a/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/cache/ReplicatedMapNotificationAdapter.java
+++ b/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/cache/ReplicatedMapNotificationAdapter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.api.distributed.cache;
+
+import java.util.List;
+import java.util.Map;
+import org.jgroups.View;
+import org.jgroups.blocks.ReplicatedHashMap;
+
+/**
+ * <b>Purpose</b>: Provides an empty implementation of {@link ReplicatedHashMap.Notification}. Users
+ * who do not require to be notified about all map changes can subclass this class and implement
+ * only the methods required.
+ *
+ * @author Sergii Leshchenko
+ */
+public class ReplicatedMapNotificationAdapter implements ReplicatedHashMap.Notification {
+  @Override
+  public void entrySet(Object key, Object value) {}
+
+  @Override
+  public void entryRemoved(Object key) {}
+
+  @Override
+  public void contentsSet(Map new_entries) {}
+
+  @Override
+  public void contentsCleared() {}
+
+  @Override
+  public void viewChange(View view, List mbrs_joined, List mbrs_left) {}
+}

--- a/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/cache/StatusChangeListener.java
+++ b/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/cache/StatusChangeListener.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.api.distributed.cache;
+
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+
+/**
+ * Listener interface for being notified about workspace status changes in {@link
+ * JGroupsWorkspaceStatusCache}.
+ *
+ * <p>Note that JGroupsWorkspaceStatusCache is distributed cache and listener will receiver changes
+ * that are made by this instance or any another is a cluster.
+ *
+ * @author Sergii Leshchenko
+ */
+public interface StatusChangeListener {
+  void statusChanged(String workspaceId, WorkspaceStatus status);
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/RuntimeIdentityImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/RuntimeIdentityImpl.java
@@ -54,12 +54,16 @@ public final class RuntimeIdentityImpl implements RuntimeIdentity {
 
   @Override
   public String toString() {
-    return "RuntimeIdentityImpl: { workspace: "
+    return "RuntimeIdentityImpl{"
+        + "workspaceId='"
         + workspaceId
-        + " environment: "
+        + '\''
+        + ", envName='"
         + envName
-        + " ownerId: "
+        + '\''
+        + ", ownerId='"
         + ownerId
-        + " }";
+        + '\''
+        + '}';
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adds an ability to interrupt the start of a Kubernetes/OpenShift runtime.

It is done by adding Utility class `StartSynchronizer` that is designed to synchronize start/stop operations. Synchronization is performed by registering all start/stop operations (like start is launched, an error occurs during start, start is interrupted, etc.)
So, `KubernetesInternalRuntime` registers when the runtime is starting and then checks failure on each phase of start and interrupts start is a failure is registered.
In turn, `KubernetesInternalRuntime` checks that start is in progress on runtime stopping, if yes - then start failure will be registered. So, Thread which is performing start will receive the registered exception and interrupt start.

It also works in cluster mode, now there can be two Che Servers during Rolling Update. Synchronization between Che Servers is done by using JGroups Replicated Cache listeners. Each Che Server receives the corresponding event when a runtime stop is launched/completed.

There are 3 more changes:
1. Rework `UnrecoverableEventHandler` to fail workspace start instead interruption (earlier ) since there is such ability.  

2. Improve executing of commands in `KubernetesPods` class to throw if occurs while a WebSocket connection establishing.

3. KubernetesBootstrapper now checks start interruption before execution each of commands. Without that there is much more probability that commands fails with the following error:
```
2018-06-01 15:33:21,204[20.200:8443/...]  [ERROR] [.k.c.d.i.ExecWebSocketListener 213]  - Exec Failure: HTTP:403. Message:pods "non-existing" is forbidden: pods "non-existing" not found
java.net.ProtocolException: Expected HTTP 101 response but was '403 Forbidden'
	at okhttp3.internal.ws.RealWebSocket.checkResponse(RealWebSocket.java:216)
	at okhttp3.internal.ws.RealWebSocket$2.onResponse(RealWebSocket.java:183)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:141)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
And it leads to connection was leaked warning
```
Jun 01, 2018 3:01:42 PM okhttp3.internal.platform.Platform log
WARNING: A connection to https://172.19.20.200:8443/ was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5918

It also fixes https://github.com/eclipse/che/issues/9905

#### Release Notes
Added an ability to interrupt the start of a Kubernetes/OpenShift runtime.


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
