### PR TITLE
Selenium: set the GitHub username to lowercase when compared to the value 'Federated Identity'

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromPreferencesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromPreferencesTest.java
@@ -146,7 +146,12 @@ public class AuthorizeOnGithubFromPreferencesTest {
     // check GitHub identity is present in Keycloak account management page
     if (isMultiuser) {
       keycloakFederatedIdentitiesPage.open();
-      assertEquals(keycloakFederatedIdentitiesPage.getGitHubIdentityFieldValue(), gitHubUsername);
+
+      // set to lower case because it's a normal behaviour (issue:
+      // https://github.com/eclipse/che/issues/10138)
+      assertEquals(
+          keycloakFederatedIdentitiesPage.getGitHubIdentityFieldValue(),
+          gitHubUsername.toLowerCase());
     }
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportWizardFormTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportWizardFormTest.java
@@ -211,7 +211,12 @@ public class ImportWizardFormTest {
     // check GitHub identity is present in Keycloak account management page
     if (isMultiuser) {
       keycloakFederatedIdentitiesPage.open();
-      assertEquals(keycloakFederatedIdentitiesPage.getGitHubIdentityFieldValue(), gitHubUsername);
+
+      // set to lower case because it's a normal behaviour (issue:
+      // https://github.com/eclipse/che/issues/10138)
+      assertEquals(
+          keycloakFederatedIdentitiesPage.getGitHubIdentityFieldValue(),
+          gitHubUsername.toLowerCase());
       ide.open(ws);
     }
   }


### PR DESCRIPTION
### What does this PR do?
* Correct selenium tests which have comparing the the GitHub username with the value on the Federated Identity page in the Keycloak
* Set the Git Hub username in the lower case
* Related selenium tests: ImportWizardFormTest, AuthorizeOnGithubFromPreferencesT

### What issues does this PR fix or reference?
#10138, #10156