### PR TITLE
CHE-9148: fix workspace item in organization's workspaces list

### DIFF
--- a/dashboard/src/app/organizations/organization-details/organization-workspaces/list-organization-workspaces.controller.ts
+++ b/dashboard/src/app/organizations/organization-details/organization-workspaces/list-organization-workspaces.controller.ts
@@ -330,4 +330,15 @@ export class ListOrganizationWorkspacesController {
 
     return (total > 0) ? Math.round(total) + ' MB' : '-';
   }
+
+  /**
+   * Returns current status of a workspace.
+   * @param {string} workspaceId a workspace ID
+   * @returns {string}
+   */
+  getWorkspaceStatus(workspaceId: string): string {
+    const workspace = this.cheWorkspace.getWorkspaceById(workspaceId);
+    return workspace && workspace.status ? workspace.status : 'unknown';
+  }
+
 }

--- a/dashboard/src/app/organizations/organization-details/organization-workspaces/list-organization-workspaces.html
+++ b/dashboard/src/app/organizations/organization-details/organization-workspaces/list-organization-workspaces.html
@@ -78,10 +78,11 @@
           <!-- Name -->
           <div flex-gt-xs="25"
                layout="row"
-               class="workspace-item-name">
+               class="workspace-item-name"
+               ng-click="listOrganizationWorkspacesController.redirectToWorkspaceDetails(workspace, 'Overview')">
             <span class="che-xs-header noselect" hide-gt-xs>Name</span>
             <div layout="row" flex>
-              <workspace-status-indicator flex="none" che-status="workspace.status"></workspace-status-indicator>
+              <workspace-status-indicator flex="none" che-status="listOrganizationWorkspacesController.getWorkspaceStatus(workspace.id)"></workspace-status-indicator>
               <div class="workspace-name-clip" id="ws-full-name-{{workspace.namespace}}/{{workspace.config.name}}">
             <span
               uib-tooltip="{{'RUNNING' === workspace.status ? 'Running' : 'Last modified: ' + (workspace.attributes.updated | amTimeAgo)}}"
@@ -116,6 +117,8 @@
             <span class="che-xs-header noselect" hide-gt-xs>Actions</span>
             <div class="che-list-actions" ng-if="listOrganizationWorkspacesController.isOwnWorkspace(workspace.id)"
                  ng-if="listOrganizationWorkspacesController.isSupported(workspace) === true">
+              <che-workspace-status workspace-id="workspace.id"
+                                    name="workspace-stop-start-button"></che-workspace-status>
               <a href="#/workspace/{{workspace.namespace}}/{{workspace.config.name}}?tab=Config"
                  name="configure-workspace-button"
                  uib-tooltip="Configure workspace">


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
On organization's workspaces list page:
- makes workspace's name clickable to redirect to workspace overview page
- adds workspace's actions button to be able to start/stop a workspace
- adds workspace's status indicator

![start-workspace](https://user-images.githubusercontent.com/16220722/44029799-49101b64-9f07-11e8-86c6-266138c4456e.gif)


### What issues does this PR fix or reference?
fix #9148

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>
