### PR TITLE
NPEs on workspace start-up #10083

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcError.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcError.java
@@ -10,12 +10,14 @@
  */
 package org.eclipse.che.api.core.jsonrpc.commons;
 
+import javax.validation.constraints.NotNull;
+
 /** Represents JSON RPC error object */
 public class JsonRpcError {
   private final int code;
   private final String message;
 
-  public JsonRpcError(int code, String message) {
+  public JsonRpcError(int code, @NotNull String message) {
     this.code = code;
     this.message = message;
   }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcErrorTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcErrorTransmitter.java
@@ -40,7 +40,8 @@ public class JsonRpcErrorTransmitter {
 
     LOGGER.debug("Transmitting a JSON RPC error: " + e.getMessage());
 
-    JsonRpcError error = new JsonRpcError(e.getCode(), e.getMessage());
+    JsonRpcError error =
+        new JsonRpcError(e.getCode(), e.getMessage() == null ? "Unexpected error" : e.getMessage());
     JsonRpcResponse response = new JsonRpcResponse(e.getId(), null, error);
     String message = marshaller.marshall(response);
     transmitter.transmit(endpointId, message);


### PR DESCRIPTION
Fixes #10083

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

The fix disables to provide null as message argument of JsonRpcError and insures that null value cannot be passed there in JsonRpcErrorTransmitter.transmit()

### What issues does this PR fix or reference?

Fixes #10083 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
![lsnpefixed](https://user-images.githubusercontent.com/620781/41536607-6cf3b248-7306-11e8-80fa-795cb830fa2f.gif)

The fix disables to provide null as message argument of JsonRpcError and insures that null value cannot be passed there in JsonRpcErrorTransmitter.transmit()

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
