### PR TITLE
Update set of existing key-bindings

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.java
@@ -411,12 +411,6 @@ public interface JavaLocalizationConstant extends Messages {
   @Key("unmark.directory.as.source.description")
   String unmarkDirectoryAsSourceDescription();
 
-  @Key("parameter.info")
-  String parameterInfo();
-
-  @Key("parameter.info.description")
-  String parameterInfoDescription();
-
   @Key("button.Save")
   String buttonSave();
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/resources/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.properties
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/resources/org/eclipse/che/ide/ext/java/client/JavaLocalizationConstant.properties
@@ -177,10 +177,6 @@ label.main.class=Main class
 command.line=Command line
 command.line.description=The command compiles class and interface definitions and starts a Java application by calling main method
 
-####### Parameter info ######
-parameter.info=Parameter Hints
-parameter.info.description=Shows all parameters which constructor or method can accept
-
 ####### Code Assist ######
 code.assist.errorMessage.default = Code Assistant currently unavailable due to file parsing. Try again in a moment.
 code.assist.errorMessage.resolvingProject = Code Assistant currently unavailable due to project resolving.

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/KeyBindingsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/KeyBindingsTest.java
@@ -89,7 +89,7 @@ public class KeyBindingsTest {
     menu.runCommand(
         TestMenuCommandsConstants.Assistant.ASSISTANT,
         TestMenuCommandsConstants.Assistant.KEY_BINDINGS);
-    keyBindings.checkSearchResultKeyBinding("open", 5);
+    keyBindings.checkSearchResultKeyBinding("open", 4);
     keyBindings.clickOkButton();
   }
 

--- a/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/assistant/key-bindings.txt
+++ b/selenium/che-selenium-test/src/test/resources/org/eclipse/che/selenium/assistant/key-bindings.txt
@@ -53,7 +53,6 @@ Rename Shift+F6
 Run Test Ctrl+Alt+Z
 Debug Test Ctrl+Alt+X
 Show a popup window with documentation Ctrl+Q
-Open editor for selected item F4
 Open Implementation(s) Ctrl+Alt+B
 Java rename refactoring Shift+F6
 Move item to another package F6
@@ -61,7 +60,6 @@ Move item to another package Ctrl+X
 Find usages of the symbol at cursor Alt+F7
 Open File Structure Window Ctrl+F12
 Organize Imports action generates the import statements in a compilation unit Ctrl+Alt+O
-Shows all parameters which constructor or method can accept Ctrl+P
 Show a popup window with quick fix proposals Alt+ENTER
 Switch Contribute part displaying mode Ctrl+Alt+6
 Line Up ↑


### PR DESCRIPTION
### What does this PR do?
Fixes a test which checks set of key bindings.
Instead of **Open editor for selected item**  we have **Find Definition**
Instead of **Shows all parameters which constructor or method can accept** we have **Signature Help**

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10424