### PR TITLE
remove codenvy snapshots repo from che

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2005,11 +2005,6 @@
             <name>codenvy public</name>
             <url>https://maven.codenvycorp.com/content/groups/public/</url>
         </repository>
-        <repository>
-            <id>codenvy-public-snapshots-repo</id>
-            <name>codenvy public snapshots</name>
-            <url>https://maven.codenvycorp.com/content/repositories/codenvy-public-snapshots/</url>
-        </repository>
     </repositories>
     <build>
         <pluginManagement>


### PR DESCRIPTION
Since all snapshots are pushed now to central snapshots we don't need check for snapshots in codenvy nexus anymore
part of: https://github.com/eclipse/che/issues/6444