### PR TITLE
updated URL for the Camel LSP binary

### DIFF
--- a/agents/ls-camel/src/main/resources/installers/1.0.0/org.eclipse.che.ls.camel.script.sh
+++ b/agents/ls-camel/src/main/resources/installers/1.0.0/org.eclipse.che.ls.camel.script.sh
@@ -27,7 +27,7 @@ unset PACKAGES
 command -v tar >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" tar"; }
 command -v curl >/dev/null 2>&1 || { PACKAGES=${PACKAGES}" curl"; }
 
-AGENT_BINARIES_URI=https://github.com/camel-tooling/camel-language-server/releases/download/untagged-711bc43a03163d77702a/camel-lsp-server-1.0.0-SNAPSHOT.jar
+AGENT_BINARIES_URI=https://github.com/camel-tooling/camel-language-server/releases/download/1.0.0-SNAPSHOT/camel-lsp-server-1.0.0-SNAPSHOT.jar
 CHE_DIR=$HOME/che
 LS_DIR=${CHE_DIR}/ls-camel
 LS_LAUNCHER=${LS_DIR}/launch.sh


### PR DESCRIPTION
### What does this PR do?
This PR updates the download URL for the Camel LSP server binary. (see #9930)

### What issues does this PR fix or reference?
This PR will ensure that the binary is still found when we cleanup the old releases of Camel LSP Server.

#### Release Notes

#### Docs PR
