### PR TITLE
Remove logging of an error that is caused by a user

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -340,8 +340,10 @@ public class WorkspaceRuntimes {
     } catch (ValidationException e) {
       LOG.error(e.getLocalizedMessage(), e);
       throw new ConflictException(e.getLocalizedMessage());
-    } catch (InfrastructureException e) {
+    } catch (InternalInfrastructureException e) {
       LOG.error(e.getLocalizedMessage(), e);
+      throw new ServerException(e.getLocalizedMessage(), e);
+    } catch (InfrastructureException e) {
       throw new ServerException(e.getLocalizedMessage(), e);
     }
   }


### PR DESCRIPTION
### What does this PR do?
We have 2 types of SPI specific exceptions: InfrastructureException and InternalInfrastructureException.
We usually don't log InfrastructureException since it indicates an error that can't be fixed by a Che operator, whereas InternalInfrastructureException indicates some issue with the infrastructure and definitely need some attention from an operator.
This PR makes Che not log InfrastructureException in one of the places. 
[Here](https://github.com/eclipse/che/blob/master/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java#L178) and [here](https://github.com/eclipse/che/blob/master/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java#L399) and [there](https://github.com/eclipse/che/blob/master/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java#L512) are placed when we do the same suppressing of logging for the InfrastructureException, but not for the InternalInfrastructureException.   

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
