### PR TITLE
Selenium: fix 'run' command in 'CentOS WildFly Swarm' predefined stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1433,7 +1433,7 @@
             "previewUrl": "${server.wildfly}",
             "goal": "Run"
           },
-          "commandLine": "cd ${current.project.path}\nscl enable rh-maven33 'java -jar target/*-swarm.jar -Djava.net.preferIPv4Stack=true'"
+          "commandLine": "cd ${current.project.path}\nscl enable rh-maven33 'java -jar target/*-thorntail.jar -Djava.net.preferIPv4Stack=true'"
         }
       ],
       "projects": [],

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCentosWildFlySwarmStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCentosWildFlySwarmStackTest.java
@@ -72,7 +72,7 @@ public class CreateWorkspaceFromCentosWildFlySwarmStackTest {
     consoles.executeCommandFromProjectExplorer(
         PROJECT_NAME, BUILD_GOAL, BUILD_COMMAND, BUILD_SUCCESS);
     consoles.executeCommandFromProjectExplorer(
-        PROJECT_NAME, RUN_GOAL, RUN_COMMAND, "WildFly Swarm is Ready");
+        PROJECT_NAME, RUN_GOAL, RUN_COMMAND, "Thorntail is Ready");
     consoles.checkWebElementVisibilityAtPreviewPage(textOnPreviewPage);
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR changes 'run' command of **"CentOS WildFly Swarm"** predefined stack according to renaming **WildFly Swarm** project to **Thorntail**(https://github.com/wildfly-swarm-openshiftio-boosters/wfswarm-rest-http/pull/41).
