### PR TITLE
Add support of dockerimage and kubernetes recipes in some cases

### DIFF
--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/ComposeEnvironment.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/compose/ComposeEnvironment.java
@@ -40,6 +40,11 @@ public class ComposeEnvironment extends InternalEnvironment {
     this.services = services;
   }
 
+  @Override
+  public ComposeEnvironment setType(String type) {
+    return (ComposeEnvironment) super.setType(type);
+  }
+
   public String getVersion() {
     return version;
   }
@@ -65,12 +70,21 @@ public class ComposeEnvironment extends InternalEnvironment {
         && Objects.equals(getServices(), that.getServices())
         && Objects.equals(getRecipe(), that.getRecipe())
         && Objects.equals(getMachines(), that.getMachines())
-        && Objects.equals(getWarnings(), that.getWarnings());
+        && Objects.equals(getWarnings(), that.getWarnings())
+        && Objects.equals(getType(), that.getType())
+        && Objects.equals(getAttributes(), that.getAttributes());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, getServices(), getMachines(), getRecipe(), getWarnings());
+    return Objects.hash(
+        version,
+        getServices(),
+        getMachines(),
+        getRecipe(),
+        getWarnings(),
+        getType(),
+        getAttributes());
   }
 
   @Override
@@ -87,6 +101,10 @@ public class ComposeEnvironment extends InternalEnvironment {
         + getRecipe()
         + ", warnings="
         + getWarnings()
+        + ", type="
+        + getType()
+        + ", attributes="
+        + getAttributes()
         + '}';
   }
 }

--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/dockerfile/DockerfileEnvironment.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/dockerfile/DockerfileEnvironment.java
@@ -34,6 +34,11 @@ public class DockerfileEnvironment extends InternalEnvironment {
     this.dockerfileContent = dockerfileContent;
   }
 
+  @Override
+  public DockerfileEnvironment setType(String type) {
+    return (DockerfileEnvironment) super.setType(type);
+  }
+
   /** Returns the content of dockerfile. */
   public String getDockerfileContent() {
     return dockerfileContent;
@@ -51,12 +56,15 @@ public class DockerfileEnvironment extends InternalEnvironment {
     return Objects.equals(dockerfileContent, that.dockerfileContent)
         && Objects.equals(getRecipe(), that.getRecipe())
         && Objects.equals(getMachines(), that.getMachines())
-        && Objects.equals(getWarnings(), that.getWarnings());
+        && Objects.equals(getWarnings(), that.getWarnings())
+        && Objects.equals(getType(), that.getType())
+        && Objects.equals(getAttributes(), that.getAttributes());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(dockerfileContent, getRecipe(), getMachines(), getWarnings());
+    return Objects.hash(
+        dockerfileContent, getRecipe(), getMachines(), getWarnings(), getType(), getAttributes());
   }
 
   @Override
@@ -71,6 +79,10 @@ public class DockerfileEnvironment extends InternalEnvironment {
         + getRecipe()
         + ", warnings="
         + getWarnings()
+        + ", type="
+        + getType()
+        + ", attributes="
+        + getAttributes()
         + '}';
   }
 }

--- a/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/dockerimage/DockerImageEnvironment.java
+++ b/infrastructures/docker/environment/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/dockerimage/DockerImageEnvironment.java
@@ -34,6 +34,11 @@ public class DockerImageEnvironment extends InternalEnvironment {
     this.dockerImage = dockerImage;
   }
 
+  @Override
+  public DockerImageEnvironment setType(String type) {
+    return (DockerImageEnvironment) super.setType(type);
+  }
+
   public String getDockerImage() {
     return dockerImage;
   }
