### PR TITLE
Selenium: fix locators for Keycloak Federated Identities page

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/account/KeycloakFederatedIdentitiesPage.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/account/KeycloakFederatedIdentitiesPage.java
@@ -60,9 +60,9 @@ public class KeycloakFederatedIdentitiesPage {
   }
 
   interface Locators {
-    String GITHUB_REMOVE_BUTTON_ID = "remove-github";
+    String GITHUB_REMOVE_BUTTON_ID = "remove-link-github";
     String TITLE_XPATH = "//div[@id='tab-content']//h2[text()='Federated Identities']";
-    String GITHUB_INPUT_XPATH = "//form[//label/text()='GitHub']//input";
+    String GITHUB_INPUT_XPATH = "*//div[@id='federated-identities']//input";
   }
 
   public void open() {


### PR DESCRIPTION
### What does this PR do?
This PR fixes locators for web elements on **Keycloak** Federated Identities web page that were changed after **Keycloak** updating to 3.4.3 version.