### PR TITLE
[WIP] [POC] Rework workspace infrastructure API to apply Workspace.Next on the infrastructure side

### DIFF
--- a/deploy/kubernetes/Readme.md
+++ b/deploy/kubernetes/Readme.md
@@ -1,1 +1,1 @@
-Docs are located at [https://www.eclipse.org/che/docs/6/che/docs/kubernetes-single-user.html](https://www.eclipse.org/che/docs/6/che/docs/kubernetes-single-user.html).
+Docs are located at [https://www.eclipse.org/che/docs/kubernetes-single-user.html](https://www.eclipse.org/che/docs/kubernetes-single-user.html).

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeInfrastructure.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeInfrastructure.java
@@ -14,6 +14,7 @@ import static java.lang.String.format;
 
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
+import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.che.api.core.ValidationException;
@@ -24,6 +25,7 @@ import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
 import org.eclipse.che.workspace.infrastructure.docker.container.DockerContainers;
 import org.eclipse.che.workspace.infrastructure.docker.environment.DockerEnvironmentNormalizer;
 import org.eclipse.che.workspace.infrastructure.docker.environment.convert.DockerEnvironmentConverter;
@@ -64,8 +66,11 @@ public class DockerRuntimeInfrastructure extends RuntimeInfrastructure {
 
   @Override
   protected RuntimeContext internalPrepare(
-      RuntimeIdentity identity, InternalEnvironment environment)
+      RuntimeIdentity identity,
+      InternalEnvironment environment,
+      Collection<CheService> wsNextServices)
       throws ValidationException, InfrastructureException {
+    // TODO Docker infra doesn't support workspace Next for the time being
     DockerEnvironment dockerEnvironment = convertToDockerEnv(environment);
 
     // modify environment with everything needed to use docker machines on particular (cloud)

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -34,6 +34,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachi
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesMachineCache;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesRuntimeStateCache;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.UniqueWorkspacePVCStrategy;
@@ -101,5 +102,6 @@ public class OpenShiftInfraModule extends AbstractModule {
     MapBinder<String, WorkspaceNextApplier> wsNext =
         MapBinder.newMapBinder(binder(), String.class, WorkspaceNextApplier.class);
     wsNext.addBinding(OpenShiftEnvironment.TYPE).to(KubernetesWorkspaceNextApplier.class);
+    wsNext.addBinding(KubernetesEnvironment.TYPE).to(KubernetesWorkspaceNextApplier.class);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeInfrastructure.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/RuntimeInfrastructure.java
@@ -20,6 +20,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
 
 /**
  * Starting point of describing the contract which infrastructure provider should implement for
@@ -91,16 +92,18 @@ public abstract class RuntimeInfrastructure {
    *
    * @param id the RuntimeIdentity
    * @param environment incoming internal environment
+   * @param wsNextServices workspace next services that should be added to the environment
    * @return new RuntimeContext object
    * @throws ValidationException if incoming environment is not valid
    * @throws InfrastructureException if any other error occurred
    */
-  public RuntimeContext prepare(RuntimeIdentity id, InternalEnvironment environment)
+  public RuntimeContext prepare(
+      RuntimeIdentity id, InternalEnvironment environment, Collection<CheService> wsNextServices)
       throws ValidationException, InfrastructureException {
     for (InternalEnvironmentProvisioner provisioner : internalEnvironmentProvisioners) {
-      provisioner.provision(id, environment);
+      provisioner.provision(id, environment, wsNextServices);
     }
-    return internalPrepare(id, environment);
+    return internalPrepare(id, environment, wsNextServices);
   }
 
   /**
@@ -109,11 +112,12 @@ public abstract class RuntimeInfrastructure {
    *
    * @param id the RuntimeIdentity
    * @param environment incoming internal environment
+   * @param wsNextServices workspace next services that should be added to the environment
    * @return new RuntimeContext object
    * @throws ValidationException if incoming environment is not valid
    * @throws InfrastructureException if any other error occurred
    */
   protected abstract RuntimeContext internalPrepare(
-      RuntimeIdentity id, InternalEnvironment environment)
+      RuntimeIdentity id, InternalEnvironment environment, Collection<CheService> wsNextServices)
       throws ValidationException, InfrastructureException;
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisioner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisioner.java
@@ -14,6 +14,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 
 import com.google.inject.Singleton;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
@@ -24,6 +25,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +49,10 @@ public class InstallerConfigProvisioner implements InternalEnvironmentProvisione
   private static final Logger LOG = LoggerFactory.getLogger(RuntimeInfrastructure.class);
 
   @Override
-  public void provision(RuntimeIdentity id, InternalEnvironment internalEnvironment)
+  public void provision(
+      RuntimeIdentity id,
+      InternalEnvironment internalEnvironment,
+      Collection<CheService> wsNextServices)
       throws InfrastructureException {
     for (InternalMachineConfig machineConfig : internalEnvironment.getMachines().values()) {
       fillEnv(machineConfig.getEnv(), machineConfig.getInstallers());

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/InternalEnvironmentProvisioner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/InternalEnvironmentProvisioner.java
@@ -10,18 +10,23 @@
  */
 package org.eclipse.che.api.workspace.server.spi.provision;
 
+import java.util.Collection;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
 
 /**
- * Modifies internal environment with everything needed for some logical part of {@link
- * RuntimeInfrastructure}.
+ * Modifies internal environment and workspace next services with everything needed for some logical
+ * part of {@link RuntimeInfrastructure}.
  *
  * @author Sergii Leshchenko
  */
 public interface InternalEnvironmentProvisioner {
-  void provision(RuntimeIdentity id, InternalEnvironment internalEnvironment)
+  void provision(
+      RuntimeIdentity id,
+      InternalEnvironment internalEnvironment,
+      Collection<CheService> wsNextServices)
       throws InfrastructureException;
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/ProjectsVolumeForWsAgentProvisioner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/ProjectsVolumeForWsAgentProvisioner.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.api.workspace.server.spi.provision;
 
+import java.util.Collection;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -19,6 +20,7 @@ import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.wsnext.model.CheService;
 
 /**
  * Adds projects volumes to a machine with 'ws-agent' server.
@@ -38,7 +40,10 @@ public class ProjectsVolumeForWsAgentProvisioner implements InternalEnvironmentP
   }
 
   @Override
-  public void provision(RuntimeIdentity id, InternalEnvironment internalEnvironment)
+  public void provision(
+      RuntimeIdentity id,
+      InternalEnvironment internalEnvironment,
+      Collection<CheService> wsNextServices)
       throws InfrastructureException {
 
     Optional<String> wsAgentServerMachine =

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisionerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/InstallerConfigProvisionerTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.api.workspace.server.spi.provision;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.doReturn;
@@ -85,7 +86,7 @@ public class InstallerConfigProvisionerTest {
     machine2Env.put("existingEnv", "value");
 
     // when
-    installerConfigProvisioner.provision(runtimeIdentity, internalEnvironment);
+    installerConfigProvisioner.provision(runtimeIdentity, internalEnvironment, emptyList());
 
     // then
     assertEquals(machine1Env, ImmutableMap.of("envVar1", "value1", "envVar2", "value2"));
@@ -125,7 +126,7 @@ public class InstallerConfigProvisionerTest {
     machine2Servers.put("machine2Server", machine2Server);
 
     // when
-    installerConfigProvisioner.provision(runtimeIdentity, internalEnvironment);
+    installerConfigProvisioner.provision(runtimeIdentity, internalEnvironment, emptyList());
 
     // then
     assertEquals(

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/EnvVarEnvironmentProvisionerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/EnvVarEnvironmentProvisionerTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.api.workspace.server.spi.provision.env;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -71,7 +72,7 @@ public class EnvVarEnvironmentProvisionerTest {
     when(provider1.get(any())).thenReturn(Pair.of("test", "test"));
 
     // when
-    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment);
+    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment, emptyList());
 
     // then
     verify(provider1).get(eq(RUNTIME_IDENTITY));
@@ -86,7 +87,7 @@ public class EnvVarEnvironmentProvisionerTest {
     when(provider2.get(any())).thenReturn(Pair.of("test", "test"));
 
     // when
-    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment);
+    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment, emptyList());
 
     // then
     verify(provider1).get(eq(RUNTIME_IDENTITY));
@@ -108,7 +109,7 @@ public class EnvVarEnvironmentProvisionerTest {
     when(provider2.get(any(RuntimeIdentity.class))).thenReturn(envVar2);
 
     // when
-    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment);
+    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment, emptyList());
 
     // then
     assertEquals(machine1Env, envVarsFromProviders);
@@ -127,7 +128,7 @@ public class EnvVarEnvironmentProvisionerTest {
     when(provider1.get(any(RuntimeIdentity.class))).thenReturn(envVar1);
 
     // when
-    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment);
+    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment, emptyList());
 
     // then
     assertEquals(
@@ -149,7 +150,7 @@ public class EnvVarEnvironmentProvisionerTest {
         .thenReturn(Pair.of(existingEnvVarName, envVarValueFromProvider));
 
     // when
-    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment);
+    provisioner.provision(RUNTIME_IDENTITY, internalEnvironment, emptyList());
 
     // then
     assertEquals(ImmutableMap.of(existingEnvVarName, oldEnvVarValue), machine1Env);


### PR DESCRIPTION
### What does this PR do?
This is a **POC** that moves the addition of Workspace.Next entities to user's environment from `WorkspaceRuntimes` class to infrastructure implementation. 
This allows us to implement one workspace next provisioner per infrastructure rather than 1 per recipe type. 
This particular PR adds support of dockerimage workspaces to workspace next without any additional effort. 
I made this PR a breaking change in infrastructure API just for simplicity and clarity. If we agreed on the approach I would like to make backward compatible by adding new methods to the infrastructure API for workspace next support. 

Here is the flow used during workspace start for plain Che 6 without Workspace.Next:
![image](https://user-images.githubusercontent.com/1851863/41594716-9dc3ebe0-73c4-11e8-97c0-c974b2c4739f.png)
Here is the flow used during workspace start for Che 6 with the already merged version of Workspace.Next:
![image](https://user-images.githubusercontent.com/1851863/41594756-c95e4476-73c4-11e8-92d5-62ef1755349c.png)
Here is the flow used during workspace start for Che 6 with this PR:
![image](https://user-images.githubusercontent.com/1851863/41594792-e89f4132-73c4-11e8-9284-d3498de2b561.png)


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
