### PR TITLE
Set JWT proxy pulling strategy to Always

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
@@ -266,7 +266,7 @@ public class JwtProxyProvisioner {
         .withNewSpec()
         .withContainers(
             new ContainerBuilder()
-                .withImagePullPolicy("IfNotPresent")
+                .withImagePullPolicy("Always")
                 .withName("verifier")
                 .withImage(jwtProxyImage)
                 .withVolumeMounts(


### PR DESCRIPTION
### What does this PR do?
Now JWT Proxy uses image pull policy `IfNotPresent` which means that updates of a tag of the image are not populated on a node where this tag already exists.
I believe that pulling strategy `Always` would be a better fit for a security container.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
