### PR TITLE
Various changes of Eclipse Che selenium tests result handling

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -811,7 +811,7 @@ generateFailSafeReport () {
     done
 
     # attach screenshots
-    for file in target/site/screenshots/*
+    for file in $(ls target/site/screenshots/* | sort -r)
     do
         local test=$(basename ${file} | sed 's/\(.*\)_.*/\1/')
         local divTag="<div id=\""${test}"error\" style=\"display:none;\">"
@@ -819,15 +819,15 @@ generateFailSafeReport () {
         sed -i "s/${divTag}/${divTag}${imgTag}/" ${FAILSAFE_REPORT}
     done
 
+    attachLinkToTestReport workspace-logs
+    attachLinkToTestReport webdriver-logs
+    attachLinkToTestReport htmldumps
+
     echo "[TEST]"
     echo "[TEST] Failsafe report"
     echo -e "[TEST] \t${BLUE}file://${CUR_DIR}/${FAILSAFE_REPORT}${NO_COLOUR}"
     echo "[TEST]"
     echo "[TEST]"
-
-    attachLinkToTestReport workspace-logs
-    attachLinkToTestReport webdriver-logs
-    attachLinkToTestReport htmldumps
 }
 
 # first argument - relative path to directory inside target/site
@@ -835,7 +835,7 @@ attachLinkToTestReport() {
     # attach links to resource related to failed test
     local relativePathToResource=$1
     local dirWithResources="target/site/$relativePathToResource/*"
-    for file in $dirWithResources
+    for file in $(ls ${dirWithResources} | sort -r)
     do
         local test=$(basename ${file} | sed 's/\(.*\)\.zip/\1/' | sed 's/\(.*\)_.*/\1/')
         local divTag="<div id=\""${test}"error\" style=\"display:none;\">"

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -845,7 +845,7 @@ attachLinkToTestReport() {
     local dirWithResources="target/site/$relativePathToResource/*"
     for file in $(ls ${dirWithResources} | sort -r)
     do
-        local test=$(basename ${file} | sed 's/\(.*\)\.zip/\1/' | sed 's/\(.*\)_.*/\1/')
+        local test=$(basename ${file} | sed 's/\(.*\)_.*/\1/')
         local testDetailTag="<div id=\"${test}error\" style=\"display:none;\">"
         local filename=$(basename ${file})
         local linkTag="<p><li><a href=\"$relativePathToResource\/$filename\" target=\"_blank\"><b>$titleOfLink<\/b>: $filename<\/a><\/li><\/p>"

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -800,28 +800,34 @@ generateFailSafeReport () {
 
     local regressions=$(findRegressions)
 
-    # add REGRESSION mark
+    # add REGRESSION marks
     for r in ${regressions[*]}
     do
         local test=$(basename $(echo ${r} | tr '.' '/') | sed 's/\(.*\)_.*/\1/')
 
-        local divTag="<a href=\"#"${r}"\">"${test}"<\/a>"
-        local divRegTag="<h2>REGRESSION<\/h2>"${divTag}
-        sed -i 's/'"${divTag}"'/'"${divRegTag}"'/' ${FAILSAFE_REPORT}
+        local aTag="<a href=\"#"${r}"\">"${test}"<\/a>"
+        local divRegTag="<h2>REGRESSION<\/h2>"${aTag}
+        sed -i "s/${aTag}/${divRegTag}/" ${FAILSAFE_REPORT}
     done
+
+    # add link the che server logs archive into the 'Summary' section of failsafe report
+    local summaryTag="Summary<\/h2><a name=\"Summary\"><\/a>"
+    local cheServerLogsFile="target\/site\/che_server_logs.zip"
+    local linkToCheServerLogsTag="<p>\[<a href=\"$cheServerLogsFile\" target=\"_blank\">Eclipse Che Server logs<\/a>\]<\/p>"
+    sed -i "s/${summaryTag}/${summaryTag}${linkToCheServerLogsTag}/" ${FAILSAFE_REPORT}
 
     # attach screenshots
     for file in $(ls target/site/screenshots/* | sort -r)
     do
         local test=$(basename ${file} | sed 's/\(.*\)_.*/\1/')
-        local divTag="<div id=\""${test}"error\" style=\"display:none;\">"
-        local imgTag="<p><img src=\"screenshots\/"$(basename ${file})"\"><p>"
-        sed -i "s/${divTag}/${divTag}${imgTag}/" ${FAILSAFE_REPORT}
+        local testDetailTag="<div id=\"${test}error\" style=\"display:none;\">"
+        local screenshotTag="<p><img src=\"screenshots\/"$(basename ${file})"\"><p>"
+        sed -i "s/${testDetailTag}/${testDetailTag}${screenshotTag}/" ${FAILSAFE_REPORT}
     done
 
-    attachLinkToTestReport workspace-logs
-    attachLinkToTestReport webdriver-logs
-    attachLinkToTestReport htmldumps
+    attachLinkToTestReport workspace-logs "Workspace logs"
+    attachLinkToTestReport webdriver-logs "Browser logs"
+    attachLinkToTestReport htmldumps "Web page source"
 
     echo "[TEST]"
     echo "[TEST] Failsafe report"
@@ -831,17 +837,19 @@ generateFailSafeReport () {
 }
 
 # first argument - relative path to directory inside target/site
+# second argument - title of the link
 attachLinkToTestReport() {
     # attach links to resource related to failed test
     local relativePathToResource=$1
+    local titleOfLink=$2
     local dirWithResources="target/site/$relativePathToResource/*"
     for file in $(ls ${dirWithResources} | sort -r)
     do
         local test=$(basename ${file} | sed 's/\(.*\)\.zip/\1/' | sed 's/\(.*\)_.*/\1/')
-        local divTag="<div id=\""${test}"error\" style=\"display:none;\">"
+        local testDetailTag="<div id=\"${test}error\" style=\"display:none;\">"
         local filename=$(basename ${file})
-        local aTag="<p><li><a href=\"$relativePathToResource\/$filename\" target=\"_blank\">$relativePathToResource<\/a><\/li><\/p>"
-        sed -i "s/${divTag}/${divTag}${aTag}/" ${FAILSAFE_REPORT}
+        local linkTag="<p><li><a href=\"$relativePathToResource\/$filename\" target=\"_blank\"><b>$titleOfLink<\/b>: $filename<\/a><\/li><\/p>"
+        sed -i "s/${testDetailTag}/${testDetailTag}${linkTag}/" ${FAILSAFE_REPORT}
     done
 }
 

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -536,7 +536,7 @@ public abstract class SeleniumTestHandler
   }
 
   private String getTestResultFilename(String testReference, String fileExtension) {
-    return format("%s_%s.%s", testReference, System.nanoTime(), fileExtension);
+    return format("%s_time-%s-millis.%s", testReference, System.currentTimeMillis(), fileExtension);
   }
 
   private String getTestReference(ITestResult result) {

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReader.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/TestWorkspaceLogsReader.java
@@ -66,6 +66,11 @@ public abstract class TestWorkspaceLogsReader {
       return;
     }
 
+    // check if workspace exists
+    if (workspaceId == null) {
+      return;
+    }
+
     // check if workspace is running
     try {
       WorkspaceStatus status = workspaceServiceClient.getStatus(workspaceId);


### PR DESCRIPTION
### What does this PR do?
It improves handling of selenium tests results:
- does not treat _SeleniumTestHandler_ error as test failure;
- prevents `Workspace with id 'null' doesn't exist` error when reading logs of non-existed workspace;
- attaches screenshots and links to result resources in alphabetical order into **failsafe-report.html**;
- unifies file name of test result resources and uses current time in nanosec instead of random string
- stores logs of workspaces for all test method invocation separately;
- capture test result objects in case of TestNG configuration method error;
- don't capture results objects if test/configuration method is skipping;
- capture html dumps and logs from all opened windows;
- add link to Che server logs into E2E test report.

### What issues does this PR fix or reference?
#10257
