### PR TITLE
che #9946: Better handling of unrecoverable events for k8s & openshift infra (processing both 'container' and 'pod' events)

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -355,7 +355,7 @@ che.infra.kubernetes.ingress_start_timeout_min=5
 
 # If during workspace startup an unrecoverable event defined in the property occurs,
 # terminate workspace immediately instead of waiting until timeout
-che.infra.kubernetes.workspace_unrecoverable_events=Failed Mount,Failed Scheduling,Failed to pull image
+che.infra.kubernetes.workspace_unrecoverable_events=FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image
 
 che.infra.kubernetes.bootstrapper.binary_url=http://${CHE_HOST}:${CHE_PORT}/agent-binaries/linux_amd64/bootstrapper/bootstrapper
 che.infra.kubernetes.bootstrapper.installer_timeout_sec=180

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/event/PodEvent.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/event/PodEvent.java
@@ -11,22 +11,23 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event;
 
 import java.util.Objects;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /**
- * The event that should be published when container change occurs, e.g. image pulled, container
- * started.
+ * The event that should be published when the pod event occurs, e.g. pulling image, created
+ * container
  *
  * @author Sergii Leshchenko
  */
-public class ContainerEvent {
+public class PodEvent {
   private final String podName;
-  private final String containerName;
+  @Nullable private final String containerName;
   private final String reason;
   private final String message;
   private final String creationTimestamp;
   private final String lastTimestamp;
 
-  public ContainerEvent(
+  public PodEvent(
       String podName,
       String containerName,
       String reason,
@@ -41,12 +42,16 @@ public class ContainerEvent {
     this.lastTimestamp = lastTimestamp;
   }
 
-  /** Returns name of pod related to container. */
+  /** Returns name of pod related to the event. */
   public String getPodName() {
     return podName;
   }
 
-  /** Returns container name which produced event. */
+  /**
+   * Returns container name produced by the event. Could be null if the event is related to the pod
+   * but not any particular 'container'
+   */
+  @Nullable
   public String getContainerName() {
     return containerName;
   }
@@ -79,7 +84,7 @@ public class ContainerEvent {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    ContainerEvent that = (ContainerEvent) o;
+    PodEvent that = (PodEvent) o;
     return Objects.equals(podName, that.podName)
         && Objects.equals(containerName, that.containerName)
         && Objects.equals(reason, that.reason)
@@ -95,7 +100,7 @@ public class ContainerEvent {
 
   @Override
   public String toString() {
-    return "ContainerEvent{"
+    return "PodEvent{"
         + "podName='"
         + podName
         + '\''

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/event/PodEventHandler.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/event/PodEventHandler.java
@@ -11,12 +11,12 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event;
 
 /**
- * Defines the handling mechanism for Kubernetes container events.
+ * Defines the handling mechanism for Kubernetes events.
  *
  * @author Sergii Leshchenko
  */
-public interface ContainerEventHandler {
+public interface PodEventHandler {
 
   /** Handles the container event. */
-  void handle(ContainerEvent event);
+  void handle(PodEvent event);
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/PodEvents.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/PodEvents.java
@@ -14,30 +14,26 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.ContainerEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodEvent;
 
 /**
- * Helps to simplify the interaction with the {@link ContainerEvent}.
+ * Helps to simplify the interaction with the {@link PodEvent}.
  *
  * @author Ilya Buziuk
  */
-public final class ContainerEvents {
+public final class PodEvents {
   private static DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
 
-  private ContainerEvents() {}
+  private PodEvents() {}
 
   /**
-   * Converts the time of {@link ContainerEvent} e.g. '2018-05-15T16:17:54Z' to the {@link Date}
-   * format
+   * Converts the time of {@link PodEvent} e.g. '2018-05-15T16:17:54Z' to the {@link Date} format
    */
   public static Date convertEventTimestampToDate(String timestamp) throws ParseException {
     return dateFormat.parse(timestamp);
   }
 
-  /**
-   * Converts the {@link Date} to {@link ContainerEvent} timestamp format e.g.
-   * '2018-05-15T16:17:54Z'
-   */
+  /** Converts the {@link Date} to {@link PodEvent} timestamp format e.g. '2018-05-15T16:17:54Z' */
   public static String convertDateToEventTimestamp(Date date) {
     return dateFormat.format(date);
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/PodEventsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/PodEventsTest.java
@@ -16,31 +16,31 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /**
- * Tests {@link ContainerEvents}.
+ * Tests {@link PodEvents}.
  *
  * @author Ilya Buziuk
  */
-public class ContainerEventsTest {
+public class PodEventsTest {
 
   @Test
   public void eventDateShouldBeBeforeCurrentDate() throws ParseException {
     String eventTime = "2018-05-15T16:17:54Z";
-    Date eventDate = ContainerEvents.convertEventTimestampToDate(eventTime);
+    Date eventDate = PodEvents.convertEventTimestampToDate(eventTime);
     Assert.assertTrue(eventDate.before(new Date()));
   }
 
   @Test(expectedExceptions = ParseException.class)
   public void throwsParseExceptionWhenDateFormatIsInvalid() throws ParseException {
     String eventTime = "2018-05-15T16:143435Z";
-    ContainerEvents.convertEventTimestampToDate(eventTime);
+    PodEvents.convertEventTimestampToDate(eventTime);
   }
 
   @Test
   public void getEventTimestampFromDate() throws ParseException {
     String timestamp = "2018-05-15T16:17:54Z";
-    Date date = ContainerEvents.convertEventTimestampToDate(timestamp);
-    String timestampFromDate = ContainerEvents.convertDateToEventTimestamp(date);
-    Date dateAfterParsingTimestamp = ContainerEvents.convertEventTimestampToDate(timestampFromDate);
+    Date date = PodEvents.convertEventTimestampToDate(timestamp);
+    String timestampFromDate = PodEvents.convertDateToEventTimestamp(date);
+    Date dateAfterParsingTimestamp = PodEvents.convertEventTimestampToDate(timestampFromDate);
     Assert.assertEquals(date, dateAfterParsingTimestamp);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -110,10 +110,10 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
     // TODO https://github.com/eclipse/che/issues/7653
     // project.pods().watch(new AbnormalStopHandler());
 
-    project.pods().watchContainers(new MachineLogsPublisher());
+    project.pods().watchEvents(new MachineLogsPublisher());
     if (!unrecoverableEvents.isEmpty()) {
       Map<String, Pod> pods = getContext().getEnvironment().getPods();
-      project.pods().watchContainers(new UnrecoverableEventHandler(pods));
+      project.pods().watchEvents(new UnrecoverablePodEventHandler(pods));
     }
 
     doStartMachine(new OpenShiftServerResolver(createdServices, createdRoutes));

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -235,7 +235,7 @@ public class OpenShiftInternalRuntimeTest {
     verify(services).create(any());
     verify(secrets).create(any());
 
-    verify(project.pods(), times(2)).watchContainers(any());
+    verify(project.pods(), times(2)).watchEvents(any());
     verify(eventService, times(2)).publish(any());
     verifyEventsOrder(newEvent(M1_NAME, STARTING), newEvent(M2_NAME, STARTING));
   }
@@ -254,7 +254,7 @@ public class OpenShiftInternalRuntimeTest {
     verify(routes).create(any());
     verify(services).create(any());
 
-    verify(project.pods(), times(1)).watchContainers(any());
+    verify(project.pods(), times(1)).watchEvents(any());
     verify(eventService, times(2)).publish(any());
     verifyEventsOrder(newEvent(M1_NAME, STARTING), newEvent(M2_NAME, STARTING));
   }


### PR DESCRIPTION
### What does this PR do?
Better handling of unrecoverable events for k8s & openshift infra (processing both 'container' and 'pod' events). Previously only containers (sub-set of pod events) were processed. However, some unrecoverable events happens on pod level and simply not taken into account during processing `Unrecoverable` events. So, after discussion with @sleshchenko it was decided to process all pod events and make more precise filtering on a handler level e.g. `MachineLogsPublisher` will still publish only container events and `UnrecoverableEventHandler` would process both container & pod events

[WIP] status is just because I want to test it a bit more before pushing and probably add some javadocs

### What issues does this PR fix or reference?
che #9946 


#### Release Notes
N/A

#### Docs PR
N/A (yet)


