### PR TITLE
Fixed golang language server hover bug

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/DefaultExtensionToMimeTypeMappings.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/DefaultExtensionToMimeTypeMappings.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.api.editor.filetype;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Singleton;
+
+/** @author Dmytro Kulieshov */
+@Singleton
+public class DefaultExtensionToMimeTypeMappings {
+  private final Map<String, Set<String>> mappings =
+      ImmutableMap.<String, Set<String>>builder()
+          .put("c", ImmutableSet.of("text/x-csrc"))
+          .put("C", ImmutableSet.of("text/x-c++src"))
+          .put("cc", ImmutableSet.of("text/x-c++src"))
+          .put("cpp", ImmutableSet.of("text/x-c++src"))
+          .put("ino", ImmutableSet.of("text/x-c++src"))
+          .put("h", ImmutableSet.of("text/x-chdr"))
+          .put("hh", ImmutableSet.of("text/x-c++hdr"))
+          .put("c++", ImmutableSet.of("text/x-c++src"))
+          .put("cs", ImmutableSet.of("text/x-csharp"))
+          .put("m", ImmutableSet.of("text/x-objective-c"))
+          .put("java", ImmutableSet.of("text/x-java"))
+          .put("class", ImmutableSet.of("text/x-java"))
+          .put("scala", ImmutableSet.of("text/x-scala"))
+          .put("sbt", ImmutableSet.of("text/x-scala"))
+          .put("clj", ImmutableSet.of("text/x-clojure"))
+          .put("groovy", ImmutableSet.of("text/x-groovy"))
+          .put("gvy", ImmutableSet.of("text/x-groovy"))
+          .put("gy", ImmutableSet.of("text/x-groovy"))
+          .put("gradle", ImmutableSet.of("text/x-groovy"))
+          .put("kt", ImmutableSet.of("text/x-kotlin"))
+          .put("js", ImmutableSet.of("application/javascript", "text/javascript"))
+          .put("coffee", ImmutableSet.of("text/x-coffeescript"))
+          .put("json", ImmutableSet.of("application/json"))
+          .put("ts", ImmutableSet.of("application/javascript", "application/typescript"))
+          .put("es6", ImmutableSet.of("application/javascript", "text/javascript"))
+          .put("jsx", ImmutableSet.of("application/javascript", "text/javascript"))
+          .put("css", ImmutableSet.of("text/css"))
+          .put("scss", ImmutableSet.of("text/x-scss"))
+          .put("less", ImmutableSet.of("text/x-less"))
+          .put("sass", ImmutableSet.of("text/x-sass"))
+          .put("xml", ImmutableSet.of("application/xml"))
+          .put("html", ImmutableSet.of("text/html"))
+          .put("xhtml", ImmutableSet.of("application/xml+xhtml", "text/html"))
+          .put("htm", ImmutableSet.of("text/html"))
+          .put("dtd", ImmutableSet.of("application/xml-dtd"))
+          .put("yaml", ImmutableSet.of("text/x-yaml"))
+          .put("yml", ImmutableSet.of("text/x-yaml"))
+          .put("markdown", ImmutableSet.of("text/x-markdown"))
+          .put("mdown", ImmutableSet.of("text/x-markdown"))
+          .put("mkdn", ImmutableSet.of("text/x-markdown"))
+          .put("mkd", ImmutableSet.of("text/x-markdown"))
+          .put("md", ImmutableSet.of("text/x-markdown"))
+          .put("mdwn", ImmutableSet.of("text/x-markdown"))
+          .put("rest", ImmutableSet.of("text/x-rst"))
+          .put("rst", ImmutableSet.of("text/x-rst"))
+          .put("tex", ImmutableSet.of("text/x-latex"))
+          .put("cls", ImmutableSet.of("text/x-latex"))
+          .put("sty", ImmutableSet.of("text/x-latex"))
+          .put("py", ImmutableSet.of("text/x-python"))
+          .put("pyx", ImmutableSet.of("text/x-cython"))
+          .put("rb", ImmutableSet.of("text/x-ruby"))
+          .put("erb", ImmutableSet.of("text/html"))
+          .put("gemspec", ImmutableSet.of("text/x-ruby"))
+          .put("go", ImmutableSet.of("text/x-go"))
+          .put("rs", ImmutableSet.of("text/x-rustsrc"))
+          .put("erl", ImmutableSet.of("text/x-erlang"))
+          .put("lua", ImmutableSet.of("text/x-lua"))
+          .put("tcl", ImmutableSet.of("text/x-tcl"))
+          .put("pl", ImmutableSet.of("text/x-perl"))
+          .put("pm", ImmutableSet.of("text/x-perl"))
+          .put("php", ImmutableSet.of("text/x-php"))
+          .put("phtml", ImmutableSet.of("text/x-php"))
+          .put("ejs", ImmutableSet.of("application/x-ejs"))
+          .put("jsp", ImmutableSet.of("application/x-jsp"))
+          .put("asp", ImmutableSet.of("application/x-aspx"))
+          .put("aspx", ImmutableSet.of("application/x-aspx"))
+          .put("slim", ImmutableSet.of("text/x-slim"))
+          .put("ml", ImmutableSet.of("text/x-ocaml"))
+          .put("fs", ImmutableSet.of("text/x-fsharp"))
+          .put("lisp", ImmutableSet.of("text/x-commonlisp"))
+          .put("cl", ImmutableSet.of("text/x-commonlisp"))
+          .put("hs", ImmutableSet.of("text/x-haskell"))
+          .put("scm", ImmutableSet.of("text/x-scheme"))
+          .put("sql", ImmutableSet.of("text/x-sql"))
+          .put("properties", ImmutableSet.of("text/x-properties"))
+          .put("diff", ImmutableSet.of("text/x-diff"))
+          .put("r", ImmutableSet.of("text/x-rsrc"))
+          .put("R", ImmutableSet.of("text/x-rsrc"))
+          .put("csv", ImmutableSet.of("text/csv"))
+          .put("sh", ImmutableSet.of("text/x-sh"))
+          .put("pas", ImmutableSet.of("text/x-pascal"))
+          .put("p", ImmutableSet.of("text/x-pascal"))
+          .put("fpm", ImmutableSet.of("text/x-pascal"))
+          .put("st", ImmutableSet.of("text/x-stsrc"))
+          .put("cob", ImmutableSet.of("text/x-cobol"))
+          .put("cbl", ImmutableSet.of("text/x-cobol"))
+          .put("cpy", ImmutableSet.of("text/x-cobol"))
+          .put("f", ImmutableSet.of("text/x-fortran"))
+          .put("for", ImmutableSet.of("text/x-fortran"))
+          .put("f90", ImmutableSet.of("text/x-fortran"))
+          .put("f95", ImmutableSet.of("text/x-fortran"))
+          .put("f03", ImmutableSet.of("text/x-fortran"))
+          .put("vb", ImmutableSet.of("text/x-vb"))
+          .put("vbs", ImmutableSet.of("text/vbscript"))
+          .put("pp", ImmutableSet.of("text/x-puppet"))
+          .put("docker", ImmutableSet.of("text/x-dockerfile"))
+          .put("jag", ImmutableSet.of("text/jaggery"))
+          .build();
+
+  public Set<String> getExtensions() {
+    return ImmutableSet.copyOf(mappings.keySet());
+  }
+
+  public Set<String> getMimeTypes() {
+    Set<String> mimeTypes =
+        mappings.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
+
+    return ImmutableSet.copyOf(mimeTypes);
+  }
+
+  public Map<String, Set<String>> getMappings() {
+    return mappings;
+  }
+}

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/ExtensionFileTypeIdentifier.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/ExtensionFileTypeIdentifier.java
@@ -10,21 +10,29 @@
  */
 package org.eclipse.che.ide.api.editor.filetype;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.util.loging.Log;
 
