### PR TITLE
Selenium: increase timeout for IDE availability in ImportProjectFromGitHubTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
@@ -11,7 +11,6 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.GITHUB;
@@ -112,7 +111,7 @@ public class ImportProjectFromGitHubTest {
     projectSourcePage.clickOnAddProjectButton();
     newWorkspace.clickOnCreateButtonAndOpenInIDE();
 
-    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability(ELEMENT_TIMEOUT_SEC);
+    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     toastLoader.waitToastLoaderAndClickStartButton();
     ide.waitOpenedWorkspaceIsReadyToUse();
     projectExplorer.waitItem(projectName);


### PR DESCRIPTION
### What does this PR do?
This PR increases timeout for checking that the **IDE** is available in **ImportProjectFromGitHubTest** selenium test. This is need because of changing the flow of the workspace loading application(https://github.com/eclipse/che/pull/10263).