### PR TITLE
Wrong noVNC port fixed.

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -488,7 +488,7 @@
               ],
               "servers": {
                 "VNC" : {
-                  "port" : "6091",
+                  "port" : "6901",
                   "protocol" : "http"
                 }
               },


### PR DESCRIPTION
noVNC port should be 6901 according to
eclipse/che-dockerfiles/blob/master/recipes/android/Dockerfile#L15

Signed-off-by: Radim Hopp <rhopp@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes wrong port for noVNC in Android stack in `stacks.json`

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
