### PR TITLE
Added attributes field to workspace config object

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/WorkspaceConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/WorkspaceConfig.java
@@ -57,4 +57,10 @@ public interface WorkspaceConfig {
    * least 1 default environment and may contain N environments.
    */
   Map<String, ? extends Environment> getEnvironments();
+
+  /**
+   * Returns workspace config attributes. Workspace config attributes must not contain null keys or
+   * values.
+   */
+  Map<String, String> getAttributes();
 }

--- a/dashboard/src/app/stacks/stack-details/stack-validation.service.ts
+++ b/dashboard/src/app/stacks/stack-details/stack-validation.service.ts
@@ -78,7 +78,7 @@ export class StackValidationService {
    */
   getWorkspaceConfigValidation(workspaceConfig: che.IWorkspaceConfig): che.IValidation {
     let mandatoryKeys: Array<string> = ['name', 'environments', 'defaultEnv'];
-    let additionalKeys: Array<string> = ['commands', 'projects', 'description', 'links'];
+    let additionalKeys: Array<string> = ['commands', 'projects', 'description', 'links', 'attributes'];
     let validKeys: Array<string> = mandatoryKeys.concat(additionalKeys);
     let errors: Array<string> = [];
     let isValid: boolean = true;

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -309,6 +309,7 @@ declare namespace che {
     };
     projects?: Array <any>;
     commands?: Array <any>;
+    attributes?: {[attrName: string]: string};
   }
 
   export interface IWorkspaceEnvironment {

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/WorkspaceConfigImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/WorkspaceConfigImpl.java
@@ -35,6 +35,7 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
   private List<CommandImpl> commands;
   private List<ProjectConfigImpl> projects;
   private Map<String, EnvironmentImpl> environments;
+  private Map<String, String> attributes;
 
   public WorkspaceConfigImpl(
       String name,
@@ -42,7 +43,8 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
       String defaultEnv,
       List<? extends Command> commands,
       List<? extends ProjectConfig> projects,
-      Map<String, ? extends Environment> environments) {
+      Map<String, ? extends Environment> environments,
+      Map<String, String> attributes) {
     this.name = name;
     this.defaultEnv = defaultEnv;
     this.description = description;
@@ -59,6 +61,9 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
     if (projects != null) {
       this.projects = projects.stream().map(ProjectConfigImpl::new).collect(toList());
     }
+    if (attributes != null) {
+      this.attributes = new HashMap<>(attributes);
+    }
   }
 
   public WorkspaceConfigImpl(WorkspaceConfig workspaceConfig) {
@@ -68,7 +73,8 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
         workspaceConfig.getDefaultEnv(),
         workspaceConfig.getCommands(),
         workspaceConfig.getProjects(),
-        workspaceConfig.getEnvironments());
+        workspaceConfig.getEnvironments(),
+        workspaceConfig.getAttributes());
   }
 
   @Override
@@ -112,6 +118,14 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
   }
 
   @Override
+  public Map<String, String> getAttributes() {
+    if (attributes == null) {
+      return new HashMap<>();
+    }
+    return attributes;
+  }
+
+  @Override
   public boolean equals(Object obj) {
     if (this == obj) {
       return true;
@@ -125,7 +139,8 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
         && Objects.equals(defaultEnv, that.defaultEnv)
         && getCommands().equals(that.getCommands())
         && getProjects().equals(that.getProjects())
-        && getEnvironments().equals(that.getEnvironments());
+        && getEnvironments().equals(that.getEnvironments())
+        && getAttributes().equals(that.getAttributes());
   }
 
   @Override
@@ -137,6 +152,7 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
     hash = 31 * hash + getCommands().hashCode();
     hash = 31 * hash + getProjects().hashCode();
     hash = 31 * hash + getEnvironments().hashCode();
+    hash = 31 * hash + getAttributes().hashCode();
     return hash;
   }
 
@@ -158,6 +174,8 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
         + projects
         + ", environments="
         + environments
+        + ", attributes="
+        + attributes
         + '}';
   }
 }

