### PR TITLE
Update regex for c-based file extensions

### DIFF
--- a/plugins/plugin-clangd/che-plugin-clangd-lang-server/src/main/java/org/eclipse/plugin/clangd/languageserver/ClangDLanguageServerConfig.java
+++ b/plugins/plugin-clangd/che-plugin-clangd-lang-server/src/main/java/org/eclipse/plugin/clangd/languageserver/ClangDLanguageServerConfig.java
@@ -33,7 +33,7 @@ import org.slf4j.LoggerFactory;
 public class ClangDLanguageServerConfig implements LanguageServerConfig {
   private static final Logger LOG = LoggerFactory.getLogger(ClangDLanguageServerConfig.class);
 
-  private static final String REGEX = ".*\\.(c|h|cc|hh|cpp|hpp|cxx|hxx|C|H|CC|HH|CPP|HPP|CXX|HXX)";
+  private static final String REGEX = ".*\\.(c|h|cc|hh|cpp|hpp|cxx|hxx|C|H|CC|HH|CPP|HPP|CXX|HXX)$";
 
   private final Path launchScript;
 


### PR DESCRIPTION
### What does this PR do?
This changes proposal updates regex for c-based file extensions which opens with language server in editor. The problem was that we have special naming for the command items: path is `/commands/{goal}/{name}` and display name is `{name}.che_command_internal` and it conflicted with `clangd` language server because it provides the regex for those file types: `.*\.(c|h|cc|hh|cpp|hpp|cxx|hxx|C|H|CC|HH|CPP|HPP|CXX|HXX)`. Adding `$` to the end of the regex fixed problem, now command item successfully open in command editor.

Check regex online: https://regexr.com/3s9lv

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#10285 

#### Release Notes
N/A

#### Docs PR
N/A
