### PR TITLE
Change default sidecar memory limit to 128MB

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -98,7 +98,7 @@ che.workspace.exec_linux_amd64=${che.home}/lib/linux_amd64/exec
 che.workspace.default_memory_limit_mb=1024
 
 # RAM limit default for each sidecar that has no RAM settings in Che plugin configuration.
-che.workspace.sidecar.default_memory_limit_mb=512
+che.workspace.sidecar.default_memory_limit_mb=128
 
 # RAM request default for each machine that has no explicit RAM settings in environment.
 # this amount will be allocated on workspace container creation


### PR DESCRIPTION
### What does this PR do?
Since Theia sidecar [now](https://github.com/ws-skeleton/che-editor-theia/blob/master/etc/che-plugin.yaml#L35) has 512MB as a RAM limit in the sidecar definition we can change default Che sidecar memory limit back to lower value.
This PR changes it to 128MB.

### What issues does this PR fix or reference?
Reverts https://github.com/eclipse/che/pull/11288
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
