### PR TITLE
Fixed absence of internal servers in WorkspaceProjectSynchronizer

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/WorkspaceProjectSynchronizer.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/WorkspaceProjectSynchronizer.java
@@ -185,7 +185,9 @@ public class WorkspaceProjectSynchronizer implements ProjectSynchronizer, Worksp
     final UriBuilder builder =
         UriBuilder.fromUri(apiEndpoint)
             .path(WorkspaceService.class)
-            .path(WorkspaceService.class, "getByKey");
+            .path(WorkspaceService.class, "getByKey")
+            .queryParam("includeInternalServers", "true");
+
     final String href = builder.build(workspaceId).toString();
     try {
       return httpJsonRequestFactory


### PR DESCRIPTION
Related issue: https://github.com/eclipse/che/issues/10194

Added `includeInternalServers` query parameter to request to workspace service so workspace configuration will include internal servers as well.