### PR TITLE
Fixed helm deployment with default value of loggerConfig

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -70,9 +70,7 @@ data:
   CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"kubernetes.io/ingress.class": "nginx", "{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/rewrite-target": "/","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/ssl-redirect": "false","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout": "3600","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout": "3600"}'
 {{- end }}
   CHE_INFRA_KUBERNETES_SERVER__STRATEGY: {{ .Values.global.serverStrategy }}
-{{- if .Values.global.log.loggerConfig }}
   CHE_LOGGER_CONFIG: {{ .Values.global.log.loggerConfig }}
-{{- end }}
   CHE_LOGS_APPENDERS_IMPL: {{ .Values.global.log.appenderName }}
   CHE_WORKSPACE_HTTP__PROXY: {{ .Values.cheWorkspaceHttpProxy }}
   CHE_WORKSPACE_HTTPS__PROXY: {{ .Values.cheWorkspaceHttpsProxy }}


### PR DESCRIPTION
### What does this PR do?
loggerConfig by default empty string, as a result, it's not added to configMap. However, Che deployment requires CHE_LOGGER_CONFIG value to be present in configMap
Issue introduced #10912 
### What issues does this PR fix or reference?
n/a

#### Release Notes
Fixed helm deployment with default value of loggerConfig

#### Docs PR
n/a