### PR TITLE
Delete the 'try/catch' from the 'ContributeTabTest' according to resolving issues #9959  #10019

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/preferences/ContributeTabTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/preferences/ContributeTabTest.java
@@ -20,7 +20,6 @@ import static org.eclipse.che.selenium.pageobject.Preferences.DropDownGitInforma
 import static org.eclipse.che.selenium.pageobject.Wizard.TypeProject.MAVEN;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -41,7 +40,6 @@ import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.PullRequestPanel;
 import org.eclipse.che.selenium.pageobject.git.Git;
 import org.eclipse.che.selenium.refactor.move.MoveItemsTest;
-import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -156,16 +154,9 @@ public class ContributeTabTest {
     preferences.clickRefreshButton();
     preferences.waitContributeCheckboxIsSelected();
 
-    assertFalse(
-        preferences.isSaveButtonIsEnabled(),
-        "Known issue https://github.com/eclipse/che/issues/9959");
+    assertFalse(preferences.isSaveButtonIsEnabled());
 
-    try {
-      preferences.closeForm();
-    } catch (WebDriverException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/10019", ex);
-    }
+    preferences.closeForm();
   }
 
   @Test(priority = 1)


### PR DESCRIPTION
### What does this PR do?
* Delete the _try/catch_ from selenium test _ContributeTabTest_ according to resolving known issues
* Closed known issues: #9959, #10019
* Related issue: #10375

### What issues does this PR fix or reference?
#10375
