### PR TITLE
#10229 Publish all workspace pod events to the machine logs

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -772,19 +772,17 @@ public class KubernetesInternalRuntime<
     }
   }
 
-  /** Listens container's events and publish them as machine logs. */
+  /** Listens pod events and publish them as machine logs. */
   public class MachineLogsPublisher implements PodEventHandler {
 
     @Override
     public void handle(PodEvent event) {
       final String podName = event.getPodName();
-      final String containerName = event.getContainerName();
       try {
         for (Entry<String, KubernetesMachineImpl> entry :
             machines.getMachines(getContext().getIdentity()).entrySet()) {
           final KubernetesMachineImpl machine = entry.getValue();
-          if (machine.getPodName().equals(podName)
-              && machine.getContainerName().equals(containerName)) {
+          if (machine.getPodName().equals(podName)) {
             eventPublisher.sendMachineLogEnvent(
                 entry.getKey(),
                 event.getMessage(),


### PR DESCRIPTION
### What does this PR do?
Publish all workspace pod events to the machine logs (not only container events).

![image](https://user-images.githubusercontent.com/1461122/42094792-2b8837f8-7bb1-11e8-9e06-655d2284f75e.png)

This would enrich logs automatically with "Scheduled" & "Successful Mount Volume"

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/10229

<!-- #### Changelog -->
N/A


#### Release Notes
N/A

#### Docs PR
N/A