### PR TITLE
Fixed putting Che Subject into ServerEndpointConfig if http session is null

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/GuiceInjectorEndpointConfigurator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/GuiceInjectorEndpointConfigurator.java
@@ -34,9 +34,11 @@ public class GuiceInjectorEndpointConfigurator extends ServerEndpointConfig.Conf
   public void modifyHandshake(
       ServerEndpointConfig sec, HandshakeRequest request, HandshakeResponse response) {
     HttpSession httpSession = (HttpSession) request.getHttpSession();
-    Object sessionSubject = httpSession.getAttribute("che_subject");
-    if (sessionSubject != null) {
-      sec.getUserProperties().put("che_subject", sessionSubject);
+    if (httpSession != null) {
+      Object sessionSubject = httpSession.getAttribute("che_subject");
+      if (sessionSubject != null) {
+        sec.getUserProperties().put("che_subject", sessionSubject);
+      }
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
Fixes putting Che Subject into ServerEndpointConfig if http session is null

### What issues does this PR fix or reference?
This PR resolves a bug that is introduced in https://github.com/eclipse/che/pull/10922.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
