### PR TITLE
 Set stable version of selenium chrome-node 3.14.0-curium

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -315,8 +315,7 @@ initRunMode() {
 
     elif [[ ${MODE} == "grid" ]]; then
         export NODE_CHROME_DEBUG_SUFFIX
-        docker-compose -p=selenium up -d > /dev/null
-        docker-compose -p=selenium scale chromenode=${THREADS} > /dev/null
+        docker-compose -p=selenium up -d --scale chromenode=${THREADS} > /dev/null
 
     else
         echo "[TEST] Unrecognized mode "${MODE}

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -315,7 +315,8 @@ initRunMode() {
 
     elif [[ ${MODE} == "grid" ]]; then
         export NODE_CHROME_DEBUG_SUFFIX
-        docker-compose -p=selenium up -d --scale chromenode=${THREADS} > /dev/null
+        docker-compose -p=selenium up -d > /dev/null
+        docker-compose -p=selenium scale chromenode=${THREADS} > /dev/null
 
     else
         echo "[TEST] Unrecognized mode "${MODE}

--- a/selenium/che-selenium-test/docker-compose.yml
+++ b/selenium/che-selenium-test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   selenium_hub:
-    image: selenium/hub:3.14.0
+    image: selenium/hub:3.14.0-curium
     container_name: selenium_hub
     ports:
       - 4444:4444
@@ -20,7 +20,7 @@ services:
       - selenium_grid_internal
 
   chromenode:
-    image: selenium/node-chrome${NODE_CHROME_DEBUG_SUFFIX}:3.14.0
+    image: selenium/node-chrome${NODE_CHROME_DEBUG_SUFFIX}:3.14.0-curium
     depends_on:
       - selenium_hub
     environment:


### PR DESCRIPTION
### What does this PR do?
It downgrades version of _selenium chrome-node_ image to **3.14.0-curium** with _Google Chrome 68_ to fix unexpected regression of _E2E selenium tests_ because update 3.14.0 image to use _Google Chrome 69_.

### What issues does this PR fix or reference?
#11160