### PR TITLE
Make sure dot-files don't exist before creating them.

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
@@ -152,9 +152,7 @@ public class TestProjectServiceClient {
                   Resources.toString(getResource("projects/jdt-ls-project-files/project"), UTF_8),
                   projectName)
               .getBytes());
-      write(
-          dotClasspath,
-          toByteArray(getResource("projects/jdt-ls-project-files/classpath")));
+      write(dotClasspath, toByteArray(getResource("projects/jdt-ls-project-files/classpath")));
     }
 
     Path zip = Files.createTempFile("project", projectName);

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
@@ -142,14 +142,18 @@ public class TestProjectServiceClient {
     }
 
     if (PLAIN_JAVA.equals(template)) {
+      Path dotClasspath = createFile(sourceFolder.resolve(".classpath"));
+      Path dotProject = Files.createFile(sourceFolder.resolve(".project"));
+      Files.deleteIfExists(dotProject);
+      Files.deleteIfExists(dotClasspath);
       write(
-          createFile(sourceFolder.resolve(".project")),
+          dotProject,
           format(
                   Resources.toString(getResource("projects/jdt-ls-project-files/project"), UTF_8),
                   projectName)
               .getBytes());
       write(
-          createFile(sourceFolder.resolve(".classpath")),
+          dotClasspath,
           toByteArray(getResource("projects/jdt-ls-project-files/classpath")));
     }
 


### PR DESCRIPTION
### What does this PR do?
Deletes .project and .classpath files when importing simple java projects in selenium tests to preven file creation errrors when reusing the same sample project in multiple tests.

### What issues does this PR fix or reference?
#10388 
