### PR TITLE
Increase Refactoring Request Timeout

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/service/JavaLanguageExtensionServiceClient.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/service/JavaLanguageExtensionServiceClient.java
@@ -30,6 +30,7 @@ import static org.eclipse.che.ide.ext.java.shared.Constants.RECOMPUTE_POM_DIAGNO
 import static org.eclipse.che.ide.ext.java.shared.Constants.REFACTORING_GET_RENAME_TYPE;
 import static org.eclipse.che.ide.ext.java.shared.Constants.REFACTORING_MOVE;
 import static org.eclipse.che.ide.ext.java.shared.Constants.REFACTORING_RENAME;
+import static org.eclipse.che.ide.ext.java.shared.Constants.REFACTORING_TIMEOUT;
 import static org.eclipse.che.ide.ext.java.shared.Constants.REIMPORT_MAVEN_PROJECTS;
 import static org.eclipse.che.ide.ext.java.shared.Constants.REIMPORT_MAVEN_PROJECTS_REQUEST_TIMEOUT;
 import static org.eclipse.che.ide.ext.java.shared.Constants.REQUEST_TIMEOUT;
@@ -304,7 +305,7 @@ public class JavaLanguageExtensionServiceClient {
                 .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
                 .methodName(REFACTORING_RENAME)
                 .paramsAsDto(renameSettings)
-                .sendAndReceiveResultAsDto(RefactoringResult.class, REQUEST_TIMEOUT)
+                .sendAndReceiveResultAsDto(RefactoringResult.class, REFACTORING_TIMEOUT)
                 .onSuccess(resolve::apply)
                 .onTimeout(() -> onTimeout(reject))
                 .onFailure(error -> reject.apply(ServiceUtil.getPromiseError(error))));
@@ -364,7 +365,7 @@ public class JavaLanguageExtensionServiceClient {
                 .endpointId(WS_AGENT_JSON_RPC_ENDPOINT_ID)
                 .methodName(REFACTORING_MOVE)
                 .paramsAsDto(moveSettings)
-                .sendAndReceiveResultAsDto(RefactoringResult.class, REQUEST_TIMEOUT)
+                .sendAndReceiveResultAsDto(RefactoringResult.class, REFACTORING_TIMEOUT)
                 .onSuccess(resolve::apply)
                 .onTimeout(() -> onTimeout(reject))
                 .onFailure(error -> reject.apply(ServiceUtil.getPromiseError(error))));

--- a/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-shared/src/main/java/org/eclipse/che/ide/ext/java/shared/Constants.java
@@ -32,6 +32,7 @@ public final class Constants {
 
   // LS requests timeout constants
   public static final int REQUEST_TIMEOUT = 10_000;
+  public static final int REFACTORING_TIMEOUT = 30_000;
   public static final int EFFECTIVE_POM_REQUEST_TIMEOUT = 30_000;
   public static final int REIMPORT_MAVEN_PROJECTS_REQUEST_TIMEOUT = 60_000;
 


### PR DESCRIPTION
### What does this PR do?
It increases the request timeout on move and rename refactoring calls to 30 seconds. Since refactorings are large operations, it makes sense to have a different timeout than "hover", for example

### What issues does this PR fix or reference?
Timeout on Refactorings in Selenium Tests #11275