### PR TITLE
CHE-10756: Use regular user instead of root in theia image

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -26,4 +26,5 @@ ADD supervisord.conf /etc/
 
 RUN ${HOME}/setup.sh
 
+USER theia
 ENTRYPOINT ["/usr/bin/supervisord", "-n", "-c", "/etc/supervisord.conf"]

--- a/dockerfiles/theia/e2e/Dockerfile
+++ b/dockerfiles/theia/e2e/Dockerfile
@@ -8,6 +8,8 @@
 # Use upstream image
 FROM ${BUILD_ORGANIZATION}/${BUILD_PREFIX}-theia:${BUILD_TAG}
 
+USER root
+
 # Install packages used by Cypress
 RUN yum install -y gtk2-2.24.31-1.el7.x86_64 libnotify-0.7.7-1.el7.x86_64 GConf2 nss-3.36.0-5.el7_5.x86_64 libXScrnSaver-1.2.2-6.1.el7.x86_64 alsa-lib-1.1.4.1-2.el7.x86_64 xorg-x11-server-Xvfb-1.19.5-5.el7.x86_64 && \
     dbus-uuidgen > /var/lib/dbus/machine-id

--- a/dockerfiles/theia/src/resolutions-provider.js
+++ b/dockerfiles/theia/src/resolutions-provider.js
@@ -41,7 +41,7 @@ try {
     spawnSync('curl',[`${NPM_API_URL}/search?q=${keyWords}&size=${resultSize}`, '-o', SEARCH_JSON_PATH]);
 } catch(error) {
     console.error("Failed to get Theia depedencies. Cause: ", error);
-    process.exit(2);
+    process.exit(1);
 }
 
 const packageScopeRegexp = '^@theia/.*$';

--- a/dockerfiles/theia/src/setup.sh
+++ b/dockerfiles/theia/src/setup.sh
@@ -42,7 +42,6 @@ useradd -u 1000 -G users,wheel,root -d ${HOME} --shell /bin/bash theia
 usermod -p "*" theia
 echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
-
 for f in "/etc/passwd" "/etc/group"; do
     chgrp -R 0 ${f}
     chmod -R g+rwX ${f};
@@ -51,7 +50,6 @@ done
 cat /etc/passwd | sed s#root:x.*#root:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g > ${HOME}/passwd.template
 # Generate group.template
 cat /etc/group | sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g > ${HOME}/group.template
-
 
 # Add yarn repo
 curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo

--- a/dockerfiles/theia/src/start.sh
+++ b/dockerfiles/theia/src/start.sh
@@ -15,18 +15,23 @@ export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
 
 if ! grep -Fq "${USER_ID}" /etc/passwd; then
-    # current user is an arbitrary 
-    # user (its uid is not in the 
-    # container /etc/passwd). Let's fix that    
+    # current user is an arbitrary
+    # user (its uid is not in the
+    # container /etc/passwd). Let's fix that
     cat ${HOME}/passwd.template | \
     sed "s/\${USER_ID}/${USER_ID}/g" | \
     sed "s/\${GROUP_ID}/${GROUP_ID}/g" | \
     sed "s/\${HOME}/\/home\/theia/g" > /etc/passwd
-    
+
     cat ${HOME}/group.template | \
     sed "s/\${USER_ID}/${USER_ID}/g" | \
     sed "s/\${GROUP_ID}/${GROUP_ID}/g" | \
     sed "s/\${HOME}/\/home\/theia/g" > /etc/group
+fi
+
+# Grant access to projects volume in case of non root user with sudo rights
+if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
+    sudo chown ${USER_ID}:${GROUP_ID} /projects
 fi
 
 if [ -z "$THEIA_PORT" ]; then


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Before we used root in Theia image. It is not good way to go and moreover caused some problems, for example, with `yo` generator.
This PR adds regular user `theia` and runs Theia IDE on behalf of the user.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10756


Tested on docker infrastructure and openshift.io