### PR TITLE
Do not recognize file in workspace root as project

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/ProjectTreeChangeHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/ProjectTreeChangeHandler.java
@@ -121,11 +121,13 @@ public class ProjectTreeChangeHandler {
     private Promise<Void> doProcessMultipleChanges(List<FileChange> changes) {
       Promise<Void> multipleChainPromise = ProjectTreeChangeHandler.this.promises.resolve(null);
 
-      multipleChainPromise =
-          multipleChainPromise.thenPromise(ignored -> doProcessDeleteChanges(changes));
+      List<FileChange> preProcessedChanges = skipFilesInTheRootDirectory(changes);
 
       multipleChainPromise =
-          multipleChainPromise.thenPromise(ignored -> doProcessUpdateChanges(changes));
+          multipleChainPromise.thenPromise(ignored -> doProcessDeleteChanges(preProcessedChanges));
+
+      multipleChainPromise =
+          multipleChainPromise.thenPromise(ignored -> doProcessUpdateChanges(preProcessedChanges));
 
       return multipleChainPromise;
     }
@@ -196,12 +198,23 @@ public class ProjectTreeChangeHandler {
       return change.getType() != DELETED;
     }
 
+    private boolean isFileInRootDirectory(FileChange change) {
+      return change.isFile() && Path.valueOf(change.getPath()).segmentCount() == 1;
+    }
+
     private List<FileChange> getDeleteFileChanges(List<FileChange> changes) {
       return changes.stream().filter(this::isDeleteChange).collect(toList());
     }
 
     private List<FileChange> getUpdateFileChanges(List<FileChange> changes) {
       return changes.stream().filter(this::isNotDeleteChange).collect(toList());
+    }
+
+    private List<FileChange> skipFilesInTheRootDirectory(List<FileChange> changes) {
+      List<FileChange> newChanges = new ArrayList<>(changes);
+      newChanges.removeIf(this::isFileInRootDirectory);
+
+      return newChanges;
     }
 
     private List<Path> getUpdateFileChangePaths(List<FileChange> changes) {
@@ -252,6 +265,10 @@ public class ProjectTreeChangeHandler {
     }
 
     private Promise<Void> doProcessSingleChange(FileChange change) {
+      if (isFileInRootDirectory(change)) {
+        return promises.resolve(null);
+      }
+
       return isNullOrEmpty(change.getPath())
           ? synchronizeChanges()
           : synchronizeChanges(getResourceDelta(change));

--- a/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/FileChange.java
+++ b/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/FileChange.java
@@ -22,5 +22,7 @@ import org.eclipse.che.api.project.shared.dto.event.FileWatcherEventType;
 public interface FileChange {
   String getPath();
 
+  boolean isFile();
+
   FileWatcherEventType getType();
 }

--- a/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/event/ProjectTreeStateUpdateDto.java
+++ b/wsagent/che-core-api-project-shared/src/main/java/org/eclipse/che/api/project/shared/dto/event/ProjectTreeStateUpdateDto.java
@@ -20,6 +20,10 @@ public interface ProjectTreeStateUpdateDto extends FileChange {
 
   ProjectTreeStateUpdateDto withPath(String path);
 
+  boolean isFile();
+
+  ProjectTreeStateUpdateDto withFile(boolean isFile);
+
   FileWatcherEventType getType();
 
   ProjectTreeStateUpdateDto withType(FileWatcherEventType type);

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/RootDirCreationHandler.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/project/server/impl/RootDirCreationHandler.java
@@ -25,16 +25,19 @@ import org.eclipse.che.api.watcher.server.FileWatcherManager;
 public class RootDirCreationHandler {
   private final FileWatcherManager fileWatcherManager;
   private final ProjectConfigRegistry projectConfigRegistry;
-  private HiddenItemPathMatcher hiddenItemPathMatcher;
+  private final HiddenItemPathMatcher hiddenItemPathMatcher;
+  private final RootDirPathProvider rootDirPathProvider;
 
   @Inject
   public RootDirCreationHandler(
       FileWatcherManager fileWatcherManager,
       ProjectConfigRegistry projectConfigRegistry,
-      HiddenItemPathMatcher hiddenItemPathMatcher) {
+      HiddenItemPathMatcher hiddenItemPathMatcher,
+      RootDirPathProvider rootDirPathProvider) {
     this.fileWatcherManager = fileWatcherManager;
     this.projectConfigRegistry = projectConfigRegistry;
     this.hiddenItemPathMatcher = hiddenItemPathMatcher;
+    this.rootDirPathProvider = rootDirPathProvider;
   }
 
   @PostConstruct
@@ -43,7 +46,8 @@ public class RootDirCreationHandler {
   }
 
   private void consumeCreate(String wsPath) {
-    if (!hiddenItemPathMatcher.matches(Paths.get(wsPath))) {
+    if (!hiddenItemPathMatcher.matches(Paths.get(wsPath))
+        && Paths.get(rootDirPathProvider.get(), wsPath).toFile().isDirectory()) {
       projectConfigRegistry.putIfAbsent(wsPath, true, true);
     }
   }

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/watcher/server/detectors/ProjectTreeTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/watcher/server/detectors/ProjectTreeTracker.java
@@ -34,6 +34,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
+import org.eclipse.che.api.project.server.impl.RootDirPathProvider;
 import org.eclipse.che.api.project.shared.dto.event.ProjectTreeStateUpdateDto;
 import org.eclipse.che.api.project.shared.dto.event.ProjectTreeTrackingOperationDto;
 import org.eclipse.che.api.project.shared.dto.event.ProjectTreeTrackingOperationDto.Type;
@@ -55,15 +56,18 @@ public class ProjectTreeTracker {
   private final RequestTransmitter transmitter;
   private final FileWatcherManager fileWatcherManager;
   private final HiddenItemPathMatcher hiddenItemPathMatcher;
+  private final RootDirPathProvider rootDirPathProvider;
 
   @Inject
   public ProjectTreeTracker(
       RequestTransmitter transmitter,
       FileWatcherManager fileWatcherManager,
-      HiddenItemPathMatcher hiddenItemPathMatcher) {
+      HiddenItemPathMatcher hiddenItemPathMatcher,
+      RootDirPathProvider rootDirPathProvider) {
     this.transmitter = transmitter;
     this.fileWatcherManager = fileWatcherManager;
     this.hiddenItemPathMatcher = hiddenItemPathMatcher;
+    this.rootDirPathProvider = rootDirPathProvider;
   }
 
   @Inject
@@ -147,7 +151,7 @@ public class ProjectTreeTracker {
         timers.remove(it);
       } else {
         ProjectTreeStateUpdateDto params =
-            newDto(ProjectTreeStateUpdateDto.class).withPath(it).withType(CREATED);
+            newDto(ProjectTreeStateUpdateDto.class).withPath(it).withFile(isFile(it)).withType(CREATED);
         transmitter
             .newRequest()
             .endpointId(endpointId)
@@ -189,6 +193,10 @@ public class ProjectTreeTracker {
               },
               1_000L);
     };
+  }
+
+  private boolean isFile(String path) {
+    return Paths.get(rootDirPathProvider.get(), path).toFile().isFile();
   }
 
   private boolean isExcluded(String path) {

--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/watcher/server/detectors/ProjectTreeTracker.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/watcher/server/detectors/ProjectTreeTracker.java
@@ -151,7 +151,10 @@ public class ProjectTreeTracker {
         timers.remove(it);
       } else {
         ProjectTreeStateUpdateDto params =
-            newDto(ProjectTreeStateUpdateDto.class).withPath(it).withFile(isFile(it)).withType(CREATED);
+            newDto(ProjectTreeStateUpdateDto.class)
+                .withPath(it)
+                .withFile(isFile(it))
+                .withType(CREATED);
         transmitter
             .newRequest()
             .endpointId(endpointId)


### PR DESCRIPTION
### What does this PR do?
This changes proposal improves behavior of file manager which works with files in workspace root. At first, additional check was added to avoid create project configuration when file is created in workspace root. And on the client side we don't show notification that project is created, when it's actually a file in workspace root.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#10586 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A