### PR TITLE
Fix displaying tabs for read only editors

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
@@ -46,6 +46,7 @@ import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.EditorWithErrors;
 import org.eclipse.che.ide.api.editor.EditorWithErrors.EditorState;
+import org.eclipse.che.ide.api.editor.texteditor.HasReadOnlyProperty;
 import org.eclipse.che.ide.api.parts.EditorPartStack;
 import org.eclipse.che.ide.api.parts.EditorTab;
 import org.eclipse.che.ide.api.parts.PartPresenter;
@@ -245,11 +246,6 @@ public class EditorPartStackPresenter extends PartStackPresenter
 
             boolean isReadOnly =
                 ((EditorPartPresenter) source).getEditorInput().getFile().isReadOnly();
-            if (propId == EditorPartPresenter.PROP_INPUT) {
-              editorTab.setReadOnlyMark(isReadOnly);
-              return;
-            }
-
             if (!isReadOnly && propId == EditorPartPresenter.PROP_DIRTY) {
               editorTab.setUnsavedDataMark(((EditorPartPresenter) source).isDirty());
             }
@@ -286,6 +282,12 @@ public class EditorPartStackPresenter extends PartStackPresenter
             }
           });
     }
+
+    if (editorPart instanceof HasReadOnlyProperty) {
+      boolean isReadOnly = editorPart.getEditorInput().getFile().isReadOnly();
+      editorTab.setReadOnlyMark(isReadOnly);
+    }
+
     view.selectTab(editorPart);
   }
 


### PR DESCRIPTION
### What does this PR do?
Fix displaying tabs for read only editors
Before fix:
![readonlytab](https://user-images.githubusercontent.com/5676062/40781656-6006aee8-64e5-11e8-9579-b57205ecb68d.png)
After fix:
![readonlymark](https://user-images.githubusercontent.com/5676062/40781681-76a13aec-64e5-11e8-968a-e1b23840cdf6.png)


### What issues does this PR fix or reference?
#9865 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
