### PR TITLE
rh-che #703: Adding support of 'Impersonate-*' headers processing in OpenShift infrastructure

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
@@ -16,6 +16,7 @@ import static io.fabric8.kubernetes.client.utils.Utils.isNotNullOrEmpty;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
 import io.fabric8.kubernetes.client.utils.URLUtils;
 import io.fabric8.kubernetes.client.utils.Utils;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
@@ -228,6 +229,7 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
         builder
             .addInterceptor(
                 new OpenShiftOAuthInterceptor(clientHttpClient, OpenShiftConfig.wrap(config)))
+            .addInterceptor(new ImpersonatorInterceptor(config))
             .build();
 
     return new UnclosableOpenShiftClient(clientHttpClient, config);


### PR DESCRIPTION
### What does this PR do?
Adding support of 'Impersonate-*' headers processing via `ImpersonatorInterceptor`

Strarting from ther version `3.1.7` of kubernetes-client there is a support of `Impersonate-*` headers via 
`ImpersonatorInterceptor` [1] [2]. After updating kubernetes-client to the latest `3.1.12` version there is a possibility to support this functionality in OpenShift client that is used in Che

[1] https://github.com/fabric8io/kubernetes-client/blob/master/openshift-client/src/main/java/io/fabric8/openshift/client/DefaultOpenShiftClient.java#L256
[2] https://github.com/fabric8io/kubernetes-client/blob/master/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/ImpersonatorInterceptor.java#L36

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/703

More details could be found in the following rh-che PR https://github.com/redhat-developer/rh-che/pull/688

#### Release Notes
Support of 'Impersonate-*' headers processing in OpenShift infrastructure

#### Docs PR
N/A
