### PR TITLE
Selenium: fix unstable selenium tests from dashboard and miscellaneous packages

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -265,6 +265,7 @@ public class ProjectExplorer {
   public void waitProjectExplorer(int timeout) {
     try {
       seleniumWebDriverHelper.waitVisibility(By.id(PROJECT_EXPLORER_TREE_ITEMS), timeout);
+      loader.waitOnClosed();
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
       if (seleniumWebDriverHelper.isVisible(By.id("ide-loader-progress-bar"))) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Refactor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Refactor.java
@@ -45,12 +45,14 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.textToBePresentI
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfAllElementsLocatedBy;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -235,7 +237,12 @@ public class Refactor {
 
   /** wait the 'Rename Method' form is closed */
   public void waitRenameMethodFormIsClosed() {
-    elementWait.until(invisibilityOfElementLocated(By.xpath(RENAME_METHOD_FORM)));
+    try {
+      elementWait.until(invisibilityOfElementLocated(By.xpath(RENAME_METHOD_FORM)));
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue: https://github.com/eclipse/che/issues/10784", ex);
+    }
   }
 
   /** wait the 'Rename Field' form is open */

--- a/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -65,6 +65,7 @@
             <class name="org.eclipse.che.selenium.git.PushingChangesTest"/>
             <class name="org.eclipse.che.selenium.dashboard.ImportProjectFromGitHubTest"/>
             <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithKeepDirectoryTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.workspaces.WorkspacesListTest"/>
         </classes>
     </test>
 </suite>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -67,7 +67,6 @@
           <class name="org.eclipse.che.selenium.dashboard.workspaces.details.WorkspaceDetailsOverviewTest"/>
           <class name="org.eclipse.che.selenium.dashboard.workspaces.details.WorkspaceDetailsComposeTest"/>
           <class name="org.eclipse.che.selenium.dashboard.CreateWorkspaceTest"/>
-          <class name="org.eclipse.che.selenium.dashboard.workspaces.WorkspacesListTest"/>
           <class name="org.eclipse.che.selenium.dashboard.CreateFactoryTest"/>
           <class name="org.eclipse.che.selenium.dashboard.FactoriesListTest"/>
           <class name="org.eclipse.che.selenium.dashboard.workspaces.AddOrImportProjectFormTest"/>


### PR DESCRIPTION
### What does this PR do?
This PR does some fixes to unstable tests:
- add info about known issue #10784 to **Refactor** selenium page object;
- move **WorkspacesListTest** to one-thread-suite because in multi-thread mode other selenium tests can change expected number of all created workspaces;
- add checking that the **Loader** is closed after the **Project Explorer** is visible.
