### PR TITLE
CHE-11097: add mem limit field to sidecar model

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/CheContainer.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/CheContainer.java
@@ -28,6 +28,9 @@ public class CheContainer {
   private List<Volume> volumes = new ArrayList<>();
   private List<CheContainerPort> ports = new ArrayList<>();
 
+  @JsonProperty("memory-limit")
+  private String memoryLimit = null;
+
   public CheContainer image(String image) {
     this.image = image;
     return this;
@@ -96,6 +99,19 @@ public class CheContainer {
     this.ports = ports;
   }
 
+  public CheContainer memoryLimit(String memoryLimit) {
+    this.memoryLimit = memoryLimit;
+    return this;
+  }
+
+  public String getMemoryLimit() {
+    return memoryLimit;
+  }
+
+  public void setMemoryLimit(String memoryLimit) {
+    this.memoryLimit = memoryLimit;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -109,13 +125,15 @@ public class CheContainer {
         && Objects.equals(getEnv(), that.getEnv())
         && Objects.equals(getCommands(), that.getCommands())
         && Objects.equals(getVolumes(), that.getVolumes())
-        && Objects.equals(getPorts(), that.getPorts());
+        && Objects.equals(getPorts(), that.getPorts())
+        && Objects.equals(getPorts(), that.getPorts())
+        && Objects.equals(getMemoryLimit(), that.getMemoryLimit());
   }
 
   @Override
   public int hashCode() {
-
-    return Objects.hash(getImage(), getEnv(), getCommands(), getVolumes(), getPorts());
+    return Objects.hash(
+        getImage(), getEnv(), getCommands(), getVolumes(), getPorts(), getMemoryLimit());
   }
 
   @Override
@@ -132,6 +150,8 @@ public class CheContainer {
         + volumes
         + ", ports="
         + ports
+        + ", memoryLimit="
+        + memoryLimit
         + '}';
   }
 }


### PR DESCRIPTION
### What does this PR do?
Add mem limit field to sidecar model.
This change is taken from another PR https://github.com/eclipse/che/pull/11248.
But since now WS.NEXT flow is broken because of unsync merges in Che and plugin broker we need to merge this fix now rather than waiting till https://github.com/eclipse/che/pull/11248 is merged.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
