### PR TITLE
CHE-10365: Add websocket reconnection feature to workspace loader app

### DIFF
--- a/workspace-loader/package.json
+++ b/workspace-loader/package.json
@@ -25,7 +25,9 @@
     "webpack-dev-server": "^2.11.1",
     "webpack-merge": "^4.1.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "reconnecting-websocket": "3.2.2"
+  },
   "jest": {
     "moduleFileExtensions": [
       "ts",

--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -121,7 +121,7 @@ export class WorkspaceLoader {
     startAfterStopping = false;
 
     constructor(private readonly loader: Loader,
-                private readonly keycloak: any) {
+                private readonly keycloak?: any) {
         /** Ask dashboard to show the IDE. */
         window.parent.postMessage("show-ide", "*");
     }

--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -278,9 +278,15 @@ export class WorkspaceLoader {
      * Subscribes to the workspace events.
      */
     subscribeWorkspaceEvents() : Promise<void> {
-        let master = new CheJsonRpcMasterApi(new WebsocketClient());
+        const websocketClient = new WebsocketClient();
+        websocketClient.addListener('open', () => {
+            this.getWorkspace(this.workspace.id).then((workspace) => {
+                this.onWorkspaceStatusChanged(workspace.status ? workspace.status : '');
+            });
+        });
+        const entryPoint = this.websocketBaseURL() + WEBSOCKET_CONTEXT + this.getAuthenticationToken();
+        const master = new CheJsonRpcMasterApi(websocketClient, entryPoint);
         return new Promise((resolve) => {
-            const entryPoint = this.websocketBaseURL() + WEBSOCKET_CONTEXT + this.getAuthenticationToken();
             master.connect(entryPoint).then(() => {
                 master.subscribeEnvironmentOutput(this.workspace.id, 
                     (message: any) => this.onEnvironmentOutput(message.text));
@@ -288,7 +294,7 @@ export class WorkspaceLoader {
                 master.subscribeWorkspaceStatus(this.workspace.id, 
                     (message: any) => {
                     if (message.error) {
-                       this.loader.error(message.error);
+                        this.loader.error(message.error);
                     } else {
                         this.onWorkspaceStatusChanged(message.status);
                     }

--- a/workspace-loader/src/json-rpc/che-json-rpc-master-api.ts
+++ b/workspace-loader/src/json-rpc/che-json-rpc-master-api.ts
@@ -42,8 +42,8 @@ export class CheJsonRpcMasterApi {
     this.client = client;
 
     client.addListener('open', () => this.onConnectionOpen());
-    client.addListener('close', e => {
-      switch (e.code) {
+    client.addListener('close', (event: any) => {
+      switch (event.code) {
         case 1000: // normal close
           break;
         default:

--- a/workspace-loader/src/json-rpc/json-rpc-client.ts
+++ b/workspace-loader/src/json-rpc/json-rpc-client.ts
@@ -12,15 +12,26 @@
 import { IDeffered, Deffered } from './util';
 const JSON_RPC_VERSION: string = '2.0';
 
+export type CommunicationClientEvent = 'close' | 'error' | 'open' | 'message';
+export const CODE_REQUEST_TIMEOUT = 4000;
+
 /**
  * Interface for communication between two entrypoints.
  * The implementation can be through websocket or http protocol.
  */
 export interface ICommunicationClient {
   /**
-   * Process responses.
+   * Adds listener callbacks for specified client event.
+   * @param {CommunicationClientEvent} event an event type
+   * @param {Function} handler a callback function
    */
-  onResponse: Function;
+  addListener(event: CommunicationClientEvent, handler: Function): void;
+  /**
+   * Removes listener.
+   * @param {CommunicationClientEvent} event an event type
+   * @param {Function} handler a callback function
+   */
+  removeListener(event: CommunicationClientEvent, handler: Function): void;
   /**
    * Performs connections.
    *
@@ -29,8 +40,9 @@ export interface ICommunicationClient {
   connect(entrypoint: string): Promise<any>;
   /**
    * Close the connection.
+   * @param {number} code close code
    */
-  disconnect(): void;
+  disconnect(code?: number): void;
   /**
    * Send pointed data.
    *
@@ -77,9 +89,9 @@ export class JsonRpcClient {
     this.pendingRequests = new Map<string, IDeffered<any>>();
     this.notificationHandlers = new Map<string, Array<Function>>();
 
-    this.client.onResponse = (message: any): void => {
+    this.client.addListener("message", (message: any) => {
       this.processResponse(message);
-    };
+    });
   }
 
   /**

--- a/workspace-loader/src/json-rpc/json-rpc-client.ts
+++ b/workspace-loader/src/json-rpc/json-rpc-client.ts
@@ -22,16 +22,16 @@ export const CODE_REQUEST_TIMEOUT = 4000;
 export interface ICommunicationClient {
   /**
    * Adds listener callbacks for specified client event.
-   * @param {CommunicationClientEvent} event an event type
+   * @param {CommunicationClientEvent} eventType an event type
    * @param {Function} handler a callback function
    */
-  addListener(event: CommunicationClientEvent, handler: Function): void;
+  addListener(eventType: CommunicationClientEvent, handler: Function): void;
   /**
    * Removes listener.
-   * @param {CommunicationClientEvent} event an event type
+   * @param {CommunicationClientEvent} eventType an event type
    * @param {Function} handler a callback function
    */
-  removeListener(event: CommunicationClientEvent, handler: Function): void;
+  removeListener(eventType: CommunicationClientEvent, handler: Function): void;
   /**
    * Performs connections.
    *

--- a/workspace-loader/src/json-rpc/websocket-client.ts
+++ b/workspace-loader/src/json-rpc/websocket-client.ts
@@ -30,24 +30,24 @@ export class WebsocketClient implements ICommunicationClient {
     connect(entrypoint: string): Promise<void> {
         return new Promise((resolve, reject) => {
             this.websocketStream = new RWS(entrypoint, [], {});
-            this.websocketStream.addEventListener("open", data => {
-                const event: CommunicationClientEvent = "open";
-                this.callHandlers(event, data);
+            this.websocketStream.addEventListener("open", (event: Event) => {
+                const eventType: CommunicationClientEvent = "open";
+                this.callHandlers(eventType, event);
                 resolve();
             });
-            this.websocketStream.addEventListener("error", error => {
-                const event: CommunicationClientEvent = "error";
-                this.callHandlers(event, error);
+            this.websocketStream.addEventListener("error", (event: Event) => {
+                const eventType: CommunicationClientEvent = "error";
+                this.callHandlers(eventType, event);
                 reject();
             });
-            this.websocketStream.addEventListener("message", (message) => {
+            this.websocketStream.addEventListener("message", (message: any) => {
                 const data = JSON.parse(message.data);
-                const event: CommunicationClientEvent = "message";
-                this.callHandlers(event, data);
+                const eventType: CommunicationClientEvent = "message";
+                this.callHandlers(eventType, data);
             });
-            this.websocketStream.addEventListener("close", error => {
-                const event: CommunicationClientEvent = "close";
-                this.callHandlers(event, error);
+            this.websocketStream.addEventListener("close", (event: Event) => {
+                const eventType: CommunicationClientEvent = "close";
+                this.callHandlers(eventType, event);
             });
         });
     }
@@ -68,18 +68,18 @@ export class WebsocketClient implements ICommunicationClient {
     /**
      * Removes a listener.
      *
-     * @param {communicationClientEvent} event
+     * @param {communicationClientEvent} eventType
      * @param {Function} handler
      */
-    removeListener(event: CommunicationClientEvent, handler: Function): void {
-        if (!this.handlers[event] || !handler) {
+    removeListener(eventType: CommunicationClientEvent, handler: Function): void {
+        if (!this.handlers[eventType] || !handler) {
             return;
         }
-        const index = this.handlers[event].indexOf(handler);
+        const index = this.handlers[eventType].indexOf(handler);
         if (index === -1) {
             return;
         }
-        this.handlers[event].splice(index, 1);
+        this.handlers[eventType].splice(index, 1);
     }
 
     /**
@@ -103,7 +103,7 @@ export class WebsocketClient implements ICommunicationClient {
 
     private callHandlers(event: CommunicationClientEvent, data?: any): void {
         if (this.handlers[event] && this.handlers[event].length > 0) {
-            this.handlers[event].forEach(handler => handler(data));
+            this.handlers[event].forEach((handler: Function) => handler(data));
         }
     }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds the [reconnecting-websocket](https://www.npmjs.com/package/reconnecting-websocket) library which is handling a websocket connection closing and performs reconnection. 


CQ: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=17025

### What issues does this PR fix or reference?
#10365 


Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

