### PR TITLE
CHE-6840 Fix bug when closing editor by mouse middle key

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/widgets/editortab/EditorTabWidget.java
@@ -25,6 +25,7 @@ import com.google.gwt.event.dom.client.DoubleClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.IsWidget;
@@ -140,7 +141,19 @@ public class EditorTabWidget extends Composite
   @Override
   public void onBrowserEvent(Event event) {
     if (event.getTypeInt() == Event.ONMOUSEDOWN && event.getButton() == NativeEvent.BUTTON_MIDDLE) {
-      editorAgent.closeEditor(relatedEditorPart);
+      if (editorAgent.getOpenedEditors().size() == 1) {
+        editorAgent.closeEditor(relatedEditorPart);
+      } else {
+        // In some OS paste action is assigned to middle mouse key by default. 'closeEditor'
+        // command restores cursor position in a new editor in the same time when the paste
+        // action fires. So adding 150 ms delay prevents pasting buffer content to the editor.
+        new Timer() {
+          @Override
+          public void run() {
+            editorAgent.closeEditor(relatedEditorPart);
+          }
+        }.schedule(150);
+      }
     }
 
     super.onBrowserEvent(event);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
In some OS paste action is assigned to middle mouse key by default. `closeEditor` command restores cursor position in the new editor in the same time when the paste action fires. So adding 150 ms delay prevents pasting buffer content to the editor.

### What issues does this PR fix or reference?
#6840
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Fix bug when closing editor by mouse middle key

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A