### PR TITLE
CHE-8164: Fix error when creating project from archetype

### DIFF
--- a/plugins/plugin-maven/che-plugin-maven-generator-archetype/pom.xml
+++ b/plugins/plugin-maven/che-plugin-maven-generator-archetype/pom.xml
@@ -47,16 +47,16 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-dto</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-project</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>

--- a/plugins/plugin-maven/che-plugin-maven-generator-archetype/src/main/java/org/eclipse/che/plugin/maven/generator/archetype/ArchetypeGenerator.java
+++ b/plugins/plugin-maven/che-plugin-maven-generator-archetype/src/main/java/org/eclipse/che/plugin/maven/generator/archetype/ArchetypeGenerator.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.plugin.maven.generator.archetype;
 
+import static java.io.File.separator;
 import static org.eclipse.che.plugin.maven.shared.dto.ArchetypeOutput.State.DONE;
 import static org.eclipse.che.plugin.maven.shared.dto.ArchetypeOutput.State.ERROR;
 
@@ -22,7 +23,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.validation.constraints.NotNull;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.util.AbstractLineConsumer;
@@ -31,6 +33,7 @@ import org.eclipse.che.api.core.util.LineConsumer;
 import org.eclipse.che.api.core.util.ProcessUtil;
 import org.eclipse.che.api.core.util.ValueHolder;
 import org.eclipse.che.api.core.util.Watchdog;
+import org.eclipse.che.api.fs.server.FsManager;
 import org.eclipse.che.ide.maven.tools.MavenArtifact;
 import org.eclipse.che.ide.maven.tools.MavenUtils;
 import org.eclipse.che.plugin.maven.shared.MavenArchetype;
