### PR TITLE
Make OpenShift infrastructure create a special service account for workspaces

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -357,7 +357,11 @@ che.infra.kubernetes.ingress.domain=
 che.infra.kubernetes.namespace=
 
 # Defines Kubernetes Service Account name which should be specified to be bound to all workspaces pods.
-# Note that Che Server won't create the service account and it should exist.
+# Note that Kubernetes Infrastructure won't create the service account and it should exist.
+# OpenShift infrastructure will check if project is predefined(if `che.infra.openshift.project` is not empty):
+#  - if it is predefined then service account must exist there
+#  - if it is 'NULL' or empty string then infrastructure will create new OpenShift project per workspace
+#    and prepare workspace service account with needed roles there
 che.infra.kubernetes.service_account_name=NULL
 
 # Defines time frame that limits the Kubernetes workspace start time

--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -446,11 +446,12 @@ ${CHE_VAR_ARRAY}"
     fi
 
     if [ ! -z ${CHE_INFRA_OPENSHIFT_PROJECT} ]; then
+        # create workspace service account in the predefined workspace
         ${OC_BINARY} new-app -f ${BASE_DIR}/templates/che-workspace-service-account.yaml \
           -p SERVICE_ACCOUNT_NAME='che-workspace' \
           -p SERVICE_ACCOUNT_NAMESPACE=${CHE_INFRA_OPENSHIFT_PROJECT}
-        WORKSPACE_SERVICE_ACCOUNT_NAME="che-workspace"
     fi
