### PR TITLE
CHE_INFRASTRUCTURE and CHE_MULTIUSER vars can be now passed as system

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/configuration/InMemoryTestConfiguration.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/configuration/InMemoryTestConfiguration.java
@@ -31,6 +31,9 @@ public class InMemoryTestConfiguration implements TestConfiguration {
     for (TestConfiguration testConfiguration : configuration) {
       addAll(testConfiguration.getMap());
     }
+    // convert value of CHE_INFRASTRUCTURE to upper case to comply with Infrastructure
+    // enumeration;
+    config.put("che.infrastructure", config.get("che.infrastructure").toUpperCase());
   }
 
   public InMemoryTestConfiguration(Map<String, String> config) {

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/configuration/SeleniumTestConfiguration.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/configuration/SeleniumTestConfiguration.java
@@ -128,12 +128,6 @@ public class SeleniumTestConfiguration extends InMemoryTestConfiguration {
       name = name.replace('_', '.');
       name = name.replace("=", "_");
 
-      // convert value of CHE_INFRASTRUCTURE to upper case to comply with Infrastructure
-      // enumeration;
-      if (name.equals("che.infrastructure")) {
-        return new AbstractMap.SimpleEntry<>(name, entry.getValue().toUpperCase());
-      }
-
       return new AbstractMap.SimpleEntry<>(name, entry.getValue());
     }
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.selenium.core;
 
 import static com.google.inject.name.Names.named;
-import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.utils.PlatformUtils.isMac;
 import static org.eclipse.che.selenium.core.workspace.WorkspaceTemplate.DEFAULT;
@@ -79,8 +78,8 @@ public class CheSeleniumSuiteModule extends AbstractModule {
 
   public static final String AUXILIARY = "auxiliary";
 
-  private static final String CHE_MULTIUSER_VARIABLE = "CHE_MULTIUSER";
-  private static final String CHE_INFRASTRUCTURE_VARIABLE = "CHE_INFRASTRUCTURE";
+  private static final String CHE_MULTIUSER_VARIABLE = "che.multiuser";
+  private static final String CHE_INFRASTRUCTURE_VARIABLE = "che.infrastructure";
 
   @Override
   public void configure() {
@@ -121,19 +120,19 @@ public class CheSeleniumSuiteModule extends AbstractModule {
 
     bind(PageObjectsInjector.class).to(PageObjectsInjectorImpl.class);
 
-    if (parseBoolean(System.getenv(CHE_MULTIUSER_VARIABLE))) {
+    if (config.getBoolean(CHE_MULTIUSER_VARIABLE)) {
       install(new CheSeleniumMultiUserModule());
     } else {
       install(new CheSeleniumSingleUserModule());
     }
 
-    configureInfrastructureRelatedDependencies();
+    configureInfrastructureRelatedDependencies(config);
     configureTestExecutionModeRelatedDependencies();
   }
 
-  private void configureInfrastructureRelatedDependencies() {
+  private void configureInfrastructureRelatedDependencies(TestConfiguration config) {
     final Infrastructure cheInfrastructure =
-        Infrastructure.valueOf(System.getenv(CHE_INFRASTRUCTURE_VARIABLE).toUpperCase());
+        Infrastructure.valueOf(config.getString(CHE_INFRASTRUCTURE_VARIABLE).toUpperCase());
     switch (cheInfrastructure) {
       case OPENSHIFT:
       case K8S:


### PR DESCRIPTION
### What does this PR do?
Before this PR, properties `CHE_MULTIUSER` and `CHE_INFRASTRUCTURE` had to be set as environmental variables. After this PR is merged, it will be possible to set them as system variables.

In other words - before this PR, it was not possible to start tests with `-Dche.infrastructure=openshift` for example... After this PR this should be possible.

From my testing, this PR should not break any flow (a.k.a. setting env variable `CHE_INFRASTRUCTURE` will be enough)

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
