### PR TITLE
Wait for jdt.ls before debugging

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebuggerWatchExpressionTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/DebuggerWatchExpressionTest.java
@@ -80,6 +80,7 @@ public class DebuggerWatchExpressionTest {
 
     projectExplorer.waitItem(PROJECT);
     projectExplorer.quickExpandWithJavaScript();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT);
     debugPanel.openDebugPanel();
 
     projectExplorer.openItemByPath(PROJECT + PATH_TO_CLASS);


### PR DESCRIPTION
### What does this PR do?
Makes DebugExternalClassTest wait for jdt.ls to properly start up before proceeding to debug tests.

### What issues does this PR fix or reference?
DebugExternalClassTest does not wait for jdt.ls #11361
