### PR TITLE
Simplify OpenShift/Kubernetes admin configuration

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -330,9 +330,6 @@ che.predefined.stacks.reload_on_start=false
 
 # Configuration of Kubernetes client that Infra will use
 che.infra.kubernetes.master_url=
-che.infra.kubernetes.username=
-che.infra.kubernetes.password=
-che.infra.kubernetes.oauth_token=
 che.infra.kubernetes.trust_certs=
 
 # Defines the way how servers are exposed to the world in k8s infra.

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che_aliases.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che_aliases.properties
@@ -12,9 +12,6 @@
 # File with a map new_property_name=old_property_name1,old_property_name2
 
 che.infra.kubernetes.master_url=che.infra.openshift.master_url
-che.infra.kubernetes.username=che.infra.openshift.username
-che.infra.kubernetes.password=che.infra.openshift.password
-che.infra.kubernetes.oauth_token=che.infra.openshift.oauth_token
 che.infra.kubernetes.trust_certs=che.infra.openshift.trust_certs
 che.infra.kubernetes.bootstrapper.binary_url=che.infra.openshift.bootstrapper.binary_url
 che.infra.kubernetes.bootstrapper.installer_timeout_sec=che.infra.openshift.bootstrapper.installer_timeout_sec

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -28,9 +28,6 @@ data:
   CHE_INFRA_KUBERNETES_INGRESS_DOMAIN: {{ .Values.global.ingressDomain }}
   CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN: "5"
   CHE_INFRA_KUBERNETES_MASTER__URL: ""
-  CHE_INFRA_KUBERNETES_OAUTH__TOKEN: ""
-  CHE_INFRA_KUBERNETES_PASSWORD: ""
-  CHE_INFRA_KUBERNETES_USERNAME: ""
 {{- if and .Values.global.tls .Values.global.tls.enabled }}
   CHE_INFRA_KUBERNETES_TLS__ENABLED: {{ .Values.global.tls.enabled | quote}}
   CHE_INFRA_KUBERNETES_TLS__SECRET: {{ .Values.global.tls.secretName }}

--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -107,11 +107,6 @@ spec:
             configMapKeyRef:
               key: CHE_INFRA_KUBERNETES_MASTER__URL
               name: che
-        - name: CHE_INFRA_KUBERNETES_OAUTH__TOKEN
-          valueFrom:
-            configMapKeyRef:
-              key: CHE_INFRA_KUBERNETES_OAUTH__TOKEN
-              name: che
         - name: CHE_INFRA_KUBERNETES_PVC_STRATEGY
           valueFrom:
             configMapKeyRef:
@@ -137,20 +132,10 @@ spec:
             configMapKeyRef:
               key: JAVA_OPTS
               name: che
-        - name: CHE_INFRA_KUBERNETES_PASSWORD
-          valueFrom:
-            configMapKeyRef:
-              key: CHE_INFRA_KUBERNETES_PASSWORD
-              name: che
         - name: CHE_INFRA_KUBERNETES_TRUST__CERTS
           valueFrom:
             configMapKeyRef:
               key: CHE_INFRA_KUBERNETES_TRUST__CERTS
-              name: che
-        - name: CHE_INFRA_KUBERNETES_USERNAME
-          valueFrom:
-            configMapKeyRef:
-              key: CHE_INFRA_KUBERNETES_USERNAME
               name: che
 {{- if .Values.global.multiuser }}
 #Client_id should always be supplied in multiuser scenario

--- a/deploy/kubernetes/kubectl/che-kubernetes.yaml
+++ b/deploy/kubernetes/kubectl/che-kubernetes.yaml
@@ -50,9 +50,6 @@ items:
     CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL: http://192.168.99.100.nip.io/agent-binaries/linux_amd64/bootstrapper/bootstrapper
     CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN: "5"
     CHE_INFRA_KUBERNETES_MASTER__URL: ""
-    CHE_INFRA_KUBERNETES_OAUTH__TOKEN: ""
-    CHE_INFRA_KUBERNETES_PASSWORD: ""
-    CHE_INFRA_KUBERNETES_USERNAME: ""
     CHE_INFRA_KUBERNETES_NAMESPACE: ""
     CHE_INFRA_KUBERNETES_TRUST__CERTS: "false"
     CHE_INFRA_KUBERNETES_PVC_STRATEGY: "common"
@@ -157,11 +154,6 @@ items:
               configMapKeyRef:
                 key: CHE_INFRA_KUBERNETES_MASTER__URL
                 name: che
-          - name: CHE_INFRA_KUBERNETES_OAUTH__TOKEN
-            valueFrom:
-              configMapKeyRef:
-                key: CHE_INFRA_KUBERNETES_OAUTH__TOKEN
-                name: che
           - name: CHE_INFRA_KUBERNETES_PVC_STRATEGY
             valueFrom:
               configMapKeyRef:
