### PR TITLE
Add CheEditor object to the Workspace Next model

### DIFF
--- a/deploy/kubernetes/kubectl/wsnext/Readme.md
+++ b/deploy/kubernetes/kubectl/wsnext/Readme.md
@@ -2,23 +2,24 @@
 
 Execute 
 ```shell
-docker build --no-cache -t garagatyi/che-marketplace:1 .
+docker build --no-cache -t garagatyi/che-marketplace:os .
 ```
 Where `--no-cache` is needed to prevent usage of cached layers with marketplace files.
 Useful when you change marketplace files and rebuild the image.
 
-`-t garagatyi/che-marketplace:1` is needed to set identifier of the image. Do not forget to change `feature-api/yaml` file accordingly if you change this identifier to something else.
+`-t garagatyi/che-marketplace:os` is needed to set identifier of the image.
+Do not forget to change `feature-api.yaml` file accordingly if you change this identifier to something else.
 
 ## Use custome repository as a source of marketplace files
 
 To use a custom git repo as a source of marketplace files use next command to build the image:
 ```shell
-docker build --no-cache -t garagatyi/che-marketplace:1 --build-arg STORAGE_REPO=https://github.com/someuser/somerepo .
+docker build --no-cache -t garagatyi/che-marketplace:os --build-arg STORAGE_REPO=https://github.com/someuser/somerepo .
 ```
 
 ## Use local path as a source of marketplace files
 
 To use local path as a source of marketplace files use next command to build the image:
 ```shell
-docker build --no-cache -t garagatyi/che-marketplace:1 --build-arg STORAGE_TYPE=path --build-arg STORAGE_PATH=some_path_in_build_context path_to_build_context
+docker build --no-cache -t garagatyi/che-marketplace:os --build-arg STORAGE_TYPE=path --build-arg STORAGE_PATH=some_path_in_build_context path_to_build_context
 ```

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheContainer.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheContainer.java
@@ -10,19 +10,23 @@
  */
 package org.eclipse.che.api.workspace.server.wsnext.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+/** Represents sidecar container in Che workspace. */
 public class CheContainer {
 
   private String image = null;
   private List<EnvVar> env = new ArrayList<>();
+
+  @JsonProperty("editor-commands")
   private List<Command> commands = new ArrayList<>();
+
   private List<Volume> volumes = new ArrayList<>();
   private List<CheContainerPort> ports = new ArrayList<>();
 
-  /** */
   public CheContainer image(String image) {
     this.image = image;
     return this;

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheEditor.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/CheEditor.java
@@ -10,50 +10,32 @@
  */
 package org.eclipse.che.api.workspace.server.wsnext.model;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-
-/** Represents Che plugin in sidecar-powered workspace. */
-public class ChePlugin extends PluginBase {
-  private List<EditorCompatibility> editors = new ArrayList<>();
-
-  public ChePlugin editors(List<EditorCompatibility> editors) {
-    this.editors = editors;
-    return this;
-  }
-
-  public List<EditorCompatibility> getEditors() {
-    return editors;
-  }
-
-  public void setEditors(List<EditorCompatibility> editors) {
-    this.editors = editors;
-  }
-
+/**
+ * Represents an editor inside of Che workspace.
+ *
+ * <p>It may be classic GWT IDE, Eclipse Theia or something else.
+ */
+public class CheEditor extends PluginBase {
   @Override
   public boolean equals(Object o) {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ChePlugin)) {
+    if (!(o instanceof CheEditor)) {
       return false;
     }
-    if (!super.equals(o)) {
-      return false;
-    }
-    ChePlugin plugin = (ChePlugin) o;
-    return Objects.equals(getEditors(), plugin.getEditors());
+    CheEditor cheEditor = (CheEditor) o;
+    return super.equals(cheEditor);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), getEditors());
+    return super.hashCode();
   }
 
   @Override
   public String toString() {
-    return "ChePlugin{"
+    return "CheEditor{"
         + "name='"
         + getName()
         + '\''
@@ -67,8 +49,6 @@ public class ChePlugin extends PluginBase {
         + getContainers()
         + ", endpoints="
         + getEndpoints()
-        + ", editors="
-        + getEditors()
         + '}';
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/EditorCompatibility.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/EditorCompatibility.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Specifies compatibility with a specific Che editor and plugins needed for the compatibility. */
+public class EditorCompatibility {
+  private String name;
+  private List<String> plugins;
+
+  public String getName() {
+    return name;
+  }
+
+  public EditorCompatibility name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public EditorCompatibility plugins(List<String> plugins) {
+    this.plugins = plugins;
+    return this;
+  }
+
+  public List<String> getPlugins() {
+    return plugins;
+  }
+
+  public void setPlugins(List<String> plugins) {
+    this.plugins = plugins;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof EditorCompatibility)) {
+      return false;
+    }
+    EditorCompatibility that = (EditorCompatibility) o;
+    return Objects.equals(getName(), that.getName())
+        && Objects.equals(getPlugins(), that.getPlugins());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getPlugins());
+  }
+
+  @Override
+  public String toString() {
+    return "EditorCompatibility{" + "name='" + name + '\'' + ", plugins=" + plugins + '}';
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/PluginBase.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsnext/model/PluginBase.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.wsnext.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class PluginBase {
+
+  private String name = null;
+  private String id = null;
+  private String version = null;
+  private List<CheContainer> containers = new ArrayList<>();
+  private List<ChePluginEndpoint> endpoints = new ArrayList<>();
+
+  /** Object name. Name must be unique. */
+  public PluginBase name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public PluginBase id(String id) {
+    this.id = id;
+    return this;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public PluginBase version(String version) {
+    this.version = version;
+    return this;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
+  public PluginBase containers(List<CheContainer> containers) {
+    this.containers = containers;
+    return this;
+  }
+
+  public List<CheContainer> getContainers() {
+    return containers;
+  }
+
+  public void setContainers(List<CheContainer> containers) {
+    this.containers = containers;
+  }
+
+  public PluginBase endpoints(List<ChePluginEndpoint> endpoints) {
+    this.endpoints = endpoints;
+    return this;
+  }
+
+  public List<ChePluginEndpoint> getEndpoints() {
+    return endpoints;
+  }
+
+  public void setEndpoints(List<ChePluginEndpoint> endpoints) {
+    this.endpoints = endpoints;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PluginBase)) {
+      return false;
+    }
+    PluginBase chePlugin = (PluginBase) o;
+    return Objects.equals(getName(), chePlugin.getName())
+        && Objects.equals(getId(), chePlugin.getId())
+        && Objects.equals(getVersion(), chePlugin.getVersion())
+        && Objects.equals(getContainers(), chePlugin.getContainers())
+        && Objects.equals(getEndpoints(), chePlugin.getEndpoints());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getId(), getVersion(), getContainers(), getEndpoints());
+  }
+
+  @Override
+  public String toString() {
+    return "ChePlugin{"
+        + "name='"
+        + name
+        + '\''
+        + ", id='"
+        + id
+        + '\''
+        + ", version='"
+        + version
+        + '\''
+        + ", containers="
+        + containers
+        + ", endpoints="
+        + endpoints
+        + '}';
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Introduces changes in Workspace.Next model objects. 
Field 'commands' in CheContainer renamed to `editor-commands`.
Add CheEditor object that has all the fields ChePlugin previously had.
ChePlugin gets field `editors` that contains a list of objects called in PR EditorCompatibility.
EditorCompatibility contains fields `name` and   

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/10203

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
