### PR TITLE
[root pom] support overriding the version of dashboard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,9 +49,12 @@
         <url>https://github.com/eclipse/che</url>
     </scm>
     <properties>
-        <che.docs.version>6.12.0-SNAPSHOT</che.docs.version>
-        <che.lib.version>6.12.0-SNAPSHOT</che.lib.version>
+        <?SORTPOM IGNORE?>
         <che.version>6.12.0-SNAPSHOT</che.version>
+        <?SORTPOM RESUME?>
+        <che.dashboard.version>${che.version}</che.dashboard.version>
+        <che.docs.version>${che.version}</che.docs.version>
+        <che.lib.version>${che.version}</che.lib.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <dependencyManagement>
@@ -792,7 +795,7 @@
             <dependency>
                 <groupId>org.eclipse.che.dashboard</groupId>
                 <artifactId>che-dashboard-war</artifactId>
-                <version>${che.version}</version>
+                <version>${che.dashboard.version}</version>
                 <type>war</type>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
         <che.version>6.12.0-SNAPSHOT</che.version>
         <?SORTPOM RESUME?>
         <che.dashboard.version>${che.version}</che.dashboard.version>
-        <che.docs.version>${che.version}</che.docs.version>
-        <che.lib.version>${che.version}</che.lib.version>
+        <che.docs.version>6.12.0-SNAPSHOT</che.docs.version>
+        <che.lib.version>6.12.0-SNAPSHOT</che.lib.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
support overriding the version of che-dashbaord-war via new property che.dashboard.version

Change-Id: I3627f5572f8a0221e16bc0f08ec56407fe13a0f1
Signed-off-by: nickboldt <nboldt@redhat.com>