+@Singleton
 public class ExtensionFileTypeIdentifier implements FileTypeIdentifier {
 
   /** The known extensions registry. */
   Map<String, List<String>> mappings = new HashMap<>();
 
-  public ExtensionFileTypeIdentifier() {
-    init();
+  @Inject
+  public ExtensionFileTypeIdentifier(
+      DefaultExtensionToMimeTypeMappings defaultExtensionToMimeTypeMappings) {
+    defaultExtensionToMimeTypeMappings
+        .getMappings()
+        .forEach(
+            (extension, mimeTypes) -> mappings.put(extension, ImmutableList.copyOf(mimeTypes)));
   }
 
   @Override
@@ -48,123 +56,6 @@ public class ExtensionFileTypeIdentifier implements FileTypeIdentifier {
 
   public void registerNewExtension(String extension, List<String> contentTypes) {
     mappings.put(extension, contentTypes);
-  }
-
-  /** Prepares the know extension registry. */
-  public void init() {
-    this.mappings.put("c", makeList("text/x-csrc"));
-    this.mappings.put("C", makeList("text/x-c++src"));
-    this.mappings.put("cc", makeList("text/x-c++src"));
-    this.mappings.put("cpp", makeList("text/x-c++src"));
-    this.mappings.put("ino", makeList("text/x-c++src"));
-    this.mappings.put("h", makeList("text/x-chdr"));
-    this.mappings.put("hh", makeList("text/x-c++hdr"));
-    this.mappings.put("c++", Collections.singletonList("text/x-c++src"));
-    this.mappings.put("cs", Collections.singletonList("text/x-csharp"));
-    this.mappings.put(
-        "m", Collections.singletonList("text/x-objective-c")); // conflict with octave/matlab
-
-    this.mappings.put("java", Collections.singletonList("text/x-java"));
-    this.mappings.put("class", Collections.singletonList("text/x-java"));
-    this.mappings.put("scala", Collections.singletonList("text/x-scala"));
-    this.mappings.put("sbt", Collections.singletonList("text/x-scala")); // scala build definition
-    this.mappings.put("clj", Collections.singletonList("text/x-clojure"));
-    this.mappings.put("groovy", Collections.singletonList("text/x-groovy"));
-    this.mappings.put("gvy", Collections.singletonList("text/x-groovy"));
-    this.mappings.put("gy", Collections.singletonList("text/x-groovy"));
-    this.mappings.put(
-        "gradle", Collections.singletonList("text/x-groovy")); // gradle conf are groovy files
-    this.mappings.put("kt", Collections.singletonList("text/x-kotlin"));
-
-    this.mappings.put("js", makeList("application/javascript", "text/javascript"));
-    this.mappings.put("coffee", makeList("text/x-coffeescript"));
-    this.mappings.put("json", makeList("application/json"));
-    this.mappings.put("ts", makeList("application/javascript", "application/typescript"));
-    this.mappings.put("es6", makeList("application/javascript", "text/javascript"));
-    this.mappings.put("jsx", makeList("application/javascript", "text/javascript"));
-
-    this.mappings.put("css", makeList("text/css"));
-    this.mappings.put("scss", makeList("text/x-scss"));
-    this.mappings.put("less", makeList("text/x-less"));
-    this.mappings.put("sass", makeList("text/x-sass"));
-
-    this.mappings.put("xml", makeList("application/xml"));
-    this.mappings.put("xml", makeList("application/xml"));
-    this.mappings.put("html", makeList("text/html"));
-    this.mappings.put("xhtml", makeList("application/xml+xhtml", "text/html"));
-    this.mappings.put("htm", makeList("text/html"));
-    this.mappings.put("dtd", makeList("application/xml-dtd"));
-
-    this.mappings.put("yaml", makeList("text/x-yaml"));
-    this.mappings.put("yml", makeList("text/x-yaml"));
-
-    this.mappings.put("markdown", makeList("text/x-markdown"));
-    this.mappings.put("mdown", makeList("text/x-markdown"));
-    this.mappings.put("mkdn", makeList("text/x-markdown"));
-    this.mappings.put("mkd", makeList("text/x-markdown"));
-    this.mappings.put("md", makeList("text/x-markdown"));
-    this.mappings.put("mdwn", makeList("text/x-markdown"));
-    this.mappings.put("rest", makeList("text/x-rst")); // although most are suffixed with .txt
-    this.mappings.put("rst", makeList("text/x-rst"));
-    this.mappings.put("tex", makeList("text/x-latex"));
-    this.mappings.put("cls", makeList("text/x-latex"));
-    this.mappings.put("sty", makeList("text/x-latex"));
-
-    this.mappings.put("py", makeList("text/x-python"));
-    this.mappings.put("pyx", makeList("text/x-cython"));
-    this.mappings.put("rb", makeList("text/x-ruby"));
-    this.mappings.put("erb", makeList("text/html")); // templates with embedded ruby
-    this.mappings.put("gemspec", makeList("text/x-ruby"));
-    this.mappings.put("go", makeList("text/x-go"));
-    this.mappings.put("rs", makeList("text/x-rustsrc"));
-    this.mappings.put("erl", makeList("text/x-erlang"));
-    this.mappings.put("lua", makeList("text/x-lua"));
-    this.mappings.put("tcl", makeList("text/x-tcl"));
-    this.mappings.put("pl", makeList("text/x-perl"));
-    this.mappings.put("pm", makeList("text/x-perl")); // perl module
-
-    this.mappings.put("php", makeList("text/x-php"));
-    this.mappings.put("phtml", makeList("text/x-php"));
-    this.mappings.put("ejs", makeList("application/x-ejs"));
-    this.mappings.put("jsp", makeList("application/x-jsp"));
-    this.mappings.put("asp", makeList("application/x-aspx"));
-    this.mappings.put("aspx", makeList("application/x-aspx"));
-    this.mappings.put("slim", makeList("text/x-slim"));
-
-    this.mappings.put("ml", makeList("text/x-ocaml"));
-    this.mappings.put("fs", makeList("text/x-fsharp"));
-    this.mappings.put("lisp", makeList("text/x-commonlisp"));
-    this.mappings.put("cl", makeList("text/x-commonlisp"));
-    this.mappings.put("hs", makeList("text/x-haskell"));
-    this.mappings.put("scm", makeList("text/x-scheme"));
-
-    this.mappings.put("sql", makeList("text/x-sql"));
-    this.mappings.put("properties", makeList("text/x-properties"));
-    this.mappings.put("diff", makeList("text/x-diff"));
-    this.mappings.put("r", makeList("text/x-rsrc"));
-    this.mappings.put("R", makeList("text/x-rsrc"));
-    this.mappings.put("csv", makeList("text/csv"));
-    this.mappings.put("sh", makeList("text/x-sh")); // many are not suffixed at all !
-
-    this.mappings.put("pas", makeList("text/x-pascal"));
-    this.mappings.put("p", makeList("text/x-pascal"));
-    this.mappings.put("fpm", makeList("text/x-pascal")); // turbo pascal modules
-    this.mappings.put("st", makeList("text/x-stsrc")); // smalltalk
-
-    this.mappings.put("cob", makeList("text/x-cobol"));
-    this.mappings.put("cbl", makeList("text/x-cobol"));
-    this.mappings.put("cpy", makeList("text/x-cobol"));
-    this.mappings.put("f", makeList("text/x-fortran"));
-    this.mappings.put("for", makeList("text/x-fortran"));
-    this.mappings.put("f90", makeList("text/x-fortran"));
-    this.mappings.put("f95", makeList("text/x-fortran"));
-    this.mappings.put("f03", makeList("text/x-fortran"));
-    this.mappings.put("vb", makeList("text/x-vb"));
-    this.mappings.put("vbs", makeList("text/vbscript"));
-
-    this.mappings.put("pp", makeList("text/x-puppet"));
-    this.mappings.put("docker", makeList("text/x-dockerfile"));
-    this.mappings.put("jag", makeList("text/jaggery"));
   }
 
   /**

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/FileNameFileTypeIdentifier.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/FileNameFileTypeIdentifier.java
@@ -13,6 +13,7 @@ package org.eclipse.che.ide.api.editor.filetype;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import javax.inject.Singleton;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 
 /**
@@ -20,6 +21,7 @@ import org.eclipse.che.ide.api.resources.VirtualFile;
  *
  * @author "Mickaël Leduque"
  */
+@Singleton
 public class FileNameFileTypeIdentifier implements FileTypeIdentifier {
 
   @Override

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/FirstLineFileTypeIdentifier.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/FirstLineFileTypeIdentifier.java
@@ -14,6 +14,7 @@ import com.google.gwt.regexp.shared.MatchResult;
 import com.google.gwt.regexp.shared.RegExp;
 import java.util.Collections;
 import java.util.List;
+import javax.inject.Singleton;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.util.loging.Log;
 
@@ -22,6 +23,7 @@ import org.eclipse.che.ide.util.loging.Log;
  *
  * @author "Mickaël Leduque"
  */
+@Singleton
 public class FirstLineFileTypeIdentifier implements FileTypeIdentifier {
 
   // format: <?xml

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/MultipleMethodFileIdentifier.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/filetype/MultipleMethodFileIdentifier.java
@@ -12,6 +12,7 @@ package org.eclipse.che.ide.api.editor.filetype;
 
 import com.google.inject.Singleton;
 import java.util.List;
+import javax.inject.Inject;
 import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.util.loging.Log;
 
@@ -23,12 +24,19 @@ import org.eclipse.che.ide.util.loging.Log;
 @Singleton
 public class MultipleMethodFileIdentifier implements FileTypeIdentifier {
 
-  private final FileNameFileTypeIdentifier fileNameFileTypeIdentifier =
-      new FileNameFileTypeIdentifier();
-  private final ExtensionFileTypeIdentifier extensionFileTypeIdentifier =
-      new ExtensionFileTypeIdentifier();
-  private final FirstLineFileTypeIdentifier firstLineFileTypeIdentifier =
-      new FirstLineFileTypeIdentifier();
+  private final FileNameFileTypeIdentifier fileNameFileTypeIdentifier;
+  private final ExtensionFileTypeIdentifier extensionFileTypeIdentifier;
+  private final FirstLineFileTypeIdentifier firstLineFileTypeIdentifier;
+
+  @Inject
+  public MultipleMethodFileIdentifier(
+      FileNameFileTypeIdentifier fileNameFileTypeIdentifier,
+      ExtensionFileTypeIdentifier extensionFileTypeIdentifier,
+      FirstLineFileTypeIdentifier firstLineFileTypeIdentifier) {
+    this.fileNameFileTypeIdentifier = fileNameFileTypeIdentifier;
+    this.extensionFileTypeIdentifier = extensionFileTypeIdentifier;
+    this.firstLineFileTypeIdentifier = firstLineFileTypeIdentifier;
+  }
 
   public void registerNewExtension(String extension, List<String> contentTypes) {
     extensionFileTypeIdentifier.registerNewExtension(extension, contentTypes);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/DefaultHoverProviderInitializer.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/DefaultHoverProviderInitializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.languageserver.ide;
+
+import com.google.gwt.core.client.JsArrayString;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.ide.api.editor.filetype.DefaultExtensionToMimeTypeMappings;
+import org.eclipse.che.ide.editor.orion.client.OrionHoverRegistrant;
+import org.eclipse.che.plugin.languageserver.ide.hover.HoverProvider;
+
+/** @author Dmytro Kulieshov */
+@Singleton
+public class DefaultHoverProviderInitializer {
+
+  private final DefaultExtensionToMimeTypeMappings defaultExtensionToMimeTypeMappings;
+  private final OrionHoverRegistrant orionHoverRegistrant;
+  private final HoverProvider hoverProvider;
+
+  @Inject
+  public DefaultHoverProviderInitializer(
+      DefaultExtensionToMimeTypeMappings defaultExtensionToMimeTypeMappings,
+      OrionHoverRegistrant orionHoverRegistrant,
+      HoverProvider hoverProvider) {
+    this.defaultExtensionToMimeTypeMappings = defaultExtensionToMimeTypeMappings;
+    this.orionHoverRegistrant = orionHoverRegistrant;
+    this.hoverProvider = hoverProvider;
+  }
+
+  void initialize() {
+    JsArrayString contentTypes = JsArrayString.createArray().cast();
+    defaultExtensionToMimeTypeMappings.getMimeTypes().forEach(contentTypes::push);
+    orionHoverRegistrant.registerHover(contentTypes, hoverProvider);
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/DefaultOccurrencesProviderInitializer.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/DefaultOccurrencesProviderInitializer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.languageserver.ide;
+
+import com.google.gwt.core.client.JsArrayString;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.ide.api.editor.filetype.DefaultExtensionToMimeTypeMappings;
+import org.eclipse.che.ide.editor.orion.client.OrionOccurrencesRegistrant;
+import org.eclipse.che.plugin.languageserver.ide.highlighting.OccurrencesProvider;
+
+/** @author Dmytro Kulieshov */
+@Singleton
+public class DefaultOccurrencesProviderInitializer {
+
+  private final DefaultExtensionToMimeTypeMappings defaultExtensionToMimeTypeMappings;
+  private final OrionOccurrencesRegistrant orionOccurrencesRegistrant;
+  private final OccurrencesProvider occurrencesProvider;
+
+  @Inject
+  public DefaultOccurrencesProviderInitializer(
+      DefaultExtensionToMimeTypeMappings defaultExtensionToMimeTypeMappings,
+      OrionOccurrencesRegistrant orionOccurrencesRegistrant,
+      OccurrencesProvider occurrencesProvider) {
+    this.defaultExtensionToMimeTypeMappings = defaultExtensionToMimeTypeMappings;
+    this.orionOccurrencesRegistrant = orionOccurrencesRegistrant;
+    this.occurrencesProvider = occurrencesProvider;
+  }
+
+  void initialize() {
+    JsArrayString contentTypes = JsArrayString.createArray().cast();
+    defaultExtensionToMimeTypeMappings.getMimeTypes().forEach(contentTypes::push);
+    orionOccurrencesRegistrant.registerOccurrencesHandler(contentTypes, occurrencesProvider);
+  }
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/LanguageServerExtension.java
@@ -57,6 +57,8 @@ public class LanguageServerExtension {
   public LanguageServerExtension(
       LanguageRegexesInitializer languageRegexesInitializer,
       LanguageDescriptionInitializer languageDescriptionInitializer,
+      DefaultHoverProviderInitializer defaultHoverProviderInitializer,
+      DefaultOccurrencesProviderInitializer defaultOccurrencesProviderInitializer,
       EventBus eventBus,
       AppContext appContext,
       ShowMessageJsonRpcReceiver showMessageJsonRpcReceiver,
@@ -66,6 +68,8 @@ public class LanguageServerExtension {
         e -> {
           languageRegexesInitializer.initialize();
           languageDescriptionInitializer.initialize();
+          defaultOccurrencesProviderInitializer.initialize();
+          defaultHoverProviderInitializer.initialize();
           showMessageJsonRpcReceiver.subscribe();
           publishDiagnosticsReceiver.subscribe();
         });
@@ -73,6 +77,8 @@ public class LanguageServerExtension {
     if (appContext.getWorkspace().getStatus() == RUNNING) {
       languageRegexesInitializer.initialize();
       languageDescriptionInitializer.initialize();
+      defaultOccurrencesProviderInitializer.initialize();
+      defaultHoverProviderInitializer.initialize();
       showMessageJsonRpcReceiver.subscribe();
       publishDiagnosticsReceiver.subscribe();
     }


### PR DESCRIPTION
Related issue https://github.com/eclipse/che/issues/9781

Added default hover and occurrences provider initialization, moved default extension to mime type mappings to a separate class.