### PR TITLE
Use location instead of Eclipse workspace path for classpath

### DIFF
--- a/agents/ls-java/src/main/resources/installers/1.0.1/org.eclipse.che.ls.java.script.sh
+++ b/agents/ls-java/src/main/resources/installers/1.0.1/org.eclipse.che.ls.java.script.sh
@@ -137,4 +137,4 @@ curl -sL ${DOWNLOAD_AGENT_BINARIES_URI} | tar xzf - -C ${LS_DIR}
 echo writing start script to ${LS_LAUNCHER}
 touch ${LS_LAUNCHER}
 chmod +x ${LS_LAUNCHER}
-echo "java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4  -Declipse.product=org.eclipse.jdt.ls.core.product -noverify -Xmx1G -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4410 -jar ${LS_DIR}/plugins/org.eclipse.equinox.launcher_1.5.0.v20180512-1130.jar -configuration ./config_linux -data ${LS_DIR}/data" > ${LS_LAUNCHER}
+echo "java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4  -Declipse.product=org.eclipse.jdt.ls.core.product -noverify -Xmx1G -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4410 -jar ${LS_DIR}/plugins/org.eclipse.equinox.launcher_1.5.100.v20180607-1243.jar -configuration ./config_linux -data ${LS_DIR}/data" > ${LS_LAUNCHER}

--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/pom.xml
@@ -21,7 +21,14 @@
     <artifactId>org.eclipse.jdt.ui</artifactId>
     <packaging>jar</packaging>
     <name>Che Plugin :: Java :: Eclipse JDT UI</name>
+    <properties>
+        <dto-generator-out-directory>${project.build.directory}/generated-sources/dto/</dto-generator-out-directory>
+    </properties>
     <dependencies>
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+  			<artifactId>gson</artifactId>
+		</dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
@@ -180,6 +187,68 @@
                     </excludes>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-dto-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-server-dto</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <dtoPackages>
+                                <package>org.eclipse.che.ide.ext.java.shared</package>
+                            </dtoPackages>
+                            <outputDirectory>${dto-generator-out-directory}</outputDirectory>
+                            <genClassName>org.eclipse.che.plugin.java.server.dto.DtoServerImpls</genClassName>
+                            <impl>server</impl>
+                        </configuration>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>${project.groupId}</groupId>
+                        <artifactId>${project.artifactId}</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${dto-generator-out-directory}/META-INF</directory>
+                                    <targetPath>META-INF</targetPath>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${dto-generator-out-directory}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
         </plugins>
     </build>
 </project>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-server/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-server/pom.xml
@@ -214,6 +214,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-        </plugins>
+    	</plugins>
     </build>
 </project>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/pom.xml
@@ -21,25 +21,12 @@
     <artifactId>che-plugin-java-ext-lang-shared</artifactId>
     <name>Che Plugin :: Java :: Extension Java Shared</name>
     <properties>
-        <dto-generator-out-directory>${project.build.directory}/generated-sources/dto/</dto-generator-out-directory>
         <findbugs.failonerror>false</findbugs.failonerror>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.inject</groupId>
-            <artifactId>guice</artifactId>
-        </dependency>
-        <dependency>
+    	<dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-dto</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-commons-gwt</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>
@@ -68,18 +55,6 @@
                             </resources>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>add-source</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>add-source</goal>
-                        </goals>
-                        <configuration>
-                            <sources>
-                                <source>${dto-generator-out-directory}</source>
-                            </sources>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -94,49 +69,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.eclipse.che.core</groupId>
-                <artifactId>che-core-api-dto-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>generate-client-dto</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <dtoPackages>
-                                <package>org.eclipse.che.ide.ext.java.shared</package>
-                            </dtoPackages>
-                            <outputDirectory>${dto-generator-out-directory}</outputDirectory>
-                            <genClassName>org.eclipse.che.ide.ext.java.client.dto.DtoClientImpls</genClassName>
-                            <impl>client</impl>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>generate-server-dto</id>
-                        <phase>process-sources</phase>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                        <configuration>
-                            <dtoPackages>
-                                <package>org.eclipse.che.ide.ext.java.shared</package>
-                            </dtoPackages>
-                            <outputDirectory>${dto-generator-out-directory}</outputDirectory>
-                            <genClassName>org.eclipse.che.plugin.java.server.dto.DtoServerImpls</genClassName>
-                            <impl>server</impl>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>${project.groupId}</groupId>
-                        <artifactId>${project.artifactId}</artifactId>
-                        <version>${project.version}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
+         </plugins>
     </build>
 </project>

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/plainjava/ConfigureClasspathBaseTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/plainjava/ConfigureClasspathBaseTest.java
@@ -21,6 +21,7 @@ import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.ConfigureClasspath;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -37,6 +38,7 @@ public class ConfigureClasspathBaseTest {
   @Inject private ConfigureClasspath configureClasspath;
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
+  @Inject private Consoles consoles;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -47,6 +49,7 @@ public class ConfigureClasspathBaseTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_JAVA_MULTIMODULE);
     ide.open(ws);
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Uses location URI instead of eclipse workspace path. This is basically a bugfix

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10052
#### Release Notes
n/a: this reestablishes the same behaviour as in master

#### Docs PR
None