### PR TITLE
Add option not to start test workspaces after creation

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -300,8 +300,8 @@ public abstract class SeleniumTestHandler
         case ITestResult.SKIP:
           LOG.warn("Test {} skipped.", getCompletedTestLabel(result.getMethod()));
 
-          // don't capture test data if test is skipped because of previous test with higher priority
-          // failed
+          // don't capture test data if test is skipped because of previous test with higher
+          // priority failed
           if (testsWithFailure.containsKey(result.getMethod().getInstance().getClass().getName())) {
             return;
           }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/InjectTestWorkspace.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/InjectTestWorkspace.java
@@ -21,7 +21,7 @@ import org.eclipse.che.selenium.core.user.DefaultTestUser;
 /**
  * To instantiate {@link TestWorkspace} in test classes with none default parameters.
  *
- * @see TestWorkspaceProvider#createWorkspace(DefaultTestUser, int, String)
+ * @see TestWorkspaceProvider#createWorkspace(DefaultTestUser, int, String, boolean)
  * @author Anatolii Bazko
  */
 @Target({FIELD})
@@ -39,4 +39,7 @@ public @interface InjectTestWorkspace {
 
   /** The workspace owner. If value is empty then default user will be used. */
   String user() default "";
+
+  /** Should we start workspace just after creation. */
+  boolean startAfterCreation() default true;
 }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceImpl.java
@@ -38,6 +38,7 @@ public class TestWorkspaceImpl implements TestWorkspace {
       String name,
       DefaultTestUser owner,
       int memoryInGB,
+      boolean startAfterCreation,
       WorkspaceConfigDto template,
       TestWorkspaceServiceClient testWorkspaceServiceClient) {
     if (template == null) {
@@ -56,12 +57,15 @@ public class TestWorkspaceImpl implements TestWorkspace {
                 final Workspace ws =
                     workspaceServiceClient.createWorkspace(name, memoryInGB, GB, template);
                 long start = System.currentTimeMillis();
-                workspaceServiceClient.start(id.updateAndGet((s) -> ws.getId()), name, owner);
-                LOG.info(
-                    "Workspace name='{}' id='{}' started in {} sec.",
-                    name,
-                    ws.getId(),
-                    (System.currentTimeMillis() - start) / 1000);
+
+                if (startAfterCreation) {
+                  workspaceServiceClient.start(id.updateAndGet((s) -> ws.getId()), name, owner);
+                  LOG.info(
+                      "Workspace name='{}' id='{}' started in {} sec.",
+                      name,
+                      ws.getId(),
+                      (System.currentTimeMillis() - start) / 1000);
+                }
               } catch (Exception e) {
                 String errorMessage = format("Workspace name='%s' start failed.", name);
                 LOG.error(errorMessage, e);

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceInjector.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceInjector.java
@@ -58,7 +58,11 @@ public class TestWorkspaceInjector<T> implements MembersInjector<T> {
               : injectTestWorkspace.memoryGb();
 
       TestWorkspace testWorkspace =
-          testWorkspaceProvider.createWorkspace(testUser, memoryGb, injectTestWorkspace.template());
+          testWorkspaceProvider.createWorkspace(
+              testUser,
+              memoryGb,
+              injectTestWorkspace.template(),
+              injectTestWorkspace.startAfterCreation());
       testWorkspace.await();
 
       field.setAccessible(true);

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceProvider.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceProvider.java
@@ -25,8 +25,10 @@ public interface TestWorkspaceProvider {
    * @param owner the workspace owner
    * @param memoryGB the workspace memory size in GB
    * @param template the workspace template {@link WorkspaceTemplate}
+   * @param startAfterCreation start workspace just after creation, if <bold>true</bold>
    */
-  TestWorkspace createWorkspace(DefaultTestUser owner, int memoryGB, String template)
+  TestWorkspace createWorkspace(
+      DefaultTestUser owner, int memoryGB, String template, boolean startAfterCreation)
       throws Exception;
 
   /** Release all allocated resources. */

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceProviderImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceProviderImpl.java
@@ -78,9 +78,10 @@ public class TestWorkspaceProviderImpl implements TestWorkspaceProvider {
   }
 
   @Override
-  public TestWorkspace createWorkspace(DefaultTestUser owner, int memoryGB, String template)
+  public TestWorkspace createWorkspace(
+      DefaultTestUser owner, int memoryGB, String template, boolean startAfterCreation)
       throws Exception {
-    if (poolSize > 0 && hasDefaultValues(owner, memoryGB, template)) {
+    if (poolSize > 0 && hasDefaultValues(owner, memoryGB, template, startAfterCreation)) {
       return doGetWorkspaceFromPool();
     }
 
@@ -88,14 +89,17 @@ public class TestWorkspaceProviderImpl implements TestWorkspaceProvider {
         generateName(),
         owner,
         memoryGB,
+        startAfterCreation,
         workspaceDtoDeserializer.deserializeWorkspaceTemplate(template),
         testWorkspaceServiceClientFactory.create(owner));
   }
 
-  private boolean hasDefaultValues(DefaultTestUser testUser, int memoryGB, String template) {
+  private boolean hasDefaultValues(
+      DefaultTestUser testUser, int memoryGB, String template, boolean startAfterCreation) {
     return memoryGB == defaultMemoryGb
         && WorkspaceTemplate.DEFAULT.equals(template)
-        && testUser.getEmail().equals(defaultUser.getEmail());
+        && testUser.getEmail().equals(defaultUser.getEmail())
+        && startAfterCreation;
   }
 
   private TestWorkspace doGetWorkspaceFromPool() throws Exception {
@@ -189,6 +193,7 @@ public class TestWorkspaceProviderImpl implements TestWorkspaceProvider {
                       name,
                       defaultUser,
                       defaultMemoryGb,
+                      true,
                       workspaceDtoDeserializer.deserializeWorkspaceTemplate(
                           WorkspaceTemplate.DEFAULT),
                       testWorkspaceServiceClient);

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
@@ -145,7 +145,7 @@ public class CheSeleniumSuiteModule extends AbstractModule {
       DefaultTestUser testUser,
       @Named("workspace.default_memory_gb") int defaultMemoryGb)
       throws Exception {
-    TestWorkspace ws = workspaceProvider.createWorkspace(testUser, defaultMemoryGb, DEFAULT);
+    TestWorkspace ws = workspaceProvider.createWorkspace(testUser, defaultMemoryGb, DEFAULT, true);
     ws.await();
     return ws;
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/gwt/CheckSimpleGwtAppTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/gwt/CheckSimpleGwtAppTest.java
@@ -88,6 +88,7 @@ public class CheckSimpleGwtAppTest {
             NameGenerator.generate("check-gwt-test", 4),
             testUser,
             4,
+            true,
             workspace,
             workspaceServiceClient);
 


### PR DESCRIPTION
## What does this PR do?
It allows to define test workspace which should be created without starting just after creation, for example:
```
@InjectTestWorkspace(startAfterCreation = false)
TestWorkspace testWorkspace;
```

### What issues does this PR fix or reference?
#10008 