### PR TITLE
Fix the plugins registry location

### DIFF
--- a/dashboard/src/components/api/plugin-registry.factory.ts
+++ b/dashboard/src/components/api/plugin-registry.factory.ts
@@ -41,7 +41,7 @@ export class PluginRegistry {
   }
 
   fetchPlugins(location: string): ng.IPromise<Array<IPlugin>> {
-    let promise = this.$http({'method': 'GET', 'url': location + '/index.json'});
+    let promise = this.$http({'method': 'GET', 'url': location + '/plugins/'});
     return promise.then((result: any) => {
       return result.data;
     });


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Goes in addition to changes introduced in [following PR](https://github.com/eclipse/che-plugin-registry/pull/27) - retrieves plugins by path "/plugins/"


