### PR TITLE
Selenium: update expected stacks lists on 'New Workspaces' page

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -88,7 +88,6 @@ public class NewWorkspacePageTest {
           PHP,
           PYTHON,
           RAILS,
-          JAVA_THEIA_DOCKER,
           WORKSPACE_NEXT_HELLO_WORLD,
           WORKSPACE_NEXT_REST);
 
@@ -105,7 +104,6 @@ public class NewWorkspacePageTest {
           PHP,
           PYTHON,
           RAILS,
-          JAVA_THEIA_DOCKER,
           WORKSPACE_NEXT_HELLO_WORLD,
           WORKSPACE_NEXT_REST);
 
@@ -147,7 +145,6 @@ public class NewWorkspacePageTest {
           PYTHON,
           RAILS,
           SPRING_BOOT,
-          JAVA_THEIA_DOCKER,
           WORKSPACE_NEXT_HELLO_WORLD,
           WORKSPACE_NEXT_REST);
 
@@ -173,7 +170,6 @@ public class NewWorkspacePageTest {
           PYTHON,
           RAILS,
           SPRING_BOOT,
-          JAVA_THEIA_DOCKER,
           WORKSPACE_NEXT_HELLO_WORLD,
           WORKSPACE_NEXT_REST);
 
@@ -199,18 +195,17 @@ public class NewWorkspacePageTest {
           PYTHON,
           RAILS,
           SPRING_BOOT,
-          JAVA_THEIA_DOCKER,
           WORKSPACE_NEXT_HELLO_WORLD,
           WORKSPACE_NEXT_REST);
 
   private static final List<NewWorkspace.Stack> EXPECTED_OPENSHIFT_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS);
+      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS, JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack> EXPECTED_K8S_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS);
+      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS, JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack> EXPECTED_DOCKER_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS);
+      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS, JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack>
       EXPECTED_OPENSHIFT_QUICK_START_STACKS_REVERSE_ORDER =
@@ -219,7 +214,6 @@ public class NewWorkspacePageTest {
               BLANK,
               WORKSPACE_NEXT_REST,
               WORKSPACE_NEXT_HELLO_WORLD,
-              JAVA_THEIA_DOCKER,
               RAILS,
               PYTHON,
               PHP,
@@ -237,7 +231,6 @@ public class NewWorkspacePageTest {
           BLANK,
           WORKSPACE_NEXT_REST,
           WORKSPACE_NEXT_HELLO_WORLD,
-          JAVA_THEIA_DOCKER,
           RAILS,
           PYTHON,
           PHP,

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaDockerStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaDockerStackTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPA
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_DOCKER;
 
 import com.google.inject.Inject;
+import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
@@ -28,6 +29,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Skoryk Serhii */
+@Test(groups = {TestGroup.DOCKER})
 public class CreateWorkspaceFromJavaTheiaDockerStackTest {
   private static final String WORKSPACE_NAME = generate("workspace", 4);
 


### PR DESCRIPTION
### What does this PR do?
This PR updates selenium tests from dashboard package that work with "Theia IDE on docker" stack according to this stack config changes by https://github.com/eclipse/che/pull/11228 PR:
- adds **CreateWorkspaceFromJavaTheiaDockerStackTest** selenium test to **DOCKER** test group because "Theia IDE on docker" stack cannot start on **openshift** infrastructure;
- fix expected stacks list on New Workspace page in **NewWorkspacePageTest** selenium test.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11256
