### PR TITLE
Rename project attributes column name to avoid reserved keyword

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
@@ -307,7 +307,7 @@ public class ProjectConfigImpl implements ProjectConfig {
     @CollectionTable(
         name = "projectattribute_values",
         joinColumns = @JoinColumn(name = "projectattribute_id"))
-    @Column(name = "projectattribute_values")
+    @Column(name = "attribute_values")
     private List<String> values;
 
     public Attribute() {}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ProjectConfigImpl.java
@@ -307,7 +307,7 @@ public class ProjectConfigImpl implements ProjectConfig {
     @CollectionTable(
         name = "projectattribute_values",
         joinColumns = @JoinColumn(name = "projectattribute_id"))
-    @Column(name = "values")
+    @Column(name = "projectattribute_values")
     private List<String> values;
 
     public Attribute() {}

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.12.0/1__rename_project_attributes_values_field.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.12.0/1__rename_project_attributes_values_field.sql
@@ -10,4 +10,4 @@
 --   Red Hat, Inc. - initial API and implementation
 --
 
-ALTER TABLE projectattribute_values RENAME COLUMN values TO projectattribute_values;
+ALTER TABLE projectattribute_values RENAME COLUMN values TO attribute_values;

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.12.0/1__rename_project_attributes_values_field.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.12.0/1__rename_project_attributes_values_field.sql
@@ -1,0 +1,13 @@
+--
+-- Copyright (c) 2012-2018 Red Hat, Inc.
+-- This program and the accompanying materials are made
+-- available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+--
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+ALTER TABLE projectattribute_values RENAME COLUMN values TO projectattribute_values;


### PR DESCRIPTION
### What does this PR do?
Rename project attributes column name to avoid reserved keyword usage.

### What issues does this PR fix or reference?
#11192
#### Release Notes
N/A