+    WORKSPACE_SERVICE_ACCOUNT_NAME="che-workspace"
 
     ${OC_BINARY} new-app -f ${BASE_DIR}/templates/che-server-template.yaml \
                          -p ROUTING_SUFFIX=${OPENSHIFT_ROUTING_SUFFIX} \

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import javax.inject.Named;
@@ -29,6 +30,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFacto
 public class KubernetesNamespaceFactory {
 
   private final String namespaceName;
+  private final boolean isPredefined;
   private final KubernetesClientFactory clientFactory;
 
   @Inject
@@ -36,6 +38,7 @@ public class KubernetesNamespaceFactory {
       @Nullable @Named("che.infra.kubernetes.namespace") String namespaceName,
       KubernetesClientFactory clientFactory) {
     this.namespaceName = namespaceName;
+    this.isPredefined = !isNullOrEmpty(namespaceName);
     this.clientFactory = clientFactory;
   }
 
@@ -44,7 +47,7 @@ public class KubernetesNamespaceFactory {
    * provided with a new namespace.
    */
   public boolean isPredefined() {
-    return isNullOrEmpty(namespaceName);
+    return isPredefined;
   }
 
   /**
@@ -58,10 +61,8 @@ public class KubernetesNamespaceFactory {
    * @throws InfrastructureException if any exception occurs during namespace preparing
    */
   public KubernetesNamespace create(String workspaceId) throws InfrastructureException {
-    final String namespaceName =
-        isNullOrEmpty(this.namespaceName) ? workspaceId : this.namespaceName;
-    KubernetesNamespace namespace =
-        new KubernetesNamespace(clientFactory, namespaceName, workspaceId);
+    final String namespaceName = isPredefined ? this.namespaceName : workspaceId;
+    KubernetesNamespace namespace = doCreateNamespace(workspaceId, namespaceName);
     namespace.prepare();
     return namespace;
   }
@@ -75,6 +76,11 @@ public class KubernetesNamespaceFactory {
    * @return created namespace
    */
   public KubernetesNamespace create(String workspaceId, String namespace) {
-    return new KubernetesNamespace(clientFactory, namespace, workspaceId);
+    return doCreateNamespace(workspaceId, namespace);
+  }
+
+  @VisibleForTesting
+  KubernetesNamespace doCreateNamespace(String workspaceId, String name) {
+    return new KubernetesNamespace(clientFactory, name, workspaceId);
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link KubernetesNamespaceFactory}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class KubernetesNamespaceFactoryTest {
+  @Mock private KubernetesClientFactory clientFactory;
+  private KubernetesNamespaceFactory namespaceFactory;
+
+  @Test
+  public void shouldReturnTrueIfNamespaceIsNotEmptyOnCheckingIfNamespaceIsPredefined() {
+    // given
+    namespaceFactory = new KubernetesNamespaceFactory("predefined", clientFactory);
+
+    // when
+    boolean isPredefined = namespaceFactory.isPredefined();
+
+    // then
+    assertTrue(isPredefined);
+  }
+
+  @Test
+  public void shouldReturnTrueIfNamespaceIsEmptyOnCheckingIfNamespaceIsPredefined() {
+    // given
+    namespaceFactory = new KubernetesNamespaceFactory("", clientFactory);
+
+    // when
+    boolean isPredefined = namespaceFactory.isPredefined();
+
+    // then
+    assertFalse(isPredefined);
+  }
+
+  @Test
+  public void shouldReturnTrueIfNamespaceIsNullOnCheckingIfNamespaceIsPredefined() {
+    // given
+    namespaceFactory = new KubernetesNamespaceFactory(null, clientFactory);
+
+    // when
+    boolean isPredefined = namespaceFactory.isPredefined();
+
+    // then
+    assertFalse(isPredefined);
+  }
+
+  @Test
+  public void shouldCreateAndPrepareNamespaceWithPredefinedValueIfItIsNotEmpty() throws Exception {
+    // given
+    namespaceFactory = spy(new KubernetesNamespaceFactory("predefined", clientFactory));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
+
+    // when
+    KubernetesNamespace namespace = namespaceFactory.create("workspace123");
+
+    // then
+    assertEquals(toReturnNamespace, namespace);
+    verify(namespaceFactory).doCreateNamespace("workspace123", "predefined");
+    verify(toReturnNamespace).prepare();
+  }
+
+  @Test
+  public void shouldCreateAndPrepareNamespaceWithWorkspaceIdAsNameIfConfiguredNameIsNotPredefined()
+      throws Exception {
+    // given
+    namespaceFactory = spy(new KubernetesNamespaceFactory("", clientFactory));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
+
+    // when
+    KubernetesNamespace namespace = namespaceFactory.create("workspace123");
+
+    // then
+    assertEquals(toReturnNamespace, namespace);
+    verify(namespaceFactory).doCreateNamespace("workspace123", "workspace123");
+    verify(toReturnNamespace).prepare();
+  }
+
+  @Test
+  public void
+      shouldCreateNamespaceAndDoNotPrepareNamespaceOnCreatingNamespaceWithWorkspaceIdAndNameSpecified()
+          throws Exception {
+    // given
+    namespaceFactory = spy(new KubernetesNamespaceFactory("", clientFactory));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
+
+    // when
+    KubernetesNamespace namespace = namespaceFactory.create("workspace123", "name");
+
+    // then
+    assertEquals(toReturnNamespace, namespace);
+    verify(namespaceFactory).doCreateNamespace("workspace123", "name");
+    verify(toReturnNamespace, never()).prepare();
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -85,7 +85,8 @@ public class OpenShiftProject extends KubernetesNamespace {
     OpenShiftClient osClient = clientFactory.createOC(workspaceId);
 
     if (get(projectName, osClient) == null) {
-      create(projectName, kubeClient, osClient);
+      create(projectName, osClient);
+      waitDefaultServiceAccount(projectName, kubeClient);
     }
   }
 
@@ -104,17 +105,15 @@ public class OpenShiftProject extends KubernetesNamespace {
         configMaps()::delete);
   }
 
-  private void create(String projectName, KubernetesClient kubeClient, OpenShiftClient ocClient)
-      throws InfrastructureException {
+  private void create(String projectName, OpenShiftClient osClient) throws InfrastructureException {
     try {
-      ocClient
+      osClient
           .projectrequests()
           .createNew()
           .withNewMetadata()
           .withName(projectName)
           .endMetadata()
           .done();
-      waitDefaultServiceAccount(projectName, kubeClient);
     } catch (KubernetesClientException e) {
       throw new KubernetesInfrastructureException(e);
     }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/WorkspaceServiceAccount.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/WorkspaceServiceAccount.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project;
+
+import io.fabric8.kubernetes.api.model.ObjectReferenceBuilder;
+import io.fabric8.openshift.api.model.PolicyRuleBuilder;
+import io.fabric8.openshift.api.model.Role;
+import io.fabric8.openshift.api.model.RoleBuilder;
+import io.fabric8.openshift.client.OpenShiftClient;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+
+/**
+ * Holds logic for preparing workspace service account.
+ *
+ * <p>It checks that required service account, roles and role bindings exist and creates if needed.
+ *
+ * @author Sergii Leshchenko
+ */
+class WorkspaceServiceAccount {
+
+  private final String projectName;
+  private final String name;
+  private final OpenShiftClientFactory clientFactory;
+  private final String workspaceId;
+
+  WorkspaceServiceAccount(
+      String workspaceId,
+      String projectName,
+      String serviceAccountName,
+      OpenShiftClientFactory clientFactory) {
+    this.workspaceId = workspaceId;
+    this.projectName = projectName;
+    this.name = serviceAccountName;
+    this.clientFactory = clientFactory;
+  }
+
+  /**
+   * Make sure that workspace service account exists and has `view` and `exec` role bindings.
+   *
+   * <p>Note that `view` role is used from cluster scope and `exec` role is created in the current
+   * namespace if does not exit.
+   *
+   * @throws InfrastructureException when any exception occurred
+   */
+  void prepare() throws InfrastructureException {
+    OpenShiftClient osClient = clientFactory.createOC(workspaceId);
+
+    if (osClient.serviceAccounts().inNamespace(projectName).withName(name).get() == null) {
+      createWorkspaceServiceAccount(osClient);
+    }
+
+    String execRoleName = "exec";
+    if (osClient.roles().inNamespace(projectName).withName(execRoleName).get() == null) {
+      createExecRole(osClient, execRoleName);
+    }
+
+    String execRoleBindingName = name + "-exec";
+    if (osClient.roleBindings().inNamespace(projectName).withName(execRoleBindingName).get()
+        == null) {
+      createExecRoleBinding(osClient, execRoleBindingName);
+    }
+
+    String viewRoleBindingName = name + "-view";
+    if (osClient.roleBindings().inNamespace(projectName).withName(viewRoleBindingName).get()
+        == null) {
+      createViewRoleBinding(osClient, viewRoleBindingName);
+    }
+  }
+
+  private void createWorkspaceServiceAccount(OpenShiftClient osClient) {
+    osClient
+        .serviceAccounts()
+        .inNamespace(projectName)
+        .createOrReplaceWithNew()
+        .withAutomountServiceAccountToken(true)
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .done();
+  }
+
+  private void createExecRole(OpenShiftClient osClient, String name) {
+    Role execRole =
+        new RoleBuilder()
+            .withNewMetadata()
+            .withName(name)
+            .endMetadata()
+            .withRules(
+                new PolicyRuleBuilder().withResources("pods/exec").withVerbs("create").build())
+            .build();
+    osClient.roles().inNamespace(projectName).create(execRole);
+  }
+
+  private void createViewRoleBinding(OpenShiftClient osClient, String name) {
+    osClient
+        .roleBindings()
+        .inNamespace(projectName)
+        .createNew()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .withNewRoleRef()
+        .withName("view")
+        .endRoleRef()
+        .withSubjects(
+            new ObjectReferenceBuilder().withKind("ServiceAccount").withName(name).build())
+        .done();
+  }
+
+  private void createExecRoleBinding(OpenShiftClient osClient, String name) {
+    osClient
+        .roleBindings()
+        .inNamespace(projectName)
+        .createNew()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .withNewRoleRef()
+        .withName("exec")
+        .withNamespace(projectName)
+        .endRoleRef()
+        .withSubjects(
+            new ObjectReferenceBuilder().withKind("ServiceAccount").withName(name).build())
+        .done();
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link OpenShiftProjectFactory}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class OpenShiftProjectFactoryTest {
+  @Mock private OpenShiftClientFactory clientFactory;
+  private OpenShiftProjectFactory projectFactory;
+
+  @Test
+  public void shouldCreateAndPrepareProjectWithPredefinedValueIfItIsNotEmpty() throws Exception {
+    // given
+    projectFactory = spy(new OpenShiftProjectFactory("projectName", "", clientFactory));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
+
+    // when
+    OpenShiftProject project = projectFactory.create("workspace123");
+
+    // then
+    assertEquals(toReturnProject, project);
+    verify(projectFactory).doCreateProject("workspace123", "projectName");
+    verify(toReturnProject).prepare();
+  }
+
+  @Test
+  public void shouldCreateAndPrepareProjectWithWorkspaceIdAsNameIfConfiguredValueIsEmtpy()
+      throws Exception {
+    // given
+    projectFactory = spy(new OpenShiftProjectFactory("", "", clientFactory));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
+
+    // when
+    OpenShiftProject project = projectFactory.create("workspace123");
+
+    // then
+    assertEquals(toReturnProject, project);
+    verify(projectFactory).doCreateProject("workspace123", "workspace123");
+    verify(toReturnProject).prepare();
+  }
+
+  @Test
+  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndProjectIsNotPredefined()
+      throws Exception {
+    // given
+    projectFactory = spy(new OpenShiftProjectFactory("", "serviceAccount", clientFactory));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
+
+    WorkspaceServiceAccount serviceAccount = mock(WorkspaceServiceAccount.class);
+    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
+
+    // when
+    projectFactory.create("workspace123");
+
+    // then
+    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
+    verify(serviceAccount).prepare();
+  }
+
+  @Test
+  public void shouldNotPrepareWorkspaceServiceAccountIfItIsConfiguredAndProjectIsPredefined()
+      throws Exception {
+    // given
+    projectFactory = spy(new OpenShiftProjectFactory("namespace", "serviceAccount", clientFactory));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
+
+    // when
+    projectFactory.create("workspace123");
+
+    // then
+    verify(projectFactory, never()).doCreateServiceAccount(any(), any());
+  }
+
+  @Test
+  public void shouldNotPrepareWorkspaceServiceAccountIfItIsNotConfiguredAndProjectIsNotPredefined()
+      throws Exception {
+    // given
+    projectFactory = spy(new OpenShiftProjectFactory("", "", clientFactory));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
+
+    // when
+    projectFactory.create("workspace123");
+
+    // then
+    verify(projectFactory, never()).doCreateServiceAccount(any(), any());
+  }
+
+  @Test
+  public void
+      shouldCreateProjectAndDoNotPrepareProjectOnCreatingProjectWithWorkspaceIdAndNameSpecified()
+          throws Exception {
+    // given
+    projectFactory =
+        spy(new OpenShiftProjectFactory("projectName", "serviceAccountName", clientFactory));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
+
+    // when
+    KubernetesNamespace namespace = projectFactory.create("workspace123", "name");
+
+    // then
+    assertEquals(toReturnProject, namespace);
+    verify(projectFactory).doCreateProject("workspace123", "name");
+    verify(toReturnProject, never()).prepare();
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Improve OpenShift infrastructure to create a special service account for workspaces if there is no predefined project configured (it means that each workspace will be created in a new project which should be create by Che Server). Che Server makes sure that all needed objects (service account, roles, role bindings) exist each time before a workspace start. It is done in this way to provide backward compatibility with existing installation where some of workspaces' projects exist.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10991

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A


#### Docs PR
Will be provided further