### PR TITLE
Make host calculation more short and concise for che master

### DIFF
--- a/deploy/kubernetes/helm/che/charts/che-keycloak/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/charts/che-keycloak/templates/ingress.yaml
@@ -24,7 +24,7 @@ spec:
   tls:
   - hosts:
     - {{ template "keycloakHost" . }}
-    secretName: che-tls
+    secretName: {{ .Values.global.tls.secretName }}
 {{- end }}
   rules:
 {{- if eq .Values.global.serverStrategy "default-host" }}

--- a/deploy/kubernetes/helm/che/templates/_hostHelper.tpl
+++ b/deploy/kubernetes/helm/che/templates/_hostHelper.tpl
@@ -1,8 +1,6 @@
 {{- define "cheHost" }}
-{{- if eq .Values.global.serverStrategy "default-host" }}
+{{- if or (eq .Values.global.serverStrategy "default-host") (eq .Values.global.serverStrategy "single-host") }}
 {{- printf "%s" .Values.global.ingressDomain }}
-{{- else if eq .Values.global.serverStrategy "single-host" }}
-{{- printf "che-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
 {{- else }}
 {{- printf "che-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
 {{- end }}

--- a/deploy/kubernetes/helm/che/templates/_keycloakAuthUrlHelper.tpl
+++ b/deploy/kubernetes/helm/che/templates/_keycloakAuthUrlHelper.tpl
@@ -1,15 +1,9 @@
 {{- define "keycloakAuthUrl" }}
-  {{- if eq .Values.global.serverStrategy "default-host" }}
+  {{- if or (eq .Values.global.serverStrategy "default-host") (eq .Values.global.serverStrategy "single-host") }}
     {{- if .Values.global.tls.enabled }}
       {{- printf "https://%s/auth" .Values.global.ingressDomain }}
     {{- else }}
       {{- printf "http://%s/auth" .Values.global.ingressDomain }}
-    {{- end }}
-  {{- else if eq .Values.global.serverStrategy "single-host" }}
-    {{- if .Values.global.tls.enabled }}
-      {{- printf "https://che-%s.%s/auth" .Release.Namespace .Values.global.ingressDomain }}
-    {{- else }}
-      {{- printf "http://che-%s.%s/auth" .Release.Namespace .Values.global.ingressDomain }}
     {{- end }}
   {{- else }}
     {{- if .Values.global.tls.enabled }}

--- a/deploy/kubernetes/helm/che/templates/_keycloakHostHelper.tpl
+++ b/deploy/kubernetes/helm/che/templates/_keycloakHostHelper.tpl
@@ -1,8 +1,6 @@
 {{- define "keycloakHost" }}
-{{- if eq .Values.global.serverStrategy "default-host" }}
+{{- if or (eq .Values.global.serverStrategy "default-host") (eq .Values.global.serverStrategy "single-host") }}
 {{- printf "%s" .Values.global.ingressDomain }}
-{{- else if eq .Values.global.serverStrategy "single-host" }}
-{{- printf "che-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
 {{- else }}
 {{- printf "keycloak-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
 {{- end }}

--- a/deploy/kubernetes/helm/che/templates/certificate.yaml
+++ b/deploy/kubernetes/helm/che/templates/certificate.yaml
@@ -11,7 +11,7 @@ kind: Certificate
 metadata:
   name: che-host-cert
 spec:
-  secretName: che-tls
+  secretName: {{ .Values.global.tls.secretName }}
   issuerRef:
     name: letsencrypt
   commonName: {{ .Values.global.cheDomain }}

--- a/deploy/kubernetes/helm/che/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
   tls:
   - hosts:
     - {{ template "cheHost" . }}
-    secretName: che-tls
+    secretName: {{ .Values.global.tls.secretName }}
 {{- end }}
   rules:
 {{- if ne .Values.global.serverStrategy "default-host" }}

--- a/dockerfiles/keycloak/kc_realm_user.sh
+++ b/dockerfiles/keycloak/kc_realm_user.sh
@@ -18,7 +18,7 @@ if [ "${CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD}" == "false" ]; then
 fi
 
 cat /scripts/che-realm.json.erb | \
-                                sed -e "s@<%= scope\.lookupvar('che::che_server_url') %>@${PROTOCOL}://che-${NAMESPACE}.${ROUTING_SUFFIX}@" \
+                                sed -e "s@<%= scope\.lookupvar('che::che_server_url') %>@${PROTOCOL}://${CHE_HOST}@" \
                                 > /scripts/che-realm.json
 
 echo "Creating Admin user..."


### PR DESCRIPTION
Signed-off-by: Sergey Kuperman <sergey.kuperman@sap.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Shortens the che master hostname calculated in k8s helm scripts for single-host and default-host server strategies,
makes tls secret used in all ingresses configurable from values

