### PR TITLE
CHE-10798 Add theia-dashboard-extension into Theia Docker image

### DIFF
--- a/dockerfiles/theia/src/extensions.json
+++ b/dockerfiles/theia/src/extensions.json
@@ -29,6 +29,13 @@
             "type": "git"
         },
         {
+            "name": "@eclipse-che/theia-dashboard-extension",
+            "source": "https://github.com/eclipse/che-theia-dashboard-extension.git",
+            "folder": "theia-dashboard-extension",
+            "checkoutTo": "master",
+            "type": "git"
+        },
+        {
             "name": "@eclipse-che/che-theia-hosted-plugin-manager-extension",
             "source": "https://github.com/eclipse/che-theia-hosted-plugin-manager-extension.git",
             "checkoutTo": "latest-deps",


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

### What does this PR do?
Add theia-dashboard-extension into Theia Docker image

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10798
