### PR TITLE
Added che-theia-java-extension to default theia plugins

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-tools/workspace-tools-ide/workspace-tools-ide.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-tools/workspace-tools-ide/workspace-tools-ide.controller.ts
@@ -18,7 +18,8 @@ const CUSTOM_PLUGIN_KEYWORD = 'custom-plugin';
 const PLUGIN_SEPARATOR = ',';
 const PLUGIN_DESCRIPTION_SEPARATOR = ':';
 const DEFAULT_PLUGINS =  ['@theia/typescript', '@theia/navigator', '@theia/terminal', '@theia/outline-view',
-  '@theia/preferences', '@theia/git', '@theia/file-search', '@theia/markers', '@theia/extension-manager'];
+  '@theia/preferences', '@theia/git', '@theia/file-search', '@theia/markers', '@theia/extension-manager',
+  '@eclipse-che/theia-java-extension'];
 
 /**
  * @ngdoc controller

--- a/dockerfiles/theia/src/package.json
+++ b/dockerfiles/theia/src/package.json
@@ -11,7 +11,8 @@
         "@theia/markers": "latest",
         "@theia/extension-manager": "latest",
         "@theia/messages": "latest",
-        "@eclipse-che/theia-factory-extension": "0.0.1-1530189818"
+        "@eclipse-che/theia-factory-extension": "0.0.1-1530189818",
+        "@eclipse-che/theia-java-extension": "latest"
     },
     "devDependencies": {
         "@theia/cli": "latest"


### PR DESCRIPTION
Signed-off-by: jpinkney <josh.pinkney@mail.utoronto.ca>

### What does this PR do?
Adds che-theia-java-extension (which contains stuff that works with che-ls-jdt) to default theia plugins.

The plugin repository is here: https://github.com/eclipse/che-theia-java-plugin

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/8940