### PR TITLE
Wait for loader to close after projectexplorer refresh

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -892,6 +892,7 @@ public class ProjectExplorer {
   public void clickOnRefreshTreeButton() {
     clickOnProjectExplorerOptionsButton();
     clickOnOptionsMenuItem(REFRESH_MAIN);
+    loader.waitOnClosed();
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?
Adds a loader.waitOnClose() after refreshing the project explorer tree. This is supposed to fix the timing problems and "StaleElementExceptions".

