### PR TITLE
Fix an ability to use locally built images of Che on minishift

### DIFF
--- a/deploy/openshift/templates/che-server-template.yaml
+++ b/deploy/openshift/templates/che-server-template.yaml
@@ -211,8 +211,8 @@ parameters:
   value: nightly
 - name: IMAGE_CHE
   displayName: Eclipse Che server image
-  description: Che server Docker image. Defaults to docker.io/eclipse/che-server
-  value: docker.io/eclipse/che-server
+  description: Che server Docker image. Defaults to eclipse/che-server
+  value: eclipse/che-server
 - name: CHE_MULTIUSER
   displayName: Che Multi-user flavor
   description: False i.e. single user by default


### PR DESCRIPTION
### What does this PR do?
Latest versions of minishift ignore Che master docker image that
was built locally inside the VM.
Removing `docker.io` prefix from the image name workarounds the issue.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
