### PR TITLE
Use Deployments instead of Pods in Kubernetes/OpenShift infra

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
@@ -190,7 +190,7 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
   private void exec(BiConsumer<String, String> outputConsumer, String... command)
       throws InfrastructureException {
     namespace
-        .pods()
+        .deployments()
         .exec(
             kubernetesMachine.getPodName(),
             kubernetesMachine.getContainerName(),
@@ -201,7 +201,7 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
 
   private void exec(String... command) throws InfrastructureException {
     namespace
-        .pods()
+        .deployments()
         .exec(
             kubernetesMachine.getPodName(),
             kubernetesMachine.getContainerName(),

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -58,7 +58,7 @@ public class KubernetesNamespace {
   private final String workspaceId;
   private final String name;
 
-  private final KubernetesPods pods;
+  private final KubernetesDeployments deployments;
   private final KubernetesServices services;
   private final KubernetesPersistentVolumeClaims pvcs;
   private final KubernetesIngresses ingresses;
@@ -70,7 +70,7 @@ public class KubernetesNamespace {
       KubernetesClientFactory clientFactory,
       String workspaceId,
       String name,
-      KubernetesPods pods,
+      KubernetesDeployments deployments,
       KubernetesServices services,
       KubernetesPersistentVolumeClaims pvcs,
       KubernetesIngresses kubernetesIngresses,
@@ -78,7 +78,7 @@ public class KubernetesNamespace {
     this.clientFactory = clientFactory;
     this.workspaceId = workspaceId;
     this.name = name;
-    this.pods = pods;
+    this.deployments = deployments;
     this.services = services;
     this.pvcs = pvcs;
     this.ingresses = kubernetesIngresses;
@@ -90,7 +90,7 @@ public class KubernetesNamespace {
     this.clientFactory = clientFactory;
     this.workspaceId = workspaceId;
     this.name = name;
-    this.pods = new KubernetesPods(name, workspaceId, clientFactory);
+    this.deployments = new KubernetesDeployments(name, workspaceId, clientFactory);
     this.services = new KubernetesServices(name, workspaceId, clientFactory);
     this.pvcs = new KubernetesPersistentVolumeClaims(name, workspaceId, clientFactory);
     this.ingresses = new KubernetesIngresses(name, workspaceId, clientFactory);
@@ -122,8 +122,8 @@ public class KubernetesNamespace {
   }
 
   /** Returns object for managing {@link Pod} instances inside namespace. */
-  public KubernetesPods pods() {
-    return pods;
+  public KubernetesDeployments deployments() {
+    return deployments;
   }
 
   /** Returns object for managing {@link Service} instances inside namespace. */
@@ -148,7 +148,7 @@ public class KubernetesNamespace {
 
   /** Removes all object except persistent volume claims inside namespace. */
   public void cleanUp() throws InfrastructureException {
-    doRemove(ingresses::delete, services::delete, pods::delete, secrets::delete);
+    doRemove(ingresses::delete, services::delete, deployments::delete, secrets::delete);
   }
 
   /**

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -27,16 +27,20 @@ import io.fabric8.kubernetes.api.model.DoneableNamespace;
 import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceFluent.MetadataNested;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.Watcher.Action;
+import io.fabric8.kubernetes.client.dsl.ExtensionsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
@@ -59,7 +63,7 @@ public class KubernetesNamespaceTest {
   public static final String NAMESPACE = "testNamespace";
   public static final String WORKSPACE_ID = "workspace123";
 
-  @Mock private KubernetesPods pods;
+  @Mock private KubernetesDeployments deployments;
   @Mock private KubernetesServices services;
   @Mock private KubernetesIngresses ingresses;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
@@ -68,6 +72,19 @@ public class KubernetesNamespaceTest {
   @Mock private KubernetesClient kubernetesClient;
   @Mock private NonNamespaceOperation namespaceOperation;
   @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
+
+  // Deployments Mocks
+  @Mock private ExtensionsAPIGroupDSL extensions;
+  @Mock private MixedOperation deploymentsMixedOperation;
+  @Mock private NonNamespaceOperation deploymentsNamespaceOperation;
+  @Mock private ScalableResource deploymentResource;
+
+  // Pod Mocks
+  @Mock private MixedOperation podsMixedOperation;
+  @Mock private NonNamespaceOperation podsNamespaceOperation;
+  @Mock private PodResource podResource;
+  @Mock private Pod pod;
+  @Mock private ObjectMeta podMetadata;
 
   private KubernetesNamespace k8sNamespace;
 
@@ -85,9 +102,30 @@ public class KubernetesNamespaceTest {
     when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
     when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
 
+    // Model DSL: client.pods().inNamespace(...).withName(...).get().getMetadata().getName();
+    doReturn(podsMixedOperation).when(kubernetesClient).pods();
+    doReturn(podsNamespaceOperation).when(podsMixedOperation).inNamespace(anyString());
+    doReturn(podResource).when(podsNamespaceOperation).withName(anyString());
+    doReturn(pod).when(podResource).get();
+    doReturn(podMetadata).when(pod).getMetadata();
+
+    doReturn(extensions).when(kubernetesClient).extensions();
+    doReturn(deploymentsMixedOperation).when(extensions).deployments();
+    doReturn(deploymentsNamespaceOperation)
+        .when(deploymentsMixedOperation)
+        .inNamespace(anyString());
+    doReturn(deploymentResource).when(deploymentsNamespaceOperation).withName(anyString());
+
     k8sNamespace =
         new KubernetesNamespace(
-            clientFactory, WORKSPACE_ID, NAMESPACE, pods, services, pvcs, ingresses, secrets);
+            clientFactory,
+            WORKSPACE_ID,
+            NAMESPACE,
+            deployments,
+            services,
+            pvcs,
+            ingresses,
+            secrets);
   }
 
   @Test
@@ -123,14 +161,14 @@ public class KubernetesNamespaceTest {
 
     verify(ingresses).delete();
     verify(services).delete();
-    verify(pods).delete();
+    verify(deployments).delete();
     verify(secrets).delete();
   }
 
   @Test
   public void testKubernetesNamespaceCleaningUpIfExceptionsOccurs() throws Exception {
     doThrow(new InfrastructureException("err1.")).when(services).delete();
-    doThrow(new InfrastructureException("err2.")).when(pods).delete();
+    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
 
     InfrastructureException error = null;
     // when
@@ -212,37 +250,29 @@ public class KubernetesNamespaceTest {
 
   @Test
   public void testDeleteNonExistingPodBeforeWatch() throws Exception {
-    final MixedOperation mixedOperation = mock(MixedOperation.class);
-    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-    final PodResource podResource = mock(PodResource.class);
-    doReturn(mixedOperation).when(kubernetesClient).pods();
-    when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-    when(namespaceOperation.withName(anyString())).thenReturn(podResource);
+    final String POD_NAME = "nonExistingPod";
+    doReturn(POD_NAME).when(podMetadata).getName();
 
     doReturn(Boolean.FALSE).when(podResource).delete();
     Watch watch = mock(Watch.class);
     doReturn(watch).when(podResource).watch(any());
 
-    new KubernetesPods("", "", clientFactory).doDelete("nonExistingPod").get(5, TimeUnit.SECONDS);
+    new KubernetesDeployments("", "", clientFactory).doDelete(POD_NAME).get(5, TimeUnit.SECONDS);
 
     verify(watch).close();
   }
 
   @Test
   public void testDeletePodThrowingKubernetesClientExceptionShouldCloseWatch() throws Exception {
-    final MixedOperation mixedOperation = mock(MixedOperation.class);
-    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-    final PodResource podResource = mock(PodResource.class);
-    doReturn(mixedOperation).when(kubernetesClient).pods();
-    when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-    when(namespaceOperation.withName(anyString())).thenReturn(podResource);
+    final String POD_NAME = "nonExistingPod";
+    doReturn(POD_NAME).when(podMetadata).getName();
 
     doThrow(KubernetesClientException.class).when(podResource).delete();
     Watch watch = mock(Watch.class);
     doReturn(watch).when(podResource).watch(any());
 
     try {
-      new KubernetesPods("", "", clientFactory).doDelete("nonExistingPod").get(5, TimeUnit.SECONDS);
+      new KubernetesDeployments("", "", clientFactory).doDelete(POD_NAME).get(5, TimeUnit.SECONDS);
     } catch (KubernetesInfrastructureException e) {
       assertTrue(e.getCause() instanceof KubernetesClientException);
       verify(watch).close();
@@ -253,19 +283,15 @@ public class KubernetesNamespaceTest {
 
   @Test
   public void testDeletePodThrowingAnyExceptionShouldCloseWatch() throws Exception {
-    final MixedOperation mixedOperation = mock(MixedOperation.class);
-    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-    final PodResource podResource = mock(PodResource.class);
-    doReturn(mixedOperation).when(kubernetesClient).pods();
-    when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-    when(namespaceOperation.withName(anyString())).thenReturn(podResource);
+    final String POD_NAME = "nonExistingPod";
+    doReturn(POD_NAME).when(podMetadata).getName();
 
     doThrow(RuntimeException.class).when(podResource).delete();
     Watch watch = mock(Watch.class);
     doReturn(watch).when(podResource).watch(any());
 
     try {
-      new KubernetesPods("", "", clientFactory).doDelete("nonExistingPod").get(5, TimeUnit.SECONDS);
+      new KubernetesDeployments("", "", clientFactory).doDelete(POD_NAME).get(5, TimeUnit.SECONDS);
     } catch (RuntimeException e) {
       verify(watch).close();
       return;

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -110,10 +110,10 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
     // TODO https://github.com/eclipse/che/issues/7653
     // project.pods().watch(new AbnormalStopHandler());
 
-    project.pods().watchEvents(new MachineLogsPublisher());
+    project.deployments().watchEvents(new MachineLogsPublisher());
     if (!unrecoverableEvents.isEmpty()) {
       Map<String, Pod> pods = getContext().getEnvironment().getPods();
-      project.pods().watchEvents(new UnrecoverablePodEventHandler(pods));
+      project.deployments().watchEvents(new UnrecoverablePodEventHandler(pods));
     }
 
     doStartMachine(new OpenShiftServerResolver(createdServices, createdRoutes));

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -18,10 +18,10 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPods;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
@@ -41,13 +41,13 @@ public class OpenShiftProject extends KubernetesNamespace {
       OpenShiftClientFactory clientFactory,
       String workspaceId,
       String name,
-      KubernetesPods pods,
+      KubernetesDeployments deployments,
       KubernetesServices services,
       OpenShiftRoutes routes,
       KubernetesPersistentVolumeClaims pvcs,
       KubernetesIngresses ingresses,
       KubernetesSecrets secrets) {
-    super(clientFactory, workspaceId, name, pods, services, pvcs, ingresses, secrets);
+    super(clientFactory, workspaceId, name, deployments, services, pvcs, ingresses, secrets);
     this.clientFactory = clientFactory;
     this.routes = routes;
   }
@@ -84,7 +84,7 @@ public class OpenShiftProject extends KubernetesNamespace {
 
   /** Removes all object except persistent volume claims inside project. */
   public void cleanUp() throws InfrastructureException {
-    doRemove(routes::delete, services()::delete, pods()::delete, secrets()::delete);
+    doRemove(routes::delete, services()::delete, deployments()::delete, secrets()::delete);
   }
 
   private void create(String projectName, KubernetesClient kubeClient, OpenShiftClient ocClient)

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -70,7 +70,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.Kubernet
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPods;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
@@ -126,7 +126,7 @@ public class OpenShiftInternalRuntimeTest {
   @Mock private KubernetesServices services;
   @Mock private KubernetesSecrets secrets;
   @Mock private OpenShiftRoutes routes;
-  @Mock private KubernetesPods pods;
+  @Mock private KubernetesDeployments deployments;
   @Mock private KubernetesBootstrapper bootstrapper;
   @Mock private WorkspaceVolumesStrategy volumesStrategy;
   @Mock private WorkspaceProbesFactory workspaceProbesFactory;
@@ -195,7 +195,7 @@ public class OpenShiftInternalRuntimeTest {
     when(project.services()).thenReturn(services);
     when(project.routes()).thenReturn(routes);
     when(project.secrets()).thenReturn(secrets);
-    when(project.pods()).thenReturn(pods);
+    when(project.deployments()).thenReturn(deployments);
     when(bootstrapperFactory.create(any(), anyList(), any(), any(), any()))
         .thenReturn(bootstrapper);
     doReturn(
@@ -213,7 +213,7 @@ public class OpenShiftInternalRuntimeTest {
         ImmutableMap.of(POD_NAME, mockPod(ImmutableList.of(container)));
     when(services.create(any())).thenAnswer(a -> a.getArguments()[0]);
     when(routes.create(any())).thenAnswer(a -> a.getArguments()[0]);
-    when(pods.create(any())).thenAnswer(a -> a.getArguments()[0]);
+    when(deployments.deploy(any())).thenAnswer(a -> a.getArguments()[0]);
     when(osEnv.getServices()).thenReturn(allServices);
     when(osEnv.getRoutes()).thenReturn(allRoutes);
     when(osEnv.getPods()).thenReturn(allPods);
@@ -230,12 +230,12 @@ public class OpenShiftInternalRuntimeTest {
 
     internalRuntime.startMachines();
 
-    verify(pods).create(any());
+    verify(deployments).deploy(any());
     verify(routes).create(any());
     verify(services).create(any());
     verify(secrets).create(any());
 
-    verify(project.pods(), times(2)).watchEvents(any());
+    verify(project.deployments(), times(2)).watchEvents(any());
     verify(eventService, times(2)).publish(any());
     verifyEventsOrder(newEvent(M1_NAME, STARTING), newEvent(M2_NAME, STARTING));
   }
@@ -250,11 +250,11 @@ public class OpenShiftInternalRuntimeTest {
 
     internalRuntimeWithoutUnrecoverableEventHandler.startMachines();
 
-    verify(pods).create(any());
+    verify(deployments).deploy(any());
     verify(routes).create(any());
     verify(services).create(any());
 
-    verify(project.pods(), times(1)).watchEvents(any());
+    verify(project.deployments(), times(1)).watchEvents(any());
     verify(eventService, times(2)).publish(any());
     verifyEventsOrder(newEvent(M1_NAME, STARTING), newEvent(M2_NAME, STARTING));
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -32,9 +32,9 @@ import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPods;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
@@ -55,7 +55,7 @@ public class OpenShiftProjectTest {
   public static final String PROJECT_NAME = "testProject";
   public static final String WORKSPACE_ID = "workspace123";
 
-  @Mock private KubernetesPods pods;
+  @Mock private KubernetesDeployments deployments;
   @Mock private KubernetesServices services;
   @Mock private OpenShiftRoutes routes;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
@@ -88,7 +88,7 @@ public class OpenShiftProjectTest {
             clientFactory,
             WORKSPACE_ID,
             PROJECT_NAME,
-            pods,
+            deployments,
             services,
             routes,
             pvcs,
@@ -131,14 +131,14 @@ public class OpenShiftProjectTest {
 
     verify(routes).delete();
     verify(services).delete();
-    verify(pods).delete();
+    verify(deployments).delete();
     verify(secrets).delete();
   }
 
   @Test
   public void testOpenShiftProjectCleaningUpIfExceptionsOccurs() throws Exception {
     doThrow(new InfrastructureException("err1.")).when(services).delete();
-    doThrow(new InfrastructureException("err2.")).when(pods).delete();
+    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
 
     InfrastructureException error = null;
     // when


### PR DESCRIPTION
### What does this PR do?
Changes OpenShift infrastucture to use `DeploymentConfig`s instead of `Pod`s for workspace machines.

### What issues does this PR fix or reference?
This is related to an issue ([rh-che#668](https://github.com/redhat-developer/rh-che/issues/668)).

In OpenShift, using a `DeploymentConfig` instead of a bare `Pod` for workspaces makes more sense, as loose `Pod`s are intended to be used for short-running jobs. As we intend workspaces to run until terminated by a user, a `DeploymentConfig` makes more sense in this context.

Further, using `DeploymentConfigs` could enable us to use some of OpenShift's features for managing running workspaces later. 

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Use Deployments instead of Pods for managing workspaces when using Kubernetes/Openshift infrastructure.

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A