### PR TITLE
Added authorization for JsonRpc methods

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -338,6 +338,8 @@ public class WsMasterModule extends AbstractModule {
 
     // Permission filters
     bind(org.eclipse.che.multiuser.permission.system.SystemServicePermissionsFilter.class);
+    bind(
+        org.eclipse.che.multiuser.permission.system.SystemEventsSubscriptionPermissionsCheck.class);
 
     Multibinder<String> binder =
         Multibinder.newSetBinder(binder(), String.class, Names.named(SYSTEM_DOMAIN_ACTIONS));

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMethodInvokerFilter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMethodInvokerFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.jsonrpc.commons;
+
+/**
+ * Is used to check whether Json Rpc method can be invoked. For example, can be used to check
+ * permission before method invocation.
+ *
+ * @author Sergii Leshchenko
+ */
+public interface JsonRpcMethodInvokerFilter {
+
+  /**
+   * Check whether supplied method can be invoked.
+   *
+   * @param method method name that is going to be invoked
+   * @param params actual method parameters
+   * @throws JsonRpcException if method can not be invoked cause current environment context, e.g.
+   *     for current user, with current request attributes, etc. JsonRpcException should contain the
+   *     corresponding message and code.
+   */
+  void accept(String method, Object... params) throws JsonRpcException;
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestHandlerManager.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestHandlerManager.java
@@ -13,6 +13,8 @@ package org.eclipse.che.api.core.jsonrpc.commons;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.List;
@@ -45,6 +47,8 @@ import org.slf4j.Logger;
 @Singleton
 public class RequestHandlerManager {
   private static final Logger LOGGER = getLogger(RequestHandlerManager.class);
+
+  private final Multimap<String, JsonRpcMethodInvokerFilter> filters = ArrayListMultimap.create();
 
   private final Map<String, Category> methodToCategory = new ConcurrentHashMap<>();
   private final Map<String, OneToOneHandler> oneToOneHandlers = new ConcurrentHashMap<>();
@@ -79,6 +83,13 @@ public class RequestHandlerManager {
 
     methodToCategory.put(method, Category.ONE_TO_ONE);
     oneToOneHandlers.put(method, new OneToOneHandler<>(pClass, rClass, biFunction));
+  }
+
+  public synchronized void registerMethodInvokerFilter(
+      JsonRpcMethodInvokerFilter filter, String... methods) {
+    for (String method : methods) {
+      filters.put(method, filter);
+    }
   }
 
   public synchronized <P, R> void registerOneToPromiseOne(
@@ -204,37 +215,31 @@ public class RequestHandlerManager {
     return true;
   }
 
-  public void handle(String endpointId, String requestId, String method, JsonRpcParams params) {
+  public <P, R> void handle(
+      String endpointId, String requestId, String method, JsonRpcParams params) {
     mustBeRegistered(method);
 
     switch (methodToCategory.get(method)) {
       case ONE_TO_ONE:
-        OneToOneHandler oneToOneHandler = oneToOneHandlers.get(method);
-        transmitOne(endpointId, requestId, oneToOneHandler.handle(endpointId, params));
+        oneToOneHandlers.get(method).handle(endpointId, requestId, method, params);
         break;
       case ONE_TO_MANY:
-        OneToManyHandler oneToManyHandler = oneToManyHandlers.get(method);
-        transmitMany(endpointId, requestId, oneToManyHandler.handle(endpointId, params));
+        oneToManyHandlers.get(method).handle(endpointId, requestId, method, params);
         break;
       case MANY_TO_ONE:
-        ManyToOneHandler manyToOneHandler = manyToOneHandlers.get(method);
-        transmitOne(endpointId, requestId, manyToOneHandler.handle(endpointId, params));
+        manyToOneHandlers.get(method).handle(endpointId, requestId, method, params);
         break;
       case MANY_TO_MANY:
-        ManyToManyHandler manyToManyHandler = manyToManyHandlers.get(method);
-        transmitMany(endpointId, requestId, manyToManyHandler.handle(endpointId, params));
+        manyToManyHandlers.get(method).handle(endpointId, requestId, method, params);
         break;
       case NONE_TO_ONE:
-        NoneToOneHandler noneToOneHandler = noneToOneHandlers.get(method);
-        transmitOne(endpointId, requestId, noneToOneHandler.handle(endpointId));
+        noneToOneHandlers.get(method).handle(endpointId, requestId, method, params);
         break;
       case NONE_TO_MANY:
-        NoneToManyHandler noneToManyHandler = noneToManyHandlers.get(method);
-        transmitMany(endpointId, requestId, noneToManyHandler.handle(endpointId));
+        noneToManyHandlers.get(method).handle(endpointId, requestId, method, params);
         break;
       case ONE_TO_PROMISE_ONE:
-        OneToPromiseOneHandler promiseOneHandler = oneToPromiseOneHandlers.get(method);
-        transmitPromiseOne(endpointId, requestId, promiseOneHandler.handle(endpointId, params));
+        oneToPromiseOneHandlers.get(method).handle(endpointId, requestId, method, params);
         break;
       default:
         LOGGER.error("Something went wrong trying to find out handler category");
@@ -246,13 +251,13 @@ public class RequestHandlerManager {
 
     switch (methodToCategory.get(method)) {
       case ONE_TO_NONE:
-        oneToNoneHandlers.get(method).handle(endpointId, params);
+        oneToNoneHandlers.get(method).handle(endpointId, method, params);
         break;
       case MANY_TO_NONE:
-        manyToNoneHandlers.get(method).handle(endpointId, params);
+        manyToNoneHandlers.get(method).handle(endpointId, method, params);
         break;
       case NONE_TO_NONE:
-        noneToNoneHandlers.get(method).handle(endpointId);
+        noneToNoneHandlers.get(method).handle(method, endpointId);
         break;
       default:
         LOGGER.error("Something went wrong trying to find out handler category");
@@ -275,7 +280,21 @@ public class RequestHandlerManager {
     }
   }
 
-  private void transmitOne(String endpointId, String id, Object result) {
+  private <P> List<P> composeMany(JsonRpcParams params, Class<P> pClass) {
+    return dtoComposer.composeMany(params, pClass);
+  }
+
+  private <P> P composeOne(JsonRpcParams params, Class<P> pClass) {
+    return dtoComposer.composeOne(params, pClass);
+  }
+
+  private void filter(String method, Object... param) {
+    for (JsonRpcMethodInvokerFilter filter : filters.get(method)) {
+      filter.accept(method, param);
+    }
+  }
+
+  private <R> void transmitOne(String endpointId, String id, R result) {
     JsonRpcResult jsonRpcResult = new JsonRpcResult(result);
     JsonRpcResponse jsonRpcResponse = new JsonRpcResponse(id, jsonRpcResult, null);
     String message = marshaller.marshall(jsonRpcResponse);
@@ -289,8 +308,8 @@ public class RequestHandlerManager {
     transmitter.transmit(endpointId, message);
   }
 
-  private void transmitPromiseOne(
-      String endpointId, String requestId, JsonRpcPromise<Object> promise) {
+  private <R> void transmitPromiseOne(
+      String endpointId, String requestId, JsonRpcPromise<R> promise) {
     promise.onSuccess(result -> transmitOne(endpointId, requestId, result));
     promise.onFailure(
         jsonRpcError -> {
@@ -324,9 +343,12 @@ public class RequestHandlerManager {
       this.biFunction = biFunction;
     }
 
-    private R handle(String endpointId, JsonRpcParams params) {
-      P dto = dtoComposer.composeOne(params, pClass);
-      return biFunction.apply(endpointId, dto);
+    private void handle(String endpointId, String requestId, String method, JsonRpcParams params) {
+      P param = composeOne(params, pClass);
+      for (JsonRpcMethodInvokerFilter filter : filters.get(method)) {
+        filter.accept(method, param);
+      }
+      transmitOne(endpointId, requestId, biFunction.apply(endpointId, param));
     }
   }
 
@@ -342,9 +364,10 @@ public class RequestHandlerManager {
       this.function = function;
     }
 
-    private JsonRpcPromise<R> handle(String endpointId, JsonRpcParams params) {
-      P dto = dtoComposer.composeOne(params, pClass);
-      return function.apply(endpointId, dto);
+    private void handle(String endpointId, String requestId, String method, JsonRpcParams params) {
+      P param = dtoComposer.composeOne(params, pClass);
+      filter(method, param);
+      transmitPromiseOne(endpointId, requestId, function.apply(endpointId, param));
     }
   }
 
@@ -360,9 +383,10 @@ public class RequestHandlerManager {
       this.biFunction = biFunction;
     }
 
-    private List<R> handle(String endpointId, JsonRpcParams params) {
-      P dto = dtoComposer.composeOne(params, pClass);
-      return biFunction.apply(endpointId, dto);
+    private void handle(String endpointId, String requestId, String method, JsonRpcParams params) {
+      P param = dtoComposer.composeOne(params, pClass);
+      filter(method, param);
+      transmitMany(endpointId, requestId, biFunction.apply(endpointId, param));
     }
   }
 
@@ -375,9 +399,10 @@ public class RequestHandlerManager {
       this.biConsumer = biConsumer;
     }
 
-    private void handle(String endpointId, JsonRpcParams params) {
-      P dto = dtoComposer.composeOne(params, pClass);
-      biConsumer.accept(endpointId, dto);
+    private void handle(String endpointId, String method, JsonRpcParams params) {
+      P param = composeOne(params, pClass);
+      filter(method, param);
+      biConsumer.accept(endpointId, param);
     }
   }
 
@@ -393,9 +418,11 @@ public class RequestHandlerManager {
       this.biFunction = biFunction;
     }
 
-    private R handle(String endpointId, JsonRpcParams params) {
-      List<P> dto = dtoComposer.composeMany(params, pClass);
-      return biFunction.apply(endpointId, dto);
+    private void handle(
+        String endpointId, String requestId, String method, JsonRpcParams jsonParam) {
+      List<P> param = dtoComposer.composeMany(jsonParam, pClass);
+      filter(method, param);
+      transmitOne(endpointId, requestId, biFunction.apply(endpointId, param));
     }
   }
 
@@ -411,9 +438,11 @@ public class RequestHandlerManager {
       this.biFunction = biFunction;
     }
 
-    private List<R> handle(String endpointId, JsonRpcParams params) {
-      List<P> dto = dtoComposer.composeMany(params, pClass);
-      return biFunction.apply(endpointId, dto);
+    private void handle(
+        String endpointId, String requestId, String method, JsonRpcParams jsonParams) {
+      List<P> params = dtoComposer.composeMany(jsonParams, pClass);
+      filter(method, params);
+      transmitMany(endpointId, requestId, biFunction.apply(endpointId, params));
     }
   }
 
@@ -426,9 +455,14 @@ public class RequestHandlerManager {
       this.biConsumer = biConsumer;
     }
 
-    private void handle(String endpointId, JsonRpcParams params) {
-      List<P> dto = dtoComposer.composeMany(params, pClass);
-      biConsumer.accept(endpointId, dto);
+    private void handle(String endpointId, String method, JsonRpcParams params) {
+      List<P> listDto = composeMany(params, pClass);
+      filter(method, listDto);
+      biConsumer.accept(endpointId, listDto);
+    }
+
+    public List<P> compose(JsonRpcParams params) {
+      return dtoComposer.composeMany(params, pClass);
     }
   }
 
@@ -441,8 +475,9 @@ public class RequestHandlerManager {
       this.function = function;
     }
 
-    private R handle(String endpointId) {
-      return function.apply(endpointId);
+    private void handle(String endpointId, String requestId, String method, JsonRpcParams params) {
+      filter(method);
+      transmitOne(endpointId, requestId, function.apply(endpointId));
     }
   }
 
@@ -455,8 +490,9 @@ public class RequestHandlerManager {
       this.function = function;
     }
 
-    private List<R> handle(String endpointId) {
-      return function.apply(endpointId);
+    private void handle(String endpointId, String requestId, String method, JsonRpcParams params) {
+      filter(method);
+      transmitMany(endpointId, requestId, function.apply(endpointId));
     }
   }
 
@@ -467,7 +503,8 @@ public class RequestHandlerManager {
       this.consumer = consumer;
     }
 
-    private void handle(String endpointId) {
+    private void handle(String method, String endpointId) {
+      filter(method);
       consumer.accept(endpointId);
     }
   }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionManager.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/notification/RemoteSubscriptionManager.java
@@ -22,6 +22,9 @@ import org.eclipse.che.api.core.notification.dto.EventSubscription;
 @Singleton
 public class RemoteSubscriptionManager {
 
+  public static final String SUBSCRIBE_JSON_RPC_METHOD = "subscribe";
+  public static final String UNSUBSCRIBE_JSON_RPC_METHOD = "unSubscribe";
+
   private final EventService eventService;
   private final RequestTransmitter requestTransmitter;
   private final RemoteSubscriptionStorage remoteSubscriptionStorage;
@@ -40,14 +43,14 @@ public class RemoteSubscriptionManager {
   private void configureSubscription(RequestHandlerConfigurator requestHandlerConfigurator) {
     requestHandlerConfigurator
         .newConfiguration()
-        .methodName("subscribe")
+        .methodName(SUBSCRIBE_JSON_RPC_METHOD)
         .paramsAsDto(EventSubscription.class)
         .noResult()
         .withBiConsumer(this::consumeSubscriptionRequest);
 
     requestHandlerConfigurator
         .newConfiguration()
-        .methodName("unSubscribe")
+        .methodName(UNSUBSCRIBE_JSON_RPC_METHOD)
         .paramsAsDto(EventSubscription.class)
         .noResult()
         .withBiConsumer(this::consumeUnSubscriptionRequest);

--- a/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/OrganizationApiModule.java
+++ b/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/OrganizationApiModule.java
@@ -24,6 +24,7 @@ import org.eclipse.che.multiuser.organization.api.listener.RemoveOrganizationOnL
 import org.eclipse.che.multiuser.organization.api.notification.OrganizationNotificationEmailSender;
 import org.eclipse.che.multiuser.organization.api.permissions.OrganizationDomain;
 import org.eclipse.che.multiuser.organization.api.permissions.OrganizationPermissionsFilter;
+import org.eclipse.che.multiuser.organization.api.permissions.OrganizationRemoteSubscriptionPermissionsChecks;
 import org.eclipse.che.multiuser.organization.api.permissions.OrganizationResourceDistributionServicePermissionsFilter;
 import org.eclipse.che.multiuser.organization.api.permissions.OrganizationalAccountPermissionsChecker;
 import org.eclipse.che.multiuser.organization.api.resource.DefaultOrganizationResourcesProvider;
@@ -43,6 +44,7 @@ public class OrganizationApiModule extends AbstractModule {
   protected void configure() {
     bind(OrganizationService.class);
     bind(OrganizationPermissionsFilter.class);
+    bind(OrganizationRemoteSubscriptionPermissionsChecks.class);
     bind(RemoveOrganizationOnLastUserRemovedEventSubscriber.class).asEagerSingleton();
 
     Multibinder.newSetBinder(binder(), DefaultResourcesProvider.class)

--- a/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/listener/OrganizationEventsWebsocketBroadcaster.java
+++ b/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/listener/OrganizationEventsWebsocketBroadcaster.java
@@ -33,9 +33,8 @@ public class OrganizationEventsWebsocketBroadcaster {
 
   private final RemoteSubscriptionManager remoteSubscriptionManager;
 
-  private static final String ORGANIZATION_MEMBERSHIP_METHOD_NAME =
-      "organization/membershipChanged";
-  private static final String ORGANIZATION_CHANGED_METHOD_NAME = "organization/statusChanged";
+  public static final String ORGANIZATION_MEMBERSHIP_METHOD_NAME = "organization/membershipChanged";
+  public static final String ORGANIZATION_CHANGED_METHOD_NAME = "organization/statusChanged";
 
   @Inject
   public OrganizationEventsWebsocketBroadcaster(

--- a/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/permissions/OrganizationRemoteSubscriptionPermissionsChecks.java
+++ b/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/api/permissions/OrganizationRemoteSubscriptionPermissionsChecks.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.organization.api.permissions;
+
+import static org.eclipse.che.multiuser.organization.api.listener.OrganizationEventsWebsocketBroadcaster.ORGANIZATION_CHANGED_METHOD_NAME;
+import static org.eclipse.che.multiuser.organization.api.listener.OrganizationEventsWebsocketBroadcaster.ORGANIZATION_MEMBERSHIP_METHOD_NAME;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.multiuser.api.permission.server.PermissionsManager;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionCheck;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionManager;
+import org.eclipse.che.multiuser.api.permission.server.model.impl.AbstractPermissions;
+import org.eclipse.che.multiuser.organization.api.listener.OrganizationEventsWebsocketBroadcaster;
+
+/**
+ * Holds and registers permissions checks for organization related events.
+ *
+ * <p>Covers events published via {@link OrganizationEventsWebsocketBroadcaster}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class OrganizationRemoteSubscriptionPermissionsChecks {
+
+  private final PermissionsManager permissionsManager;
+
+  @Inject
+  public OrganizationRemoteSubscriptionPermissionsChecks(PermissionsManager permissionsManager) {
+    this.permissionsManager = permissionsManager;
+  }
+
+  @Inject
+  public void register(RemoteSubscriptionPermissionManager permissionFilter) {
+    MembershipsChangedSubscriptionCheck membershipsEventsCheck =
+        new MembershipsChangedSubscriptionCheck();
+
+    permissionFilter.registerCheck(membershipsEventsCheck, ORGANIZATION_MEMBERSHIP_METHOD_NAME);
+
+    OrganizationChangedSubscriptionCheck organizationChangedCheck =
+        new OrganizationChangedSubscriptionCheck(permissionsManager);
+    permissionFilter.registerCheck(organizationChangedCheck, ORGANIZATION_CHANGED_METHOD_NAME);
+  }
+
+  @VisibleForTesting
+  static class MembershipsChangedSubscriptionCheck implements RemoteSubscriptionPermissionCheck {
+
+    @Override
+    public void check(String methodName, Map<String, String> scope) throws ForbiddenException {
+      String userId = scope.get("userId");
+      if (userId == null) {
+        throw new ForbiddenException("User id must be specified in scope");
+      }
+
+      String currentUserId = EnvironmentContext.getCurrent().getSubject().getUserId();
+
+      if (!currentUserId.equals(userId)) {
+        throw new ForbiddenException("It is only allowed to listen to own memberships changes");
+      }
+    }
+  }
+
+  @VisibleForTesting
+  static class OrganizationChangedSubscriptionCheck implements RemoteSubscriptionPermissionCheck {
+
+    private final PermissionsManager permissionsManager;
+
+    public OrganizationChangedSubscriptionCheck(PermissionsManager permissionsManager) {
+      this.permissionsManager = permissionsManager;
+    }
+
+    @Override
+    public void check(String methodName, Map<String, String> scope) throws ForbiddenException {
+      String organizationId = scope.get("organizationId");
+      if (organizationId == null) {
+        throw new ForbiddenException("Organization id must be specified in scope");
+      }
+
+      String currentUserId = EnvironmentContext.getCurrent().getSubject().getUserId();
+
+      try {
+        // check if user has any permissions in organisation
+        // to listen to related events
+        AbstractPermissions permissions =
+            permissionsManager.get(currentUserId, OrganizationDomain.DOMAIN_ID, organizationId);
+      } catch (ConflictException | ServerException e) {
+        throw new ForbiddenException("Error occurred while permission fetching: " + e.getMessage());
+      } catch (NotFoundException e) {
+        throw new ForbiddenException(
+            "User doesn't have any permissions for the specified organization");
+      }
+    }
+  }
+}

--- a/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/permissions/OrganizationRemoteSubscriptionPermissionsChecksTest.java
+++ b/multiuser/api/che-multiuser-api-organization/src/test/java/org/eclipse/che/multiuser/organization/api/permissions/OrganizationRemoteSubscriptionPermissionsChecksTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.organization.api.permissions;
+
+import static org.eclipse.che.multiuser.organization.api.listener.OrganizationEventsWebsocketBroadcaster.ORGANIZATION_CHANGED_METHOD_NAME;
+import static org.eclipse.che.multiuser.organization.api.listener.OrganizationEventsWebsocketBroadcaster.ORGANIZATION_MEMBERSHIP_METHOD_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.multiuser.api.permission.server.PermissionsManager;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionManager;
+import org.eclipse.che.multiuser.api.permission.server.model.impl.AbstractPermissions;
+import org.eclipse.che.multiuser.organization.api.permissions.OrganizationRemoteSubscriptionPermissionsChecks.MembershipsChangedSubscriptionCheck;
+import org.eclipse.che.multiuser.organization.api.permissions.OrganizationRemoteSubscriptionPermissionsChecks.OrganizationChangedSubscriptionCheck;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link OrganizationRemoteSubscriptionPermissionsChecks}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class OrganizationRemoteSubscriptionPermissionsChecksTest {
+  @Mock private Subject subject;
+
+  @Mock private PermissionsManager permissionsManager;
+  @Mock private RemoteSubscriptionPermissionManager permissionManager;
+
+  @InjectMocks private OrganizationRemoteSubscriptionPermissionsChecks permissionsChecks;
+
+  @BeforeMethod
+  public void setUp() {
+    EnvironmentContext.getCurrent().setSubject(subject);
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    EnvironmentContext.reset();
+  }
+
+  @Test
+  public void shouldRegisterChecks() {
+    // when
+    permissionsChecks.register(permissionManager);
+
+    // then
+    verify(permissionManager)
+        .registerCheck(
+            any(OrganizationChangedSubscriptionCheck.class), eq(ORGANIZATION_CHANGED_METHOD_NAME));
+    verify(permissionManager)
+        .registerCheck(
+            any(MembershipsChangedSubscriptionCheck.class),
+            eq(ORGANIZATION_MEMBERSHIP_METHOD_NAME));
+  }
+
+  @Test(
+      expectedExceptions = ForbiddenException.class,
+      expectedExceptionsMessageRegExp = "User id must be specified in scope")
+  public void shouldThrowExceptionIfUserIdIsMissing() throws Exception {
+    // given
+    MembershipsChangedSubscriptionCheck check = new MembershipsChangedSubscriptionCheck();
+    when(subject.getUserId()).thenReturn("user2");
+
+    // when
+    check.check(ORGANIZATION_MEMBERSHIP_METHOD_NAME, Collections.emptyMap());
+  }
+
+  @Test(
+      expectedExceptions = ForbiddenException.class,
+      expectedExceptionsMessageRegExp = "It is only allowed to listen to own memberships changes")
+  public void shouldThrowExceptionIfUserTryToListenToForeignMemberships() throws Exception {
+    // given
+    MembershipsChangedSubscriptionCheck check = new MembershipsChangedSubscriptionCheck();
+    when(subject.getUserId()).thenReturn("user2");
+
+    // when
+    check.check(ORGANIZATION_MEMBERSHIP_METHOD_NAME, ImmutableMap.of("userId", "user1"));
+  }
+
+  @Test
+  public void shouldDoNothingIfUserTryToListenToOwnMemberships() throws Exception {
+    // given
+    MembershipsChangedSubscriptionCheck check = new MembershipsChangedSubscriptionCheck();
+    when(subject.getUserId()).thenReturn("user1");
+
+    // when
+    check.check(ORGANIZATION_MEMBERSHIP_METHOD_NAME, ImmutableMap.of("userId", "user1"));
+  }
+
+  @Test(
+      expectedExceptions = ForbiddenException.class,
+      expectedExceptionsMessageRegExp = "Organization id must be specified in scope")
+  public void shouldThrowExceptionIfOrganizationIdIsMissing() throws Exception {
+    // given
+    OrganizationChangedSubscriptionCheck check =
+        new OrganizationChangedSubscriptionCheck(permissionsManager);
+
+    // when
+    check.check(ORGANIZATION_MEMBERSHIP_METHOD_NAME, Collections.emptyMap());
+  }
+
+  @Test(
+      expectedExceptions = ForbiddenException.class,
+      expectedExceptionsMessageRegExp =
+          "User doesn't have any permissions for the specified organization")
+  public void shouldThrowExceptionIfUserDoesNotHaveAnyPermissionsToRequestedOrganization()
+      throws Exception {
+    // given
+    OrganizationChangedSubscriptionCheck check =
+        new OrganizationChangedSubscriptionCheck(permissionsManager);
+    when(subject.getUserId()).thenReturn("user1");
+    when(permissionsManager.get("user1", OrganizationDomain.DOMAIN_ID, "org123"))
+        .thenThrow(new NotFoundException(""));
+
+    // when
+    check.check(ORGANIZATION_MEMBERSHIP_METHOD_NAME, ImmutableMap.of("organizationId", "org123"));
+  }
+
+  @Test
+  public void shouldDoNothingIfUserTryToListenEventsOfOrganizationWhereHeHasPermissions()
+      throws Exception {
+    // given
+    OrganizationChangedSubscriptionCheck check =
+        new OrganizationChangedSubscriptionCheck(permissionsManager);
+    when(subject.getUserId()).thenReturn("user1");
+    when(permissionsManager.get("user1", OrganizationDomain.DOMAIN_ID, "org123"))
+        .thenReturn(mock(AbstractPermissions.class));
+
+    // when
+    check.check(ORGANIZATION_MEMBERSHIP_METHOD_NAME, ImmutableMap.of("organizationId", "org123"));
+  }
+}

--- a/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/PermissionsModule.java
+++ b/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/PermissionsModule.java
@@ -21,6 +21,7 @@ import org.eclipse.che.multiuser.api.permission.server.filter.RemovePermissionsF
 import org.eclipse.che.multiuser.api.permission.server.filter.SetPermissionsFilter;
 import org.eclipse.che.multiuser.api.permission.server.filter.check.RemovePermissionsChecker;
 import org.eclipse.che.multiuser.api.permission.server.filter.check.SetPermissionsChecker;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionManager;
 
 /** @author Sergii Leschenko */
 public class PermissionsModule extends AbstractModule {
@@ -30,6 +31,7 @@ public class PermissionsModule extends AbstractModule {
     bind(SetPermissionsFilter.class);
     bind(RemovePermissionsFilter.class);
     bind(GetPermissionsFilter.class);
+    bind(RemoteSubscriptionPermissionManager.class).asEagerSingleton();
 
     // Creates empty multibinder to avoid error during container starting
     Multibinder.newSetBinder(

--- a/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jsonrpc/JsonRpcPermissionsFilterAdapter.java
+++ b/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jsonrpc/JsonRpcPermissionsFilterAdapter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.api.permission.server.jsonrpc;
+
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcException;
+import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcMethodInvokerFilter;
+
+/**
+ * <b>Purpose</b>: Provides an implementation of JsonRpcMethodInvokerFilter that allow to throw
+ * {@link ForbiddenException} that will be wrapped into {@link JsonRpcException}.
+ *
+ * @author Sergii Leshchenko
+ */
+public abstract class JsonRpcPermissionsFilterAdapter implements JsonRpcMethodInvokerFilter {
+
+  @Override
+  public void accept(String method, Object... params) throws JsonRpcException {
+    try {
+      doAccept(method, params);
+    } catch (ForbiddenException e) {
+      throw new JsonRpcException(403, e.getMessage());
+    }
+  }
+
+  protected abstract void doAccept(String method, Object... params) throws ForbiddenException;
+}

--- a/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jsonrpc/RemoteSubscriptionPermissionCheck.java
+++ b/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jsonrpc/RemoteSubscriptionPermissionCheck.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.api.permission.server.jsonrpc;
+
+import java.util.Map;
+import org.eclipse.che.api.core.ForbiddenException;
+
+/**
+ * Check that should be performed before remote subscribing.
+ *
+ * @author Sergii Leshchenko
+ * @see org.eclipse.che.api.core.notification.RemoteSubscriptionManager
+ */
+public interface RemoteSubscriptionPermissionCheck {
+
+  /**
+   * Check that the current subject is allowed to listen to the specified method events
+   *
+   * @param methodName method name to subscribe
+   * @param scope scope of subscription
+   * @throws ForbiddenException if the current subject does not have needed permissions
+   * @throws ForbiddenException if any other exception occurred during permissions check
+   */
+  void check(String methodName, Map<String, String> scope) throws ForbiddenException;
+}

--- a/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jsonrpc/RemoteSubscriptionPermissionManager.java
+++ b/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jsonrpc/RemoteSubscriptionPermissionManager.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.api.permission.server.jsonrpc;
+
+import static java.lang.String.format;
+import static org.eclipse.che.api.core.notification.RemoteSubscriptionManager.SUBSCRIBE_JSON_RPC_METHOD;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerManager;
+import org.eclipse.che.api.core.notification.dto.EventSubscription;
+
+/**
+ * Filters invocation of {@link
+ * org.eclipse.che.api.core.notification.RemoteSubscriptionManager#SUBSCRIBE_JSON_RPC_METHOD} and
+ * performs the corresponding {@link RemoteSubscriptionPermissionCheck} to make sure that user is
+ * authorized to listen to requested events.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class RemoteSubscriptionPermissionManager {
+
+  private final Map<String, RemoteSubscriptionPermissionCheck> methodToCheck;
+
+  public RemoteSubscriptionPermissionManager() {
+    this.methodToCheck = new HashMap<>();
+  }
+
+  @Inject
+  void register(RequestHandlerManager requestHandlerManager) {
+    requestHandlerManager.registerMethodInvokerFilter(
+        new RemoteSubscriptionFilter(), SUBSCRIBE_JSON_RPC_METHOD);
+  }
+
+  /**
+   * Registers permissions check for the specified methods
+   *
+   * @param permissionCheck permissions check that should be invoked before subscription
+   * @param methods methods to filter
+   * @throws IllegalStateException if any of specified methods already has registered check
+   */
+  public synchronized void registerCheck(
+      RemoteSubscriptionPermissionCheck permissionCheck, String... methods) {
+    for (String method : methods) {
+      if (methodToCheck.containsKey(method)) {
+        throw new IllegalStateException(
+            format("Permissions check is already registered for method '%s'", method));
+      }
+
+      methodToCheck.put(method, permissionCheck);
+    }
+  }
+
+  private class RemoteSubscriptionFilter extends JsonRpcPermissionsFilterAdapter {
+    @Override
+    protected void doAccept(String method, Object... params) throws ForbiddenException {
+      EventSubscription param = (EventSubscription) params[0];
+
+      RemoteSubscriptionPermissionCheck permissionCheck = methodToCheck.get(param.getMethod());
+      if (permissionCheck != null) {
+        permissionCheck.check(param.getMethod(), param.getScope());
+      }
+    }
+  }
+}

--- a/multiuser/keycloak/che-multiuser-keycloak-server/pom.xml
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/pom.xml
@@ -132,10 +132,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.multiuser</groupId>
-            <artifactId>che-multiuser-machine-authentication</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.multiuser</groupId>
             <artifactId>che-multiuser-machine-authentication-shared</artifactId>
         </dependency>
         <dependency>
@@ -154,6 +150,11 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.multiuser</groupId>
+            <artifactId>che-multiuser-machine-authentication</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/pom.xml
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/pom.xml
@@ -64,10 +64,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-account</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
         <dependency>
@@ -143,6 +139,11 @@
         <dependency>
             <groupId>com.jayway.restassured</groupId>
             <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-account</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/multiuser/permission/che-multiuser-permission-system/pom.xml
+++ b/multiuser/permission/che-multiuser-permission-system/pom.xml
@@ -26,6 +26,10 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>

--- a/multiuser/permission/che-multiuser-permission-system/src/main/java/org/eclipse/che/multiuser/permission/system/SystemEventsSubscriptionPermissionsCheck.java
+++ b/multiuser/permission/che-multiuser-permission-system/src/main/java/org/eclipse/che/multiuser/permission/system/SystemEventsSubscriptionPermissionsCheck.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.system;
+
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.system.server.SystemEventsWebsocketBroadcaster;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.multiuser.api.permission.server.SystemDomain;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionCheck;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionManager;
+
+/** @author Sergii Leshchenko */
+@Singleton
+public class SystemEventsSubscriptionPermissionsCheck implements RemoteSubscriptionPermissionCheck {
+  @Inject
+  public void register(RemoteSubscriptionPermissionManager permissionFilter) {
+    permissionFilter.registerCheck(this, SystemEventsWebsocketBroadcaster.SYSTEM_STATE_METHOD_NAME);
+  }
+
+  @Override
+  public void check(String methodName, Map<String, String> scope) throws ForbiddenException {
+    EnvironmentContext.getCurrent()
+        .getSubject()
+        .checkPermission(SystemDomain.DOMAIN_ID, null, SystemDomain.MANAGE_SYSTEM_ACTION);
+  }
+}

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/WorkspaceApiPermissionsModule.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/WorkspaceApiPermissionsModule.java
@@ -20,6 +20,7 @@ import org.eclipse.che.multiuser.api.permission.server.SuperPrivilegesChecker;
 import org.eclipse.che.multiuser.api.permission.server.filter.check.RemovePermissionsChecker;
 import org.eclipse.che.multiuser.api.permission.server.filter.check.SetPermissionsChecker;
 import org.eclipse.che.multiuser.api.permission.shared.model.PermissionsDomain;
+import org.eclipse.che.multiuser.permission.workspace.server.filters.InstallerServicePermissionFilter;
 import org.eclipse.che.multiuser.permission.workspace.server.filters.PublicPermissionsRemoveChecker;
 import org.eclipse.che.multiuser.permission.workspace.server.filters.StackDomainSetPermissionsChecker;
 import org.eclipse.che.multiuser.permission.workspace.server.filters.StackPermissionsFilter;
@@ -34,6 +35,7 @@ public class WorkspaceApiPermissionsModule extends AbstractModule {
   protected void configure() {
     bind(WorkspacePermissionsFilter.class);
     bind(StackPermissionsFilter.class);
+    bind(InstallerServicePermissionFilter.class).asEagerSingleton();
 
     bind(WorkspaceCreatorPermissionsProvider.class).asEagerSingleton();
     bind(StackCreatorPermissionsProvider.class).asEagerSingleton();

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/WorkspaceApiPermissionsModule.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/WorkspaceApiPermissionsModule.java
@@ -25,17 +25,20 @@ import org.eclipse.che.multiuser.permission.workspace.server.filters.PublicPermi
 import org.eclipse.che.multiuser.permission.workspace.server.filters.StackDomainSetPermissionsChecker;
 import org.eclipse.che.multiuser.permission.workspace.server.filters.StackPermissionsFilter;
 import org.eclipse.che.multiuser.permission.workspace.server.filters.WorkspacePermissionsFilter;
+import org.eclipse.che.multiuser.permission.workspace.server.filters.WorkspaceRemoteSubscriptionPermissionFilter;
 import org.eclipse.che.multiuser.permission.workspace.server.stack.MultiuserStackLoader;
 import org.eclipse.che.multiuser.permission.workspace.server.stack.StackCreatorPermissionsProvider;
 import org.eclipse.che.multiuser.permission.workspace.server.stack.StackDomain;
 
 /** @author Sergii Leschenko */
 public class WorkspaceApiPermissionsModule extends AbstractModule {
+
   @Override
   protected void configure() {
     bind(WorkspacePermissionsFilter.class);
     bind(StackPermissionsFilter.class);
     bind(InstallerServicePermissionFilter.class).asEagerSingleton();
+    bind(WorkspaceRemoteSubscriptionPermissionFilter.class).asEagerSingleton();
 
     bind(WorkspaceCreatorPermissionsProvider.class).asEagerSingleton();
     bind(StackCreatorPermissionsProvider.class).asEagerSingleton();

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/filters/InstallerServicePermissionFilter.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/filters/InstallerServicePermissionFilter.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.workspace.server.filters;
+
+import static org.eclipse.che.api.workspace.shared.Constants.BOOTSTRAPPER_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_LOG_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_STATUS_CHANGED_METHOD;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerManager;
+import org.eclipse.che.api.workspace.shared.dto.event.BootstrapperStatusEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.InstallerLogEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.InstallerStatusEvent;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.JsonRpcPermissionsFilterAdapter;
+import org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain;
+
+/**
+ * Add permissions checking before {@link
+ * org.eclipse.che.api.workspace.server.bootstrap.InstallerService} methods invocation.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class InstallerServicePermissionFilter extends JsonRpcPermissionsFilterAdapter {
+  @Inject
+  public void register(RequestHandlerManager requestHandlerManager) {
+    requestHandlerManager.registerMethodInvokerFilter(
+        this,
+        BOOTSTRAPPER_STATUS_CHANGED_METHOD,
+        INSTALLER_STATUS_CHANGED_METHOD,
+        INSTALLER_LOG_METHOD);
+  }
+
+  @Override
+  public void doAccept(String method, Object... params) throws ForbiddenException {
+    String workspaceId;
+    switch (method) {
+      case BOOTSTRAPPER_STATUS_CHANGED_METHOD:
+        workspaceId = ((BootstrapperStatusEvent) params[0]).getRuntimeId().getWorkspaceId();
+        break;
+      case INSTALLER_LOG_METHOD:
+        workspaceId = ((InstallerLogEvent) params[0]).getRuntimeId().getWorkspaceId();
+        break;
+      case INSTALLER_STATUS_CHANGED_METHOD:
+        workspaceId = ((InstallerStatusEvent) params[0]).getRuntimeId().getWorkspaceId();
+        break;
+      default:
+        throw new ForbiddenException("Unknown method is configured to be filtered.");
+    }
+
+    Subject currentSubject = EnvironmentContext.getCurrent().getSubject();
+    if (!currentSubject.hasPermission(
+        WorkspaceDomain.DOMAIN_ID, workspaceId, WorkspaceDomain.RUN)) {
+      throw new ForbiddenException(
+          "User doesn't have the required permissions to the specified workspace");
+    }
+  }
+}

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspaceRemoteSubscriptionPermissionFilter.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspaceRemoteSubscriptionPermissionFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.workspace.server.filters;
+
+import static org.eclipse.che.api.workspace.shared.Constants.BOOTSTRAPPER_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_LOG_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_LOG_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.SERVER_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STATUS_CHANGED_METHOD;
+
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionCheck;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionManager;
+import org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain;
+
+/**
+ * Holds and registers permissions checks for workspaces related events.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class WorkspaceRemoteSubscriptionPermissionFilter
+    implements RemoteSubscriptionPermissionCheck {
+
+  @Inject
+  public void register(RemoteSubscriptionPermissionManager permissionFilter) {
+    permissionFilter.registerCheck(
+        this,
+        WORKSPACE_STATUS_CHANGED_METHOD,
+        MACHINE_STATUS_CHANGED_METHOD,
+        SERVER_STATUS_CHANGED_METHOD,
+        MACHINE_LOG_METHOD,
+        INSTALLER_LOG_METHOD,
+        INSTALLER_STATUS_CHANGED_METHOD,
+        BOOTSTRAPPER_STATUS_CHANGED_METHOD);
+  }
+
+  @Override
+  public void check(String methodName, Map<String, String> scope) throws ForbiddenException {
+    String workspaceId = scope.get("workspaceId");
+
+    if (workspaceId == null) {
+      throw new ForbiddenException("Workspace id must be specified in scope");
+    }
+
+    Subject currentSubject = EnvironmentContext.getCurrent().getSubject();
+    if (!currentSubject.hasPermission(WorkspaceDomain.DOMAIN_ID, workspaceId, WorkspaceDomain.RUN)
+        && !currentSubject.hasPermission(
+            WorkspaceDomain.DOMAIN_ID, workspaceId, WorkspaceDomain.USE)) {
+      throw new ForbiddenException(
+          "The current user doesn't have permissions to listen to the specified workspace events");
+    }
+  }
+}

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspaceRemoteSubscriptionPermissionFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspaceRemoteSubscriptionPermissionFilterTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.workspace.server.filters;
+
+import static org.eclipse.che.api.workspace.shared.Constants.BOOTSTRAPPER_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_LOG_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_LOG_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.SERVER_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STATUS_CHANGED_METHOD;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.multiuser.api.permission.server.jsonrpc.RemoteSubscriptionPermissionManager;
+import org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDomain;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link WorkspaceRemoteSubscriptionPermissionFilter}
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class WorkspaceRemoteSubscriptionPermissionFilterTest {
+
+  @Mock private RemoteSubscriptionPermissionManager permissionManager;
+
+  @Mock private Subject subject;
+
+  private WorkspaceRemoteSubscriptionPermissionFilter permissionFilter;
+
+  @BeforeMethod
+  public void setUp() {
+    EnvironmentContext.getCurrent().setSubject(subject);
+    permissionFilter = new WorkspaceRemoteSubscriptionPermissionFilter();
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    EnvironmentContext.reset();
+  }
+
+  @Test
+  public void shouldRegisterItself() {
+    // when
+    permissionFilter.register(permissionManager);
+
+    // then
+    permissionManager.registerCheck(
+        permissionFilter,
+        WORKSPACE_STATUS_CHANGED_METHOD,
+        MACHINE_STATUS_CHANGED_METHOD,
+        SERVER_STATUS_CHANGED_METHOD,
+        MACHINE_LOG_METHOD,
+        INSTALLER_LOG_METHOD,
+        INSTALLER_STATUS_CHANGED_METHOD,
+        BOOTSTRAPPER_STATUS_CHANGED_METHOD);
+  }
+
+  @Test(
+      expectedExceptions = ForbiddenException.class,
+      expectedExceptionsMessageRegExp =
+          "The current user doesn't have permissions to listen to the specified workspace events")
+  public void shouldThrowExceptionIfUserDoesNotHaveRunNorUsePermissions() throws Exception {
+    // given
+    when(subject.hasPermission(WorkspaceDomain.DOMAIN_ID, "ws123", WorkspaceDomain.RUN))
+        .thenReturn(false);
+    when(subject.hasPermission(WorkspaceDomain.DOMAIN_ID, "ws123", WorkspaceDomain.USE))
+        .thenReturn(false);
+
+    // when
+    permissionFilter.check("ignored", ImmutableMap.of("workspaceId", "ws123"));
+  }
+
+  @Test(
+      expectedExceptions = ForbiddenException.class,
+      expectedExceptionsMessageRegExp = "Workspace id must be specified in scope")
+  public void shouldThrowExceptionIfWorkspaceIdIsMissing() throws Exception {
+    // given
+    when(subject.hasPermission(WorkspaceDomain.DOMAIN_ID, "ws123", WorkspaceDomain.RUN))
+        .thenReturn(false);
+    when(subject.hasPermission(WorkspaceDomain.DOMAIN_ID, "ws123", WorkspaceDomain.USE))
+        .thenReturn(false);
+
+    // when
+    permissionFilter.check("ignored", Collections.emptyMap());
+  }
+
+  @Test
+  public void shouldDoNothingIfUserDoesNotHaveRunPermissions() throws Exception {
+    // given
+    when(subject.hasPermission(WorkspaceDomain.DOMAIN_ID, "ws123", WorkspaceDomain.RUN))
+        .thenReturn(true);
+    when(subject.hasPermission(WorkspaceDomain.DOMAIN_ID, "ws123", WorkspaceDomain.USE))
+        .thenReturn(false);
+
+    // when
+    permissionFilter.check("ignored", ImmutableMap.of("workspaceId", "ws123"));
+  }
+
+  @Test
+  public void shouldDoNothingIfUserDoesNotHaveUsePermissions() throws Exception {
+    // given
+    when(subject.hasPermission(WorkspaceDomain.DOMAIN_ID, "ws123", WorkspaceDomain.RUN))
+        .thenReturn(false);
+    when(subject.hasPermission(WorkspaceDomain.DOMAIN_ID, "ws123", WorkspaceDomain.USE))
+        .thenReturn(true);
+
+    // when
+    permissionFilter.check("ignored", ImmutableMap.of("workspaceId", "ws123"));
+  }
+}


### PR DESCRIPTION
### What does this PR do?
1. Introduces new JsonRpcMethodInvokerFilter component which allows to bind filter before JsonRpc method invocation.
2. Add permissions filter for JsonRpcInstallerService. All json rpc methods are reviewed and filters are added where it is needed.
3. Add component which allows to bind permissions check by remote subscription method. All json rpc remote subscriptions methods are reviewed and checks are added where it is needed.

Here is an example of an invocating JsonRpc method and remote subscribing without required permissions:
![screenshot_20180829_142910](https://user-images.githubusercontent.com/5887312/44784977-0ad65f00-ab98-11e8-8e7e-b076f0a37323.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10861

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Added authorization checks before calling of JsonRpc methods


#### Docs PR
N/A