### PR TITLE
Fix start of workspaces of Eclipse Che Singleuser on OCP

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -345,15 +345,15 @@ Update strategy: ${UPDATE_STRATEGY}
 Setup OpenShift oAuth: ${SETUP_OCP_OAUTH}
 Environment variables:
 ${CHE_VAR_ARRAY}"
+    CHE_INFRA_OPENSHIFT_PROJECT=${CHE_OPENSHIFT_PROJECT}
+    CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER=NULL
+
     if [ "${CHE_MULTIUSER}" == "true" ]; then
       if [ "${CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD}" == "false" ]; then
         export KEYCLOAK_PARAM="-p CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD=false"
       fi
       ${OC_BINARY} new-app -f ${BASE_DIR}/templates/multi/postgres-template.yaml
       wait_for_postgres
-
-      CHE_INFRA_OPENSHIFT_PROJECT=${CHE_OPENSHIFT_PROJECT}
-      CHE_INFRA_OPENSHIFT_OAUTH__IDENTITY__PROVIDER=NULL
 
       if [ "${SETUP_OCP_OAUTH}" == "true" ]; then
         # create secret with OpenShift certificate


### PR DESCRIPTION
### What does this PR do?
It fixes error of start workspaces of Eclipse Che Singleuser on OCP because of wrong value of `CHE_INFRA_OPENSHIFT_PROJECT` variable:
```
1) Error in custom provider, java.util.concurrent.ExecutionException: java.lang.IllegalStateException: Workspace name='workspacepdg166' start failed.
  at org.eclipse.che.selenium.core.CheSeleniumSuiteModule.getWorkspace(CheSeleniumSuiteModule.java:148)
...
Caused by: org.eclipse.che.api.core.ServerException: Failure executing: POST at: https://172.30.3.246:8443/apis/project.openshift.io/v1/projectrequests. Message: Forbidden!Configured service account doesn't have access. Service account may have been revoked. projectrequests.project.openshift.io is forbidden: User "system:serviceaccount:eclipse-che:che" cannot create projectrequests.project.openshift.io at the cluster scope: You may not request a new project via this API.. The error may be caused by an expired token or changed password. Update Che server deployment with a new token or password.
```

### What issues does this PR fix or reference?
#10143 