### PR TITLE
 Does not claim recovery is supported on docker infra

### DIFF
--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeInfrastructure.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeInfrastructure.java
@@ -80,6 +80,9 @@ public class DockerRuntimeInfrastructure extends RuntimeInfrastructure {
 
   @Override
   public Set<RuntimeIdentity> getIdentities() throws InfrastructureException {
+    // Due to https://github.com/eclipse/che/issues/5814, recovering is not fully possible
+    // so infrastructure should not claim support of it.
+    // return containers.findIdentities();
     throw new UnsupportedOperationException("Runtimes tracking currently does not supported.");
   }
 

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeInfrastructure.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeInfrastructure.java
@@ -80,7 +80,7 @@ public class DockerRuntimeInfrastructure extends RuntimeInfrastructure {
 
   @Override
   public Set<RuntimeIdentity> getIdentities() throws InfrastructureException {
-    return containers.findIdentities();
+    throw new UnsupportedOperationException("Runtimes tracking currently does not supported.");
   }
 
   private DockerEnvironment convertToDockerEnv(InternalEnvironment sourceEnv)

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTermination.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTermination.java
@@ -123,12 +123,12 @@ public class WorkspaceServiceTermination implements ServiceTermination {
    */
   @Override
   public void suspend() throws InterruptedException, UnsupportedOperationException {
-    Preconditions.checkState(runtimes.refuseStart());
     try {
       runtimeInfrastructure.getIdentities();
     } catch (UnsupportedOperationException | InfrastructureException e) {
       throw new UnsupportedOperationException("Current infrastructure does not support suspend.");
     }
+    Preconditions.checkState(runtimes.refuseStart());
     WorkspaceSuspendedEventsPropagator propagator = new WorkspaceSuspendedEventsPropagator();
     eventService.subscribe(propagator);
     try {


### PR DESCRIPTION
### What does this PR do?
Make Docker infra does not claim recovery is supported;
Fix in WS termination to allow execute termination after unsuccessful suspending;

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9885


#### Release Notes
N/A (bug)


#### Docs PR
N/A (bug)