### PR TITLE
Setup OCP to create objects under the certain user account

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -18,6 +18,8 @@
 # Print Che logo
 # --------------
 
+set -e
+
 echo
 cat <<EOF
 [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [38;5;52m1[38;5;94m0[38;5;136m1[38;5;215m0[38;5;215m0[38;5;136m0[38;5;94m0[38;5;58m0[0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m [0m
@@ -342,6 +344,7 @@ Che version: ${CHE_IMAGE_TAG}
 Image: ${CHE_IMAGE_REPO}
 Pull policy: ${IMAGE_PULL_POLICY}
 Update strategy: ${UPDATE_STRATEGY}
+Setup OpenShift oAuth: ${SETUP_OCP_OAUTH}
 Environment variables:
 ${CHE_VAR_ARRAY}"
     if [ "${CHE_MULTIUSER}" == "true" ]; then
@@ -350,9 +353,54 @@ ${CHE_VAR_ARRAY}"
       fi
       ${OC_BINARY} new-app -f ${BASE_DIR}/templates/multi/postgres-template.yaml
       wait_for_postgres
-      ${OC_BINARY} new-app -f ${BASE_DIR}/templates/multi/keycloak-template.yaml -p ROUTING_SUFFIX=${OPENSHIFT_ROUTING_SUFFIX} -p PROTOCOL=${HTTP_PROTOCOL} ${KEYCLOAK_PARAM}
+
+      CHE_INFRA_OPENSHIFT_PROJECT=${CHE_OPENSHIFT_PROJECT}
+      CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER=NULL
+
+      if [ "${SETUP_OCP_OAUTH}" == "true" ]; then
+        # create secret with OpenShift certificate
+        $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/openshift-certificate-secret.yaml -p CERTIFICATE="$(cat /var/lib/origin/openshift.local.config/master/ca.crt)"
+      fi
+
+      ${OC_BINARY} new-app -f ${BASE_DIR}/templates/multi/keycloak-template.yaml \
+        -p ROUTING_SUFFIX=${OPENSHIFT_ROUTING_SUFFIX} \
+        -p PROTOCOL=${HTTP_PROTOCOL} \
+        -p KEYCLOAK_USER=${KEYCLOAK_USER} \
+        -p KEYCLOAK_PASSWORD=${KEYCLOAK_PASSWORD} \
+        ${KEYCLOAK_PARAM}
       wait_for_keycloak
+
+      if [ "${SETUP_OCP_OAUTH}" == "true" ]; then
+        # register oAuth client in OpenShift
+        $OC_BINARY login -u "system:admin" > /dev/null
+        KEYCLOAK_ROUTE=$($OC_BINARY get route/keycloak --namespace=${CHE_OPENSHIFT_PROJECT} -o=jsonpath={'.spec.host'})
+        $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/oauth-client.yaml \
+          -p REDIRECT_URI="http://${KEYCLOAK_ROUTE}/auth/realms/che/broker/${OCP_IDENTITY_PROVIDER_ID}/endpoint" \
+          -p OCP_OAUTH_CLIENT_ID=${OCP_OAUTH_CLIENT_ID} \
+          -p OCP_OAUTH_CLIENT_SECRET=${OCP_OAUTH_CLIENT_SECRET} \
+
+        # register OpenShift Identity Provider in Keycloak
+        $OC_BINARY login -u "${OPENSHIFT_USERNAME}" -p "${OPENSHIFT_PASSWORD}" > /dev/null
+        KEYCLOAK_POD_NAME=$(${OC_BINARY} get pod --namespace=${CHE_OPENSHIFT_PROJECT} -l app=keycloak --no-headers | awk '{print $1}')
+        ${OC_BINARY} exec ${KEYCLOAK_POD_NAME} -- /opt/jboss/keycloak/bin/kcadm.sh create identity-provider/instances -r che \
+          -s alias=${OCP_IDENTITY_PROVIDER_ID} \
+          -s providerId=${OCP_IDENTITY_PROVIDER_ID} \
+          -s enabled=true \
+          -s storeToken=true \
+          -s addReadTokenRoleOnCreate=true \
+          -s config.useJwksUrl="true" \
+          -s config.clientId=${OCP_OAUTH_CLIENT_ID} \
+          -s config.clientSecret=${OCP_OAUTH_CLIENT_SECRET} \
+          -s config.baseUrl="${OPENSHIFT_ENDPOINT}" \
+          -s config.defaultScope="user:full" \
+          --no-config --server http://localhost:8080/auth --user ${KEYCLOAK_USER} --password ${KEYCLOAK_PASSWORD} --realm master
+
+        # setup Che variables related to oAuth identity provider
+        CHE_INFRA_OPENSHIFT_PROJECT=
+        CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER=${OCP_IDENTITY_PROVIDER_ID}
+      fi
     fi
+
     ${OC_BINARY} new-app -f ${BASE_DIR}/templates/che-server-template.yaml \
                          -p ROUTING_SUFFIX=${OPENSHIFT_ROUTING_SUFFIX} \
                          -p IMAGE_CHE=${CHE_IMAGE_REPO} \
@@ -362,6 +410,8 @@ ${CHE_VAR_ARRAY}"
                          -p CHE_MULTIUSER=${CHE_MULTIUSER} \
                          -p PROTOCOL=${HTTP_PROTOCOL} \
                          -p WS_PROTOCOL=${WS_PROTOCOL} \
+                         -p CHE_INFRA_OPENSHIFT_PROJECT=${CHE_INFRA_OPENSHIFT_PROJECT} \
+                         -p CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER=${CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER} \
                          -p TLS=${TLS} \
                          ${ENV}
 

--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -377,7 +377,7 @@ ${CHE_VAR_ARRAY}"
         $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/oauth-client.yaml \
           -p REDIRECT_URI="http://${KEYCLOAK_ROUTE}/auth/realms/che/broker/${OCP_IDENTITY_PROVIDER_ID}/endpoint" \
           -p OCP_OAUTH_CLIENT_ID=${OCP_OAUTH_CLIENT_ID} \
-          -p OCP_OAUTH_CLIENT_SECRET=${OCP_OAUTH_CLIENT_SECRET} \
+          -p OCP_OAUTH_CLIENT_SECRET=${OCP_OAUTH_CLIENT_SECRET}
 
         # register OpenShift Identity Provider in Keycloak
         $OC_BINARY login -u "${OPENSHIFT_USERNAME}" -p "${OPENSHIFT_PASSWORD}" > /dev/null

--- a/deploy/openshift/ocp.sh
+++ b/deploy/openshift/ocp.sh
@@ -55,6 +55,24 @@ export CHE_INFRA_KUBERNETES_MASTER__URL=${CHE_INFRA_KUBERNETES_MASTER__URL:-${OP
 
 DEFAULT_WAIT_FOR_CHE=true
 export WAIT_FOR_CHE=${WAIT_FOR_CHE:-${DEFAULT_WAIT_FOR_CHE}}
+
+DEFAULT_SETUP_OCP_OAUTH=false
+export SETUP_OCP_OAUTH=${SETUP_OCP_OAUTH:-${DEFAULT_SETUP_OCP_OAUTH}}
+
+DEFAULT_OCP_IDENTITY_PROVIDER_ID=openshift-v3
+export OCP_IDENTITY_PROVIDER_ID=${OCP_IDENTITY_PROVIDER_ID:-${DEFAULT_OCP_IDENTITY_PROVIDER_ID}}
+
+DEFAULT_OCP_OAUTH_CLIENT_ID=ocp-client
+export OCP_OAUTH_CLIENT_ID=${OCP_OAUTH_CLIENT_ID:-${DEFAULT_OCP_OAUTH_CLIENT_ID}}
+
+DEFAULT_OCP_OAUTH_CLIENT_SECRET=ocp-client-secret
+export OCP_OAUTH_CLIENT_SECRET=${OCP_OAUTH_CLIENT_SECRET:-${DEFAULT_OCP_OAUTH_CLIENT_SECRET}}
+
+DEFAULT_KEYCLOAK_USER=admin
+export KEYCLOAK_USER=${KEYCLOAK_USER:-${DEFAULT_KEYCLOAK_USER}}
+
+DEFAULT_KEYCLOAK_PASSWORD=admin
+export KEYCLOAK_PASSWORD=${KEYCLOAK_PASSWORD:-${DEFAULT_KEYCLOAK_PASSWORD}}
 }
 
 test_dns_provider() {
@@ -212,6 +230,7 @@ parse_args() {
     --debug - deploy Che in a debug mode, create and expose debug route
     --image-che - override default Che image. Example: --image-che=org/repo:tag. Tag is mandatory!
     --remove-che - remove existing che project
+    --setup-ocp-oauth - register OCP oauth client and setup Keycloak and Che to use OpenShift Identity Provider
     ===================================
     ENV vars
     CHE_IMAGE_TAG - set che-server image tag, default: nightly
@@ -243,7 +262,7 @@ parse_args() {
                shift
            ;;
            --deploy-che)
-               DEPLOY_CHE="true"
+               DEPLOY_CHE=true
                shift
            ;;
            --multiuser)
@@ -276,6 +295,10 @@ parse_args() {
            ;;
            --remove-che)
            shift
+           ;;
+           --setup-ocp-oauth)
+               export SETUP_OCP_OAUTH=true
+               shift
            ;;
            --help)
                echo -e "$HELP"

--- a/deploy/openshift/templates/multi/oauth-client.yaml
+++ b/deploy/openshift/templates/multi/oauth-client.yaml
@@ -1,0 +1,29 @@
+# Copyright (c) 2012-2018 Red Hat, Inc
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: openshift-oauth-client
+  annotations:
+    description: Che
+objects:
+- apiVersion: v1
+  kind: OAuthClient
+  metadata:
+    name: ${OCP_OAUTH_CLIENT_ID}
+  secret: ${OCP_OAUTH_CLIENT_SECRET}
+  redirectURIs:
+    - ${REDIRECT_URI}
+  grantMethod: prompt
+parameters:
+- name: REDIRECT_URI
+  displayName: Redirect URI for OpenShift identity provider
+- name: OCP_OAUTH_CLIENT_ID
+  displayName: OAuth client ID
+- name: OCP_OAUTH_CLIENT_SECRET
+  displayName: OAuth client secret


### PR DESCRIPTION
### What does this PR do?
It adds parameter `--setup-ocp-oauth` to **ocp.sh** script to setup all staff which we need to create  OpenShift objects under the current user account on OCP:
- creates secret from **oauth-client.yaml** with OpenShift certificate borrowing from _/var/lib/origin/openshift.local.config/master/ca.crt_;
- registers OAuth client in OCP;
- registers _OpenShift identity provider_ in Keycloak;
- deploys Che with proper variables to use _OpenShift identity provider_.

### What issues does this PR fix or reference?
#9818