### PR TITLE
Added propagation of plugin broker failing error

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/UnrecoverablePodEventListener.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/UnrecoverablePodEventListener.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.util;
+
+import com.google.common.base.Strings;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodEventHandler;
+
+/**
+ * Listens Pod events and propagates unrecoverable events via the specified handler.
+ *
+ * @author Sergii Leshchenko
+ * @author Ilya Buziuk
+ */
+public class UnrecoverablePodEventListener implements PodEventHandler {
+
+  private final Set<String> pods;
+  private final Consumer<PodEvent> unrecoverableEventHandler;
+  private final Set<String> unrecoverableEvents;
+
+  public UnrecoverablePodEventListener(
+      Set<String> unrecoverableEvents,
+      Set<String> pods,
+      Consumer<PodEvent> unrecoverableEventHandler) {
+    this.unrecoverableEvents = unrecoverableEvents;
+    this.pods = pods;
+    this.unrecoverableEventHandler = unrecoverableEventHandler;
+  }
+
+  @Override
+  public void handle(PodEvent event) {
+    if (isWorkspaceEvent(event) && isUnrecoverable(event)) {
+      unrecoverableEventHandler.accept(event);
+    }
+  }
+
+  /** Returns true if event belongs to one of the workspace pods, false otherwise */
+  private boolean isWorkspaceEvent(PodEvent event) {
+    String podName = event.getPodName();
+    if (Strings.isNullOrEmpty(podName)) {
+      return false;
+    }
+    // Note it is necessary to compare via startsWith rather than equals here, as pods managed by
+    // deployments have their name set as [deploymentName]-[hash]. `workspacePodName` is used to
+    // define the deployment name, so pods that are created aren't an exact match.
+    return pods.stream().anyMatch(podName::startsWith);
+  }
+
+  /**
+   * Returns true if event reason or message matches one of the comma separated values defined in
+   * 'che.infra.kubernetes.workspace_unrecoverable_events',false otherwise
+   *
+   * @param event event to check
+   */
+  private boolean isUnrecoverable(PodEvent event) {
+    boolean isUnrecoverable = false;
+    String reason = event.getReason();
+    String message = event.getMessage();
+    // Consider unrecoverable if event reason 'equals' one of the property values e.g. "Failed
+    // Mount"
+    if (unrecoverableEvents.contains(reason)) {
+      isUnrecoverable = true;
+    } else {
+      for (String e : unrecoverableEvents) {
+        // Consider unrecoverable if event message 'startsWith' one of the property values e.g.
+        // "Failed to pull image"
+        if (message != null && message.startsWith(e)) {
+          isUnrecoverable = true;
+        }
+      }
+    }
+    return isUnrecoverable;
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/UnrecoverablePodEventListenerFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/UnrecoverablePodEventListenerFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.util;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodEvent;
+
+/**
+ * Helps to create {@link UnrecoverablePodEventListener} instaces.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class UnrecoverablePodEventListenerFactory {
+
+  private final Set<String> unrecoverableEvents;
+
+  @Inject
+  public UnrecoverablePodEventListenerFactory(
+      @Named("che.infra.kubernetes.workspace_unrecoverable_events") String[] unrecoverableEvents) {
+    this.unrecoverableEvents = ImmutableSet.copyOf(unrecoverableEvents);
+  }
+
+  /**
+   * Creates unrecoverable events listener.
+   *
+   * @param pods pods which unrecoverable events should be propagated
+   * @param unrecoverableEventHandler handler which is invoked when unrecoverable event occurs
+   * @return created unrecoverable events listener
+   * @throws IllegalStateException is unrecoverable events are not configured.
+   * @see #isConfigured()
+   */
+  public UnrecoverablePodEventListener create(
+      Set<String> pods, Consumer<PodEvent> unrecoverableEventHandler) {
+    if (!isConfigured()) {
+      throw new IllegalStateException("Unrecoverable events are not configured");
+    }
+
+    return new UnrecoverablePodEventListener(unrecoverableEvents, pods, unrecoverableEventHandler);
+  }
+
+  /**
+   * Returns true if unrecoverable events are configured and it's possible to create unrecoverable
+   * events listener, false otherwise
+   */
+  public boolean isConfigured() {
+    return !unrecoverableEvents.isEmpty();
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
@@ -11,17 +11,25 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases;
 
+import static java.lang.String.format;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableSet;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Pod;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListener;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListenerFactory;
 import org.slf4j.Logger;
 
 /**
@@ -39,10 +47,21 @@ public class DeployBroker extends BrokerPhase {
 
   private final KubernetesNamespace namespace;
   private final KubernetesEnvironment brokerEnvironment;
+  private final UnrecoverablePodEventListenerFactory factory;
+  private final String workspaceId;
+  private final CompletableFuture<List<ChePlugin>> pluginsFuture;
 
-  public DeployBroker(KubernetesNamespace namespace, KubernetesEnvironment brokerEnvironment) {
+  public DeployBroker(
+      String workspaceId,
+      KubernetesNamespace namespace,
+      KubernetesEnvironment brokerEnvironment,
+      CompletableFuture<List<ChePlugin>> pluginsFuture,
+      UnrecoverablePodEventListenerFactory factory) {
+    this.workspaceId = workspaceId;
     this.namespace = namespace;
     this.brokerEnvironment = brokerEnvironment;
+    this.factory = factory;
+    this.pluginsFuture = pluginsFuture;
   }
 
   @Override
@@ -55,12 +74,23 @@ public class DeployBroker extends BrokerPhase {
         namespace.configMaps().create(configMap);
       }
 
-      for (Pod toCreate : brokerEnvironment.getPods().values()) {
-        deployments.deploy(toCreate);
+      Pod pluginBrokerPod = getPluginBrokerPod(brokerEnvironment.getPods());
+
+      if (factory.isConfigured()) {
+        UnrecoverablePodEventListener unrecoverableEventListener =
+            factory.create(
+                ImmutableSet.of(pluginBrokerPod.getMetadata().getName()),
+                this::handleUnrecoverableEvent);
+        namespace.deployments().watchEvents(unrecoverableEventListener);
       }
+
+      Pod deployedPod = deployments.deploy(pluginBrokerPod);
+
+      deployments.waitRunningAsync(deployedPod.getMetadata().getName());
 
       return nextPhase.execute();
     } finally {
+      namespace.deployments().stopWatch();
       try {
         deployments.delete();
       } catch (InfrastructureException e) {
@@ -73,5 +103,33 @@ public class DeployBroker extends BrokerPhase {
             "Broker deployment config map removal failed. Error: " + ex.getLocalizedMessage(), ex);
       }
     }
+  }
+
+  private void handleUnrecoverableEvent(PodEvent podEvent) {
+    String reason = podEvent.getReason();
+    String message = podEvent.getMessage();
+    LOG.error(
+        "Unrecoverable event occurred during plugin broking for workspace '{}' startup: {}, {}, {}",
+        workspaceId,
+        reason,
+        message,
+        podEvent.getPodName());
+    pluginsFuture.completeExceptionally(
+        new InfrastructureException(
+            format(
+                "Unrecoverable event occurred: '%s', '%s', '%s'",
+                reason, message, podEvent.getPodName())));
+  }
+
+  private Pod getPluginBrokerPod(Map<String, Pod> pods) throws InfrastructureException {
+    if (pods.size() != 1) {
+      throw new InternalInfrastructureException(
+          format(
+              "Plugin broker environment must have only "
+                  + "one pod. Workspace `%s` contains `%s` pods.",
+              workspaceId, pods.size()));
+    }
+
+    return pods.values().iterator().next();
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
@@ -54,6 +54,7 @@ public class DeployBroker extends BrokerPhase {
       for (ConfigMap configMap : brokerEnvironment.getConfigMaps().values()) {
         namespace.configMaps().create(configMap);
       }
+
       for (Pod toCreate : brokerEnvironment.getPods().values()) {
         deployments.deploy(toCreate);
       }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/ListenBrokerEvents.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/ListenBrokerEvents.java
@@ -18,11 +18,11 @@ import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.events.BrokerEvent;
-import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.events.BrokerResultListener;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.events.BrokerStatusListener;
 
 /**
  * Subscribes to Che plugin broker events, passes future that should be completed upon broker result
- * received to {@link BrokerResultListener} and calls next {@link BrokerPhase}.
+ * received to {@link BrokerStatusListener} and calls next {@link BrokerPhase}.
  *
  * <p>This API is in <b>Beta</b> and is subject to changes or removal.
  *
@@ -45,14 +45,14 @@ public class ListenBrokerEvents extends BrokerPhase {
   }
 
   public List<ChePlugin> execute() throws InfrastructureException {
-    BrokerResultListener brokerResultListener =
-        new BrokerResultListener(workspaceId, toolingFuture);
+    BrokerStatusListener brokerStatusListener =
+        new BrokerStatusListener(workspaceId, toolingFuture);
     try {
-      eventService.subscribe(brokerResultListener, BrokerEvent.class);
+      eventService.subscribe(brokerStatusListener, BrokerEvent.class);
 
       return nextPhase.execute();
     } finally {
-      eventService.unsubscribe(brokerResultListener);
+      eventService.unsubscribe(brokerStatusListener);
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/WaitBrokerResult.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/WaitBrokerResult.java
@@ -37,7 +37,6 @@ public class WaitBrokerResult extends BrokerPhase {
 
   public WaitBrokerResult(
       CompletableFuture<List<ChePlugin>> toolingFuture, int resultWaitingTimeout) {
-
     this.toolingFuture = toolingFuture;
     this.resultWaitingTimeout = resultWaitingTimeout;
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerEvent.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerEvent.java
@@ -14,18 +14,18 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.events;
 import com.google.common.annotations.Beta;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
-import org.eclipse.che.api.workspace.shared.dto.BrokerResultEvent;
 import org.eclipse.che.api.workspace.shared.dto.BrokerStatus;
+import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
 
 /**
  * Event sent by a plugin broker with results of broker invocation.
  *
- * <p>This class differs from {@link BrokerResultEvent} it is version of latter with a prettier
- * format. It has workspace tooling in a POJO representation instead of stringified JSON.
+ * <p>This class differs from {@link BrokerStatusChangedEvent} it is version of latter with a
+ * prettier format. It has workspace tooling in a POJO representation instead of stringified JSON.
  *
  * <p>This API is in <b>Beta</b> and is subject to changes or removal.
  *
- * @see BrokerResultEvent
+ * @see BrokerStatusChangedEvent
  */
 @Beta
 public class BrokerEvent {
@@ -37,7 +37,7 @@ public class BrokerEvent {
   @SuppressWarnings("unused")
   public BrokerEvent() {}
 
-  public BrokerEvent(BrokerResultEvent resultEvent, List<ChePlugin> tooling) {
+  public BrokerEvent(BrokerStatusChangedEvent resultEvent, List<ChePlugin> tooling) {
     this.error = resultEvent.getError();
     this.status = resultEvent.getStatus();
     this.workspaceId = resultEvent.getWorkspaceId();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerService.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerService.java
@@ -24,13 +24,13 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
-import org.eclipse.che.api.workspace.shared.dto.BrokerResultEvent;
+import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.slf4j.Logger;
 
 /**
- * Configure JSON_RPC consumers of Che plugin broker events. Also converts {@link BrokerResultEvent}
- * to {@link BrokerEvent}.
+ * Configure JSON_RPC consumers of Che plugin broker events. Also converts {@link
+ * BrokerStatusChangedEvent} to {@link BrokerEvent}.
  *
  * <p>This API is in <b>Beta</b> and is subject to changes or removal.
  *
@@ -58,24 +58,22 @@ public class BrokerService {
     requestHandler
         .newConfiguration()
         .methodName(BROKER_STATUS_CHANGED_METHOD)
-        .paramsAsDto(BrokerResultEvent.class)
+        .paramsAsDto(BrokerStatusChangedEvent.class)
         .noResult()
         .withConsumer(this::handle);
 
     requestHandler
         .newConfiguration()
         .methodName(BROKER_RESULT_METHOD)
-        .paramsAsDto(BrokerResultEvent.class)
+        .paramsAsDto(BrokerStatusChangedEvent.class)
         .noResult()
         .withConsumer(this::handle);
   }
 
-  private void handle(BrokerResultEvent event) {
+  private void handle(BrokerStatusChangedEvent event) {
     // Tooling has fields that can't be parsed by DTO and JSON_RPC framework works with DTO only
     String encodedTooling = event.getTooling();
-    if (event.getStatus() == null
-        || event.getWorkspaceId() == null
-        || (event.getError() == null && event.getTooling() == null)) {
+    if (event.getStatus() == null || event.getWorkspaceId() == null) {
       LOG.error("Broker event skipped due to illegal content: {}", event);
       return;
     }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/UnrecoverablePodEventListenerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/UnrecoverablePodEventListenerTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Date;
+import java.util.Set;
+import java.util.function.Consumer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodEvent;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link UnrecoverablePodEventListener}.
+ *
+ * @author Sergii Leshchenko
+ * @author Ilya Buziuk
+ */
+@Listeners(MockitoTestNGListener.class)
+public class UnrecoverablePodEventListenerTest {
+
+  private static final String WORKSPACE_POD_NAME = "app";
+  private static final String CONTAINER_NAME_1 = "test1";
+  private static final String EVENT_CREATION_TIMESTAMP = "2018-05-15T16:17:54Z";
+
+  /* Pods created by a deployment are created with a random suffix, so Pod names won't match
+  exactly. */
+  private static final String POD_NAME_RANDOM_SUFFIX = "-12345";
+
+  private static final Set<String> UNRECOVERABLE_EVENTS =
+      ImmutableSet.of("Failed Mount", "Failed Scheduling", "Failed to pull image");
+
+  @Mock private Consumer<PodEvent> unrecoverableEventConsumer;
+
+  private UnrecoverablePodEventListener unrecoverableEventListener;
+
+  @BeforeMethod
+  public void setUp() {
+    unrecoverableEventListener =
+        new UnrecoverablePodEventListener(
+            UNRECOVERABLE_EVENTS, ImmutableSet.of(WORKSPACE_POD_NAME), unrecoverableEventConsumer);
+  }
+
+  @Test
+  public void testHandleUnrecoverableEventByReason() throws Exception {
+    // given
+    String unrecoverableEventReason = "Failed Mount";
+    PodEvent unrecoverableEvent =
+        mockContainerEvent(
+            WORKSPACE_POD_NAME,
+            unrecoverableEventReason,
+            "Failed to mount volume 'claim-che-workspace'",
+            EVENT_CREATION_TIMESTAMP,
+            getCurrentTimestampWithOneHourShiftAhead());
+
+    // when
+    unrecoverableEventListener.handle(unrecoverableEvent);
+
+    // then
+    verify(unrecoverableEventConsumer).accept(unrecoverableEvent);
+  }
+
+  @Test
+  public void testHandleUnrecoverableEventByMessage() throws Exception {
+    // given
+    String unrecoverableEventMessage = "Failed to pull image eclipse/che-server:nightly-centos";
+    PodEvent unrecoverableEvent =
+        mockContainerEvent(
+            WORKSPACE_POD_NAME,
+            "Pulling",
+            unrecoverableEventMessage,
+            EVENT_CREATION_TIMESTAMP,
+            getCurrentTimestampWithOneHourShiftAhead());
+
+    // when
+    unrecoverableEventListener.handle(unrecoverableEvent);
+
+    // then
+    verify(unrecoverableEventConsumer).accept(unrecoverableEvent);
+  }
+
+  @Test
+  public void testDoNotHandleUnrecoverableEventFromNonWorkspacePod() throws Exception {
+    // given
+    final String unrecoverableEventMessage =
+        "Failed to pull image eclipse/che-server:nightly-centos";
+    final PodEvent unrecoverableEvent =
+        mockContainerEvent(
+            "NonWorkspacePod",
+            "Pulling",
+            unrecoverableEventMessage,
+            EVENT_CREATION_TIMESTAMP,
+            getCurrentTimestampWithOneHourShiftAhead());
+
+    // when
+    unrecoverableEventListener.handle(unrecoverableEvent);
+
+    // then
+    verify(unrecoverableEventConsumer, never()).accept(any());
+  }
+
+  @Test
+  public void testHandleRegularEvent() throws Exception {
+    // given
+    final PodEvent regularEvent =
+        mockContainerEvent(
+            WORKSPACE_POD_NAME,
+            "Pulling",
+            "pulling image",
+            EVENT_CREATION_TIMESTAMP,
+            getCurrentTimestampWithOneHourShiftAhead());
+
+    // when
+    unrecoverableEventListener.handle(regularEvent);
+
+    // then
+    verify(unrecoverableEventConsumer, never()).accept(any());
+  }
+
+  /**
+   * Mock a container event, as though it was triggered by the OpenShift API. As workspace Pods are
+   * created indirectly through deployments, they are given generated names with the provided name
+   * as a root. <br>
+   * Use this method in a test to ensure that tested code manages this fact correctly. For example,
+   * code such as unrecoverable events handling cannot directly look at an event's pod name and
+   * compare it to the internal representation, and so must confirm the event is relevant in some
+   * other way.
+   */
+  private static PodEvent mockContainerEvent(
+      String podName,
+      String reason,
+      String message,
+      String creationTimestamp,
+      String lastTimestamp) {
+    final PodEvent event = mock(PodEvent.class);
+    when(event.getPodName()).thenReturn(podName + POD_NAME_RANDOM_SUFFIX);
+    when(event.getContainerName()).thenReturn(CONTAINER_NAME_1);
+    when(event.getReason()).thenReturn(reason);
+    when(event.getMessage()).thenReturn(message);
+    when(event.getCreationTimeStamp()).thenReturn(creationTimestamp);
+    when(event.getLastTimestamp()).thenReturn(lastTimestamp);
+    return event;
+  }
+
+  private String getCurrentTimestampWithOneHourShiftAhead() {
+    Date currentTimestampWithOneHourShiftAhead = new Date(new Date().getTime() + 3600 * 1000);
+    return PodEvents.convertDateToEventTimestamp(currentTimestampWithOneHourShiftAhead);
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBrokerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBrokerTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertSame;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListener;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListenerFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link DeployBroker}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class DeployBrokerTest {
+
+  public static final String PLUGIN_BROKER_POD_NAME = "pluginBrokerPodName";
+  @Mock private BrokerPhase nextBrokerPhase;
+
+  @Mock private KubernetesNamespace k8sNamespace;
+  @Mock private KubernetesDeployments k8sDeployments;
+  @Mock private KubernetesConfigsMaps k8sConfigMaps;
+
+  @Mock private KubernetesEnvironment k8sEnvironment;
+  @Mock private ConfigMap configMap;
+  private Pod pod;
+
+  @Mock private CompletableFuture<List<ChePlugin>> pluginsFutures;
+  @Mock private UnrecoverablePodEventListenerFactory unrecoverableEventListenerFactory;
+
+  private List<ChePlugin> plugins = emptyList();
+
+  private DeployBroker deployBrokerPhase;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    deployBrokerPhase =
+        new DeployBroker(
+            "workspaceId",
+            k8sNamespace,
+            k8sEnvironment,
+            pluginsFutures,
+            unrecoverableEventListenerFactory);
+    deployBrokerPhase.then(nextBrokerPhase);
+
+    when(nextBrokerPhase.execute()).thenReturn(plugins);
+
+    when(k8sNamespace.configMaps()).thenReturn(k8sConfigMaps);
+    when(k8sNamespace.deployments()).thenReturn(k8sDeployments);
+
+    pod = new PodBuilder().withNewMetadata().withName(PLUGIN_BROKER_POD_NAME).endMetadata().build();
+    when(k8sEnvironment.getPods()).thenReturn(ImmutableMap.of(PLUGIN_BROKER_POD_NAME, pod));
+    when(k8sEnvironment.getConfigMaps()).thenReturn(ImmutableMap.of("configMap", configMap));
+
+    when(k8sDeployments.deploy(any())).thenReturn(pod);
+  }
+
+  @Test
+  public void shouldDeployPluginBrokerEnvironment() throws Exception {
+    // when
+    List<ChePlugin> result = deployBrokerPhase.execute();
+
+    // then
+    assertSame(result, plugins);
+    verify(k8sConfigMaps).create(configMap);
+    verify(k8sDeployments).deploy(pod);
+    verify(k8sDeployments).waitRunningAsync(PLUGIN_BROKER_POD_NAME);
+
+    verify(k8sDeployments).stopWatch();
+    verify(k8sDeployments).delete();
+    verify(k8sConfigMaps).delete();
+  }
+
+  @Test
+  public void shouldListenToUnrecoverableEventsIfFactoryIsConfigured() throws Exception {
+    // given
+    when(unrecoverableEventListenerFactory.isConfigured()).thenReturn(true);
+    UnrecoverablePodEventListener listener = mock(UnrecoverablePodEventListener.class);
+    when(unrecoverableEventListenerFactory.create(any(), any())).thenReturn(listener);
+
+    // when
+    deployBrokerPhase.execute();
+
+    // then
+    verify(unrecoverableEventListenerFactory).isConfigured();
+    verify(unrecoverableEventListenerFactory)
+        .create(eq(ImmutableSet.of(PLUGIN_BROKER_POD_NAME)), any());
+    verify(k8sDeployments).watchEvents(listener);
+    verify(k8sDeployments).stopWatch();
+  }
+
+  @Test
+  public void shouldDoNotListenToUnrecoverableEventsIfFactoryIsConfigured() throws Exception {
+    // given
+    when(unrecoverableEventListenerFactory.isConfigured()).thenReturn(false);
+
+    // when
+    deployBrokerPhase.execute();
+
+    // then
+    verify(unrecoverableEventListenerFactory).isConfigured();
+    verify(unrecoverableEventListenerFactory, never())
+        .create(eq(ImmutableSet.of(PLUGIN_BROKER_POD_NAME)), any());
+    verify(k8sDeployments, never()).watchEvents(any());
+    verify(k8sDeployments).stopWatch();
+  }
+
+  @Test(
+      expectedExceptions = InternalInfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Plugin broker environment must have only one pod\\. Workspace `workspaceId` contains `0` pods\\.")
+  public void shouldThrowExceptionIfThereIsNoAnyPodsInEnvironment() throws Exception {
+    // given
+    when(k8sEnvironment.getPods()).thenReturn(emptyMap());
+
+    // when
+    deployBrokerPhase.execute();
+  }
+
+  @Test(
+      expectedExceptions = InternalInfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Plugin broker environment must have only one pod\\. Workspace `workspaceId` contains `2` pods\\.")
+  public void shouldThrowExceptionIfThereAreMoreThanOnePodsInEnvironment() throws Exception {
+    // given
+    when(k8sEnvironment.getPods()).thenReturn(ImmutableMap.of("pod1", pod, "pod2", pod));
+
+    // when
+    deployBrokerPhase.execute();
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.events;
+
+import static java.util.Collections.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
+import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
+import org.eclipse.che.api.workspace.shared.dto.BrokerStatus;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link BrokerStatusListener}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class BrokerStatusListenerTest {
+
+  public static final String WORKSPACE_ID = "workspace123";
+  @Mock private CompletableFuture<List<ChePlugin>> finishFuture;
+
+  private BrokerStatusListener brokerStatusListener;
+
+  @BeforeMethod
+  public void setUp() {
+    brokerStatusListener = new BrokerStatusListener(WORKSPACE_ID, finishFuture);
+  }
+
+  @Test
+  public void shouldDoNothingIfEventWithForeignWorkspaceIdIsReceived() {
+    // given
+    BrokerEvent event = new BrokerEvent().withWorkspaceId("foreignWorkspace");
+
+    // when
+    brokerStatusListener.onEvent(event);
+
+    // then
+    verifyNoMoreInteractions(finishFuture);
+  }
+
+  @Test
+  public void shouldDoNothingWhenStartedEventIsReceived() {
+    // given
+    BrokerEvent event =
+        new BrokerEvent().withWorkspaceId(WORKSPACE_ID).withStatus(BrokerStatus.STARTED);
+
+    // when
+    brokerStatusListener.onEvent(event);
+
+    // then
+    verifyNoMoreInteractions(finishFuture);
+  }
+
+  @Test
+  public void shouldCompleteFinishFutureWhenDoneEventIsReceivedAndToolingIsNotNull() {
+    // given
+    BrokerEvent event =
+        new BrokerEvent()
+            .withWorkspaceId(WORKSPACE_ID)
+            .withStatus(BrokerStatus.DONE)
+            .withTooling(emptyList());
+
+    // when
+    brokerStatusListener.onEvent(event);
+
+    // then
+    verify(finishFuture).complete(emptyList());
+  }
+
+  @Test
+  public void shouldCompleteExceptionallyFinishFutureWhenDoneEventIsReceivedButToolingIsNull() {
+    // given
+    BrokerEvent event =
+        new BrokerEvent()
+            .withWorkspaceId(WORKSPACE_ID)
+            .withStatus(BrokerStatus.DONE)
+            .withTooling(null);
+
+    // when
+    brokerStatusListener.onEvent(event);
+
+    // then
+    verify(finishFuture).completeExceptionally(any(InternalInfrastructureException.class));
+  }
+
+  @Test
+  public void shouldCompleteExceptionallyFinishFutureWhenFailedEventIsReceived() {
+    // given
+    BrokerEvent event =
+        new BrokerEvent()
+            .withWorkspaceId(WORKSPACE_ID)
+            .withStatus(BrokerStatus.FAILED)
+            .withError("error");
+
+    // when
+    brokerStatusListener.onEvent(event);
+
+    // then
+    verify(finishFuture).completeExceptionally(any(InfrastructureException.class));
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.events;
 
-import static java.util.Collections.*;
+import static java.util.Collections.emptyList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -50,19 +50,6 @@ public class BrokerStatusListenerTest {
   public void shouldDoNothingIfEventWithForeignWorkspaceIdIsReceived() {
     // given
     BrokerEvent event = new BrokerEvent().withWorkspaceId("foreignWorkspace");
-
-    // when
-    brokerStatusListener.onEvent(event);
-
-    // then
-    verifyNoMoreInteractions(finishFuture);
-  }
-
-  @Test
-  public void shouldDoNothingWhenStartedEventIsReceived() {
-    // given
-    BrokerEvent event =
-        new BrokerEvent().withWorkspaceId(WORKSPACE_ID).withStatus(BrokerStatus.STARTED);
 
     // when
     brokerStatusListener.onEvent(event);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
-import com.google.common.collect.ImmutableSet;
 import com.google.inject.assistedinject.Assisted;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -39,6 +38,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRunti
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.RuntimeEventsPublisher;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListener;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListenerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.SidecarToolingProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProject;
@@ -51,14 +52,14 @@ import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftServer
 public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShiftEnvironment> {
 
   private final OpenShiftProject project;
-  private final Set<String> unrecoverableEvents;
+  private final UnrecoverablePodEventListenerFactory unrecoverablePodEventListenerFactory;
 
   @Inject
   public OpenShiftInternalRuntime(
       @Named("che.infra.kubernetes.workspace_start_timeout_min") int workspaceStartTimeout,
       @Named("che.infra.kubernetes.ingress_start_timeout_min") int ingressStartTimeout,
-      @Named("che.infra.kubernetes.workspace_unrecoverable_events") String[] unrecoverableEvents,
       NoOpURLRewriter urlRewriter,
+      UnrecoverablePodEventListenerFactory unrecoverablePodEventListenerFactory,
       KubernetesBootstrapperFactory bootstrapperFactory,
       ServersCheckerFactory serverCheckerFactory,
       WorkspaceVolumesStrategy volumesStrategy,
@@ -71,15 +72,15 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
       StartSynchronizerFactory startSynchronizerFactory,
       Set<InternalEnvironmentProvisioner> internalEnvironmentProvisioners,
       OpenShiftEnvironmentProvisioner kubernetesEnvironmentProvisioner,
-      SidecarToolingProvisioner toolingProvisioner,
+      SidecarToolingProvisioner<OpenShiftEnvironment> toolingProvisioner,
       @Assisted OpenShiftRuntimeContext context,
       @Assisted OpenShiftProject project,
       @Assisted List<Warning> warnings) {
     super(
         workspaceStartTimeout,
         ingressStartTimeout,
-        unrecoverableEvents,
         urlRewriter,
+        unrecoverablePodEventListenerFactory,
         bootstrapperFactory,
         serverCheckerFactory,
         volumesStrategy,
@@ -97,7 +98,7 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
         project,
         warnings);
     this.project = project;
-    this.unrecoverableEvents = ImmutableSet.copyOf(unrecoverableEvents);
+    this.unrecoverablePodEventListenerFactory = unrecoverablePodEventListenerFactory;
   }
 
   @Override
@@ -125,9 +126,12 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
     // project.pods().watch(new AbnormalStopHandler());
 
     project.deployments().watchEvents(new MachineLogsPublisher());
-    if (!unrecoverableEvents.isEmpty()) {
+    if (unrecoverablePodEventListenerFactory.isConfigured()) {
       Map<String, Pod> pods = getContext().getEnvironment().getPods();
-      project.deployments().watchEvents(new UnrecoverablePodEventHandler(pods));
+      UnrecoverablePodEventListener handler =
+          unrecoverablePodEventListenerFactory.create(
+              pods.keySet(), this::handleUnrecoverableEvent);
+      project.deployments().watchEvents(handler);
     }
 
     doStartMachine(new OpenShiftServerResolver(createdServices, createdRoutes));

--- a/multiuser/permission/che-multiuser-permission-infra-kubernetes/src/main/java/org/eclipse/che/multiuser/permission/workspace/infra/kubernetes/BrokerServicePermissionFilter.java
+++ b/multiuser/permission/che-multiuser-permission-infra-kubernetes/src/main/java/org/eclipse/che/multiuser/permission/workspace/infra/kubernetes/BrokerServicePermissionFilter.java
@@ -18,7 +18,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerManager;
-import org.eclipse.che.api.workspace.shared.dto.BrokerResultEvent;
+import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.multiuser.api.permission.server.jsonrpc.JsonRpcPermissionsFilterAdapter;
@@ -44,7 +44,7 @@ public class BrokerServicePermissionFilter extends JsonRpcPermissionsFilterAdapt
     switch (method) {
       case BROKER_STATUS_CHANGED_METHOD:
       case BROKER_RESULT_METHOD:
-        workspaceId = ((BrokerResultEvent) params[0]).getWorkspaceId();
+        workspaceId = ((BrokerStatusChangedEvent) params[0]).getWorkspaceId();
         break;
       default:
         throw new ForbiddenException("Unknown method is configured to be filtered.");

--- a/multiuser/permission/che-multiuser-permission-infra-kubernetes/src/test/java/org/eclipse/che/multiuser/permission/workspace/infra/kubernetes/BrokerServicePermissionFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-infra-kubernetes/src/test/java/org/eclipse/che/multiuser/permission/workspace/infra/kubernetes/BrokerServicePermissionFilterTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerManager;
-import org.eclipse.che.api.workspace.shared.dto.BrokerResultEvent;
+import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.dto.server.DtoFactory;
@@ -78,7 +78,7 @@ public class BrokerServicePermissionFilterTest {
 
     // when
     permissionFilter.doAccept(
-        method, DtoFactory.newDto(BrokerResultEvent.class).withWorkspaceId("ws123"));
+        method, DtoFactory.newDto(BrokerStatusChangedEvent.class).withWorkspaceId("ws123"));
   }
 
   @Test(dataProvider = "coveredMethods")
@@ -89,7 +89,7 @@ public class BrokerServicePermissionFilterTest {
 
     // when
     permissionFilter.doAccept(
-        method, DtoFactory.newDto(BrokerResultEvent.class).withWorkspaceId("ws123"));
+        method, DtoFactory.newDto(BrokerStatusChangedEvent.class).withWorkspaceId("ws123"));
   }
 
   @Test(
@@ -98,7 +98,7 @@ public class BrokerServicePermissionFilterTest {
   public void shouldThrowExceptionIfUnknownMethodIsInvoking() throws Exception {
     // when
     permissionFilter.doAccept(
-        "unknown", DtoFactory.newDto(BrokerResultEvent.class).withWorkspaceId("ws123"));
+        "unknown", DtoFactory.newDto(BrokerStatusChangedEvent.class).withWorkspaceId("ws123"));
   }
 
   @DataProvider

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/BrokerStatusChangedEvent.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/BrokerStatusChangedEvent.java
@@ -22,26 +22,27 @@ import org.eclipse.che.dto.shared.DTO;
  * @author Oleksandr Garagatyi
  */
 @DTO
-public interface BrokerResultEvent {
+public interface BrokerStatusChangedEvent {
 
   /** Status of execution of a broker process. */
   BrokerStatus getStatus();
 
-  BrokerResultEvent withStatus(BrokerStatus status);
+  BrokerStatusChangedEvent withStatus(BrokerStatus status);
 
   /** ID of a workspace this event is related to. */
   String getWorkspaceId();
 
-  BrokerResultEvent withWorkspaceId(String workspaceId);
+  BrokerStatusChangedEvent withWorkspaceId(String workspaceId);
 
   /**
    * Error message that explains the reason of the broker process failure.
    *
-   * <p>When this method returns non-null value method {@link #getTooling()} must return null.
+   * <p>This method must return non-null value if {@link #getStatus() status} is {@link
+   * BrokerStatus#FAILED}.
    */
   String getError();
 
-  BrokerResultEvent withError(String error);
+  BrokerStatusChangedEvent withError(String error);
 
   /**
    * Stringified workspace tooling in JSON format.
@@ -50,9 +51,10 @@ public interface BrokerResultEvent {
    * framework (dashes in field name, field name not matching POJO getter), so we have to stringify
    * it to pass over Che JSON_RPC framework.
    *
-   * <p>When this method returns non-null value method {@link #getError()} must return null.
+   * <p>This method must return non-null value if {@link #getStatus() status} is {@link
+   * BrokerStatus#DONE}.
    */
   String getTooling();
 
-  BrokerResultEvent withTooling(String tooling);
+  BrokerStatusChangedEvent withTooling(String tooling);
 }


### PR DESCRIPTION
### What does this PR do?
It adds propagation of plugin broker failing error and instead of `Plugins installation process timed out`.
Changes are separate into different commits:
1. CHE-11070 Add waiting until Plugin Broker Pod become RUNNING before proceeding to next phase. But actually, it does not solve an issue with propagating original error since `Restart policy` is `Always` because of creating pods via `Deployments` and Pod status is always `Running` while a particular container may be failed and restarted with some period.
2. Make BrokerEvent suitable to be used for STARTED status event. It includes renaming `BrokerResultEvent` to `BrokerStatusChangedEvent` and removes check that error or plugin list is required.
3. Extract unrecoverable events listener from KubernetesInternalRuntime. It is needed to be able to reuse it in Plugin Broker.
4. Added listening to unrecoverable events during Plugin Broker starting.

Example what a user sees when plugin broker fails to start because of non-existing image
![screenshot_20180926_154525](https://user-images.githubusercontent.com/5887312/46080733-66016e80-c1a3-11e8-9c02-0762bd352b12.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11070
https://github.com/eclipse/che/issues/11068

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A