### PR TITLE
explicitly declare dependency on xtend.lib so we can set version; also set version for xtext.xbase.lib.gwt

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -117,10 +117,6 @@
             <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.xtext</groupId>
-            <artifactId>org.eclipse.xtext.xbase.lib.gwt</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
use latest release of xtext/xtend based on variable in parent pom org.eclipse.xtext.version so we can align on the same version for both

Change-Id: Ia0902deb90b69e1c1d93357607193cca77a8872b
Signed-off-by: nickboldt <nboldt@redhat.com>