### PR TITLE
Fix config initialization

### DIFF
--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerService.java
@@ -43,15 +43,18 @@ class LanguageServerService {
   private final RequestHandlerConfigurator configurator;
   private final LanguageServerInitializer languageServerInitializer;
   private final Registry<String> languageFilterRegistry;
+  private final LanguageServerConfigInitializer configInitializer;
 
   @Inject
   LanguageServerService(
       RequestHandlerConfigurator configurator,
       LanguageServerInitializer languageServerInitializer,
-      RegistryContainer registryContainer) {
+      RegistryContainer registryContainer,
+      LanguageServerConfigInitializer configInitializer) {
     this.configurator = configurator;
     this.languageServerInitializer = languageServerInitializer;
     this.languageFilterRegistry = registryContainer.languageFilterRegistry;
+    this.configInitializer = configInitializer;
   }
 
   @PostConstruct
@@ -75,6 +78,8 @@ class LanguageServerService {
     LOG.debug("Received 'languageServer/getLanguageRegexes' request");
     List<LanguageRegexDto> languageRegexes = newLinkedList();
 
+    configInitializer.initialize();
+
     for (Entry<String, String> entry : languageFilterRegistry.getAll().entrySet()) {
       LanguageRegexDto languageRegexDto = new LanguageRegexDto();
       languageRegexDto.setNamePattern(entry.getValue());
@@ -89,6 +94,8 @@ class LanguageServerService {
   private ServerCapabilitiesDto initialize(String wsPath) {
     try {
       LOG.debug("Received 'languageServer/initialize' request for path: {}", wsPath);
+
+      configInitializer.initialize();
 
       ServerCapabilitiesDto serverCapabilitiesDto =
           new ServerCapabilitiesDto(languageServerInitializer.initialize(wsPath).get(1, MINUTES));


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
`LanguageServerConfigInitializer.initialize()` is invoked after workspace is started. It means that client knows nothing about registered language servers and autocomplition doesn't work until page is refreshed.

