### PR TITLE
Selenium: Change the timeout to resolve dependencies in the 'ImportAndValidateEclipseCheProjectTest'

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/ImportAndValidateEclipseCheProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/ImportAndValidateEclipseCheProjectTest.java
@@ -82,7 +82,7 @@ public class ImportAndValidateEclipseCheProjectTest {
   @Test
   public void checkImportAndResolveDependenciesEclipceCheProject() {
     final int timeoutToOpenInfoPanel = 120;
-    final int timeoutToClosingInfoPanel = 2900;
+    final int timeoutToClosingInfoPanel = 5400;
 
     // import the eclipse-che project
     projectExplorer.waitProjectExplorer();


### PR DESCRIPTION
### What does this PR do?
* This PR increases the timeout to resolve dependencies in the selenium test _ImportAndValidateEclipseCheProjectTest_

### What issues does this PR fix or reference?
#10897 