### PR TITLE
Added API to simplify registration and utilization of stale subscriptions

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcModule.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcModule.java
@@ -38,6 +38,8 @@ public class JsonRpcModule extends AbstractModule {
     bind(JsonRpcQualifier.class).to(GsonJsonRpcQualifier.class);
     bind(JsonRpcComposer.class).to(GsonJsonRpcComposer.class);
 
+    bind(JsonRpcSubscriptionManager.class).asEagerSingleton();
+
     bind(RequestProcessor.class).to(ServerSideRequestProcessor.class);
     bind(TimeoutActionRunner.class).to(ServerSideTimeoutActionRunner.class);
   }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcSubscriptionManager.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcSubscriptionManager.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import static com.google.common.collect.Sets.newConcurrentHashSet;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import com.google.inject.Singleton;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.core.websocket.impl.WebSocketSessionRegistry;
+import org.eclipse.che.commons.schedule.ScheduleRate;
+import org.slf4j.Logger;
+
+/**
+ * Manager is responsible for registration of server side subscription handling over JSON-RPC
+ * protocol.
+ */
+@Singleton
+public class JsonRpcSubscriptionManager {
+  private static final Logger LOGGER = getLogger(JsonRpcSubscriptionManager.class);
+
+  private final Set<String> possiblyClosedEndpointIds = new HashSet<>();
+
+  private final Set<String> endpointIds = newConcurrentHashSet();
+  private final Set<UnSubscribeAction> unSubscribeActions = newConcurrentHashSet();
+
+  private final RequestHandlerConfigurator requestHandlerConfigurator;
+  private final RequestTransmitter requestTransmitter;
+  private final WebSocketSessionRegistry webSocketSessionRegistry;
+
+  @Inject
+  public JsonRpcSubscriptionManager(
+      RequestHandlerConfigurator requestHandlerConfigurator,
+      RequestTransmitter requestTransmitter,
+      WebSocketSessionRegistry webSocketSessionRegistry) {
+    this.requestHandlerConfigurator = requestHandlerConfigurator;
+    this.requestTransmitter = requestTransmitter;
+    this.webSocketSessionRegistry = webSocketSessionRegistry;
+  }
+
+  /**
+   * Simple task to clear stale subscriptions, we check if endpoint is available if not we firstly
+   * put it into the list of possible closed endpoints, the next step we clear the connection and
+   * all related subscriptions by running 'onUnsubscribe' actions.
+   */
+  @ScheduleRate(period = 15)
+  private void cleanStaleSubscriptions() {
+    Set<String> closedEndpointIds = new HashSet<>();
+    for (String possiblyClosedEndpointId : possiblyClosedEndpointIds) {
+      if (webSocketSessionRegistry.isClosed(possiblyClosedEndpointId)) {
+        closedEndpointIds.add(possiblyClosedEndpointId);
+      }
+    }
+    possiblyClosedEndpointIds.clear();
+
+    for (String closedEndpointId : closedEndpointIds) {
+      for (UnSubscribeAction unSubscribeAction : unSubscribeActions) {
+        unSubscribeAction.performIfMatches(closedEndpointId);
+      }
+    }
+
+    for (String endpointId : endpointIds) {
+      if (webSocketSessionRegistry.isClosed(endpointId)) {
+        possiblyClosedEndpointIds.add(endpointId);
+      }
+    }
+  }
+
+  /**
+   * Register a server side subscription handling
+   *
+   * @param name name of the subscription (e.g. "file/modification")
+   * @param eventClass class of the event that should be sent to client side
+   * @param subscribeBiConsumer action that is performed when client initiate the subscription
+   * @param unSubscribeConsumer action that is performed when client cancels the subscription or the
+   *     connection is closed
+   * @param <E> type parameter that represents class of the event that will be sent to client die
+   */
+  public synchronized <C, E> void register(
+      String name,
+      Class<E> eventClass,
+      Consumer<EventTransmitter<E>> subscribeBiConsumer,
+      Runnable unSubscribeConsumer) {
+
+    requestHandlerConfigurator
+        .newConfiguration()
+        .methodName("subscribe/" + name)
+        .noParams()
+        .noResult()
+        .withConsumer(
+            endpointId -> {
+              endpointIds.add(endpointId);
+
+              subscribeBiConsumer.accept(
+                  event ->
+                      requestTransmitter
+                          .newRequest()
+                          .endpointId(endpointId)
+                          .methodName("publish/" + name)
+                          .paramsAsDto(eventClass)
+                          .sendAndSkipResult());
+
+              unSubscribeActions.add(
+                  new UnSubscribeAction() {
+                    @Override
+                    public void performIfMatches(String endpointId1) {
+                      if (endpointId1.equals(endpointId)) {
+                        unSubscribeConsumer.run();
+                      }
+                    }
+
+                    @Override
+                    public void performIfMatches(String endpointId1, String name1) {
+                      if (endpointId1.equals(endpointId) && name1.equals(name)) {
+                        unSubscribeConsumer.run();
+                      }
+                    }
+                  });
+            });
+
+    requestHandlerConfigurator
+        .newConfiguration()
+        .methodName("unsubscribe/" + name)
+        .noParams()
+        .noResult()
+        .withConsumer(
+            endpointId -> {
+              for (UnSubscribeAction unSubscribeAction : unSubscribeActions) {
+                unSubscribeAction.performIfMatches(endpointId, name);
+              }
+            });
+  }
+
+  /**
+   * Register a server side subscription handling
+   *
+   * @param name name of the subscription (e.g. "file/modification")
+   * @param subCtxClass class of subscription context (e.g. we subscribe to "file/modification" but
+   *     we want to track only specific file, we can pass the location in a subscription context
+   *     represented by DTO
+   * @param eventClass class of the event that should be sent to client side
+   * @param subscribeBiConsumer action that is performed when client initiate the subscription
+   * @param unSubscribeConsumer action that is performed when client cancels the subscription or the
+   *     connection is closed
+   * @param <C> type parameter that represents the class of subscription context
+   * @param <E> type parameter that represents class of the event that will be sent to client die
+   */
+  public synchronized <C, E> void register(
+      String name,
+      Class<C> subCtxClass,
+      Class<E> eventClass,
+      BiConsumer<C, EventTransmitter<E>> subscribeBiConsumer,
+      Consumer<C> unSubscribeConsumer) {
+
+    requestHandlerConfigurator
+        .newConfiguration()
+        .methodName("subscribe/" + name)
+        .paramsAsDto(subCtxClass)
+        .noResult()
+        .withBiConsumer(
+            (endpointId, subCtx) -> {
+              endpointIds.add(endpointId);
+
+              subscribeBiConsumer.accept(
+                  subCtx,
+                  event ->
+                      requestTransmitter
+                          .newRequest()
+                          .endpointId(endpointId)
+                          .methodName("publish/" + name)
+                          .paramsAsDto(eventClass)
+                          .sendAndSkipResult());
+
+              unSubscribeActions.add(
+                  new UnSubscribeAction() {
+                    @Override
+                    public void performIfMatches(String endpointId1) {
+                      if (endpointId1.equals(endpointId)) {
+                        unSubscribeConsumer.accept(subCtx);
+                      }
+                    }
+
+                    @Override
+                    public void performIfMatches(String endpointId1, String name1, Object subCtx1) {
+                      if (endpointId1.equals(endpointId)
+                          && name1.equals(name)
+                          && subCtx1.equals(subCtx)) {
+                        unSubscribeConsumer.accept(subCtx);
+                      }
+                    }
+                  });
+            });
+
+    requestHandlerConfigurator
+        .newConfiguration()
+        .methodName("unsubscribe/" + name)
+        .paramsAsDto(subCtxClass)
+        .noResult()
+        .withBiConsumer(
+            (endpointId, subCtx) -> {
+              for (UnSubscribeAction unSubscribeAction : unSubscribeActions) {
+                unSubscribeAction.performIfMatches(endpointId, name, subCtx);
+              }
+            });
+  }
+
+  public interface EventTransmitter<T> {
+    void transmit(T event);
+  }
+
+  private interface UnSubscribeAction {
+    void performIfMatches(String endpointId);
+
+    default void performIfMatches(String endpointId, String name) {}
+
+    default void performIfMatches(String endpointId, String name, Object subCtx) {}
+  }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketSessionRegistry.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebSocketSessionRegistry.java
@@ -54,6 +54,18 @@ public class WebSocketSessionRegistry {
     return Optional.ofNullable(sessionsMap.get(endpointId));
   }
 
+  public boolean isOpen(String endpointId) {
+    if (sessionsMap.containsKey(endpointId)) {
+      return sessionsMap.get(endpointId).isOpen();
+    } else {
+      return false;
+    }
+  }
+
+  public boolean isClosed(String endpointId) {
+    return !isOpen(endpointId);
+  }
+
   public Set<Session> getByPartialMatch(String partialEndpointId) {
     return sessionsMap
         .entrySet()

--- a/ide/che-core-ide-app/pom.xml
+++ b/ide/che-core-ide-app/pom.xml
@@ -204,6 +204,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.vectomatic</groupId>
             <artifactId>lib-gwt-svg</artifactId>
             <scope>provided</scope>

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcSubscriptionManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/JsonRpcSubscriptionManager.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.jsonrpc;
+
+import static org.slf4j.LoggerFactory.getLogger;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.jetty.util.ConcurrentHashSet;
+import org.slf4j.Logger;
+
+/**
+ * Client side class simplifies subscription management by providing a more convenient API for
+ * initiating subscription and reacting on events that comes from server side.
+ */
+public abstract class JsonRpcSubscriptionManager {
+  private static final Logger LOGGER = getLogger(JsonRpcSubscriptionManager.class);
+
+  private final RequestTransmitter requestTransmitter;
+  private final RequestHandlerConfigurator requestHandlerConfigurator;
+
+  private final Map<String, Set<Consumer>> methodsToConsumers = new ConcurrentHashMap<>();
+
+  private final String endpointId;
+
+  public JsonRpcSubscriptionManager(
+      RequestTransmitter requestTransmitter,
+      RequestHandlerConfigurator requestHandlerConfigurator,
+      String endpointId) {
+    this.requestTransmitter = requestTransmitter;
+    this.requestHandlerConfigurator = requestHandlerConfigurator;
+    this.endpointId = endpointId;
+  }
+
+  /**
+   * Subscribe to a specific events
+   *
+   * @param name name of a subscription
+   * @param subCtx subscription context, specific information (e.g. file path)
+   * @param eventClass class of event that server will send
+   * @param eventConsumer consumer that will accept events send by server
+   * @param <E> type that represents class of events
+   */
+  public synchronized <E> void subscribe(
+      String name, Object subCtx, Class<E> eventClass, Consumer<E> eventConsumer) {
+    subscribeInternally(name, subCtx, eventClass, eventConsumer);
+  }
+
+  /**
+   * Subscribe to a specific events
+   *
+   * @param name name of a subscription
+   * @param eventClass class of event that server will send
+   * @param eventConsumer consumer that will accept events send by server
+   * @param <E> type that represents class of events
+   */
+  public synchronized <E> void subscribe(
+      String name, Class<E> eventClass, Consumer<E> eventConsumer) {
+    subscribeInternally(name, null, eventClass, eventConsumer);
+  }
+
+  private <E> void subscribeInternally(
+      String name, Object subCtx, Class<E> eventClass, Consumer<E> eventConsumer) {
+
+    Set<Consumer> consumerActions = methodsToConsumers.get(name);
+    if (consumerActions == null) {
+      requestHandlerConfigurator
+          .newConfiguration()
+          .methodName("publish/" + name)
+          .paramsAsDto(eventClass)
+          .noResult()
+          .withConsumer(
+              event -> {
+                for (Consumer consumer :
+                    methodsToConsumers.computeIfAbsent(name, __ -> new ConcurrentHashSet<>())) {
+                  consumer.accept(event);
+                }
+              });
+    } else {
+      consumerActions.add(eventConsumer);
+    }
+
+    if (subCtx == null) {
+      requestTransmitter
+          .newRequest()
+          .endpointId(endpointId)
+          .methodName("subscribe/" + name)
+          .noParams()
+          .sendAndSkipResult();
+    } else {
+      requestTransmitter
+          .newRequest()
+          .endpointId(endpointId)
+          .methodName("subscribe/" + name)
+          .paramsAsDto(subCtx)
+          .sendAndSkipResult();
+    }
+  }
+
+  public synchronized void unsubscribe(String name, Object subCtx) {
+    requestTransmitter
+        .newRequest()
+        .endpointId(endpointId)
+        .methodName("unsubscribe/" + name)
+        .paramsAsDto(subCtx)
+        .sendAndSkipResult();
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsAgentJsonRpcSubscriptionManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsAgentJsonRpcSubscriptionManager.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.jsonrpc;
+
+import static org.eclipse.che.ide.api.jsonrpc.Constants.WS_AGENT_JSON_RPC_ENDPOINT_ID;
+
+import com.google.inject.Singleton;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+
+/** Workspace agent client side subscription manager */
+@Singleton
+public class WsAgentJsonRpcSubscriptionManager extends JsonRpcSubscriptionManager {
+
+  @Inject
+  public WsAgentJsonRpcSubscriptionManager(
+      RequestTransmitter requestTransmitter,
+      RequestHandlerConfigurator requestHandlerConfigurator) {
+    super(requestTransmitter, requestHandlerConfigurator, WS_AGENT_JSON_RPC_ENDPOINT_ID);
+  }
+}

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsMasterJsonRpcSubscriptionManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsMasterJsonRpcSubscriptionManager.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.jsonrpc;
+
+import static org.eclipse.che.ide.api.jsonrpc.Constants.WS_MASTER_JSON_RPC_ENDPOINT_ID;
+
+import com.google.inject.Singleton;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+
+/** Workspace master client side subscription manager */
+@Singleton
+public class WsMasterJsonRpcSubscriptionManager extends JsonRpcSubscriptionManager {
+
+  @Inject
+  public WsMasterJsonRpcSubscriptionManager(
+      RequestTransmitter requestTransmitter,
+      RequestHandlerConfigurator requestHandlerConfigurator) {
+    super(requestTransmitter, requestHandlerConfigurator, WS_MASTER_JSON_RPC_ENDPOINT_ID);
+  }
+}


### PR DESCRIPTION
Related issue, https://github.com/eclipse/che/issues/6177

Added API to simplify registration and utilization of stale subscriptions. Now there are `WsAgentJsonRpcSubscriptionManager` and `WsMasterJsonRpcSubscriptionManager` classes that are called to simplify event subscription procedure on client side. While on server side there is `JsonRpcSubscriptionManager` that may be used to register subscription handlers for server side along with subscription utilization actions in case the connection is closed or subscription is cancelled.

