### PR TITLE
Move organization management selenium tests into the CheOneThreadTest.xml

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -44,9 +44,18 @@
             </method-selector>
         </method-selectors>
         <classes>
+            <class name="org.eclipse.che.selenium.dashboard.organization.AddWorkspaceToOrganizationTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfParentOrganizationTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfSubOrganizationTest"/>
             <class name="org.eclipse.che.selenium.dashboard.organization.CreateRootOrganizationTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.DeleteOrganizationTest"/>
             <class name="org.eclipse.che.selenium.dashboard.organization.DeleteOrganizationByBulkTest"/>
             <class name="org.eclipse.che.selenium.dashboard.organization.DeleteOrganizationInListTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.FilterOrganizationTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.MemberOrganizationTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.OrganizationMembersTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.RenameOrganizationTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.organization.ShareWorkspaceTest"/>
             <class name="org.eclipse.che.selenium.dashboard.organization.SystemAdminOrganizationTest"/>
             <class name="org.eclipse.che.selenium.git.AuthorizeOnGithubFromDashboardTest"/>
             <class name="org.eclipse.che.selenium.git.AuthorizeOnGithubFromPreferencesTest"/>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -74,15 +74,6 @@
           <class name="org.eclipse.che.selenium.dashboard.workspaces.AddOrImportProjectFormTest"/>
           <class name="org.eclipse.che.selenium.dashboard.workspaces.NewWorkspacePageTest"/>
           <class name="org.eclipse.che.selenium.dashboard.organization.UserEmptyOrganizationTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfParentOrganizationTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfSubOrganizationTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.DeleteOrganizationTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.FilterOrganizationTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.MemberOrganizationTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.OrganizationMembersTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.RenameOrganizationTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.AddWorkspaceToOrganizationTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.organization.ShareWorkspaceTest"/>
           <class name="org.eclipse.che.selenium.debugger.ChangeVariableWithEvaluatingTest"/>
           <class name="org.eclipse.che.selenium.debugger.CheckBreakPointStateTest"/>
           <class name="org.eclipse.che.selenium.debugger.CppProjectDebuggingTest"/>


### PR DESCRIPTION
### What does this PR do?
It makes selenium tests more stable by executing organization related E2E selenium tests of Eclipse Che in a single thread so that they don't interfere other tests.
Drawback: it increases time of selenium test execution in about 5 minutes.

### What issues does this PR fix or reference?
#10704