### PR TITLE
Fixed error logging for Go LS when going to definition

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/che/jdt/javaeditor/JavaReconciler.java
+++ b/plugins/plugin-java/che-plugin-java-ext-jdt/org-eclipse-jdt-ui/src/main/java/org/eclipse/che/jdt/javaeditor/JavaReconciler.java
@@ -248,9 +248,7 @@ public class JavaReconciler {
     } catch (NotFoundException e) {
       String errorMessage = "Can not handle file operation: " + e.getMessage();
 
-      LOG.error(errorMessage);
-
-      transmitError(400, errorMessage, endpointId);
+      LOG.debug(errorMessage);
     }
   }
 

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/editor/server/impl/EditorWorkingCopyManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/editor/server/impl/EditorWorkingCopyManager.java
@@ -123,9 +123,7 @@ public class EditorWorkingCopyManager {
     } catch (NotFoundException e) {
       String errorMessage = "Can not handle editor changes: " + e.getLocalizedMessage();
 
-      LOG.error(errorMessage);
-
-      transmitError(400, errorMessage, endpointId);
+      LOG.debug(errorMessage);
     }
   }
 


### PR DESCRIPTION
Related issue: https://github.com/eclipse/che/issues/10035

Fixed error logging for Go LS when going to definition.