### PR TITLE
Added 'centos-php' tag to web-php-simple sample.

### DIFF
--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -660,40 +660,13 @@
       "location": "https://github.com/che-samples/web-php-simple.git",
       "parameters": {}
     },
-    "commands": [
-      {
-        "name": "start apache",
-        "type": "custom",
-        "commandLine": "service apache2 start \n tail -f /var/log/apache2/access.log -f /var/log/apache2/error.log",
-        "attributes": {
-          "previewUrl": "${server.80/tcp}/${current.project.relpath}",
-          "goal": "Run"
-        }
-      },
-      {
-        "name": "stop apache",
-        "type": "custom",
-        "commandLine": "service apache2 stop",
-        "attributes": {
-          "previewUrl": "",
-          "goal": "Run"
-        }
-      },
-      {
-        "name": "restart apache",
-        "type": "custom",
-        "commandLine": "service apache2 restart",
-        "attributes": {
-          "previewUrl": "${server.80/tcp}/${current.project.relpath}",
-          "goal": "Run"
-        }
-      }
-    ],
+    "commands": [],
     "links": [],
     "category": "Samples",
     "tags": [
       "apache",
-      "php"
+      "php",
+      "centos-php"
     ]
   },
   {


### PR DESCRIPTION
Also removed commands from the same sample. The default commands differ
in centos and ubuntu based images (apache2 vs httpd commands) - let the
stack handle default commands for this simple sample.

Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Added 'centos-php' tag to `web-php-simple` sample, so it shows up as a sample for centos based php stack (used for example in che.openshift.io)

It also removes command from web-php-simple sample, because they are specific to ubuntu based stack (Ubuntu - `apache2`, CentOS - `httpd`). I think it is OK, because both stacks ([upstream Ubuntu based](https://github.com/eclipse/che/blob/master/ide/che-core-ide-stacks/src/main/resources/stacks.json#L1000) and [rh-che CentOS based](https://github.com/redhat-developer/rh-che/blob/master/assembly/fabric8-stacks/src/main/resources/stacks.json#L928)) have the appropriate commands configured.
WDYT @eivantsov ?

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/850

[1] - https://github.com/eclipse/che/blob/master/ide/che-core-ide-stacks/src/main/resources/stacks.json#L1000

[2] - https://github.com/redhat-developer/rh-che/blob/master/assembly/fabric8-stacks/src/main/resources/stacks.json#L928