### PR TITLE
Fix Che server protocol deserialization in k8s/OS infras

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Annotations.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Annotations.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes;
 
+import com.google.common.base.Strings;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -115,11 +116,17 @@ public class Annotations {
         if (refMatcher.matches()) {
           String ref = refMatcher.group("ref");
           if (!servers.containsKey(ref)) {
+            // Null is serialized to empty string in annotations, but empty string as protocol
+            // doesn't make any sense, so convert empty protocol to null which is respected
+            // in other components
+            String protocol =
+                Strings.emptyToNull(
+                    annotations.get(String.format(SERVER_PROTOCOL_ANNOTATION_FMT, ref)));
             servers.put(
                 ref,
                 new ServerConfigImpl(
                     annotations.get(String.format(SERVER_PORT_ANNOTATION_FMT, ref)),
-                    annotations.get(String.format(SERVER_PROTOCOL_ANNOTATION_FMT, ref)),
+                    protocol,
                     annotations.get(String.format(SERVER_PATH_ANNOTATION_FMT, ref)),
                     GSON.fromJson(
                         annotations.get(String.format(SERVER_ATTR_ANNOTATION_FMT, ref)),


### PR DESCRIPTION
### What does this PR do?
When server doesn't declare protocol K8s/OS server
serialization/deserialization process works incorrectly - it
restores protocol as empty string and it doesn't make any sense
for a server URL. This commit restores empty protocol as null
which is respected by other components and it gets replaced by
default value 'tcp'.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
