### PR TITLE
Added page which set up authentication cookie via jwtproxy

### DIFF
--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.html
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.html
@@ -15,7 +15,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>Title</title>
+    <title>Workspace Loader</title>
 
     <script type="text/javascript">
 
@@ -194,7 +194,7 @@
             const re = new RegExp(/(https?:\/\/[^\/]+?)(?:$|\/).*/),
                 //                  \    /     \     /
                 //                  scheme    host:port
-                url = redirectUrl.replace(re, "$1" + "/authenticate");
+                url = redirectUrl.replace(re, "$1" + "/jwt/auth");
             return new Promise((resolve, reject) => {
                 const request = new XMLHttpRequest();
                 request.open('GET', url);
@@ -257,7 +257,7 @@
 </head>
 
 <body>
-    LOADER
+    Loading a workspace...
 </body>
 
 </html>

--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.html
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.html
@@ -12,11 +12,252 @@
 -->
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <title>Title</title>
+
+    <script type="text/javascript">
+
+        class KeycloakLoader {
+            /**
+             * Load keycloak settings
+             */
+            loadKeycloakSettings() {
+                const msg = "Cannot load keycloak settings. This is normal for single-user mode.";
+
+                return new Promise((resolve, reject) => {
+                    try {
+                        const request = new XMLHttpRequest();
+
+                        request.onerror = request.onabort = function () {
+                            reject(msg);
+                        };
+
+                        request.onload = () => {
+                            if (request.status == 200) {
+                                resolve(this.injectKeycloakScript(JSON.parse(request.responseText)));
+                            } else {
+                                reject(null);
+                            }
+                        };
+
+                        const url = "/api/keycloak/settings";
+                        request.open("GET", url, true);
+                        request.send();
+                    } catch (e) {
+                        reject(msg + e.message);
+                    }
+                });
+            }
+
+            /**
+             * Injects keycloak javascript
+             */
+            injectKeycloakScript(keycloakSettings) {
+                return new Promise((resolve, reject) => {
+                    const script = document.createElement('script');
+                    script.type = 'text/javascript';
+                    script.language = 'javascript';
+                    script.async = true;
+                    script.src = keycloakSettings['che.keycloak.js_adapter_url'];
+
+                    script.onload = () => {
+                        resolve(this.initKeycloak(keycloakSettings));
+                    };
+
+                    script.onerror = script.onabort = () => {
+                        reject('Cannot load ' + script.src);
+                    };
+
+                    document.head.appendChild(script);
+                });
+            }
+
+            /**
+             * Initialize keycloak
+             */
+            initKeycloak(keycloakSettings) {
+                return new Promise((resolve, reject) => {
+                    function keycloakConfig() {
+                        const theOidcProvider = keycloakSettings['che.keycloak.oidc_provider'];
+                        if (!theOidcProvider) {
+                            return {
+                                url: keycloakSettings['che.keycloak.auth_server_url'],
+                                realm: keycloakSettings['che.keycloak.realm'],
+                                clientId: keycloakSettings['che.keycloak.client_id']
+                            };
+                        } else {
+                            return {
+                                oidcProvider: theOidcProvider,
+                                clientId: keycloakSettings['che.keycloak.client_id']
+                            };
+                        }
+                    }
+                    const keycloak = Keycloak(keycloakConfig());
+
+                    window['_keycloak'] = keycloak;
+
+                    var useNonce;
+                    if (typeof keycloakSettings['che.keycloak.use_nonce'] === 'string') {
+                        useNonce = keycloakSettings['che.keycloak.use_nonce'].toLowerCase() === 'true';
+                    }
+                    keycloak
+                        .init({ onLoad: 'login-required', checkLoginIframe: false, useNonce: useNonce })
+                        .success(() => {
+                            resolve(keycloak);
+                        })
+                        .error(() => {
+                            reject('[Keycloak] Failed to initialize Keycloak');
+                        });
+                });
+            }
+
+        }
+
+        function getQueryParam(name) {
+            const params = window.location.search.substr(1),
+                paramEntries = params.split('&');
+            entry = paramEntries.find(_entry => {
+                return _entry.startsWith(name + '=');
+            });
+            if (!entry) {
+                return;
+            }
+            const [_, value] = entry.split('=');
+            return decodeURIComponent(value);
+        }
+
+        function asyncGetWorkspace(workspaceId) {
+            return new Promise((resolve, reject) => {
+                const request = new XMLHttpRequest();
+                request.open("GET", '/api/workspace/' + workspaceId);
+                this.setAuthorizationHeader(request).then((xhr) => {
+                    xhr.send();
+                    xhr.onreadystatechange = () => {
+                        if (xhr.readyState !== 4) {
+                            return;
+                        }
+                        if (xhr.status !== 200) {
+                            reject(xhr.status ? xhr.statusText : "Unknown error");
+                            return;
+                        }
+                        resolve(JSON.parse(xhr.responseText));
+                    };
+                });
+            });
+        }
+
+        function setAuthorizationHeader(xhr) {
+            return new Promise((resolve, reject) => {
+                if (window._keycloak && window._keycloak.token) {
+                    window._keycloak.updateToken(5).success(() => {
+                        xhr.setRequestHeader('Authorization', 'Bearer ' + window._keycloak.token);
+                        resolve(xhr);
+                    }).error(() => {
+                        window._keycloak.login();
+                        reject('Failed to refresh token');
+                    });
+                }
+
+                resolve(xhr);
+            });
+        }
+
+        function asyncCheckServiceLink(workspace, redirectUrl) {
+            return new Promise((resolve, reject) => {
+                if (!workspace.runtime) {
+                    reject("Can't check service link: Workspace isn't RUNNING at the moment.");
+                    return;
+                }
+
+                const server = workspace.runtime.links.find(link => redirectUrl.startsWith(link));
+                if (server) {
+                    resolve(server);
+                } else {
+                    reject("Workspace doesn't have a server which matches with URL: " + redirectUrl);
+                }
+            });
+        }
+
+        function asyncGetWsToken(workspace, redirectUrl) {
+            return new Promise((resolve, reject) => {
+                if (workspace.runtime) {
+                    resolve(workspace.runtime.machineToken);
+                } else {
+                    reject("Can't get ws-token: Workspace isn't RUNNING at the moment.");
+                }
+            });
+        }
+
+        function asyncAuthenticate(redirectUrl, token) {
+            const re = new RegExp(/(https?:\/\/[^\/]+?)(?:$|\/).*/),
+                //                  \    /     \     /
+                //                  scheme    host:port
+                url = redirectUrl.replace(re, "$1" + "/authenticate");
+            return new Promise((resolve, reject) => {
+                const request = new XMLHttpRequest();
+                request.open('GET', url);
+                request.setRequestHeader('Authorization', 'Bearer ' + token);
+                request.withCredentials = true;
+                request.send();
+                request.onreadystatechange = () => {
+                    if (request.readyState !== 4) {
+                        return;
+                    }
+                    if (request.status !== 204) {
+                        reject(request.status ? request.statusText : "Unknown error");
+                        return;
+                    }
+                    resolve();
+                };
+            });
+        }
+
+        (function () {
+            const keycloackAuthenticationPromise = new KeycloakLoader().loadKeycloakSettings();
+
+            const workspaceId = getQueryParam('workspaceId'),
+                redirectUrl = getQueryParam('redirectUrl');
+            const getWorkspacePromise = new Promise((resolve, reject) => {
+                if (!workspaceId) {
+                    reject("Workspace ID isn't found in query parameters.");
+                }
+                if (!redirectUrl) {
+                    reject("Redirect URL isn't found in query parameters.");
+                }
+                resolve();
+            }).then(_ => {
+                return keycloackAuthenticationPromise;
+            }).then(_ => {
+                return asyncGetWorkspace(workspaceId);
+            });
+
+            const checkServiceUrlPromise = getWorkspacePromise.then(workspace => {
+                return asyncCheckServiceLink(workspace, redirectUrl);
+            })
+
+            const tokenAuthenticationPromise = getWorkspacePromise.then(workspace => {
+                return asyncGetWsToken(workspace);
+            }).then(token => {
+                return asyncAuthenticate(redirectUrl, token);
+            });
+
+            Promise.all([keycloackAuthenticationPromise, checkServiceUrlPromise, tokenAuthenticationPromise])
+                .then(_ => {
+                    window.location.replace(redirectUrl);
+                })
+                .catch(error => {
+                    console.error('Something went wrong: \n', error);
+                    alert('Error. Check logs in browser\'s console.');
+                });
+        })();
+
+    </script>
 </head>
+
 <body>
-LOADER
+    LOADER
 </body>
+
 </html>

--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.html
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.html
@@ -1,0 +1,22 @@
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+LOADER
+</body>
+</html>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds the page that will set up an authentication cookie via jwtproxy.
It is supposed that jwtproxy will redirect unauthorized requests to this page to set up an authentication cookie.
It does the following steps:

1. Fetch keycloak token.
2. Fetch configuration of the specified workspace.
3. Check if redirectUrl is a server of the specified workspace.
4. Sends requests to jwtproxy to set up Authorization cookie.
5. Redirects to the URL specified in redirectUrl query param.

### What issues does this PR fix or reference?
#10349 
