### PR TITLE
Fix version of jdtls runner

### DIFF
--- a/agents/ls-java/src/main/resources/installers/1.0.1/org.eclipse.che.ls.java.script.sh
+++ b/agents/ls-java/src/main/resources/installers/1.0.1/org.eclipse.che.ls.java.script.sh
@@ -137,4 +137,4 @@ curl -sL ${DOWNLOAD_AGENT_BINARIES_URI} | tar xzf - -C ${LS_DIR}
 echo writing start script to ${LS_LAUNCHER}
 touch ${LS_LAUNCHER}
 chmod +x ${LS_LAUNCHER}
-echo "java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4  -Declipse.product=org.eclipse.jdt.ls.core.product -noverify -Xmx1G -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4410 -jar ${LS_DIR}/plugins/org.eclipse.equinox.launcher_1.5.100.v20180607-1243.jar -configuration ./config_linux -data ${LS_DIR}/data" > ${LS_LAUNCHER}
+echo "java -Declipse.application=org.eclipse.jdt.ls.core.id1 -Dosgi.bundles.defaultStartLevel=4  -Declipse.product=org.eclipse.jdt.ls.core.product -noverify -Xmx1G -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=4410 -jar ${LS_DIR}/plugins/org.eclipse.equinox.launcher_1.5.100.v20180611-1436.jar -configuration ./config_linux -data ${LS_DIR}/data" > ${LS_LAUNCHER}


### PR DESCRIPTION
Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This fixes JDT LS runner version to be 1.5.100.v20180611-1436

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
