### PR TITLE
Don't throw an exception if none LS was found

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/settings/compiler/JavaCompilerPreferencePresenterTest.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/test/java/org/eclipse/che/ide/ext/java/client/settings/compiler/JavaCompilerPreferencePresenterTest.java
@@ -53,7 +53,6 @@ import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.ide.api.notification.NotificationManager;
 import org.eclipse.che.ide.api.preferences.PreferencePagePresenter.DirtyStateListener;
 import org.eclipse.che.ide.api.preferences.PreferencesManager;
-import org.eclipse.che.ide.api.workspace.event.WorkspaceRunningEvent;
 import org.eclipse.che.ide.ext.java.client.JavaLocalizationConstant;
 import org.eclipse.che.ide.ext.java.client.inject.factories.PropertyWidgetFactory;
 import org.eclipse.che.ide.ext.java.client.settings.property.PropertyWidget;
@@ -88,7 +87,6 @@ public class JavaCompilerPreferencePresenterTest {
   @Mock private Promise<Map<String, String>> mapPromise;
   @Mock private AcceptsOneWidget container;
   @Mock private PropertyWidget widget;
-  @Mock private WorkspaceRunningEvent workspaceRunningEvent;
 
   @Captor private ArgumentCaptor<Map<String, String>> mapCaptor;
   @Captor private ArgumentCaptor<Operation<Map<String, String>>> operationCaptor;
@@ -125,7 +123,6 @@ public class JavaCompilerPreferencePresenterTest {
     when(widget.getSelectedValue()).thenReturn(VALUE_2);
     when(preferencesManager.getValue(anyString())).thenReturn(VALUE_1);
 
-    presenter.onWorkspaceRunning(workspaceRunningEvent);
     presenter.go(container);
 
     verify(mapPromise).then(operationCaptor.capture());
@@ -148,7 +145,6 @@ public class JavaCompilerPreferencePresenterTest {
     when(widget.getSelectedValue()).thenReturn(VALUE_2);
     when(preferencesManager.getValue(anyString())).thenReturn(VALUE_1);
 
-    presenter.onWorkspaceRunning(workspaceRunningEvent);
     presenter.go(container);
 
     verify(mapPromise).then(operationCaptor.capture());
@@ -219,7 +215,6 @@ public class JavaCompilerPreferencePresenterTest {
 
   @Test
   public void propertiesShouldBeDisplayed() throws Exception {
-    presenter.onWorkspaceRunning(workspaceRunningEvent);
     presenter.go(container);
 
     verify(mapPromise).then(operationCaptor.capture());
@@ -239,7 +234,6 @@ public class JavaCompilerPreferencePresenterTest {
 
     when(notificationManagerProvider.get()).thenReturn(notificationManager);
 
-    presenter.onWorkspaceRunning(workspaceRunningEvent);
     presenter.go(container);
 
     verify(mapPromise).catchError(errorOperationCaptor.capture());

--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
@@ -955,7 +955,9 @@ public class JavaLanguageServerExtensionService {
    */
   public JavaCoreOptions getJavaCoreOptions(List<String> filter) {
     Type type = new TypeToken<JavaCoreOptions>() {}.getType();
-    return doGetOne(Commands.GET_JAVA_CORE_OPTIONS_СOMMAND, new ArrayList<>(filter), type);
+    JavaCoreOptions result =
+        doGetOne(Commands.GET_JAVA_CORE_OPTIONS_СOMMAND, new ArrayList<>(filter), type);
+    return result == null ? new JavaCoreOptions() : result;
   }
 
   /** Updates JDT LS java core options. */

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerInitializer.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerInitializer.java
@@ -107,9 +107,8 @@ public class LanguageServerInitializer {
    * any point - skips them and proceeds with the rest.
    *
    * @param wsPath absolute workspace path
-   * @return accumulated server capabilities of all initialized language servers
-   * @throws CompletionException if no server initialized throws {@link LanguageServerException}
-   *     wrapped by {@link CompletionException}
+   * @return accumulated server capabilities of all initialized language servers or empty
+   *     capabilities if none language server was found for current path
    */
   public CompletableFuture<ServerCapabilities> initialize(String wsPath) {
     return supplyAsync(
@@ -135,10 +134,8 @@ public class LanguageServerInitializer {
 
           LOG.debug("Calculating number of initialized servers and accumulating capabilities");
           if (serverCapabilitiesSet.isEmpty()) {
-            String message = String.format("Could not initialize any server for '%s'", wsPath);
-            LOG.error(message);
-            LanguageServerException cause = new LanguageServerException(message);
-            throw new CompletionException(cause);
+            // None language server was found for current path
+            return new ServerCapabilities();
           } else {
             return serverCapabilitiesSet
                 .stream()


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
1. Add a way to check if jdt.ls installer exists in workspace's configuration;
2. Add initialization methods which is called when workspace is ready;
3. Don't ask for Java compiler options when workspace is running.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11091
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
