### PR TITLE
Adapt the CSharpFileEditingTest after latest changes in Csharp language server

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
@@ -69,14 +69,12 @@ public class CSharpFileEditingTest {
 
   @AfterMethod
   public void restartWorkspace() throws Exception {
-    if (testWorkspaceServiceClient.getStatus(workspace.getId()).equals(WorkspaceStatus.RUNNING)) {
       editor.closeAllTabs();
       testWorkspaceServiceClient.stop(workspace.getName(), workspace.getOwner().getName());
       ide.open(workspace);
       ide.waitOpenedWorkspaceIsReadyToUse();
       restoreDependenciesForLanguageServerByCommand();
       projectExplorer.quickRevealToItemWithJavaScript(PROJECT_NAME + "/Program.cs");
-    }
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
@@ -15,7 +15,6 @@ import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.IN
 import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
-import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
@@ -69,12 +68,12 @@ public class CSharpFileEditingTest {
 
   @AfterMethod
   public void restartWorkspace() throws Exception {
-      editor.closeAllTabs();
-      testWorkspaceServiceClient.stop(workspace.getName(), workspace.getOwner().getName());
-      ide.open(workspace);
-      ide.waitOpenedWorkspaceIsReadyToUse();
-      restoreDependenciesForLanguageServerByCommand();
-      projectExplorer.quickRevealToItemWithJavaScript(PROJECT_NAME + "/Program.cs");
+    editor.closeAllTabs();
+    testWorkspaceServiceClient.stop(workspace.getName(), workspace.getOwner().getName());
+    ide.open(workspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    restoreDependenciesForLanguageServerByCommand();
+    projectExplorer.quickRevealToItemWithJavaScript(PROJECT_NAME + "/Program.cs");
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
@@ -10,14 +10,16 @@
  */
 package org.eclipse.che.selenium.languageserver;
 
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MINIMUM_SEC;
+import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.*;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
-import java.util.List;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
+import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -30,11 +32,9 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Wizard;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
-import org.openqa.selenium.By;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
+import org.openqa.selenium.TimeoutException;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -56,16 +56,67 @@ public class CSharpFileEditingTest {
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private TestCommandServiceClient testCommandServiceClient;
   @Inject private CommandsPalette commandsPalette;
-
+  @Inject TestWorkspaceServiceClient testWorkspaceServiceClient;
   @Inject private Consoles consoles;
 
   @BeforeClass
   public void setUp() throws Exception {
     ide.open(workspace);
+    createDotNetAppFromWizard();
+    restoreLanguageServer();
+    projectExplorer.quickRevealToItemWithJavaScript(PROJECT_NAME + "/Program.cs");
+  }
+
+  @AfterMethod
+  public void restartWorkspace() throws Exception {
+    if (testWorkspaceServiceClient.getStatus(workspace.getId()).equals(WorkspaceStatus.RUNNING)) {
+      editor.closeAllTabs();
+      testWorkspaceServiceClient.stop(workspace.getName(), workspace.getOwner().getName());
+      ide.open(workspace);
+      ide.waitOpenedWorkspaceIsReadyToUse();
+      restoreLanguageServer();
+      projectExplorer.quickRevealToItemWithJavaScript(PROJECT_NAME + "/Program.cs");
+    }
   }
 
   @Test
-  public void checkLaunchingCodeserver() {
+  public void checkCodeEditing() {
+    projectExplorer.openItemByPath(PROJECT_NAME + "/Program.cs");
+    checkCodeValidation();
+  }
+
+  @Test(priority = 1)
+  public void checkInitializingAfterFirstStarting() {
+    projectExplorer.openItemByPath(PROJECT_NAME + "/Program.cs");
+    try {
+      editor.waitMarkerInPosition(INFO, 1);
+      editor.waitMarkerInPosition(INFO, 2);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("https://github.com/eclipse/che/issues/10151");
+    }
+  }
+
+  public void checkCodeValidation() {
+    editor.goToCursorPositionVisible(24, 12);
+    for (int i = 0; i < 9; i++) {
+      editor.typeTextIntoEditor(Keys.BACK_SPACE.toString());
+    }
+    editor.waitMarkerInPosition(ERROR, 23);
+    editor.waitMarkerInPosition(ERROR, 21);
+    checkAutocompletion();
+  }
+
+  private void checkAutocompletion() {
+    editor.goToCursorPositionVisible(23, 49);
+    editor.typeTextIntoEditor(".");
+    editor.launchAutocomplete();
+    editor.enterAutocompleteProposal("Build ");
+    editor.typeTextIntoEditor("();");
+    editor.waitAllMarkersInvisibility(ERROR);
+  }
+
+  private void createDotNetAppFromWizard() {
     projectExplorer.waitProjectExplorer();
     menu.runCommand(
         TestMenuCommandsConstants.Workspace.WORKSPACE,
@@ -74,51 +125,11 @@ public class CSharpFileEditingTest {
     wizard.typeProjectNameOnWizard(PROJECT_NAME);
     wizard.clickCreateButton();
     wizard.waitCloseProjectConfigForm();
-    projectExplorer.openItemByPath(PROJECT_NAME);
-    projectExplorer.waitItem(PROJECT_NAME + "/Program.cs", 240);
-    projectExplorer.openItemByPath(PROJECT_NAME + "/Program.cs");
-    loader.waitOnClosed();
-    checkLanguageServerInitStateAndLaunch();
-    editor.goToCursorPositionVisible(24, 12);
-    for (int i = 0; i < 9; i++) {
-      editor.typeTextIntoEditor(Keys.BACK_SPACE.toString());
-    }
-    editor.waitMarkerInPosition(ERROR, 23);
-    editor.waitMarkerInPosition(ERROR, 21);
-    editor.goToCursorPositionVisible(23, 49);
-    editor.typeTextIntoEditor(".");
-    editor.launchAutocomplete();
-    editor.enterAutocompleteProposal("Build() ");
-    editor.typeTextIntoEditor(";");
-    editor.waitAllMarkersInvisibility(ERROR);
   }
 
-  private void checkLanguageServerInitStateAndLaunch() {
-    if (isLanguageServerInitFailed()) {
-      reInitLanguageServer();
-    }
-  }
-
-  private void reInitLanguageServer() {
+  private void restoreLanguageServer() {
     commandsPalette.openCommandPalette();
     commandsPalette.startCommandByDoubleClick(COMMAND_NAME_FOR_RESTORE_LS);
     consoles.waitExpectedTextIntoConsole("Restore completed");
-    editor.closeAllTabs();
-    projectExplorer.openItemByPath(PROJECT_NAME + "/Program.cs");
-    loader.waitOnClosed();
-  }
-
-  private boolean isLanguageServerInitFailed() {
-    String xpathLocatorForEventMessages =
-        "//div[contains(@id,'gwt-debug-notification-wrappergwt-uid')]";
-    List<WebElement> textMessages =
-        new WebDriverWait(seleniumWebDriver, MINIMUM_SEC)
-            .until(
-                ExpectedConditions.presenceOfAllElementsLocatedBy(
-                    By.xpath(xpathLocatorForEventMessages)));
-    return textMessages
-        .stream()
-        .anyMatch(
-            message -> message.getAttribute("textContent").contains("Timeout initializing error"));
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.che.selenium.languageserver;
 
-import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.INFO;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
+import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.INFO;
 import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
@@ -63,7 +63,7 @@ public class CSharpFileEditingTest {
   public void setUp() throws Exception {
     ide.open(workspace);
     createDotNetAppFromWizard();
-    restoreLanguageServer();
+    restoreDependenciesForLanguageServerByCommand();
     projectExplorer.quickRevealToItemWithJavaScript(PROJECT_NAME + "/Program.cs");
   }
 
@@ -74,7 +74,7 @@ public class CSharpFileEditingTest {
       testWorkspaceServiceClient.stop(workspace.getName(), workspace.getOwner().getName());
       ide.open(workspace);
       ide.waitOpenedWorkspaceIsReadyToUse();
-      restoreLanguageServer();
+      restoreDependenciesForLanguageServerByCommand();
       projectExplorer.quickRevealToItemWithJavaScript(PROJECT_NAME + "/Program.cs");
     }
   }
@@ -93,7 +93,7 @@ public class CSharpFileEditingTest {
       editor.waitMarkerInPosition(INFO, 2);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("https://github.com/eclipse/che/issues/10151");
+      fail("Known issue: https://github.com/eclipse/che/issues/10151", ex);
     }
   }
 
@@ -102,7 +102,7 @@ public class CSharpFileEditingTest {
     for (int i = 0; i < 9; i++) {
       editor.typeTextIntoEditor(Keys.BACK_SPACE.toString());
     }
-    editor.waitMarkerInPosition(ERROR, 23);
+    editor.waitMarkerInPosition(INFO, 23);
     editor.waitMarkerInPosition(ERROR, 21);
     checkAutocompletion();
   }
@@ -113,7 +113,7 @@ public class CSharpFileEditingTest {
     editor.launchAutocomplete();
     editor.enterAutocompleteProposal("Build ");
     editor.typeTextIntoEditor("();");
-    editor.waitAllMarkersInvisibility(ERROR);
+    editor.waitAllMarkersInvisibility(INFO);
   }
 
   private void createDotNetAppFromWizard() {
@@ -127,7 +127,7 @@ public class CSharpFileEditingTest {
     wizard.waitCloseProjectConfigForm();
   }
 
-  private void restoreLanguageServer() {
+  private void restoreDependenciesForLanguageServerByCommand() {
     commandsPalette.openCommandPalette();
     commandsPalette.startCommandByDoubleClick(COMMAND_NAME_FOR_RESTORE_LS);
     consoles.waitExpectedTextIntoConsole("Restore completed");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.selenium.languageserver;
 
-import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.*;
+import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.INFO;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.testng.Assert.fail;
 


### PR DESCRIPTION
### What does this PR do?
* After latest changes for C# language server we have next issue: https://github.com/eclipse/che/issues/10047, so this PR accounts  this behavior.
* Also during the reworking the test has been created new issue: https://github.com/eclipse/che/issues/10151. This test covers the usecase with codevalidation after first opennning a file.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9925
@dmytro-ndp @SkorikSergey @Ohrimenko1988 