### PR TITLE
Add org.eclipse.che.ls.java installer into E2E test workspace templates

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/default.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/default.json
@@ -6,7 +6,8 @@
           "installers":[
             "org.eclipse.che.terminal",
             "org.eclipse.che.ws-agent",
-            "org.eclipse.che.exec"
+            "org.eclipse.che.exec",
+            "org.eclipse.che.ls.java"
           ],
           "attributes": {
             "memoryLimitBytes": "desired_memory_value"

--- a/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/ubuntu_jdk8.json
+++ b/selenium/che-selenium-test/src/test/resources/templates/workspace/openshift/ubuntu_jdk8.json
@@ -6,7 +6,8 @@
           "installers": [
             "org.eclipse.che.terminal",
             "org.eclipse.che.ws-agent",
-            "org.eclipse.che.exec"
+            "org.eclipse.che.exec",
+            "org.eclipse.che.ls.java"
           ],
           "attributes": {
             "memoryLimitBytes": "desired_memory_value"


### PR DESCRIPTION
### What does this PR do?
Adds missed installer *"org.eclipse.che.ls.java"* into the OpenShift-related E2E test workspace templates.

### What issues does this PR fix or reference?
#11304