### PR TITLE
Added cascade removing of Kubernetes runtime state when a workspace is removed

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -32,10 +32,7 @@ import org.eclipse.che.api.workspace.server.wsnext.WorkspaceNextApplier;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
-import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
-import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesMachineCache;
-import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesRuntimeStateCache;
+import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesRuntimeCacheModule;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.RemoveNamespaceOnWorkspaceRemove;
@@ -117,8 +114,7 @@ public class KubernetesInfraModule extends AbstractModule {
         .annotatedWith(com.google.inject.name.Names.named("infra.kubernetes.ingress.annotations"))
         .toProvider(IngressAnnotationsProvider.class);
 
-    bind(KubernetesRuntimeStateCache.class).to(JpaKubernetesRuntimeStateCache.class);
-    bind(KubernetesMachineCache.class).to(JpaKubernetesMachineCache.class);
+    install(new JpaKubernetesRuntimeCacheModule());
 
     MapBinder<String, WorkspaceNextApplier> wsNext =
         MapBinder.newMapBinder(binder(), String.class, WorkspaceNextApplier.class);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/BeforeKubernetesRuntimeStateRemovedEvent.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/BeforeKubernetesRuntimeStateRemovedEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.cache;
+
+import org.eclipse.che.core.db.cascade.event.RemoveEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesRuntimeState;
+
+/**
+ * Published before {@link KubernetesRuntimeState kubernetes runtime state} removed.
+ *
+ * @author Sergii Leshchenko
+ */
+public class BeforeKubernetesRuntimeStateRemovedEvent extends RemoveEvent {
+
+  private final KubernetesRuntimeState k8sRuntimeState;
+
+  public BeforeKubernetesRuntimeStateRemovedEvent(KubernetesRuntimeState k8sRuntimeState) {
+    this.k8sRuntimeState = k8sRuntimeState;
+  }
+
+  public KubernetesRuntimeState getRuntimeState() {
+    return k8sRuntimeState;
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/jpa/JpaKubernetesRuntimeCacheModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/jpa/JpaKubernetesRuntimeCacheModule.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa;
+
+import com.google.inject.AbstractModule;
+import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
+import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
+
+/** @author Sergii Leshchenko */
+public class JpaKubernetesRuntimeCacheModule extends AbstractModule {
+  @Override
+  protected void configure() {
+    bind(KubernetesRuntimeStateCache.class).to(JpaKubernetesRuntimeStateCache.class);
+    bind(KubernetesMachineCache.class).to(JpaKubernetesMachineCache.class);
+    bind(JpaKubernetesRuntimeStateCache.RemoveKubernetesRuntimeBeforeWorkspaceRemoved.class)
+        .asEagerSingleton();
+    bind(JpaKubernetesMachineCache.RemoveKubernetesMachinesBeforeRuntimesRemoved.class)
+        .asEagerSingleton();
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/model/KubernetesRuntimeState.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/model/KubernetesRuntimeState.java
@@ -25,10 +25,14 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 @Entity(name = "KubernetesRuntime")
 @Table(name = "che_k8s_runtime")
 @NamedQueries({
-  @NamedQuery(name = "KubernetesRuntime.getAll", query = "SELECT r FROM KubernetesRuntime r")
+  @NamedQuery(name = "KubernetesRuntime.getAll", query = "SELECT r FROM KubernetesRuntime r"),
+  @NamedQuery(
+    name = "KubernetesRuntime.getByWorkspaceId",
+    query = "SELECT r FROM KubernetesRuntime r WHERE r.runtimeId.workspaceId = :workspaceId"
+  )
 })
 public class KubernetesRuntimeState {
-  @EmbeddedId private RuntimeId runtimeRuntimeId;
+  @EmbeddedId private RuntimeId runtimeId;
 
   @Column(name = "namespace")
   private String namespace;
@@ -40,7 +44,7 @@ public class KubernetesRuntimeState {
 
   public KubernetesRuntimeState(
       RuntimeIdentity runtimeIdentity, String namespace, WorkspaceStatus status) {
-    this.runtimeRuntimeId =
+    this.runtimeId =
         new RuntimeId(
             runtimeIdentity.getWorkspaceId(),
             runtimeIdentity.getEnvName(),
@@ -58,7 +62,7 @@ public class KubernetesRuntimeState {
   }
 
   public RuntimeId getRuntimeId() {
-    return runtimeRuntimeId;
+    return runtimeId;
   }
 
   public WorkspaceStatus getStatus() {
@@ -83,7 +87,7 @@ public class KubernetesRuntimeState {
       return false;
     }
     final KubernetesRuntimeState that = (KubernetesRuntimeState) obj;
-    return Objects.equals(runtimeRuntimeId, that.runtimeRuntimeId)
+    return Objects.equals(runtimeId, that.runtimeId)
         && Objects.equals(namespace, that.namespace)
         && Objects.equals(status, that.status);
   }
@@ -91,7 +95,7 @@ public class KubernetesRuntimeState {
   @Override
   public int hashCode() {
     int hash = 7;
-    hash = 31 * hash + Objects.hashCode(runtimeRuntimeId);
+    hash = 31 * hash + Objects.hashCode(runtimeId);
     hash = 31 * hash + Objects.hashCode(namespace);
     hash = 31 * hash + Objects.hashCode(status);
     return hash;
@@ -100,8 +104,8 @@ public class KubernetesRuntimeState {
   @Override
   public String toString() {
     return "KubernetesRuntimeState{"
-        + "runtimeRuntimeId="
-        + runtimeRuntimeId
+        + "runtimeId="
+        + runtimeId
         + ", namespace='"
         + namespace
         + '\''

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -30,10 +30,7 @@ import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.D
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientTermination;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
-import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
-import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesMachineCache;
-import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesRuntimeStateCache;
+import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesRuntimeCacheModule;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.UniqueWorkspacePVCStrategy;
@@ -91,8 +88,7 @@ public class OpenShiftInfraModule extends AbstractModule {
         Multibinder.newSetBinder(binder(), EnvVarProvider.class);
     envVarProviders.addBinding().to(LogsRootEnvVariableProvider.class);
 
-    bind(KubernetesRuntimeStateCache.class).to(JpaKubernetesRuntimeStateCache.class);
-    bind(KubernetesMachineCache.class).to(JpaKubernetesMachineCache.class);
+    install(new JpaKubernetesRuntimeCacheModule());
 
     Multibinder.newSetBinder(binder(), ServiceTermination.class)
         .addBinding()

--- a/wsmaster/integration-tests/cascade-removal/pom.xml
+++ b/wsmaster/integration-tests/cascade-removal/pom.xml
@@ -113,6 +113,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-test</artifactId>
             <scope>test</scope>
         </dependency>
@@ -129,6 +134,11 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-sql-schema</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.infrastructure</groupId>
+            <artifactId>infrastructure-kubernetes</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
@@ -20,6 +20,9 @@ import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.account.shared.model.Account;
 import org.eclipse.che.account.spi.AccountImpl;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
+import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
 import org.eclipse.che.api.user.server.model.impl.ProfileImpl;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
@@ -28,13 +31,18 @@ import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.api.workspace.server.model.impl.SourceStorageImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackComponentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
 import org.eclipse.che.api.workspace.server.stack.image.StackIcon;
+import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesMachineImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesRuntimeState;
 
 /**
  * Defines method for creating tests object instances.
@@ -151,6 +159,29 @@ public final class TestObjectsFactory {
         .setStackIcon(
             new StackIcon(id + "-icon", id + "-media-type", "0x1234567890abcdef".getBytes()))
         .build();
+  }
+
+  public static KubernetesRuntimeState createK8sRuntimeState(String workspaceId) {
+    return new KubernetesRuntimeState(
+        new RuntimeIdentityImpl(workspaceId, "envName", "ownerId"),
+        "test-namespace",
+        WorkspaceStatus.RUNNING);
+  }
+
+  public static KubernetesMachineImpl createK8sMachine(KubernetesRuntimeState k8sRuntimeState) {
+    return new KubernetesMachineImpl(
+        k8sRuntimeState.getRuntimeId().getWorkspaceId(),
+        NameGenerator.generate("machine-", 5),
+        NameGenerator.generate("pod-", 5),
+        NameGenerator.generate("container-", 5),
+        MachineStatus.RUNNING,
+        ImmutableMap.of("test", "true"),
+        ImmutableMap.of(
+            "server",
+            new ServerImpl(
+                "http://localhost:8080/api",
+                ServerStatus.RUNNING,
+                ImmutableMap.of("key", "value"))));
   }
 
   private TestObjectsFactory() {}

--- a/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
+++ b/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
@@ -207,6 +207,10 @@ public class PostgreSqlTckModule extends TckModule {
 
     bind(KubernetesRuntimeStateCache.class).to(JpaKubernetesRuntimeStateCache.class);
     bind(KubernetesMachineCache.class).to(JpaKubernetesMachineCache.class);
+    bind(JpaKubernetesRuntimeStateCache.RemoveKubernetesRuntimeBeforeWorkspaceRemoved.class)
+        .asEagerSingleton();
+    bind(JpaKubernetesMachineCache.RemoveKubernetesMachinesBeforeRuntimesRemoved.class)
+        .asEagerSingleton();
   }
 
   private static void waitConnectionIsEstablished(String dbUrl, String dbUser, String dbPassword) {


### PR DESCRIPTION
### What does this PR do?
It's not a case when not stopped workspace is removed, but for some reasons it happens. This PR adds cascade removing of Kubernetes runtime state when a workspace is removed not to lock removing of a workspace. The corresponding error will be logged in Che Server logs.

### What issues does this PR fix or reference?
-

#### Release Notes
N/A

#### Docs PR
N/A