@@ -187,20 +179,10 @@ items:
               configMapKeyRef:
                 key: JAVA_OPTS
                 name: che
-          - name: CHE_INFRA_KUBERNETES_PASSWORD
-            valueFrom:
-              configMapKeyRef:
-                key: CHE_INFRA_KUBERNETES_PASSWORD
-                name: che
           - name: CHE_INFRA_KUBERNETES_TRUST__CERTS
             valueFrom:
               configMapKeyRef:
                 key: CHE_INFRA_KUBERNETES_TRUST__CERTS
-                name: che
-          - name: CHE_INFRA_KUBERNETES_USERNAME
-            valueFrom:
-              configMapKeyRef:
-                key: CHE_INFRA_KUBERNETES_USERNAME
                 name: che
           - name: CHE_INFRA_KUBERNETES_NAMESPACE
             valueFrom:

--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -55,9 +55,6 @@ ENV vars: this script automatically detect envs vars beginning with "CHE_" and p
 CHE_IMAGE_REPO - Che server Docker image, defaults to "eclipse-che-server"
 CHE_IMAGE_TAG - Set che-server image tag, defaults to "nightly"
 CHE_INFRA_OPENSHIFT_PROJECT - namespace for workspace objects (defaults to current namespace of Che pod (CHE_OPENSHIFT_PROJECT which defaults to eclipse-che)). It can be overriden with -p|--project param. A separate ws namespace can be used only if username/password or token is provided
-CHE_INFRA_KUBERNETES_USERNAME - OpenShift username to create workspace objects with. Not used by default (service account is used instead)
-CHE_INFRA_KUBERNETES_PASSWORD - OpenShift password
-CHE_INFRA_KUBERNETES_OAUTH__TOKEN - OpenShift token to create workspace objects with. Not used by default (service account is used instead)
 CHE_INFRA_KUBERNETES_PVC_STRATEGY - One PVC per workspace (unique) or one PVC shared by all workspaced (common). Defaults to unique
 CHE_INFRA_KUBERNETES_PVC_QUANTITY - PVC default claim. Set to 1Gi.
 CHE_KEYCLOAK_AUTH__SERVER__URL - URL of a Keycloak auth server. Defaults to route of a Keycloak deployment

--- a/deploy/openshift/templates/che-server-template.yaml
+++ b/deploy/openshift/templates/che-server-template.yaml
@@ -91,12 +91,6 @@ objects:
             value: "5"
           - name: CHE_INFRA_KUBERNETES_MASTER__URL
             value: "${CHE_INFRA_KUBERNETES_MASTER__URL}"
-          - name: CHE_INFRA_KUBERNETES_OAUTH__TOKEN
-            value: "${OPENSHIFT_TOKEN}"
-          - name: CHE_INFRA_KUBERNETES_USERNAME
-            value: "${OPENSHIFT_USERNAME}"
-          - name: CHE_INFRA_KUBERNETES_PASSWORD
-            value: "${OPENSHIFT_PASSWORD}"
           - name: CHE_INFRA_OPENSHIFT_PROJECT
             value: "${CHE_INFRA_OPENSHIFT_PROJECT}"
           - name: CHE_INFRA_KUBERNETES_PVC_STRATEGY
@@ -202,15 +196,6 @@ parameters:
   displayName: Che Multi-user flavor
   description: False i.e. single user by default
   value: 'false'
-- name: OPENSHIFT_USERNAME
-  displayName: OpenShift Username
-  description: OpenShift username that will be used to create workspace objects
-- name: OPENSHIFT_PASSWORD
-  displayName: OpenShift Password
-  description: OpenShift Password that will be used to create workspace objects
-- name: OPENSHIFT_TOKEN
-  displayName: OpenShift token
-  description: OpenShift token to be used to create workspace objects. Must be set if username/password are impossible to use. Do not set if username/pass are provided!
 - name: PROTOCOL
   displayName: HTTP protocol
   description: Protocol to be used in Che communications

--- a/dockerfiles/init/manifests/che.env
+++ b/dockerfiles/init/manifests/che.env
@@ -448,9 +448,6 @@ CHE_SINGLE_PORT=false
 
 #Configuration of Kubernetes client that Infra will use
 #CHE_INFRA_KUBERNETES_MASTER__URL=
