### PR TITLE
Fix logic error in CSharpFileEditingTest

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
@@ -110,7 +110,7 @@ public class CSharpFileEditingTest {
     editor.launchAutocomplete();
     editor.enterAutocompleteProposal("Build ");
     editor.typeTextIntoEditor("();");
-    editor.waitAllMarkersInvisibility(INFO);
+    editor.waitAllMarkersInvisibility(ERROR);
   }
 
   private void createDotNetAppFromWizard() {


### PR DESCRIPTION
### What does this PR do?
* Fix logic error in the test. In the user story after fixing errors - we should wait disappearing of `error` marker. But we wait disappearance of  `info` marker.