### PR TITLE
Set face name for 'Refresh Contribution Branch Name' button to avoid NPE

### DIFF
--- a/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/parts/contribute/ContributePartViewImpl.java
+++ b/plugins/plugin-pullrequest-parent/che-plugin-pullrequest-ide/src/main/java/org/eclipse/che/plugin/pullrequest/client/parts/contribute/ContributePartViewImpl.java
@@ -12,6 +12,7 @@ package org.eclipse.che.plugin.pullrequest.client.parts.contribute;
 
 import static com.google.gwt.dom.client.Style.Cursor.POINTER;
 import static com.google.gwt.dom.client.Style.Unit.PX;
+import static org.vectomatic.dom.svg.ui.SVGButtonBase.SVGFaceName.UP;
 
 import com.google.gwt.event.dom.client.ChangeEvent;
 import com.google.gwt.event.dom.client.ChangeHandler;
@@ -134,6 +135,7 @@ public class ContributePartViewImpl extends BaseView<ContributePartView.ActionDe
     this.refreshContributionBranchNameListButton.getElement().getStyle().setWidth(23, PX);
     this.refreshContributionBranchNameListButton.getElement().getStyle().setHeight(20, PX);
     this.refreshContributionBranchNameListButton.getElement().getStyle().setCursor(POINTER);
+    this.refreshContributionBranchNameListButton.showFace(UP);
     this.refreshContributionBranchNameListButton
         .getElement()
         .getStyle()


### PR DESCRIPTION
### What does this PR do?
Set face name for 'Refresh Contribution Branch Name' button to avoid NPE

### What issues does this PR fix or reference?
Observed behavior before fix:
![refreshb](https://user-images.githubusercontent.com/5676062/41234970-5b6e9882-6d96-11e8-902e-3783d2694694.gif)


Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
