### PR TITLE
Filter test configuration methods which belong to improper groups

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -62,7 +62,7 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testng.IAnnotationTransformer;
+import org.testng.IAnnotationTransformer2;
 import org.testng.IConfigurationListener;
 import org.testng.IExecutionListener;
 import org.testng.IInvokedMethod;
@@ -75,6 +75,9 @@ import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 import org.testng.SkipException;
 import org.testng.TestException;
+import org.testng.annotations.IConfigurationAnnotation;
+import org.testng.annotations.IDataProviderAnnotation;
+import org.testng.annotations.IFactoryAnnotation;
 import org.testng.annotations.ITestAnnotation;
 
 /**
@@ -91,7 +94,7 @@ public abstract class SeleniumTestHandler
         ISuiteListener,
         IInvokedMethodListener,
         IExecutionListener,
-        IAnnotationTransformer {
+        IAnnotationTransformer2 {
 
   private static final Logger LOG = LoggerFactory.getLogger(SeleniumTestHandler.class);
   private static final AtomicBoolean isCleanUpCompleted = new AtomicBoolean();
@@ -281,6 +284,21 @@ public abstract class SeleniumTestHandler
       ITestAnnotation annotation, Class testClass, Constructor testConstructor, Method testMethod) {
     testFilter.excludeTestOfImproperGroup(annotation);
   }
+
+  @Override
+  public void transform(
+      IConfigurationAnnotation annotation,
+      Class testClass,
+      Constructor testConstructor,
+      Method testMethod) {
+    testFilter.excludeTestOfImproperGroup(annotation);
+  }
+
+  @Override
+  public void transform(IDataProviderAnnotation annotation, Method method) {}
+
+  @Override
+  public void transform(IFactoryAnnotation annotation, Method method) {}
 
   /** Injects dependencies into the given test class using {@link Guice} and custom injectors. */
   private void injectDependencies(ITestContext testContext, Object testInstance) throws Exception {

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/TestFilter.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/TestFilter.java
@@ -19,7 +19,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.constant.Infrastructure;
-import org.testng.annotations.ITestAnnotation;
+import org.testng.annotations.ITestOrConfiguration;
 
 /**
  * This class is aimed to filter TestNG tests.
@@ -50,12 +50,12 @@ public class TestFilter {
    * @param annotation annotation of test method which reflects {@link org.testng.annotations.Test}
    *     annotation attributes.
    */
-  public void excludeTestOfImproperGroup(ITestAnnotation annotation) {
+  public void excludeTestOfImproperGroup(ITestOrConfiguration annotation) {
     if (annotation.getGroups().length == 0) {
       return;
     }
 
-    List<String> groups = new ArrayList<String>(Arrays.asList(annotation.getGroups()));
+    List<String> groups = new ArrayList<>(Arrays.asList(annotation.getGroups()));
 
     // exclude test with group from excludedGroups
     if (excludedGroups != null

--- a/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/TestFilterTest.java
+++ b/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/TestFilterTest.java
@@ -27,7 +27,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.ITestAnnotation;
+import org.testng.annotations.ITestOrConfiguration;
 import org.testng.annotations.Test;
 
 /** @author Dmytro Nochevnov */
@@ -38,7 +38,7 @@ public class TestFilterTest {
   public static final String EMPTY_EXCLUDED_GROUPS = "";
   public static final boolean CHE_SINGLEUSER = false;
   public static final boolean CHE_MULTIUSER = true;
-  @Mock private ITestAnnotation mockTestAnnotation;
+  @Mock private ITestOrConfiguration mockTestAnnotation;
 
   @BeforeMethod
   public void setup() {


### PR DESCRIPTION
### What does this PR do?
It takes into account TestNG configuration methods which can belong to certain test group when filtering tests by group:
- [ImportWizardFormTest.removeGitHubIdentity()](https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-ocp/Selenium_20tests_20report/failsafe-report.html#org.eclipse.che.selenium.gitImportWizardFormTest)
- [AuthorizeOnGithubFromDashboardTest.removeGitHubIdentity()](https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-ocp/Selenium_20tests_20report/failsafe-report.html#org.eclipse.che.selenium.gitAuthorizeOnGithubFromDashboardTest)
- [AuthorizeOnGithubFromPreferencesTest.removeGitHubIdentity()](https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-ocp/Selenium_20tests_20report/failsafe-report.html#org.eclipse.che.selenium.gitAuthorizeOnGithubFromPreferencesTest)

### What issues does this PR fix or reference?
#10583