### PR TITLE
Fix start of a workspace with Theia on k8s infra

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -21,7 +21,8 @@
                     "type": "ide"
                   },
                   "protocol": "http",
-                  "port": "3000"
+                  "port": "3000",
+                  "path": "/"
                 },
                 "theia-dev": {
                   "attributes": {
@@ -85,6 +86,7 @@
                 "theia": {
                   "protocol": "http",
                   "port": "3000",
+                  "path": "/",
                   "attributes": {
                     "type": "ide"
                   }


### PR DESCRIPTION
### What does this PR do?
When default-host strategy for server links evaluation is used
on k8s infra Theia server has a link without trailing slash.
This leads to a situation when Theia doesn't load because its
main javascript is not loaded properly (URL gets truncated to
parent and then name of the script is added).
This PR adds a trailing slash to Theia server definition to
fix this.
Theia stack for Openshift recipe is changed to align
configuration of dockerimage and openshift stacks.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
