### PR TITLE
Selenium: adapt selenium tests that work with Theia stack

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -149,7 +149,7 @@ public class NewWorkspace {
     ECLIPSE_VERTX("vert.x"),
     GO("go-default"),
     JAVA_CENTOS("java-centos"),
-    JAVA_THEIA_DOCKER("java-theia-docker"),
+    JAVA_THEIA_DOCKER("simple-theia-docker"),
     JAVA_THEIA_OPENSHIFT("java-theia-openshift"),
     JAVA_MYSQL_CENTOS("java-centos-mysql"),
     JAVA_DEBIAN("java-debian"),

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.che.selenium.dashboard.workspaces;
 
 import static java.util.Arrays.asList;
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.ANDROID;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.BLANK;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.CENTOS_BLANK;
@@ -43,7 +44,6 @@ import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.util.List;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
@@ -66,7 +66,8 @@ public class NewWorkspacePageTest {
   private static final String JDK_SUGGESTION_TITLE = "JDK";
   private static final String JAVA_SUGGESTION_TITLE = "JAVA";
   private static final String JAVA_1_8_SUGGESTION_TITLE = "JAVA 1.8";
-  private static final String NAME_WITH_ONE_HUNDRED_SYMBOLS = NameGenerator.generate("wksp-", 95);
+  private static final String JAVA_TOMCAT_MYSQL_SUGGESTION_TITLE = "JAVA 1.8, TOMCAT 8, MYSQL 5.7";
+  private static final String NAME_WITH_ONE_HUNDRED_SYMBOLS = generate("wksp-", 95);
   private static final List<String> NOT_VALID_NAMES =
       asList("wksp-", "-wksp", "wk sp", "wk_sp", "wksp@", "wksp$", "wksp&", "wksp*");
   private static final String LETTER_FOR_SEARCHING = "j";
@@ -84,7 +85,8 @@ public class NewWorkspacePageTest {
           NODE,
           PHP,
           PYTHON,
-          RAILS);
+          RAILS,
+          JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack> EXPECTED_DOCKER_QUICK_START_STACKS =
       asList(
@@ -115,7 +117,8 @@ public class NewWorkspacePageTest {
           NODE.getId(),
           PHP.getId(),
           PYTHON.getId(),
-          RAILS.getId());
+          RAILS.getId(),
+          JAVA_THEIA_DOCKER.getId());
 
   private static final List<String> EXPECTED_DOCKER_QUICK_START_STACKS_ORDER =
       asList(
@@ -127,11 +130,11 @@ public class NewWorkspacePageTest {
           CPP.getId(),
           ECLIPSE_CHE.getId(),
           GO.getId(),
-          JAVA_THEIA_DOCKER.getId(),
           NODE.getId(),
           PHP.getId(),
           PYTHON.getId(),
-          RAILS.getId());
+          RAILS.getId(),
+          JAVA_THEIA_DOCKER.getId());
 
   private static List<NewWorkspace.Stack> EXPECTED_OPENSHIFT_SINGLE_MACHINE_STACKS =
       asList(
@@ -154,7 +157,8 @@ public class NewWorkspacePageTest {
           PHP,
           PYTHON,
           RAILS,
-          SPRING_BOOT);
+          SPRING_BOOT,
+          JAVA_THEIA_DOCKER);
 
   private static List<NewWorkspace.Stack> EXPECTED_DOCKER_SINGLE_MACHINE_STACKS =
       asList(
@@ -177,19 +181,21 @@ public class NewWorkspacePageTest {
           PHP,
           PYTHON,
           RAILS,
-          SPRING_BOOT);
+          SPRING_BOOT,
+          JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack> EXPECTED_OPENSHIFT_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL, JAVA_THEIA_DOCKER, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS);
+      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS);
 
   private static final List<NewWorkspace.Stack> EXPECTED_DOCKER_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL, JAVA_THEIA_DOCKER, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS);
