### PR TITLE
#10881 move dashboard to its own profile and assembly with dashboard to a separate file, so we can build Che Server w/o dashboard (until Bower -> Yarn migration done)

### DIFF
--- a/assembly/assembly-main/pom.xml
+++ b/assembly/assembly-main/pom.xml
@@ -72,11 +72,6 @@
             <type>jar</type>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.che.dashboard</groupId>
-            <artifactId>che-dashboard-war</artifactId>
-            <type>war</type>
-        </dependency>
-        <dependency>
             <groupId>org.eclipse.che.docs</groupId>
             <artifactId>che-docs</artifactId>
             <type>war</type>
@@ -152,4 +147,41 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>dashboard</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-assembly-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>make-assembly</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>single</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>${project.basedir}/src/assembly/assembly-with-dashboard.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.che.dashboard</groupId>
+                    <artifactId>che-dashboard-war</artifactId>
+                    <type>war</type>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/assembly/assembly-main/src/assembly/assembly-with-dashboard.xml
+++ b/assembly/assembly-main/src/assembly/assembly-with-dashboard.xml
@@ -47,7 +47,7 @@
                 <include>org.eclipse.che:assembly-wsmaster-war</include>
             </includes>
         </dependencySet>
-        <!-- <dependencySet>
+        <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
             <unpack>false</unpack>
             <outputDirectory>tomcat/webapps</outputDirectory>
@@ -55,7 +55,7 @@
             <includes>
                 <include>org.eclipse.che.dashboard:che-dashboard-war</include>
             </includes>
-        </dependencySet> -->
+        </dependencySet>
         <dependencySet>
             <useProjectArtifact>false</useProjectArtifact>
             <unpack>false</unpack>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
         <module>ide/che-ide-core</module>
         <module>ide/che-ide-full</module>
         <module>ide/che-ide-gwt-app</module>
-        <module>dashboard</module>
         <module>workspace-loader</module>
         <module>assembly</module>
         <module>selenium</module>
@@ -2069,6 +2068,15 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>dashboard</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>dashboard</module>
+            </modules>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
https://github.com/eclipse/che/issues/10881 move dashboard to its own profile and assembly with dashboard to a separate file, so we can build Che Server w/o dashboard (until Bower -> Yarn migration done)

Change-Id: I2a035e8e0e1ca18fa9e2b65d512270b3e9939eb8
Signed-off-by: nickboldt <nboldt@redhat.com>