### PR TITLE
Selenium: move WorkingWithJavaMySqlStackTest and WorkingWithNodeWsTest selenium tests to stack package

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/WorkingWithJavaMySqlStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/WorkingWithJavaMySqlStackTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.selenium.workspaces;
+package org.eclipse.che.selenium.stack;
 
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestBuildConstants.BUILD_SUCCESS;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/WorkingWithNodeWsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/WorkingWithNodeWsTest.java
@@ -8,7 +8,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.selenium.workspaces;
+package org.eclipse.che.selenium.stack;
 
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.RUN;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -274,8 +274,8 @@
           <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRefreshTest"/>
           <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRenameWorkspaceTest"/>
           <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterWorkspaceRestartTest"/>
-          <class name="org.eclipse.che.selenium.workspaces.WorkingWithJavaMySqlStackTest"/>
-          <class name="org.eclipse.che.selenium.workspaces.WorkingWithNodeWsTest"/>
+          <class name="org.eclipse.che.selenium.stack.WorkingWithJavaMySqlStackTest"/>
+          <class name="org.eclipse.che.selenium.stack.WorkingWithNodeWsTest"/>
           <class name="org.eclipse.che.selenium.workspaces.WorkspaceFromOfficialUbuntuImageStartTest"/>
           <class name="org.eclipse.che.selenium.workspaces.CheckStoppingWsByTimeoutTest"/>
           <class name="org.eclipse.che.selenium.dashboard.AccountTest"/>


### PR DESCRIPTION
### What does this PR do?
This PR moves **WorkingWithJavaMySqlStackTest** and **WorkingWithNodeWsTest** selenium tests from **selenium.workspace** to **selenium.stack** package.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10050