### PR TITLE
Check result of code assist after move operation

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/CodeAssistAfterMoveItemTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/CodeAssistAfterMoveItemTest.java
@@ -10,7 +10,9 @@
  */
 package org.eclipse.che.selenium.refactor.move;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.DEFAULT_TIMEOUT;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
+import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.WARNING;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -21,6 +23,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
+import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -32,6 +35,7 @@ import org.testng.annotations.Test;
 /** @author Aleksandr Shmaraev */
 public class CodeAssistAfterMoveItemTest {
 
+  private static final String APPLY_WORKSPACE_CHANGES = "Apply Workspace Changes\nDone";
   private static final String PROJECT_NAME = NameGenerator.generate("CodeAssistAfterMoveItem-", 4);
   private static final String pathToPackageInChePrefix = PROJECT_NAME + "/src/main/java";
 
@@ -43,6 +47,7 @@ public class CodeAssistAfterMoveItemTest {
   @Inject private Refactor refactor;
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private Consoles consoles;
+  @Inject private Events events;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -79,7 +84,8 @@ public class CodeAssistAfterMoveItemTest {
     editor.enterTextIntoFixErrorPropByDoubleClick("Import 'A5' (r)");
     loader.waitOnClosed();
     editor.waitTextIntoEditor("import r.A5;");
-    editor.waitMarkerInvisibility(ERROR, 33);
+    editor.waitMarkerInPosition(WARNING, 33);
+    events.clickEventLogBtn();
 
     // move item 'A5' into package 'p1'
     projectExplorer.waitAndSelectItem(pathToPackageInChePrefix + "/r/A5.java");
@@ -91,6 +97,7 @@ public class CodeAssistAfterMoveItemTest {
     refactor.clickOkButtonRefactorForm();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
+    events.waitExpectedMessage(APPLY_WORKSPACE_CHANGES, DEFAULT_TIMEOUT);
     projectExplorer.waitItem(pathToPackageInChePrefix + "/p1/A5.java");
     projectExplorer.waitDisappearItemByPath(pathToPackageInChePrefix + "/r/A5.java");
     editor.waitTextIntoEditor("import p1.A5;");


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
### What does this PR do?
Check when refactoring's changes were applied and check warning markers.
Fixes **org.eclipse.che.selenium.refactor.move.CodeAssistAfterMoveItemTest**

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10427