### PR TITLE
Watch connection manager never closed when trying to delete a non-existing POD

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPods.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPods.java
@@ -15,6 +15,7 @@ import static java.util.concurrent.CompletableFuture.allOf;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.Event;
 import io.fabric8.kubernetes.api.model.ObjectReference;
@@ -553,27 +554,26 @@ public class KubernetesPods {
     }
   }
 
-  private CompletableFuture<Void> doDelete(String name) throws InfrastructureException {
+  @VisibleForTesting
+  CompletableFuture<Void> doDelete(String name) throws InfrastructureException {
     Watch toCloseOnException = null;
     try {
       final PodResource<Pod, DoneablePod> podResource =
           clientFactory.create(workspaceId).pods().inNamespace(namespace).withName(name);
-      CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
+      final CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
       final Watch watch = podResource.watch(new DeleteWatcher(deleteFuture));
       toCloseOnException = watch;
-      deleteFuture =
-          deleteFuture.whenComplete(
-              (v, e) -> {
-                if (e != null) {
-                  LOG.warn("Failed to remove pod {} cause {}", name, e.getMessage());
-                }
-                watch.close();
-              });
       Boolean deleteSucceeded = podResource.delete();
       if (deleteSucceeded == null || !deleteSucceeded) {
-        watch.close();
+        deleteFuture.complete(null);
       }
-      return deleteFuture;
+      return deleteFuture.whenComplete(
+          (v, e) -> {
+            if (e != null) {
+              LOG.warn("Failed to remove pod {} cause {}", name, e.getMessage());
+            }
+            watch.close();
+          });
     } catch (KubernetesClientException ex) {
       if (toCloseOnException != null) {
         toCloseOnException.close();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -20,6 +20,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import io.fabric8.kubernetes.api.model.DoneableNamespace;
 import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
@@ -38,6 +40,7 @@ import io.fabric8.kubernetes.client.dsl.Resource;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.mockito.Mock;
 import org.mockito.stubbing.Answer;
 import org.mockito.testng.MockitoTestNGListener;
@@ -221,6 +224,51 @@ public class KubernetesNamespaceTest {
     new KubernetesPods("", "", clientFactory).doDelete("nonExistingPod").get(5, TimeUnit.SECONDS);
 
     verify(watch).close();
+  }
+
+  @Test
+  public void testDeletePodThrowingKubernetesClientExceptionShouldCloseWatch() throws Exception {
+    final MixedOperation mixedOperation = mock(MixedOperation.class);
+    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
+    final PodResource podResource = mock(PodResource.class);
+    doReturn(mixedOperation).when(kubernetesClient).pods();
+    when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
+    when(namespaceOperation.withName(anyString())).thenReturn(podResource);
+
+    doThrow(KubernetesClientException.class).when(podResource).delete();
+    Watch watch = mock(Watch.class);
+    doReturn(watch).when(podResource).watch(any());
+
+    try {
+      new KubernetesPods("", "", clientFactory).doDelete("nonExistingPod").get(5, TimeUnit.SECONDS);
+    } catch (KubernetesInfrastructureException e) {
+      assertTrue(e.getCause() instanceof KubernetesClientException);
+      verify(watch).close();
+      return;
+    }
+    fail("The exception should have been rethrown");
+  }
+
+  @Test
+  public void testDeletePodThrowingAnyExceptionShouldCloseWatch() throws Exception {
+    final MixedOperation mixedOperation = mock(MixedOperation.class);
+    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
+    final PodResource podResource = mock(PodResource.class);
+    doReturn(mixedOperation).when(kubernetesClient).pods();
+    when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
+    when(namespaceOperation.withName(anyString())).thenReturn(podResource);
+
+    doThrow(RuntimeException.class).when(podResource).delete();
+    Watch watch = mock(Watch.class);
+    doReturn(watch).when(podResource).watch(any());
+
+    try {
+      new KubernetesPods("", "", clientFactory).doDelete("nonExistingPod").get(5, TimeUnit.SECONDS);
+    } catch (RuntimeException e) {
+      verify(watch).close();
+      return;
+    }
+    fail("The exception should have been rethrown");
   }
 
   private MetadataNested prepareCreateNamespaceRequest() {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -209,8 +209,6 @@ public class KubernetesNamespaceTest {
 
   @Test
   public void testDeleteNonExistingPodBeforeWatch() {
-    System.out.println(
-        "Start the test of testDeleteNonExistingPodBeforeWatch testDeleteNonExistingPodBeforeWatch testDeleteNonExistingPodBeforeWatch");
     final MixedOperation mixedOperation = mock(MixedOperation.class);
     final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
     final PodResource podResource = mock(PodResource.class);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -35,9 +35,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.mockito.Mock;
@@ -208,7 +206,7 @@ public class KubernetesNamespaceTest {
   }
 
   @Test
-  public void testDeleteNonExistingPodBeforeWatch() {
+  public void testDeleteNonExistingPodBeforeWatch() throws Exception {
     final MixedOperation mixedOperation = mock(MixedOperation.class);
     final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
     final PodResource podResource = mock(PodResource.class);
@@ -220,14 +218,7 @@ public class KubernetesNamespaceTest {
     Watch watch = mock(Watch.class);
     doReturn(watch).when(podResource).watch(any());
 
-    try {
-      new KubernetesPods("", "", clientFactory).doDelete("nonExistingPod").get(5, TimeUnit.SECONDS);
-    } catch (InfrastructureException
-        | InterruptedException
-        | ExecutionException
-        | TimeoutException e) {
-      e.printStackTrace();
-    }
+    new KubernetesPods("", "", clientFactory).doDelete("nonExistingPod").get(5, TimeUnit.SECONDS);
 
     verify(watch).close();
   }


### PR DESCRIPTION
### What does this PR do?

This PR fixes a nasty bug that occurs in some conditions when trying to delete a non-existing command POD:  the corresponding watch connection manager is never closed and this leads to an infinite loop of regular attempts to reconnect web-sockets to a non-existing POD.
  
### What issues does this PR fix or reference?

This is the root cause of https://github.com/redhat-developer/rh-che/issues/672.
