### PR TITLE
Fix a bug in the Che GWT maven plugin that prevents RhChe to build with upstream `master`

### DIFF
--- a/core/che-core-gwt-maven-plugin/src/main/java/org/eclipse/che/plugin/gwt/ProcessExcludesMojo.java
+++ b/core/che-core-gwt-maven-plugin/src/main/java/org/eclipse/che/plugin/gwt/ProcessExcludesMojo.java
@@ -160,7 +160,7 @@ public class ProcessExcludesMojo extends AbstractMojo {
         String[] split = pattern.split(":");
         String groupId = split[0];
         String artifactId = split[1];
-        String version = fullIdeArtifact.getVersion();
+        String version = fullIdeArtifact.getBaseVersion();
 
         Artifact artifact = repositorySystem.createArtifact(groupId, artifactId, version, "jar");
         String gwtModule = readGwtModuleName(artifact);


### PR DESCRIPTION
### What does this PR do?

This PR fixes the root cause of the CI build failures that can be found here: https://ci.codenvycorp.com/job/rh-che-ci-master

It is a bug in the Che GWT maven plugin (in the `ProcessExcludesMojo`) that prevents `rh-che` to build correctly against the Che upstream `master` branch.

The fix consists in using the `baseVersion` (i.e. `6.8.0-SNAPSHOT` for example), instead of the precise version (i.e. `6.8.0-20180625.090508-19` for example) when trying to resolve excluded artifacts, since the precise version available in the Maven repositories can be a different between the main artifact and excluded artifacts.

### What issues does this PR fix or reference?

It fixes CI build failures that can be found here: https://ci.codenvycorp.com/job/rh-che-ci-master
