### PR TITLE
Update project config when event is fired

### DIFF
--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerLauncher.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerLauncher.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.languageserver.LanguageServiceUtils.removePref
 import static org.eclipse.che.api.languageserver.util.JsonUtil.convertToJson;
 import static org.eclipse.che.jdt.ls.extension.api.Commands.CLIENT_UPDATE_PROJECT;
 import static org.eclipse.che.jdt.ls.extension.api.Commands.CLIENT_UPDATE_PROJECTS_CLASSPATH;
+import static org.eclipse.che.jdt.ls.extension.api.Commands.CLIENT_UPDATE_PROJECT_CONFIG;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -137,6 +138,7 @@ public class JavaLanguageServerLauncher implements LanguageServerConfig {
         params.setArguments(fixedPathList);
         break;
       case CLIENT_UPDATE_PROJECT:
+      case CLIENT_UPDATE_PROJECT_CONFIG:
         Object projectUri = params.getArguments().get(0);
         params.setArguments(
             singletonList(removePrefixUri(convertToJson(projectUri).getAsString())));

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -84,6 +84,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-gwt</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ExecuteClientCommandProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ExecuteClientCommandProcessor.java
@@ -13,13 +13,18 @@ package org.eclipse.che.plugin.languageserver.ide.service;
 
 import static org.eclipse.che.jdt.ls.extension.api.Commands.CLIENT_UPDATE_PROJECT;
 import static org.eclipse.che.jdt.ls.extension.api.Commands.CLIENT_UPDATE_PROJECTS_CLASSPATH;
+import static org.eclipse.che.jdt.ls.extension.api.Commands.CLIENT_UPDATE_PROJECT_CONFIG;
 
 import com.google.gwt.json.client.JSONString;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
+import java.util.List;
+
 import org.eclipse.che.ide.api.app.AppContext;
+import org.eclipse.che.ide.project.ProjectServiceClient;
 import org.eclipse.che.ide.project.node.ProjectClasspathChangedEvent;
+import org.eclipse.che.ide.resource.Path;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 
 /**
@@ -32,11 +37,14 @@ import org.eclipse.lsp4j.ExecuteCommandParams;
 public class ExecuteClientCommandProcessor {
   private EventBus eventBus;
   private AppContext appContext;
+  private final ProjectServiceClient projectService;
 
   @Inject
-  public ExecuteClientCommandProcessor(EventBus eventBus, AppContext appContext) {
+  public ExecuteClientCommandProcessor(EventBus eventBus, AppContext appContext,
+                                       ProjectServiceClient projectService) {
     this.eventBus = eventBus;
     this.appContext = appContext;
+    this.projectService = projectService;
   }
 
   public void execute(ExecuteCommandParams params) {
@@ -49,6 +57,9 @@ public class ExecuteClientCommandProcessor {
       case CLIENT_UPDATE_PROJECT:
         updateProject(stringValue(params.getArguments()));
         break;
+        case CLIENT_UPDATE_PROJECT_CONFIG:
+            updateProjectConfig(stringValue(params.getArguments()));
+            break;
       default:
         break;
     }
@@ -66,7 +77,25 @@ public class ExecuteClientCommandProcessor {
             });
   }
 
+    private void updateProjectConfig(String project) {
+        appContext
+                .getWorkspaceRoot()
+                .getContainer(project)
+                .then(
+                        container -> {
+                            projectService.getProject(Path.valueOf(project)).then(projectConfigDto -> {
+                                projectService.updateProject(projectConfigDto).then(arg -> {
+                                    if (container.isPresent()) {
+                                        container.get().synchronize();
+                                    }
+                                });
+                            });
+                        });    }
+
+
   private String stringValue(Object value) {
-    return value instanceof JSONString ? ((JSONString) value).stringValue() : String.valueOf(value);
+    return value instanceof JSONString
+        ? ((JSONString) value).stringValue()
+        : (value instanceof List ? stringValue(((List) value).get(0)) : String.valueOf(value));
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ExecuteClientCommandProcessor.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/service/ExecuteClientCommandProcessor.java
@@ -20,7 +20,6 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 import java.util.List;
-
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.project.ProjectServiceClient;
 import org.eclipse.che.ide.project.node.ProjectClasspathChangedEvent;
@@ -40,8 +39,8 @@ public class ExecuteClientCommandProcessor {
   private final ProjectServiceClient projectService;
 
   @Inject
-  public ExecuteClientCommandProcessor(EventBus eventBus, AppContext appContext,
-                                       ProjectServiceClient projectService) {
+  public ExecuteClientCommandProcessor(
+      EventBus eventBus, AppContext appContext, ProjectServiceClient projectService) {
     this.eventBus = eventBus;
     this.appContext = appContext;
     this.projectService = projectService;
@@ -57,9 +56,9 @@ public class ExecuteClientCommandProcessor {
       case CLIENT_UPDATE_PROJECT:
         updateProject(stringValue(params.getArguments()));
         break;
-        case CLIENT_UPDATE_PROJECT_CONFIG:
-            updateProjectConfig(stringValue(params.getArguments()));
-            break;
+      case CLIENT_UPDATE_PROJECT_CONFIG:
+        updateProjectConfig(stringValue(params.getArguments()));
+        break;
       default:
         break;
     }
@@ -77,21 +76,27 @@ public class ExecuteClientCommandProcessor {
             });
   }
 
-    private void updateProjectConfig(String project) {
-        appContext
-                .getWorkspaceRoot()
-                .getContainer(project)
-                .then(
-                        container -> {
-                            projectService.getProject(Path.valueOf(project)).then(projectConfigDto -> {
-                                projectService.updateProject(projectConfigDto).then(arg -> {
-                                    if (container.isPresent()) {
-                                        container.get().synchronize();
-                                    }
+  private void updateProjectConfig(String project) {
+    appContext
+        .getWorkspaceRoot()
+        .getContainer(project)
+        .then(
+            container -> {
+              projectService
+                  .getProject(Path.valueOf(project))
+                  .then(
+                      projectConfigDto -> {
+                        projectService
+                            .updateProject(projectConfigDto)
+                            .then(
+                                arg -> {
+                                  if (container.isPresent()) {
+                                    container.get().synchronize();
+                                  }
                                 });
-                            });
-                        });    }
-
+                      });
+            });
+  }
 
   private String stringValue(Object value) {
     return value instanceof JSONString

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/ProjectServiceApi.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/ProjectServiceApi.java
@@ -65,6 +65,7 @@ import org.eclipse.che.api.fs.server.FsDtoConverter;
 import org.eclipse.che.api.fs.server.FsManager;
 import org.eclipse.che.api.project.server.ProjectManager;
 import org.eclipse.che.api.project.server.ProjectService;
+import org.eclipse.che.api.project.server.notification.PreProjectDeletedEvent;
 import org.eclipse.che.api.project.server.notification.ProjectCreatedEvent;
 import org.eclipse.che.api.project.server.notification.ProjectDeletedEvent;
 import org.eclipse.che.api.project.server.notification.ProjectItemModifiedEvent;
@@ -237,6 +238,8 @@ public class ProjectServiceApi {
     wsPath = absolutize(wsPath);
 
     if (projectManager.isRegistered(wsPath)) {
+      eventService.publish(new PreProjectDeletedEvent(wsPath));
+
       projectManager
           .delete(wsPath)
           .map(RegisteredProject::getPath)

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/RootDirRemovalHandler.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/RootDirRemovalHandler.java
@@ -19,6 +19,7 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.project.server.ProjectManager;
+import org.eclipse.che.api.project.server.notification.PreProjectDeletedEvent;
 import org.eclipse.che.api.project.server.notification.ProjectDeletedEvent;
 import org.eclipse.che.api.project.shared.RegisteredProject;
 import org.eclipse.che.api.watcher.server.FileWatcherManager;
@@ -59,6 +60,8 @@ public class RootDirRemovalHandler {
   private void consumeDelete(String wsPath) {
     try {
       if (projectConfigRegistry.isRegistered(wsPath)) {
+        eventService.publish(new PreProjectDeletedEvent(wsPath));
+
         projectConfigRegistry
             .getAll(wsPath)
             .stream()


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Updates project configuration when event is emitted

### What issues does this PR fix or reference?
The artifactId of the `pom.xml` is used as a display name in the tab. When user modifies `pom.xml` the tab name has to be changed respectively. 