### PR TITLE
Don't trim stack trace and capture skipped selenium test results

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -295,19 +295,26 @@ public abstract class SeleniumTestHandler
 
           testsWithFailure.put(result.getTestClass().getRealClass().getName(), result.getMethod());
 
-          captureScreenshot(result);
-          captureHtmlSource(result);
-          captureTestWorkspaceLogs(result);
-          storeWebDriverLogs(result);
-
           break;
 
         case ITestResult.SKIP:
           LOG.warn("Test {} skipped.", getCompletedTestLabel(result.getMethod()));
+
+          // don't capture test data if test is skipped because of previous test with higher priority
+          // failed
+          if (testsWithFailure.containsKey(result.getMethod().getInstance().getClass().getName())) {
+            return;
+          }
+
           break;
 
         default:
       }
+
+      captureScreenshot(result);
+      captureHtmlSource(result);
+      captureTestWorkspaceLogs(result);
+      storeWebDriverLogs(result);
     }
   }
 

--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -234,6 +234,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <trimStackTrace>false</trimStackTrace>
                             <properties>
                                 <property>
                                     <name>configfailurepolicy</name>


### PR DESCRIPTION
### What does this PR do?
It is fix reporting of Eclipse Che E2E selenium test results:
- to capture test results (screenshots, workspace logs etc.) in case of configuration method failed;
- to expand stack trace in test report:

**before**:
![screenshot from 2018-06-12 16-05-20](https://user-images.githubusercontent.com/1197777/41292268-c0306c22-6e5a-11e8-834c-530a1da3305a.png)
```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 46.324 s <<< FAILURE! - in org.eclipse.che.selenium.miscellaneous.DialogAboutTest
[ERROR] dialogAboutTest(org.eclipse.che.selenium.miscellaneous.DialogAboutTest)  Time elapsed: 33.701 s  <<< FAILURE!
java.lang.AssertionError: null
	at org.eclipse.che.selenium.miscellaneous.DialogAboutTest.dialogAboutTest(DialogAboutTest.java:33)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   DialogAboutTest.dialogAboutTest:33 null
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

**after**:
![screenshot from 2018-06-12 15-56-30](https://user-images.githubusercontent.com/1197777/41292277-c2fdc2e2-6e5a-11e8-85c4-253dbda296e4.png)
```
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 2, Time elapsed: 12.128 s <<< FAILURE! - in org.eclipse.che.selenium.miscellaneous.DialogAboutTest
[ERROR] setup(org.eclipse.che.selenium.miscellaneous.DialogAboutTest)  Time elapsed: 10.272 s  <<< FAILURE!
java.lang.AssertionError: null
	at org.testng.Assert.fail(Assert.java:94)
	at org.testng.Assert.fail(Assert.java:101)
	at org.eclipse.che.selenium.miscellaneous.DialogAboutTest.setup(DialogAboutTest.java:33)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:85)
	at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:552)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:215)
	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:140)
	at org.testng.internal.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:170)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:104)
	at org.testng.TestRunner.privateRun(TestRunner.java:767)
	at org.testng.TestRunner.run(TestRunner.java:617)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:348)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:343)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:305)
	at org.testng.SuiteRunner.run(SuiteRunner.java:254)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1224)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1149)
	at org.testng.TestNG.run(TestNG.java:1057)
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:135)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:99)
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:146)
	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:373)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:334)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:119)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:407)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   DialogAboutTest.setup:33 null
[INFO] 
[ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 2
```
