### PR TITLE
Make Authorization header value more uniform and use 'Bearer' prefix

### DIFF
--- a/multiuser/machine-auth/che-multiuser-machine-authentication-ide/src/main/java/org/eclipse/che/multiuser/machine/authentication/ide/MachineAsyncRequest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-ide/src/main/java/org/eclipse/che/multiuser/machine/authentication/ide/MachineAsyncRequest.java
@@ -38,7 +38,7 @@ public class MachineAsyncRequest extends AsyncRequest {
   @Override
   public Promise<Void> send() {
     requestBuilder.setIncludeCredentials(true);
-    header(AUTHORIZATION, token);
+    header(AUTHORIZATION, "Bearer " + token);
     return super.send();
   }
 
@@ -67,7 +67,7 @@ public class MachineAsyncRequest extends AsyncRequest {
   @Override
   public void send(final AsyncRequestCallback<?> callback) {
     requestBuilder.setIncludeCredentials(true);
-    header(AUTHORIZATION, token);
+    header(AUTHORIZATION, "Bearer " + token);
     super.send(callback);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/server/WsAgentServerLivenessProbeConfigFactory.java
@@ -71,7 +71,8 @@ public class WsAgentServerLivenessProbeConfigFactory implements HttpProbeConfigF
           uri.getScheme(),
           uri.getPath(),
           singletonMap(
-              HttpHeaders.AUTHORIZATION, machineTokenProvider.getToken(userId, workspaceId)),
+              HttpHeaders.AUTHORIZATION,
+              "Bearer " + machineTokenProvider.getToken(userId, workspaceId)),
           successThreshold,
           3,
           120,

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/probe/WorkspaceProbesFactoryTest.java
@@ -85,7 +85,7 @@ public class WorkspaceProbesFactoryTest {
         "localhost",
         4040,
         "https",
-        singletonMap(HttpHeaders.AUTHORIZATION, TOKEN));
+        singletonMap(HttpHeaders.AUTHORIZATION, "Bearer " + TOKEN));
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?

Adds 'Bearer' prefix into `Authentication` header of all machine-token signed requests.
Thats made to unify tokens format with oidc protocol and avoid potential problems with 3rd party authenticators (like jwtproxy or smthn else)

### What issues does this PR fix or reference?


#### Release Notes
N/A


#### Docs PR
N/A