### PR TITLE
 Fix selenium tests in 'git' package to increase reliability

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AmendCommitTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AmendCommitTest.java
@@ -88,7 +88,7 @@ public class AmendCommitTest {
 
   @Test
   public void checkAmendPreviousCommit() {
-    String pathToFile = PROJECT_NAME + "/src/main/java/org.eclipse.qa.examples";
+    String pathToFileItem = PROJECT_NAME + "/src/main/java/org.eclipse.qa.examples";
     String javaFileName = "AppController.java";
 
     projectExplorer.waitProjectExplorer();
@@ -109,7 +109,7 @@ public class AmendCommitTest {
 
     // edit java file and commit the change
     projectExplorer.waitAndSelectItem(PROJECT_NAME);
-    projectExplorer.expandPathInProjectExplorerAndOpenFile(pathToFile, javaFileName);
+    projectExplorer.expandPathInProjectExplorerAndOpenFile(pathToFileItem, javaFileName);
     editor.waitActive();
     editor.setCursorToLine(15);
     editor.typeTextIntoEditor("//" + CHANGE_CONTENT);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AmendCommitTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AmendCommitTest.java
@@ -88,6 +88,9 @@ public class AmendCommitTest {
 
   @Test
   public void checkAmendPreviousCommit() {
+    String pathToFile = PROJECT_NAME + "/src/main/java/org.eclipse.qa.examples";
+    String javaFileName = "AppController.java";
+
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.waitAndSelectItem(PROJECT_NAME);
@@ -106,10 +109,9 @@ public class AmendCommitTest {
 
     // edit java file and commit the change
     projectExplorer.waitAndSelectItem(PROJECT_NAME);
-    projectExplorer.quickExpandWithJavaScript();
-    projectExplorer.openItemByPath(PATH_TO_FILE);
+    projectExplorer.expandPathInProjectExplorerAndOpenFile(pathToFile, javaFileName);
     editor.waitActive();
-    editor.setCursorToLine(12);
+    editor.setCursorToLine(15);
     editor.typeTextIntoEditor("//" + CHANGE_CONTENT);
     editor.waitTextIntoEditor("//" + CHANGE_CONTENT);
     menu.runCommand(GIT, COMMIT);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesByMultiSelectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/CommitFilesByMultiSelectTest.java
@@ -181,7 +181,6 @@ public class CommitFilesByMultiSelectTest {
     git.closeGitInfoPanel();
     projectExplorer.selectMultiFilesByCtrlKeys(
         PROJECT_NAME + "/my-webapp/src/main/java/helloworld/AppController.java");
-    menu.runCommand(TestMenuCommandsConstants.Git.GIT, TestMenuCommandsConstants.Git.ADD_TO_INDEX);
     menu.runCommand(TestMenuCommandsConstants.Git.GIT, TestMenuCommandsConstants.Git.COMMIT);
     git.waitAndRunCommit(COMMIT_MESSAGE_1);
     menu.runCommand(TestMenuCommandsConstants.Git.GIT, TestMenuCommandsConstants.Git.STATUS);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullTest.java
@@ -29,6 +29,7 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
+import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -52,6 +53,7 @@ public class GitPullTest {
   @Inject private org.eclipse.che.selenium.pageobject.git.Git git;
   @Inject private CodenvyEditor editor;
   @Inject private TestUserPreferencesServiceClient testUserPreferencesServiceClient;
+  @Inject private NotificationsPopupPanel notificationsPopupPanel;
 
   @BeforeClass
   public void prepare() throws Exception {
@@ -95,6 +97,8 @@ public class GitPullTest {
     testRepo.deleteFolder(Paths.get(folderWithPlainFilesPath), "remove file");
 
     performPull();
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
+
     checkPullAfterRemovingContent(
         readmeTxtFileName,
         String.format("/%s/%s/%s", PROJECT_NAME, folderWithPlainFilesPath, readmeTxtFileName));


### PR DESCRIPTION
### What does this PR do?

* Correct some selenium tests from the _git_ package to increase their reliability when run on CI:
   - _AmendCommitTest_ -  replace the _quickExpandWithJavaScript_() method on the expandPathInProjectExplorerAndOpenFile()
  -  _CommitFilesByMultiSelectTest_ - delete calling _addToIndex_ from test class as redundant and potentially leading to fail the test
  -  _GitPullTest_ - add the waiting to closing the notification pop-up after git pull to provide refresh the editor 
### What issues does this PR fix or reference?
#11105 