### PR TITLE
Simplify the theia stack from 2 machines to 1 with Theia only

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -1,12 +1,11 @@
 [
   {
-    "id": "java-theia-docker",
+    "id": "simple-theia-docker",
     "creator": "ide",
-    "name": "Java Theia (docker)",
-    "description": "Che development + Theia in a sidecar container (docker)",
+    "name": "Theia IDE on docker",
+    "description": "Theia in a sidecar container (docker)",
     "scope": "general",
     "tags": [
-      "Java 1.8",
       "Theia",
       "Alpine",
       "CentOS"
@@ -16,49 +15,41 @@
         "default": {
           "machines": {
             "theia": {
-              "attributes": {},
               "servers": {
                 "theia": {
-                  "protocol": "http",
-                  "port": "3000",
                   "attributes": {
                     "type": "ide"
-                  }
+                  },
+                  "protocol": "http",
+                  "port": "3000"
                 },
                 "theia-dev": {
-                  "protocol": "http",
-                  "port": "3030",
                   "attributes": {
                     "type": "ide-dev"
-                  }
+                  },
+                  "protocol": "http",
+                  "port": "3030"
                 }
               },
+              "installers": [],
               "volumes": {
                 "projects": {
                   "path": "/projects"
                 }
               },
-              "installers": [],
               "env": {
+                "CHE_MACHINE_NAME": "theia",
                 "HOSTED_PLUGIN_HOSTNAME": "0.0.0.0"
-              }
-            },
-            "dev-machine": {
-              "attributes": {},
-              "servers": {},
-              "volumes": {
-                "projects": {
-                  "path": "/projects"
-                }
               },
-              "installers": [],
-              "env": {}
+              "attributes": {
+                "memoryLimitBytes": "2147483648"
+              }
             }
           },
           "recipe": {
-            "type": "compose",
-            "content": "services:\n theia:\n  image: eclipse/che-theia:0.4.0-next.b17727c1-nightly\n  mem_limit: 1073741824\n dev-machine:\n  image: eclipse/che-dev:nightly\n  mem_limit: 2147483648\n  depends_on:\n    - theia",
-            "contentType": "application/x-yaml"
+            "contentType": "",
+            "type": "dockerimage",
+            "content": "eclipse/che-theia:0.4.0-next.b17727c1-nightly"
           }
         }
       },


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Simplifies the Theia stack to contain only one Theia machine by removing dev-machine (which is not used in this case) and switching from compose to dockerimage recipe type. It works on Openshift as well. 

