### PR TITLE
Add Bearer token prefix for project service requests

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
@@ -38,6 +38,8 @@ import org.eclipse.che.selenium.core.provider.TestWorkspaceAgentApiEndpointUrlPr
  */
 @Singleton
 public class TestProjectServiceClient {
+
+  private final String BEARER_TOKEN_PREFIX = "Bearer ";
   private final TestMachineServiceClient machineServiceClient;
   private final HttpJsonRequestFactory requestFactory;
   private final TestWorkspaceAgentApiEndpointUrlProvider workspaceAgentApiEndpointUrlProvider;
@@ -64,7 +66,8 @@ public class TestProjectServiceClient {
     requestFactory
         .fromUrl(workspaceAgentApiEndpointUrlProvider.get(workspaceId) + "project/" + projectName)
         .usePutMethod()
-        .setAuthorizationHeader(machineServiceClient.getMachineApiToken(workspaceId))
+        .setAuthorizationHeader(
+            BEARER_TOKEN_PREFIX + machineServiceClient.getMachineApiToken(workspaceId))
         .setBody(project)
         .request();
   }
@@ -73,7 +76,8 @@ public class TestProjectServiceClient {
   public void deleteResource(String workspaceId, String path) throws Exception {
     requestFactory
         .fromUrl(workspaceAgentApiEndpointUrlProvider.get(workspaceId) + "project/" + path)
-        .setAuthorizationHeader(machineServiceClient.getMachineApiToken(workspaceId))
+        .setAuthorizationHeader(
+            BEARER_TOKEN_PREFIX + machineServiceClient.getMachineApiToken(workspaceId))
         .useDeleteMethod()
         .request();
   }
@@ -82,7 +86,8 @@ public class TestProjectServiceClient {
     String url = workspaceAgentApiEndpointUrlProvider.get(workspaceId) + "project/folder/" + folder;
     requestFactory
         .fromUrl(url)
-        .setAuthorizationHeader(machineServiceClient.getMachineApiToken(workspaceId))
+        .setAuthorizationHeader(
+            BEARER_TOKEN_PREFIX + machineServiceClient.getMachineApiToken(workspaceId))
         .usePostMethod()
         .request();
   }
@@ -100,7 +105,8 @@ public class TestProjectServiceClient {
       httpConnection.setRequestMethod("POST");
       httpConnection.setRequestProperty("Content-Type", "application/zip");
       httpConnection.addRequestProperty(
-          "Authorization", machineServiceClient.getMachineApiToken(workspaceId));
+          "Authorization",
+          BEARER_TOKEN_PREFIX + machineServiceClient.getMachineApiToken(workspaceId));
       httpConnection.setDoOutput(true);
 
       try (OutputStream outputStream = httpConnection.getOutputStream()) {
@@ -156,7 +162,8 @@ public class TestProjectServiceClient {
       httpConnection.setRequestMethod("POST");
       httpConnection.setRequestProperty("Content-Type", "text/plain");
       httpConnection.addRequestProperty(
-          "Authorization", machineServiceClient.getMachineApiToken(workspaceId));
+          "Authorization",
+          BEARER_TOKEN_PREFIX + machineServiceClient.getMachineApiToken(workspaceId));
       httpConnection.setDoOutput(true);
       try (OutputStream output = httpConnection.getOutputStream()) {
         output.write(content.getBytes("UTF-8"));
@@ -178,7 +185,8 @@ public class TestProjectServiceClient {
     String apiUrl = workspaceAgentApiEndpointUrlProvider.get(workspaceId) + "project";
     return requestFactory
         .fromUrl(apiUrl)
-        .setAuthorizationHeader(machineServiceClient.getMachineApiToken(workspaceId))
+        .setAuthorizationHeader(
+            BEARER_TOKEN_PREFIX + machineServiceClient.getMachineApiToken(workspaceId))
         .request()
         .asList(ProjectConfigDto.class)
         .get(0);
@@ -195,7 +203,8 @@ public class TestProjectServiceClient {
       httpConnection.setRequestMethod("PUT");
       httpConnection.setRequestProperty("Content-Type", "text/plain");
       httpConnection.addRequestProperty(
-          "Authorization", machineServiceClient.getMachineApiToken(workspaceId));
+          "Authorization",
+          BEARER_TOKEN_PREFIX + machineServiceClient.getMachineApiToken(workspaceId));
       httpConnection.setDoOutput(true);
 
       try (OutputStream output = httpConnection.getOutputStream()) {

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestProjectServiceClient.java
@@ -39,7 +39,7 @@ import org.eclipse.che.selenium.core.provider.TestWorkspaceAgentApiEndpointUrlPr
 @Singleton
 public class TestProjectServiceClient {
 
-  private final String BEARER_TOKEN_PREFIX = "Bearer ";
+  private static final String BEARER_TOKEN_PREFIX = "Bearer ";
   private final TestMachineServiceClient machineServiceClient;
   private final HttpJsonRequestFactory requestFactory;
   private final TestWorkspaceAgentApiEndpointUrlProvider workspaceAgentApiEndpointUrlProvider;


### PR DESCRIPTION
### What does this PR do?
This PR adds "Bearer" token identifier for the all project service related requests, since it is required by jwtproxy. 
That can greatly reduce number of failing tests on jwtproxy auth.


### What issues does this PR fix or reference?



#### Release Notes
N/A


#### Docs PR
N/A