### PR TITLE
CHE-10121: fix behavior of the factory's "Create" button

### DIFF
--- a/dashboard/src/app/factories/create-factory/create-factory.html
+++ b/dashboard/src/app/factories/create-factory/create-factory.html
@@ -19,7 +19,8 @@
   <div class="create-factory" ng-hide="createFactoryCtrl.isLoading">
     <ng-form name="factoryNameForm">
       <!-- Name -->
-      <che-input-box che-label-name="Name"
+      <che-input-box ng-init="createFactoryCtrl.setForm(factoryNameForm)"
+                     che-label-name="Name"
                      che-form="factoryNameForm"
                      che-name="name"
                      che-place-holder="Name of the factory"

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateFactoryTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateFactoryTest.java
@@ -202,7 +202,7 @@ public class CreateFactoryTest {
     // enter factory name with a less than 3 symbols
     createFactoryPage.typeFactoryName(generate("", 2));
     createFactoryPage.waitErrorMessage(TOO_SHORT_NAME_MESAAGE);
-    assertTrue(createFactoryPage.isCreateFactoryButtonEnabled());
+    assertFalse(createFactoryPage.isCreateFactoryButtonEnabled());
 
     // enter factory name with exactly 3 symbols
     createFactoryPage.typeFactoryName(MIN_FACTORY_NAME);
@@ -212,12 +212,12 @@ public class CreateFactoryTest {
     // enter factory name with special symbols
     createFactoryPage.typeFactoryName(SPECIAL_SYMBOLS_NAME);
     createFactoryPage.waitErrorMessage(SPECIAL_SYMBOLS_ERROR_MESSAGE);
-    assertTrue(createFactoryPage.isCreateFactoryButtonEnabled());
+    assertFalse(createFactoryPage.isCreateFactoryButtonEnabled());
 
     // enter factory name with more than 20 symbols
     createFactoryPage.typeFactoryName(generate("", 21));
     createFactoryPage.waitErrorMessage(TOO_LONG_NAME_MESSAGE);
-    assertTrue(createFactoryPage.isCreateFactoryButtonEnabled());
+    assertFalse(createFactoryPage.isCreateFactoryButtonEnabled());
 
     // enter factory name with exactly 20 symbols
     createFactoryPage.typeFactoryName(MAX_FACTORY_NAME);


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Any invalid factory name disables the factory's "Create" button.

### What issues does this PR fix or reference?
#10121 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A - bugfix

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A - bugfix

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>