@@ -50,12 +55,15 @@ public class DockerImageEnvironment extends InternalEnvironment {
     return Objects.equals(dockerImage, that.dockerImage)
         && Objects.equals(getRecipe(), that.getRecipe())
         && Objects.equals(getMachines(), that.getMachines())
-        && Objects.equals(getWarnings(), that.getWarnings());
+        && Objects.equals(getWarnings(), that.getWarnings())
+        && Objects.equals(getType(), that.getType())
+        && Objects.equals(getAttributes(), that.getAttributes());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(dockerImage, getRecipe(), getMachines(), getWarnings());
+    return Objects.hash(
+        dockerImage, getRecipe(), getMachines(), getWarnings(), getType(), getAttributes());
   }
 
   @Override
@@ -70,6 +78,10 @@ public class DockerImageEnvironment extends InternalEnvironment {
         + getRecipe()
         + ", warnings="
         + getWarnings()
+        + ", type="
+        + getType()
+        + ", attributes="
+        + getAttributes()
         + '}';
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeInfrastructure.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/DockerRuntimeInfrastructure.java
@@ -90,6 +90,13 @@ public class DockerRuntimeInfrastructure extends RuntimeInfrastructure {
   private DockerEnvironment convertToDockerEnv(InternalEnvironment sourceEnv)
       throws ValidationException {
     String recipeType = sourceEnv.getRecipe().getType();
+    String envType = sourceEnv.getType();
+    if (!recipeType.equals(envType)) {
+      throw new ValidationException(
+          format(
+              "Environments with different type and source type are not supported. Type '%s'. Source type '%s'.",
+              envType, recipeType));
+    }
     DockerEnvironmentConverter converter = envConverters.get(recipeType);
     if (converter == null) {
       throw new ValidationException(

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/ComposeEnvironmentConverter.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/ComposeEnvironmentConverter.java
@@ -72,6 +72,7 @@ public class ComposeEnvironmentConverter implements DockerEnvironmentConverter {
     }
     return new DockerEnvironment(
             environment.getRecipe(), environment.getMachines(), environment.getWarnings())
-        .setContainers(containers);
+        .setContainers(containers)
+        .setType(DockerEnvironment.TYPE);
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/DockerImageEnvironmentConverter.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/DockerImageEnvironmentConverter.java
@@ -42,7 +42,8 @@ public class DockerImageEnvironmentConverter implements DockerEnvironmentConvert
 
     DockerEnvironment dockerEnv =
         new DockerEnvironment(
-            environment.getRecipe(), environment.getMachines(), environment.getWarnings());
+                environment.getRecipe(), environment.getMachines(), environment.getWarnings())
+            .setType(DockerEnvironment.TYPE);
     dockerEnv.getContainers().put(machineName, container);
     return dockerEnv;
   }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/DockerfileEnvironmentConverter.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/DockerfileEnvironmentConverter.java
@@ -40,7 +40,8 @@ public class DockerfileEnvironmentConverter implements DockerEnvironmentConverte
 
     DockerEnvironment cheContainerEnv =
         new DockerEnvironment(
-            environment.getRecipe(), environment.getMachines(), environment.getWarnings());
+                environment.getRecipe(), environment.getMachines(), environment.getWarnings())
+            .setType(DockerEnvironment.TYPE);
     DockerContainerConfig container =
         new DockerContainerConfig()
             .setBuild(new DockerBuildContext().setDockerfileContent(dockerfile));

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/model/DockerEnvironment.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/model/DockerEnvironment.java
@@ -28,6 +28,8 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
  * @author Alexander Garagatyi
  */
 public class DockerEnvironment extends InternalEnvironment {
+  public static final String TYPE = "docker";
+
   private LinkedHashMap<String, DockerContainerConfig> containers;
   private String network;
 
@@ -48,6 +50,11 @@ public class DockerEnvironment extends InternalEnvironment {
     super(recipe, machines, warnings);
     this.containers = containers;
     this.network = network;
+  }
+
+  @Override
+  public DockerEnvironment setType(String type) {
+    return (DockerEnvironment) super.setType(type);
   }
 
   public DockerEnvironment(DockerEnvironment environment) throws InfrastructureException {
@@ -100,12 +107,21 @@ public class DockerEnvironment extends InternalEnvironment {
         && Objects.equals(getNetwork(), that.getNetwork())
         && Objects.equals(getRecipe(), that.getRecipe())
         && Objects.equals(getMachines(), that.getMachines())
-        && Objects.equals(getWarnings(), that.getWarnings());
+        && Objects.equals(getWarnings(), that.getWarnings())
+        && Objects.equals(getType(), that.getType())
+        && Objects.equals(getAttributes(), that.getAttributes());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getContainers(), getNetwork(), getMachines(), getRecipe(), getWarnings());
+    return Objects.hash(
+        getContainers(),
+        getNetwork(),
+        getMachines(),
+        getRecipe(),
+        getWarnings(),
+        getType(),
+        getAttributes());
   }
 
   @Override
@@ -122,6 +138,10 @@ public class DockerEnvironment extends InternalEnvironment {
         + getRecipe()
         + ", warnings="
         + getWarnings()
+        + ", type="
+        + getType()
+        + ", attributes="
+        + getAttributes()
         + '}';
   }
 }

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/ComposeEnvironmentConverterTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/ComposeEnvironmentConverterTest.java
@@ -141,6 +141,7 @@ public class ComposeEnvironmentConverterTest {
                 "machine1", cheContainer1,
                 "machine2", cheContainer2,
                 "machine3", cheContainer3)));
