### PR TITLE
Selenium: fix unstable selenium tests from dashboard and miscellaneous packages

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceImpl.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceImpl.java
@@ -88,8 +88,8 @@ public class TestWorkspaceImpl implements TestWorkspace {
   }
 
   @Override
-  public String getName() throws ExecutionException, InterruptedException {
-    return future.thenApply(aVoid -> name).get();
+  public String getName() {
+    return name;
   }
 
   @Override
@@ -106,13 +106,10 @@ public class TestWorkspaceImpl implements TestWorkspace {
   @Override
   @SuppressWarnings("FutureReturnValueIgnored")
   public void delete() {
-    future.thenAccept(
-        aVoid -> {
-          try {
-            workspaceServiceClient.delete(name, owner.getName());
-          } catch (Exception e) {
-            throw new RuntimeException(format("Failed to remove workspace '%s'", this), e);
-          }
-        });
+    try {
+      workspaceServiceClient.delete(name, owner.getName());
+    } catch (Exception e) {
+      throw new RuntimeException(format("Failed to remove workspace '%s'", this), e);
+    }
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceProjects.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/WorkspaceProjects.java
@@ -186,12 +186,15 @@ public class WorkspaceProjects {
    * @param projectName name of project
    */
   public void openSettingsForProjectByName(String projectName) {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            visibilityOfElementLocated(
-                By.xpath(String.format(Locators.PROJECT_BY_NAME, projectName))))
-        .click();
-    waitProjectDetailsPage();
+    seleniumWebDriverHelper.waitAndClick(
+        By.xpath(String.format(Locators.PROJECT_BY_NAME, projectName)));
+
+    try {
+      seleniumWebDriverHelper.waitVisibility(By.xpath(Locators.DELETE_PROJECT));
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/8931");
+    }
   }
 
   /** click on 'DELETE' button in settings of project */
@@ -237,13 +240,8 @@ public class WorkspaceProjects {
   }
 
   public void waitProjectDetailsPage() {
-    try {
-      waitSearchField();
-      waitAddNewProjectButton();
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/8931");
-    }
+    waitSearchField();
+    waitAddNewProjectButton();
   }
 
   public boolean isCheckboxEnabled(String projectName) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/AddOrImportProjectFormTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/AddOrImportProjectFormTest.java
@@ -436,9 +436,11 @@ public class AddOrImportProjectFormTest {
     prepareJavaWorkspaceAndOpenCreateDialog(TEST_JAVA_WORKSPACE_NAME_EDIT);
     newWorkspace.waitWorkspaceCreatedDialogIsVisible();
     newWorkspace.clickOnOpenInIDEButton();
-    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
+
     testWorkspaceServiceClient.waitStatus(
         TEST_JAVA_WORKSPACE_NAME_EDIT, defaultTestUser.getName(), RUNNING);
+    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
+
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(SPRING_SAMPLE_NAME);
     projectExplorer.expandPathInProjectExplorerAndOpenFile(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
@@ -73,6 +73,9 @@ public class WorkspacesListTest {
   @InjectTestWorkspace(memoryGb = 2, startAfterCreation = false)
   private TestWorkspace blankWorkspace;
 
+  @InjectTestWorkspace(memoryGb = 2, startAfterCreation = false)
+  private TestWorkspace deleteWorkspace;
+
   @InjectTestWorkspace(template = UBUNTU_JDK8, memoryGb = 3)
   private TestWorkspace javaWorkspace;
 
@@ -351,22 +354,15 @@ public class WorkspacesListTest {
     assertTrue(newestCreatedWorkspaceItem.equals(expectedNewestWorkspaceItem));
   }
 
-  @Test(priority = 1)
-  public void deleteWorkspacesByCheckboxes() {
+  @Test
+  public void deleteWorkspacesByCheckboxes() throws Exception {
     workspaces.waitPageLoading();
 
-    workspaces.selectWorkspaceByCheckbox(expectedNewestWorkspaceItem.getWorkspaceName());
+    workspaces.selectWorkspaceByCheckbox(deleteWorkspace.getName());
     workspaces.clickOnDeleteWorkspacesBtn();
     workspaces.clickOnDeleteButtonInDialogWindow();
 
-    workspaces.waitWorkspaceIsNotPresent(expectedNewestWorkspaceItem.getWorkspaceName());
-
-    workspaces.selectAllWorkspacesByBulk();
-    workspaces.clickOnDeleteWorkspacesBtn();
-    workspaces.clickOnDeleteButtonInDialogWindow();
-
-    workspaces.waitWorkspaceIsNotPresent(expectedBlankItem.getWorkspaceName());
-    workspaces.waitWorkspaceIsNotPresent(expectedJavaItem.getWorkspaceName());
+    workspaces.waitWorkspaceIsNotPresent(deleteWorkspace.getName());
   }
 
   private void checkExpectedBlankWorkspaceDisplaying() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
@@ -74,7 +74,7 @@ public class WorkspacesListTest {
   private TestWorkspace blankWorkspace;
 
   @InjectTestWorkspace(memoryGb = 2, startAfterCreation = false)
-  private TestWorkspace deleteWorkspace;
+  private TestWorkspace workspaceToDelete;
 
   @InjectTestWorkspace(template = UBUNTU_JDK8, memoryGb = 3)
   private TestWorkspace javaWorkspace;
@@ -358,11 +358,11 @@ public class WorkspacesListTest {
   public void deleteWorkspacesByCheckboxes() throws Exception {
     workspaces.waitPageLoading();
 
-    workspaces.selectWorkspaceByCheckbox(deleteWorkspace.getName());
+    workspaces.selectWorkspaceByCheckbox(workspaceToDelete.getName());
     workspaces.clickOnDeleteWorkspacesBtn();
     workspaces.clickOnDeleteButtonInDialogWindow();
 
-    workspaces.waitWorkspaceIsNotPresent(deleteWorkspace.getName());
+    workspaces.waitWorkspaceIsNotPresent(workspaceToDelete.getName());
   }
 
   private void checkExpectedBlankWorkspaceDisplaying() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/MachinesAsynchronousStartTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/MachinesAsynchronousStartTest.java
@@ -52,7 +52,7 @@ public class MachinesAsynchronousStartTest {
 
   @AfterClass
   public void cleanUp() throws Exception {
-    testWorkspaceServiceClient.delete(brokenWorkspace.getName(), defaultTestUser.getName());
+    brokenWorkspace.delete();
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -281,6 +281,8 @@
           <class name="org.eclipse.che.selenium.workspaces.WorkspaceFromOfficialUbuntuImageStartTest"/>
           <class name="org.eclipse.che.selenium.workspaces.CheckStoppingWsByTimeoutTest"/>
           <class name="org.eclipse.che.selenium.dashboard.AccountTest"/>
+
+          <!-- Next tests can unexpectedly affect on other tests and so should be executed at the end -->
           <class name="org.eclipse.che.selenium.dashboard.StacksListTest"/>
         </classes>
     </test>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -70,7 +70,6 @@
           <class name="org.eclipse.che.selenium.dashboard.workspaces.WorkspacesListTest"/>
           <class name="org.eclipse.che.selenium.dashboard.CreateFactoryTest"/>
           <class name="org.eclipse.che.selenium.dashboard.FactoriesListTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.StacksListTest"/>
           <class name="org.eclipse.che.selenium.dashboard.workspaces.AddOrImportProjectFormTest"/>
           <class name="org.eclipse.che.selenium.dashboard.workspaces.NewWorkspacePageTest"/>
           <class name="org.eclipse.che.selenium.dashboard.organization.UserEmptyOrganizationTest"/>
@@ -282,6 +281,7 @@
           <class name="org.eclipse.che.selenium.workspaces.WorkspaceFromOfficialUbuntuImageStartTest"/>
           <class name="org.eclipse.che.selenium.workspaces.CheckStoppingWsByTimeoutTest"/>
           <class name="org.eclipse.che.selenium.dashboard.AccountTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.StacksListTest"/>
         </classes>
     </test>
 


### PR DESCRIPTION
### What does this PR do?
This PR does some fixes to unstable tests:
- move **StacksListTest** selenium test to the end of **CheSuite.xml** test suite because sometimes there is conflict with other tests that work with stacks;
- fix workspace deleting in **MachinesAsynchronousStartTest** selenium test;
- in **WorkspacesListTest** test remove priority=1 from checkWorkspaceActions() method because it never starts according to failed test method with lesser priority.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10724