### PR TITLE
Fix css styles for Firefox

### DIFF
--- a/ide/che-core-ide-api/src/main/resources/org/eclipse/che/ide/api/parts/partstack.css
+++ b/ide/che-core-ide-api/src/main/resources/org/eclipse/che/ide/api/parts/partstack.css
@@ -38,8 +38,7 @@ div[maximized="true"] svg[name="workBenchIconMaximize"] * {
     overflow: visible;
 
     background: tabLineError 0 1.3em;
-    background-repeat-y: no-repeat;
-    background-repeat-x: repeat;
+    background-repeat: repeat-x;
     background-size: 15px 7px;
 }
 
@@ -51,7 +50,6 @@ div[maximized="true"] svg[name="workBenchIconMaximize"] * {
     overflow: visible;
 
     background: tabLineWarning 0 1.3em;
-    background-repeat-y: no-repeat;
-    background-repeat-x: repeat;
+    background-repeat: repeat-x;
     background-size: 15px 7px;
 }


### PR DESCRIPTION
### What does this PR do?
This changes proposal fixes css styles for Firefox:

<img width="853" alt="eclipse che 2018-08-28 16-17-41" src="https://user-images.githubusercontent.com/1968177/44725651-81168b00-aade-11e8-81bf-5448b13a8824.png">

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#10905 

#### Release Notes
N/A

#### Docs PR
N/A
