### PR TITLE
Increase remove node-loader handler timeout

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/TreeResourceRevealer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/explorer/project/TreeResourceRevealer.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.api.promises.client.callback.AsyncPromiseHelper.cr
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -233,15 +234,13 @@ public class TreeResourceRevealer {
                   if (handler[0] != null) {
                     // Do not remove the handler immediately to not to lose 'loadChildren' events
                     // that were fired after the children request.
-                    Scheduler.get()
-                        .scheduleFixedDelay(
-                            () -> {
-                              handler[0].removeHandler();
-                              return false;
-                            },
-                            1000);
+                    new Timer() {
+                      @Override
+                      public void run() {
+                        handler[0].removeHandler();
+                      }
+                    }.schedule(2000);
                   }
-
                   final List<Node> children =
                       tree.getNodeStorage().getChildren(event.getRequestedNode());
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

We have a bug that sometimes happens on CI: java package does not expand when creating a new java class with sub-directories e.g. `test1.test2.test.3.NewClass.java`. This problem was already fixed by adding a delay before removing the node-loader handler, but it still sometimes happens on CI. Increasing a delay should solve the problem on CI.

### What issues does this PR fix or reference?
#8122 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Increase remove node-loader handler timeout

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A