### PR TITLE
CHE-10540: stop progress on websocket error

### DIFF
--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -187,7 +187,7 @@ export class WorkspaceLoader {
                     if (xhr.readyState !== 4) { return; }
                     if (xhr.status !== 200) {
                         const errorMessage = 'Failed to get the workspace' + this.getRequestErrorMessage(xhr);
-                        reject(errorMessage);
+                        reject(new Error(errorMessage));
                         return;
                     }
                     resolve(JSON.parse(xhr.responseText));
@@ -209,7 +209,7 @@ export class WorkspaceLoader {
                     if (xhr.readyState !== 4) { return; }
                     if (xhr.status !== 200) {
                         const errorMessage = 'Failed to start the workspace'  + this.getRequestErrorMessage(xhr);
-                        reject(errorMessage);
+                        reject(new Error(errorMessage));
                         return;
                     }
                     resolve(JSON.parse(xhr.responseText));
@@ -258,13 +258,9 @@ export class WorkspaceLoader {
 
         const runningOnConnectionPromise = masterApiConnectionPromise
             .then((masterApi: CheJsonRpcMasterApi) => {
-                return new Promise((resolve) => {
+                return new Promise((resolve, reject) => {
                     masterApi.addListener('open', () => {
-                        this.getWorkspace(this.workspace.id).then((workspace) => {
-                            if (workspace.status === 'RUNNING') {
-                                resolve();
-                            }
-                        });
+                        this.checkWorkspaceRuntime().then(resolve, reject);
                     });
                 });
             });
@@ -306,13 +302,27 @@ export class WorkspaceLoader {
             masterApi.subscribeWorkspaceStatus(this.workspace.id,
                 (message: any) => {
                     if (message.error) {
-                        reject(`Failed to run the workspace: "${message.error}"`);
+                        reject(new Error(`Failed to run the workspace: "${message.error}"`));
                     } else if (message.status === 'RUNNING') {
-                        resolve();
+                        this.checkWorkspaceRuntime().then(resolve, reject);
                     } else if (message.status === 'STOPPED') {
                         this.startWorkspace().catch((error: any) => reject(error));
                     }
                 });
+        });
+    }
+
+    checkWorkspaceRuntime(): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.getWorkspace(this.workspace.id).then((workspace) => {
+                if (workspace.status === 'RUNNING') {
+                    if (workspace.runtime) {
+                        resolve();
+                    } else {
+                        reject(new Error('You do not have permissions to access workspace runtime, in this case IDE cannot be loaded.'));
+                    }
+                }
+            });
         });
     }
 

--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -322,7 +322,7 @@ export class WorkspaceLoader {
             masterApi.subscribeWorkspaceStatus(this.workspace.id,
                 (message: any) => {
                     if (message.error) {
-                        this.loader.error(message.error);
+                        reject(`Failed to run the workspace: "${message.error}"`);
                     } else if (message.status === 'RUNNING') {
                         resolve();
                     } else if (message.status === 'STOPPED') {

--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -186,30 +186,13 @@ export class WorkspaceLoader {
                 xhr.onreadystatechange = () => {
                     if (xhr.readyState !== 4) { return; }
                     if (xhr.status !== 200) {
-                        let response;
-                        try {
-                            response = JSON.parse(xhr.responseText);
-                        } catch (e) {}
-
-                        if (response) {
-                            reject(response);
-                        } else if (xhr.statusText) {
-                            reject(xhr.statusText);
-                        } else {
-                            reject("Unknown error");
-                        }
+                        const errorMessage = 'Failed to get the workspace' + this.getRequestErrorMessage(xhr);
+                        reject(errorMessage);
                         return;
                     }
                     resolve(JSON.parse(xhr.responseText));
                 };
             });
-        }).catch((error: any) => {
-            let errorMessage = '';
-            if (error) {
-                errorMessage = error.message ? error.message.toString() : error.toString();
-            }
-            errorMessage = `Failed to get the workspace` + (errorMessage ? `: "${errorMessage}"` : '.');
-            return Promise.reject(errorMessage);
         });
     }
 
@@ -225,31 +208,32 @@ export class WorkspaceLoader {
                 xhr.onreadystatechange = () => {
                     if (xhr.readyState !== 4) { return; }
                     if (xhr.status !== 200) {
-                        let response;
-                        try {
-                            response = JSON.parse(xhr.responseText);
-                        } catch (e) {}
-
-                        if (response) {
-                            reject(response);
-                        } else if (xhr.statusText) {
-                            reject(xhr.statusText);
-                        } else {
-                            reject("Unknown error");
-                        }
+                        const errorMessage = 'Failed to start the workspace'  + this.getRequestErrorMessage(xhr);
+                        reject(errorMessage);
                         return;
                     }
                     resolve(JSON.parse(xhr.responseText));
                 };
             });
-        }).catch((error: any) => {
-            let errorMessage = '';
-            if (error) {
-                errorMessage = error.message ? error.message.toString() : error.toString();
-            }
-            errorMessage = `Failed to start the workspace` + (errorMessage ? `: "${errorMessage}"` : '.');
-            return Promise.reject(errorMessage);
         });
