### PR TITLE
Fix selenium test groups management

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -119,8 +119,8 @@ public abstract class SeleniumTestHandler
   private String gitHubPassword;
 
   @Inject
-  @Named("sys.excludedGroups")
-  private String excludedGroups;
+  @Named("sys.includedGroups")
+  private String includedGroups;
 
   @Inject private DefaultTestUser defaultTestUser;
   @Inject private TestWorkspaceProvider testWorkspaceProvider;
@@ -149,7 +149,7 @@ public abstract class SeleniumTestHandler
 
   private void revokeGithubOauthToken() {
     // do not revoke if github tests are not being executed
-    if (excludedGroups != null && excludedGroups.contains(TestGroup.GITHUB)) {
+    if (includedGroups != null && !includedGroups.contains(TestGroup.GITHUB)) {
       return;
     }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -211,8 +211,9 @@ public abstract class SeleniumTestHandler
   @Override
   public void onStart(ISuite suite) {
     suite.setParentInjector(injector);
-    LOG.info(
-        "Starting suite '{}' with {} test methods.", suite.getName(), suite.getAllMethods().size());
+    long numberOfEnabledTests =
+        suite.getAllMethods().parallelStream().filter(ITestNGMethod::getEnabled).count();
+    LOG.info("Starting suite '{}' with {} test methods.", suite.getName(), numberOfEnabledTests);
   }
 
   /** Check if webdriver session can be created without errors. */

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/TestFilter.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/TestFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.inject;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.google.inject.name.Named;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.che.selenium.core.TestGroup;
+import org.eclipse.che.selenium.core.constant.Infrastructure;
+import org.testng.annotations.ITestAnnotation;
+
+/**
+ * This class is aimed to filter TestNG tests.
+ *
+ * @author Dmytro Nochevnov
+ */
+@Singleton
+public class TestFilter {
+
+  private final boolean isMultiuser;
+  private final Infrastructure infrastructure;
+  private final String excludedGroups;
+
+  @Inject
+  public TestFilter(
+      @Named("sys.excludedGroups") String excludedGroups,
+      @Named("che.multiuser") boolean isMultiuser,
+      @Named("che.infrastructure") Infrastructure infrastructure) {
+    this.isMultiuser = isMultiuser;
+    this.infrastructure = infrastructure;
+    this.excludedGroups = excludedGroups;
+  }
+
+  /**
+   * This method disable the test which belongs to test group which is being excluded or doesn't
+   * comply current infrastructure, or doesn't support Singleuser/Multiuser type of Eclipse Che.
+   *
+   * @param annotation annotation of test method which reflects {@link org.testng.annotations.Test}
+   *     annotation attributes.
+   */
+  public void excludeTestOfImproperGroup(ITestAnnotation annotation) {
+    if (annotation.getGroups().length == 0) {
+      return;
+    }
+
+    List<String> groups = new ArrayList<String>(Arrays.asList(annotation.getGroups()));
+
+    // exclude test with group from excludedGroups
+    if (excludedGroups != null
+        && Arrays.stream(excludedGroups.split(",")).anyMatch(groups::contains)) {
+      annotation.setEnabled(false);
+      return;
+    }
+
+    // exclude test which doesn't comply multiuser flag
+    if (isMultiuser
+        && groups.contains(TestGroup.SINGLEUSER)
+        && !groups.contains(TestGroup.MULTIUSER)) {
+      annotation.setEnabled(false);
+      return;
+    }
+
+    // exclude test which doesn't comply singleuser flag
+    if (!isMultiuser
+        && groups.contains(TestGroup.MULTIUSER)
+        && !groups.contains(TestGroup.SINGLEUSER)) {
+      annotation.setEnabled(false);
+      return;
+    }
+
+    // exclude test which doesn't support current infrastructure
+    groups.remove(TestGroup.SINGLEUSER);
+    groups.remove(TestGroup.MULTIUSER);
+    groups.remove(TestGroup.GITHUB);
+    if (!groups.isEmpty() && !groups.contains(infrastructure.toString().toLowerCase())) {
+      annotation.setEnabled(false);
+    }
+  }
+}

--- a/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/TestFilterTest.java
+++ b/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/TestFilterTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core.inject;
+
+import static org.eclipse.che.selenium.core.TestGroup.DOCKER;
+import static org.eclipse.che.selenium.core.TestGroup.GITHUB;
+import static org.eclipse.che.selenium.core.TestGroup.K8S;
+import static org.eclipse.che.selenium.core.TestGroup.MULTIUSER;
+import static org.eclipse.che.selenium.core.TestGroup.OPENSHIFT;
+import static org.eclipse.che.selenium.core.TestGroup.OSIO;
+import static org.eclipse.che.selenium.core.TestGroup.SINGLEUSER;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.che.selenium.core.constant.Infrastructure;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.ITestAnnotation;
+import org.testng.annotations.Test;
+
+/** @author Dmytro Nochevnov */
+public class TestFilterTest {
+
+  public static final String SOME_GROUP = "some_group";
+  public static final String[] EMPTY_TEST_GROUPS = {};
+  public static final String EMPTY_EXCLUDED_GROUPS = "";
+  public static final boolean CHE_SINGLEUSER = false;
+  public static final boolean CHE_MULTIUSER = true;
+  @Mock private ITestAnnotation mockTestAnnotation;
+
+  @BeforeMethod
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test(dataProvider = "disableTestGroupManagementData")
+  public void shouldDisableTest(
+      String[] testGroups,
+      String excludedGroups,
+      boolean isMultiuser,
+      Infrastructure infrastructure) {
+    // given
+    TestFilter testFilter = new TestFilter(excludedGroups, isMultiuser, infrastructure);
+    doReturn(testGroups).when(mockTestAnnotation).getGroups();
+
+    // when
+    testFilter.excludeTestOfImproperGroup(mockTestAnnotation);
+
+    // then
+    verify(mockTestAnnotation).setEnabled(false);
+  }
+
+  @DataProvider
+  public Object[][] disableTestGroupManagementData() {
+    return new Object[][] {
+      {new String[] {GITHUB}, GITHUB, CHE_MULTIUSER, Infrastructure.OPENSHIFT},
+      {new String[] {GITHUB}, SOME_GROUP + "," + GITHUB, CHE_SINGLEUSER, Infrastructure.OPENSHIFT},
+      {new String[] {OPENSHIFT}, GITHUB, CHE_MULTIUSER, Infrastructure.DOCKER},
+      {new String[] {MULTIUSER}, SOME_GROUP, CHE_SINGLEUSER, Infrastructure.DOCKER},
+      {
+        new String[] {OPENSHIFT, OSIO}, EMPTY_EXCLUDED_GROUPS, CHE_SINGLEUSER, Infrastructure.DOCKER
+      },
+      {
+        new String[] {DOCKER, SINGLEUSER},
+        EMPTY_EXCLUDED_GROUPS,
+        CHE_MULTIUSER,
+        Infrastructure.DOCKER
+      },
+      {
+        new String[] {K8S, SINGLEUSER, MULTIUSER},
+        EMPTY_EXCLUDED_GROUPS,
+        CHE_MULTIUSER,
+        Infrastructure.DOCKER
+      }
+    };
+  }
+
+  @Test(dataProvider = "enableTestGroupManagementData")
+  public void shouldEnableTest(
+      String[] testGroups,
+      String excludedGroups,
+      boolean isMultiuser,
+      Infrastructure infrastructure) {
+    // given
+    TestFilter testFilter = new TestFilter(excludedGroups, isMultiuser, infrastructure);
+    doReturn(testGroups).when(mockTestAnnotation).getGroups();
+
+    // when
+    testFilter.excludeTestOfImproperGroup(mockTestAnnotation);
+
+    // then
+    verify(mockTestAnnotation, never()).setEnabled(false);
+  }
+
+  @DataProvider
+  public Object[][] enableTestGroupManagementData() {
+    return new Object[][] {
+      {EMPTY_TEST_GROUPS, EMPTY_EXCLUDED_GROUPS, CHE_SINGLEUSER, Infrastructure.OPENSHIFT},
+      {EMPTY_TEST_GROUPS, EMPTY_EXCLUDED_GROUPS, CHE_MULTIUSER, Infrastructure.DOCKER},
+      {EMPTY_TEST_GROUPS, GITHUB, CHE_SINGLEUSER, Infrastructure.DOCKER},
+      {new String[] {GITHUB}, SOME_GROUP, CHE_MULTIUSER, Infrastructure.OPENSHIFT},
+      {
+        new String[] {GITHUB, OPENSHIFT},
+        EMPTY_EXCLUDED_GROUPS,
+        CHE_MULTIUSER,
+        Infrastructure.OPENSHIFT
+      },
+      {
+        new String[] {GITHUB, OPENSHIFT, DOCKER},
+        EMPTY_EXCLUDED_GROUPS,
+        CHE_MULTIUSER,
+        Infrastructure.DOCKER
+      },
+      {new String[] {MULTIUSER}, EMPTY_EXCLUDED_GROUPS, CHE_MULTIUSER, Infrastructure.OPENSHIFT},
+      {
+        new String[] {GITHUB, SINGLEUSER, MULTIUSER},
+        EMPTY_EXCLUDED_GROUPS,
+        CHE_SINGLEUSER,
+        Infrastructure.OPENSHIFT
+      },
+      {
+        new String[] {SINGLEUSER, MULTIUSER, OPENSHIFT},
+        EMPTY_EXCLUDED_GROUPS,
+        CHE_MULTIUSER,
+        Infrastructure.OPENSHIFT
+      }
+    };
+  }
+}

--- a/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/TestFilterTest.java
+++ b/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/TestFilterTest.java
@@ -78,6 +78,7 @@ public class TestFilterTest {
         CHE_MULTIUSER,
         Infrastructure.DOCKER
       },
+      {new String[] {OPENSHIFT}, EMPTY_EXCLUDED_GROUPS, CHE_SINGLEUSER, Infrastructure.DOCKER},
       {
         new String[] {K8S, SINGLEUSER, MULTIUSER},
         EMPTY_EXCLUDED_GROUPS,

--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -264,6 +264,7 @@
                                 </property>
                             </systemProperties>
                             <systemPropertyVariables>
+                                <includedGroups>${includedGroups}</includedGroups>
                                 <excludedGroups>${excludedGroups}</excludedGroups>
                             </systemPropertyVariables>
                         </configuration>

--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -264,7 +264,6 @@
                                 </property>
                             </systemProperties>
                             <systemPropertyVariables>
-                                <includedGroups>${includedGroups}</includedGroups>
                                 <excludedGroups>${excludedGroups}</excludedGroups>
                             </systemPropertyVariables>
                         </configuration>

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/AccountTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/AccountTest.java
@@ -28,7 +28,7 @@ import org.eclipse.che.selenium.pageobject.dashboard.account.KeycloakPasswordPag
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Test(groups = TestGroup.MULTIUSER)
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class AccountTest {
 
   private Account changedTestUserAccount;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
@@ -35,7 +35,7 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class AddWorkspaceToOrganizationTest {
 
   private static final String WORKSPACE_FOR_ADMIN_1 = generate("workspace", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfParentOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfParentOrganizationTest.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class AdminOfParentOrganizationTest {
   private int initialOrgCount;
   private TestOrganizationServiceClient userTestOrganizationServiceClient;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfSubOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AdminOfSubOrganizationTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class AdminOfSubOrganizationTest {
   private int initialOrgNumber;
   private TestOrganizationServiceClient testOrganizationServiceClient;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/CreateRootOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/CreateRootOrganizationTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class CreateRootOrganizationTest {
   private static final String PARENT_ORG_NAME = generate("parent-", 4);
   private static final String CHILD_ORG_NAME = generate("child-", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationByBulkTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationByBulkTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class DeleteOrganizationByBulkTest {
   private static final int TEST_ROOT_ORG_NUMBER = 2;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationInListTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationInListTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class DeleteOrganizationInListTest {
   private int initialOrgNumber;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/DeleteOrganizationTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class DeleteOrganizationTest {
   private int initialOrgNumber;
   private TestOrganizationServiceClient testOrganizationServiceClient;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/FilterOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/FilterOrganizationTest.java
@@ -37,7 +37,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class FilterOrganizationTest {
   private static final String WRONG_ORG_NAME = generate("wrong-org-", 7);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/MemberOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/MemberOrganizationTest.java
@@ -42,7 +42,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class MemberOrganizationTest {
   private int initialOrgNumber;
   private TestOrganizationServiceClient testOrganizationServiceClient;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/OrganizationMembersTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/OrganizationMembersTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Sergey Skorik */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class OrganizationMembersTest {
   private static final String NEW_ORG_NAME = generate("new-org-", 5);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/RenameOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/RenameOrganizationTest.java
@@ -36,7 +36,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class RenameOrganizationTest {
   private static final String NEW_PARENT_ORG_NAME = generate("new-parent-", 5);
   private static final String NEW_CHILD_ORG_NAME = generate("new-child-", 5);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/ShareWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/ShareWorkspaceTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Test(groups = TestGroup.MULTIUSER)
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class ShareWorkspaceTest {
 
   private static final String WORKSPACE_NAME = generate("workspace", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/SystemAdminOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/SystemAdminOrganizationTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class SystemAdminOrganizationTest {
   private int initialRootOrgNumber;
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/UserEmptyOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/UserEmptyOrganizationTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
  *
  * @author Ann Shumilova
  */
-@Test(groups = {TestGroup.MULTIUSER})
+@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class UserEmptyOrganizationTest {
 
   private TestOrganizationServiceClient organizationServiceClient;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsComposeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsComposeTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Skoryk Serhii */
-@Test(groups = {TestGroup.DOCKER})
+@Test(groups = {TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
 public class WorkspaceDetailsComposeTest {
 
   private static final String WORKSPACE = generate("java-mysql", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsComposeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsComposeTest.java
@@ -40,7 +40,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Skoryk Serhii */
-@Test(groups = {TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
+@Test(groups = {TestGroup.DOCKER})
 public class WorkspaceDetailsComposeTest {
 
   private static final String WORKSPACE = generate("java-mysql", 4);

--- a/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -16,20 +16,27 @@
        verbose="10"
        parallel="classes"
        thread-count="1">
-
     <test name="all">
         <method-selectors>
             <method-selector>
                 <script language="beanshell">
                     <![CDATA[
     boolean isTestGroupsAgreedWithRequestedGroups() {
-      excludedGroupsVal = System.getProperty("excludedGroups");
-      if (excludedGroupsVal == null || excludedGroupsVal.isEmpty() || groups.isEmpty()) {
+      if (groups.isEmpty()) {
         return true;
       }
 
+      excludedGroupsVal = System.getProperty("excludedGroups");
       excludedGroups = excludedGroupsVal.split(",");
+
+      includedGroupsVal = System.getProperty("includedGroups");
+      includedGroups = includedGroupsVal.split(",");
+
       for (String group: groups.keySet()) {
+        if (Arrays.asList(includedGroups).contains(group)) {
+          return true;
+        }
+
         if (Arrays.asList(excludedGroups).contains(group)) {
           return false;
         }

--- a/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -26,18 +26,16 @@
         return true;
       }
 
-      excludedGroupsVal = System.getProperty("excludedGroups");
-      excludedGroups = excludedGroupsVal.split(",");
-
       includedGroupsVal = System.getProperty("includedGroups");
-      includedGroups = includedGroupsVal.split(",");
-
-      for (String group: groups.keySet()) {
-        if (Arrays.asList(includedGroups).contains(group)) {
+      for (String includedGroup: includedGroupsVal.split(",")) {
+        if (groups.contains(includedGroup)) {
           return true;
         }
+      }
 
-        if (Arrays.asList(excludedGroups).contains(group)) {
+      excludedGroupsVal = System.getProperty("excludedGroups");
+      for (String excludedGroup: excludedGroupsVal.split(",")) {
+        if (groups.contains(excludedGroup)) {
           return false;
         }
       }

--- a/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -17,37 +17,6 @@
        parallel="classes"
        thread-count="1">
     <test name="all">
-        <method-selectors>
-            <method-selector>
-                <script language="beanshell">
-                    <![CDATA[
-    boolean isTestGroupsAgreedWithRequestedGroups() {
-      if (groups.isEmpty()) {
-        return true;
-      }
-
-      includedGroupsVal = System.getProperty("includedGroups");
-      for (String includedGroup: includedGroupsVal.split(",")) {
-        if (groups.contains(includedGroup)) {
-          return true;
-        }
-      }
-
-      excludedGroupsVal = System.getProperty("excludedGroups");
-      for (String excludedGroup: excludedGroupsVal.split(",")) {
-        if (groups.contains(excludedGroup)) {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    isTestGroupsAgreedWithRequestedGroups();
-]]>
-                </script>
-            </method-selector>
-        </method-selectors>
         <classes>
             <class name="org.eclipse.che.selenium.dashboard.organization.AddWorkspaceToOrganizationTest"/>
             <class name="org.eclipse.che.selenium.dashboard.organization.AdminOfParentOrganizationTest"/>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -18,18 +18,26 @@
        thread-count="4">
 
     <test name="all">
-        <method-selectors>
-            <method-selector>
-                <script language="beanshell">
+      <method-selectors>
+        <method-selector>
+          <script language="beanshell">
                     <![CDATA[
     boolean isTestGroupsAgreedWithRequestedGroups() {
-      excludedGroupsVal = System.getProperty("excludedGroups");
-      if (excludedGroupsVal == null || excludedGroupsVal.isEmpty() || groups.isEmpty()) {
+      if (groups.isEmpty()) {
         return true;
       }
 
+      excludedGroupsVal = System.getProperty("excludedGroups");
       excludedGroups = excludedGroupsVal.split(",");
+
+      includedGroupsVal = System.getProperty("includedGroups");
+      includedGroups = includedGroupsVal.split(",");
+
       for (String group: groups.keySet()) {
+        if (Arrays.asList(includedGroups).contains(group)) {
+          return true;
+        }
+
         if (Arrays.asList(excludedGroups).contains(group)) {
           return false;
         }
@@ -40,10 +48,9 @@
 
     isTestGroupsAgreedWithRequestedGroups();
 ]]>
-                </script>
-            </method-selector>
-        </method-selectors>
-
+          </script>
+        </method-selector>
+      </method-selectors>
       <classes>
           <class name="org.eclipse.che.selenium.assistant.CheckFindActionFeatureInCheTest"/>
           <class name="org.eclipse.che.selenium.assistant.KeyBindingsTest"/>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -27,18 +27,16 @@
         return true;
       }
 
-      excludedGroupsVal = System.getProperty("excludedGroups");
-      excludedGroups = excludedGroupsVal.split(",");
-
       includedGroupsVal = System.getProperty("includedGroups");
-      includedGroups = includedGroupsVal.split(",");
-
-      for (String group: groups.keySet()) {
-        if (Arrays.asList(includedGroups).contains(group)) {
+      for (String includedGroup: includedGroupsVal.split(",")) {
+        if (groups.contains(includedGroup)) {
           return true;
         }
+      }
 
-        if (Arrays.asList(excludedGroups).contains(group)) {
+      excludedGroupsVal = System.getProperty("excludedGroups");
+      for (String excludedGroup: excludedGroupsVal.split(",")) {
+        if (groups.contains(excludedGroup)) {
           return false;
         }
       }

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -18,37 +18,6 @@
        thread-count="4">
 
     <test name="all">
-      <method-selectors>
-        <method-selector>
-          <script language="beanshell">
-                    <![CDATA[
-    boolean isTestGroupsAgreedWithRequestedGroups() {
-      if (groups.isEmpty()) {
-        return true;
-      }
-
-      includedGroupsVal = System.getProperty("includedGroups");
-      for (String includedGroup: includedGroupsVal.split(",")) {
-        if (groups.contains(includedGroup)) {
-          return true;
-        }
-      }
-
-      excludedGroupsVal = System.getProperty("excludedGroups");
-      for (String excludedGroup: excludedGroupsVal.split(",")) {
-        if (groups.contains(excludedGroup)) {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    isTestGroupsAgreedWithRequestedGroups();
-]]>
-          </script>
-        </method-selector>
-      </method-selectors>
       <classes>
           <class name="org.eclipse.che.selenium.assistant.CheckFindActionFeatureInCheTest"/>
           <class name="org.eclipse.che.selenium.assistant.KeyBindingsTest"/>


### PR DESCRIPTION
### What does this PR do?
It fixes selenium test groups management as follow:
- it makes it possible to define the test to be executed on the different infrastructures (not all) at a time, for example, on OpenShift and K8S.
- it moves beanshell script inside test suite xml, which looks hard to understand and to support, to the **SeleniumTestHandler** java class.

### What issues does this PR fix or reference?
#10583