### PR TITLE
Fix image-che-flag

### DIFF
--- a/deploy/openshift/ocp.sh
+++ b/deploy/openshift/ocp.sh
@@ -270,8 +270,8 @@ parse_args() {
                shift
            ;;
            --image-che=*)
-               export CHE_IMAGE_REPO=$(echo "${key#*=}" | sed 's/:.*//')
-               export CHE_IMAGE_TAG=$(echo "${key#*=}" | sed 's/.*://')
+               export CHE_IMAGE_REPO=$(echo "${i#*=}" | sed 's/:.*//')
+               export CHE_IMAGE_TAG=$(echo "${i#*=}" | sed 's/.*://')
                shift
            ;;
            --remove-che)


### PR DESCRIPTION
Use the right env name to fix --image-che flag in ocp.sh script - `i` instead of `key`