### PR TITLE
Selenium: remove info about known issues, fix unstable tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
@@ -13,10 +13,10 @@ package org.eclipse.che.selenium.pageobject;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MINIMUM_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -79,7 +79,7 @@ public class Swagger {
   private void expandWorkSpaceItem() {
     Wait fluentWait =
         new FluentWait(seleniumWebDriver)
-            .withTimeout(WIDGET_TIMEOUT_SEC, SECONDS)
+            .withTimeout(ELEMENT_TIMEOUT_SEC, SECONDS)
             .pollingEvery(MINIMUM_SEC, SECONDS)
             .ignoring(StaleElementReferenceException.class, NoSuchElementException.class);
     fluentWait.until((ExpectedCondition<Boolean>) input -> workSpaceLink.isEnabled());

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Swagger.java
@@ -16,6 +16,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.MINIMUM_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -78,7 +79,7 @@ public class Swagger {
   private void expandWorkSpaceItem() {
     Wait fluentWait =
         new FluentWait(seleniumWebDriver)
-            .withTimeout(LOAD_PAGE_TIMEOUT_SEC, SECONDS)
+            .withTimeout(WIDGET_TIMEOUT_SEC, SECONDS)
             .pollingEvery(MINIMUM_SEC, SECONDS)
             .ignoring(StaleElementReferenceException.class, NoSuchElementException.class);
     fluentWait.until((ExpectedCondition<Boolean>) input -> workSpaceLink.isEnabled());

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/TestWebElementRenderChecker.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/TestWebElementRenderChecker.java
@@ -11,15 +11,15 @@
  */
 package org.eclipse.che.selenium.pageobject;
 
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
-import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
-import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.StaleElementReferenceException;
@@ -27,17 +27,17 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.FluentWait;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 @Singleton
 public class TestWebElementRenderChecker {
   private final SeleniumWebDriver seleniumWebDriver;
-  private final WebDriverWait loadPageWebDriverWait;
+  private final SeleniumWebDriverHelper seleniumWebDriverHelper;
 
   @Inject
-  public TestWebElementRenderChecker(SeleniumWebDriver seleniumWebDriver) {
+  public TestWebElementRenderChecker(
+      SeleniumWebDriver seleniumWebDriver, SeleniumWebDriverHelper seleniumWebDriverHelper) {
     this.seleniumWebDriver = seleniumWebDriver;
-    this.loadPageWebDriverWait = new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC);
+    this.seleniumWebDriverHelper = seleniumWebDriverHelper;
   }
 
   /**
@@ -117,10 +117,10 @@ public class TestWebElementRenderChecker {
   }
 
   private WebElement waitAndGetWebElement(WebElement webElement) {
-    return loadPageWebDriverWait.until(visibilityOf(webElement));
+    return seleniumWebDriverHelper.waitVisibility(webElement, ELEMENT_TIMEOUT_SEC);
   }
 
   private WebElement waitAndGetWebElement(By locator) {
-    return loadPageWebDriverWait.until(visibilityOfElementLocated(locator));
+    return seleniumWebDriverHelper.waitVisibility(locator, ELEMENT_TIMEOUT_SEC);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateFactoryTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateFactoryTest.java
@@ -228,9 +228,7 @@ public class CreateFactoryTest {
     createFactoryPage.typeFactoryName(FACTORY_NAME_EXIST);
     createFactoryPage.waitErrorMessage(EXIST_NAME_ERROR_MESSAGE);
 
-    assertFalse(
-        createFactoryPage.isCreateFactoryButtonEnabled(),
-        "Known issue https://github.com/eclipse/che/issues/10121");
+    assertTrue(createFactoryPage.isCreateFactoryButtonEnabled());
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateFactoryTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateFactoryTest.java
@@ -228,7 +228,7 @@ public class CreateFactoryTest {
     createFactoryPage.typeFactoryName(FACTORY_NAME_EXIST);
     createFactoryPage.waitErrorMessage(EXIST_NAME_ERROR_MESSAGE);
 
-    assertTrue(createFactoryPage.isCreateFactoryButtonEnabled());
+    assertFalse(createFactoryPage.isCreateFactoryButtonEnabled());
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/AddWorkspaceToOrganizationTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.che.selenium.pageobject.dashboard.NavigationBar.MenuIt
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
@@ -30,7 +29,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationLi
 import org.eclipse.che.selenium.pageobject.dashboard.organization.OrganizationPage;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
-import org.openqa.selenium.WebDriverException;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -152,13 +150,7 @@ public class AddWorkspaceToOrganizationTest {
     organizationPage.clickOnWorkspacesTab();
     workspaces.waitWorkspaceIsPresent(WORKSPACE_FOR_MEMBER_1);
     workspaces.selectWorkspaceItemName(WORKSPACE_FOR_MEMBER_1);
-
-    try {
-      workspaceDetails.waitToolbarTitleName(WORKSPACE_FOR_MEMBER_1);
-    } catch (WebDriverException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/9148", ex);
-    }
+    workspaceDetails.waitToolbarTitleName(WORKSPACE_FOR_MEMBER_1);
   }
 
   private void createWorkspace(String organizationName, String workspaceName) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -41,7 +41,6 @@ import static org.openqa.selenium.Keys.ARROW_DOWN;
 import static org.openqa.selenium.Keys.ARROW_UP;
 import static org.openqa.selenium.Keys.ESCAPE;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.util.List;
@@ -52,7 +51,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -455,13 +453,7 @@ public class NewWorkspacePageTest {
     newWorkspace.clickOnQuickStartButton();
     newWorkspace.waitStacksOrder(expectedQuickStartStacksOrder);
     newWorkspace.clickNameButton();
-
-    try {
-      newWorkspace.waitStacksOrder(expectedQuickStartStacksReverseOrder);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che/issues/5650", ex);
-    }
+    newWorkspace.waitStacksOrder(expectedQuickStartStacksReverseOrder);
 
     newWorkspace.clickNameButton();
     newWorkspace.waitStacksOrder(expectedQuickStartStacksOrder);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/NodeJsDebugTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/NodeJsDebugTest.java
@@ -83,7 +83,14 @@ public class NodeJsDebugTest {
         TestMenuCommandsConstants.Run.RUN_MENU,
         TestMenuCommandsConstants.Run.DEBUG,
         TestMenuCommandsConstants.Run.DEBUG + "/" + nameOfDebugCommand);
-    notifications.waitExpectedMessageOnProgressPanelAndClosed("Remote debugger connected");
+
+    try {
+      notifications.waitExpectedMessageOnProgressPanelAndClosed("Remote debugger connected");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10728");
+    }
+
     editorPageObj.waitTabFileWithSavedStatus(APP_FILE);
     editorPageObj.waitActive();
     debugPanel.waitDebugHighlightedText("/*");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
@@ -116,10 +116,9 @@ public class CreateFactoryFromUiWithKeepDirTest {
     // TODO sometimes after importing project doest not open to keep folder. Need investigate later
     try {
       projectExplorer.openItemByPath(PROJECT_NAME + "/" + KEEPED_DIR);
-    } catch (Exception e) {
-      LOG.error(e.getLocalizedMessage(), e);
-      projectExplorer.openItemByPath(PROJECT_NAME);
-      projectExplorer.openItemByPath(PROJECT_NAME + "/" + KEEPED_DIR);
+    } catch (TimeoutException e) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10852", e);
     }
 
     events.clickEventLogBtn();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
@@ -175,14 +175,9 @@ public class WorkingWithTerminalTest {
   public void shouldResizeTerminal() {
     openMC("/");
 
-    try {
-      // check the root content of the midnight commander
-      for (String partOfContent : CHECK_MC_OPENING) {
-        terminal.waitTextInFirstTerminal(partOfContent);
-      }
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che-lib/issues/57", ex);
+    // check the root content of the midnight commander
+    for (String partOfContent : CHECK_MC_OPENING) {
+      terminal.waitTextInFirstTerminal(partOfContent);
     }
 
     terminal.waitNoTextInFirstTerminal(".dockerenv");
@@ -191,12 +186,7 @@ public class WorkingWithTerminalTest {
 
     // check resize of the terminal
     for (String partOfContent : CHECK_MC_OPENING) {
-      try {
-        terminal.waitTextInFirstTerminal(partOfContent);
-      } catch (TimeoutException ex) {
-        // remove try-catch block after issue has been resolved
-        fail("Known issue https://github.com/eclipse/che-lib/issues/57");
-      }
+      terminal.waitTextInFirstTerminal(partOfContent);
     }
 
     terminal.waitTextInFirstTerminal(".dockerenv");
@@ -222,14 +212,9 @@ public class WorkingWithTerminalTest {
     terminal.typeIntoActiveTerminal(Keys.ARROW_DOWN.toString());
     terminal.typeIntoActiveTerminal(Keys.ENTER.toString());
 
-    try {
-      // check the home content of the midnight commander
-      for (String partOfContent : CHECK_MC_OPENING) {
-        terminal.waitTextInFirstTerminal(partOfContent);
-      }
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue https://github.com/eclipse/che-lib/issues/57", ex);
+    // check the home content of the midnight commander
+    for (String partOfContent : CHECK_MC_OPENING) {
+      terminal.waitTextInFirstTerminal(partOfContent);
     }
 
     terminal.typeIntoActiveTerminal(Keys.F10.toString());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
@@ -171,9 +171,14 @@ public class WorkingWithTerminalTest {
   public void shouldResizeTerminal() {
     openMC("/");
 
-    // check the root content of the midnight commander
-    for (String partOfContent : CHECK_MC_OPENING) {
-      terminal.waitTextInFirstTerminal(partOfContent);
+    try {
+      // check the root content of the midnight commander
+      for (String partOfContent : CHECK_MC_OPENING) {
+        terminal.waitTextInFirstTerminal(partOfContent);
+      }
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10854", ex);
     }
 
     terminal.waitNoTextInFirstTerminal(".dockerenv");
@@ -182,7 +187,12 @@ public class WorkingWithTerminalTest {
 
     // check resize of the terminal
     for (String partOfContent : CHECK_MC_OPENING) {
-      terminal.waitTextInFirstTerminal(partOfContent);
+      try {
+        terminal.waitTextInFirstTerminal(partOfContent);
+      } catch (TimeoutException ex) {
+        // remove try-catch block after issue has been resolved
+        fail("Known issue https://github.com/eclipse/che/issues/10854");
+      }
     }
 
     terminal.waitTextInFirstTerminal(".dockerenv");
@@ -208,9 +218,14 @@ public class WorkingWithTerminalTest {
     terminal.typeIntoActiveTerminal(Keys.ARROW_DOWN.toString());
     terminal.typeIntoActiveTerminal(Keys.ENTER.toString());
 
-    // check the home content of the midnight commander
-    for (String partOfContent : CHECK_MC_OPENING) {
-      terminal.waitTextInFirstTerminal(partOfContent);
+    try {
+      // check the home content of the midnight commander
+      for (String partOfContent : CHECK_MC_OPENING) {
+        terminal.waitTextInFirstTerminal(partOfContent);
+      }
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue https://github.com/eclipse/che/issues/10854", ex);
     }
 
     terminal.typeIntoActiveTerminal(Keys.F10.toString());


### PR DESCRIPTION
### What does this PR do?
This PR:
- removes info about next resolved issues from selenium tests - https://github.com/eclipse/che/issues/5650, https://github.com/eclipse/che/issues/9148, https://github.com/eclipse/che/issues/10121, https://github.com/eclipse/che-lib/issues/57 (https://github.com/eclipse/che/issues/10848);
- increase timeout for checking that "**Workspace is Created**" form on the **New Workspaces** page opened(https://github.com/eclipse/che/issues/10849);
- increase timeout for unstable **SwaggerTest**;
- add info about known https://github.com/eclipse/che/issues/10852 issue to **CreateFactoryFromUiWithKeepDirTest** test.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10848, https://github.com/eclipse/che/issues/10849
