### PR TITLE
Wait for loader to close after jdt.ls workspace updated message.

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -420,6 +420,10 @@ public class Consoles {
   /** wait JDT LS message about project is updated */
   public void waitJDTLSProjectResolveFinishedMessage(String project) {
     waitExpectedTextIntoConsole(String.format(LANGUAGE_SERVER_UPDATE_MESSAGE, project));
+    // once a new project has been added to the workspace, stuff in the project
+    // explorer will be updated, for example showing packages instead of folders
+    // wait for this to be finished
+    loader.waitOnClosed();
   }
 
   /** get visible text from command console */


### PR DESCRIPTION
### What does this PR do?
Introduces a loader.waitForClosed() after getting the "workspace udpated" message from jdt.ls. The background is that the project explorer is updating at this time and if we do an expand of the tree, the tree may be collapsed again because it changes.
This PR servers to test the hypothesis that this is leadiung to various ci-test failures.