### PR TITLE
Add 'che-theia-terminal-extension' and 'che-theia-task-plugin' to the Theia image

### DIFF
--- a/dockerfiles/theia/src/extensions.json
+++ b/dockerfiles/theia/src/extensions.json
@@ -47,6 +47,20 @@
             "folder": "che-theia-java-extension",
             "checkoutTo": "master",
             "type": "git"
+        },
+        {
+            "name": "che-theia-terminal",
+            "source": "https://github.com/eclipse/che-theia-terminal-extension.git",
+            "folder": "che-theia-terminal",
+            "checkoutTo": "ee583bf4e7956502a2d9a4fab55b06bcbe7b0117",
+            "type": "git"
+        },
+        {
+            "name": "@eclipse-che/theia-task-extension",
+            "source": "https://github.com/eclipse/che-theia-task-plugin.git",
+            "folder": "che-theia-task-extension",
+            "checkoutTo": "47450ee167a7d8429550c45be48f93230bf44ebd",
+            "type": "git"
         }
     ]
 }

--- a/dockerfiles/theia/src/package.json
+++ b/dockerfiles/theia/src/package.json
@@ -5,7 +5,6 @@
         "@theia/typescript": "latest",
         "@theia/editor": "latest",
         "@theia/navigator": "latest",
-        "@theia/terminal": "latest",
         "@theia/outline-view": "latest",
         "@theia/preferences": "latest",
         "@theia/git": "latest",

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -7,7 +7,6 @@
     "scope": "general",
     "tags": [
       "Theia",
-      "Alpine",
       "CentOS"
     ],
     "workspaceConfig": {
@@ -45,12 +44,24 @@
               "attributes": {
                 "memoryLimitBytes": "2147483648"
               }
+            },
+            "machine-exec": {
+              "servers": {
+                "machine-exec": {
+                  "attributes": {
+                    "type": "terminal"
+                  },
+                  "protocol": "ws",
+                  "port": "4444"
+                }
+              },
+              "installers": []
             }
           },
           "recipe": {
-            "contentType": "",
-            "type": "dockerimage",
-            "content": "eclipse/che-theia:0.3.14-nightly"
+            "contentType": "application/x-yaml",
+            "type": "compose",
+            "content": "services:\n  machine-exec:\n    image: 'aandrienko/che-machine-exec:latest'\n    mem_limit: 536870912\n  theia:\n    image: 'eclipse/che-theia:0.3.14-nightly'\n    mem_limit: 1073741824\n    depends_on:\n      - machine-exec\n"
           }
         }
       },
@@ -119,11 +130,23 @@
               },
               "installers": [],
               "env": {}
+            },
+            "ws/machine-exec": {
+              "servers": {
+                "machine-exec": {
+                  "attributes": {
+                    "type": "terminal"
+                  },
+                  "protocol": "ws",
+                  "port": "4444"
+                }
+              },
+              "installers": []
             }
           },
           "recipe": {
             "type": "openshift",
-            "content": "---\nkind: List\nitems:\n-\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n  spec:\n    containers:\n      -\n        image: eclipse/che-theia:0.3.14-nightly\n        name: theia\n      -\n        image: eclipse/che-dev:nightly\n        name: dev",
+            "content": "---\nkind: List\nitems:\n-\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n  spec:\n    containers:\n      -\n        image: eclipse/che-theia:0.3.14-nightly\n        name: theia\n      -\n        image: eclipse/che-dev:nightly\n        name: dev\n      -\n        image: aandrienko/che-machine-exec:latest\n        name: machine-exec",
             "contentType": "application/x-yaml"
           }
         }

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -61,7 +61,7 @@
           "recipe": {
             "contentType": "application/x-yaml",
             "type": "compose",
-            "content": "services:\n  machine-exec:\n    image: 'aandrienko/che-machine-exec:latest'\n    mem_limit: 536870912\n  theia:\n    image: 'eclipse/che-theia:0.3.14-nightly'\n    mem_limit: 1073741824\n    depends_on:\n      - machine-exec\n"
+            "content": "services:\n  machine-exec:\n    image: 'wsskeleton/che-machine-exec:latest'\n    mem_limit: 536870912\n  theia:\n    image: 'eclipse/che-theia:0.3.14-nightly'\n    mem_limit: 1073741824\n    depends_on:\n      - machine-exec\n"
           }
         }
       },
@@ -146,7 +146,7 @@
           },
           "recipe": {
             "type": "openshift",
-            "content": "---\nkind: List\nitems:\n-\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n  spec:\n    containers:\n      -\n        image: eclipse/che-theia:0.3.14-nightly\n        name: theia\n      -\n        image: eclipse/che-dev:nightly\n        name: dev\n      -\n        image: aandrienko/che-machine-exec:latest\n        name: machine-exec",
+            "content": "---\nkind: List\nitems:\n-\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n  spec:\n    containers:\n      -\n        image: eclipse/che-theia:0.3.14-nightly\n        name: theia\n      -\n        image: eclipse/che-dev:nightly\n        name: dev\n      -\n        image: wsskeleton/che-machine-exec:latest\n        name: machine-exec",
             "contentType": "application/x-yaml"
           }
         }


### PR DESCRIPTION
### What does this PR do?
Add 'che-theia-terminal-extension', 'che-theia-task-plugin' to the Theia image. 
Integration che-machine-exec.
Remove default Theia terminal extension from package.json of the Theia image.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10314

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

