### PR TITLE
CHE-10808: Use master branch of Che-Theia-hosted-plugin-manager-extension

### DIFF
--- a/dockerfiles/theia/src/extensions.json
+++ b/dockerfiles/theia/src/extensions.json
@@ -38,7 +38,7 @@
         {
             "name": "@eclipse-che/che-theia-hosted-plugin-manager-extension",
             "source": "https://github.com/eclipse/che-theia-hosted-plugin-manager-extension.git",
-            "checkoutTo": "latest-deps",
+            "checkoutTo": "master",
             "type": "git"
         },
         {


### PR DESCRIPTION
### What does this PR do?
Before resolutions have been merged we used separate branch with specific npm packages versions to make che-theia-hosted-plugin-manager-extension works against latest Theia release.
Now, when resolutions are applied in our Theia image, we can use master branch of the extension without a need to patch the extension an each Theia release (unless API breaking changes introduced).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10808