### PR TITLE
New folders do not register in the jdt.ls workspace #10115

### DIFF
--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/pom.xml
@@ -39,6 +39,14 @@
             <artifactId>commons-io</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
@@ -85,6 +93,10 @@
         <dependency>
             <groupId>org.eclipse.che.plugin</groupId>
             <artifactId>che-plugin-java-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.lsp4j</groupId>
+            <artifactId>org.eclipse.lsp4j</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/main/java/org/eclipse/che/plugin/java/plain/server/inject/PlainJavaProjectModule.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/main/java/org/eclipse/che/plugin/java/plain/server/inject/PlainJavaProjectModule.java
@@ -32,5 +32,6 @@ public class PlainJavaProjectModule extends AbstractModule {
     newSetBinder(binder(), ProjectHandler.class).addBinding().to(PlainJavaInitHandler.class);
 
     bind(ClasspathUpdaterService.class);
+    bind(PlainJavaProjectSourceFolderWatcher.class).asEagerSingleton();
   }
 }

--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/main/java/org/eclipse/che/plugin/java/plain/server/inject/PlainJavaProjectSourceFolderWatcher.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/main/java/org/eclipse/che/plugin/java/plain/server/inject/PlainJavaProjectSourceFolderWatcher.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.java.plain.server.inject;
+
+import static java.nio.file.Files.isDirectory;
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.languageserver.LanguageServiceUtils.prefixURI;
+import static org.eclipse.che.api.languageserver.LanguageServiceUtils.removeUriScheme;
+import static org.eclipse.che.jdt.ls.extension.api.Commands.GET_PROJECT_SOURCE_LOCATIONS_COMMAND;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import java.lang.reflect.Type;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.languageserver.ExtendedLanguageServer;
+import org.eclipse.che.api.languageserver.FindServer;
+import org.eclipse.che.api.project.server.notification.ProjectUpdatedEvent;
+import org.eclipse.che.api.watcher.server.FileWatcherManager;
+import org.eclipse.che.api.watcher.server.impl.FileWatcherByPathMatcher;
+import org.eclipse.che.plugin.java.inject.JavaModule;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.services.LanguageServer;
+
+/**
+ * Reports the create/update/delete changes on project source folders to jdt.ls
+ *
+ * @author V. Rubezhny
+ */
+public class PlainJavaProjectSourceFolderWatcher {
+  private static final Gson gson =
+      new GsonBuilder().disableHtmlEscaping().serializeNulls().create();
+
+  private final FileWatcherManager manager;
+  private final FileWatcherByPathMatcher matcher;
+  private final FindServer lsRegistry;
+
+  private final EventService eventService;
+
+  private final CopyOnWriteArrayList<Integer> watcherIds = new CopyOnWriteArrayList<>();
+
+  @Inject
+  public PlainJavaProjectSourceFolderWatcher(
+      FileWatcherManager manager,
+      FileWatcherByPathMatcher matcher,
+      FindServer lsRegistry,
+      EventService eventService) {
+    this.manager = manager;
+    this.matcher = matcher;
+    this.lsRegistry = lsRegistry;
+    this.eventService = eventService;
+  }
+
+  @PostConstruct
+  protected void startWatchers() {
+    int watcherId =
+        manager.registerByMatcher(
+            folderMatcher(),
+            s -> report(s, FileChangeType.Created),
+            s -> {},
+            s -> report(s, FileChangeType.Deleted));
+
+    watcherIds.add(watcherId);
+    eventService.subscribe(this::onProjectUpdated, ProjectUpdatedEvent.class);
+  }
+
+  @PreDestroy
+  public void stopWatchers() {
+    watcherIds.stream().forEach(id -> manager.unRegisterByMatcher(id));
+  }
+
+  private void onProjectUpdated(ProjectUpdatedEvent event) {
+    ExecuteCommandParams params =
+        new ExecuteCommandParams(
+            GET_PROJECT_SOURCE_LOCATIONS_COMMAND, singletonList(prefixURI(event.getProjectPath())));
+
+    ExtendedLanguageServer languageServer = lsRegistry.byId(JavaModule.LS_ID);
+    if (languageServer == null) {
+      return;
+    }
+
+    languageServer
+        .getServer()
+        .getWorkspaceService()
+        .executeCommand(params)
+        .thenAccept(
+            result -> {
+              if (result == null) {
+                return;
+              }
+              Type type = new TypeToken<ArrayList<String>>() {}.getType();
+              List<String> paths = gson.fromJson(gson.toJson(result), type);
+              paths.stream().forEach(f -> matcher.accept(Paths.get(removeUriScheme(prefixURI(f)))));
+            });
+  }
+
+  private PathMatcher folderMatcher() {
+    return it -> isDirectory(it);
+  }
+
+  private void report(String path, FileChangeType changeType) {
+    ExtendedLanguageServer languageServer = lsRegistry.byId(JavaModule.LS_ID);
+    if (languageServer != null) {
+      send(languageServer.getServer(), path, changeType);
+    }
+  }
+
+  private void send(LanguageServer server, String path, FileChangeType changeType) {
+    DidChangeWatchedFilesParams params =
+        new DidChangeWatchedFilesParams(
+            Collections.singletonList(new FileEvent(prefixURI(path), changeType)));
+    server.getWorkspaceService().didChangeWatchedFiles(params);
+  }
+}

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/plainjava/PlainJavaProjectConfigureClasspathTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/plainjava/PlainJavaProjectConfigureClasspathTest.java
@@ -30,6 +30,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.ConfigureClasspath;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -64,6 +65,7 @@ public class PlainJavaProjectConfigureClasspathTest {
   @Inject private Loader loader;
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
+  @Inject private Consoles consoles;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -75,6 +77,7 @@ public class PlainJavaProjectConfigureClasspathTest {
     testProjectServiceClient.importProject(
         ws.getId(), Paths.get(resource.toURI()), LIB_PROJECT, ProjectTemplates.PLAIN_JAVA);
     ide.open(ws);
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test


### PR DESCRIPTION
This adds the reporting creation/modification/deletion of source folders to jdt.ls

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fix adds a listener for changes inside source folders (Create/Update/Delete) in order to report them to jds.ls.

![ls10115-part2](https://user-images.githubusercontent.com/620781/44527230-86db2d80-a6e6-11e8-9429-c985f41da542.gif)

### What issues does this PR fix or reference?

Fixes eclipse/che#10115
Depends on eclipse/che-ls-jdt#70
Depends on eclipse/eclipse.jdt.ls#755

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
