### PR TITLE
Clean cached classpath on error

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/command/ClasspathContainer.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/command/ClasspathContainer.java
@@ -17,7 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.promises.client.Promise;
-import org.eclipse.che.api.promises.client.js.Promises;
+import org.eclipse.che.api.promises.client.PromiseProvider;
 import org.eclipse.che.ide.ext.java.client.project.classpath.ClasspathChangedEvent;
 import org.eclipse.che.ide.ext.java.client.service.JavaLanguageExtensionServiceClient;
 import org.eclipse.che.jdt.ls.extension.api.dto.ClasspathEntry;
@@ -32,12 +32,16 @@ public class ClasspathContainer implements ClasspathChangedEvent.ClasspathChange
   public static String JRE_CONTAINER = "org.eclipse.jdt.launching.JRE_CONTAINER";
 
   private final JavaLanguageExtensionServiceClient extensionService;
+  private final PromiseProvider promiseProvider;
   private Map<String, Promise<List<ClasspathEntry>>> classpath;
 
   @Inject
   public ClasspathContainer(
-      JavaLanguageExtensionServiceClient extensionService, EventBus eventBus) {
+      JavaLanguageExtensionServiceClient extensionService,
+      EventBus eventBus,
+      PromiseProvider promiseProvider) {
     this.extensionService = extensionService;
+    this.promiseProvider = promiseProvider;
     classpath = new HashMap<>();
 
     eventBus.addHandler(ClasspathChangedEvent.TYPE, this);
@@ -54,7 +58,14 @@ public class ClasspathContainer implements ClasspathChangedEvent.ClasspathChange
     if (classpath.containsKey(projectPath)) {
       return classpath.get(projectPath);
     } else {
-      Promise<List<ClasspathEntry>> result = extensionService.classpathTree(projectPath);
+      Promise<List<ClasspathEntry>> result =
+          extensionService
+              .classpathTree(projectPath)
+              .catchErrorPromise(
+                  error -> {
+                    classpath.remove(projectPath);
+                    return promiseProvider.reject(error);
+                  });
       classpath.put(projectPath, result);
       return result;
     }
@@ -62,6 +73,6 @@ public class ClasspathContainer implements ClasspathChangedEvent.ClasspathChange
 
   @Override
   public void onClasspathChanged(ClasspathChangedEvent event) {
-    classpath.put(event.getPath(), Promises.resolve(event.getEntries()));
+    classpath.put(event.getPath(), promiseProvider.resolve(event.getEntries()));
   }
 }


### PR DESCRIPTION
### What does this PR do?
Cleans the cached request for classpath when an error occurs in the request.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10331
