### PR TITLE
Fixup for testing Java Compiler settings

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/preferences/PreferencesPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/preferences/PreferencesPresenter.java
@@ -125,7 +125,10 @@ public class PreferencesPresenter
     view.setPreferences(preferencesMap);
 
     view.enableSaveButton(false);
-    view.selectPreference(preferencesMap.entrySet().iterator().next().getValue().iterator().next());
+    PreferencePagePresenter preferencePagePresenter =
+        preferencesMap.entrySet().iterator().next().getValue().iterator().next();
+    view.selectPreference(preferencePagePresenter);
+    preferencePagePresenter.go(view.getContentPanel());
     view.showDialog();
   }
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/settings/compiler/JavaCompilerPreferencePresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/settings/compiler/JavaCompilerPreferencePresenter.java
@@ -151,7 +151,17 @@ public class JavaCompilerPreferencePresenter extends AbstractPreferencePagePrese
   /** {@inheritDoc} */
   @Override
   public void go(AcceptsOneWidget container) {
-    container.setWidget(view);
+    if (widgets.isEmpty()) {
+      preferencesManager
+          .loadPreferences()
+          .then(
+              properties -> {
+                options.forEach(this::provideWidget);
+                container.setWidget(view);
+              });
+    } else {
+      container.setWidget(view);
+    }
   }
 
   @Override

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/preferences/CheckErrorsWarningsTabTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/preferences/CheckErrorsWarningsTabTest.java
@@ -98,13 +98,13 @@ public class CheckErrorsWarningsTabTest {
     consoles.closeProcessesArea();
     menu.runCommand(TestMenuCommandsConstants.Profile.PROFILE_MENU, PREFERENCES);
     changeAllSettingsInErrorsWarningsTab(Preferences.DropDownValueForErrorWaitingWidget.WARNING);
-    Assert.assertEquals(editor.getMarkersQuantity(WARNING_OVERVIEW), 13);
+    Assert.assertEquals(editor.getMarkersQuantity(WARNING_OVERVIEW), 12);
     Assert.assertEquals(editor.getMarkersQuantity(WARNING), 22);
 
     editor.waitAnnotationsAreNotPresent(ERROR_OVERVIEW);
     menu.runCommand(TestMenuCommandsConstants.Profile.PROFILE_MENU, PREFERENCES);
     changeAllSettingsInErrorsWarningsTab(Preferences.DropDownValueForErrorWaitingWidget.ERROR);
-    Assert.assertEquals(editor.getMarkersQuantity(ERROR_OVERVIEW), 13);
+    Assert.assertEquals(editor.getMarkersQuantity(ERROR_OVERVIEW), 12);
     Assert.assertEquals(editor.getMarkersQuantity(ERROR), 22);
     editor.waitAnnotationsAreNotPresent(WARNING_OVERVIEW);
     menu.runCommand(TestMenuCommandsConstants.Profile.PROFILE_MENU, PREFERENCES);

--- a/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/default-spring-project/pom.xml
@@ -20,8 +20,8 @@
     <version>1.0-SNAPSHOT</version>
     <name>qa-spring-sample</name>
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
     <dependencies>
         <dependency>

--- a/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/pom.xml
+++ b/selenium/che-selenium-test/src/test/resources/projects/spring-project-with-main-method/pom.xml
@@ -15,7 +15,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>
    <groupId>org.eclipse.che.examples</groupId>
-   <artifactId>qa-spring-sample</artifactId>
+   <artifactId>qa-spring-with-main</artifactId>
    <packaging>war</packaging>
    <version>1.0-SNAPSHOT</version>
    <name>qa-spring-sample</name>


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

- Change maven.compiler.source to 1.8 in tested project
- Initialize Error/Warning widget if they were not initialized 
- Update number of warnings and errors in the editor

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10455