### PR TITLE
Do not initialize Contribution Workflow when process of initialization has started

### DIFF
--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributionMixinProvider.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/ContributionMixinProvider.java
@@ -172,6 +172,7 @@ public class ContributionMixinProvider {
       return;
     }
 
+    lastSelected = project;
     vcsHostingServiceProvider
         .getVcsHostingService(project)
         .then(


### PR DESCRIPTION
### What does this PR do?
We initialize Contribution Workflow  when:
- selection is changed (project is selected)
- part stack is changed (contribute part is active)

To avoid initialization of Contribution Workflow several times when we get a few events simultaneously we should skip the events when process of initialization has started

### What issues does this PR fix or reference?
#9987

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>