### PR TITLE
Show meaningful message when we cannot authenticate user (due to absend email or other error)

### DIFF
--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -64,10 +64,10 @@ function buildKeycloakConfig(keycloakSettings: any): any {
   }
 }
 interface IResolveFn<T> {
-  (value: T | PromiseLike<T>): Promise<T>;
+  (value?: T | PromiseLike<T>): void;
 }
 interface IRejectFn<T> {
-  (reason: any): Promise<T>;
+  (reason?: any): void;
 }
 function keycloakLoad(keycloakSettings: any) {
   return new Promise((resolve: IResolveFn<any>, reject: IRejectFn<any>) => {
@@ -91,6 +91,46 @@ function keycloakInit(keycloakConfig: any, theUseNonce: boolean) {
       reject(error);
     });
   });
+}
+function setAuthorizationHeader(xhr: XMLHttpRequest, keycloak: any): Promise<any> {
+  return new Promise((resolve: IResolveFn<any>, reject: IRejectFn<any>) => {
+    if (keycloak && keycloak.token) {
+      keycloak.updateToken(5).success(() => {
+        xhr.setRequestHeader('Authorization', 'Bearer ' + keycloak.token);
+        resolve(xhr);
+      }).error(() => {
+        console.log('Failed to refresh token');
+        keycloak.login();
+        reject('Authorization is needed.');
+      });
+      return;
+    }
+
+    resolve(xhr);
+  });
+}
+function getApis(keycloak: any): Promise<void> {
+  const request = new XMLHttpRequest();
+  request.open('GET', '/api');
+  return setAuthorizationHeader(request, keycloak).then((xhr: XMLHttpRequest) => {
+    return new Promise<void>((resolve: IResolveFn<void>, reject: IRejectFn<void>) => {
+      xhr.send();
+      xhr.onreadystatechange = () => {
+        if (xhr.readyState !== 4) { return; }
+        if (xhr.status === 200) {
+          resolve();
+        } else {
+          reject(xhr.statusText ? xhr.statusText : 'Unknown error');
+        }
+      };
+    });
+  });
+}
+function showErrorMessage(errorMessage: string) {
+  const div = document.createElement('p');
+  div.className = 'authorization-error';
+  div.innerHTML = errorMessage + '<br/>Click <a href="/">here</a> to reload page.';
+  document.querySelector('.main-page-loader').appendChild(div);
 }
 
 const keycloakAuth = {
@@ -125,7 +165,15 @@ angular.element(document).ready(() => {
   }).catch((error: any) => {
     console.error('Keycloak initialization failed with error: ', error);
   }).then(() => {
+    const keycloak = (window as any)._keycloak;
+    // try to reach the API
+    // to check if user is authorized to do that
+    return getApis(keycloak);
+  }).then(() => {
     (angular as any).resumeBootstrap();
+  }).catch((error: string) => {
+    console.error(`Can't GET "/api". ${error ? 'Error: ' : ''}`, error);
+    showErrorMessage(error);
   });
 });
 

--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -120,7 +120,7 @@ function getApis(keycloak: any): Promise<void> {
         if (xhr.status === 200) {
           resolve();
         } else {
-          reject(xhr.statusText ? xhr.statusText : 'Unknown error');
+          reject(xhr.responseText ? xhr.responseText : 'Unknown error');
         }
       };
     });

--- a/dashboard/src/app/index.styl
+++ b/dashboard/src/app/index.styl
@@ -254,3 +254,11 @@ md-tabs-wrapper
   font-family 'Open Sans'
   font-size 12px
   border-radius 2px
+
+.authorization-error
+  color: $error-color
+  font-weight: 600
+  width: 100%
+  text-align: center
+  position: absolute
+  top: 50%

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilter.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilter.java
@@ -12,10 +12,13 @@
 package org.eclipse.che.multiuser.keycloak.server;
 
 import io.jsonwebtoken.JwtParser;
+import java.io.IOException;
 import javax.inject.Inject;
 import javax.servlet.Filter;
 import javax.servlet.FilterConfig;
+import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * Base abstract class for the Keycloak-related servlet filters.
@@ -46,4 +49,10 @@ public abstract class AbstractKeycloakFilter implements Filter {
 
   @Override
   public void destroy() {}
+
+  protected void sendError(ServletResponse res, int errorCode, String message) throws IOException {
+    HttpServletResponse response = (HttpServletResponse) res;
+    response.getOutputStream().write(message.getBytes());
+    response.setStatus(errorCode);
+  }
 }

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakAuthenticationFilter.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakAuthenticationFilter.java
@@ -23,7 +23,6 @@ import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import org.eclipse.che.commons.auth.token.RequestTokenExtractor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +46,7 @@ public class KeycloakAuthenticationFilter extends AbstractKeycloakFilter {
 
     final String token = tokenExtractor.getToken(request);
     if (token == null) {
-      send401(res, "Authorization token is missed");
+      sendError(res, 401, "Authorization token is missed");
       return;
     }
 
@@ -61,19 +60,13 @@ public class KeycloakAuthenticationFilter extends AbstractKeycloakFilter {
       LOG.debug("JWT = ", jwt);
       // OK, we can trust this JWT
     } catch (ExpiredJwtException e) {
-      send401(res, "The specified token is expired");
+      sendError(res, 401, "The specified token is expired");
       return;
     } catch (JwtException e) {
-      send401(res, "Token validation failed: " + e.getMessage());
+      sendError(res, 401, "Token validation failed: " + e.getMessage());
       return;
     }
     request.setAttribute("token", jwt);
     chain.doFilter(req, res);
-  }
-
-  private void send401(ServletResponse res, String message) throws IOException {
-    HttpServletResponse response = (HttpServletResponse) res;
-    response.getOutputStream().write(message.getBytes());
-    response.setStatus(401);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add fix to show meaningful message when we cannot authenticate user (due to absend email or other error).  That means Che authentication, not Keycloak one (those errors are shown on login page)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10768



#### Release Notes
N/A


#### Docs PR
https://github.com/eclipse/che-docs/pull/464

![screenshot_20180823_135944](https://user-images.githubusercontent.com/1651062/44521751-d4eb3380-a6dc-11e8-90bd-f6051616467e.png)
