### PR TITLE
Do not skip selenium test which should run always

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -364,8 +364,13 @@ public abstract class SeleniumTestHandler
           break;
 
         case ITestResult.SKIP:
+          String skipReasonDetails =
+              result.getThrowable() != null
+                  ? " The reason: " + result.getThrowable().getLocalizedMessage()
+                  : "";
           if (result.getMethod().isTest()) {
-            LOG.warn("Test {} skipped.", getCompletedTestLabel(result.getMethod()));
+            LOG.warn(
+                "Test {} skipped.{}", getCompletedTestLabel(result.getMethod()), skipReasonDetails);
           }
 
           // don't capture test data if test is skipped because of previous test with higher

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/SeleniumTestHandler.java
@@ -627,9 +627,10 @@ public abstract class SeleniumTestHandler
     ITestResult failedTestResult =
         testsWithFailure.get(testMethodToSkip.getInstance().getClass().getName());
 
-    // Test with lower priority value is started firstly by TestNG.
+    // skip test with lower priority value and if it shouldn't always run
     if (failedTestResult != null
-        && testMethodToSkip.getPriority() > failedTestResult.getMethod().getPriority()) {
+        && testMethodToSkip.getPriority() > failedTestResult.getMethod().getPriority()
+        && !testMethodToSkip.isAlwaysRun()) {
       throw new SkipException(
           format(
               "Skipping test %s because it depends on test %s which has failed earlier.",


### PR DESCRIPTION
### What does this PR do?
It adds an ability not to skip test after previous test with higher priority failed if test has flag `alwaysRun=true`.

### What issues does this PR fix or reference?
#11226 