### PR TITLE
Make WorkingWithTerminalTest not to depend on command prompt in terminal

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
@@ -89,25 +89,21 @@ public class WorkingWithTerminalTest {
 
   @BeforeMethod
   private void prepareNewTerminal() {
-    try {
-      panelSelector.selectPanelTypeFromPanelSelector(LEFT_BOTTOM_ID);
+    panelSelector.selectPanelTypeFromPanelSelector(LEFT_BOTTOM_ID);
 
-      projectExplorer.waitItem(PROJECT_NAME);
+    projectExplorer.waitItem(PROJECT_NAME);
 
-      if (terminal.terminalIsPresent()) {
-        consoles.closeTerminalIntoConsoles();
-        terminal.waitTerminalIsNotPresent(1);
-      }
-
-      consoles.clickOnPlusMenuButton();
-      consoles.clickOnTerminalItemInContextMenu();
-
-      terminal.selectFirstTerminalTab();
-      terminal.waitTerminalConsole();
-      terminal.waitFirstTerminalIsNotEmpty();
-    } catch (Exception e) {
-      LOG.error(e.getLocalizedMessage(), e);
+    if (terminal.terminalIsPresent()) {
+      consoles.closeTerminalIntoConsoles();
+      terminal.waitTerminalIsNotPresent(1);
     }
+
+    consoles.clickOnPlusMenuButton();
+    consoles.clickOnTerminalItemInContextMenu();
+
+    terminal.selectFirstTerminalTab();
+    terminal.waitTerminalConsole();
+    terminal.waitFirstTerminalIsNotEmpty();
   }
 
   @Test
@@ -239,7 +235,6 @@ public class WorkingWithTerminalTest {
   public void shouldCreateFileTest() {
     terminal.typeIntoActiveTerminal("cd ~" + Keys.ENTER);
     terminal.typeIntoActiveTerminal("ls" + Keys.ENTER);
-    terminal.waitFirstTerminalIsNotEmpty();
     terminal.waitTextInFirstTerminal("che");
     terminal.typeIntoActiveTerminal("touch a.txt" + Keys.ENTER);
 
@@ -278,9 +273,7 @@ public class WorkingWithTerminalTest {
     // clear terminal
     terminal.typeIntoActiveTerminal("clear" + Keys.ENTER);
     terminal.waitNoTextInFirstTerminal("clear");
-
-    terminal.waitFirstTerminalIsNotEmpty();
-    terminal.waitTextInFirstTerminal(workspace.getId());
+    terminal.waitTextInFirstTerminal("@");
   }
 
   @Test
@@ -290,9 +283,7 @@ public class WorkingWithTerminalTest {
     // clear terminal
     terminal.typeIntoActiveTerminal("reset" + Keys.ENTER.toString());
     terminal.waitNoTextInFirstTerminal("reset");
-
-    terminal.waitFirstTerminalIsNotEmpty();
-    terminal.waitTextInFirstTerminal(workspace.getId());
+    terminal.waitTextInFirstTerminal("@");
   }
 
   @Test
@@ -319,7 +310,6 @@ public class WorkingWithTerminalTest {
 
     // check "F1"
     terminal.typeIntoActiveTerminal(Keys.F1.toString());
-    terminal.waitFirstTerminalIsNotEmpty();
     terminal.waitTextInFirstTerminal(MC_HELP_DIALOG);
     terminal.typeIntoActiveTerminal(Keys.F10.toString());
     terminal.waitNoTextInFirstTerminal(MC_HELP_DIALOG);


### PR DESCRIPTION
### What does this PR do?
It fixes **WorkingWithTerminalTest** not to depend on command line prompt in terminal which varies in _Eclipse Che_ of different infrastructures.

It also removes redundant verifications and try/catch block.

### What issues does this PR fix or reference?
#9909