### PR TITLE
Handle markdown in LSP doc popups

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/MarkedOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/MarkedOverlay.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+/**
+ * This class gives access to the marked.js module from orion editor.
+ *
+ * @author Thomas Mäder
+ */
+
+import com.google.gwt.core.client.JavaScriptObject;
+import java.util.function.Consumer;
+import org.eclipse.che.api.promises.client.Promise;
+import org.eclipse.che.api.promises.client.js.Promises;
+
+public class MarkedOverlay extends JavaScriptObject {
+
+  private static Promise<MarkedOverlay> markedPromise = create();
+
+  protected MarkedOverlay() {}
+
+  public static Promise<MarkedOverlay> getMarkedPromise() {
+    return markedPromise;
+  }
+
+  private static Promise<MarkedOverlay> create() {
+    return Promises.create(
+        (resolve, reject) -> {
+          create(
+              (marked) -> {
+                resolve.apply(marked);
+              });
+        });
+  }
+
+  private static native void create(Consumer<MarkedOverlay> callback) /*-{
+        $wnd.require(['marked/marked'], function (marked) {
+            var m = {};
+            m.marked= marked;
+            callback.@java.util.function.Consumer::accept(*)(m);
+        });
+    }-*/;
+
+  /**
+   * Converts the given markdown to HTML
+   *
+   * @param markdown marked string
+   * @return the html version of the same content
+   */
+  public final native String toHTML(String markdown) /*-{
+        return this.marked(markdown, {
+                sanitize: true
+            });
+    }-*/;
+}

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/codeassist/CompletionItemBasedCompletionProposal.java
@@ -31,8 +31,10 @@ import org.eclipse.che.ide.api.editor.link.LinkedModel;
 import org.eclipse.che.ide.api.editor.text.LinearRange;
 import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.icon.Icon;
+import org.eclipse.che.ide.editor.orion.client.jso.MarkedOverlay;
 import org.eclipse.che.ide.filters.Match;
 import org.eclipse.che.ide.util.Pair;
+import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.plugin.languageserver.ide.LanguageServerResources;
 import org.eclipse.che.plugin.languageserver.ide.editor.codeassist.snippet.SnippetResolver;
 import org.eclipse.che.plugin.languageserver.ide.editor.quickassist.ApplyWorkspaceEditAction;
@@ -87,30 +89,43 @@ public class CompletionItemBasedCompletionProposal implements CompletionProposal
 
   @Override
   public void getAdditionalProposalInfo(final AsyncCallback<Widget> callback) {
-    if (completionItem.getItem().getDocumentation() == null && canResolve()) {
-      resolve()
-          .then(
-              item -> {
-                completionItem = item;
-                resolved = true;
-                callback.onSuccess(createAdditionalInfoWidget());
-              })
-          .catchError(
-              e -> {
-                callback.onFailure(e.getCause());
-              });
-    } else {
-      callback.onSuccess(createAdditionalInfoWidget());
-    }
+    MarkedOverlay.getMarkedPromise()
+        .then(
+            (marked) -> {
+              if (completionItem.getItem().getDocumentation() == null && canResolve()) {
+                resolve()
+                    .then(
+                        item -> {
+                          completionItem = item;
+                          resolved = true;
+                          callback.onSuccess(createAdditionalInfoWidget(marked));
+                        })
+                    .catchError(
+                        e -> {
+                          callback.onFailure(e.getCause());
+                        });
+              } else {
+                callback.onSuccess(createAdditionalInfoWidget(marked));
+              }
+            });
   }
 
