### PR TITLE
Added exec plugin to ws-next stacks

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -199,7 +199,7 @@
       "name": "skeleton",
       "attributes": {
         "editor": "org.eclipse.che.editor.theia:1.0.0",
-        "plugins": "che-dummy-plugin:0.0.1"
+        "plugins": "che-dummy-plugin:0.0.1,che-machine-exec-plugin:0.0.1"
       },
       "commands": [],
       "links": []
@@ -247,7 +247,7 @@
       "name": "skeleton",
       "attributes": {
         "editor": "org.eclipse.che.editor.theia:1.0.0",
-        "plugins": "che-service-plugin:0.0.1"
+        "plugins": "che-service-plugin:0.0.1,che-machine-exec-plugin:0.0.1"
       },
       "commands": [],
       "links": []


### PR DESCRIPTION
### What does this PR do?

Add the `machine-exec-plugin` to the workspace.next stacks that otherwise don't work properly.

### What issues does this PR fix or reference?

When starting hosted Theia (using stack `wsnext-service-openshift` or `wsnext-helloworld-openshift`on minishift) the console shows the following error:

```
root ERROR Uncaught Exception: Error: No server with type "terminal" found.
root ERROR Error: No server with type "terminal" found.
```
