### PR TITLE
Parse THEIA_PORT environment variable

### DIFF
--- a/dockerfiles/theia/src/start.sh
+++ b/dockerfiles/theia/src/start.sh
@@ -10,6 +10,19 @@
 
 if [ -z "$THEIA_PORT" ]; then
     export THEIA_PORT=3000
+else
+    # Parse THEIA_PORT env var in case it has weird value, such as tcp://10.108.137.206:3000
+    theia_port_number_regexp='^[0-9]+$'
+    if ! [[ "$THEIA_PORT" =~ $theia_port_number_regexp ]]; then
+        # THEIA_PORT contains something other than a number
+        theia_port_tcp_uri_regexp='^tcp://[0-9a-zA-Z.]+:[0-9]+$'
+        if [[ "$THEIA_PORT" =~ $theia_port_tcp_uri_regexp ]]; then
+            # Remove tcp://....: prefix
+            THEIA_PORT=${THEIA_PORT##*:}
+        else
+            echo  1>&2 "Environment variable THEIA_PORT contains unexpected value:$THEIA_PORT"
+        fi
+    fi
 fi
 
 yarn theia start /projects --hostname=0.0.0.0 --port=${THEIA_PORT}


### PR DESCRIPTION
### What does this PR do?
Parse THEIA_PORT environment variable in Theia start.sh script
to prevent failure of Theia start on k8s when there is a k8s
service "theia" and k8s injects THEIA_PORT environment variable
with a value such as tcp://19.19.191.19:3000

### What issues does this PR fix or reference?
Related to service discovery in Workspace.Next https://github.com/eclipse/che/issues/9913
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
