### PR TITLE
Change the loading flow by always wait the runtime before open IDE

### DIFF
--- a/workspace-loader/src/loader/loader.ts
+++ b/workspace-loader/src/loader/loader.ts
@@ -47,6 +47,26 @@ export class Loader {
         }
     }
 
+    /**
+     * Adds an error message to output console.
+     *
+     * @param message error message
+     */
+    error(message: string): void {
+        let container = document.getElementById("workspace-console-container");
+        if (container.childElementCount > 500) {
+            container.removeChild(container.firstChild)
+        }
+
+        let element = document.createElement("pre");
+        element.className = "error";
+        element.innerHTML = message;
+        container.appendChild(element);
+        if (element.scrollIntoView) {
+            element.scrollIntoView();
+        }
+    }
+
     onclick(): void {
         if (document.getElementById('workspace-loader').hasAttribute("max")) {
             document.getElementById('workspace-loader').removeAttribute("max");

--- a/workspace-loader/src/loader/loader.ts
+++ b/workspace-loader/src/loader/loader.ts
@@ -33,7 +33,7 @@ export class Loader {
      * 
      * @param message message to log
      */
-    log(message: string): void {
+    log(message: string): HTMLElement {
         let container = document.getElementById("workspace-console-container");
         if (container.childElementCount > 500) {
             container.removeChild(container.firstChild)
@@ -45,6 +45,7 @@ export class Loader {
         if (element.scrollIntoView) {
             element.scrollIntoView();
         }
+        return element;
     }
 
     /**
@@ -53,18 +54,8 @@ export class Loader {
      * @param message error message
      */
     error(message: string): void {
-        let container = document.getElementById("workspace-console-container");
-        if (container.childElementCount > 500) {
-            container.removeChild(container.firstChild)
-        }
-
-        let element = document.createElement("pre");
+        let element = this.log(message);
         element.className = "error";
-        element.innerHTML = message;
-        container.appendChild(element);
-        if (element.scrollIntoView) {
-            element.scrollIntoView();
-        }
     }
 
     onclick(): void {

--- a/workspace-loader/src/style.css
+++ b/workspace-loader/src/style.css
@@ -100,6 +100,10 @@
     cursor: pointer;
 }
 
+#workspace-console pre.error {
+    color: #e22812;
+}
+
 #workspace-loader[max] {
     top: 5%;
 }


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Changes the flow of the workspace loading application: 
1.  we used to check only workspace config for existing IDE server -> now we are waiting for runtime to appear and check the runtime.
2. GWT IDE used to show all loading sequence immediately -> now we wait for runtime and only then redirect to GWT IDE if no IDE server was found.
3. Added errors handling  and displaying in workspace loader.


### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/9870


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
