### PR TITLE
allow to not define GITHUB_TOKEN to build.sh if api rate limit on github is enough

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -14,8 +14,7 @@ ARG THEIA_VERSION=0.4.0-next.b17727c1
 
 EXPOSE 3000 3030
 
-ENV GITHUB_TOKEN=${GITHUB_TOKEN} \
-    THEIA_VERSION=${THEIA_VERSION} \
+ENV THEIA_VERSION=${THEIA_VERSION} \
     USE_LOCAL_GIT=true \
     HOME=/home/theia
 
@@ -25,8 +24,28 @@ ADD src/ ${HOME}/
 ADD supervisord.conf /etc/
 
 RUN \
-    # Install needed software
-    apk update && apk add --no-cache make gcc g++ python git bash supervisor jq && \
+    # Install basic software used for checking github API rate limit
+    apk update && apk add --no-cache curl jq ca-certificates openssl && \
+    # update certificates
+    update-ca-certificates && \
+    # define in env variable GITHUB_TOKEN only if it is defined
+    # else check if github rate limit is enough, else will abort requiring to set GITHUB_TOKEN value
+    if [ "$GITHUB_TOKEN" != "" ]; then \
+      export GITHUB_TOKEN=$GITHUB_TOKEN; \
+      echo "Setting GITHUB_TOKEN value as provided"; \
+    else \
+      export GITHUB_LIMIT=$(curl -s 'https://api.github.com/rate_limit' | jq '.rate .remaining'); \
+      echo "Current API rate limit https://api.github.com is ${GITHUB_LIMIT}"; \ 
+      if [ "${GITHUB_LIMIT}" -lt 10 ]; then \
+        printf "\033[0;31m\n\n\nRate limit on https://api.github.com is reached so in order to build this image, "; \
+        printf "the build argument GITHUB_TOKEN needs to be provided so build will not fail.\n\n\n\033[0m"; \
+        exit 1; \
+      else \
+        echo "GITHUB_TOKEN variable not set but https://api.github.com rate limit has enough slots"; \
+      fi \
+    fi && \
+    # install remaining packages
+    apk add --no-cache make gcc g++ python git bash supervisor && \
     rm -rf /tmp/* /var/cache/apk/* && \
     # Change version of Theia to specified in THEIA_VERSION
     ${HOME}/versions.sh && rm ${HOME}/versions.sh && \


### PR DESCRIPTION
### What does this PR do?

Make build arg GITHUB_TOKEN optional is not required (if limit is not reached)

If build arg is not provided but that the rate limit is reached, it will exit asking user to provide GITHUB_TOKEN

### What issues does this PR fix or reference?
N/A

Change-Id: I29c575124f73afce39fda5a3fe92e57de387223c
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
