### PR TITLE
Use verbaccio config.

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -22,6 +22,7 @@ ENV THEIA_VERSION=${THEIA_VERSION} \
 WORKDIR ${HOME}
 
 ADD src/ ${HOME}/
+ADD config.yaml ${HOME}/.config/verdaccio/
 ADD supervisord.conf /etc/
 
 RUN ${HOME}/setup.sh

--- a/dockerfiles/theia/README.md
+++ b/dockerfiles/theia/README.md
@@ -11,7 +11,7 @@ using build script:
 with native docker:
 
 ```
-docker build -t eclipse/che-theia:0.3.10-nightly --build-arg GITHUB_TOKEN={your token} --build-arg THEIA_VERSION=0.3.10 .
+docker build -t eclipse/che-theia:0.3.10-nightly --build-arg GITHUB_TOKEN=${GITHUB_TOKEN} --build-arg THEIA_VERSION=0.3.10 .
 ```
 
 ## Theia version

--- a/dockerfiles/theia/config.yaml
+++ b/dockerfiles/theia/config.yaml
@@ -1,0 +1,63 @@
+#
+# This is the default config file. It allows all users to do anything,
+# so don't use it on production systems.
+#
+# Look here for more config file examples:
+# https://github.com/verdaccio/verdaccio/tree/master/conf
+#
+
+# path to a directory with all packages
+storage: /home/theia/.config/verdaccio/storage
+# path to a directory with plugins to include
+plugins: /home/theia/.config/verdaccio/plugins
+
+web:
+  # WebUI is enabled as default, if you want disable it, just uncomment this line
+  #enable: false
+  title: Verdaccio
+
+auth:
+  htpasswd:
+    file: ./htpasswd
+    # Maximum amount of users allowed to register, defaults to "+inf".
+    # You can set this to -1 to disable registration.
+    #max_users: 1000
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
+
+  '**':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish packages
+    # (anyone can register by default, remember?)
+    publish: $authenticated
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+# To use `npm audit` uncomment the following section
+middlewares:
+  audit:
+    enabled: true
+
+# log settings
+logs:
+  - {type: file, path: verdaccio.log, format: pretty, level: info}
+# maximum size of uploaded json document
+# increase it if you have "request entity too large" errors  
+max_body_size: 1000mb


### PR DESCRIPTION
### What does this PR do?

Use verbacio config to define max_body_size for request entity. I'ts prevent fail theia image build if was applied theia extension with big size.
Redirect verbaccio logs to file with help config. We detach Verbaccio process, so input from this application became mixed with Theia image build output:
https://github.com/eclipse/che/issues/11229
Little useful fix up for README.md file.

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11229


