### PR TITLE
Added subject propagation during WebSocket methods calls

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterServletModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterServletModule.java
@@ -63,8 +63,7 @@ public class WsMasterServletModule extends ServletModule {
   }
 
   private void configureMultiUserMode() {
-    // Not contains '/websocket/' and not ends with '/ws' or '/eventbus'
-    filterRegex("^(?!.*/websocket/)(?!.*(/ws|/eventbus)$).*").through(MachineLoginFilter.class);
+    filterRegex(".*").through(MachineLoginFilter.class);
     install(new KeycloakServletModule());
   }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideRequestProcessor.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideRequestProcessor.java
@@ -22,6 +22,7 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessor;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
+import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
 
 @Singleton
 public class ServerSideRequestProcessor implements RequestProcessor {
@@ -55,6 +56,6 @@ public class ServerSideRequestProcessor implements RequestProcessor {
 
   @Override
   public void process(Runnable runnable) {
-    executorService.execute(runnable);
+    executorService.execute(ThreadLocalPropagateContext.wrap(runnable));
   }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/GuiceInjectorEndpointConfigurator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/GuiceInjectorEndpointConfigurator.java
@@ -13,6 +13,9 @@ package org.eclipse.che.api.core.websocket.impl;
 
 import com.google.inject.Injector;
 import javax.inject.Inject;
+import javax.servlet.http.HttpSession;
+import javax.websocket.HandshakeResponse;
+import javax.websocket.server.HandshakeRequest;
 import javax.websocket.server.ServerEndpointConfig;
 
 /**
@@ -25,5 +28,15 @@ public class GuiceInjectorEndpointConfigurator extends ServerEndpointConfig.Conf
 
   public <T> T getEndpointInstance(Class<T> endpointClass) {
     return injector.getInstance(endpointClass);
+  }
+
+  @Override
+  public void modifyHandshake(
+      ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response) {
+    HttpSession httpSession = (HttpSession) request.getHttpSession();
+    Object sessionSubject = httpSession.getAttribute("che_subject");
+    if (sessionSubject != null) {
+      sec.getUserProperties().put("che_subject", sessionSubject);
+    }
   }
 }

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilter.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilter.java
@@ -17,7 +17,6 @@ import javax.inject.Inject;
 import javax.servlet.Filter;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 /**
@@ -31,11 +30,7 @@ public abstract class AbstractKeycloakFilter implements Filter {
   @Inject protected JwtParser jwtParser;
 
   /** when a request came from a machine with valid token then auth is not required */
-  boolean shouldSkipAuthentication(HttpServletRequest request, String token) {
-    if (token == null) {
-      return request.getRequestURI() != null
-          && request.getRequestURI().endsWith("api/keycloak/OIDCKeycloak.js");
-    }
+  boolean shouldSkipAuthentication(String token) {
     try {
       jwtParser.parse(token);
       return false;

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakAuthenticationFilter.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakAuthenticationFilter.java
@@ -52,7 +52,7 @@ public class KeycloakAuthenticationFilter extends AbstractKeycloakFilter {
 
     Jws<Claims> jwt;
     try {
-      if (shouldSkipAuthentication(request, token)) {
+      if (shouldSkipAuthentication(token)) {
         chain.doFilter(req, res);
         return;
       }

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakEnvironmentInitalizationFilter.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakEnvironmentInitalizationFilter.java
@@ -68,7 +68,7 @@ public class KeycloakEnvironmentInitalizationFilter extends AbstractKeycloakFilt
 
     final HttpServletRequest httpRequest = (HttpServletRequest) request;
     final String token = tokenExtractor.getToken(httpRequest);
-    if (shouldSkipAuthentication(httpRequest, token)) {
+    if (shouldSkipAuthentication(token)) {
       filterChain.doFilter(request, response);
       return;
     }

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/deploy/KeycloakServletModule.java
@@ -19,18 +19,25 @@ import org.eclipse.che.multiuser.keycloak.server.KeycloakEnvironmentInitalizatio
 import org.eclipse.che.multiuser.keycloak.server.UnavailableResourceInMultiUserFilter;
 
 public class KeycloakServletModule extends ServletModule {
+
+  private static final String KEYCLOAK_FILTER_PATHS =
+      "^"
+          // not equals to /keycloak/OIDCKeycloak.js
+          + "(?!/keycloak/OIDCKeycloak.js)"
+          // not contains /docs/ (for swagger)
+          + "(?!.*(/docs/))"
+          // not ends with '/oauth/callback/' or '/keycloak/settings/' or '/system/state'
+          + "(?!.*(/keycloak/settings/?|/oauth/callback/?|/system/state/?)$)"
+          // all other
+          + ".*";
+
   @Override
   protected void configureServlets() {
     bind(KeycloakAuthenticationFilter.class).in(Singleton.class);
 
-    // Not contains /docs/ (for swagger) and not ends with '/oauth/callback/' or
-    // '/keycloak/settings/' or '/system/state'
-    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/oauth/callback/?|/system/state/?)$).*")
-        .through(KeycloakAuthenticationFilter.class);
-    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/oauth/callback/?|/system/state/?)$).*")
-        .through(KeycloakEnvironmentInitalizationFilter.class);
-    filterRegex("^(?!.*(/docs/))(?!.*(/keycloak/settings/?|/api/oauth/callback/?)$).*")
-        .through(IdentityIdLoggerFilter.class);
+    filterRegex(KEYCLOAK_FILTER_PATHS).through(KeycloakAuthenticationFilter.class);
+    filterRegex(KEYCLOAK_FILTER_PATHS).through(KeycloakEnvironmentInitalizationFilter.class);
+    filterRegex(KEYCLOAK_FILTER_PATHS).through(IdentityIdLoggerFilter.class);
 
     // Ban change password (POST /user/password) and create a user (POST /user/) methods
     // but not remove user (DELETE /user/{USER_ID}

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/test/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilterTest.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/test/java/org/eclipse/che/multiuser/keycloak/server/AbstractKeycloakFilterTest.java
@@ -50,27 +50,21 @@ public class AbstractKeycloakFilterTest {
   }
 
   @Test
-  public void testShouldSkipAuthWhenRetrievingOIDCKeycloakJsFile() {
-    when(request.getRequestURI()).thenReturn("https://localhost:8080/api/keycloak/OIDCKeycloak.js");
-    assertTrue(abstractKeycloakFilter.shouldSkipAuthentication(request, null));
-  }
-
-  @Test
   public void testShouldNotSkipAuthWhenNullTokenProvided() {
-    assertFalse(abstractKeycloakFilter.shouldSkipAuthentication(request, null));
+    assertFalse(abstractKeycloakFilter.shouldSkipAuthentication(null));
   }
 
   @Test
   public void testShouldNotSkipAuthWhenProvidedTokenIsNotMachine() {
     Jwt mock = Mockito.mock(Jwt.class);
     doReturn(mock).when(jwtParser).parse(anyString());
-    assertFalse(abstractKeycloakFilter.shouldSkipAuthentication(request, "token"));
+    assertFalse(abstractKeycloakFilter.shouldSkipAuthentication("token"));
   }
 
   @Test
   public void testAuthIsNotNeededWhenMachineTokenProvided() {
     when(jwtParser.parse(anyString())).thenThrow(MachineTokenJwtException.class);
-    assertTrue(abstractKeycloakFilter.shouldSkipAuthentication(request, "token"));
+    assertTrue(abstractKeycloakFilter.shouldSkipAuthentication("token"));
   }
 
   static class TestLoginFilter extends AbstractKeycloakFilter {

--- a/multiuser/machine-auth/che-multiuser-machine-authentication-agent/src/main/java/org/eclipse/che/multiuser/machine/authentication/agent/MachineLoginFilter.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-agent/src/main/java/org/eclipse/che/multiuser/machine/authentication/agent/MachineLoginFilter.java
@@ -79,7 +79,8 @@ public class MachineLoginFilter implements Filter {
 
     // sets subject from session
     final Subject sessionSubject;
-    if (session != null && (sessionSubject = (Subject) session.getAttribute("principal")) != null) {
+    if (session != null
+        && (sessionSubject = (Subject) session.getAttribute("che_subject")) != null) {
       try {
         EnvironmentContext.getCurrent().setSubject(sessionSubject);
         chain.doFilter(request, response);
@@ -115,7 +116,7 @@ public class MachineLoginFilter implements Filter {
                 false);
         EnvironmentContext.getCurrent().setSubject(subject);
         final HttpSession httpSession = httpRequest.getSession(true);
-        httpSession.setAttribute("principal", subject);
+        httpSession.setAttribute("che_subject", subject);
         chain.doFilter(request, response);
       } finally {
         EnvironmentContext.reset();

--- a/multiuser/machine-auth/che-multiuser-machine-authentication-agent/src/test/java/org/eclipse/che/multiuser/machine/authentication/agent/MachineLoginFilterTest.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication-agent/src/test/java/org/eclipse/che/multiuser/machine/authentication/agent/MachineLoginFilterTest.java
@@ -59,7 +59,7 @@ public class MachineLoginFilterTest {
 
   private static final String SIGNATURE_ALGORITHM = "RSA";
   private static final String WORKSPACE_ID = "workspace31";
-  private static final String PRINCIPAL = "principal";
+  private static final String SUBJECT = "che_subject";
   private static final String USER_ID = "test_user31";
   private static final String USER_NAME = "test_user";
 
@@ -105,11 +105,11 @@ public class MachineLoginFilterTest {
 
   @Test
   public void testProcessRequestWithSubjectFromSession() throws Exception {
-    when(sessionMock.getAttribute(PRINCIPAL)).thenReturn(subject);
+    when(sessionMock.getAttribute(SUBJECT)).thenReturn(subject);
 
     machineLoginFilter.doFilter(getRequestMock(sessionMock, machineToken), responseMock, chainMock);
 
-    verify(sessionMock).getAttribute(PRINCIPAL);
+    verify(sessionMock).getAttribute(SUBJECT);
     verifyZeroInteractions(tokenExtractorMock);
   }
 
@@ -129,7 +129,7 @@ public class MachineLoginFilterTest {
     machineLoginFilter.doFilter(getRequestMock(null, machineToken), responseMock, chainMock);
 
     verify(tokenExtractorMock).getToken(any(HttpServletRequest.class));
-    verify(sessionMock).setAttribute(PRINCIPAL, subject);
+    verify(sessionMock).setAttribute(SUBJECT, subject);
     verifyZeroInteractions(responseMock);
   }
 

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineLoginFilter.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineLoginFilter.java
@@ -33,6 +33,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.user.server.UserManager;
@@ -83,21 +84,24 @@ public class MachineLoginFilter implements Filter {
     }
     // check token signature and verify is this token machine or not
     try {
-      final Claims claims = jwtParser.parseClaimsJws(token).getBody();
+      HttpSession session = ((HttpServletRequest) request).getSession(true);
+      Subject sessionSubject = (Subject) session.getAttribute("che_subject");
+      if (sessionSubject == null || !sessionSubject.getToken().equals(token)) {
+        try {
+          sessionSubject = extractSubject(token);
+          session.setAttribute("che_subject", sessionSubject);
+        } catch (NotFoundException e) {
+          sendErr(
+              response,
+              SC_UNAUTHORIZED,
+              "Authentication with machine token failed because user for this token no longer exist.");
+          return;
+        }
+      }
+
       try {
-        final String userId = claims.get(USER_ID_CLAIM, String.class);
-        // check if user with such id exists
-        final String userName = userManager.getById(userId).getName();
-        final Subject authorizedSubject =
-            new AuthorizedSubject(
-                new SubjectImpl(userName, userId, token, false), permissionChecker);
-        EnvironmentContext.getCurrent().setSubject(authorizedSubject);
-        chain.doFilter(addUserInRequest(httpRequest, authorizedSubject), response);
-      } catch (NotFoundException ex) {
-        sendErr(
-            response,
-            SC_UNAUTHORIZED,
-            "Authentication with machine token failed because user for this token no longer exist.");
+        EnvironmentContext.getCurrent().setSubject(sessionSubject);
+        chain.doFilter(addUserInRequest(httpRequest, sessionSubject), response);
       } finally {
         EnvironmentContext.reset();
       }
@@ -110,6 +114,16 @@ public class MachineLoginFilter implements Filter {
           SC_UNAUTHORIZED,
           format("Authentication with machine token failed cause: %s", e.getMessage()));
     }
+  }
+
+  private Subject extractSubject(String token) throws NotFoundException, ServerException {
+    final Claims claims = jwtParser.parseClaimsJws(token).getBody();
+    final String userId = claims.get(USER_ID_CLAIM, String.class);
+    // check if user with such id exists
+    final String userName = userManager.getById(userId).getName();
+
+    return new AuthorizedSubject(
+        new SubjectImpl(userName, userId, token, false), permissionChecker);
   }
 
   /** Sets given error code with err message into give response. */


### PR DESCRIPTION
### What does this PR do?
Adds subject propagation during WebSocket methods calls. It includes:
- Adds storing of Che Subject into http session in MachineLogin filters
- Removes excluding for WebSocket endpoint path from MachineLoginFilter binding;
- Adds settings subject into `EnvironmentContext` during WebSocket methods calls;

It also does the following small fix:
- Moves exclude of OIDCKeycloak.js to mapping instead of Filter class;

### What issues does this PR fix or reference?
It is needed for https://github.com/eclipse/che/issues/10861.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A


#### Docs PR
N/A