### PR TITLE
Added an ability to remove user when third-party user management service is configured

### DIFF
--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
@@ -36,6 +36,6 @@ public class KeycloakServletModule extends ServletModule {
     // but not remove user (DELETE /user/{USER_ID}
     filterRegex("^/user(/password/?|/)?$").through(UnavailableResourceInMultiUserFilter.class);
 
-    filterRegex("/profile/.*/attributes").through(UnavailableResourceInMultiUserFilter.class);
+    filterRegex("^/profile/(.*/)?attributes$").through(UnavailableResourceInMultiUserFilter.class);
   }
 }

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
@@ -32,7 +32,10 @@ public class KeycloakServletModule extends ServletModule {
     filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/api/oauth/callback/?)$).*")
         .through(IdentityIdLoggerFilter.class);
 
-    filterRegex("/user/?.*").through(UnavailableResourceInMultiUserFilter.class);
+    // Ban change password (POST /user/password) and create a user (POST /user/) methods
+    // but not remove user (DELETE /user/{USER_ID}
+    filterRegex("^/user(/password/?|/)?$").through(UnavailableResourceInMultiUserFilter.class);
+
     filterRegex("/profile/.*/attributes").through(UnavailableResourceInMultiUserFilter.class);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adds an ability to remove user when third-party user management service is configured.

Note that removing user via Che won't remove user on third-party user management service (like keycloak) and removed user still will be able to use Che with the cached token or after next login (user entity will be recreated).
Also, it is impossible to remove a user if he has running any workspaces. It is needed to stop all the workspaces before a user removing.

Also, it contains a fix non-related to issue:
Fix binding of UnavailableResourceInMultiUserFilter for ProfileService's methods. 
Previously, it banned only update profile attributes of the specified user (PUT /profile/{USER_ID}/attributes) but methods related to a current user were still available (DELETE /profile/attributes and PUT /profile/attributes)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10620

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

#### Docs PR
N/A