### PR TITLE
Adding support of the ephemeral workspaces (using `emptyDir` volume instead of PVC) via 'persistVolumes' attribute

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
@@ -99,7 +99,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     final String workspaceId = identity.getWorkspaceId();
-    if (ephemeralWorkspaceAdapter.isEphemeral(workspaceId)) {
+    if (ephemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
       ephemeralWorkspaceAdapter.provision(k8sEnv, identity);
       return;
     }
@@ -124,7 +124,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
   @Override
   public void prepare(KubernetesEnvironment k8sEnv, String workspaceId)
       throws InfrastructureException {
-    if (ephemeralWorkspaceAdapter.isEphemeral(workspaceId)) {
+    if (ephemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
       return;
     }
     final Collection<PersistentVolumeClaim> claims = k8sEnv.getPersistentVolumeClaims().values();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static org.eclipse.che.api.workspace.shared.Constants.MOUNT_SOURCES_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolumeMount;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+
+@Singleton
+public class EphemeralWorkspaceAdapter {
+  private WorkspaceManager workspaceManager;
+
+  @Inject
+  public EphemeralWorkspaceAdapter(WorkspaceManager workspaceManager) {
+    this.workspaceManager = workspaceManager;
+  }
+
+  /**
+   * @param workspaceId
+   * @return true if workspace config contains `mountSources` attribute which is set to false
+   * @throws InternalInfrastructureException
+   */
+  public boolean isEphemeral(String workspaceId) throws InternalInfrastructureException {
+    try {
+      WorkspaceImpl workspace = workspaceManager.getWorkspace(workspaceId);
+      String mountSources = workspace.getConfig().getAttributes().get(MOUNT_SOURCES_ATTRIBUTE);
+      return "false".equals(mountSources);
+    } catch (NotFoundException | ServerException e) {
+      throw new InternalInfrastructureException(
+          "Failed to load workspace info" + e.getMessage(), e);
+    }
+  }
+
+  public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+    for (Pod pod : k8sEnv.getPods().values()) {
+      PodSpec podSpec = pod.getSpec();
+      for (Container container : podSpec.getContainers()) {
+        String machineName = Names.machineName(pod, container);
+        InternalMachineConfig machineConfig = k8sEnv.getMachines().get(machineName);
+        Map<String, Volume> volumes = k8sEnv.getMachines().get(machineName).getVolumes();
+        addMachineVolumes(identity.getWorkspaceId(), pod, container, volumes);
+      }
+    }
+  }
+
+  private void addMachineVolumes(
+      String workspaceId, Pod pod, Container container, Map<String, Volume> volumes)
+      throws InfrastructureException {
+    if (volumes.isEmpty()) {
+      return;
+    }
+
+    for (Entry<String, Volume> volumeEntry : volumes.entrySet()) {
+      final String volumePath = volumeEntry.getValue().getPath();
+      final String volumeName =
+          LOGS_VOLUME_NAME.equals(volumeEntry.getKey())
+              ? volumeEntry.getKey() + '-' + pod.getMetadata().getName()
+              : volumeEntry.getKey();
+
+      final String uniqueVolumeMountName = Names.generateName("ephemeral-");
+
+      // binds pvc to pod and container
+      container
+          .getVolumeMounts()
+          .add(
+              newVolumeMount(
+                  uniqueVolumeMountName,
+                  volumePath,
+                  getSubPath(workspaceId, volumeName, Names.machineName(pod, container))));
+      addEmptyDirVolumeIfAbsent(pod.getSpec(), uniqueVolumeMountName);
+    }
+  }
+
+  private void addEmptyDirVolumeIfAbsent(PodSpec podSpec, String uniqueVolumeMountName) {
+    if (podSpec
+        .getVolumes()
+        .stream()
+        .noneMatch(volume -> volume.getName().equals(uniqueVolumeMountName))) {
+      podSpec
+          .getVolumes()
+          .add(
+              new VolumeBuilder()
+                  .withName(uniqueVolumeMountName)
+                  .withNewEmptyDir()
+                  .withMedium("Memory")
+                  .endEmptyDir()
+                  .build());
+    }
+  }
+
+  private String getSubPath(String workspaceId, String volumeName, String machineName) {
+    // logs must be located inside the folder related to the machine because few machines can
+    // contain the identical agents and in this case, a conflict is possible.
+    if (LOGS_VOLUME_NAME.equals(volumeName)) {
+      return workspaceId + '/' + volumeName + '/' + machineName;
+    }
+    return workspaceId + '/' + volumeName;
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
@@ -46,7 +46,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
  */
 @Singleton
 public class EphemeralWorkspaceAdapter {
-  private final String EPHEMERAL_VOLUME_NAME_PREFIX = "ephemeral-che-workspace-";
+  private static final String EPHEMERAL_VOLUME_NAME_PREFIX = "ephemeral-che-workspace-";
   private WorkspaceManager workspaceManager;
 
   @Inject
@@ -68,7 +68,7 @@ public class EphemeralWorkspaceAdapter {
       return isEphemeral(workspace);
     } catch (NotFoundException | ServerException e) {
       throw new InternalInfrastructureException(
-          "Failed to load workspace info" + e.getMessage(), e);
+          "Failed to load workspace info " + e.getMessage(), e);
     }
   }
 
@@ -78,7 +78,6 @@ public class EphemeralWorkspaceAdapter {
    *     this case regardless of the PVC strategy, workspace volumes would be created as `emptyDir`.
    *     When a workspace Pod is removed for any reason, the data in the `emptyDir` volume is
    *     deleted forever
-   * @throws InternalInfrastructureException
    */
   public boolean isEphemeral(Workspace workspace) {
     String mountSources = workspace.getConfig().getAttributes().get(MOUNT_SOURCES_ATTRIBUTE);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
@@ -35,7 +35,15 @@ import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
-/** @author Ilya Buziuk (ibuziuk) */
+/**
+ * Allows to create ephemeral workspaces (with no PVC attached) based on workspace config
+ * `mountSources` attribute. If `mountSources` attribute is set to false, workspace volumes would be
+ * created as `emptyDir` regardless of the PVC strategy. When a workspace Pod is removed for any
+ * reason, the data in the `emptyDir` volume is deleted forever.
+ *
+ * @see <a href="https://kubernetes.io/docs/concepts/storage/volumes/#emptydir">emptyDir</a>
+ * @author Ilya Buziuk
+ */
 @Singleton
 public class EphemeralWorkspaceAdapter {
   private final String EPHEMERAL_VOLUME_NAME_PREFIX = "ephemeral-che-workspace-";

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
@@ -89,7 +89,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     final String workspaceId = identity.getWorkspaceId();
-    if (ephemeralWorkspaceAdapter.isEphemeral(workspaceId)) {
+    if (ephemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
       ephemeralWorkspaceAdapter.provision(k8sEnv, identity);
       return;
     }
@@ -114,7 +114,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
   @Override
   public void prepare(KubernetesEnvironment k8sEnv, String workspaceId)
       throws InfrastructureException {
-    if (ephemeralWorkspaceAdapter.isEphemeral(workspaceId)) {
+    if (ephemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
       return;
     }
     if (!k8sEnv.getPersistentVolumeClaims().isEmpty()) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleaner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleaner.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
-import static org.eclipse.che.api.workspace.shared.Constants.MOUNT_SOURCES_ATTRIBUTE;
-
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import javax.inject.Named;
@@ -57,26 +55,16 @@ public class WorkspacePVCCleaner {
     if (pvcEnabled && !namespaceFactory.isPredefined())
       eventService.subscribe(
           event -> {
-            final String workspaceId = event.getWorkspace().getId();
+            final Workspace workspace = event.getWorkspace();
             try {
-              if (!isEphemeral(event.getWorkspace())) {
-                strategy.cleanup(workspaceId);
-              }
+              strategy.cleanup(workspace);
             } catch (InfrastructureException ex) {
               LOG.error(
-                  "Failed to cleanup workspace '{}' data. Cause: {}", workspaceId, ex.getMessage());
+                  "Failed to cleanup workspace '{}' data. Cause: {}",
+                  workspace.getId(),
+                  ex.getMessage());
             }
           },
           WorkspaceRemovedEvent.class);
-  }
-
-  /**
-   * @param workspace
-   * @return true if workspace config contains `mountSources` attribute which is set to false, which
-   *     means that workspace is ephemeral with no PVC attached
-   */
-  private boolean isEphemeral(final Workspace workspace) {
-    String mountSources = workspace.getConfig().getAttributes().get(MOUNT_SOURCES_ATTRIBUTE);
-    return "false".equals(mountSources);
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspaceVolumesStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspaceVolumesStrategy.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
+import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
@@ -47,8 +48,8 @@ public interface WorkspaceVolumesStrategy extends ConfigurationProvisioner {
   /**
    * Cleanups workspace backed up data in a strategy specific way.
    *
-   * @param workspaceId the workspace identifier for which cleanup will be performed
+   * @param workspace the workspace for which cleanup will be performed
    * @throws InfrastructureException when any error while cleanup occurs
    */
-  void cleanup(String workspaceId) throws InfrastructureException;
+  void cleanup(Workspace workspace) throws InfrastructureException;
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
@@ -96,6 +97,7 @@ public class CommonPVCStrategyTest {
   @Mock private KubernetesNamespaceFactory factory;
   @Mock private KubernetesNamespace k8sNamespace;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
+  @Mock private Workspace workspace;
   @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
 
   private CommonPVCStrategy commonPVCStrategy;
@@ -158,6 +160,7 @@ public class CommonPVCStrategyTest {
 
     mockName(pod, POD_NAME);
     mockName(pod2, POD_NAME_2);
+    when(workspace.getId()).thenReturn(WORKSPACE_ID);
   }
 
   @Test
@@ -272,7 +275,7 @@ public class CommonPVCStrategyTest {
 
   @Test
   public void testCleanup() throws Exception {
-    commonPVCStrategy.cleanup(WORKSPACE_ID);
+    commonPVCStrategy.cleanup(workspace);
 
     verify(pvcSubPathHelper).removeDirsAsync(WORKSPACE_ID, WORKSPACE_ID);
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -96,6 +96,7 @@ public class CommonPVCStrategyTest {
   @Mock private KubernetesNamespaceFactory factory;
   @Mock private KubernetesNamespace k8sNamespace;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
+  @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
 
   private CommonPVCStrategy commonPVCStrategy;
 
@@ -103,7 +104,13 @@ public class CommonPVCStrategyTest {
   public void setup() throws Exception {
     commonPVCStrategy =
         new CommonPVCStrategy(
-            PVC_NAME, PVC_QUANTITY, PVC_ACCESS_MODE, true, pvcSubPathHelper, factory);
+            PVC_NAME,
+            PVC_QUANTITY,
+            PVC_ACCESS_MODE,
+            true,
+            pvcSubPathHelper,
+            factory,
+            ephemeralWorkspaceAdapter);
 
     Map<String, InternalMachineConfig> machines = new HashMap<>();
     InternalMachineConfig machine1 = mock(InternalMachineConfig.class);
@@ -208,7 +215,13 @@ public class CommonPVCStrategyTest {
   public void testDoNotAddsSubpathsWhenPreCreationIsNotNeeded() throws Exception {
     commonPVCStrategy =
         new CommonPVCStrategy(
-            PVC_NAME, PVC_QUANTITY, PVC_ACCESS_MODE, false, pvcSubPathHelper, factory);
+            PVC_NAME,
+            PVC_QUANTITY,
+            PVC_ACCESS_MODE,
+            false,
+            pvcSubPathHelper,
+            factory,
+            ephemeralWorkspaceAdapter);
 
     commonPVCStrategy.provision(k8sEnv, IDENTITY);
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapterTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static org.eclipse.che.api.workspace.shared.Constants.MOUNT_SOURCES_ATTRIBUTE;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link EphemeralWorkspaceAdapter}.
+ *
+ * @author Ilya Buziuk
+ */
+@Listeners(MockitoTestNGListener.class)
+public class EphemeralWorkspaceAdapterTest {
+  private static final String EPHEMERAL_WORKSPACE_ID = "workspace123";
+  private static final String NON_EPHEMERAL_WORKSPACE_ID = "workspace234";
+
+  @Mock Workspace nonEphemeralWorkspace;
+  @Mock Workspace ephemeralWorkspace;
+  @Mock WorkspaceManager workspaceManager;
+
+  private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
+
+  @BeforeMethod
+  public void setup() throws Exception {
+    ephemeralWorkspaceAdapter = new EphemeralWorkspaceAdapter(workspaceManager);
+
+    // ephemeral workspace configuration
+    when(ephemeralWorkspace.getId()).thenReturn(EPHEMERAL_WORKSPACE_ID);
+    WorkspaceConfig ephemeralWorkspaceConfig = mock(WorkspaceConfig.class);
+    when(ephemeralWorkspace.getConfig()).thenReturn(ephemeralWorkspaceConfig);
+    Map<String, String> ephemeralConfigAttributes =
+        Collections.singletonMap(MOUNT_SOURCES_ATTRIBUTE, "false");
+    when(ephemeralWorkspaceConfig.getAttributes()).thenReturn(ephemeralConfigAttributes);
+
+    // regular / non-ephemeral workspace configuration
+    when(nonEphemeralWorkspace.getId()).thenReturn(NON_EPHEMERAL_WORKSPACE_ID);
+    WorkspaceConfig nonEphemeralWorkspaceConfig = mock(WorkspaceConfig.class);
+    when(nonEphemeralWorkspace.getConfig()).thenReturn(nonEphemeralWorkspaceConfig);
+    Map<String, String> nonEphemeralConfigAttributes = Collections.emptyMap();
+    when(nonEphemeralWorkspace.getAttributes()).thenReturn(nonEphemeralConfigAttributes);
+  }
+
+  @Test
+  public void testIsEphemeralWorkspace() throws Exception {
+    assertTrue(ephemeralWorkspaceAdapter.isEphemeral(ephemeralWorkspace));
+    assertFalse(ephemeralWorkspaceAdapter.isEphemeral(nonEphemeralWorkspace));
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapterTest.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
-import static org.eclipse.che.api.workspace.shared.Constants.MOUNT_SOURCES_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
@@ -46,14 +46,14 @@ public class EphemeralWorkspaceAdapterTest {
 
   @BeforeMethod
   public void setup() throws Exception {
-    ephemeralWorkspaceAdapter = new EphemeralWorkspaceAdapter(workspaceManager);
+    ephemeralWorkspaceAdapter = new EphemeralWorkspaceAdapter();
 
     // ephemeral workspace configuration
     when(ephemeralWorkspace.getId()).thenReturn(EPHEMERAL_WORKSPACE_ID);
     WorkspaceConfig ephemeralWorkspaceConfig = mock(WorkspaceConfig.class);
     when(ephemeralWorkspace.getConfig()).thenReturn(ephemeralWorkspaceConfig);
     Map<String, String> ephemeralConfigAttributes =
-        Collections.singletonMap(MOUNT_SOURCES_ATTRIBUTE, "false");
+        Collections.singletonMap(PERSIST_VOLUMES_ATTRIBUTE, "false");
     when(ephemeralWorkspaceConfig.getAttributes()).thenReturn(ephemeralConfigAttributes);
 
     // regular / non-ephemeral workspace configuration

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -90,13 +90,15 @@ public class UniqueWorkspacePVCStrategyTest {
   @Mock private Container container;
   @Mock private Container container2;
   @Mock private Container container3;
+  @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
 
   private UniqueWorkspacePVCStrategy strategy;
 
   @BeforeMethod
   public void setup() throws Exception {
     strategy =
-        new UniqueWorkspacePVCStrategy(PVC_NAME_PREFIX, PVC_QUANTITY, PVC_ACCESS_MODE, factory);
+        new UniqueWorkspacePVCStrategy(
+            PVC_NAME_PREFIX, PVC_QUANTITY, PVC_ACCESS_MODE, factory, ephemeralWorkspaceAdapter);
 
     Map<String, InternalMachineConfig> machines = new HashMap<>();
     InternalMachineConfig machine1 = mock(InternalMachineConfig.class);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -37,6 +37,7 @@ import io.fabric8.kubernetes.api.model.PodSpec;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
@@ -90,6 +91,7 @@ public class UniqueWorkspacePVCStrategyTest {
   @Mock private Container container;
   @Mock private Container container2;
   @Mock private Container container3;
+  @Mock private Workspace workspace;
   @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
 
   private UniqueWorkspacePVCStrategy strategy;
@@ -142,6 +144,8 @@ public class UniqueWorkspacePVCStrategyTest {
 
     mockName(pod, POD_NAME);
     mockName(pod2, POD_NAME_2);
+
+    when(workspace.getId()).thenReturn(WORKSPACE_ID);
   }
 
   @Test
@@ -230,7 +234,7 @@ public class UniqueWorkspacePVCStrategyTest {
 
   @Test
   public void testRemovesPVCWhenCleanupCalled() throws Exception {
-    strategy.cleanup(WORKSPACE_ID);
+    strategy.cleanup(workspace);
 
     verify(pvcs).delete(ImmutableMap.of(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID));
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleanerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleanerTest.java
@@ -21,7 +21,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
@@ -89,8 +91,11 @@ public class WorkspacePVCCleanerTest {
                   invocationOnMock.getArgument(0);
               final WorkspaceRemovedEvent event = mock(WorkspaceRemovedEvent.class);
               final Workspace removed = mock(Workspace.class);
+              final WorkspaceConfig config = mock(WorkspaceConfig.class);
               when(event.getWorkspace()).thenReturn(removed);
               when(removed.getId()).thenReturn(WORKSPACE_ID);
+              when(removed.getConfig()).thenReturn(config);
+              when(removed.getConfig().getAttributes()).thenReturn(Collections.emptyMap());
               argument.onEvent(event);
               return invocationOnMock;
             })
@@ -110,8 +115,11 @@ public class WorkspacePVCCleanerTest {
                   invocationOnMock.getArgument(0);
               final WorkspaceRemovedEvent event = mock(WorkspaceRemovedEvent.class);
               final Workspace removed = mock(Workspace.class);
+              final WorkspaceConfig config = mock(WorkspaceConfig.class);
               when(event.getWorkspace()).thenReturn(removed);
               when(removed.getId()).thenReturn(WORKSPACE_ID);
+              when(removed.getConfig()).thenReturn(config);
+              when(removed.getConfig().getAttributes()).thenReturn(Collections.emptyMap());
               argument.onEvent(event);
               return invocationOnMock;
             })

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -95,7 +95,8 @@ public final class Constants {
    * OpenShift infrastructure. Should be set/read from {@link WorkspaceConfig#getAttributes}.
    *
    * <p>Value is expected to be boolean, and if set to 'false' regardless of the PVC strategy,
-   * workspace volumes would be created as `emptyDir`
+   * workspace volumes would be created as `emptyDir`. When a workspace Pod is removed for any
+   * reason, the data in the `emptyDir` volume is deleted forever
    *
    * @see <a
    *     href="https://www.eclipse.org/che/docs/kubernetes-admin-guide.html#che-workspaces-storage">Che

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -103,7 +103,7 @@ public final class Constants {
    *     PVC strategies</a>
    * @see <a href="https://kubernetes.io/docs/concepts/storage/volumes/#emptydir">emptyDir</a>
    */
-  public static final String MOUNT_SOURCES_ATTRIBUTE = "mountSources";
+  public static final String PERSIST_VOLUMES_ATTRIBUTE = "persistVolumes";
 
   /**
    * Contains a list of workspace tooling plugins that should be used in a workspace. Should be

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -91,6 +91,20 @@ public final class Constants {
   public static final String WORKSPACE_TOOLING_EDITOR_ATTRIBUTE = "editor";
 
   /**
+   * The attribute allows to configure workspace to be ephemeral with no PVC attached on K8S /
+   * OpenShift infrastructure. Should be set/read from {@link WorkspaceConfig#getAttributes}.
+   *
+   * <p>Value is expected to be boolean, and if set to 'false' regardless of the PVC strategy,
+   * workspace volumes would be created as `emptyDir`
+   *
+   * @see <a
+   *     href="https://www.eclipse.org/che/docs/kubernetes-admin-guide.html#che-workspaces-storage">Che
+   *     PVC strategies</a>
+   * @see <a href="https://kubernetes.io/docs/concepts/storage/volumes/#emptydir">emptyDir</a>
+   */
+  public static final String MOUNT_SOURCES_ATTRIBUTE = "mountSources";
+
+  /**
    * Contains a list of workspace tooling plugins that should be used in a workspace. Should be
    * set/read from {@link WorkspaceConfig#getAttributes}.
    *


### PR DESCRIPTION
### What does this PR do?
 Adding support of the ephemeral workspaces (using `emptyDir` volume instead of PVC) via `mountSources` attribute. Once `persistVolumes` attribute is set to `false` all workspace volumes would be created not according to the defined as `emptyDirs` :

```
    Mounts:
      /another/volume from ephemeral-z8cst7yy (rw)
      /projects from ephemeral-3euiezrk (rw)
      /test/my/volume from ephemeral-gqhpebls (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from default-token-jhsmm (ro)
      /workspace_logs from ephemeral-wjc5yu37 (rw)
Conditions:
  Type           Status
  Initialized    True 
  Ready          True 
  PodScheduled   True 
Volumes:
  ephemeral-gqhpebls:
    Type:    EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:  
  ephemeral-3euiezrk:
    Type:    EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:  
  ephemeral-z8cst7yy:
    Type:    EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium:  
  ephemeral-wjc5yu37:
    Type:    EmptyDir (a temporary directory that shares a pod's lifetime)
    Medium: 
```

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/11350
https://github.com/redhat-developer/rh-che/issues/860

<!-- #### Changelog -->
WIP

#### Release Notes
WIP

#### Docs PR
WIP
