### PR TITLE
Add support of Workspace Next to Openshift  infrastructure 

### DIFF
--- a/deploy/kubernetes/kubectl/wsnext/feature-api.yaml
+++ b/deploy/kubernetes/kubectl/wsnext/feature-api.yaml
@@ -1,3 +1,9 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
 ---
 apiVersion: v1
 kind: List

--- a/deploy/openshift/Readme.md
+++ b/deploy/openshift/Readme.md
@@ -1,1 +1,1 @@
-Docs are located at [https://www.eclipse.org/che/docs/6/che/docs/openshift-single-user.html](https://www.eclipse.org/che/docs/6/che/docs/openshift-single-user.html).
+Docs are located at [https://www.eclipse.org/che/docs/openshift-single-user.html](https://www.eclipse.org/che/docs/openshift-single-user.html).

--- a/deploy/openshift/templates/che-server-template.yaml
+++ b/deploy/openshift/templates/che-server-template.yaml
@@ -142,6 +142,8 @@ objects:
                 key: ca.crt
                 name: openshift-identity-provider
                 optional: true
+          - name: CHE_WORKSPACE_FEATURE_API
+            value: "http://feature-api-service:3000"
           image: ${IMAGE_CHE}:${CHE_VERSION}
           imagePullPolicy: "${PULL_POLICY}"
           livenessProbe:

--- a/deploy/openshift/templates/wsnext/feature-api.yaml
+++ b/deploy/openshift/templates/wsnext/feature-api.yaml
@@ -1,0 +1,89 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: feature-api
+  annotations:
+    description: Che Workspace Next Feature API
+objects:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: feature-api-service
+  spec:
+    ports:
+    - name: feature-api
+      port: 3000
+      protocol: TCP
+      targetPort: 3000
+    selector:
+      app: feature-api
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: feature-api
+  spec:
+    replicas: 1
+    revisionHistoryLimit: 2
+    selector:
+      app: feature-api
+    strategy:
+      type: ${STRATEGY}
+    template:
+      metadata:
+        labels:
+          app: feature-api
+      spec:
+        containers:
+        - env:
+          - name: CHE_REGISTRY_UPDATE_INTERVAL
+            value: "${CHE_REGISTRY_UPDATE_INTERVAL}"
+          - name: CHE_REGISTRY_GITHUB_URL
+            value: "${CHE_REGISTRY_GITHUB_URL}"
+          image: ${IMAGE}
+          imagePullPolicy: "${PULL_POLICY}"
+          name: feature-api
+          ports:
+          - containerPort: 3000
+            name: feature-api
+          resources:
+            limits:
+              memory: 600Mi
+            requests:
+              memory: 256Mi
+          terminationMessagePath: "/dev/termination-log"
+          terminationMessagePolicy: File
+        restartPolicy: Always
+    triggers:
+    - type: ConfigChange
+
+parameters:
+- name: CHE_REGISTRY_GITHUB_URL
+  displayName: URL of Github repo with Feature API objects
+  description: URL of Github repo that contains Feature API objects
+  value: "https://github.com/garagatyi/che-registry.git"
+- name: CHE_REGISTRY_UPDATE_INTERVAL
+  displayName: Interval of fetching changes from CHE_REGISTRY_GITHUB_URL in seconds
+  description: Specifies how often in seconds Feature API will fetch changes in Feature API objects from Github repo that contains those objects
+  value: "60"
+- name: IMAGE
+  displayName: Feature API image
+  description: Feature API docker image. Defaults to ksmster/kubsrv:0.2.1
+  value: ksmster/kubsrv:0.2.1
+- name: STRATEGY
+  displayName: Update Strategy
+  description: Feature API update strategy. Defaults to Rolling
+  value: 'Rolling'
+- name: PULL_POLICY
+  displayName: Che server image pull policy
+  description: Always pull by default. Can be IfNotPresent
+  value: 'Always'
+labels:
+  app: feature-api
+  template: feature-api

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -24,6 +24,7 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentF
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiExternalEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiInternalEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.EnvVarProvider;
+import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextApplier;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientTermination;
@@ -44,6 +45,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesC
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.LogsRootEnvVariableProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.ServersConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.ExternalServerExposerStrategy;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsnext.KubernetesWorkspaceNextApplier;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProjectFactory;
@@ -95,5 +97,9 @@ public class OpenShiftInfraModule extends AbstractModule {
     Multibinder.newSetBinder(binder(), ServiceTermination.class)
         .addBinding()
         .to(KubernetesClientTermination.class);
+
+    MapBinder<String, WorkspaceNextApplier> wsNext =
+        MapBinder.newMapBinder(binder(), String.class, WorkspaceNextApplier.class);
+    wsNext.addBinding(OpenShiftEnvironment.TYPE).to(KubernetesWorkspaceNextApplier.class);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add support of Workspace Next to Openshift recipe, infrastructure. 
Adds a template to deploy Feature API to Openshift. 

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
