### PR TITLE
Switch editors in read only mode when ws agent has stopped

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -1186,6 +1186,9 @@ public interface CoreLocalizationConstant extends Messages {
   @Key("message.projectCreated")
   String projectCreated(String projectName);
 
+  @Key("message.switch.editors.in.readOnly.mode")
+  String messageSwitchEditorsInReadOnlyMode();
+
   @Key("ssh.connect.info")
   String sshConnectInfo(
       String machineName,

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
@@ -46,6 +46,7 @@ import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.EditorWithErrors;
 import org.eclipse.che.ide.api.editor.EditorWithErrors.EditorState;
+import org.eclipse.che.ide.api.editor.texteditor.HasReadOnlyProperty;
 import org.eclipse.che.ide.api.parts.EditorPartStack;
 import org.eclipse.che.ide.api.parts.EditorTab;
 import org.eclipse.che.ide.api.parts.PartPresenter;
@@ -245,11 +246,6 @@ public class EditorPartStackPresenter extends PartStackPresenter
 
             boolean isReadOnly =
                 ((EditorPartPresenter) source).getEditorInput().getFile().isReadOnly();
-            if (propId == EditorPartPresenter.PROP_INPUT) {
-              editorTab.setReadOnlyMark(isReadOnly);
-              return;
-            }
-
             if (!isReadOnly && propId == EditorPartPresenter.PROP_DIRTY) {
               editorTab.setUnsavedDataMark(((EditorPartPresenter) source).isDirty());
             }
@@ -286,6 +282,12 @@ public class EditorPartStackPresenter extends PartStackPresenter
             }
           });
     }
+
+    if (editorPart instanceof HasReadOnlyProperty) {
+      boolean isReadOnly = editorPart.getEditorInput().getFile().isReadOnly();
+      editorTab.setReadOnlyMark(isReadOnly);
+    }
+
     view.selectTab(editorPart);
   }
 

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -278,6 +278,7 @@ messages.startingMachine=Starting machine \"{0}\"
 messages.startingOperation=Starting {0}
 messages.machine.not.found=Machine {0} not found
 message.projectCreated=Project {0} created
+message.switch.editors.in.readOnly.mode=Workspace agent is not running, opened editors are in read only mode
 
 ############### Buttons ###############################
 ok = OK

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -278,7 +278,7 @@ messages.startingMachine=Starting machine \"{0}\"
 messages.startingOperation=Starting {0}
 messages.machine.not.found=Machine {0} not found
 message.projectCreated=Project {0} created
-message.switch.editors.in.readOnly.mode=Workspace agent is not running, opened editors are in read only mode
+message.switch.editors.in.readOnly.mode=Workspace agent is not running, open editors are switched to read-only mode
 
 ############### Buttons ###############################
 ok = OK


### PR DESCRIPTION
### What does this PR do?
Switch editors in read only mode when ws agent has stopped

### What issues does this PR fix or reference?
#9620 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

![readonly](https://user-images.githubusercontent.com/5676062/40842126-7beffb3e-65b5-11e8-9389-6c42f87193e4.gif)
