### PR TITLE
Wait for jdt.ls to have started

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/ConditionalBreakpointsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/ConditionalBreakpointsTest.java
@@ -81,6 +81,7 @@ public class ConditionalBreakpointsTest {
     projectExplorer.waitItem(PROJECT);
     commandsPalette.openCommandPalette();
     commandsPalette.startCommandByDoubleClick("build");
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT);
     projectExplorer.quickExpandWithJavaScript();
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
@@ -101,7 +101,9 @@ public class CreateFactoryFromUiWithKeepDirTest {
   @Test
   public void createFactoryFromUiWithKeepDirTest() throws Exception {
     projectExplorer.waitProjectExplorer();
+    consoles.waitJDTLSStartedMessage();
     makeKeepDirectoryFromGitUrl(PROJECT_URL, PROJECT_NAME, KEEPED_DIR);
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
     setUpModuleForFactory();
     consoles.clickOnProcessesButton();
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/MacrosCommandsEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/MacrosCommandsEditorTest.java
@@ -57,6 +57,7 @@ public class MacrosCommandsEditorTest {
     testProjectServiceClient.importProject(
         ws.getId(), Paths.get(resource.toURI()), PROJ_NAME, ProjectTemplates.PLAIN_JAVA);
     ide.open(ws);
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJ_NAME);
   }
 
   @Test(priority = 1)


### PR DESCRIPTION
### What does this PR do?
Adds code that waits for jdt.ls to be ready to some selenium tests.

### What issues does this PR fix or reference?
Some Java-Related Test Don't Wait for jdt.ls Startup #11273
