### PR TITLE
Added more information in error output

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -18,7 +18,12 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.Kube
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.Quantity;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -146,10 +146,9 @@ public class PVCSubPathHelper {
       PodStatus finishedStatus = finished.getStatus();
       if (POD_PHASE_FAILED.equals(finishedStatus.getPhase())) {
         LOG.error(
-            "Job command '{}' execution is failed. Reason '{}', message '{}'.",
+            "Job command '{}' execution is failed. Status '{}'.",
             Arrays.toString(command),
-            finishedStatus.getReason(),
-            finishedStatus.getMessage());
+            finishedStatus);
       }
     } catch (InfrastructureException ex) {
       LOG.error(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -18,11 +18,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.Kube
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.*;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -142,8 +138,13 @@ public class PVCSubPathHelper {
       deployments = factory.create(workspaceId).deployments();
       deployments.create(pod);
       final Pod finished = deployments.wait(podName, WAIT_POD_TIMEOUT_MIN, POD_PREDICATE::apply);
-      if (POD_PHASE_FAILED.equals(finished.getStatus().getPhase())) {
-        LOG.error("Job command '{}' execution is failed.", Arrays.toString(command));
+      PodStatus finishedStatus = finished.getStatus();
+      if (POD_PHASE_FAILED.equals(finishedStatus.getPhase())) {
+        LOG.error(
+            "Job command '{}' execution is failed. Reason '{}', message '{}'.",
+            Arrays.toString(command),
+            finishedStatus.getReason(),
+            finishedStatus.getMessage());
       }
     } catch (InfrastructureException ex) {
       LOG.error(


### PR DESCRIPTION
### What does this PR do?
Added more information in error output.
In ws-master logs after selenium test, I've noticed a lot of errors like this 

```
2018-07-16 19:24:35,026[er-ThreadPool-2]  [ERROR] [e.c.w.i.k.n.p.PVCSubPathHelper 146]  - Job command '[rm, -rf, /tmp/job_mount/workspace1wfd4rtu91ncd9fm]' execution is failed.
2018-07-16 19:24:35,732[er-ThreadPool-1]  [ERROR] [e.c.w.i.k.n.p.PVCSubPathHelper 146]  - Job command '[rm, -rf, /tmp/job_mount/workspaceo9jme0bwa8ebxmjv]' execution is failed.
```
This PR is made to provide more details in such cases.
### What issues does this PR fix or reference?
n/a
<!-- #### Changelog -->
Added more information in error output.

#### Release Notes
Added more information in error output.


#### Docs PR
n/a
