### PR TITLE
Fix formatting of CSharpFileEditingTest

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/CSharpFileEditingTest.java
@@ -95,7 +95,6 @@ public class CSharpFileEditingTest {
       // remove try-catch block after issue has been resolved
       fail("Known issue: https://github.com/eclipse/che/issues/10151", ex);
     }
-
   }
 
   public void checkCodeValidation() {


### PR DESCRIPTION
### What does this PR do?
It removes odd empty line from CSharpFileEditingTest to comply with formatting rules.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/commit/ea7d7c23e44cc2cccf2ca9eb3c1fab8339dd9097