### PR TITLE
Do not expose workspace runtime for user if he does not have `use` permission

### DIFF
--- a/multiuser/machine-auth/che-multiuser-machine-authentication/pom.xml
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/pom.xml
@@ -108,7 +108,15 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-api-permission</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-machine-authentication-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-permission-workspace</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>
@@ -181,6 +189,21 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <!-- compiler inlines constants, so it is impossible to find reference on dependency -->
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <ignoredDependencies>
+                                <ignoreDependency>org.eclipse.che.multiuser:che-multiuser-api-permission</ignoreDependency>
+                            </ignoredDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenProviderImpl.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenProviderImpl.java
@@ -12,12 +12,20 @@
 package org.eclipse.che.multiuser.machine.authentication.server;
 
 import static java.lang.String.format;
+import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain.DOMAIN_ID;
+import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain.USE;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.workspace.server.token.MachineAccessForbidden;
+import org.eclipse.che.api.workspace.server.token.MachineTokenException;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.multiuser.api.permission.server.PermissionChecker;
 
 /**
  * Provides machine token from {@link MachineTokenRegistry}.
@@ -29,15 +37,19 @@ import org.eclipse.che.commons.subject.Subject;
  */
 @Singleton
 public class MachineTokenProviderImpl implements MachineTokenProvider {
+
+  private final PermissionChecker permissionChecker;
   private final MachineTokenRegistry tokenRegistry;
 
   @Inject
-  public MachineTokenProviderImpl(MachineTokenRegistry tokenRegistry) {
+  public MachineTokenProviderImpl(
+      PermissionChecker permissionChecker, MachineTokenRegistry tokenRegistry) {
+    this.permissionChecker = permissionChecker;
     this.tokenRegistry = tokenRegistry;
   }
 
   @Override
-  public String getToken(String workspaceId) {
+  public String getToken(String workspaceId) throws MachineTokenException {
     final Subject subject = EnvironmentContext.getCurrent().getSubject();
     if (subject.isAnonymous()) {
       throw new IllegalStateException(
@@ -50,7 +62,18 @@ public class MachineTokenProviderImpl implements MachineTokenProvider {
   }
 
   @Override
-  public String getToken(String userId, String workspaceId) {
+  public String getToken(String userId, String workspaceId) throws MachineTokenException {
+    try {
+      if (!permissionChecker.hasPermission(userId, DOMAIN_ID, workspaceId, USE)) {
+        throw new MachineAccessForbidden(
+            format(
+                "The user `%s` doesn't have the required `use` permission for workspace `%s`",
+                userId, workspaceId));
+      }
+    } catch (ServerException | NotFoundException | ConflictException e) {
+      throw new MachineTokenException(e.getMessage(), e);
+    }
+
     return tokenRegistry.getOrCreateToken(userId, workspaceId);
   }
 }

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenProviderImplTest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/test/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenProviderImplTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+
+import org.eclipse.che.api.workspace.server.token.MachineAccessForbidden;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.multiuser.api.permission.server.PermissionChecker;
+import org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link MachineTokenProviderImpl}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class MachineTokenProviderImplTest {
+  @Mock private PermissionChecker permissionChecker;
+
+  @Mock private MachineTokenRegistry tokenRegistry;
+
+  @InjectMocks private MachineTokenProviderImpl tokenProvider;
+
+  @Mock private Subject currentSubject;
+
+  @BeforeMethod
+  public void setUp() {
+    EnvironmentContext environmentContext = new EnvironmentContext();
+    environmentContext.setSubject(currentSubject);
+    EnvironmentContext.setCurrent(environmentContext);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    EnvironmentContext.reset();
+  }
+
+  @Test
+  public void shouldReturnMachineTokenForCurrentSubject() throws Exception {
+    // given
+    doReturn("user123").when(currentSubject).getUserId();
+    doReturn("secret").when(tokenRegistry).getOrCreateToken(any(), any());
+    doReturn(true)
+        .when(permissionChecker)
+        .hasPermission("user123", WorkspaceDomain.DOMAIN_ID, "workspace123", WorkspaceDomain.USE);
+
+    // when
+    String token = tokenProvider.getToken("workspace123");
+
+    // then
+    assertEquals(token, "secret");
+    verify(tokenRegistry).getOrCreateToken("user123", "workspace123");
+    verify(permissionChecker)
+        .hasPermission("user123", WorkspaceDomain.DOMAIN_ID, "workspace123", WorkspaceDomain.USE);
+  }
+
+  @Test(
+    expectedExceptions = IllegalStateException.class,
+    expectedExceptionsMessageRegExp =
+        "Unable to get machine token of the workspace "
+            + "'workspace123' because it does not exist for an anonymous user\\."
+  )
+  public void shouldThrowExceptionIfCurrentSubjectIsAnonymous() throws Exception {
+    // given
+    doReturn(true).when(currentSubject).isAnonymous();
+
+    // when
+    tokenProvider.getToken("workspace123");
+  }
+
+  @Test(
+    expectedExceptions = MachineAccessForbidden.class,
+    expectedExceptionsMessageRegExp =
+        "The user `user123` doesn't have the required `use` permission for workspace `workspace123`"
+  )
+  public void shouldThrowExceptionIfCurrentSubjectDoesNotHavePermissionToRetrieveToken()
+      throws Exception {
+    // given
+    doReturn(false)
+        .when(permissionChecker)
+        .hasPermission("user123", WorkspaceDomain.DOMAIN_ID, "workspace123", WorkspaceDomain.USE);
+    doReturn("user123").when(currentSubject).getUserId();
+    doReturn("secret").when(tokenRegistry).getOrCreateToken(any(), any());
+
+    // when
+    tokenProvider.getToken("workspace123");
+  }
+
+  @Test
+  public void shouldReturnMachineTokenForTheSpecifiedUser() throws Exception {
+    // given
+    doReturn("secret").when(tokenRegistry).getOrCreateToken(any(), any());
+    doReturn(true)
+        .when(permissionChecker)
+        .hasPermission("user123", WorkspaceDomain.DOMAIN_ID, "workspace123", WorkspaceDomain.USE);
+
+    // when
+    String token = tokenProvider.getToken("user123", "workspace123");
+
+    // then
+    assertEquals(token, "secret");
+    verify(tokenRegistry).getOrCreateToken("user123", "workspace123");
+    verify(permissionChecker)
+        .hasPermission("user123", WorkspaceDomain.DOMAIN_ID, "workspace123", WorkspaceDomain.USE);
+  }
+
+  @Test(
+    expectedExceptions = MachineAccessForbidden.class,
+    expectedExceptionsMessageRegExp =
+        "The user `user123` doesn't have the required `use` permission for workspace `workspace123`"
+  )
+  public void shouldThrowExceptionIfTheSpecifiedUserDoesNotHavePermissionToRetrieveToken()
+      throws Exception {
+    // given
+    doReturn(false)
+        .when(permissionChecker)
+        .hasPermission("user123", WorkspaceDomain.DOMAIN_ID, "workspace123", WorkspaceDomain.USE);
+    doReturn("secret").when(tokenRegistry).getOrCreateToken(any(), any());
+
+    // when
+    tokenProvider.getToken("user123", "workspace123");
+  }
+}

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspacePermissionsFilter.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspacePermissionsFilter.java
@@ -18,7 +18,6 @@ import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDom
 import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain.DOMAIN_ID;
 import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain.READ;
 import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain.RUN;
-import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain.USE;
 
 import java.util.Map;
 import java.util.Set;
@@ -145,23 +144,6 @@ public class WorkspacePermissionsFilter extends CheMethodInvokerFilter {
       case "updateCommand":
         key = ((String) arguments[0]);
         action = CONFIGURE;
-        break;
-
-        // MachineService methods
-      case "startMachine":
-      case "stopMachine":
-        key = ((String) arguments[0]);
-        action = RUN;
-        break;
-
-      case "getMachineById":
-      case "getMachines":
-      case "executeCommandInMachine":
-      case "getProcesses":
-      case "stopProcess":
-      case "getProcessLogs":
-        key = ((String) arguments[0]);
-        action = USE;
         break;
 
       default:

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -59,6 +59,7 @@ import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.token.MachineAccessForbidden;
 import org.eclipse.che.api.workspace.server.token.MachineTokenException;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
 import org.eclipse.che.api.workspace.shared.Constants;
@@ -818,6 +819,9 @@ public class WorkspaceService extends Service {
     if (runtimeDto != null) {
       try {
         runtimeDto.setMachineToken(machineTokenProvider.getToken(workspace.getId()));
+      } catch (MachineAccessForbidden e) {
+        // set runtime to null since user doesn't have the required permissions
+        workspaceDto.setRuntime(null);
       } catch (MachineTokenException e) {
         throw new ServerException(e.getMessage(), e);
       }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/token/MachineAccessForbidden.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/token/MachineAccessForbidden.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.token;
+
+/**
+ * An exception should be thrown by {@link MachineTokenProvider} when an user doesn't have the
+ * needed permissions.
+ *
+ * @author Sergii Leshchenko
+ */
+public class MachineAccessForbidden extends MachineTokenException {
+
+  public MachineAccessForbidden(String message) {
+    super(message);
+  }
+
+  public MachineAccessForbidden(Exception e) {
+    super(e);
+  }
+
+  public MachineAccessForbidden(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/token/MachineTokenProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/token/MachineTokenProvider.java
@@ -26,8 +26,9 @@ public interface MachineTokenProvider {
    * EnvironmentContext#getSubject()}.
    *
    * @param workspaceId identifier of workspace to fetch token
+   * @throws IllegalStateException when the current subject in context is {@link Subject#ANONYMOUS}
+   * @throws MachineAccessForbidden when the current subject doesn't have the needed permissions
    * @throws MachineTokenException when any exception occurs on token fetching
-   * @throws IllegalStateException when subject in context is {@link Subject#ANONYMOUS}
    */
   String getToken(String workspaceId) throws MachineTokenException;
 
@@ -35,6 +36,7 @@ public interface MachineTokenProvider {
    * Returns the machine's token for the specified pair: user, workspace.
    *
    * @param workspaceId identifier of workspace to fetch token
+   * @throws MachineAccessForbidden when the specified user doesn't have the needed permissions
    * @throws MachineTokenException when any exception occurs on token fetching
    */
   String getToken(String userId, String workspaceId) throws MachineTokenException;


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is fixing a security issue when a user who is able to read workspace configuration is able to use the workspace. It is fixed by:
- checking user permissions before machine token generation;
- do not expose workspace runtime if a user doesn't have the corresponding permissions;

Also, this PR removes outdated MachineService's methods from WorkspacePermissionsFilter.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10536

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A


#### Docs PR
N/A