### PR TITLE
Manage the list of plugins from Che plugins registry

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -24,7 +24,7 @@ export  interface IInitData {
   workspaceDetails: che.IWorkspace;
 }
 
-const TAB: Array<string> = ['Overview', 'Projects', 'Machines', 'Installers', 'Servers', 'Env_Variables', 'Volumes', 'Config', 'SSH', 'Tools'];
+const TAB: Array<string> = ['Overview', 'Projects', 'Machines', 'Installers', 'Servers', 'Env_Variables', 'Volumes', 'Config', 'SSH', 'Tools', 'Plugins'];
 
 /**
  * @ngdoc controller
@@ -66,6 +66,7 @@ export class WorkspaceDetailsController {
   private errorMessage: string = '';
   private tabsValidationTimeout: ng.IPromise<any>;
   private toolsFilter: Function;
+  private pluginRegistry: string;
   /**
    * There are unsaved changes to apply (with restart) when is't <code>true</code>.
    */
@@ -95,6 +96,7 @@ export class WorkspaceDetailsController {
     this.ideSvc = ideSvc;
     this.workspaceDetailsService = workspaceDetailsService;
     this.workspacesService = workspacesService;
+    this.pluginRegistry = cheWorkspace.getWorkspaceSettings() != null ? cheWorkspace.getWorkspaceSettings().cheWorkspacePluginRegistryUrl : null;
 
     if (!initData.workspaceDetails) {
       cheNotification.showError(`There is no workspace with name ${initData.workspaceName}`);

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -178,6 +178,20 @@
       </md-tab-body>
     </md-tab>
 
+    <!-- Plugins tab -->
+    <md-tab ng-if="workspaceDetailsController.pluginRegistry"
+      md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Plugins);">
+      <md-tab-label>
+        <span class="che-tab-label-title">Plugins</span>
+      </md-tab-label>
+      <md-tab-body>
+        <workspace-plugins workspace-config="workspaceDetailsController.workspaceDetails.config"
+                           plugin-registry-location="workspaceDetailsController.pluginRegistry"
+                           on-change="workspaceDetailsController.checkEditMode(true)">
+        </workspace-plugins>
+      </md-tab-body>
+    </md-tab>
+
     <!-- Other tabs -->
     <md-tab ng-repeat="section in workspaceDetailsController.getPages()"
             ng-init="workspaceDetailsController.addTab(section.title);"

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins-config.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins-config.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+
+import {WorkspacePluginsController} from './workspace-plugins.controller';
+import {WorkspacePlugins} from './workspace-plugins.directive';
+
+/**
+ * @author Ann Shumilova
+ */
+export class WorkspacePluginsConfig {
+
+  constructor(register: che.IRegisterService) {
+    register.controller('WorkspacePluginsController', WorkspacePluginsController);
+    register.directive('workspacePlugins', WorkspacePlugins);
+  }
+}

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.controller.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+import {IPlugin, PluginRegistry} from '../../../../components/api/plugin-registry.factory';
+import IWorkspaceConfig = che.IWorkspaceConfig;
+import {CheNotification} from '../../../../components/notification/che-notification.factory';
+
+const PLUGINS_ATTRIBUTE = 'plugins';
+const EDITOR_ATTRIBUTE = 'editor';
+const PLUGIN_SEPARATOR = ',';
+const PLUGIN_VERSION_SEPARATOR = ':';
+const PLUGIN_TYPE = 'Che Plugin';
+const EDITOR_TYPE = 'Che Editor';
+
+/**
+ * @ngdoc controller
+ * @name workspaces.details.plugins.controller:WorkspacePluginsController
+ * @description This class is handling the controller for details of workspace : section plugin
+ * @author Ann Shumilova
+ */
+export class WorkspacePluginsController {
+  static $inject = ['pluginRegistry', 'cheListHelperFactory', '$scope', 'cheNotification'];
+
+  workspaceConfig: IWorkspaceConfig;
+  pluginRegistryLocation: string;
+
+  pluginRegistry: PluginRegistry;
+  cheNotification: CheNotification;
+  onChange: Function;
+  isLoading: boolean;
+
+  pluginOrderBy = 'name';
+  plugins: Array<IPlugin> = [];
+  selectedPlugins: Array<string> = [];
+  selectedEditor: string = '';
+
+  pluginFilter: any;
+
+  private cheListHelper: che.widget.ICheListHelper;
+
+  /**
+   * Default constructor that is using resource
+   */
+  constructor(pluginRegistry: PluginRegistry, cheListHelperFactory: che.widget.ICheListHelperFactory, $scope: ng.IScope,
+              cheNotification: CheNotification) {
+    this.pluginRegistry = pluginRegistry;
+    this.cheNotification = cheNotification;
+
+    const helperId = 'workspace-plugins';
+    this.cheListHelper = cheListHelperFactory.getHelper(helperId);
+
+    $scope.$on('$destroy', () => {
+      cheListHelperFactory.removeHelper(helperId);
+    });
+
+    this.pluginFilter = {name: ''};
+
+    const deRegistrationFn = $scope.$watch(() => {
+      return this.workspaceConfig;
+    }, (workspaceConfig: IWorkspaceConfig) => {
+      if (!workspaceConfig) {
+        return;
+      }
+      this.updatePlugins();
+    }, true);
+
+    $scope.$on('$destroy', () => {
+      deRegistrationFn();
+    });
+
+    this.loadPlugins();
+  }
+
+  /**
+   * Loads the list of plugins from registry.
+   */
+  loadPlugins(): void {
+    this.isLoading = true;
+    this.pluginRegistry.fetchPlugins(this.pluginRegistryLocation).then((result: Array<IPlugin>) => {
+      this.isLoading = false;
+      this.plugins = result;
+      this.updatePlugins();
+    }, (error: any) => {
+      this.isLoading = false;
+      this.cheNotification.showError(error.data && error.data.message ? error.data.message : 'Failed to load plugins.');
+    });
+  }
+
+  /**
+   * Callback when name is changed.
+   *
+   * @param str {string} a string to filter projects names
+   */
+  onSearchChanged(str: string): void {
+    this.pluginFilter.name = str;
+    this.cheListHelper.applyFilter('name', this.pluginFilter);
+  }
+
+  /**
+   * Update plugin information based on UI changes.
+   *
+   * @param {IPlugin} plugin
+   */
+  updatePlugin(plugin: IPlugin): void {
+    let name = plugin.id + PLUGIN_VERSION_SEPARATOR + plugin.version;
+
+    if (plugin.type === EDITOR_TYPE) {
+      this.selectedEditor = plugin.isEnabled ? name : '';
+      this.workspaceConfig.attributes[EDITOR_ATTRIBUTE] = this.selectedEditor;
+    } else {
+      if (plugin.isEnabled) {
+        this.selectedPlugins.push(name);
+      } else {
+        this.selectedPlugins.splice(this.selectedPlugins.indexOf(name), 1);
+      }
+      this.workspaceConfig.attributes[PLUGINS_ATTRIBUTE] = this.selectedPlugins.join(PLUGIN_SEPARATOR);
+    }
+    this.onChange();
+  }
+
+  /**
+   * Update the state of plugins.
+   */
+  private updatePlugins(): void {
+    // get selected plugins from workspace configuration attribute - "plugins" (coma separated values):
+    this.selectedPlugins = this.workspaceConfig && this.workspaceConfig.attributes && this.workspaceConfig.attributes[PLUGINS_ATTRIBUTE] ?
+      this.workspaceConfig.attributes[PLUGINS_ATTRIBUTE].split(PLUGIN_SEPARATOR) : [];
+    // get selected plugins from workspace configuration attribute - "editor":
+    this.selectedEditor = this.workspaceConfig && this.workspaceConfig.attributes && this.workspaceConfig.attributes[EDITOR_ATTRIBUTE] ?
+     this.workspaceConfig.attributes[EDITOR_ATTRIBUTE] : '';
+    // check each plugin's enabled state:
+    this.plugins.forEach((plugin: IPlugin) => {
+      plugin.isEnabled = this.isPluginEnabled(plugin);
+    });
+
+    this.cheListHelper.setList(this.plugins, 'name');
+  }
+
+  /**
+   *
+   * @param {IPlugin} plugin
+   * @returns {boolean} the plugin's enabled state
+   */
+  private isPluginEnabled(plugin: IPlugin): boolean {
+    // name in the format: id:version
+    let name = plugin.id + PLUGIN_VERSION_SEPARATOR + plugin.version;
+    // check based on type (editor or plugin):
+    return plugin.type === PLUGIN_TYPE ? (this.selectedPlugins.indexOf(name) >= 0) : name === this.selectedEditor;
+  }
+}

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.directive.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+/**
+ * @ngdoc directive
+ * @name workspaces.details.tools.directive:workspacePlugins
+ * @restrict E
+ * @element
+ *
+ * @description
+ * <workspace-plugins></workspace-plugins>` for displaying workspace plugins.
+ *
+ * @author Ann Shumilova
+ */
+export class WorkspacePlugins implements ng.IDirective {
+  restrict = 'E';
+  templateUrl = 'app/workspaces/workspace-details/workspace-plugins/workspace-plugins.html';
+
+  controller = 'WorkspacePluginsController';
+  controllerAs = 'workspacePluginsController';
+
+  bindToController = true;
+
+  scope: {
+    [propName: string]: string
+  };
+
+  /**
+   * Default constructor that is using resource
+   */
+  constructor() {
+    this.scope = {
+      onChange: '&',
+      workspaceConfig: '=',
+      pluginRegistryLocation: '='
+    };
+  }
+}

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.html
@@ -1,0 +1,80 @@
+<md-progress-linear ng-show="workspacePluginsController.isLoading" md-mode="indeterminate"></md-progress-linear>
+<div flex layout="column" md-theme="maincontent-theme" class="plugins-page">
+  <che-list-header-additional-parts>
+    <div che-multi-transclude-part="che-list-add-button">
+    </div>
+    <div che-multi-transclude-part="che-list-search">
+      <che-list-header-search placeholder="Search"
+                              query="workspacePluginsController.pluginFilter.name"
+                              on-change="workspacePluginsController.onSearchChanged(query)"></che-list-header-search>
+    </div>
+  </che-list-header-additional-parts>
+
+  <che-list-header che-hide-header="workspacePluginsController.cheListHelper.visibleItemsNumber === 0">
+    <div flex="100"
+         layout="row"
+         layout-align="start stretch"
+         class="che-list-item-row">
+      <div layout="row" layout-align="center center" class="che-list-item-checkbox"></div>
+      <div flex layout="row" layout-align="start center" class="che-list-item-details">
+        <che-list-header-column flex="10" layout="column" layout-align="center start"
+                                che-sort-value="workspacePluginsController.pluginOrderBy"
+                                che-sort-item="isEnabled"
+                                che-column-title="Enable"></che-list-header-column>
+        <che-list-header-column flex="25" layout="column" layout-align="center start"
+                                che-sort-value="workspacePluginsController.pluginOrderBy"
+                                che-sort-item="name"
+                                che-column-title="Name"></che-list-header-column>
+        <che-list-header-column flex="15" layout="column" layout-align="center start"
+                                che-column-title="Version"></che-list-header-column>
+        <che-list-header-column flex="50" layout="column" layout-align="center start"
+                                che-column-title="Description"></che-list-header-column>
+      </div>
+    </div>
+  </che-list-header>
+  <!-- plugins list  -->
+  <che-list class="plugins-list" flex
+            ng-if="workspacePluginsController.plugins && workspacePluginsController.plugins.length > 0">
+    <div class="plugin-item"
+         ng-repeat="plugin in workspacePluginsController.cheListHelper.getVisibleItems() | orderBy:[workspacePluginsController.pluginOrderBy, 'name' ]">
+      <che-list-item flex>
+        <div flex="100"
+             layout="row"
+             layout-align="start stretch"
+             plugin-item-name="{{plugin.name}}"
+             plugin-item-version="{{plugin.version}}"
+             class="che-list-item-row">
+          <div layout="row" layout-align="center center" class="che-list-item-checkbox"></div>
+          <div flex layout="row" layout-align="start center">
+            <!-- isEnabled -->
+            <div flex="10">
+              <md-switch ng-model="plugin.isEnabled"
+                         ng-change="workspacePluginsController.updatePlugin(plugin)"
+                         aria-label="plugin"
+                         plugin-switch="{{plugin.name}}">
+              </md-switch>
+            </div>
+            <!-- Name -->
+            <div flex="25">
+              <span class="che-list-item-name" plugin-name="{{plugin.name}}">{{plugin.name}}</span>
+            </div>
+            <!-- Version -->
+            <div flex="15">
+              <span class="che-list-item-name" plugin-version="{{plugin.version}}">{{plugin.version}}</span>
+            </div>
+            <!-- Description -->
+            <div flex="50">
+              <span class="che-list-item-secondary" plugin-description="{{plugin.description}}">{{plugin.description}}</span>
+            </div>
+          </div>
+        </div>
+      </che-list-item>
+    </div>
+  </che-list>
+  <div class="che-list-empty">
+    <span ng-show="workspacePluginsController.plugins.length > 0 && workspacePluginsController.cheListHelper.visibleItemsNumber === 0">
+      No plugins found.
+    </span>
+    <span ng-show="workspacePluginsController.plugins.length === 0">There are no plugins.</span>
+  </div>
+</div>

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.styl
@@ -1,0 +1,54 @@
+.plugins-page
+  margin 0 25px
+
+  .che-list-header-additional-parts
+      padding-left 0
+      padding-right 0
+      padding-bottom 10px
+    md-item
+      border-top none
+    .che-list-header-content
+      *
+        margin-left 0
+        margin-right 0
+      div.che-list-item-row
+        min-height 47px
+        line-height 47px
+        background-color $cat-gray-color
+        border 1px solid $very-light-grey-color
+      .che-list-item-checkbox
+        min-width 50px
+        height inherit
+
+  div.che-list-header-column
+    line-height inheri
+    .header-sort-direction
+      position absolute
+
+  .plugins-list
+    margin-left 0
+    margin-right 0
+    margin-bottom 1px
+    che-box-shadow()
+  .plugins-list .plugin-item
+    position relative
+    background-color $che-white-color
+    border 1px solid $very-light-grey-color
+    border-top none
+    *
+      outline none
+    md-item.che-list-item
+      display block
+      border none
+    md-item-content
+      display block
+      border none
+      md-switch
+        margin 0
+        overflow visible !important
+      .che-list-item-row
+        line-height 47px
+        height 47px
+        .che-list-item-checkbox
+          min-width 50px
+          height inherit

--- a/dashboard/src/app/workspaces/workspaces-config.ts
+++ b/dashboard/src/app/workspaces/workspaces-config.ts
@@ -82,6 +82,7 @@ import {WorkspaceDetailsConfig} from './workspace-details/workspace-details-conf
 import {WorkspaceWarnings} from './workspace-details/warnings/workspace-warnings.directive';
 import {WorkspaceWarningsController} from './workspace-details/warnings/workspace-warnings.controller';
 import {WorkspacesService} from './workspaces.service';
+import {WorkspacePluginsConfig} from './workspace-details/workspace-plugins/workspace-plugins-config';
 
 /**
  * @ngdoc controller
@@ -98,6 +99,7 @@ export class WorkspacesConfig {
     new StackSelectorSearchFilter(register);
     new StackSelectorTagsFilter(register);
     new WorkspaceDetailsConfig(register);
+    new WorkspacePluginsConfig(register);
     /* tslint:enable */
 
     register.controller('ListWorkspacesCtrl', ListWorkspacesCtrl);

--- a/dashboard/src/components/api/che-api-config.ts
+++ b/dashboard/src/components/api/che-api-config.ts
@@ -42,6 +42,7 @@ import {CheTeam} from './che-team.factory';
 import {CheTeamEventsManager} from './che-team-events-manager.factory';
 import {CheInvite} from './che-invite.factory';
 import {NpmRegistry} from './npm-registry.factory';
+import {PluginRegistry} from './plugin-registry.factory';
 
 export class ApiConfig {
 
@@ -77,5 +78,6 @@ export class ApiConfig {
     register.factory('cheTeamEventsManager', CheTeamEventsManager);
     register.factory('cheInvite', CheInvite);
     register.factory('npmRegistry', NpmRegistry);
+    register.factory('pluginRegistry', PluginRegistry);
   }
 }

--- a/dashboard/src/components/api/plugin-registry.factory.ts
+++ b/dashboard/src/components/api/plugin-registry.factory.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+export interface IPlugin {
+  id: string;
+  name: string;
+  type: string;
+  version: string;
+  description?: string;
+  isEnabled: boolean;
+}
+
+
+/**
+ * This class is handling plugin registry api
+ * @author Ann Shumilova
+ */
+export class PluginRegistry {
+  static $inject = ['$http'];
+
+  /**
+   * Angular Http service.
+   */
+  private $http: ng.IHttpService;
+
+  /**
+   * Default constructor that is using resource
+   */
+  constructor($http: ng.IHttpService) {
+    this.$http = $http;
+  }
+
+  fetchPlugins(location: string): ng.IPromise<Array<IPlugin>> {
+    let promise = this.$http({'method': 'GET', 'url': location + '/index.json'});
+    return promise.then((result: any) => {
+      return result.data;
+    });
+  }
+}

--- a/dashboard/src/components/api/workspace/che-workspace.factory.ts
+++ b/dashboard/src/components/api/workspace/che-workspace.factory.ts
@@ -25,6 +25,7 @@ const WS_AGENT_WS_LINK: string = 'wsagent/ws';
 
 interface IWorkspaceSettings {
   supportedRecipeTypes: string;
+  cheWorkspacePluginRegistryUrl: string;
 }
 
 interface ICHELicenseResource<T> extends ng.resource.IResourceClass<T> {
@@ -748,7 +749,7 @@ export class CheWorkspace {
    *
    * @returns {any} the system settings for workspaces
    */
-  getWorkspaceSettings(): any {
+  getWorkspaceSettings(): IWorkspaceSettings {
     return this.workspaceSettings;
   }
 


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Brings ability for the user to select Che plugins on workspace details page on "Plugins" tab.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10780

