### PR TITLE
Fix sequential start of workspace machines

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Constants.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Constants.java
@@ -31,6 +31,9 @@ public final class Constants {
   /** The label that contains a value with workspace id to which object belongs to. */
   public static final String CHE_WORKSPACE_ID_LABEL = "che.workspace_id";
 
+  /** The label that contains name of deployment responsible for Pod. */
+  public static final String CHE_DEPLOYMENT_NAME_LABEL = "che.deployment_name";
+
   /** The label that contains a value with volume name. */
   public static final String CHE_VOLUME_NAME_LABEL = "che.workspace.volume_name";
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue when running on Kubernetes/OpenShift where workspace are started sequentially. This blocking breaks some useful functionality and can cause issues if a Pod is unable to start fully.

Instead of waiting for the Deployment to be ready (meaning all Pods in running state), return the Pod as soon as it is created.

A docker image with these changes should be available at `amisevsk/che-server:issue-10295`.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10295

#### Docs PR
N/A (bugfix)