### PR TITLE
fix build.sh for theia image

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -77,7 +77,7 @@ init() {
       --dockerfile:*)
         DOCKERFILE="${1#*:}"
         shift ;;
-      --build-args:*)
+      --build-arg*:*)
         BUILD_ARGS_CSV="${1#*:}"
         prepare_build_args $BUILD_ARGS_CSV
         shift ;;

--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -21,6 +21,13 @@ skip_tests() {
   fi
 }
 
+prepare_build_args() {
+    IFS=',' read -r -a BUILD_ARGS_ARRAY <<< "$@"
+    for i in ${BUILD_ARGS_ARRAY[@]}; do
+    BUILD_ARGS+="--build-arg $i "
+    done
+}
+
 init() {
   BLUE='\033[1;34m'
   GREEN='\033[0;32m'
@@ -39,7 +46,7 @@ init() {
   ARGS=""
   OPTIONS=""
   DOCKERFILE=""
-  BUILD_ARG=""
+  BUILD_ARGS=""
 
   while [ $# -gt 0 ]; do
     case $1 in
@@ -70,8 +77,9 @@ init() {
       --dockerfile:*)
         DOCKERFILE="${1#*:}"
         shift ;;
-      --build-arg:*)
-        BUILD_ARG="--build-arg ${1#*:}"
+      --build-args:*)
+        BUILD_ARGS_CSV="${1#*:}"
+        prepare_build_args $BUILD_ARGS_CSV
         shift ;;
       --*)
         printf "${RED}Unknown parameter: $1${NC}\n"; exit 2 ;;
@@ -120,7 +128,7 @@ build_image() {
   printf "${BOLD}Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG${NC}\n"
   # Replace macros in Dockerfiles
   cat ${DIR}/${DOCKERFILE} | sed s/\$\{BUILD_ORGANIZATION\}/${ORGANIZATION}/ | sed s/\$\{BUILD_PREFIX\}/${PREFIX}/ | sed s/\$\{BUILD_TAG\}/${TAG}/ > ${DIR}/.Dockerfile
-  cd "${DIR}" && docker build -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARG} .
+  cd "${DIR}" && docker build -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARGS} .
   rm ${DIR}/.Dockerfile
   if [ $? -eq 0 ]; then
     printf "Build of ${BLUE}${IMAGE_NAME} ${GREEN}[OK]${NC}\n"

--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -10,11 +10,10 @@
 FROM node:8-alpine
 
 ARG GITHUB_TOKEN
-ARG THEIA_VERSION
+ARG THEIA_VERSION=0.3.10
 ENV USE_LOCAL_GIT=true \
-    GITHUB_TOKEN=${GITHUB_TOKEN}
-
-RUN if [ -z "${THEIA_VERSION}" ]; then echo -e '\033[0;31m' Set up build argument 'THEIA_VERSION' '\033[0m'; exit 1; fi
+    GITHUB_TOKEN=${GITHUB_TOKEN} \
+    THEIA_VERSION=${THEIA_VERSION}
 
 # build dependencies requireed to compile a custom Theia
 RUN apk add --no-cache make gcc g++ python git openssh bash supervisor jq

--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -3,9 +3,9 @@
 ## Build image manually
 Example:
 using build script:
-./build.sh --build-args:GITHUB_TOKEN=$GITHUB_TOKEN,THEIA_VERSION=0.3.10 --tag:nightly
+./build.sh --build-args:GITHUB_TOKEN=$GITHUB_TOKEN,THEIA_VERSION=0.3.10 --tag:0.3.10-nightly
 with native docker:
-docker build -t eclipse/che-theia:nightly --build-arg GITHUB_TOKEN={your token} --build-arg THEIA_VERSION=0.3.10 .
+docker build -t eclipse/che-theia:0.3.10-nightly --build-arg GITHUB_TOKEN={your token} --build-arg THEIA_VERSION=0.3.10 .
 
 ## Theia version
 

--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -2,6 +2,9 @@
 
 ## Build image manually
 Example:
+using build script:
+./build.sh --build-args:GITHUB_TOKEN=$GITHUB_TOKEN,THEIA_VERSION=0.3.10 --tag:nightly
+with native docker:
 docker build -t eclipse/che-theia:nightly --build-arg GITHUB_TOKEN={your token} --build-arg THEIA_VERSION=0.3.10 .
 
 ## Theia version


### PR DESCRIPTION
- add an ability to support multiple build args in `build.include`
- add an ability to override theia version using `build.sh`
needed for: https://github.com/eclipse/che/issues/9718#issuecomment-392681224


Please not that with this PR we set concrete default Theia version in dockerfile.  It will be possible to override it locally with build arg but to update theia version we will need change Dockerfile.