+    }
+
+    getRequestErrorMessage(xhr: XMLHttpRequest): string {
+        let errorMessage;
+        try {
+            const response = JSON.parse(xhr.responseText);
+            errorMessage = response.message;
+        } catch (e) { }
+
+        if (errorMessage) {
+            return errorMessage;
+        }
+
+        if (xhr.statusText) {
+            return xhr.statusText;
+        }
+
+        return "Unknown error";
     }
 
     /**

--- a/workspace-loader/test/test.spec.ts
+++ b/workspace-loader/test/test.spec.ts
@@ -264,8 +264,18 @@ describe('Workspace Loader', () => {
 
             describe('then becomes RUNNING', () => {
 
-                beforeEach(() => {
+                beforeEach((done) => {
+                    workspaceLoader.getWorkspace.and.callFake(() => {
+                        return new Promise((resolve) => {
+                            fakeWorkspaceConfig.status = 'RUNNING';
+                            fakeWorkspaceConfig.runtime = {} as che.IWorkspaceRuntime;
+                            resolve(fakeWorkspaceConfig);
+                        });
+                    });
+
                     statusChangeCallback({ status: 'RUNNING' });
+
+                    workspaceLoadPromise.then(done);
                 });
 
                 it('should open an IDE', () => {
@@ -391,6 +401,7 @@ describe('Workspace Loader', () => {
     describe('if workspace is STOPPING', () => {
         let workspaceLoader: WorkspaceLoader;
         let statusChangeCallback: Function;
+        let workspaceLoadPromise: Promise<any>;
 
         beforeEach((done) => {
             const loader = new Loader();
@@ -426,7 +437,7 @@ describe('Workspace Loader', () => {
                 return Promise.resolve();
             });
 
-            workspaceLoader.load();
+            workspaceLoadPromise = workspaceLoader.load();
         });
 
         it('should not open an IDE immediately', () => {
@@ -457,8 +468,18 @@ describe('Workspace Loader', () => {
 
             describe('then becomes RUNNING', () => {
 
-                beforeEach(() => {
+                beforeEach((done) => {
+                    workspaceLoader.getWorkspace.and.callFake(() => {
+                        return new Promise((resolve) => {
+                            fakeWorkspaceConfig.status = 'RUNNING';
+                            fakeWorkspaceConfig.runtime = {} as che.IWorkspaceRuntime;
+                            resolve(fakeWorkspaceConfig);
+                        });
+                    });
+
                     statusChangeCallback({ status: 'RUNNING' });
+
+                    workspaceLoadPromise.then(done);
                 });
 
                 it('should open an IDE', () => {

--- a/workspace-loader/test/test.spec.ts
+++ b/workspace-loader/test/test.spec.ts
@@ -123,7 +123,7 @@ describe('Workspace Loader', () => {
 
             spyOn(workspaceLoader, "openIDE").and.callThrough();
             spyOn(workspaceLoader, "openURL");
-            workspaceLoader.load().then(() => done());
+            workspaceLoader.load().then(done);
         });
 
         it('should call openURL method with correct parameter', () => {
@@ -152,7 +152,7 @@ describe('Workspace Loader', () => {
 
             spyOn(workspaceLoader, "openIDE").and.callThrough();
             spyOn(workspaceLoader, "openURL");
-            workspaceLoader.load().then(() => done());
+            workspaceLoader.load().then(done);
         });
 
         it('should open IDE directly', () => {
@@ -182,7 +182,7 @@ describe('Workspace Loader', () => {
 
             spyOn(workspaceLoader, "openIDE");
 
-            workspaceLoader.load().then(() => done());
+            workspaceLoader.load().then(done);
         });
 
         it('should not connect to workspace master API', () => {
@@ -201,6 +201,7 @@ describe('Workspace Loader', () => {
     describe('if workspace is STOPPED and then starts successfully', () => {
         let workspaceLoader: WorkspaceLoader;
         let statusChangeCallback: Function;
+        let workspaceLoadPromise: Promise<any>;
 
         beforeEach((done) => {
             const loader = new Loader();
@@ -236,7 +237,7 @@ describe('Workspace Loader', () => {
                 return Promise.resolve();
             });
 
-            workspaceLoader.load();
+            workspaceLoadPromise = workspaceLoader.load();
         });
 
         it('should not open an IDE', () => {
@@ -270,6 +271,35 @@ describe('Workspace Loader', () => {
                 it('should open an IDE', () => {
                     expect(workspaceLoader.openIDE).toHaveBeenCalled();
                 });
+
+            });
+
+            describe('then receives an error on websocket', () => {
+
+                beforeEach((done) => {
+                    statusChangeCallback({ error: 'Something bad happened.' });
+
+                    workspaceLoadPromise.then(done);
+                });
+
+                it('should not open an IDE', () => {
+                    expect(workspaceLoader.openIDE).not.toHaveBeenCalled();
+                });
+
+                it('should hide loader and progress bar', () => {
+                    const workspaceLoaderLabel = document.getElementById('workspace-loader-label'),
+                        workspaceLoaderProgress = document.getElementById('workspace-loader-progress');
+
+                    expect(workspaceLoaderLabel.style.display).toEqual('none');
+                    expect(workspaceLoaderProgress.style.display).toEqual('none');
+                });
+
+                it('should show message with "try again" prompt', () => {
+                    const workspaceLoaderReload = document.getElementById('workspace-loader-reload');
+
+                    expect(workspaceLoaderReload).toBeTruthy();
+                    expect(workspaceLoaderReload.style.display).not.toEqual('none');
+                })
 
             });
 
@@ -336,7 +366,7 @@ describe('Workspace Loader', () => {
         describe('then the request for starting the workspace fails', () => {
 
             beforeEach((done) => {
-                workspaceLoadPromise.then(() => done());
+                workspaceLoadPromise.then(done);
             });
 
             it('should hide loader and progress bar', () => {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When workspace loader starts a workspace and receives an error on websocket, then error appears and the progress bar hides.
![restart2](https://user-images.githubusercontent.com/16220722/43773246-cd33a50a-9a4d-11e8-90a5-8d41a6dd5984.gif)


### What issues does this PR fix or reference?
fix #10540 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix