### PR TITLE
Validate infrastructure related configuration only on start workspace

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -41,6 +41,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.api.workspace.shared.event.WorkspaceCreatedEvent;
 import org.eclipse.che.commons.annotation.Nullable;
@@ -343,7 +344,7 @@ public class WorkspaceManager {
             });
   }
 
-  public Set<String> getSupportedRecipes() {
+  Set<String> getSupportedRecipes() {
     return runtimes.getSupportedRecipes();
   }
 
@@ -357,9 +358,16 @@ public class WorkspaceManager {
               workspace.getNamespace(), workspace.getConfig().getName(), envName));
     }
     workspace.getAttributes().put(UPDATED_ATTRIBUTE_NAME, Long.toString(currentTimeMillis()));
-    workspaceDao.update(workspace);
     final String env = firstNonNull(envName, workspace.getConfig().getDefaultEnv());
 
+    // validate environment in advance
+    try {
+      runtimes.validate(workspace.getConfig().getEnvironments().get(env));
+    } catch (InfrastructureException | ValidationException e) {
+      throw new ServerException(e);
+    }
+
+    workspaceDao.update(workspace);
     runtimes
         .startAsync(workspace, env, firstNonNull(options, Collections.emptyMap()))
         .thenAccept(aVoid -> handleStartupSuccess(workspace))

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -344,7 +344,10 @@ public class WorkspaceManager {
             });
   }
 
-  Set<String> getSupportedRecipes() {
+  /**
+   * @return set of supported recipe types
+   */
+  public Set<String> getSupportedRecipes() {
     return runtimes.getSupportedRecipes();
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -344,9 +344,7 @@ public class WorkspaceManager {
             });
   }
 
-  /**
-   * @return set of supported recipe types
-   */
+  /** @return set of supported recipe types */
   public Set<String> getSupportedRecipes() {
     return runtimes.getSupportedRecipes();
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -344,7 +344,7 @@ public class WorkspaceManager {
             });
   }
 
-  /** @return set of supported recipe types */
+  /** Returns a set of supported recipe types */
   public Set<String> getSupportedRecipes() {
     return runtimes.getSupportedRecipes();
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
@@ -17,7 +17,6 @@ import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMO
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
@@ -29,7 +28,6 @@ import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.config.Recipe;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 
 /**
  * Validator for {@link Workspace}.
@@ -48,13 +46,6 @@ public class WorkspaceValidator {
 
   private static final Pattern VOLUME_NAME = Pattern.compile("[a-z][a-z0-9]{1,18}");
   private static final Pattern VOLUME_PATH = Pattern.compile("/.+");
-
-  private final WorkspaceRuntimes runtimes;
-
-  @Inject
-  public WorkspaceValidator(WorkspaceRuntimes runtimes) {
-    this.runtimes = runtimes;
-  }
 
   /**
    * Checks whether given workspace configuration object is in application valid state, so it
@@ -93,12 +84,6 @@ public class WorkspaceValidator {
       for (Entry<String, ? extends MachineConfig> machineEntry :
           environment.getMachines().entrySet()) {
         validateMachine(machineEntry.getKey(), machineEntry.getValue());
-      }
-
-      try {
-        runtimes.validate(environment);
-      } catch (InfrastructureException e) {
-        throw new ServerException(e);
       }
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
@@ -29,7 +29,6 @@ import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.config.Recipe;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 
 /**
  * Validator for {@link Workspace}.
@@ -49,12 +48,8 @@ public class WorkspaceValidator {
   private static final Pattern VOLUME_NAME = Pattern.compile("[a-z][a-z0-9]{1,18}");
   private static final Pattern VOLUME_PATH = Pattern.compile("/.+");
 
-  private final WorkspaceRuntimes runtimes;
-
   @Inject
-  public WorkspaceValidator(WorkspaceRuntimes runtimes) {
-    this.runtimes = runtimes;
-  }
+  public WorkspaceValidator() {}
 
   /**
    * Checks whether given workspace configuration object is in application valid state, so it
@@ -93,12 +88,6 @@ public class WorkspaceValidator {
       for (Entry<String, ? extends MachineConfig> machineEntry :
           environment.getMachines().entrySet()) {
         validateMachine(machineEntry.getKey(), machineEntry.getValue());
-      }
-
-      try {
-        runtimes.validate(environment);
-      } catch (InfrastructureException e) {
-        throw new ServerException(e);
       }
     }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
@@ -55,8 +55,7 @@ public class WorkspaceValidator {
    * @throws ValidationException if any of validation constraints is violated
    * @throws ServerException when any other error occurs during environment validation
    */
-  public void validateConfig(WorkspaceConfig config)
-      throws ValidationException, ServerException {
+  public void validateConfig(WorkspaceConfig config) throws ValidationException, ServerException {
     // configuration object properties
     checkNotNull(config.getName(), "Workspace name required");
     check(

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
@@ -18,7 +18,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 import javax.inject.Singleton;
-import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.Workspace;
@@ -54,12 +53,10 @@ public class WorkspaceValidator {
    *
    * @param config configuration to validate
    * @throws ValidationException if any of validation constraints is violated
-   * @throws NotFoundException when configuration contains a recipe with a type which is not
-   *     supported by currently available workspace infrastructures
    * @throws ServerException when any other error occurs during environment validation
    */
   public void validateConfig(WorkspaceConfig config)
-      throws ValidationException, NotFoundException, ServerException {
+      throws ValidationException, ServerException {
     // configuration object properties
     checkNotNull(config.getName(), "Workspace name required");
     check(

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
@@ -30,7 +30,6 @@ import org.eclipse.che.api.workspace.shared.dto.ServerConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.VolumeDto;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
@@ -43,7 +42,6 @@ import org.testng.annotations.Test;
  */
 @Listeners(MockitoTestNGListener.class)
 public class WorkspaceValidatorTest {
-  @Mock private WorkspaceRuntimes workspaceRuntimes;
 
   @InjectMocks private WorkspaceValidator wsValidator;
 


### PR DESCRIPTION
### Motivation: 

Currently, we validate recipe on both workspace create/update and start.
It is not convenient policy since in this case we consider workspace/stack storage to have only workspaces with ONLY the same supported type(s) of infrastructure as supported by runtime.
It is not convenient for portable workspaces since:

- it does not allow to have several environments of different recipe types inside a workspace 
- we can consider keeping shared registry among different infrastructures
- we can consider using environment of one type to be imported and used as a template for other, "supported" type on demand

### Side effect:

Workspace storage may contain incorrect recipes but that's a reasonable drawback since it will be validated before start

### What does this PR do?

Logic of recipe validating moved from "generic" validation part to start Workspace