-#CHE_INFRA_KUBERNETES_USERNAME=
-#CHE_INFRA_KUBERNETES_PASSWORD=
-#CHE_INFRA_KUBERNETES_OAUTH__TOKEN=
 #CHE_INFRA_KUBERNETES_TRUST__CERTS=
 
 # Defines Kubernetes namespace in which all workspaces will be created.

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
@@ -53,9 +53,6 @@ public class KubernetesClientFactory {
   @Inject
   public KubernetesClientFactory(
       @Nullable @Named("che.infra.kubernetes.master_url") String masterUrl,
-      @Nullable @Named("che.infra.kubernetes.username") String username,
-      @Nullable @Named("che.infra.kubernetes.password") String password,
-      @Nullable @Named("che.infra.kubernetes.oauth_token") String oauthToken,
       @Nullable @Named("che.infra.kubernetes.trust_certs") Boolean doTrustCerts,
       @Named("che.infra.kubernetes.client.http.async_requests.max") int maxConcurrentRequests,
       @Named("che.infra.kubernetes.client.http.async_requests.max_per_host")
@@ -63,8 +60,7 @@ public class KubernetesClientFactory {
       @Named("che.infra.kubernetes.client.http.connection_pool.max_idle") int maxIdleConnections,
       @Named("che.infra.kubernetes.client.http.connection_pool.keep_alive_min")
           int connectionPoolKeepAlive) {
-    this.defaultConfig =
-        buildDefaultConfig(masterUrl, username, password, oauthToken, doTrustCerts);
+    this.defaultConfig = buildDefaultConfig(masterUrl, doTrustCerts);
     OkHttpClient temporary = HttpClientUtils.createHttpClient(defaultConfig);
     OkHttpClient.Builder builder = temporary.newBuilder();
     ConnectionPool oldPool = temporary.connectionPool();
@@ -141,23 +137,10 @@ public class KubernetesClientFactory {
    * Builds the default Kubernetes {@link Config} that will be the base configuration to create
    * per-workspace configurations.
    */
-  protected Config buildDefaultConfig(
-      String masterUrl, String username, String password, String oauthToken, Boolean doTrustCerts) {
+  protected Config buildDefaultConfig(String masterUrl, Boolean doTrustCerts) {
     ConfigBuilder configBuilder = new ConfigBuilder();
     if (!isNullOrEmpty(masterUrl)) {
       configBuilder.withMasterUrl(masterUrl);
-    }
-
-    if (!isNullOrEmpty(username)) {
-      configBuilder.withUsername(username);
-    }
-
-    if (!isNullOrEmpty(password)) {
-      configBuilder.withPassword(password);
-    }
-
-    if (!isNullOrEmpty(oauthToken)) {
-      configBuilder.withOauthToken(oauthToken);
     }
 
     if (doTrustCerts != null) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java
@@ -59,9 +59,6 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
   public OpenShiftClientFactory(
       OpenShiftClientConfigFactory configBuilder,
       @Nullable @Named("che.infra.kubernetes.master_url") String masterUrl,
-      @Nullable @Named("che.infra.kubernetes.username") String username,
-      @Nullable @Named("che.infra.kubernetes.password") String password,
-      @Nullable @Named("che.infra.kubernetes.oauth_token") String oauthToken,
       @Nullable @Named("che.infra.kubernetes.trust_certs") Boolean doTrustCerts,
       @Named("che.infra.kubernetes.client.http.async_requests.max") int maxConcurrentRequests,
       @Named("che.infra.kubernetes.client.http.async_requests.max_per_host")
@@ -71,9 +68,6 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
           int connectionPoolKeepAlive) {
     super(
         masterUrl,
-        username,
-        password,
-        oauthToken,
         doTrustCerts,
         maxConcurrentRequests,
         maxConcurrentRequestsPerHost,
@@ -118,23 +112,10 @@ public class OpenShiftClientFactory extends KubernetesClientFactory {
   }
 
   @Override
-  protected Config buildDefaultConfig(
-      String masterUrl, String username, String password, String oauthToken, Boolean doTrustCerts) {
+  protected Config buildDefaultConfig(String masterUrl, Boolean doTrustCerts) {
     OpenShiftConfigBuilder configBuilder = new OpenShiftConfigBuilder();
     if (!isNullOrEmpty(masterUrl)) {
       configBuilder.withMasterUrl(masterUrl);
-    }
-
-    if (!isNullOrEmpty(username)) {
-      configBuilder.withUsername(username);
-    }
-
-    if (!isNullOrEmpty(password)) {
-      configBuilder.withPassword(password);
-    }
-
-    if (!isNullOrEmpty(oauthToken)) {
-      configBuilder.withOauthToken(oauthToken);
     }
 
     if (doTrustCerts != null) {


### PR DESCRIPTION
### What does this PR do?
Remove the properties 
- `che.infra.kubernetes.username`
- `che.infra.kubernetes.password`
- `che.infra.kubernetes.oauth_token`

according to discussion in issue https://github.com/eclipse/che/issues/9961#issuecomment-396529377

As a result of this PR, the single-project use case of Che is simplified to just relying on the Che service account. This means that if workspaces are to be created in a different namespace, the service account will require cluster admin rights as noted in the updated docs PR.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9961

#### Docs PR
https://github.com/eclipse/che-docs/pull/439