### PR TITLE
Change steps for increasing stability tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Events.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Events.java
@@ -145,7 +145,7 @@ public class Events {
     waitEmptyEventsPanel();
   }
 
-  public void clickOnEventPanelAndWaitMassage(String message) {
+  public void clickOnEventPanelAndWaitMessage(String message) {
     clickEventLogBtn();
     waitExpectedMessage(message);
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Events.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Events.java
@@ -144,4 +144,9 @@ public class Events {
     }
     waitEmptyEventsPanel();
   }
+
+  public void clickOnEventPanelAndWaitMassage(String message) {
+    clickEventLogBtn();
+    waitExpectedMessage(message);
+  }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
@@ -67,7 +67,7 @@ public class CheckFactoryWithPerUserCreatePolicyTest {
 
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     projectExplorer.waitProjectExplorer();
-    events.clickOnEventPanelAndWaitMassage("Project Spring imported");
+    events.clickOnEventPanelAndWaitMessage("Project Spring imported");
 
     String workspaceUrl = seleniumWebDriver.getCurrentUrl();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
@@ -22,6 +22,7 @@ import org.eclipse.che.selenium.core.factory.FactoryTemplate;
 import org.eclipse.che.selenium.core.factory.TestFactory;
 import org.eclipse.che.selenium.core.factory.TestFactoryInitializer;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
+import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
@@ -40,6 +41,7 @@ public class CheckFactoryWithPerUserCreatePolicyTest {
   @Inject private TestFactoryInitializer testFactoryInitializer;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
+  @Inject private Events events;
   private TestFactory testFactory;
   private final Logger LOG = LoggerFactory.getLogger(CheckFactoryWithPerUserCreatePolicyTest.class);
 
@@ -65,7 +67,7 @@ public class CheckFactoryWithPerUserCreatePolicyTest {
 
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     projectExplorer.waitProjectExplorer();
-    notificationsPopupPanel.waitExpectedMessageOnProgressPanelAndClosed("Project Spring imported");
+    events.clickOnEventPanelAndWaitMassage("Project Spring imported");
 
     String workspaceUrl = seleniumWebDriver.getCurrentUrl();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
@@ -67,7 +67,14 @@ public class CheckFactoryWithPerUserCreatePolicyTest {
 
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     projectExplorer.waitProjectExplorer();
-    events.clickOnEventPanelAndWaitMessage("Project Spring imported");
+    try {
+
+      notificationsPopupPanel.waitExpectedMessageOnProgressPanelAndClosed(
+          "Project Spring imported");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10728");
+    }
 
     String workspaceUrl = seleniumWebDriver.getCurrentUrl();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
@@ -22,7 +22,6 @@ import org.eclipse.che.selenium.core.factory.FactoryTemplate;
 import org.eclipse.che.selenium.core.factory.TestFactory;
 import org.eclipse.che.selenium.core.factory.TestFactoryInitializer;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
-import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
@@ -41,7 +40,6 @@ public class CheckFactoryWithPerUserCreatePolicyTest {
   @Inject private TestFactoryInitializer testFactoryInitializer;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
-  @Inject private Events events;
   private TestFactory testFactory;
   private final Logger LOG = LoggerFactory.getLogger(CheckFactoryWithPerUserCreatePolicyTest.class);
 
@@ -67,8 +65,8 @@ public class CheckFactoryWithPerUserCreatePolicyTest {
 
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     projectExplorer.waitProjectExplorer();
-    try {
 
+    try {
       notificationsPopupPanel.waitExpectedMessageOnProgressPanelAndClosed(
           "Project Spring imported");
     } catch (TimeoutException ex) {
@@ -77,7 +75,6 @@ public class CheckFactoryWithPerUserCreatePolicyTest {
     }
 
     String workspaceUrl = seleniumWebDriver.getCurrentUrl();
-
     // accept factory
     testFactory.open(seleniumWebDriver);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -41,7 +41,6 @@ import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole;
 import org.openqa.selenium.TimeoutException;
-import org.openqa.selenium.WebDriverException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -128,7 +128,7 @@ public class JavaTestPluginTestNgTest {
     assertTrue(
         testErrorMessage.startsWith(APP_TEST_ONE_FAIL_OUTPUT_TEMPLATE),
         "Actual message was: " + testErrorMessage);
-    events.clickOnEventPanelAndWaitMassage("Test runner executed successfully.");
+    events.clickOnEventPanelAndWaitMessage("Test runner executed successfully.");
   }
 
   @Test(priority = 1)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -33,7 +33,6 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
-import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -86,7 +85,6 @@ public class JavaTestPluginTestNgTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private NotificationsPopupPanel notifications;
-  @Inject private Events events;
   @Inject private Menu menu;
   @Inject private TestCommandServiceClient testCommandServiceClient;
   @Inject private TestProjectServiceClient testProjectServiceClient;
@@ -122,7 +120,6 @@ public class JavaTestPluginTestNgTest {
 
     // then
     try {
-
       notifications.waitExpectedMessageOnProgressPanelAndClosed(
           "Test runner executed successfully.");
     } catch (TimeoutException ex) {
@@ -148,24 +145,27 @@ public class JavaTestPluginTestNgTest {
     editor.waitActive();
     editor.goToCursorPositionVisible(26, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
-    try {
 
+    try {
       notifications.waitExpectedMessageOnProgressPanelAndClosed(
           "Test runner executed successfully.");
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
       fail("Known issue https://github.com/eclipse/che/issues/10728");
     }
+
     pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppAnother");
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(PASSED).size() == 1);
     editor.goToCursorPositionVisible(31, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
+
     try {
       pluginConsole.waitMethodMarkedAsFailed("shouldFailOfAppAnother");
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
       fail("Known issue https://github.com/eclipse/che/issues/7338", ex);
     }
+
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(FAILED).size() == 1);
     String testErrorMessage = pluginConsole.getTestErrorMessage();
     assertTrue(
@@ -184,20 +184,22 @@ public class JavaTestPluginTestNgTest {
     editor.waitActive();
     editor.goToCursorPositionVisible(26, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
-    try {
 
+    try {
       notifications.waitExpectedMessageOnProgressPanelAndClosed(
           "Test runner executed successfully.");
     } catch (WebDriverException ex) {
       // remove try-catch block after issue has been resolved
       fail("Known issue https://github.com/eclipse/che/issues/10728");
     }
+
     try {
       pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppAnother");
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
       fail("Known issue https://github.com/eclipse/che/issues/7338", ex);
     }
+
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(PASSED).size() == 1);
     editor.goToCursorPositionVisible(31, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -188,7 +188,7 @@ public class JavaTestPluginTestNgTest {
     try {
       notifications.waitExpectedMessageOnProgressPanelAndClosed(
           "Test runner executed successfully.");
-    } catch (WebDriverException ex) {
+    } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
       fail("Known issue https://github.com/eclipse/che/issues/10728");
     }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -33,6 +33,7 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
+import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -84,6 +85,7 @@ public class JavaTestPluginTestNgTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private NotificationsPopupPanel notifications;
+  @Inject private Events events;
   @Inject private Menu menu;
   @Inject private TestCommandServiceClient testCommandServiceClient;
   @Inject private TestProjectServiceClient testProjectServiceClient;
@@ -118,15 +120,15 @@ public class JavaTestPluginTestNgTest {
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
 
     // then
-    notifications.waitExpectedMessageOnProgressPanelAndClosed("Test runner executed successfully.");
-    pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppOne");
     pluginConsole.waitMethodMarkedAsFailed("shouldFailOfAppOne");
+    pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppOne");
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(PASSED).size() == 1);
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(FAILED).size() == 1);
     String testErrorMessage = pluginConsole.getTestErrorMessage();
     assertTrue(
         testErrorMessage.startsWith(APP_TEST_ONE_FAIL_OUTPUT_TEMPLATE),
         "Actual message was: " + testErrorMessage);
+    events.clickOnEventPanelAndWaitMassage("Test runner executed successfully.");
   }
 
   @Test(priority = 1)
@@ -138,7 +140,6 @@ public class JavaTestPluginTestNgTest {
     editor.waitActive();
     editor.goToCursorPositionVisible(26, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
-    notifications.waitExpectedMessageOnProgressPanelAndClosed("Test runner executed successfully.");
     pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppAnother");
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(PASSED).size() == 1);
     editor.goToCursorPositionVisible(31, 17);
@@ -167,7 +168,6 @@ public class JavaTestPluginTestNgTest {
     editor.waitActive();
     editor.goToCursorPositionVisible(26, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
-    notifications.waitExpectedMessageOnProgressPanelAndClosed("Test runner executed successfully.");
     try {
       pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppAnother");
     } catch (TimeoutException ex) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -42,6 +42,7 @@ import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole;
 import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.WebDriverException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -120,15 +121,22 @@ public class JavaTestPluginTestNgTest {
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
 
     // then
-    pluginConsole.waitMethodMarkedAsFailed("shouldFailOfAppOne");
+    try {
+
+      notifications.waitExpectedMessageOnProgressPanelAndClosed(
+          "Test runner executed successfully.");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10728");
+    }
     pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppOne");
+    pluginConsole.waitMethodMarkedAsFailed("shouldFailOfAppOne");
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(PASSED).size() == 1);
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(FAILED).size() == 1);
     String testErrorMessage = pluginConsole.getTestErrorMessage();
     assertTrue(
         testErrorMessage.startsWith(APP_TEST_ONE_FAIL_OUTPUT_TEMPLATE),
         "Actual message was: " + testErrorMessage);
-    events.clickOnEventPanelAndWaitMessage("Test runner executed successfully.");
   }
 
   @Test(priority = 1)
@@ -140,6 +148,14 @@ public class JavaTestPluginTestNgTest {
     editor.waitActive();
     editor.goToCursorPositionVisible(26, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
+    try {
+
+      notifications.waitExpectedMessageOnProgressPanelAndClosed(
+          "Test runner executed successfully.");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10728");
+    }
     pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppAnother");
     assertTrue(pluginConsole.getAllNamesOfMethodsMarkedDefinedStatus(PASSED).size() == 1);
     editor.goToCursorPositionVisible(31, 17);
@@ -168,6 +184,14 @@ public class JavaTestPluginTestNgTest {
     editor.waitActive();
     editor.goToCursorPositionVisible(26, 17);
     menu.runCommand(RUN_MENU, TEST, TEST_NG_TEST_DROP_DAWN_ITEM);
+    try {
+
+      notifications.waitExpectedMessageOnProgressPanelAndClosed(
+          "Test runner executed successfully.");
+    } catch (WebDriverException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10728");
+    }
     try {
       pluginConsole.waitMethodMarkedAsPassed("shouldSuccessOfAppAnother");
     } catch (TimeoutException ex) {


### PR DESCRIPTION
We have 2 unstable parts in the JavaTestPluginTestNgTest and CheckFactoryWithPerUserCreatePolicyTest tests which was described in the [issue](https://github.com/eclipse/che/issues/10728)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10728
### What does this PR do?
* Replace checking notifications messages from Notification pop ups to Events panel
* Add new method in the Events page object class which combine opening Events panel and wait the message
* Remove extra checks messages from `JavaTestPluginTestNgTest`
@dmytro-ndp, @vkuznyetsov, @SkorikSergey, @Ohrimenko1988 