### PR TITLE
CHE-10730: Change log level from Error to Debug when failed to parse xml file

### DIFF
--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/main/java/org/eclipse/che/plugin/testing/testng/server/TestNGRunner.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/main/java/org/eclipse/che/plugin/testing/testng/server/TestNGRunner.java
@@ -214,7 +214,7 @@ public class TestNGRunner extends AbstractJavaTestRunner {
       SAXParser parser = factory.newSAXParser();
       parser.parse(file.getContents(), suiteParser);
     } catch (ParserConfigurationException | SAXException | IOException e) {
-      LOG.error("It is not possible to parse file " + fileLocation, e);
+      LOG.debug("It is not possible to parse file " + fileLocation);
     } catch (CoreException e) {
       LOG.error("It is not possible to read file " + fileLocation, e);
     }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Change log level from Error to Warning when failed to parse xml file

### What issues does this PR fix or reference?
#10730 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Change log level from Error to Warning when failed to parse xml file

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A