### PR TITLE
Don't use eclipse.text classes to convert text edits

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/quickassist/ApplyWorkspaceEditAction.java
@@ -40,6 +40,7 @@ import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.document.Document;
 import org.eclipse.che.ide.api.editor.events.FileEvent;
+import org.eclipse.che.ide.api.editor.text.TextPosition;
 import org.eclipse.che.ide.api.editor.texteditor.HandlesUndoRedo;
 import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.notification.Notification;
@@ -410,8 +411,16 @@ public class ApplyWorkspaceEditAction extends BaseAction {
       Range r = e.getRange();
       Position start = r.getStart();
       Position end = r.getEnd();
-      document.replace(
-          start.getLine(), start.getCharacter(), end.getLine(), end.getCharacter(), e.getNewText());
+      int startIndex =
+          document.getIndexFromPosition(new TextPosition(start.getLine(), start.getCharacter()));
+      // python ls, for example shows as end position index 0 of the line after the change. If the
+      // change is on the last line, we crash
+      int endIndex =
+          document.getIndexFromPosition(new TextPosition(end.getLine(), end.getCharacter()));
+      if (endIndex < 0) {
+        endIndex = document.getContentsCharCount();
+      }
+      document.replace(startIndex, endIndex - startIndex, e.getNewText());
     }
   }
 }

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/CharStreamEditor.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/CharStreamEditor.java
@@ -25,8 +25,14 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 
+/**
+ * Applies LSP edits to a stream of characters and writes the edited chars to an output. In the
+ * process, a list of undo edits is generated.
+ *
+ * @author Thomas Mäder
+ */
 public class CharStreamEditor {
-  private static final Comparator<TextEdit> COMPARATOR =
+  public static final Comparator<TextEdit> COMPARATOR =
       RangeComparator.transform(new RangeComparator(), TextEdit::getRange);
   private ArrayList<TextEdit> edits;
   private int currentReadLine = 0;

--- a/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/CharStreamIterator.java
+++ b/wsagent/che-core-api-languageserver-shared/src/main/java/org/eclipse/che/api/languageserver/shared/util/CharStreamIterator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver.shared.util;
+
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+import org.eclipse.lsp4j.Position;
+
+/**
+ * Line aware iterator over a stream of characters.
+ *
+ * @author Thomas Mäder
+ */
+public class CharStreamIterator {
+  public static BiConsumer<Integer, Integer> NULL_CONSUMER =
+      new BiConsumer<Integer, Integer>() {
+        @Override
+        public void accept(Integer t, Integer u) {}
+      };
+
+  private int currentReadLine = 0;
+  private int currentReadChar = 0;
+  private int currentOffset = 0;
+  private int ch;
+  private Supplier<Integer> source;
+
+  public CharStreamIterator(Supplier<Integer> source) {
+    this.source = source;
+    ch = source.get();
+  }
+
+  public void advanceTo(Position start, BiConsumer<Integer, Integer> dest) {
+    while (ch >= 0
+        && (currentReadLine < start.getLine() || currentReadChar < start.getCharacter())) {
+      dest.accept(ch, currentOffset);
+      if (ch == '\r') {
+        currentReadLine++;
+        currentReadChar = 0;
+        ch = source.get();
+        currentOffset++;
+        if (ch == '\n') {
+          dest.accept(ch, currentOffset);
+          ch = source.get();
+          currentOffset++;
+        }
+      } else if (ch == '\n') {
+        currentReadLine++;
+        currentReadChar = 0;
+        ch = source.get();
+        currentOffset++;
+      } else {
+        currentReadChar++;
+        ch = source.get();
+        currentOffset++;
+      }
+    }
+  }
+}

--- a/wsagent/che-core-api-languageserver/pom.xml
+++ b/wsagent/che-core-api-languageserver/pom.xml
@@ -95,10 +95,6 @@
             <artifactId>org.eclipse.lsp4j.jsonrpc</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.text</groupId>
-            <artifactId>org.eclipse.text</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.everrest</groupId>
             <artifactId>everrest-core</artifactId>
         </dependency>

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/TextDocumentService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/TextDocumentService.java
@@ -20,17 +20,18 @@ import static org.eclipse.che.api.languageserver.LanguageServiceUtils.prefixURI;
 import static org.eclipse.che.api.languageserver.LanguageServiceUtils.removePrefixUri;
 import static org.eclipse.che.api.languageserver.LanguageServiceUtils.removeUriScheme;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Singleton;
 import java.io.BufferedInputStream;
-import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -41,6 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -71,14 +73,13 @@ import org.eclipse.che.api.languageserver.shared.model.ExtendedWorkspaceEdit;
 import org.eclipse.che.api.languageserver.shared.model.RenameResult;
 import org.eclipse.che.api.languageserver.shared.model.SnippetParameters;
 import org.eclipse.che.api.languageserver.shared.model.SnippetResult;
+import org.eclipse.che.api.languageserver.shared.util.CharStreamEditor;
+import org.eclipse.che.api.languageserver.shared.util.CharStreamIterator;
 import org.eclipse.che.api.languageserver.shared.util.LinearRangeComparator;
 import org.eclipse.che.api.languageserver.util.LSOperation;
 import org.eclipse.che.api.languageserver.util.LineReader;
 import org.eclipse.che.api.languageserver.util.OperationUtil;
 import org.eclipse.che.jdt.ls.extension.api.dto.LinearRange;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.Document;
-import org.eclipse.jface.text.IRegion;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
@@ -100,6 +101,7 @@ import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.MarkedString;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.SignatureHelp;
@@ -324,7 +326,8 @@ public class TextDocumentService {
               List<Either<SymbolInformation, DocumentSymbol>> locations) {
             locations.forEach(
                 o -> {
-                  // minimal fix for https://github.com/eclipse/che/issues/11139 when updating lsp4j
+                  // minimal fix for https://github.com/eclipse/che/issues/11139 when updating
+                  // lsp4j
                   if (o.isLeft()) {
                     SymbolInformation si = o.getLeft();
                     si.getLocation().setUri(removePrefixUri(si.getLocation().getUri()));
@@ -794,41 +797,77 @@ public class TextDocumentService {
     }
   }
 
-  private List<ExtendedTextEdit> convertToExtendedEdit(List<TextEdit> edits, String filePath) {
+  private static List<ExtendedTextEdit> convertToExtendedEdit(
+      List<TextEdit> edits, String filePath) {
     try {
       // for some reason C# LS sends ws related path,
       if (!isStartWithProject(filePath)) {
         filePath = prefixProject(filePath);
       }
-      String fileContent =
-          com.google.common.io.Files.toString(new File(filePath), Charset.defaultCharset());
-      Document document = new Document(fileContent);
-      return edits
-          .stream()
-          .map(
-              textEdit -> {
-                ExtendedTextEdit result = new ExtendedTextEdit();
-                result.setRange(textEdit.getRange());
-                result.setNewText(textEdit.getNewText());
-                try {
-                  IRegion lineInformation =
-                      document.getLineInformation(textEdit.getRange().getStart().getLine());
-                  String lineText =
-                      document.get(lineInformation.getOffset(), lineInformation.getLength());
-                  result.setLineText(lineText);
-                  result.setInLineStart(textEdit.getRange().getStart().getCharacter());
-                  result.setInLineEnd(textEdit.getRange().getEnd().getCharacter());
-                } catch (BadLocationException e) {
-                  LOG.error("Can't read file line", e);
-                }
+      CharStreamIterator charStreamIter =
+          new CharStreamIterator(CharStreamEditor.forReader(new FileReader(filePath)));
 
-                return result;
-              })
-          .collect(Collectors.toList());
+      return convertToExtendedEdits(edits, charStreamIter);
     } catch (IOException e) {
       LOG.error("Can't read file", e);
+      return Collections.emptyList();
     }
-    return Collections.emptyList();
+  }
+
+  @VisibleForTesting
+  static List<ExtendedTextEdit> convertToExtendedEdits(
+      List<TextEdit> edits, CharStreamIterator charStreamIter) {
+    // don't manipulate the original collection
+    edits = new ArrayList<>(edits);
+    edits.sort(CharStreamEditor.COMPARATOR);
+
+    List<ExtendedTextEdit> result = new ArrayList<>(edits.size());
+    Iterator<TextEdit> editIterator = edits.iterator();
+    if (editIterator.hasNext()) {
+      TextEdit edit = editIterator.next();
+      while (edit != null) {
+        int currentLine = edit.getRange().getStart().getLine();
+        Position lineStart = new Position(edit.getRange().getStart().getLine(), 0);
+        Position nextLineStart = new Position(edit.getRange().getStart().getLine() + 1, 0);
+        charStreamIter.advanceTo(lineStart, CharStreamIterator.NULL_CONSUMER);
+        StringBuilder lineText = new StringBuilder();
+        charStreamIter.advanceTo(
+            nextLineStart,
+            new BiConsumer<Integer, Integer>() {
+
+              @Override
+              public void accept(Integer t, Integer u) {
+                if (t != '\r' && t != '\n') {
+                  lineText.append((char) t.intValue());
+                }
+              }
+            });
+        while (edit != null && edit.getRange().getStart().getLine() == currentLine) {
+          result.add(doConvert(edit, lineText));
+          if (editIterator.hasNext()) {
+            edit = editIterator.next();
+          } else {
+            edit = null;
+          }
+        }
+      }
+    }
+    return result;
+  }
+
+  private static ExtendedTextEdit doConvert(TextEdit edit, StringBuilder currentLine) {
+    ExtendedTextEdit extendedEdit = new ExtendedTextEdit();
+    extendedEdit.setRange(edit.getRange());
+    extendedEdit.setNewText(edit.getNewText());
+
+    extendedEdit.setLineText(currentLine.toString());
+    extendedEdit.setInLineStart(edit.getRange().getStart().getCharacter());
+    if (edit.getRange().getEnd().getLine() == edit.getRange().getStart().getLine()) {
+      extendedEdit.setInLineEnd(edit.getRange().getEnd().getCharacter());
+    } else {
+      extendedEdit.setInLineEnd(Math.max(0, currentLine.length() - 1));
+    }
+    return extendedEdit;
   }
 
   private String getFileContent(String uri) {

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/TextDocumentService.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/TextDocumentService.java
@@ -799,13 +799,13 @@ public class TextDocumentService {
 
   private static List<ExtendedTextEdit> convertToExtendedEdit(
       List<TextEdit> edits, String filePath) {
-    try {
-      // for some reason C# LS sends ws related path,
-      if (!isStartWithProject(filePath)) {
-        filePath = prefixProject(filePath);
-      }
+    // for some reason C# LS sends ws related path,
+    if (!isStartWithProject(filePath)) {
+      filePath = prefixProject(filePath);
+    }
+    try (FileReader reader = new FileReader(filePath)) {
       CharStreamIterator charStreamIter =
-          new CharStreamIterator(CharStreamEditor.forReader(new FileReader(filePath)));
+          new CharStreamIterator(CharStreamEditor.forReader(reader));
 
       return convertToExtendedEdits(edits, charStreamIter);
     } catch (IOException e) {

--- a/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/ExtendedTextEditTest.java
+++ b/wsagent/che-core-api-languageserver/src/test/java/org/eclipse/che/api/languageserver/ExtendedTextEditTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.languageserver;
+
+import static org.eclipse.che.api.languageserver.TextDocumentService.convertToExtendedEdits;
+import static org.testng.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import org.eclipse.che.api.languageserver.shared.model.ExtendedTextEdit;
+import org.eclipse.che.api.languageserver.shared.util.CharStreamIterator;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+import org.testng.annotations.Test;
+
+public class ExtendedTextEditTest {
+  @Test
+  public void testConvertSingleEdit() {
+    List<ExtendedTextEdit> converted =
+        convertToExtendedEdits(
+            Collections.singletonList(new TextEdit(range(0, 1, 0, 5), "blabla")),
+            new CharStreamIterator(source("abcdefghiklmnop")));
+    assertEquals(converted.size(), 1);
+    ExtendedTextEdit edit = converted.get(0);
+    expect(edit, range(0, 1, 0, 5), "blabla", "abcdefghiklmnop", 1, 5);
+  }
+
+  @Test
+  public void testConvertLineSpanning() {
+    List<ExtendedTextEdit> converted =
+        convertToExtendedEdits(
+            Collections.singletonList(new TextEdit(range(0, 1, 1, 5), "blabla")),
+            new CharStreamIterator(source("abcdefghiklmnop\nfoobar")));
+    assertEquals(converted.size(), 1);
+    ExtendedTextEdit edit = converted.get(0);
+    assertEquals(edit.getRange(), range(0, 1, 1, 5));
+    assertEquals(edit.getNewText(), "blabla");
+    assertEquals(edit.getLineText(), "abcdefghiklmnop");
+    assertEquals(edit.getInLineStart(), 1);
+    assertEquals(edit.getInLineEnd(), 14);
+  }
+
+  @Test
+  public void testConvertTwoInLine() {
+    List<ExtendedTextEdit> converted =
+        convertToExtendedEdits(
+            Arrays.asList(
+                new TextEdit(range(0, 1, 0, 5), "blabla"),
+                new TextEdit(range(0, 7, 1, 2), "sibi"),
+                new TextEdit(range(1, 3, 1, 4), "subu")),
+            new CharStreamIterator(source("abcdefghiklmnop\nfoobar")));
+    assertEquals(converted.size(), 3);
+    expect(converted.get(0), range(0, 1, 0, 5), "blabla", "abcdefghiklmnop", 1, 5);
+    expect(converted.get(1), range(0, 7, 1, 2), "sibi", "abcdefghiklmnop", 7, 14);
+    expect(converted.get(2), range(1, 3, 1, 4), "subu", "foobar", 3, 4);
+  }
+
+  private void expect(
+      ExtendedTextEdit first,
+      Range range,
+      String newText,
+      String line,
+      int startInLine,
+      int endInLine) {
+    assertEquals(first.getRange(), range);
+    assertEquals(first.getNewText(), newText);
+    assertEquals(first.getLineText(), line);
+    assertEquals(first.getInLineStart(), startInLine);
+    assertEquals(first.getInLineEnd(), endInLine);
+  }
+
+  private static Range range(int startLine, int startChar, int endLine, int endChar) {
+    return new Range(pos(startLine, startChar), pos(endLine, endChar));
+  }
+
+  private static Position pos(int startLine, int startChar) {
+    return new Position(startLine, startChar);
+  }
+
+  public Supplier<Integer> source(String input) {
+    return new Supplier<Integer>() {
+      private int pos = 0;
+
+      @Override
+      public Integer get() {
+        if (pos >= input.length()) {
+          return -1;
+        } else {
+          return (int) input.charAt(pos++);
+        }
+      }
+    };
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Replaces usage of org.jface.Document, etc. with our own implementation. Eclipse bundles have been removed from the build in the jdt.ls branch. 

### What issues does this PR fix or reference?
TextDocumentService uses Eclipse text support #11305 