### PR TITLE
 CHE-11097: Allow setting sidecar memory limit in ws attributes

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -102,6 +102,7 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
             .setContainer(k8sContainer)
             .setContainerEndpoints(containerEndpoints)
             .setDefaultSidecarMemorySizeAttribute(defaultSidecarMemoryLimitBytes)
+            .setAttributes(kubernetesEnvironment.getAttributes())
             .build();
 
     InternalMachineConfig machineConfig = machineResolver.resolve();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverBuilder.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 
 import io.fabric8.kubernetes.api.model.Container;
 import java.util.List;
+import java.util.Map;
 import org.eclipse.che.api.workspace.server.wsplugins.model.CheContainer;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePluginEndpoint;
 
@@ -23,17 +24,23 @@ public class MachineResolverBuilder {
   private CheContainer cheContainer;
   private String defaultSidecarMemorySizeAttribute;
   private List<ChePluginEndpoint> containerEndpoints;
+  private Map<String, String> wsAttributes;
 
   public MachineResolver build() {
     if (container == null
         || cheContainer == null
         || defaultSidecarMemorySizeAttribute == null
+        || wsAttributes == null
         || containerEndpoints == null) {
       throw new IllegalStateException();
     }
 
     return new MachineResolver(
-        container, cheContainer, defaultSidecarMemorySizeAttribute, containerEndpoints);
+        container,
+        cheContainer,
+        defaultSidecarMemorySizeAttribute,
+        containerEndpoints,
+        wsAttributes);
   }
 
   public MachineResolverBuilder setContainer(Container container) {
@@ -54,6 +61,11 @@ public class MachineResolverBuilder {
 
   public MachineResolverBuilder setContainerEndpoints(List<ChePluginEndpoint> containerEndpoints) {
     this.containerEndpoints = containerEndpoints;
+    return this;
+  }
+
+  public MachineResolverBuilder setAttributes(Map<String, String> wsConfigAttributes) {
+    this.wsAttributes = wsConfigAttributes;
     return this;
   }
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -104,6 +104,8 @@ public final class Constants {
    */
   public static final String WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE = "plugins";
 
+  public static final String SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE = "sidecar.%s.memory_limit";
+
   /**
    * Describes workspace runtimes which perform start/stop of this workspace. Should be set/read
    * from {@link Workspace#getAttributes}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/CheContainer.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/CheContainer.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 public class CheContainer {
 
   private String image = null;
+  private String name = null;
   private List<EnvVar> env = new ArrayList<>();
 
   @JsonProperty("editor-commands")
@@ -42,6 +43,19 @@ public class CheContainer {
 
   public void setImage(String image) {
     this.image = image;
+  }
+
+  public CheContainer name(String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
   }
 
   /** List of environment variables to set in the container. Cannot be updated. */
@@ -138,13 +152,14 @@ public class CheContainer {
         && Objects.equals(getCommands(), that.getCommands())
         && Objects.equals(getVolumes(), that.getVolumes())
         && Objects.equals(getPorts(), that.getPorts())
-        && Objects.equals(getMemoryLimit(), that.getMemoryLimit());
+        && Objects.equals(getMemoryLimit(), that.getMemoryLimit())
+        && Objects.equals(getName(), that.getName());
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        getImage(), getEnv(), getCommands(), getVolumes(), getPorts(), getMemoryLimit());
+        getImage(), getEnv(), getCommands(), getVolumes(), getPorts(), getMemoryLimit(), getName());
   }
 
   @Override
@@ -163,6 +178,8 @@ public class CheContainer {
         + ports
         + ", memoryLimit="
         + memoryLimit
+        + ", name="
+        + name
         + '}';
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adding workspace config attribute
`sidecar.<name of a sidecar from plugin definition>.memory_limit`
overrides sidecar memory limit with the value of the attribute
converted to bytes number.
Example:
Attribute `sidecar.theia-ide.memory_limit": "300Mi` sets Theia ide
sidecar container memory limit to 314572800 bytes.

### What issues does this PR fix or reference?
Related to #11097

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
