### PR TITLE
Log at the DEBUG level when xml document parsing is quiet

### DIFF
--- a/core/commons/che-core-commons-xml/pom.xml
+++ b/core/commons/che-core-commons-xml/pom.xml
@@ -31,6 +31,10 @@
             <artifactId>guava</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/core/commons/che-core-commons-xml/src/main/java/org/eclipse/che/commons/xml/QuietXmlErrorHandler.java
+++ b/core/commons/che-core-commons-xml/src/main/java/org/eclipse/che/commons/xml/QuietXmlErrorHandler.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.commons.xml;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.ErrorHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+/**
+ * The handler is designed for using at xml document parsing and logs messages at the DEBUG level
+ * only.
+ *
+ * @author Roman Nikitenko
+ */
+public class QuietXmlErrorHandler implements ErrorHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(QuietXmlErrorHandler.class);
+
+  @Override
+  public void warning(SAXParseException exception) throws SAXException {
+    LOG.debug("Warning at parsing xml document: " + exception.getLocalizedMessage(), exception);
+  }
+
+  @Override
+  public void error(SAXParseException exception) throws SAXException {
+    LOG.debug("Error at parsing xml document: " + exception.getLocalizedMessage(), exception);
+  }
+
+  @Override
+  public void fatalError(SAXParseException exception) throws SAXException {
+    LOG.debug("Fatal error at parsing xml document: " + exception.getLocalizedMessage(), exception);
+    throw exception;
+  }
+}

--- a/core/commons/che-core-commons-xml/src/main/java/org/eclipse/che/commons/xml/XMLTree.java
+++ b/core/commons/che-core-commons-xml/src/main/java/org/eclipse/che/commons/xml/XMLTree.java
@@ -375,6 +375,7 @@ public final class XMLTree {
   private Document parseQuietly(byte[] xml) {
     try {
       final DocumentBuilder db = DOCUMENT_BUILDER_FACTORY.newDocumentBuilder();
+      db.setErrorHandler(new QuietXmlErrorHandler());
       return db.parse(new ByteArrayInputStream(xml));
     } catch (Exception ex) {
       throw XMLTreeException.wrap(ex);

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/PomChangeListener.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/server/core/project/PomChangeListener.java
@@ -59,7 +59,7 @@ public class PomChangeListener {
     this.editorWorkingCopyManager = editorWorkingCopyManager;
     this.workspacePath = pathProvider.get();
 
-    launcher.scheduleWithFixedDelay(this::updateProms, 20, 3, TimeUnit.SECONDS);
+    launcher.scheduleWithFixedDelay(this::updateProjects, 20, 3, TimeUnit.SECONDS);
 
     eventService.subscribe(
         new EventSubscriber<ProjectItemModifiedEvent>() {
@@ -99,14 +99,12 @@ public class PomChangeListener {
         Model.readFrom(new File(workspacePath, path));
       }
     } catch (Exception e) {
-      JavaPlugin.log(e);
       return false;
     }
     return true;
   }
 
-  //    @ScheduleDelay(initialDelay = 30, delay = 3)
-  protected void updateProms() {
+  protected void updateProjects() {
     try {
       if (projectToUpdate.size() == 0) {
         return;

--- a/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/main/java/org/eclipse/che/plugin/testing/testng/server/TestNGRunner.java
+++ b/plugins/plugin-testing-java/plugin-testing-testng/che-plugin-testing-testng-server/src/main/java/org/eclipse/che/plugin/testing/testng/server/TestNGRunner.java
@@ -214,7 +214,7 @@ public class TestNGRunner extends AbstractJavaTestRunner {
       SAXParser parser = factory.newSAXParser();
       parser.parse(file.getContents(), suiteParser);
     } catch (ParserConfigurationException | SAXException | IOException e) {
-      LOG.error("It is not possible to parse file " + fileLocation, e);
+      LOG.debug("It is not possible to parse file " + fileLocation);
     } catch (CoreException e) {
       LOG.error("It is not possible to read file " + fileLocation, e);
     }


### PR DESCRIPTION
### What does this PR do?
- Do not log any errors when pom file is changed and maven model is broken. 
At this state we just need to know  - is pom valid or not and logs are useless. 
We have another entity to provide a list of problems for client side. 
- Replace error handler at quiet xml document parsing.
The new error handler will log messages at the DEBUG level instead of the default error handler prints all messages in the dev machine console at the moment. 

### What issues does this PR fix or reference?
#10754 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>