### PR TITLE
Added authorization checks for all factory service's methods

### DIFF
--- a/multiuser/permission/che-multiuser-permission-factory/pom.xml
+++ b/multiuser/permission/che-multiuser-permission-factory/pom.xml
@@ -26,12 +26,24 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-factory</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
@@ -61,7 +73,12 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-factory</artifactId>
+            <artifactId>che-core-api-dto</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-factory-shared</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/multiuser/permission/che-multiuser-permission-factory/src/main/java/org/eclipse/che/multiuser/permission/factory/FactoryPermissionsFilter.java
+++ b/multiuser/permission/che-multiuser-permission-factory/src/main/java/org/eclipse/che/multiuser/permission/factory/FactoryPermissionsFilter.java
@@ -11,8 +11,14 @@
  */
 package org.eclipse.che.multiuser.permission.factory;
 
+import javax.inject.Inject;
 import javax.ws.rs.Path;
 import org.eclipse.che.api.core.ApiException;
+import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.factory.Factory;
+import org.eclipse.che.api.factory.server.FactoryManager;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.everrest.CheMethodInvokerFilter;
@@ -21,13 +27,21 @@ import org.everrest.core.Filter;
 import org.everrest.core.resource.GenericResourceMethod;
 
 /**
- * Restricts access to methods of FactoryService by user's permissions
+ * Restricts access to methods of FactoryService by user's permissions.
  *
  * @author Anton Korneta
+ * @author Sergii Leshchenko
  */
 @Filter
 @Path("/factory/{path:.*}")
 public class FactoryPermissionsFilter extends CheMethodInvokerFilter {
+
+  private final FactoryManager factoryManager;
+
+  @Inject
+  public FactoryPermissionsFilter(FactoryManager factoryManager) {
+    this.factoryManager = factoryManager;
+  }
 
   @Override
   protected void filter(GenericResourceMethod genericResourceMethod, Object[] arguments)
@@ -35,20 +49,42 @@ public class FactoryPermissionsFilter extends CheMethodInvokerFilter {
     final String methodName = genericResourceMethod.getMethod().getName();
 
     final Subject currentSubject = EnvironmentContext.getCurrent().getSubject();
-    String action;
-    String workspaceId;
 
     switch (methodName) {
       case "getFactoryJson":
         {
-          workspaceId = ((String) arguments[0]);
-          action = WorkspaceDomain.READ;
-          break;
+          String workspaceId = ((String) arguments[0]);
+
+          currentSubject.checkPermission(
+              WorkspaceDomain.DOMAIN_ID, workspaceId, WorkspaceDomain.READ);
+          return;
         }
-      default:
-        // public methods
+      case "removeFactory":
+        checkSubjectIsCreator((String) arguments[0], currentSubject, "remove");
         return;
+      case "updateFactory":
+        checkSubjectIsCreator((String) arguments[0], currentSubject, "update");
+        return;
+
+      case "getFactory":
+      case "saveFactory":
+      case "getFactoryByAttribute":
+      case "resolveFactory":
+        // public methods
+        // do nothing
+        return;
+
+      default:
+        throw new ForbiddenException("The user does not have permission to perform this operation");
     }
-    currentSubject.checkPermission(WorkspaceDomain.DOMAIN_ID, workspaceId, action);
+  }
+
+  private void checkSubjectIsCreator(String factoryId, Subject currentSubject, String action)
+      throws NotFoundException, ServerException, ForbiddenException {
+    Factory factory = factoryManager.getById(factoryId);
+    String creatorId = factory.getCreator().getUserId();
+    if (!creatorId.equals(currentSubject.getUserId())) {
+      throw new ForbiddenException("It is not allowed to " + action + " foreign factory");
+    }
   }
 }

--- a/multiuser/permission/che-multiuser-permission-factory/src/test/java/org/eclipse/che/multiuser/permission/factory/FactoryPermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-factory/src/test/java/org/eclipse/che/multiuser/permission/factory/FactoryPermissionsFilterTest.java
@@ -17,20 +17,30 @@ import static org.eclipse.che.multiuser.permission.workspace.server.WorkspaceDom
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import com.jayway.restassured.response.Response;
+import java.util.Map;
+import javax.ws.rs.core.UriInfo;
 import org.eclipse.che.api.core.ForbiddenException;
+import org.eclipse.che.api.core.model.factory.Factory;
+import org.eclipse.che.api.factory.server.FactoryManager;
 import org.eclipse.che.api.factory.server.FactoryService;
+import org.eclipse.che.api.factory.server.model.impl.AuthorImpl;
+import org.eclipse.che.api.factory.shared.dto.FactoryDto;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.dto.server.DtoFactory;
 import org.everrest.assured.EverrestJetty;
 import org.everrest.core.Filter;
 import org.everrest.core.GenericContainerRequest;
