### PR TITLE
[Selenium] Fix expected number of process counter in CheckIntelligenceCommandFromToolbarTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Wizard.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Wizard.java
@@ -14,12 +14,15 @@ package org.eclipse.che.selenium.pageobject;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.List;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -356,8 +359,13 @@ public class Wizard {
   }
 
   public void waitCloseProjectConfigForm() {
-    new WebDriverWait(seleniumWebDriver, 30)
-        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(Locators.MAIN_FORM_ID)));
+    try {
+      new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC)
+          .until(ExpectedConditions.invisibilityOfElementLocated(By.id(Locators.MAIN_FORM_ID)));
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10713", ex);
+    }
   }
 
   /** wait parent directory name on the 'Project Configuration' form */

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
@@ -16,25 +16,20 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.W
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.TestGroup;
-import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
-import org.eclipse.che.selenium.pageobject.CheTerminal;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
-import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Wizard;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsToolbar;
 import org.openqa.selenium.By;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
@@ -55,9 +50,6 @@ public class CheckIntelligenceCommandFromToolbarTest {
   @Inject private CommandsToolbar commandsToolbar;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
-  @Inject private NotificationsPopupPanel notificationsPanel;
-  @Inject private CheTerminal terminal;
-  @Inject private TestProjectServiceClient projectService;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -69,7 +61,7 @@ public class CheckIntelligenceCommandFromToolbarTest {
   @Test
   public void launchClonedWepAppTest() throws Exception {
     menu.runCommand(WORKSPACE, CREATE_PROJECT);
-    selectProjectAndCreateSpringProject();
+    wizard.selectProjectAndCreate(Wizard.SamplesName.WEB_JAVA_SPRING, PROJECT_NAME);
     wizard.waitCreateProjectWizardFormIsClosed();
     projectExplorer.waitItem(PROJECT_NAME);
     commandsToolbar.clickWithHoldAndLaunchCommandFromList(PROJECT_NAME + ": build and run");
@@ -189,14 +181,5 @@ public class CheckIntelligenceCommandFromToolbarTest {
   private String getBodyText() {
     return new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC)
         .until((ExpectedCondition<String>) driver -> getBody().getText());
-  }
-
-  private void selectProjectAndCreateSpringProject() {
-    try {
-      wizard.selectProjectAndCreate(Wizard.SamplesName.WEB_JAVA_SPRING, PROJECT_NAME);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/10713", ex);
-    }
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
@@ -110,7 +110,7 @@ public class CheckIntelligenceCommandFromToolbarTest {
 
     waitOnAvailablePreviewPage(currentWindow, "Enter your name:");
     commandsToolbar.waitTimerValuePattern("\\d\\d:\\d\\d");
-    commandsToolbar.waitNumOfProcessCounter(2);
+    commandsToolbar.waitNumOfProcessCounter(3);
 
     checkTestAppByPreviewButtonAndReturnToIde(currentWindow, "Enter your name:");
     commandsToolbar.clickExecStopBtn();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CommandsEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CommandsEditorTest.java
@@ -67,7 +67,7 @@ public class CommandsEditorTest {
   }
 
   @Test
-  public void checkComamandsEditor() {
+  public void checkCommandsEditor() {
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();


### PR DESCRIPTION
### What does this PR do?
This PR changed expected number of process counter to '3' in **CheckIntelligenceCommandFromToolbarTest** selenium test.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10776