--- a/ide/commons-gwt/pom.xml
+++ b/ide/commons-gwt/pom.xml
@@ -44,10 +44,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/TestObjects.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/TestObjects.java
@@ -40,7 +40,13 @@ public class TestObjects {
         generate("wsId", 8),
         createAccount(),
         new WorkspaceConfigImpl(
-            generate("wsName", 8), "description", "defEnv", emptyList(), emptyList(), emptyMap()));
+            generate("wsName", 8),
+            "description",
+            "defEnv",
+            emptyList(),
+            emptyList(),
+            emptyMap(),
+            emptyMap()));
   }
 
   public static KubernetesRuntimeState createRuntimeState(WorkspaceImpl workspace) {

--- a/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/TestObjectsFactory.java
+++ b/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/TestObjectsFactory.java
@@ -69,7 +69,7 @@ public final class TestObjectsFactory {
 
   public static WorkspaceConfigImpl createWorkspaceConfig(String id) {
     return new WorkspaceConfigImpl(
-        id + "_name", id + "description", "default-env", null, null, null);
+        id + "_name", id + "description", "default-env", null, null, null, null);
   }
 
   public static WorkspaceImpl createWorkspace(String id, Account account) {

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserJpaWorkspaceDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserJpaWorkspaceDaoTest.java
@@ -64,11 +64,15 @@ public class MultiuserJpaWorkspaceDaoTest {
     workspaces =
         new WorkspaceImpl[] {
           new WorkspaceImpl(
-              "ws1", account, new WorkspaceConfigImpl("wrksp1", "", "cfg1", null, null, null)),
+              "ws1",
+              account,
+              new WorkspaceConfigImpl("wrksp1", "", "cfg1", null, null, null, null)),
           new WorkspaceImpl(
-              "ws2", account, new WorkspaceConfigImpl("wrksp2", "", "cfg2", null, null, null)),
+              "ws2",
+              account,
+              new WorkspaceConfigImpl("wrksp2", "", "cfg2", null, null, null, null)),
           new WorkspaceImpl(
-              "ws3", account, new WorkspaceConfigImpl("wrksp3", "", "cfg3", null, null, null))
+              "ws3", account, new WorkspaceConfigImpl("wrksp3", "", "cfg3", null, null, null, null))
         };
     Injector injector = Guice.createInjector(new WorkspaceTckModule());
     manager = injector.getInstance(EntityManager.class);

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/RemoveWorkersBeforeWorkspaceRemovedEventSubscriberTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/RemoveWorkersBeforeWorkspaceRemovedEventSubscriberTest.java
@@ -63,7 +63,7 @@ public class RemoveWorkersBeforeWorkspaceRemovedEventSubscriberTest {
 
     workspace =
         new WorkspaceImpl(
-            "ws1", account, new WorkspaceConfigImpl("", "", "cfg1", null, null, null));
+            "ws1", account, new WorkspaceConfigImpl("", "", "cfg1", null, null, null, null));
 
     workers =
         new WorkerImpl[] {

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/tck/WorkerDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/tck/WorkerDaoTest.java
@@ -85,13 +85,17 @@ public class WorkerDaoTest {
     workspaceRepository.createAll(
         Arrays.asList(
             new WorkspaceImpl(
-                "ws0", account, new WorkspaceConfigImpl("ws-name0", "", "cfg0", null, null, null)),
+                "ws0",
+                account,
+                new WorkspaceConfigImpl("ws-name0", "", "cfg0", null, null, null, null)),
             new WorkspaceImpl(
-                "ws1", account, new WorkspaceConfigImpl("ws-name1", "", "cfg1", null, null, null)),
+                "ws1",
+                account,
+                new WorkspaceConfigImpl("ws-name1", "", "cfg1", null, null, null, null)),
             new WorkspaceImpl(
                 "ws2",
                 account,
-                new WorkspaceConfigImpl("ws-name2", "", "cfg2", null, null, null))));
+                new WorkspaceConfigImpl("ws-name2", "", "cfg2", null, null, null, null))));
 
     workerRepository.createAll(
         Stream.of(workers).map(WorkerImpl::new).collect(Collectors.toList()));

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/WorkspaceConfigDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/WorkspaceConfigDto.java
@@ -75,5 +75,13 @@ public interface WorkspaceConfigDto extends WorkspaceConfig, Hyperlinks {
   WorkspaceConfigDto withEnvironments(Map<String, EnvironmentDto> environments);
 
   @Override
+  @FactoryParameter(obligation = OPTIONAL)
+  Map<String, String> getAttributes();
+
+  void setAttributes(Map<String, String> attributes);
+
+  WorkspaceConfigDto withAttributes(Map<String, String> attributes);
+
+  @Override
   WorkspaceConfigDto withLinks(List<Link> links);
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -97,6 +97,7 @@ public final class DtoConverter {
         .withCommands(commands)
         .withProjects(projects)
         .withEnvironments(environments)
+        .withAttributes(workspace.getAttributes())
         .withDescription(workspace.getDescription());
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -312,7 +312,7 @@ public class WorkspaceRuntimes {
     final RuntimeIdentity runtimeId = new RuntimeIdentityImpl(workspaceId, envName, ownerId);
     try {
       InternalEnvironment internalEnv =
-          createInternalEnvironment(environment, workspace.getAttributes());
+          createInternalEnvironment(environment, workspace.getConfig().getAttributes());
       RuntimeContext runtimeContext = infrastructure.prepare(runtimeId, internalEnv);
       InternalRuntime runtime = runtimeContext.getRuntime();
 
@@ -587,7 +587,7 @@ public class WorkspaceRuntimes {
     InternalRuntime runtime;
     try {
       InternalEnvironment internalEnv =
-          createInternalEnvironment(environment, workspace.getAttributes());
+          createInternalEnvironment(environment, workspace.getConfig().getAttributes());
       runtime = infra.prepare(identity, internalEnv).getRuntime();
 
       try (Unlocker ignored = lockService.writeLock(workspace.getId())) {
@@ -741,7 +741,7 @@ public class WorkspaceRuntimes {
   }
 
   private InternalEnvironment createInternalEnvironment(
-      Environment environment, Map<String, String> workspaceAttributes)
+      Environment environment, Map<String, String> workspaceConfigAttributes)
       throws InfrastructureException, ValidationException, NotFoundException {
     String recipeType = environment.getRecipe().getType();
     InternalEnvironmentFactory factory = environmentFactories.get(recipeType);
@@ -751,7 +751,7 @@ public class WorkspaceRuntimes {
     }
     InternalEnvironment internalEnvironment = factory.create(environment);
 
-    applyWorkspaceNext(internalEnvironment, workspaceAttributes, recipeType);
+    applyWorkspaceNext(internalEnvironment, workspaceConfigAttributes, recipeType);
 
     return internalEnvironment;
   }

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.10.0/1__add_workspace_cfg_attributes.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.10.0/1__add_workspace_cfg_attributes.sql
@@ -1,0 +1,26 @@
+--
+-- Copyright (c) 2012-2018 Red Hat, Inc.
+-- This program and the accompanying materials are made
+-- available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+--
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+--Workspace config attributes ---------------------------------------------------------
+CREATE TABLE che_workspace_cfg_attributes (
+    workspace_id    BIGINT,
+    attributes      VARCHAR(255),
+    attributes_key  VARCHAR(255)
+);
+
+--constraints
+ALTER TABLE che_workspace_cfg_attributes ADD CONSTRAINT fk_che_workspace_cfg_attr_workspace_id FOREIGN KEY (workspace_id) REFERENCES workspaceconfig (id);
+--------------------------------------------------------------------------------
+
+--indexes
+CREATE INDEX index_che_workspace_cfg_attributes_ws_id ON che_workspace_cfg_attributes (workspace_id);
+--------------------------------------------------------------------------------

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/TestObjectsFactory.java
@@ -90,7 +90,8 @@ public final class TestObjectsFactory {
         asList(createProjectConfig(id + "-project1"), createProjectConfig(id + "-project2")),
         ImmutableMap.of(
             id + "env1", createEnv(),
-            id + "env2", createEnv()));
+            id + "env2", createEnv()),
+        ImmutableMap.of("attr1", "value1", "attr2", "value2"));
   }
 
   public static ProjectConfigImpl createProjectConfig(String name) {

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -50,11 +50,6 @@
             <artifactId>infrastructure-kubernetes</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.infrastructure</groupId>
-            <artifactId>infrastructure-kubernetes</artifactId>
-            <classifier>tests</classifier>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-machine-authentication</artifactId>
             <classifier>tests</classifier>
@@ -219,18 +214,6 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>analyze</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <excludes>
@@ -242,6 +225,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
+                    <execution>
+                        <id>analyze</id>
+                        <configuration>
+                            <skip>true</skip>
+                        </configuration>
+                    </execution>
                     <execution>
                         <goals>
                             <goal>unpack-dependencies</goal>


### PR DESCRIPTION
### What does this PR do?
Adds attributes field to workspace config object.

Fetches Che plugins from WorkspaceConfig's attributes instead of Workspace's ones. It allows using Che plugins in stacks and factories.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10368

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