@@ -39,6 +49,7 @@ import org.everrest.core.resource.GenericResourceMethod;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -53,16 +64,16 @@ public class FactoryPermissionsFilterTest {
   @SuppressWarnings("unused")
   private static final EnvironmentFilter FILTER = new EnvironmentFilter();
 
-  @SuppressWarnings("unused")
-  @InjectMocks
-  FactoryPermissionsFilter permissionsFilter;
-
   @Mock private static Subject subject;
 
-  @Mock FactoryService service;
+  @Mock private FactoryService service;
+
+  @Mock private FactoryManager factoryManager;
+
+  @InjectMocks private FactoryPermissionsFilter permissionsFilter;
 
   @Test
-  public void shouldCheckPermissionsOnGettingFactoryJson() throws Exception {
+  public void shouldCheckPermissionsOnGettingFactoryJsonByWorkspaceId() throws Exception {
     final Response response =
         given()
             .auth()
@@ -76,7 +87,7 @@ public class FactoryPermissionsFilterTest {
   }
 
   @Test
-  public void shouldThrowExceptionWhenUserDoesHavePermissionsToReadWorkspaceOnGettingFactoryJson()
+  public void shouldReturnForbiddenWhenUserDoesHavePermissionsToReadWorkspaceOnGettingFactoryJson()
       throws Exception {
     doThrow(new ForbiddenException("User in not authorized"))
         .when(subject)
@@ -93,7 +104,110 @@ public class FactoryPermissionsFilterTest {
   }
 
   @Test
-  public void shouldNotCheckPermissionsWhenUnlistedMethodIsCalled() throws Exception {
+  public void shouldMakeSureThatUserIsCreatorOnUpdatingFactory() throws Exception {
+    doReturn("user123").when(subject).getUserId();
+
+    Factory factory = mock(Factory.class);
+    doReturn(new AuthorImpl("user123", 12345L)).when(factory).getCreator();
+    when(factoryManager.getById("factory123")).thenReturn(factory);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .body(DtoFactory.newDto(FactoryDto.class))
+            .when()
+            .put(SECURE_PATH + "/factory/factory123");
+
+    assertEquals(response.getStatusCode(), 204);
+    verify(service).updateFactory(eq("factory123"), any(FactoryDto.class));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUserIsNotCreatorOnUpdatingFactory() throws Exception {
+    doReturn("user321").when(subject).getUserId();
+
+    Factory factory = mock(Factory.class);
+    doReturn(new AuthorImpl("user123", 12345L)).when(factory).getCreator();
+    when(factoryManager.getById("factory123")).thenReturn(factory);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .contentType("application/json")
+            .body(DtoFactory.newDto(FactoryDto.class))
+            .when()
+            .put(SECURE_PATH + "/factory/factory123");
+
+    assertEquals(response.getStatusCode(), 403);
+    verify(service, never()).updateFactory(any(), any());
+  }
+
+  @Test
+  public void shouldMakeSureThatUserIsCreatorOnRemovingFactory() throws Exception {
+    doReturn("user123").when(subject).getUserId();
+
+    Factory factory = mock(Factory.class);
+    doReturn(new AuthorImpl("user123", 12345L)).when(factory).getCreator();
+    when(factoryManager.getById("factory123")).thenReturn(factory);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .delete(SECURE_PATH + "/factory/factory123");
+
+    assertEquals(response.getStatusCode(), 204);
+    verify(service).removeFactory(eq("factory123"));
+  }
+
+  @Test
+  public void shouldReturnForbiddenWhenUserIsNotCreatorOnRemovingForeignFactory() throws Exception {
+    doReturn("user321").when(subject).getUserId();
+
+    Factory factory = mock(Factory.class);
+    doReturn(new AuthorImpl("user123", 12345L)).when(factory).getCreator();
+    when(factoryManager.getById("factory123")).thenReturn(factory);
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .delete(SECURE_PATH + "/factory/factory123");
+
+    assertEquals(response.getStatusCode(), 403);
+    verify(service, never()).removeFactory(any());
+  }
+
+  @Test(dataProvider = "publicMethods")
+  public void shouldDoNothingWhenPublicMethodMethodIsCalled(String name, Class[] parameterTypes)
+      throws Exception {
+    GenericResourceMethod genericResourceMethod = mock(GenericResourceMethod.class);
+    when(genericResourceMethod.getMethod())
+        .thenReturn(FactoryService.class.getMethod(name, parameterTypes));
+
+    permissionsFilter.filter(genericResourceMethod, new Object[0]);
+  }
+
+  @DataProvider(name = "publicMethods")
+  public Object[][] publicMethods() {
+    return new Object[][] {
+      {"saveFactory", new Class[] {FactoryDto.class}},
+      {"getFactory", new Class[] {String.class, Boolean.class}},
+      {"resolveFactory", new Class[] {Map.class, Boolean.class}},
+      {"getFactoryByAttribute", new Class[] {Integer.class, Integer.class, UriInfo.class}},
+    };
+  }
+
+  @Test(
+      expectedExceptions = ForbiddenException.class,
+      expectedExceptionsMessageRegExp =
+          "The user does not have permission to perform this operation")
+  public void shouldThrowForbiddenExceptionWhenUnlistedMethodIsCalled() throws Exception {
     GenericResourceMethod genericResourceMethod = mock(GenericResourceMethod.class);
     when(genericResourceMethod.getMethod())
         .thenReturn(FactoryService.class.getMethod("getServiceDescriptor"));
@@ -103,6 +217,7 @@ public class FactoryPermissionsFilterTest {
 
   @Filter
   public static class EnvironmentFilter implements RequestFilter {
+
     public void doFilter(GenericContainerRequest request) {
       EnvironmentContext.getCurrent().setSubject(subject);
     }


### PR DESCRIPTION
### What does this PR do?
Previously it was possible to remove any factory by id. This PR adds authorization checks for all factory service's methods. Public ones are explicitly listed.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11155

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A