### PR TITLE
Added doc for CHE_LOGGER_CONFIG in che.env file

### DIFF
--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -63,6 +63,11 @@
 # in system output of PID 1 process of container. Useful for storing logs in systems such as Logstash.
 # CHE_LOGS_APPENDERS_IMPL=plaintext
 
+# Sets configuration for listed loggers.
+# It is comma separated list of <LOGGER_NAME>=<LOGGER_LEVEL>.
+# In case if some logger name or logger level are omitted this pair will be silently ignored.
+#CHE_LOGGER_CONFIG=<LOGGER_NAME_1>=<LOGGER_LEVEL_1>,<LOGGER_NAME_2>=<LOGGER_LEVEL_2>
+
 
 ########################################################################################
 #####                                                                              #####


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Settings of `CHE_LOGGER_CONFIG` may be a helpful feature for Che Server debugging but I faced an issue that it is not listed in `che.env` neither `che.properties`. Each time I spend some time to find `EnvironmentVariablesLogLevelPropagator` and check correct name and format for enabling this functionality. So, this PR adds mini-doc for CHE_LOGGER_CONFIG in che.env file.

### What issues does this PR fix or reference?

#### Release Notes
N/A

#### Docs PR
N/A