+    cheContainersEnvironment.setType(DockerEnvironment.TYPE);
     return cheContainersEnvironment;
   }
 }

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/DockerImageEnvironmentConverterTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/DockerImageEnvironmentConverterTest.java
@@ -17,7 +17,6 @@ import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.collections.Maps.newLinkedHashMap;
 
 import com.google.common.collect.ImmutableMap;
 import org.eclipse.che.api.core.ValidationException;
@@ -79,7 +78,8 @@ public class DockerImageEnvironmentConverterTest {
     DockerEnvironment expectedEnv =
         new DockerEnvironment(
                 recipe, singletonMap(DEFAULT_MACHINE_NAME, machineConfig), emptyList())
-            .setContainers(newLinkedHashMap(singletonMap(DEFAULT_MACHINE_NAME, expectedContainer)));
+            .setContainers(newLinkedHashMap(singletonMap(DEFAULT_MACHINE_NAME, expectedContainer)))
+            .setType(DockerEnvironment.TYPE);
 
     // when
     DockerEnvironment actual = converter.convert(environment);

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/DockerfileEnvironmentConverterTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/environment/convert/DockerfileEnvironmentConverterTest.java
@@ -81,6 +81,7 @@ public class DockerfileEnvironmentConverterTest {
             .setContainers(newLinkedHashMap(singletonMap(DEFAULT_MACHINE_NAME, container)));
     expected.setMachines(singletonMap(DEFAULT_MACHINE_NAME, machineConfig));
     expected.setRecipe(recipe);
+    expected.setType(DockerEnvironment.TYPE);
 
     // when
     DockerEnvironment actual = converter.convert(environment);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfrastructure.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfrastructure.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes;
 
 import static java.lang.String.format;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.inject.Inject;
@@ -75,9 +76,11 @@ public class KubernetesInfrastructure extends RuntimeInfrastructure {
     if (source instanceof DockerImageEnvironment) {
       return dockerImageEnvConverter.convert((DockerImageEnvironment) source);
     }
+
     throw new InternalInfrastructureException(
         format(
             "Environment type '%s' is not supported. Supported environment types: %s",
-            source.getRecipe().getType(), KubernetesEnvironment.TYPE));
+            source.getType(),
+            Joiner.on(",").join(KubernetesEnvironment.TYPE, DockerImageEnvironment.TYPE)));
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
@@ -56,6 +56,11 @@ public class KubernetesEnvironment extends InternalEnvironment {
     setAttributes(k8sEnv.getAttributes());
   }
 
+  @Override
+  public KubernetesEnvironment setType(String type) {
+    return (KubernetesEnvironment) super.setType(type);
+  }
+
   public static Builder builder() {
     return new Builder();
   }
@@ -111,6 +116,7 @@ public class KubernetesEnvironment extends InternalEnvironment {
 
   public static class Builder {
     protected InternalRecipe internalRecipe;
+    protected String type = TYPE;
     protected final Map<String, InternalMachineConfig> machines = new HashMap<>();
     protected final List<Warning> warnings = new ArrayList<>();
     protected final Map<String, Pod> pods = new HashMap<>();
@@ -168,8 +174,13 @@ public class KubernetesEnvironment extends InternalEnvironment {
       return this;
     }
 
-    public Builder setWorkspaceConfigAttributes(Map<String, String> attributes) {
+    public Builder setAttributes(Map<String, String> attributes) {
       this.attributes.putAll(attributes);
+      return this;
+    }
+
+    public Builder setType(String type) {
+      this.type = type;
       return this;
     }
 
@@ -186,6 +197,7 @@ public class KubernetesEnvironment extends InternalEnvironment {
               secrets,
               configMaps);
       kubernetesEnvironment.setAttributes(attributes);
+      kubernetesEnvironment.setType(type);
       return kubernetesEnvironment;
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
@@ -53,6 +53,7 @@ public class KubernetesEnvironment extends InternalEnvironment {
         k8sEnv.getPersistentVolumeClaims(),
         k8sEnv.getSecrets(),
         k8sEnv.getConfigMaps());
+    setAttributes(k8sEnv.getAttributes());
   }
 
   public static Builder builder() {
@@ -118,6 +119,7 @@ public class KubernetesEnvironment extends InternalEnvironment {
     protected final Map<String, PersistentVolumeClaim> pvcs = new HashMap<>();
     protected final Map<String, Secret> secrets = new HashMap<>();
     protected final Map<String, ConfigMap> configMaps = new HashMap<>();
+    protected final Map<String, String> attributes = new HashMap<>();
 
     protected Builder() {}
 
@@ -166,9 +168,25 @@ public class KubernetesEnvironment extends InternalEnvironment {
       return this;
     }
 
+    public Builder setWorkspaceConfigAttributes(Map<String, String> attributes) {
+      this.attributes.putAll(attributes);
+      return this;
+    }
+
     public KubernetesEnvironment build() {
-      return new KubernetesEnvironment(
-          internalRecipe, machines, warnings, pods, services, ingresses, pvcs, secrets, configMaps);
+      KubernetesEnvironment kubernetesEnvironment =
+          new KubernetesEnvironment(
+              internalRecipe,
+              machines,
+              warnings,
+              pods,
+              services,
+              ingresses,
+              pvcs,
+              secrets,
+              configMaps);
+      kubernetesEnvironment.setAttributes(attributes);
+      return kubernetesEnvironment;
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/convert/DockerImageEnvironmentConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/convert/DockerImageEnvironmentConverter.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import javax.inject.Singleton;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
@@ -64,9 +65,10 @@ public class DockerImageEnvironmentConverter {
             .build();
     return KubernetesEnvironment.builder()
         .setMachines(environment.getMachines())
-        .setInternalRecipe(environment.getRecipe())
+        .setInternalRecipe(new InternalRecipe(KubernetesEnvironment.TYPE, null, ""))
         .setWarnings(environment.getWarnings())
         .setPods(ImmutableMap.of(POD_NAME, pod))
+        .setWorkspaceConfigAttributes(environment.getAttributes())
         .build();
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/convert/DockerImageEnvironmentConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/convert/DockerImageEnvironmentConverter.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import javax.inject.Singleton;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
@@ -65,10 +64,11 @@ public class DockerImageEnvironmentConverter {
             .build();
     return KubernetesEnvironment.builder()
         .setMachines(environment.getMachines())
-        .setInternalRecipe(new InternalRecipe(KubernetesEnvironment.TYPE, null, ""))
+        .setInternalRecipe(environment.getRecipe())
         .setWarnings(environment.getWarnings())
         .setPods(ImmutableMap.of(POD_NAME, pod))
-        .setWorkspaceConfigAttributes(environment.getAttributes())
+        .setAttributes(environment.getAttributes())
+        .setType(KubernetesEnvironment.TYPE)
         .build();
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
@@ -55,11 +55,11 @@ public class SidecarToolingProvisioner<E extends KubernetesEnvironment> {
       return;
     }
 
-    String recipeType = environment.getRecipe().getType();
+    String recipeType = environment.getType();
     ChePluginsApplier pluginsApplier = workspaceNextAppliers.get(recipeType);
     if (pluginsApplier == null) {
       throw new InfrastructureException(
-          "Sidecar tooling configuration is not supported with recipe type " + recipeType);
+          "Sidecar tooling configuration is not supported with environment type " + recipeType);
     }
 
     List<ChePlugin> chePlugins = pluginBrokerManager.getTooling(id, pluginsMeta);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -33,6 +33,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironment
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesRuntimeCacheModule;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.UniqueWorkspacePVCStrategy;
@@ -67,6 +69,7 @@ public class OpenShiftInfraModule extends AbstractModule {
         MapBinder.newMapBinder(binder(), String.class, InternalEnvironmentFactory.class);
 
     factories.addBinding(OpenShiftEnvironment.TYPE).to(OpenShiftEnvironmentFactory.class);
+    factories.addBinding(KubernetesEnvironment.TYPE).to(KubernetesEnvironmentFactory.class);
     factories.addBinding(DockerImageEnvironment.TYPE).to(DockerImageEnvironmentFactory.class);
 
     bind(RuntimeInfrastructure.class).to(OpenShiftInfrastructure.class);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfrastructure.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfrastructure.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.openshift;
 
 import static java.lang.String.format;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import javax.inject.Inject;
@@ -88,6 +89,7 @@ public class OpenShiftInfrastructure extends RuntimeInfrastructure {
     throw new InternalInfrastructureException(
         format(
             "Environment type '%s' is not supported. Supported environment types: %s",
-            source.getRecipe().getType(), OpenShiftEnvironment.TYPE));
+            source.getType(),
+            Joiner.on(",").join(OpenShiftEnvironment.TYPE, KubernetesEnvironment.TYPE)));
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
@@ -40,14 +40,8 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
   public OpenShiftEnvironment(KubernetesEnvironment k8sEnv) {
     super(k8sEnv);
     this.routes = new HashMap<>();
-    setRecipe(
-        new InternalRecipe(
-            TYPE, k8sEnv.getRecipe().getContentType(), k8sEnv.getRecipe().getContent()));
+    setType(TYPE);
     setAttributes(k8sEnv.getAttributes());
-  }
-
-  public static Builder builder() {
-    return new Builder();
   }
 
   public OpenShiftEnvironment(
@@ -63,6 +57,16 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
       Map<String, Route> routes) {
     super(internalRecipe, machines, warnings, pods, services, ingresses, pvcs, secrets, configMaps);
     this.routes = routes;
+    setType(TYPE);
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Override
+  public OpenShiftEnvironment setType(String type) {
+    return (OpenShiftEnvironment) super.setType(type);
   }
 
   /** Returns services that should be created when environment starts. */
@@ -73,7 +77,9 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
   public static class Builder extends KubernetesEnvironment.Builder {
     private final Map<String, Route> routes = new HashMap<>();
 
-    private Builder() {}
+    private Builder() {
+      setType(TYPE);
+    }
 
     @Override
     public Builder setInternalRecipe(InternalRecipe internalRecipe) {
@@ -148,6 +154,7 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
               configMaps,
               routes);
       openShiftEnvironment.setAttributes(attributes);
+      openShiftEnvironment.setType(type);
       return openShiftEnvironment;
     }
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
@@ -25,7 +25,6 @@ import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.Builder;
 
 /**
  * Holds objects of OpenShift environment.
@@ -41,6 +40,10 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
   public OpenShiftEnvironment(KubernetesEnvironment k8sEnv) {
     super(k8sEnv);
     this.routes = new HashMap<>();
+    setRecipe(
+        new InternalRecipe(
+            TYPE, k8sEnv.getRecipe().getContentType(), k8sEnv.getRecipe().getContent()));
+    setAttributes(k8sEnv.getAttributes());
   }
 
   public static Builder builder() {
@@ -132,17 +135,20 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
     }
 
     public OpenShiftEnvironment build() {
-      return new OpenShiftEnvironment(
-          internalRecipe,
-          machines,
-          warnings,
-          pods,
-          services,
-          ingresses,
-          pvcs,
-          secrets,
-          configMaps,
-          routes);
+      OpenShiftEnvironment openShiftEnvironment =
+          new OpenShiftEnvironment(
+              internalRecipe,
+              machines,
+              warnings,
+              pods,
+              services,
+              ingresses,
+              pvcs,
+              secrets,
+              configMaps,
+              routes);
+      openShiftEnvironment.setAttributes(attributes);
+      return openShiftEnvironment;
     }
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironment.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironment.java
@@ -20,6 +20,7 @@ import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /**
  * Representation of {@link Environment} which holds internal representations of environment
@@ -37,6 +38,7 @@ public abstract class InternalEnvironment {
   private Map<String, InternalMachineConfig> machines;
   private List<Warning> warnings;
   private Map<String, String> attributes;
+  private String type;
 
   protected InternalEnvironment() {}
 
@@ -45,9 +47,29 @@ public abstract class InternalEnvironment {
     this.recipe = recipe;
     this.machines = machines;
     this.warnings = warnings;
+    this.type = recipe != null ? recipe.getType() : null;
+  }
+
+  /**
+   * Returns internal environment type - an identifier of the type of the environment.
+   *
+   * <p>It can differ from the type of {@link InternalRecipe#getType()} in certain cases. An example
+   * of such a case is converting of an environment from one type to another for the purposes of an
+   * infrastructure. In this case, {@link InternalRecipe#getType()} shows an origin type of the
+   * environment whereas this method might return the type of the environment after the conversion.
+   */
+  @Nullable
+  public String getType() {
+    return type;
+  }
+
+  public InternalEnvironment setType(String type) {
+    this.type = type;
+    return this;
   }
 
   /** Returns environment recipe which includes recipe content. */
+  @Nullable
   public InternalRecipe getRecipe() {
     return recipe;
   }
@@ -104,6 +126,9 @@ public abstract class InternalEnvironment {
    */
   @Beta
   public Map<String, String> getAttributes() {
+    if (attributes == null) {
+      attributes = new HashMap<>();
+    }
     return attributes;
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalRecipe.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalRecipe.java
@@ -28,7 +28,7 @@ public class InternalRecipe {
   private final String contentType;
   private final String content;
 
-  InternalRecipe(String type, String contentType, String content) {
+  public InternalRecipe(String type, String contentType, String content) {
     this.type = type;
     this.contentType = contentType;
     this.content = content;

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalRecipe.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalRecipe.java
@@ -28,7 +28,7 @@ public class InternalRecipe {
   private final String contentType;
   private final String content;
 
-  public InternalRecipe(String type, String contentType, String content) {
+  InternalRecipe(String type, String contentType, String content) {
     this.type = type;
     this.contentType = contentType;
     this.content = content;


### PR DESCRIPTION
### What does this PR do?
Add support of 'dockerimage' recipe to WS.NEXT flow on openshift
and kubernetes infras.
Add support of 'kubernetes' recipe on openshift infra.

### What issues does this PR fix or reference?
Fixes #9871 
Fixes #9979

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
