### PR TITLE
Selenium: remove selenium tests from OSIO test group

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -19,7 +19,6 @@ import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspace
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
@@ -39,7 +38,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
-@Test(groups = TestGroup.OSIO)
 public class CreateAndDeleteProjectsTest {
 
   private static final String WORKSPACE = generate("workspace", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateWorkspaceTest.java
@@ -20,7 +20,6 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
@@ -30,7 +29,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /** @author Serhii Skoryk */
-@Test(groups = TestGroup.OSIO)
 public class CreateWorkspaceTest {
 
   private final String WORKSPACE_NAME = NameGenerator.generate("workspace", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/DeleteRunningWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/DeleteRunningWorkspaceTest.java
@@ -14,7 +14,6 @@ import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspace
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.OVERVIEW;
 
 import com.google.inject.Inject;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -27,7 +26,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
-@Test(groups = TestGroup.OSIO)
 public class DeleteRunningWorkspaceTest {
 
   @Inject private Dashboard dashboard;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/DeleteStoppingWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/DeleteStoppingWorkspaceTest.java
@@ -15,7 +15,6 @@ import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspace
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.TabNames.OVERVIEW;
 
 import com.google.inject.Inject;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails;
@@ -25,7 +24,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
-@Test(groups = TestGroup.OSIO)
 public class DeleteStoppingWorkspaceTest {
 
   @Inject private Dashboard dashboard;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportMavenProjectFromGitTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportMavenProjectFromGitTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutionException;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestGitHubRepository;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
@@ -36,7 +35,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
-@Test(groups = TestGroup.OSIO)
 public class ImportMavenProjectFromGitTest {
 
   private final String WORKSPACE = generate("ImtMvnPrjGit", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Test(groups = {TestGroup.GITHUB, TestGroup.OSIO})
+@Test(groups = {TestGroup.GITHUB})
 public class ImportProjectFromGitHubTest {
   private static final String WORKSPACE =
       generate(ImportProjectFromGitHubTest.class.getSimpleName(), 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromZipTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromZipTest.java
@@ -19,7 +19,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.ExecutionException;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestGitHubRepository;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
@@ -36,7 +35,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
-@Test(groups = TestGroup.OSIO)
 public class ImportProjectFromZipTest {
 
   private final String WORKSPACE = generate("ImptPrjFromZip", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/RenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/RenameWorkspaceTest.java
@@ -18,7 +18,6 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import java.io.IOException;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
@@ -31,7 +30,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
-@Test(groups = TestGroup.OSIO)
 public class RenameWorkspaceTest {
 
   private static final int MIN_WORKSPACE_NAME_SIZE = 3;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
@@ -21,7 +21,6 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
@@ -45,7 +44,6 @@ import org.testng.annotations.Test;
  * @author Sergey Skorik
  * @author Ihor Okhrimenko
  */
-@Test(groups = TestGroup.OSIO)
 public class WorkspacesListTest {
   private static final int BLANK_WS_MB = 2048;
   private static final int JAVA_WS_MB = 3072;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsComposeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsComposeTest.java
@@ -39,7 +39,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Skoryk Serhii */
-@Test(groups = {TestGroup.DOCKER, TestGroup.OSIO})
+@Test(groups = {TestGroup.DOCKER})
 public class WorkspaceDetailsComposeTest {
 
   private static final String WORKSPACE = generate("java-mysql", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsSingleMachineTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsSingleMachineTest.java
@@ -29,7 +29,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
@@ -53,7 +52,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Skoryk Serhii */
-@Test(groups = TestGroup.OSIO)
 public class WorkspaceDetailsSingleMachineTest {
   private static final String PROJECT_NAME = generate("project", 4);
   private static final ImmutableMap<String, Boolean> EXPECTED_INSTALLERS =


### PR DESCRIPTION
### What does this PR do?
This PR removes selenium tests from OSIO test group(remove **@Test(groups = TestGroup.OSIO)**) because of #10448 issue.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10448

#### Release Notes

#### Docs PR