### PR TITLE
Fixup for testing Organize imports operation

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/OrganizeImportsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/assistant/OrganizeImportsTest.java
@@ -37,16 +37,11 @@ import org.testng.annotations.Test;
 public class OrganizeImportsTest {
   private static final String PROJECT_NAME =
       NameGenerator.generate(OrganizeImportsTest.class.getSimpleName(), 4);
-  private static final String SOURCE_FOLDER = "src/main/java";
   private static final String PATH_TO_CLASS_IN_SPRING_PACKAGE =
       PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/" + "AppController.java";
   private static final String TEST_FILE_NAME = "TestClass.java";
   private static final String PATH_TO_A_PACKAGE = PROJECT_NAME + "/src/main/java/a";
-  private static final String PATH_TO_CLASS_IN_A_PACKAGE =
-      PROJECT_NAME + "/src/main/java/a/TestClass.java";
   private static final String PATH_TO_B_PACKAGE = PROJECT_NAME + "/src/main/java/b";
-  private static final String PATH_TO_CLASS_IN_B_PACKAGE =
-      PROJECT_NAME + "/src/main/java/b/TestClass.java";
   private static final String NAME_OF_A_PACKAGE = "a.TestClass";
   private static final String NAME_OF_B_PACKAGE = "b.TestClass";
   private static final String NAME_OF_LIST_PACKAGE = "java.util.List";
@@ -102,7 +97,6 @@ public class OrganizeImportsTest {
         TestMenuCommandsConstants.Assistant.ASSISTANT,
         TestMenuCommandsConstants.Assistant.ORGANIZE_IMPORTS);
     loader.waitOnClosed();
-    editor.waitAllMarkersInvisibility(ERROR);
     Assert.assertTrue(
         editor.checkWhatTextLinePresentOnce(
             "import org.springframework.web.servlet.ModelAndView;"));
@@ -111,6 +105,7 @@ public class OrganizeImportsTest {
     editor.typeTextIntoEditorWithoutDelayForSaving(
         "import org.springframework.web.servlet.ModelAndView;");
     loader.waitOnClosed();
+    editor.waitAllMarkersInvisibility(ERROR);
     editor.goToCursorPositionVisible(20, 8);
     editor.launchPropositionAssistPanel();
     editor.enterTextIntoFixErrorPropByEnter("Organize imports");
@@ -151,12 +146,8 @@ public class OrganizeImportsTest {
     organizeImports.selectImport(NAME_OF_B_PACKAGE);
     organizeImports.clickOnNextButton();
     organizeImports.clickOnFinishButton();
+    loader.waitOnClosed();
     editor.waitAllMarkersInvisibility(ERROR);
-    loader.waitOnClosed();
-
-    projectExplorer.waitItem(PATH_TO_CLASS_IN_SPRING_PACKAGE);
-    projectExplorer.openItemByPath(PATH_TO_CLASS_IN_SPRING_PACKAGE);
-    loader.waitOnClosed();
 
     Assert.assertTrue(editor.checkWhatTextLinePresentOnce("import b.TestClass;"));
     Assert.assertTrue(editor.checkWhatTextLinePresentOnce("import java.util.ArrayList;"));

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/pom.xml
@@ -20,8 +20,8 @@
     <version>1.0-SNAPSHOT</version>
     <name>qa-spring-sample</name>
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>
### What does this PR do?
Fixes `org.eclipse.che.selenium.assistant.OrganizeImportsTest` test.
Change version of `maven.compiler.target` and check error markers.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10445