### PR TITLE
Render context menu correctly in different screen resolutions

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/ContextMenu.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/menu/ContextMenu.java
@@ -14,6 +14,7 @@ package org.eclipse.che.ide.menu;
 import static com.google.gwt.dom.client.Style.Unit.PX;
 
 import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.RootPanel;
@@ -135,8 +136,16 @@ public class ContextMenu implements CloseMenuHandler, ActionSelectedHandler {
       popupMenu.getElement().getStyle().setLeft(x, PX);
     }
 
-    if (y + popupMenu.getOffsetHeight() > Window.getClientHeight()) {
-      popupMenu.getElement().getStyle().setTop(y - popupMenu.getOffsetHeight() - 1, PX);
+    // adjust popup menu by the client window height (add scrollbars if necessary)
+    if (popupMenu.getOffsetHeight() > Window.getClientHeight()) {
+      popupMenu.getElement().getStyle().setOverflowY(Style.Overflow.SCROLL);
+      popupMenu.getElement().getStyle().setTop(5., PX);
+      popupMenu.getElement().getStyle().setBottom(5., PX);
+    } else if (y + popupMenu.getOffsetHeight() > Window.getClientHeight()) {
+      popupMenu
+          .getElement()
+          .getStyle()
+          .setTop(Math.max(y - popupMenu.getOffsetHeight() - 1, 5), PX);
     } else {
       popupMenu.getElement().getStyle().setTop(y, PX);
     }


### PR DESCRIPTION
### What does this PR do?
This changes proposal add functionality that allows context menu correct renders itself with different screen resolutions. This means, if window size less than context menu hight, then scrollbar will be added to current context menu.

<img width="920" alt="eclipse che 2018-08-09 19-14-30" src="https://user-images.githubusercontent.com/1968177/43911647-a904ce2c-9c08-11e8-9eab-1775ace92160.png">

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#10447 

#### Release Notes
N/A

#### Docs PR
N/A
