### PR TITLE
Add ability to see and copy commit id value from git history dialog

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitLocalizationConstant.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/GitLocalizationConstant.java
@@ -788,4 +788,7 @@ public interface GitLocalizationConstant extends Messages {
 
   @Key("console.revert.command.name")
   String consoleRevertCommandName();
+
+  @Key("commit.id")
+  String commitID();
 }

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/AlteredFiles.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/AlteredFiles.java
@@ -31,6 +31,8 @@ public class AlteredFiles {
   protected final Project project;
   protected final LinkedHashMap<String, Status> alteredFilesStatuses;
   protected final List<String> alteredFilesList;
+  protected final String commitA;
+  protected final String commitB;
 
   /**
    * Parses raw git diff string and creates advanced representation.
@@ -39,6 +41,10 @@ public class AlteredFiles {
    * @param diff plain result of git diff operation
    */
   public AlteredFiles(Project project, String diff) {
+    this(project, diff, null, null);
+  }
+
+  public AlteredFiles(Project project, String diff, String commitA, String commitB) {
     this.project = project;
 
     alteredFilesStatuses = new LinkedHashMap<>();
@@ -53,6 +59,27 @@ public class AlteredFiles {
     }
 
     alteredFilesList = new ArrayList<>(alteredFilesStatuses.keySet());
+
+    this.commitA = commitA;
+    this.commitB = commitB;
+  }
+
+  /**
+   * Returns the commit A from the current diff.
+   *
+   * @return commit A or {@code null} if such wasn't provided
+   */
+  public String getCommitA() {
+    return commitA;
+  }
+
+  /**
+   * Returns the commit B from the current diff.
+   *
+   * @return commit B or {@code null} if such wasn't provided
+   */
+  public String getCommitB() {
+    return commitB;
   }
 
   /** Returns project in which git repository is located. */

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelViewImpl.java
@@ -14,12 +14,15 @@ import static java.util.Comparator.naturalOrder;
 import static org.eclipse.che.ide.ext.git.client.compare.changespanel.ViewMode.TREE;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.LayoutPanel;
+import com.google.gwt.user.client.ui.TextBox;
 import com.google.inject.Inject;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,6 +46,7 @@ import org.eclipse.che.ide.ui.smartTree.compare.NameComparator;
 import org.eclipse.che.ide.ui.smartTree.data.Node;
 import org.eclipse.che.ide.ui.smartTree.event.SelectionChangedEvent.SelectionChangedHandler;
 import org.eclipse.che.ide.ui.smartTree.presentation.PresentationRenderer;
+import org.eclipse.che.ide.ui.zeroclipboard.ClipboardButtonBuilder;
 
 /**
  * Implementation of {@link ChangesPanelView}.
@@ -58,6 +62,7 @@ public class ChangesPanelViewImpl extends Composite implements ChangesPanelView 
   @UiField Button changeViewModeButton;
   @UiField Button expandButton;
   @UiField Button collapseButton;
+  @UiField TextBox commitHash;
 
   @UiField(provided = true)
   final GitLocalizationConstant locale;
@@ -73,7 +78,10 @@ public class ChangesPanelViewImpl extends Composite implements ChangesPanelView 
 
   @Inject
   public ChangesPanelViewImpl(
-      GitResources resources, GitLocalizationConstant locale, NodesResources nodesResources) {
+      GitResources resources,
+      GitLocalizationConstant locale,
+      NodesResources nodesResources,
+      ClipboardButtonBuilder clipboardButtonBuilder) {
     this.res = resources;
     this.locale = locale;
     this.nodesResources = nodesResources;
@@ -89,6 +97,12 @@ public class ChangesPanelViewImpl extends Composite implements ChangesPanelView 
     changesPanel.add(tree);
 
     createButtons();
+
+    Element copyToClipboardElement = clipboardButtonBuilder.withResourceWidget(commitHash).build();
+    copyToClipboardElement.getStyle().setFloat(Style.Float.RIGHT);
+    copyToClipboardElement.getStyle().setPosition(Style.Position.ABSOLUTE);
+    copyToClipboardElement.getStyle().setTop(0., Style.Unit.PX);
+    copyToClipboardElement.getStyle().setRight(5., Style.Unit.PX);
   }
 
   @Override
@@ -117,6 +131,8 @@ public class ChangesPanelViewImpl extends Composite implements ChangesPanelView 
                       new ChangedFileNode(
                           file, files.getStatusByFilePath(file), res, delegate, false)));
     }
+
+    commitHash.setText(files.getCommitB());
   }
 
   @Override

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelViewImpl.ui.xml
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/changespanel/ChangesPanelViewImpl.ui.xml
@@ -23,6 +23,20 @@
             width: 30px;
             min-width: auto;
         }
+
+        .right {
+            float: right;
+        }
+
+        .commitIdLabel {
+            display: inline;
+            padding-right: 5px;
+        }
+
+        .commitIdTextBox {
+            width: 270px;
+            padding-right: 25px;
+        }
     </ui:style>
 
     <g:DockLayoutPanel width="100%" height="100%">
@@ -31,6 +45,10 @@
                 <g:Button ui:field="changeViewModeButton" addStyleNames="{style.button}"/>
                 <g:Button ui:field="expandButton" addStyleNames="{style.button}"/>
                 <g:Button ui:field="collapseButton" addStyleNames="{style.button}"/>
+                <g:FlowPanel addStyleNames="{style.right}">
+                    <g:Label text="{locale.commitID}" addStyleNames="{style.commitIdLabel}"/>
+                    <g:TextBox ui:field="commitHash" addStyleNames="{style.commitIdTextBox}"/>
+                </g:FlowPanel>
             </g:FlowPanel>
         </g:north>
         <g:center>

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/selectablechangespanel/SelectableChangesPanelViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/selectablechangespanel/SelectableChangesPanelViewImpl.java
@@ -18,6 +18,7 @@ import org.eclipse.che.ide.ext.git.client.GitResources;
 import org.eclipse.che.ide.ext.git.client.compare.changespanel.ChangesPanelViewImpl;
 import org.eclipse.che.ide.project.shared.NodesResources;
 import org.eclipse.che.ide.resource.Path;
+import org.eclipse.che.ide.ui.zeroclipboard.ClipboardButtonBuilder;
 
 /**
  * Implementation of {@link SelectableChangesPanelView}.
@@ -32,8 +33,11 @@ public class SelectableChangesPanelViewImpl extends ChangesPanelViewImpl
 
   @Inject
   public SelectableChangesPanelViewImpl(
-      GitResources resources, GitLocalizationConstant locale, NodesResources nodesResources) {
-    super(resources, locale, nodesResources);
+      GitResources resources,
+      GitLocalizationConstant locale,
+      NodesResources nodesResources,
+      ClipboardButtonBuilder clipboardButtonBuilder) {
+    super(resources, locale, nodesResources, clipboardButtonBuilder);
   }
 
   @Override

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryPresenter.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/history/HistoryPresenter.java
@@ -184,7 +184,7 @@ public class HistoryPresenter implements HistoryView.ActionDelegate {
                     .show();
                 return;
               }
-              AlteredFiles alteredFiles = new AlteredFiles(project, diff);
+              AlteredFiles alteredFiles = new AlteredFiles(project, diff, revisionA, revisionB);
               if (alteredFiles.getFilesQuantity() == 1) {
                 comparePresenter.showCompareBetweenRevisions(
                     alteredFiles, null, revisionA, revisionB);

--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/GitLocalizationConstant.properties
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/resources/org/eclipse/che/ide/ext/git/client/GitLocalizationConstant.properties
@@ -307,3 +307,4 @@ console.revert.command.name=Git revert commit
 commited=Commited
 failed.to.delete.repository=Failed to delete repository
 merge.failed=Failed to merge
+commit.id=Commit ID:


### PR DESCRIPTION
### What does this PR do?
This enhancement proposal adds ability to see and copy git commit id from the file list dialog.

![commit-id](https://user-images.githubusercontent.com/1968177/41219716-dfe8c15c-6d67-11e8-93fb-a2757b1c8bf6.gif)

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#7408 

#### Release Notes
Add ability to see and copy commit id value from git history dialog

#### Docs PR
N/A