-  private Widget createAdditionalInfoWidget() {
+  private Widget createAdditionalInfoWidget(MarkedOverlay marked) {
     Either<String, MarkupContent> markup = completionItem.getItem().getDocumentation();
     // markup type is plain text or markdown. Both are ok natively.
-    String documentation = markup.isLeft() ? markup.getLeft() : markup.getRight().getValue();
+    String documentation = null;
+    if (markup != null) {
+      documentation = markup.isLeft() ? markup.getLeft() : markup.getRight().getValue();
+    }
 
     if (documentation == null || documentation.trim().isEmpty()) {
       documentation = "No documentation found.";
+    }
+
+    try {
+      documentation = marked.toHTML(documentation);
+    } catch (Exception e) {
+      Log.error(getClass(), e);
     }
 
     HTML widget = new HTML(documentation);

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/webdriver/SeleniumWebDriverHelper.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/webdriver/SeleniumWebDriverHelper.java
@@ -704,11 +704,19 @@ public class SeleniumWebDriverHelper {
    * @param timeout waiting time in seconds
    */
   public void waitTextContains(WebElement element, String expectedText, int timeout) {
+    String[] actual = new String[1];
     webDriverWaitFactory
         .get(timeout)
+        .withMessage(
+            () -> {
+              return "expected \n'" + expectedText + "'\nbut was \n'" + actual[0] + "'\n";
+            })
         .until(
             (ExpectedCondition<Boolean>)
-                driver -> waitVisibility(element, timeout).getText().contains(expectedText));
+                driver -> {
+                  actual[0] = waitVisibility(element, timeout).getText();
+                  return actual[0].contains(expectedText);
+                });
   }
 
   /**

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
@@ -566,9 +566,7 @@ public class CodenvyEditor {
    * @param text text which should be typed
    */
   public void typeTextIntoEditor(String text) {
-    loader.waitOnClosed();
     seleniumWebDriverHelper.sendKeys(text);
-    loader.waitOnClosed();
   }
 
   /**
@@ -662,7 +660,6 @@ public class CodenvyEditor {
 
   /** Launches code assistant by "ctrl" + "space" keys pressing. */
   public void launchAutocomplete() {
-    loader.waitOnClosed();
     Actions action = actionsFactory.createAction(seleniumWebDriver);
     action.keyDown(CONTROL).perform();
     typeTextIntoEditor(SPACE.toString());
@@ -897,7 +894,7 @@ public class CodenvyEditor {
    */
   public void selectAutocompleteProposal(String item) {
     seleniumWebDriverHelper.waitAndClick(
-        By.xpath(format(AUTOCOMPLETE_CONTAINER + "/li/span[text()='%s']", item)));
+        By.xpath(format(AUTOCOMPLETE_CONTAINER + "/li/span[.='%s']", item)));
   }
 
   /**
@@ -2067,8 +2064,11 @@ public class CodenvyEditor {
         By.xpath(format(Locators.TEXT_TO_MOVE_CURSOR_XPATH, text)));
   }
 
-  public void checkProposalDocumentation(String expectedText) {
-    seleniumWebDriverHelper.waitTextContains(proposalDoc, expectedText);
+  public String getProposalDocumentationHTML() {
+    return seleniumWebDriverHelper
+        .waitVisibility(proposalDoc)
+        .findElement(By.tagName("div"))
+        .getAttribute("innerHTML");
   }
 
   public void launchCommentCodeFeature() {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -290,8 +290,6 @@ public class ProjectExplorer {
    * @param timeout waiting timeout in seconds
    */
   public void waitItem(String path, int timeout) {
-    loader.waitOnClosed();
-
     seleniumWebDriverHelper.waitVisibility(
         By.xpath(format(PROJECT_EXPLORER_ITEM_TEMPLATE, path)), timeout);
   }
@@ -302,8 +300,6 @@ public class ProjectExplorer {
    * @param reference git reference e.g. branch, tag or commit
    */
   public void waitReferenceName(String reference) {
-    loader.waitOnClosed();
-
     seleniumWebDriverHelper.waitTextEqualsTo(projectReference, "(" + reference + ")");
   }
 
@@ -443,8 +439,6 @@ public class ProjectExplorer {
    * @return found {@link WebElement}
    */
   public WebElement waitVisibilityByName(String name, int timeOut) {
-    loader.waitOnClosed();
-
     return seleniumWebDriverHelper.waitVisibility(
         By.xpath(format("//div[@id='gwt-debug-projectTree']//div[text()='%s']", name)), timeOut);
   }
@@ -633,7 +627,6 @@ public class ProjectExplorer {
    * @param folderType folder's type, defined in {@link FolderTypes}
    */
   public void waitDefinedTypeOfFolder(String path, FolderTypes folderType) {
-    loader.waitOnClosed();
     seleniumWebDriverHelper.waitVisibility(
         By.xpath(
             format(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
@@ -10,6 +10,9 @@
  */
 package org.eclipse.che.selenium.editor.autocomplete;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import com.google.inject.Inject;
 import java.io.IOException;
 import java.net.URL;
@@ -24,8 +27,6 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -38,8 +39,6 @@ public class AutocompleteProposalJavaDocTest {
   private static final String PATH_FOR_EXPAND_APP_CLASS =
       PROJECT + "/app/src/main/java/multimodule";
   private static final String BOOK_IMPL_CLASS_NAME = "BookImpl";
-  private static final Logger LOG = LoggerFactory.getLogger(AutocompleteProposalJavaDocTest.class);
-  private static final String PATH_FOR_EXPAND_IMPL_CLASS = "model/src/main/java/multimodule.model";
 
   @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
@@ -49,6 +48,10 @@ public class AutocompleteProposalJavaDocTest {
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private Consoles consoles;
+
+  // no links are present in completion item javadoc due to
+  // https://github.com/eclipse/eclipse.jdt.ls/issues/731
+  // also, links would be displayed, but not handled currently.
 
   @BeforeClass
   public void setup() throws Exception {
@@ -88,19 +91,36 @@ public class AutocompleteProposalJavaDocTest {
     loader.waitOnClosed();
     editor.goToCursorPositionVisible(30, 30);
     editor.launchAutocompleteAndWaitContainer();
-    editor.selectAutocompleteProposal("concat(String part1, String part2, char divider) : String");
+    editor.selectAutocompleteProposal(
+        "concat(String part1, String part2, char divider) : String App");
 
     // then
-    editor.checkProposalDocumentation(
-        ".*<p><b>Deprecated.</b> <i> As of version 1.0, use "
-            + "<code><a href='.*/javadoc/get\\?.*projectpath=/multi-module-java-with-ext-libs/app&handle=%E2%98%82%3Dmulti-module-java-with-ext-libs.*org.apache.commons.lang.StringUtils%E2%98%82join%E2%98%82Object\\+%5B%5D%E2%98%82char'>org.apache.commons.lang.StringUtils.join\\(Object \\[\\], char\\)</a></code>"
-            + "</i><p>Returns concatination of two strings into one divided by special symbol."
-            + "<dl><dt>Parameters:</dt>"
-            + "<dd><b>part1</b> part 1 to concat.</dd>"
-            + "<dd><b>part2</b> part 2 to concat.</dd>"
-            + "<dd><b>divider</b> divider of part1 and part2.</dd>"
-            + "<dt>Returns:</dt><dd> concatination of two strings into one.</dd><dt>Throws:</dt>"
-            + "<dd><a href='.*/javadoc/get\\?.*projectpath=/multi-module-java-with-ext-libs/app&handle=%E2%98%82%3Dmulti-module-java-with-ext-libs%5C%2Fapp%2Fsrc%5C%2Fmain%5C%2Fjava%3Cmultimodule%7BApp.java%E2%98%83App%7Econcat%7EQString%3B%7EQString%3B%7EC%E2%98%82NullPointerException'>NullPointerException</a>.*if one of the part has null value.</dd></dl>.*");
+    assertEquals(
+        editor.getProposalDocumentationHTML(),
+        "<p><strong>Deprecated</strong>  <em>As of version 1.0, use <a href=\"jdt://contents/commons-lang-2.6.jar/org.apache.commons.lang/StringUtils.class?=app/%5C/home%5C/user%5C/.m2%5C/repository%5C/commons-lang%5C/commons-lang%5C/2.6%5C/commons-lang-2.6.jar%3Corg.apache.commons.lang%28StringUtils.class#3169\">org.apache.commons.lang.StringUtils.join(Object [], char)</a></em></p>\n"
+            + "<p>Returns concatination of two strings into one divided by special symbol.</p>\n"
+            + "<ul>\n"
+            + "<li><p><strong>Parameters:</strong></p>\n"
+            + "<ul>\n"
+            + "<li><p><strong>part1</strong> part 1 to concat.</p>\n"
+            + "</li>\n"
+            + "<li><p><strong>part2</strong> part 2 to concat.</p>\n"
+            + "</li>\n"
+            + "<li><p><strong>divider</strong> divider of part1 and part2.</p>\n"
+            + "</li>\n"
+            + "</ul>\n"
+            + "</li>\n"
+            + "<li><p><strong>Returns:</strong></p>\n"
+            + "<ul>\n"
+            + "<li>concatination of two strings into one.</li>\n"
+            + "</ul>\n"
+            + "</li>\n"
+            + "<li><p><strong>Throws:</strong></p>\n"
+            + "<ul>\n"
+            + "<li><a href=\"jdt://contents/rt.jar/java.lang/NullPointerException.class?=app/%5C/usr%5C/lib%5C/jvm%5C/java-8-openjdk-amd64%5C/jre%5C/lib%5C/rt.jar%3Cjava.lang%28NullPointerException.class#53\">NullPointerException</a> - if one of the part has null value.</li>\n"
+            + "</ul>\n"
+            + "</li>\n"
+            + "</ul>\n");
   }
 
   @Test
@@ -108,12 +128,12 @@ public class AutocompleteProposalJavaDocTest {
     // when
     editor.waitActive();
     loader.waitOnClosed();
-    editor.goToCursorPositionVisible(19, 1);
+    editor.goToCursorPositionVisible(31, 14);
     editor.launchAutocompleteAndWaitContainer();
-    editor.selectAutocompleteProposal("App()");
+    editor.selectAutocompleteProposal("App() multimodule.App");
 
     // then
-    editor.checkProposalDocumentation(".*No documentation found.*");
+    assertEquals(editor.getProposalDocumentationHTML(), "<p>No documentation found.</p>\n");
   }
 
   @Test
@@ -123,19 +143,34 @@ public class AutocompleteProposalJavaDocTest {
     loader.waitOnClosed();
     editor.goToCursorPositionVisible(24, 20);
     editor.launchAutocompleteAndWaitContainer();
-    editor.selectAutocompleteProposal("isEquals(Object o) : boolean ");
+    editor.selectAutocompleteProposal("isEquals(Object o) : boolean Book");
 
     // then
-    editor.checkProposalDocumentation(
-        ".*Returns <code>true</code> if the argument is equal to instance. otherwise <code>false</code>"
-            + "<dl><dt>Parameters:</dt>"
-            + "<dd><b>o</b> an object.</dd>"
-            + "<dt>Returns:</dt>"
-            + "<dd> Returns <code>true</code> if the argument is equal to instance. otherwise <code>false</code></dd>"
-            + "<dt>Since:</dt>"
-            + "<dd> 1.0</dd>"
-            + "<dt>See Also:</dt>.*"
-            + "<dd><a href='.*/javadoc/get\\?.*projectpath=/multi-module-java-with-ext-libs/model&handle=%E2%98%82%3Dmulti-module-java-with-ext-libs%5C%2Fmodel%2Fsrc%5C%2Fmain%5C%2Fjava%3Cmultimodule.model%7BBook.java%E2%98%83Book%7EisEquals%7EQObject%3B%E2%98%82java.lang.Object%E2%98%82equals%E2%98%82Object'>java.lang.Object.equals\\(Object\\)</a></dd></dl>.*");
+    assertEquals(
+        editor.getProposalDocumentationHTML(),
+        "<p>Returns <code>true</code> if the argument is equal to instance. otherwise <code>false</code></p>\n"
+            + "<ul>\n"
+            + "<li><p><strong>Parameters:</strong></p>\n"
+            + "<ul>\n"
+            + "<li><strong>o</strong> an object.</li>\n"
+            + "</ul>\n"
+            + "</li>\n"
+            + "<li><p><strong>Returns:</strong></p>\n"
+            + "<ul>\n"
+            + "<li>Returns <code>true</code> if the argument is equal to instance. otherwise <code>false</code></li>\n"
+            + "</ul>\n"
+            + "</li>\n"
+            + "<li><p><strong>Since:</strong></p>\n"
+            + "<ul>\n"
+            + "<li>1.0</li>\n"
+            + "</ul>\n"
+            + "</li>\n"
+            + "<li><p><strong>See Also:</strong></p>\n"
+            + "<ul>\n"
+            + "<li><a href=\"jdt://contents/rt.jar/java.lang/Object.class?=app/%5C/usr%5C/lib%5C/jvm%5C/java-8-openjdk-amd64%5C/jre%5C/lib%5C/rt.jar%3Cjava.lang%28Object.class#148\">java.lang.Object.equals(Object)</a></li>\n"
+            + "</ul>\n"
+            + "</li>\n"
+            + "</ul>\n");
   }
 
   @Test
@@ -151,10 +186,13 @@ public class AutocompleteProposalJavaDocTest {
     editor.waitActive();
     editor.goToCursorPositionVisible(21, 12);
     editor.launchAutocompleteAndWaitContainer();
-    editor.selectAutocompleteProposal("BookImpl");
+    editor.selectAutocompleteProposal("BookImpl - multimodule.model");
 
     // then
-    editor.checkProposalDocumentation(".*UPDATE. Implementation of Book interface..*");
+    assertTrue(
+        editor
+            .getProposalDocumentationHTML()
+            .contains("UPDATE. Implementation of Book interface."));
   }
 
   @Test
@@ -164,26 +202,31 @@ public class AutocompleteProposalJavaDocTest {
     loader.waitOnClosed();
     editor.goToCursorPositionVisible(24, 20);
     editor.launchAutocompleteAndWaitContainer();
-    editor.selectAutocompleteProposal("hashCode() : int");
+    editor.selectAutocompleteProposal("hashCode() : int Object");
 
     // then
-    editor.checkProposalDocumentation(
-        ".*Returns a hash code value for the object. "
-            + "This method is supported for the benefit of hash tables such as those provided by "
-            + "<code><a href='.*/javadoc/get\\?.*projectpath=/multi-module-java-with-ext-libs/app&handle=%E2%98%82%3Dmulti-module-java-with-ext-libs.*%3Cjava.lang%28Object.class%E2%98%83Object%7EhashCode%E2%98%82java.util.HashMap'>java.util.HashMap</a></code>.*");
+    assertTrue(
+        editor
+            .getProposalDocumentationHTML()
+            .contains(
+                "Returns a hash code value for the object. "
+                    + "This method is supported for the benefit of hash tables such as those provided by"));
   }
 
   @Test
   public void shouldWorkAroundAbsentSourcesOfExternalLib() throws IOException {
+
+    // This test fails because jdt.ls does download source for the class being used here. Need to
+    // find or construct an artifact that has no source.
     // when
     editor.waitActive();
     loader.waitOnClosed();
     editor.goToCursorPositionVisible(30, 23);
     editor.launchAutocompleteAndWaitContainer();
-    editor.selectAutocompleteProposal("info(String arg0) : void");
+    editor.selectAutocompleteProposal("info(String msg) : void Logger");
 
     // then
-    editor.checkProposalDocumentation(".*No documentation found.*");
+    assertEquals(editor.getProposalDocumentationHTML(), ".*No documentation found.*");
 
     // when
     editor.closeAutocomplete();
@@ -201,7 +244,8 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectAutocompleteProposal("info(String msg) : void");
 
     // then
-    editor.checkProposalDocumentation(
+    assertEquals(
+        editor.getProposalDocumentationHTML(),
         ".*Log a message at the .* level."
             + "<dl><dt>Parameters:</dt>"
             + "<dd><b>msg</b>"

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/CheckFileWatcherExcludeFeatureTest.java
@@ -81,7 +81,7 @@ public class CheckFileWatcherExcludeFeatureTest {
   public void checkFileWatcherIgnoreFileAfterIncludingAndExcludingFileWatching() throws Exception {
     String fileNameForExcluding = "pom.xml";
     String pathToExcludedFile = PROJECT_NAME + "/" + fileNameForExcluding;
-    projectExplorer.waitItemInvisibility(".che");
+    projectExplorer.waitItem(PROJECT_NAME + "/.che");
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByVisibleNameInExplorer(FILE_WATCHER_IGNORE_FILE_NAME);
     editor.waitActive();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/YamlFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/YamlFileEditingTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ER
 import static org.eclipse.che.selenium.pageobject.Preferences.DropDownLanguageServerSettings.YAML;
 import static org.openqa.selenium.Keys.DELETE;
 import static org.openqa.selenium.Keys.ENTER;
+import static org.testng.Assert.assertEquals;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -108,10 +109,12 @@ public class YamlFileEditingTest {
     editor.launchAutocompleteAndWaitContainer();
     editor.waitTextIntoAutocompleteContainer("diskName");
     editor.selectAutocompleteProposal("diskName");
-    editor.checkProposalDocumentation("The Name of the data disk in the blob storage");
+    assertEquals(
+        editor.getProposalDocumentationHTML(), "The Name of the data disk in the blob storage");
     editor.waitTextIntoAutocompleteContainer("diskURI");
     editor.selectAutocompleteProposal("diskURI");
-    editor.checkProposalDocumentation("The URI the data disk in the blob storage");
+    assertEquals(
+        editor.getProposalDocumentationHTML(), "The URI the data disk in the blob storage");
 
     // select proposal and check expected text in the Editor
     editor.enterAutocompleteProposal("kind");

--- a/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/app/src/main/java/multimodule/App.java
+++ b/selenium/che-selenium-test/src/test/resources/projects/multi-module-java-with-ext-libs/app/src/main/java/multimodule/App.java
@@ -28,6 +28,7 @@ public class App {
         // external lib ch.qos.logback with sources which are accessible by maven; need to download sources from maven repo.
         org.slf4j.Logger logbackLogger = org.slf4j.LoggerFactory.getLogger(App.class);
         logbackLogger.info(concat("Info from ", "logbackLogger", ' '));
+        new App();
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?
Adds handling of markdown in the widgets that show additional doc (i.e. javadoc) for completions and signature help in LSP editors.

### What issues does this PR fix or reference?
#10499

