### PR TITLE
Do not set incorrect presentable text marker for pom file

### DIFF
--- a/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/resource/PomInterceptor.java
+++ b/plugins/plugin-maven/che-plugin-maven-ide/src/main/java/org/eclipse/che/plugin/maven/client/resource/PomInterceptor.java
@@ -15,6 +15,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.ARTIFACT_ID;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.MAVEN_ID;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.POM_XML;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.UNKNOWN_VALUE;
 
 import com.google.inject.Singleton;
 import org.eclipse.che.ide.api.resources.Project;
@@ -42,7 +43,7 @@ public class PomInterceptor implements ResourceInterceptor {
           && project.isTypeOf(MAVEN_ID)
           && resource.getParent().getLocation().equals(project.getLocation())) {
         String artifact = project.getAttribute(ARTIFACT_ID);
-        if (!isNullOrEmpty(artifact)) {
+        if (!isNullOrEmpty(artifact) && !UNKNOWN_VALUE.equals(artifact)) {
           resource.addMarker(new PresentableTextMarker(artifact));
         }
       }

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/MavenModelReader.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/MavenModelReader.java
@@ -21,6 +21,7 @@ import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_SOURCE
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_TEST_OUTPUT_DIRECTORY;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_TEST_RESOURCES_FOLDER;
 import static org.eclipse.che.plugin.maven.shared.MavenAttributes.DEFAULT_TEST_SOURCE_FOLDER;
+import static org.eclipse.che.plugin.maven.shared.MavenAttributes.UNKNOWN_VALUE;
 
 import java.io.File;
 import java.io.IOException;
@@ -386,9 +387,9 @@ public class MavenModelReader {
   }
 
   private void fillModelByDefaults(MavenModel model) {
-    model.setMavenKey(new MavenKey("unknown", "unknown", "unknown"));
+    model.setMavenKey(new MavenKey(UNKNOWN_VALUE, UNKNOWN_VALUE, UNKNOWN_VALUE));
 
-    final MavenKey parentKey = new MavenKey("unknown", "unknown", "unknown");
+    final MavenKey parentKey = new MavenKey(UNKNOWN_VALUE, UNKNOWN_VALUE, UNKNOWN_VALUE);
     model.setParent(new MavenParent(parentKey, "../pom.xml"));
 
     model.setPackaging("jar");

--- a/plugins/plugin-maven/che-plugin-maven-shared/src/main/java/org/eclipse/che/plugin/maven/shared/MavenAttributes.java
+++ b/plugins/plugin-maven/che-plugin-maven-shared/src/main/java/org/eclipse/che/plugin/maven/shared/MavenAttributes.java
@@ -50,6 +50,8 @@ public interface MavenAttributes {
 
   String POM_XML = "pom.xml";
 
+  String UNKNOWN_VALUE = "unknown";
+
   /** Name of WebSocket chanel */
   String MAVEN_CHANEL_NAME = "maven:workspace";
 


### PR DESCRIPTION
### What does this PR do?
Current behavior: editor tab for pom.xml file has "unknown" title when maven model is broken
![pom_old](https://user-images.githubusercontent.com/5676062/44733308-fc346d00-aaef-11e8-87a4-402c0780961b.png)

New behavior:  editor tab for pom.xml file has "pom.xml" title when maven model is broken
![pom_new](https://user-images.githubusercontent.com/5676062/44733408-369e0a00-aaf0-11e8-957b-1a8bdf777833.png)

![pom](https://user-images.githubusercontent.com/5676062/44733722-d8255b80-aaf0-11e8-8969-0c540d1db44e.gif)

### What issues does this PR fix or reference?
#10755 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>
