### PR TITLE
Show warning dialog after refactoring operation if something isn't valid

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/wizard/MovePresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/move/wizard/MovePresenter.java
@@ -156,8 +156,8 @@ public class MovePresenter implements MoveView.ActionDelegate, RefactoringAction
     extensionService
         .move(moveSettings)
         .then(
-            workspaceEdit -> {
-              previewPresenter.show(workspaceEdit, this);
+            refactoringResult -> {
+              previewPresenter.show(refactoringResult.getCheWorkspaceEdit(), this);
             })
         .catchError(
             error -> {
@@ -173,9 +173,9 @@ public class MovePresenter implements MoveView.ActionDelegate, RefactoringAction
     extensionService
         .move(moveSettings)
         .then(
-            workspaceEdit -> {
+            refactoringResult -> {
               view.close();
-              applyWorkspaceEditAction.applyWorkspaceEdit(workspaceEdit);
+              applyWorkspaceEditAction.applyWorkspaceEdit(refactoringResult.getCheWorkspaceEdit());
               setEditorFocus();
             })
         .catchError(

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/rename/wizard/RenamePresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/refactoring/rename/wizard/RenamePresenter.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.jdt.ls.extension.api.RefactoringSeverity.OK;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.List;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
@@ -34,8 +35,13 @@ import org.eclipse.che.ide.ext.java.client.refactoring.preview.PreviewPresenter;
 import org.eclipse.che.ide.ext.java.client.refactoring.rename.wizard.RenameView.ActionDelegate;
 import org.eclipse.che.ide.ext.java.client.refactoring.rename.wizard.similarnames.SimilarNamesConfigurationPresenter;
 import org.eclipse.che.ide.ext.java.client.service.JavaLanguageExtensionServiceClient;
+import org.eclipse.che.ide.ui.dialogs.DialogFactory;
+import org.eclipse.che.ide.ui.dialogs.confirm.ConfirmCallback;
+import org.eclipse.che.jdt.ls.extension.api.RefactoringSeverity;
 import org.eclipse.che.jdt.ls.extension.api.RenameKind;
 import org.eclipse.che.jdt.ls.extension.api.dto.CheWorkspaceEdit;
+import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringResult;
+import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatusEntry;
 import org.eclipse.che.jdt.ls.extension.api.dto.RenameSelectionParams;
 import org.eclipse.che.jdt.ls.extension.api.dto.RenameSettings;
 import org.eclipse.che.jdt.ls.extension.api.dto.RenamingElementInfo;
@@ -57,6 +63,7 @@ public class RenamePresenter implements ActionDelegate, RefactoringActionDelegat
   private final ApplyWorkspaceEditAction applyWorkspaceEditAction;
   private final JavaLocalizationConstant locale;
   private final DtoBuildHelper dtoBuildHelper;
+  private final DialogFactory dialogFactory;
   private final EditorAgent editorAgent;
   private final NotificationManager notificationManager;
   private final PreviewPresenter previewPresenter;
@@ -72,6 +79,7 @@ public class RenamePresenter implements ActionDelegate, RefactoringActionDelegat
       ApplyWorkspaceEditAction applyWorkspaceEditAction,
       JavaLocalizationConstant locale,
       DtoBuildHelper dtoBuildHelper,
+      DialogFactory dialogFactory,
       EditorAgent editorAgent,
       NotificationManager notificationManager,
       PreviewPresenter previewPresenter,
@@ -82,6 +90,7 @@ public class RenamePresenter implements ActionDelegate, RefactoringActionDelegat
     this.applyWorkspaceEditAction = applyWorkspaceEditAction;
     this.locale = locale;
     this.dtoBuildHelper = dtoBuildHelper;
+    this.dialogFactory = dialogFactory;
     this.editorAgent = editorAgent;
     this.notificationManager = notificationManager;
     this.view.setDelegate(this);
@@ -198,7 +207,23 @@ public class RenamePresenter implements ActionDelegate, RefactoringActionDelegat
   /** {@inheritDoc} */
   @Override
   public void onAcceptButtonClicked() {
-    getChanges().then(this::applyRefactoring);
+    getChanges()
+        .then(
+            refactoringResult -> {
+              RefactoringSeverity severity =
+                  refactoringResult.getRefactoringStatus().getRefactoringSeverity();
+              switch (severity) {
+                case WARNING:
+                case ERROR:
+                  showWarningDialog(refactoringResult);
+                  break;
+                case FATAL:
+                  view.showErrorMessage(refactoringResult.getRefactoringStatus());
+                  break;
+                default:
+                  applyRefactoring(refactoringResult.getCheWorkspaceEdit());
+              }
+            });
   }
 
   /** {@inheritDoc} */
@@ -275,13 +300,17 @@ public class RenamePresenter implements ActionDelegate, RefactoringActionDelegat
   private void showPreview() {
     getChanges()
         .then(
-            workspaceEdit -> {
-              previewPresenter.show(workspaceEdit, this);
+            refactoringResult -> {
+              CheWorkspaceEdit edit = refactoringResult.getCheWorkspaceEdit();
+              if (edit == null) {
+                return;
+              }
+              previewPresenter.show(edit, this);
               previewPresenter.setTitle(locale.renameItemTitle());
             });
   }
 
-  private Promise<CheWorkspaceEdit> getChanges() {
+  private Promise<RefactoringResult> getChanges() {
     RenameSettings renameSettings = createRenameSettings();
     RenameParams renameParams = createRenameParams(renameSettings);
 
@@ -332,6 +361,24 @@ public class RenamePresenter implements ActionDelegate, RefactoringActionDelegat
     view.close();
     applyWorkspaceEditAction.applyWorkspaceEdit(workspaceEdit);
     setEditorFocus();
+  }
+
+  private void showWarningDialog(RefactoringResult refactoringResult) {
+    List<RefactoringStatusEntry> entries =
+        refactoringResult.getRefactoringStatus().getRefactoringStatusEntries();
+
+    ConfirmCallback confirmCallback =
+        () -> applyRefactoring(refactoringResult.getCheWorkspaceEdit());
+
+    dialogFactory
+        .createConfirmDialog(
+            locale.warningOperationTitle(),
+            entries.isEmpty() ? locale.warningOperationContent() : entries.get(0).getMessage(),
+            locale.renameRename(),
+            locale.buttonCancel(),
+            confirmCallback,
+            () -> {})
+        .show();
   }
 
   private RenameSettings createRenameSettings() {

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/service/JavaLanguageExtensionServiceClient.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/service/JavaLanguageExtensionServiceClient.java
@@ -51,7 +51,6 @@ import org.eclipse.che.api.promises.client.js.Promises;
 import org.eclipse.che.api.promises.client.js.RejectFunction;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.workspace.WorkspaceReadyEvent;
-import org.eclipse.che.jdt.ls.extension.api.dto.CheWorkspaceEdit;
 import org.eclipse.che.jdt.ls.extension.api.dto.ClasspathEntry;
 import org.eclipse.che.jdt.ls.extension.api.dto.CreateMoveParams;
 import org.eclipse.che.jdt.ls.extension.api.dto.ExtendedSymbolInformation;
@@ -66,6 +65,7 @@ import org.eclipse.che.jdt.ls.extension.api.dto.MoveSettings;
 import org.eclipse.che.jdt.ls.extension.api.dto.OrganizeImportParams;
 import org.eclipse.che.jdt.ls.extension.api.dto.OrganizeImportsResult;
 import org.eclipse.che.jdt.ls.extension.api.dto.ReImportMavenProjectsCommandParameters;
+import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringResult;
 import org.eclipse.che.jdt.ls.extension.api.dto.RefactoringStatus;
 import org.eclipse.che.jdt.ls.extension.api.dto.RenameSelectionParams;
 import org.eclipse.che.jdt.ls.extension.api.dto.RenameSettings;
@@ -295,7 +295,7 @@ public class JavaLanguageExtensionServiceClient {
   }
 
   /** Rename refactoring. */
-  public Promise<CheWorkspaceEdit> rename(RenameSettings renameSettings) {
+  public Promise<RefactoringResult> rename(RenameSettings renameSettings) {
     return Promises.create(
         (resolve, reject) ->
             requestTransmitter
@@ -303,7 +303,7 @@ public class JavaLanguageExtensionServiceClient {
                 .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
                 .methodName(REFACTORING_RENAME)
                 .paramsAsDto(renameSettings)
-                .sendAndReceiveResultAsDto(CheWorkspaceEdit.class, REQUEST_TIMEOUT)
+                .sendAndReceiveResultAsDto(RefactoringResult.class, REQUEST_TIMEOUT)
                 .onSuccess(resolve::apply)
                 .onTimeout(() -> onTimeout(reject))
                 .onFailure(error -> reject.apply(ServiceUtil.getPromiseError(error))));
@@ -355,7 +355,7 @@ public class JavaLanguageExtensionServiceClient {
   }
 
   /** Move refactoring. */
-  public Promise<CheWorkspaceEdit> move(MoveSettings moveSettings) {
+  public Promise<RefactoringResult> move(MoveSettings moveSettings) {
     return Promises.create(
         (resolve, reject) ->
             requestTransmitter
@@ -363,7 +363,7 @@ public class JavaLanguageExtensionServiceClient {
                 .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
                 .methodName(REFACTORING_MOVE)
                 .paramsAsDto(moveSettings)
-                .sendAndReceiveResultAsDto(CheWorkspaceEdit.class, REQUEST_TIMEOUT)
+                .sendAndReceiveResultAsDto(RefactoringResult.class, REQUEST_TIMEOUT)
                 .onSuccess(resolve::apply)
                 .onTimeout(() -> onTimeout(reject))
                 .onFailure(error -> reject.apply(ServiceUtil.getPromiseError(error))));

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/methods/RenameStaticMethodsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/methods/RenameStaticMethodsTest.java
@@ -47,7 +47,7 @@ public class RenameStaticMethodsTest {
   private static final String pathToPackageInChePrefix =
       nameOfProject + "/src" + "/main" + "/java" + "/renameStaticMethods";
   private static final String testsFail5ErrorMess =
-      "Related method 'm' (declared in 'renameStaticMethods.testFail5.A') is native. Renaming will cause an UnsatisfiedLinkError on runtime.";
+      "Renaming native methods will cause an unsatisfied link error on runtime.";
 
   private String pathToCurrentPackage;
   private String contentFromInA;


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
After preparing changes of refactoring operation it may have some error/warning status. So the main idea of current PR is to show warning dialog before applying changes.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10034