### PR TITLE
Stabilize selenium test UploadIntoProjectTest

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/UploadIntoProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/UploadIntoProjectTest.java
@@ -71,7 +71,7 @@ public class UploadIntoProjectTest {
         ProjectTemplates.MAVEN_SPRING);
 
     ide.open(testWorkspace);
-    projectExplorer.waitVisibleItem(PROJECT_NAME);
+    projectExplorer.waitProjectInitialization(PROJECT_NAME);
   }
 
   @BeforeMethod

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromSpringBootStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromSpringBootStackTest.java
@@ -21,7 +21,6 @@ import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.RUN_C
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.BUILD_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.DEBUG_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.RUN_GOAL;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.SPRING_BOOT;
 
 import com.google.common.collect.ImmutableList;
@@ -72,7 +71,7 @@ public class CreateWorkspaceFromSpringBootStackTest {
     createWorkspaceHelper.createWorkspaceFromStackWithProjects(
         SPRING_BOOT, WORKSPACE_NAME, projects);
 
-    ide.switchToIdeAndWaitWorkspaceIsReadyToUse(APPLICATION_START_TIMEOUT_SEC);
+    ide.switchToIdeAndWaitWorkspaceIsReadyToUse();
 
     projectExplorer.waitProjectInitialization(SPRING_BOOT_HEALTH_CHECK_PROJECT);
     projectExplorer.waitProjectInitialization(SPRING_BOOT_HTTP_PROJECT);


### PR DESCRIPTION
### What does this PR do?
It stabilize selenium test **UploadIntoProjectTest** which sometimes fails on the command `projectExplorer.waitVisibleItem(PROJECT_NAME);` like it was [in this execution](https://ci.codenvycorp.com/view/qa/job/che-integration-tests-master-ocp/354/testReport/org.eclipse.che.selenium.projectexplorer/UploadIntoProjectTest/shouldUploadDirectoryWithDefaultOptions/). 