### PR TITLE
Make clickable the whole workspace item row in workspaces list of an organization

### DIFF
--- a/dashboard/src/app/organizations/organization-details/organization-workspaces/list-organization-workspaces.html
+++ b/dashboard/src/app/organizations/organization-details/organization-workspaces/list-organization-workspaces.html
@@ -95,19 +95,22 @@
           </div>
           <!-- RAM -->
           <div flex-gt-xs="15"
-               class="che-list-item-name workspace-item-ram">
+               class="che-list-item-name workspace-item-ram"
+               ng-click="listOrganizationWorkspacesController.redirectToWorkspaceDetails(workspace, 'Overview')">
             <span class="che-xs-header noselect" hide-gt-xs>RAM</span>
             <span class="workspace-consumed-value" name="workspace-ram-value">{{listOrganizationWorkspacesController.getMemoryLimit(workspace)}}</span>
           </div>
           <!-- Projects -->
           <div flex-gt-xs="15"
-               class="che-list-item-name workspace-item-projects">
+               class="che-list-item-name workspace-item-projects"
+               ng-click="listOrganizationWorkspacesController.redirectToWorkspaceDetails(workspace, 'Overview')">
             <span class="che-xs-header noselect" hide-gt-xs>Projects</span>
             <span class="che-hover" name="workspace-projects-value">{{workspace.config.projects.length}}</span>
           </div>
           <!-- Stack ID -->
           <div flex-gt-xs="30"
-               class="che-list-item-name workspace-item-stack">
+               class="che-list-item-name workspace-item-stack"
+               ng-click="listOrganizationWorkspacesController.redirectToWorkspaceDetails(workspace, 'Overview')">
             <span class="che-xs-header noselect" hide-gt-xs>Stack</span>
             <span class="che-hover" name="workspace-stacks-name">{{workspace.attributes.stackId}}</span>
           </div>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR adds a fix to make clickable the whole workspace item row in workspaces list of an organization. 
Excluding action buttons, previously clickable was only workspace name.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/9148
