### PR TITLE
Disables format action in menu when formatting is not supported

### DIFF
--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/formatter/ContentFormatter.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/editor/formatter/ContentFormatter.java
@@ -24,4 +24,14 @@ public interface ContentFormatter {
   void format(Document document);
 
   void install(TextEditor editor);
+
+  /**
+   * Indicates if the content formatter implementation can format the document at its current state.
+   *
+   * @param document the document to be formatted
+   * @return
+   */
+  default boolean canFormat(Document document) {
+    return true;
+  }
 }

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionEditorPresenter.java
@@ -914,7 +914,8 @@ public class OrionEditorPresenter extends AbstractEditorPresenter
       }
     }
     if (TextEditorOperations.FORMAT == operation) {
-      if (getConfiguration().getContentFormatter() != null) {
+      ContentFormatter contentFormatter = getConfiguration().getContentFormatter();
+      if (contentFormatter != null && contentFormatter.canFormat(document)) {
         return true;
       }
     }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/LanguageServerFormatter.java
@@ -87,6 +87,32 @@ public class LanguageServerFormatter implements ContentFormatter {
   }
 
   @Override
+  public boolean canFormat(Document document) {
+    TextRange selectedRange = document.getSelectedTextRange();
+
+    boolean requiresFullDocumentFormatting;
+    if (selectedRange == null) {
+      requiresFullDocumentFormatting = true;
+    } else {
+      requiresFullDocumentFormatting = selectedRange.getFrom().equals(selectedRange.getTo());
+    }
+
+    if (requiresFullDocumentFormatting) {
+      try {
+        return capabilities.getDocumentFormattingProvider();
+      } catch (NullPointerException e) {
+        return false;
+      }
+    } else {
+      try {
+        return capabilities.getDocumentRangeFormattingProvider();
+      } catch (NullPointerException e) {
+        return false;
+      }
+    }
+  }
+
+  @Override
   public void install(TextEditor editor) {
     this.editor = editor;
     if (capabilities.getDocumentOnTypeFormattingProvider() != null


### PR DESCRIPTION
Related issue: https://github.com/eclipse/che/issues/10066

Disables format action in menu when formatting is not supported.