### PR TITLE
Optimizing che-theia-factory loading sequence by adding it to the def…

### DIFF
--- a/dockerfiles/theia/src/package.json
+++ b/dockerfiles/theia/src/package.json
@@ -11,7 +11,7 @@
         "@theia/markers": "latest",
         "@theia/extension-manager": "latest",
         "@theia/messages": "latest",
-        "@eclipse-che/theia-factory-extension": "latest"
+        "@eclipse-che/theia-factory-extension": "0.0.1-1530189818"
     },
     "devDependencies": {
         "@theia/cli": "latest"

--- a/dockerfiles/theia/src/package.json
+++ b/dockerfiles/theia/src/package.json
@@ -10,7 +10,8 @@
         "@theia/file-search": "latest",
         "@theia/markers": "latest",
         "@theia/extension-manager": "latest",
-        "@theia/messages": "latest"
+        "@theia/messages": "latest",
+        "@eclipse-che/theia-factory-extension": "latest"
     },
     "devDependencies": {
         "@theia/cli": "latest"


### PR DESCRIPTION
…ault che-theia docker image (#10062)

Signed-off-by: Sun Seng David TAN <sutan@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adding che-theia-factory extension to the default che-theia docker image to avoid recompiling at startup.

### What issues does this PR fix or reference?
#10062

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Optimizing che-theia-factory loading sequence by adding it to the default che-theia docker image 