@@ -48,22 +51,25 @@ public class ArchetypeGenerator {
   private static final Logger LOG = LoggerFactory.getLogger(ArchetypeGenerator.class);
 
   private EventService eventService;
+  private final FsManager fsManager;
 
   @Inject
-  public ArchetypeGenerator(EventService eventService) {
+  public ArchetypeGenerator(EventService eventService, FsManager fsManager) {
     this.eventService = eventService;
+    this.fsManager = fsManager;
   }
 
   /**
    * Generates a new project from the specified archetype by given maven artifact descriptor.
    *
+   * @param projectName name of the project
    * @param workDir folder where command will execute in common use root dir of workspace
    * @param archetype archetype from which need to generate new project
    * @param mavenArtifact maven artifact descriptor
    * @throws ServerException if an error occurs while generating project
    */
   public void generateFromArchetype(
-      @NotNull File workDir, @NotNull MavenArchetype archetype, MavenArtifact mavenArtifact)
+      String projectName, File workDir, MavenArchetype archetype, MavenArtifact mavenArtifact)
       throws ServerException {
     Map<String, String> archetypeProperties = new HashMap<>();
     archetypeProperties.put(
@@ -74,6 +80,7 @@ public class ArchetypeGenerator {
     archetypeProperties.put("-DgroupId", mavenArtifact.getGroupId());
     archetypeProperties.put("-DartifactId", mavenArtifact.getArtifactId());
     archetypeProperties.put("-Dversion", mavenArtifact.getVersion());
+    archetypeProperties.put("-Dbasedir", workDir.toPath().resolve(projectName).toString());
     if (archetype.getRepository() != null) {
       archetypeProperties.put("-DarchetypeRepository", archetype.getRepository());
     }
@@ -83,11 +90,18 @@ public class ArchetypeGenerator {
     final CommandLine commandLine = createCommandLine(archetypeProperties);
     try {
       execute(commandLine.toShellCommand(), workDir);
-    } catch (TimeoutException e) {
-      LOG.error(e.getMessage());
-    } catch (IOException e) {
-      LOG.error(e.getMessage());
-    } catch (InterruptedException e) {
+      // TODO Remove this block and use 'basedir' option of the Maven Archetype Plugin when the
+      // related issue will be solved: https://issues.apache.org/jira/browse/ARCHETYPE-311.
+      // Maven Archetype Plugin creates project directory with 'artifact-id' name, so need to rename
+      // it to specified project name.
+      if (!fsManager.exists(projectName) && fsManager.exists(mavenArtifact.getArtifactId())) {
+        fsManager.move(separator + mavenArtifact.getArtifactId(), separator + projectName);
+      }
+    } catch (TimeoutException
+        | IOException
+        | InterruptedException
+        | ConflictException
+        | NotFoundException e) {
       LOG.error(e.getMessage());
     }
   }

--- a/plugins/plugin-maven/che-plugin-maven-generator-archetype/src/test/java/org/eclipse/che/plugin/maven/generator/archetype/ArchetypeGeneratorTest.java
+++ b/plugins/plugin-maven/che-plugin-maven-generator-archetype/src/test/java/org/eclipse/che/plugin/maven/generator/archetype/ArchetypeGeneratorTest.java
@@ -18,6 +18,7 @@ import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.List;
 import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.fs.server.FsManager;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.ide.maven.tools.MavenArtifact;
 import org.eclipse.che.plugin.maven.shared.MavenArchetype;
@@ -41,14 +42,15 @@ public class ArchetypeGeneratorTest {
     when(mavenArchetype.getGroupId()).thenReturn("org.apache.openejb.maven");
     when(mavenArchetype.getVersion()).thenReturn("1.7.1");
     File workDir = Files.createTempDirectory("workDir").toFile();
-    ArchetypeGenerator archetypeGenerator = new ArchetypeGenerator(eventService);
+    ArchetypeGenerator archetypeGenerator =
+        new ArchetypeGenerator(eventService, mock(FsManager.class));
     String artifactId = NameGenerator.generate("artifactId", 5);
     String groupId = NameGenerator.generate("groupId", 5);
     MavenArtifact mavenArtifact = new MavenArtifact();
     mavenArtifact.setArtifactId(artifactId);
     mavenArtifact.setGroupId(groupId);
     mavenArtifact.setVersion("1.0-SNAPSHOT");
-    archetypeGenerator.generateFromArchetype(workDir, mavenArchetype, mavenArtifact);
+    archetypeGenerator.generateFromArchetype("projectName", workDir, mavenArchetype, mavenArtifact);
     String[] list = workDir.list();
     List<String> strings = Arrays.asList(list);
     Assert.assertTrue(strings.contains(artifactId));

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/projecttype/handler/ArchetypeGenerationStrategy.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/projecttype/handler/ArchetypeGenerationStrategy.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.project.server.impl.RootDirPathProvider;
 import org.eclipse.che.api.project.server.type.AttributeValue;
 import org.eclipse.che.ide.maven.tools.MavenArtifact;
 import org.eclipse.che.plugin.maven.generator.archetype.ArchetypeGenerator;
@@ -41,10 +42,13 @@ import org.eclipse.che.plugin.maven.shared.MavenArchetype;
 public class ArchetypeGenerationStrategy implements GeneratorStrategy {
 
   private final ArchetypeGenerator archetypeGenerator;
+  private final RootDirPathProvider rootDirPathProvider;
 
   @Inject
-  public ArchetypeGenerationStrategy(ArchetypeGenerator archetypeGenerator) {
+  public ArchetypeGenerationStrategy(
+      ArchetypeGenerator archetypeGenerator, RootDirPathProvider rootDirPathProvider) {
     this.archetypeGenerator = archetypeGenerator;
+    this.rootDirPathProvider = rootDirPathProvider;
   }
 
   public String getId() {
@@ -110,6 +114,6 @@ public class ArchetypeGenerationStrategy implements GeneratorStrategy {
     mavenArtifact.setArtifactId(getFirst(artifactId.getList(), projectName));
     mavenArtifact.setVersion(getFirst(version.getList(), DEFAULT_VERSION));
     archetypeGenerator.generateFromArchetype(
-        projectName, new File("/projects"), mavenArchetype, mavenArtifact);
+        projectName, new File(rootDirPathProvider.get()), mavenArchetype, mavenArtifact);
   }
 }

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/projecttype/handler/ArchetypeGenerationStrategy.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/projecttype/handler/ArchetypeGenerationStrategy.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.eclipse.che.api.core.ConflictException;
-import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.project.server.type.AttributeValue;
 import org.eclipse.che.ide.maven.tools.MavenArtifact;
@@ -45,7 +43,7 @@ public class ArchetypeGenerationStrategy implements GeneratorStrategy {
   private final ArchetypeGenerator archetypeGenerator;
 
   @Inject
-  public ArchetypeGenerationStrategy(ArchetypeGenerator archetypeGenerator) throws ServerException {
+  public ArchetypeGenerationStrategy(ArchetypeGenerator archetypeGenerator) {
     this.archetypeGenerator = archetypeGenerator;
   }
 
@@ -56,7 +54,7 @@ public class ArchetypeGenerationStrategy implements GeneratorStrategy {
   @Override
   public void generateProject(
       String projectPath, Map<String, AttributeValue> attributes, Map<String, String> options)
-      throws ForbiddenException, ConflictException, ServerException {
+      throws ServerException {
 
     AttributeValue artifactId = attributes.get(ARTIFACT_ID);
     AttributeValue groupId = attributes.get(GROUP_ID);
@@ -106,11 +104,12 @@ public class ArchetypeGenerationStrategy implements GeneratorStrategy {
             archetypeRepository,
             archetypeProperties);
 
-    String projectName = projectPath.substring(projectPath.lastIndexOf(separator));
+    String projectName = projectPath.substring(projectPath.lastIndexOf(separator) + 1);
     final MavenArtifact mavenArtifact = new MavenArtifact();
     mavenArtifact.setGroupId(getFirst(groupId.getList(), projectName));
     mavenArtifact.setArtifactId(getFirst(artifactId.getList(), projectName));
     mavenArtifact.setVersion(getFirst(version.getList(), DEFAULT_VERSION));
-    archetypeGenerator.generateFromArchetype(new File("/projects"), mavenArchetype, mavenArtifact);
+    archetypeGenerator.generateFromArchetype(
+        projectName, new File("/projects"), mavenArchetype, mavenArtifact);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckGeneratingMavenArchetypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckGeneratingMavenArchetypeTest.java
@@ -26,7 +26,9 @@ import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
 public class CheckGeneratingMavenArchetypeTest {
-  private static final String NAME_OF_ARTIFACT = NameGenerator.generate("quickStart", 4);
+  private static final String PROJECT_NAME = NameGenerator.generate("quickStart", 4);
+  private static final String ARTIFACT_ID = "artifact";
+  private static final String GROUP_ID = "group";
   @Inject private Wizard projectWizard;
   @Inject private Menu menu;
   @Inject private ProjectExplorer projectExplorer;
@@ -42,31 +44,33 @@ public class CheckGeneratingMavenArchetypeTest {
             "  <groupId>%s</groupId>\n"
                 + "  <artifactId>%s</artifactId>\n"
                 + "  <version>1.0-SNAPSHOT</version>",
-            NAME_OF_ARTIFACT, NAME_OF_ARTIFACT);
+            GROUP_ID, ARTIFACT_ID);
 
     Stream<String> expectedItems =
         Stream.of(
-            NAME_OF_ARTIFACT + "/src/main/java/" + NAME_OF_ARTIFACT + "/App.java",
-            NAME_OF_ARTIFACT + "/src/test/java/" + NAME_OF_ARTIFACT + "/AppTest.java",
-            NAME_OF_ARTIFACT + "/pom.xml");
+            PROJECT_NAME + "/src/main/java/" + GROUP_ID + "/App.java",
+            PROJECT_NAME + "/src/test/java/" + GROUP_ID + "/AppTest.java",
+            PROJECT_NAME + "/pom.xml");
     ide.open(workspace);
     menu.runCommand(
         TestMenuCommandsConstants.Workspace.WORKSPACE,
         TestMenuCommandsConstants.Workspace.CREATE_PROJECT);
     projectWizard.selectTypeProject(Wizard.TypeProject.MAVEN);
-    projectWizard.typeProjectNameOnWizard(NAME_OF_ARTIFACT);
+    projectWizard.typeProjectNameOnWizard(PROJECT_NAME);
     projectWizard.clickNextButton();
     projectWizard.waitOpenProjectConfigForm();
     projectWizard.selectArcheTypeFromList(Wizard.Archetypes.QUICK_START);
-    projectWizard.checkArtifactIdOnWizardContainsText(NAME_OF_ARTIFACT);
-    projectWizard.checkGroupIdOnWizardContainsText(NAME_OF_ARTIFACT);
+    projectWizard.setArtifactIdOnWizard(ARTIFACT_ID);
+    projectWizard.checkArtifactIdOnWizardContainsText(ARTIFACT_ID);
+    projectWizard.setGroupIdOnWizard(GROUP_ID);
+    projectWizard.checkGroupIdOnWizardContainsText(GROUP_ID);
     projectWizard.checkVersionOnWizardContainsText("1.0-SNAPSHOT");
     projectWizard.clickCreateButton();
-    projectExplorer.waitItem(NAME_OF_ARTIFACT);
+    projectExplorer.waitItem(PROJECT_NAME);
     console.waitExpectedTextIntoConsole(TestBuildConstants.BUILD_SUCCESS);
     projectExplorer.quickExpandWithJavaScript();
     expectedItems.forEach(projectExplorer::waitItem);
-    projectExplorer.openItemByPath(NAME_OF_ARTIFACT + "/pom.xml");
+    projectExplorer.openItemByPath(PROJECT_NAME + "/pom.xml");
     editor.waitTextIntoEditor(expectedContnetInPomXml);
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When creating a project with the help of Maven Archetype Plugin it names project directory by `artifact-id`. If `artifact-id` != project name specified in the first page of the project wizard, error happens. Maven Archetype Plugin has `basedir` property that can solve this problem, but there is a bug in the plugin: https://issues.apache.org/jira/browse/ARCHETYPE-311. Rename the project directory to specified project name solves the problem.

Improved related selenium test.

### What issues does this PR fix or reference?
#8164

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Fix error when creating project from archetype

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A