### PR TITLE
enable building workspace-loader via embedded npm (frontend-maven-plugin)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2010,6 +2010,22 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>com.github.eirslett</groupId>
+                    <artifactId>frontend-maven-plugin</artifactId>
+                    <!-- Use the latest released version:
+                    https://repo1.maven.org/maven2/com/github/eirslett/frontend-maven-plugin/ -->
+                    <version>1.6</version>
+                    <configuration>
+                        <nodeVersion>v5.6.0</nodeVersion>
+                        <!-- optional: with node >4.0.0 will use npm provided by node distribution -->
+                        <!-- <npmVersion>2.15.9</npmVersion> -->
+                        <!-- must use http for NCL builds -->
+                        <downloadRoot>http://nodejs.org/dist/</downloadRoot>
+                        <npmDownloadRoot>http://registry.npmjs.org/npm/-/</npmDownloadRoot>
+                        <npmRegistryURL>http://registry.npmjs.org/</npmRegistryURL>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.eclipse.che.core</groupId>
                     <artifactId>che-core-dynamodule-maven-plugin</artifactId>
                     <version>${che.version}</version>

--- a/workspace-loader/pom.xml
+++ b/workspace-loader/pom.xml
@@ -131,6 +131,54 @@
             <build>
                 <plugins>
                     <plugin>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>install node and npm</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm install</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install reconnecting-websocket ts-loader typescript uglifyjs-webpack-plugin webpack-dev-server webpack-merge css-loader jest style-loader extract-text-webpack-plugin html-webpack-plugin webpack-merge webpack clean-webpack-plugin --save-dev --fetch-retry-mintimeout 60000 --fetch-retries 10 --maxsockets 2</arguments>
+                                    <npmRegistryURL>http://registry.npmjs.org/</npmRegistryURL>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm run build</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>run build</arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm run test</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>run test</arguments>
+                                    <skip>${skipTests}</skip>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
                             <execution>
@@ -142,14 +190,14 @@
                                 <configuration>
                                     <target>
                                         <!-- install node modules -->
-                                        <exec dir="${basedir}" executable="npm" failonerror="true">
+                                        <!-- <exec dir="${basedir}" executable="npm" failonerror="true">
                                             <arg value="install" />
-                                        </exec>
+                                        </exec> -->
                                         <!-- build workspace loader -->
-                                        <exec dir="${basedir}" executable="npm" failonerror="true">
+                                        <!-- <exec dir="${basedir}" executable="npm" failonerror="true">
                                             <arg value="run" />
                                             <arg value="build" />
-                                        </exec>
+                                        </exec> -->
                                     </target>
                                 </configuration>
                             </execution>
@@ -162,10 +210,10 @@
                                 <configuration>
                                     <target>
                                         <!-- test workspace loader -->
-                                        <exec dir="${basedir}" executable="npm" failonerror="true">
+                                        <!-- <exec dir="${basedir}" executable="npm" failonerror="true">
                                             <arg value="run" />
                                             <arg value="test" />
-                                        </exec>
+                                        </exec> -->
                                     </target>
                                 </configuration>
                             </execution>


### PR DESCRIPTION

Change-Id: I992c97a7064ee361d282714cddab95702a7b1563
Signed-off-by: nickboldt <nboldt@redhat.com>

### What does this PR do?

With this PR, you can build workspace-loader without having to first install npm.

If I can figure out how to do the same for dashboard, I'll amend this PR to add another commit. Right now, it fails with this error:

```
[INFO] [18:23:53] Starting 'fonts'...
[ERROR] TypeError: Cannot read property 'join' of undefined TypeError: Cannot read property 'join' of undefined
[ERROR]     at _callee3$ (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/awesome-typescript-loader/dist.babel/index.js:281:76)
[ERROR]     at tryCatch (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/regenerator-runtime/runtime.js:65:40)
[ERROR]     at GeneratorFunctionPrototype.invoke [as _invoke] (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/regenerator-runtime/runtime.js:303:22)
[ERROR]     at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/regenerator-runtime/runtime.js:117:21)
[ERROR]     at fulfilled (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/awesome-typescript-loader/dist.babel/index.js:31:32)
[ERROR]     at run (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/core-js/modules/es6.promise.js:75:22)
[ERROR]     at /home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/core-js/modules/es6.promise.js:92:30
[ERROR]     at flush (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/core-js/modules/_microtask.js:18:9)
[ERROR]     at nextTickCallbackWith0Args (node.js:453:9)
[ERROR]     at process._tickCallback (node.js:382:13)
[ERROR] [Error: callback(): The callback was already called.] 'Error: callback(): The callback was already called.\n    at context.callback (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/webpack-core/lib/NormalModuleMixin.js:143:11)\n    at _callee3$ (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/awesome-typescript-loader/dist.babel/index.js:292:25)\n    at tryCatch (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/regenerator-runtime/runtime.js:65:40)\n    at GeneratorFunctionPrototype.invoke [as _invoke] (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/regenerator-runtime/runtime.js:303:22)\n    at GeneratorFunctionPrototype.prototype.(anonymous function) [as next] (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/regenerator-runtime/runtime.js:117:21)\n    at fulfilled (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/awesome-typescript-loader/dist.babel/index.js:31:32)\n    at run (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/core-js/modules/es6.promise.js:75:22)\n    at /home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/core-js/modules/es6.promise.js:92:30\n    at flush (/home/nboldt/5-Che/0.github_upstream/che/dashboard/node_modules/core-js/modules/_microtask.js:18:9)\n    at nextTickCallbackWith0Args (node.js:453:9)\n    at process._tickCallback (node.js:382:13)'
[INFO] [18:25:04] gulp-inject 204 files into index.styl.
```

### What issues does this PR fix or reference?

See also https://github.com/eclipse/che-lib/pull/103
https://github.com/eclipse/che/issues/10641

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
