### PR TITLE
Source folders of Plain Java project are not properly shown in Projec…

### DIFF
--- a/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/main/java/org/eclipse/che/plugin/java/plain/server/projecttype/PlainJavaProjectUpdateUtil.java
+++ b/plugins/plugin-java/che-plugin-java-plain/che-plugin-java-plain-server/src/main/java/org/eclipse/che/plugin/java/plain/server/projecttype/PlainJavaProjectUpdateUtil.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.java.plain.server.projecttype;
+
+import static org.eclipse.che.api.fs.server.WsPathUtils.absolutize;
+import static org.eclipse.che.api.languageserver.LanguageServiceUtils.removePrefixUri;
+import static org.eclipse.che.api.languageserver.util.JsonUtil.convertToJson;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.che.api.core.BadRequestException;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.project.server.ProjectManager;
+import org.eclipse.che.api.project.server.impl.NewProjectConfigImpl;
+import org.eclipse.che.api.project.shared.NewProjectConfig;
+import org.eclipse.che.api.project.shared.RegisteredProject;
+import org.eclipse.che.jdt.ls.extension.api.Notifications;
+import org.eclipse.che.plugin.java.languageserver.NotifyJsonRpcTransmitter;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+
+public class PlainJavaProjectUpdateUtil {
+  public static CompletableFuture<Object> updateProjectConfig(
+      ProjectManager projectManager, String projectWsPath)
+      throws IOException, ForbiddenException, ConflictException, NotFoundException, ServerException,
+          BadRequestException {
+    String wsPath = absolutize(projectWsPath);
+    RegisteredProject project =
+        projectManager
+            .get(wsPath)
+            .orElseThrow(() -> new NotFoundException("Can't find project: " + projectWsPath));
+
+    NewProjectConfig projectConfig =
+        new NewProjectConfigImpl(
+            projectWsPath, project.getName(), project.getType(), project.getSource());
+    RegisteredProject result = projectManager.update(projectConfig);
+    return CompletableFuture.completedFuture(result.getPath());
+  }
+
+  public static void notifyClientOnProjectUpdate(
+      NotifyJsonRpcTransmitter notifyTransmitter, String projectPath) {
+    List<Object> parameters = new ArrayList<>();
+    parameters.add(removePrefixUri(convertToJson(projectPath).getAsString()));
+    notifyTransmitter.sendNotification(
+        new ExecuteCommandParams(Notifications.UPDATE_ON_PROJECT_CLASSPATH_CHANGED, parameters));
+  }
+}


### PR DESCRIPTION
…t Explorer after WS is restarted #10456

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fix adds a listener for Project Updated event which updates the plain java projects configuration on the client side on jdt.ls start (on workspace start and/or restart).

![ls10456](https://user-images.githubusercontent.com/620781/44876980-dc917600-aca2-11e8-9e97-302c262ee89b.gif)

### What issues does this PR fix or reference?

Fixes eclipse/che#10456

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
