### PR TITLE
Fix name of 'Java Theia(openshift)' stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -67,7 +67,7 @@
   {
     "id": "java-theia-openshift",
     "creator": "ide",
-    "name": "Java Theia (openshift)",
+    "name": "Java Theia on openshift",
     "description": "Che development + Theia in a sidecar container (openshift)",
     "scope": "general",
     "tags": [

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -67,7 +67,7 @@
   {
     "id": "java-theia-openshift",
     "creator": "ide",
-    "name": "Java Theia on openshift",
+    "name": "Java Theia on OpenShift",
     "description": "Che development + Theia in a sidecar container (openshift)",
     "scope": "general",
     "tags": [


### PR DESCRIPTION
### What does this PR do?
Change name of the "**Java Theia (openshift)**" stack to "**Java Theia on openshift"** because stack names can't contain parentheses.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10759