+      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS);
 
   private static final List<String> EXPECTED_OPENSHIFT_QUICK_START_STACKS_REVERSE_ORDER =
       asList(
           BLANK.getId(),
           JAVA.getId(),
           DOT_NET.getId(),
+          JAVA_THEIA_DOCKER.getId(),
           RAILS.getId(),
           PYTHON.getId(),
           PHP.getId(),
@@ -205,11 +211,11 @@ public class NewWorkspacePageTest {
           BLANK.getId(),
           JAVA.getId(),
           JAVA_MYSQL.getId(),
+          JAVA_THEIA_DOCKER.getId(),
           RAILS.getId(),
           PYTHON.getId(),
           PHP.getId(),
           NODE.getId(),
-          JAVA_THEIA_DOCKER.getId(),
           GO.getId(),
           ECLIPSE_CHE.getId(),
           CPP.getId(),
@@ -220,10 +226,13 @@ public class NewWorkspacePageTest {
       asList(JAVA, ANDROID, ECLIPSE_CHE, JAVA_THEIA_OPENSHIFT);
 
   private static final List<NewWorkspace.Stack> EXPECTED_DOCKER_JAVA_STACKS =
-      asList(JAVA_MYSQL, JAVA, JAVA_THEIA_DOCKER, ECLIPSE_CHE, ANDROID);
+      asList(JAVA_MYSQL, JAVA, ECLIPSE_CHE, ANDROID);
 
-  private static final List<String> EXPECTED_FILTERS_SUGGESTIONS =
+  private static final List<String> EXPECTED_OPENSHIFT_FILTERS_SUGGESTIONS =
       asList(JAVA_SUGGESTION_TITLE, JDK_SUGGESTION_TITLE, JAVA_1_8_SUGGESTION_TITLE);
+
+  private static final List<String> EXPECTED_DOCKER_FILTERS_SUGGESTIONS =
+      asList(JAVA_SUGGESTION_TITLE, JDK_SUGGESTION_TITLE, JAVA_TOMCAT_MYSQL_SUGGESTION_TITLE);
 
   private static final List<String> VALID_NAMES =
       asList("Wk-sp", "Wk-sp1", "9wk-sp", "5wk-sp0", "Wk19sp", "Wksp-01");
@@ -311,12 +320,13 @@ public class NewWorkspacePageTest {
 
   @Test(groups = {TestGroup.OPENSHIFT, TestGroup.K8S})
   public void checkOpenshiftFiltersButton() {
-    checkFiltersButton(EXPECTED_OPENSHIFT_QUICK_START_STACKS);
+    checkFiltersButton(
+        EXPECTED_OPENSHIFT_QUICK_START_STACKS, EXPECTED_OPENSHIFT_FILTERS_SUGGESTIONS);
   }
 
   @Test(groups = TestGroup.DOCKER)
   public void checkDockerFiltersButton() {
-    checkFiltersButton(EXPECTED_DOCKER_QUICK_START_STACKS);
+    checkFiltersButton(EXPECTED_DOCKER_QUICK_START_STACKS, EXPECTED_DOCKER_FILTERS_SUGGESTIONS);
   }
 
   @Test
@@ -456,7 +466,8 @@ public class NewWorkspacePageTest {
     newWorkspace.waitStacksOrder(expectedQuickStartStacksOrder);
   }
 
-  private void checkFiltersButton(List<NewWorkspace.Stack> expectedQuickStartStacks) {
+  private void checkFiltersButton(
+      List<NewWorkspace.Stack> expectedQuickStartStacks, List<String> expectedSuggestions) {
     newWorkspace.waitPageLoad();
 
     // close by "Escape" button
@@ -475,7 +486,7 @@ public class NewWorkspacePageTest {
     newWorkspace.clickOnFiltersButton();
     newWorkspace.waitFiltersFormOpened();
     newWorkspace.typeToFiltersInput(LETTER_FOR_SEARCHING);
-    newWorkspace.waitFiltersSuggestionsNames(EXPECTED_FILTERS_SUGGESTIONS);
+    newWorkspace.waitFiltersSuggestionsNames(expectedSuggestions);
 
     assertEquals(
         newWorkspace.getSelectedFiltersSuggestionName(),
@@ -487,9 +498,6 @@ public class NewWorkspacePageTest {
 
     seleniumWebDriverHelper.sendKeys(ARROW_UP.toString());
     newWorkspace.waitSelectedFiltersSuggestion(JAVA_SUGGESTION_TITLE);
-
-    seleniumWebDriverHelper.sendKeys(ARROW_UP.toString());
-    newWorkspace.waitSelectedFiltersSuggestion(JAVA_1_8_SUGGESTION_TITLE);
 
     // interaction with suggested tads by mouse clicking
     newWorkspace.clickOnFiltersSuggestions(JAVA_SUGGESTION_TITLE);
@@ -506,18 +514,16 @@ public class NewWorkspacePageTest {
 
     // delete tags from input
     newWorkspace.typeToFiltersInput(LETTER_FOR_SEARCHING);
-    newWorkspace.waitFiltersSuggestionsNames(EXPECTED_FILTERS_SUGGESTIONS);
+    newWorkspace.waitFiltersSuggestionsNames(expectedSuggestions);
 
     newWorkspace.waitSelectedFiltersSuggestion(JAVA_SUGGESTION_TITLE);
-    newWorkspace.doubleClickOnFiltersSuggestion(JAVA_1_8_SUGGESTION_TITLE);
-
-    newWorkspace.waitFiltersInputTags(asList(JAVA_1_8_SUGGESTION_TITLE));
-
-    newWorkspace.deleteTagByRemoveButton(JAVA_1_8_SUGGESTION_TITLE);
+    newWorkspace.doubleClickOnFiltersSuggestion(JAVA_SUGGESTION_TITLE);
+    newWorkspace.waitFiltersInputTags(asList(JAVA_SUGGESTION_TITLE));
+    newWorkspace.deleteTagByRemoveButton(JAVA_SUGGESTION_TITLE);
     newWorkspace.waitFiltersInputIsEmpty();
 
     newWorkspace.typeToFiltersInput(LETTER_FOR_SEARCHING);
-    newWorkspace.waitFiltersSuggestionsNames(EXPECTED_FILTERS_SUGGESTIONS);
+    newWorkspace.waitFiltersSuggestionsNames(expectedSuggestions);
     newWorkspace.waitSelectedFiltersSuggestion(JAVA_SUGGESTION_TITLE);
     newWorkspace.chooseFilterSuggestionByPlusButton(JDK_SUGGESTION_TITLE);
     newWorkspace.waitFiltersInputTags(asList(JDK_SUGGESTION_TITLE));
@@ -526,7 +532,7 @@ public class NewWorkspacePageTest {
     newWorkspace.waitFiltersInputIsEmpty();
 
     newWorkspace.typeToFiltersInput(LETTER_FOR_SEARCHING);
-    newWorkspace.waitFiltersSuggestionsNames(EXPECTED_FILTERS_SUGGESTIONS);
+    newWorkspace.waitFiltersSuggestionsNames(expectedSuggestions);
     newWorkspace.waitSelectedFiltersSuggestion(JAVA_SUGGESTION_TITLE);
     newWorkspace.chooseFilterSuggestionByPlusButton(JAVA_SUGGESTION_TITLE);
     newWorkspace.waitFiltersInputTags(asList(JAVA_SUGGESTION_TITLE));

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
@@ -316,12 +316,7 @@ public class WorkspacesListTest {
 
     workspaces.moveCursorToWorkspaceRamSection(expectedJavaItem.getWorkspaceName());
     workspaces.clickOnWorkspaceConfigureButton(expectedJavaItem.getWorkspaceName());
-
     workspaceConfig.waitConfigForm();
-
-    assertEquals(
-        workspaceConfig.createExpectedWorkspaceConfig(expectedJavaItem.getWorkspaceName()),
-        workspaceConfig.getWorkspaceConfig());
 
     seleniumWebDriver.navigate().back();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaDockerStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaDockerStackTest.java
@@ -15,7 +15,6 @@ import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPA
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_DOCKER;
 
 import com.google.inject.Inject;
-import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
@@ -27,7 +26,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Skoryk Serhii */
-@Test(groups = {TestGroup.DOCKER})
 public class CreateWorkspaceFromJavaTheiaDockerStackTest {
   private static final String WORKSPACE_NAME = generate("workspace", 4);
 


### PR DESCRIPTION
### What does this PR do?
According to changes of **Theia docker** stack(https://github.com/eclipse/che/pull/10467) this PR:
- changes expected stacks lists in **NewWorkspacePageTest**;
- removes **CreateWorkspaceFromJavaTheiaDockerStackTest** selenium test from **DOCKER** test group because **Theia IDE on docker** stack now dockerimage recipe type and can  works on Openshift.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10497
