### PR TITLE
Selenium: Correct the closing 'Preferences' form in the 'AfterMethod' of 'ContributeTabTest'

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/preferences/ContributeTabTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/preferences/ContributeTabTest.java
@@ -96,12 +96,12 @@ public class ContributeTabTest {
 
   @AfterMethod
   public void closeForm() {
-    if (askDialog.isOpened()) {
-      askDialog.confirmAndWaitClosed();
-    }
-
     if (preferences.isPreferencesFormOpened()) {
       preferences.clickOnCloseButton();
+    }
+
+    if (askDialog.isOpened()) {
+      askDialog.confirmAndWaitClosed();
     }
 
     preferences.waitPreferencesFormIsClosed();


### PR DESCRIPTION
### What does this PR do?
* Correct the processing closing the ask dialog and the _Preferences_ forms when test fails by two known issues
* Related selenium test: _ContibuteTabTest_
### What issues does this PR fix or reference?
#10067, #9959, #10019
