### PR TITLE
Set Che QE team members as owners of selenium tests sub-project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,3 +54,6 @@ wsagent/che-core-api-project/src/test/java/org/eclipse/che/api/search/** @skabas
 
 # deploy
 deploy/** @riuvshin @l0rd @garagatyi @eivantsov @sleshchenko
+
+# selenium tests
+selenium/** @musienko-maxim @dmytro-ndp @Ohrimenko1988


### PR DESCRIPTION
### What does this PR do?
It sets next members of Che QE team as an owners of _Eclipse Che_ E2E selenium tests situated in the sub-project [che/selenium](https://github.com/eclipse/che/tree/master/selenium): @musienko-maxim, @dmytro-ndp, @Ohrimenko1988 

### What issues does this PR fix or reference?
It will prevent from merging unchecked changes into selenium tests which could cause regression like the follow #10612 into the **master** branch.