### PR TITLE
Update LSP4J to 0.5.0.M1

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -236,6 +236,8 @@
                     <excludes>
                         <exclude>org.eclipse.lsp4j.WatchKind</exclude>
                         <exclude>org.eclipse.lsp4j.MarkupKind</exclude>
+                        <exclude>org.eclipse.lsp4j.CodeActionKind</exclude>
+                        <exclude>org.eclipse.lsp4j.FoldingRangeKind</exclude>
                     </excludes>
                     <dtoPackages>
                         <package>org.eclipse.lsp4j</package>

--- a/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/lsp/MavenTextDocumentService.java
+++ b/plugins/plugin-maven/che-plugin-maven-server/src/main/java/org/eclipse/che/plugin/maven/lsp/MavenTextDocumentService.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.CodeLensParams;
@@ -30,6 +31,7 @@ import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
+import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
@@ -88,13 +90,13 @@ public class MavenTextDocumentService implements TextDocumentService {
   }
 
   @Override
-  public CompletableFuture<List<? extends SymbolInformation>> documentSymbol(
+  public CompletableFuture<List<Either<SymbolInformation, DocumentSymbol>>> documentSymbol(
       DocumentSymbolParams params) {
     return null;
   }
 
   @Override
-  public CompletableFuture<List<? extends Command>> codeAction(CodeActionParams params) {
+  public CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params) {
     return null;
   }
 

--- a/wsagent/che-core-api-languageserver/pom.xml
+++ b/wsagent/che-core-api-languageserver/pom.xml
@@ -160,6 +160,8 @@
                     <excludes>
                         <exclude>org.eclipse.lsp4j.WatchKind</exclude>
                         <exclude>org.eclipse.lsp4j.MarkupKind</exclude>
+                        <exclude>org.eclipse.lsp4j.CodeActionKind</exclude>
+                        <exclude>org.eclipse.lsp4j.FoldingRangeKind</exclude>
                     </excludes>
                     <dtoPackages>
                         <package>org.eclipse.lsp4j</package>


### PR DESCRIPTION
### What does this PR do?
Updates lsp4j to 0.5.0.M1to handle some selenium test failures related to lsp4j marshalling of Either<X, Y> types.

### What issues does this PR fix or reference?
 #10782 

Companion PR: https://github.com/eclipse/che-parent/pull/81