### PR TITLE
Handle markdown in additional content widgets.

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/MarkedOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/MarkedOverlay.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+/**
+ * This class gives access to the marked.js module from orion editor.
+ *
+ * @author Thomas Mäder
+ */
+
+import com.google.gwt.core.client.JavaScriptObject;
+import java.util.function.Consumer;
+
+public class MarkedOverlay extends JavaScriptObject {
+
+  private static MarkedOverlay INSTANCE;
+
+  static {
+    create(
+        marked -> {
+          INSTANCE = marked;
+        });
+  }
+
+  public static MarkedOverlay getInstance() {
+    return INSTANCE;
+  }
+
+  protected MarkedOverlay() {}
+
+  private static native void create(Consumer<MarkedOverlay> callback) /*-{
+        $wnd.require(['marked/marked'], function (marked) {
+            var m = {};
+            m.marked= marked;
+            callback.@java.util.function.Consumer::accept(*)(m);
+        });
+    }-*/;
+
+  /**
+   * Converts the given markdown to HTML
+   * 
+   * @param markdown marked string
+   * @return the html version of the same content
+   */
+  public final native String toHTML(String markdown) /*-{
+        return this.marked(markdown, {
+                sanitize: true
+            });
+    }-*/;
+}

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/signature/SignatureWidget.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/signature/SignatureWidget.java
@@ -42,6 +42,7 @@ import org.eclipse.che.ide.api.editor.signature.ParameterInfo;
 import org.eclipse.che.ide.api.editor.signature.SignatureHelp;
 import org.eclipse.che.ide.api.editor.signature.SignatureInfo;
 import org.eclipse.che.ide.editor.orion.client.OrionEditorWidget;
+import org.eclipse.che.ide.editor.orion.client.jso.MarkedOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionKeyModeOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionPixelPositionOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionTextViewOverlay;
@@ -185,6 +186,8 @@ public class SignatureWidget implements EventListener {
     if (documentation == null || documentation.trim().isEmpty()) {
       documentation = "No documentation found.";
     }
+
+    documentation = MarkedOverlay.getInstance().toHTML(documentation);
 
     HTML widget = new HTML(documentation);
     widget.getElement().getStyle().setWhiteSpace(WhiteSpace.PRE_LINE);

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
@@ -31,6 +31,7 @@ import org.eclipse.che.ide.api.editor.link.LinkedModel;
 import org.eclipse.che.ide.api.editor.text.LinearRange;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.icon.Icon;
+import org.eclipse.che.ide.editor.orion.client.jso.MarkedOverlay;
 import org.eclipse.che.ide.filters.Match;
 import org.eclipse.che.ide.util.Pair;
 import org.eclipse.che.plugin.languageserver.ide.LanguageServerResources;
@@ -112,6 +113,8 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
     if (documentation == null || documentation.trim().isEmpty()) {
       documentation = "No documentation found.";
     }
+
+    documentation = MarkedOverlay.getInstance().toHTML(documentation);
 
     HTML widget = new HTML(documentation);
     widget.setWordWrap(true);


### PR DESCRIPTION
### What does this PR do?
Adds handling of markdown in the widgets that show additional doc (i.e. javadoc) for completions and signature help in LSP editors.

### What issues does this PR fix or reference?
#10499

