### PR TITLE
Save all webdriver network logs with request URL starting from 'ws://'

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/webdriver/log/WebDriverLogsReader.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/webdriver/log/WebDriverLogsReader.java
@@ -141,8 +141,7 @@ public class WebDriverLogsReader {
 
   private boolean isUrlFromCheTraffic(String url) {
     return url != null
-        && (url.matches(format("https?://%s[:\\d]*/api/.*", cheHost))
-            || url.matches(format("wss?://%s[:\\d]*/(api|connect|wsagent).*", cheHost)));
+        && (url.matches(format("https?://%s[:\\d]*/api/.*", cheHost)) || url.matches("wss?://.*"));
   }
 
   private String formatTime(long timestamp) {


### PR DESCRIPTION
### What does this PR do?
It fixes selenium webdriver logs reader to store all network logs with request URL to **ws://**.

### What issues does this PR fix or reference?
#11021