### PR TITLE
Set vcs status marker only for resource related editor tabs

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/part/editor/EditorPartStackPresenter.java
@@ -53,6 +53,7 @@ import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.ide.api.parts.PartStackView.TabItem;
 import org.eclipse.che.ide.api.parts.PropertyListener;
 import org.eclipse.che.ide.api.parts.base.MaximizePartEvent;
+import org.eclipse.che.ide.api.resources.Resource;
 import org.eclipse.che.ide.api.resources.ResourceChangedEvent;
 import org.eclipse.che.ide.api.resources.ResourceChangedEvent.ResourceChangedHandler;
 import org.eclipse.che.ide.api.resources.ResourceDelta;
@@ -226,15 +227,17 @@ public class EditorPartStackPresenter extends PartStackPresenter
 
     final EditorTab editorTab = tabItemFactory.createEditorPartButton(editorPart, this);
 
-    appContext
-        .getWorkspaceRoot()
-        .getFile(file.getLocation())
-        .then(
-            optional -> {
-              if (optional.isPresent()) {
-                editorTab.setTitleColor(optional.get().getVcsStatus().getColor());
-              }
-            });
+    if (file instanceof Resource) {
+      appContext
+          .getWorkspaceRoot()
+          .getFile(file.getLocation())
+          .then(
+              optional -> {
+                if (optional.isPresent()) {
+                  editorTab.setTitleColor(optional.get().getVcsStatus().getColor());
+                }
+              });
+    }
 
     editorPart.addPropertyListener(
         new PropertyListener() {


### PR DESCRIPTION
### What does this PR do?
Set vcs status marker ONLY for resource related editor tabs.
For example, we should skip this step at opening command editor or effective pom. 

### What issues does this PR fix or reference?
the PR does not fix #10309 (we should investigate this one), but allows to avoid last two errors described [here](https://github.com/eclipse/che/issues/10309#issuecomment-404104105)  

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>