### PR TITLE
Check when ws-edit changes were applied

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/FailMoveItemTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/FailMoveItemTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.che.selenium.refactor.move;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 
 import com.google.common.base.Joiner;
@@ -25,6 +26,7 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CheTerminal;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
+import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -35,6 +37,7 @@ import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev on 05.01.16 */
 public class FailMoveItemTest {
+  private static final String APPLY_WORKSPACE_CHANGES = "Apply Workspace Changes\nDone";
   private static final String PROJECT_NAME = NameGenerator.generate("FailMoveItemProject-", 4);
   private static final String pathToPackageInChePrefix = PROJECT_NAME + "/src" + "/main" + "/java";
 
@@ -50,6 +53,7 @@ public class FailMoveItemTest {
   @Inject private Refactor refactor;
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private Consoles consoles;
+  @Inject private Events events;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -66,6 +70,7 @@ public class FailMoveItemTest {
     projectExplorer.waitVisibleItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
     loader.waitOnClosed();
+    events.clickEventLogBtn();
   }
 
   @AfterMethod(alwaysRun = true)
@@ -90,7 +95,10 @@ public class FailMoveItemTest {
     refactor.chooseDestinationForItem("p1");
     refactor.setAndWaitStateUpdateReferencesCheckbox(false);
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
+    loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     editor.waitTextIntoEditor(contentFromOutA);
     editor.clickOnSelectedElementInEditor("r.A17");
     editor.waitMarkerInPosition(ERROR, 14);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/FailMoveItemTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/FailMoveItemTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.selenium.refactor.move;
 
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.DEFAULT_TIMEOUT;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 
 import com.google.common.base.Joiner;
@@ -97,8 +97,7 @@ public class FailMoveItemTest {
     refactor.clickOkButtonRefactorForm();
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
-    loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     editor.waitTextIntoEditor(contentFromOutA);
     editor.clickOnSelectedElementInEditor("r.A17");
     editor.waitMarkerInPosition(ERROR, 14);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/MoveItemsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/MoveItemsTest.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.refactor.move;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -23,6 +25,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
+import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -32,6 +35,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev on 18.12.15 */
@@ -39,6 +43,7 @@ public class MoveItemsTest {
   private static final Logger LOG = LoggerFactory.getLogger(MoveItemsTest.class);
   private static final String PROJECT_NAME = NameGenerator.generate("MoveItemsProject-", 4);
   private static final String pathToPackageInChePrefix = PROJECT_NAME + "/src/main/java";
+  private static final String APPLY_WORKSPACE_CHANGES = "Apply Workspace Changes\nDone";
 
   private String contentFromInA, contentFromInB;
   private String contentFromOutA, contentFromOutB;
@@ -52,6 +57,7 @@ public class MoveItemsTest {
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private Consoles consoles;
+  @Inject private Events events;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -67,6 +73,12 @@ public class MoveItemsTest {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
     loader.waitOnClosed();
+    events.clickEventLogBtn();
+  }
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    events.clearAllMessages();
   }
 
   @AfterMethod
@@ -106,7 +118,10 @@ public class MoveItemsTest {
     refactor.clickOnExpandIconTree("/src/main/java");
     refactor.chooseDestinationForItem("p1");
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
+    loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A0.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A0.java");
@@ -126,7 +141,10 @@ public class MoveItemsTest {
     refactor.clickOnExpandIconTree("/src/main/java");
     refactor.chooseDestinationForItem("p1");
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
+    loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A1.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A1.java");
@@ -159,6 +177,7 @@ public class MoveItemsTest {
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A2.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/r/fred2/B2.java");
@@ -188,6 +207,7 @@ public class MoveItemsTest {
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     editor.waitTextIntoEditor(contentFromOutB);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A3.java");
     editor.waitTextIntoEditor(contentFromOutA);
@@ -211,7 +231,10 @@ public class MoveItemsTest {
     refactor.waitTextInErrorMessage("A file or folder cannot be moved to its own parent.");
     refactor.chooseDestinationForItem("r.r");
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
+    loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/r/r/A5.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A5.java");
@@ -231,7 +254,10 @@ public class MoveItemsTest {
     refactor.clickOnExpandIconTree("/src/main/java");
     refactor.chooseDestinationForItem("p1");
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
+    loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A6.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A6.java");
@@ -256,7 +282,10 @@ public class MoveItemsTest {
     refactor.chooseDestinationForItem("(default package)");
     refactor.waitTextInMoveForm("Java references will not be updated.");
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
+    loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/A7.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A7.java");
@@ -276,7 +305,10 @@ public class MoveItemsTest {
     refactor.clickOnExpandIconTree("/src/main/java");
     refactor.chooseDestinationForItem("p1");
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
+    loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/Klass.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(
@@ -297,7 +329,10 @@ public class MoveItemsTest {
     refactor.clickOnExpandIconTree("/src/main/java");
     refactor.chooseDestinationForItem("p1");
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
+    loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A9.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A9.java");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/MoveItemsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/MoveItemsTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.selenium.refactor.move;
 
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.DEFAULT_TIMEOUT;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -120,8 +120,7 @@ public class MoveItemsTest {
     refactor.clickOkButtonRefactorForm();
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
-    loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A0.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A0.java");
@@ -143,8 +142,7 @@ public class MoveItemsTest {
     refactor.clickOkButtonRefactorForm();
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
-    loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A1.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A1.java");
@@ -177,7 +175,7 @@ public class MoveItemsTest {
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A2.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/r/fred2/B2.java");
@@ -207,7 +205,7 @@ public class MoveItemsTest {
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     editor.waitTextIntoEditor(contentFromOutB);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A3.java");
     editor.waitTextIntoEditor(contentFromOutA);
@@ -233,8 +231,7 @@ public class MoveItemsTest {
     refactor.clickOkButtonRefactorForm();
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
-    loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/r/r/A5.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A5.java");
@@ -256,8 +253,7 @@ public class MoveItemsTest {
     refactor.clickOkButtonRefactorForm();
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
-    loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A6.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A6.java");
@@ -284,8 +280,7 @@ public class MoveItemsTest {
     refactor.clickOkButtonRefactorForm();
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
-    loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/A7.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A7.java");
@@ -307,8 +302,7 @@ public class MoveItemsTest {
     refactor.clickOkButtonRefactorForm();
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
-    loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/Klass.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(
@@ -331,8 +325,7 @@ public class MoveItemsTest {
     refactor.clickOkButtonRefactorForm();
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
-    loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.openItemByPath(pathToPackageInChePrefix + "/p1/A9.java");
     editor.waitTextIntoEditor(contentFromOutA);
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A9.java");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/MoveJavaClassToSubpackageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/MoveJavaClassToSubpackageTest.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.che.selenium.refactor.move;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -18,6 +20,7 @@ import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.Consoles;
+import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -27,7 +30,7 @@ import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev */
 public class MoveJavaClassToSubpackageTest {
-
+  private static final String APPLY_WORKSPACE_CHANGES = "Apply Workspace Changes\nDone";
   private static final String PROJECT_NAME =
       NameGenerator.generate("MoveJavaClassToSubpackageProject-", 4);
 
@@ -38,6 +41,7 @@ public class MoveJavaClassToSubpackageTest {
   @Inject private Refactor refactor;
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private Consoles consoles;
+  @Inject private Events events;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -49,6 +53,7 @@ public class MoveJavaClassToSubpackageTest {
         ProjectTemplates.MAVEN_SPRING);
     ide.open(workspace);
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
+    events.clickEventLogBtn();
   }
 
   @Test
@@ -64,8 +69,10 @@ public class MoveJavaClassToSubpackageTest {
     refactor.clickOnExpandIconTree("/src/main/java");
     refactor.chooseDestinationForItem("org.eclipse.qa");
     refactor.clickOkButtonRefactorForm();
+    loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/AppController.java");
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/MoveJavaClassToSubpackageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/MoveJavaClassToSubpackageTest.java
@@ -10,7 +10,7 @@
  */
 package org.eclipse.che.selenium.refactor.move;
 
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.DEFAULT_TIMEOUT;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -72,7 +72,7 @@ public class MoveJavaClassToSubpackageTest {
     loader.waitOnClosed();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
-    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, LOAD_PAGE_TIMEOUT_SEC);
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/AppController.java");
   }
 }


### PR DESCRIPTION
The fix for some unstable tests from `org.eclipse.che.selenium.refactor.move`.
Sometimes tests check the state of the project tree before applying refactoring changes. Firstly we need to wait  when all WorkspaceEdit changes were applied.

It is needed for https://github.com/eclipse/che/issues/10399