### PR TITLE
CHE-10687: fix log message, add check for runtime in running workspace

### DIFF
--- a/workspace-loader/package.json
+++ b/workspace-loader/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "test:watch": "jest --watch",
     "build": "webpack --config webpack.prod.js",
     "start": "webpack-dev-server --open --config webpack.dev.js"
   },

--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -186,7 +186,7 @@ export class WorkspaceLoader {
                 xhr.onreadystatechange = () => {
                     if (xhr.readyState !== 4) { return; }
                     if (xhr.status !== 200) {
-                        const errorMessage = 'Failed to get the workspace' + this.getRequestErrorMessage(xhr);
+                        const errorMessage = 'Failed to get the workspace: "' + this.getRequestErrorMessage(xhr) + '"';
                         reject(new Error(errorMessage));
                         return;
                     }
@@ -208,7 +208,7 @@ export class WorkspaceLoader {
                 xhr.onreadystatechange = () => {
                     if (xhr.readyState !== 4) { return; }
                     if (xhr.status !== 200) {
-                        const errorMessage = 'Failed to start the workspace'  + this.getRequestErrorMessage(xhr);
+                        const errorMessage = 'Failed to start the workspace: "'  + this.getRequestErrorMessage(xhr) + '"';
                         reject(new Error(errorMessage));
                         return;
                     }
@@ -241,7 +241,9 @@ export class WorkspaceLoader {
      */
     handleWorkspace(): Promise<void> {
         if (this.workspace.status === 'RUNNING') {
-            return Promise.resolve();
+            return new Promise((resolve, reject) => {
+                this.checkWorkspaceRuntime().then(resolve, reject);
+            });
         } else if (this.workspace.status === 'STOPPING') {
             this.startAfterStopping = true;
         }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds fixes to workspace loader app:
- fix an error message;
- check if runtime is defined in case if a workspace already has been running;

### What issues does this PR fix or reference?
fix #10687 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>
