### PR TITLE
Make Che logging variables configurable via helm

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -70,7 +70,14 @@ data:
   CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"kubernetes.io/ingress.class": "nginx", "{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/rewrite-target": "/","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/ssl-redirect": "false","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout": "3600","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout": "3600"}'
 {{- end }}
   CHE_INFRA_KUBERNETES_SERVER__STRATEGY: {{ .Values.global.serverStrategy }}
+{{- if .Values.global.log.loggerConfig }}
+  CHE_LOGGER_CONFIG: {{ .Values.global.log.loggerConfig }}
+{{- end }}
+{{- if .Values.global.log.customAppenderName }}
+  CHE_LOGS_APPENDERS_IMPL: {{ .Values.global.log.customAppenderName }}
+{{- else }}
   CHE_LOGS_APPENDERS_IMPL: "plaintext"
+{{- end }}
   CHE_WORKSPACE_HTTP__PROXY: {{ .Values.cheWorkspaceHttpProxy }}
   CHE_WORKSPACE_HTTPS__PROXY: {{ .Values.cheWorkspaceHttpsProxy }}
   CHE_WORKSPACE_NO__PROXY: {{ .Values.cheWorkspaceNoProxy }}

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -73,11 +73,7 @@ data:
 {{- if .Values.global.log.loggerConfig }}
   CHE_LOGGER_CONFIG: {{ .Values.global.log.loggerConfig }}
 {{- end }}
-{{- if .Values.global.log.customAppenderName }}
-  CHE_LOGS_APPENDERS_IMPL: {{ .Values.global.log.customAppenderName }}
-{{- else }}
-  CHE_LOGS_APPENDERS_IMPL: "plaintext"
-{{- end }}
+  CHE_LOGS_APPENDERS_IMPL: {{ .Values.global.log.appenderName }}
   CHE_WORKSPACE_HTTP__PROXY: {{ .Values.cheWorkspaceHttpProxy }}
   CHE_WORKSPACE_HTTPS__PROXY: {{ .Values.cheWorkspaceHttpsProxy }}
   CHE_WORKSPACE_NO__PROXY: {{ .Values.cheWorkspaceNoProxy }}

--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -245,6 +245,11 @@ spec:
             configMapKeyRef:
               key: CHE_LOGS_APPENDERS_IMPL
               name: che
+        - name: CHE_LOGGER_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              key: CHE_LOGGER_CONFIG
+              name: che
         - name: CHE_WORKSPACE_HTTP__PROXY
           valueFrom:
             configMapKeyRef:

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -46,4 +46,4 @@ global:
   workspaceIdleTimeout: "-1"
   log:
     loggerConfig: ""
-    customAppenderName: ""
+    appenderName: "plaintext"

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -44,3 +44,6 @@ global:
   pvcClaim: "1Gi"
   cheWorkspacesNamespace: ""
   workspaceIdleTimeout: "-1"
+  log:
+    loggerConfig: ""
+    customAppenderName: ""


### PR DESCRIPTION
### What does this PR do?

This PR allows for che6 helm installations to specify a value for the CHE_LOGGER_CONFIG env variable which allows setting different log levels of different packages.
It also allows to specify a name of a custom appender using CHE_LOGS_APPENDERS_IMPL. as is documented in the following page: https://www.eclipse.org/che/docs/logging.html