### PR TITLE
Don't skip maven site plugin in selenium tests

### DIFF
--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -184,6 +184,13 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <configuration>
@@ -299,7 +306,7 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>unpack-depedency</id>
+                        <id>unpack-dependency</id>
                         <phase>process-test-resources</phase>
                         <goals>
                             <goal>unpack-dependencies</goal>


### PR DESCRIPTION
### What does this PR do?
It enables maven site plugin to generate **target/site/css** and **target/site/js** directories which is needed for test report html page.

### What issues does this PR fix or reference?
#10257