### PR TITLE
Fix exceptions at opening an editor that does not correspond to an existing resource

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/FileOpenCloseEventListener.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/core/FileOpenCloseEventListener.java
@@ -20,6 +20,8 @@ import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.events.FileEvent;
 import org.eclipse.che.ide.api.filewatcher.ClientServerEventService;
+import org.eclipse.che.ide.api.resources.Resource;
+import org.eclipse.che.ide.api.resources.VirtualFile;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.util.loging.Log;
 
@@ -45,8 +47,13 @@ public class FileOpenCloseEventListener {
         new FileEvent.FileEventHandler() {
           @Override
           public void onFileOperation(FileEvent event) {
-            final Path path = event.getFile().getLocation();
-            final EditorAgent editorAgent = editorAgentProvider.get();
+            VirtualFile file = event.getFile();
+            if (!(file instanceof Resource)) {
+              return;
+            }
+
+            Path path = file.getLocation();
+            EditorAgent editorAgent = editorAgentProvider.get();
 
             switch (event.getOperationType()) {
               case OPEN:

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/reconcile/PomReconciler.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/reconcile/PomReconciler.java
@@ -116,6 +116,10 @@ public class PomReconciler {
     try {
       Model.readFrom(new ByteArrayInputStream(pomContent.getBytes(defaultCharset())));
 
+      if (isNullOrEmpty(projectPath)) {
+        return result;
+      }
+
       IProject project = ResourcesPlugin.getWorkspace().getRoot().getProject(projectPath);
       MavenProject mavenProject = mavenProjectManager.findMavenProject(project);
       if (mavenProject == null) {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/editor/server/impl/EditorWorkingCopyManager.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/editor/server/impl/EditorWorkingCopyManager.java
@@ -201,9 +201,7 @@ public class EditorWorkingCopyManager {
     } catch (NotFoundException e) {
       String errorMessage = "Can not handle file operation: " + e.getMessage();
 
-      LOG.error(errorMessage);
-
-      transmitError(400, errorMessage, endpointId);
+      LOG.debug(errorMessage);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
1. Do not track an editor on server side when this one does not correspond to an existing file system resource(command editor, effective pom and so on).
2. Fix some exceptions(NPE when It is impossible to recognize a related project, IndexOutOfBoundsException when project path and file path are not related)
 
### What issues does this PR fix or reference?
#10222 #8984 #9655
the PR does not fix #10309 (we should investigate this one), but allows to avoid first two errors described [here](https://github.com/eclipse/che/issues/10309#issuecomment-404104105)

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>