### PR TITLE
Selenium: stabilize FindUsagesBaseOperationTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FindUsages.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FindUsages.java
@@ -15,7 +15,9 @@ import static java.lang.String.format;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.webdriver.WebDriverWaitFactory;
 import org.openqa.selenium.By;
@@ -109,6 +111,7 @@ public class FindUsages {
   public void clickOnIconNodeInFindUsagesPanel(String nameNode) {
     seleniumWebDriverHelper.waitAndClick(
         By.xpath(format(Locators.FIND_USAGES_ICON_NODE, nameNode)));
+    WaitUtils.sleepQuietly(500, TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -119,6 +122,7 @@ public class FindUsages {
   public void selectNodeInFindUsagesByDoubleClick(String node) {
     seleniumWebDriverHelper.moveCursorToAndDoubleClick(
         By.xpath(format(Locators.FIND_USAGES_NODE, node)));
+    WaitUtils.sleepQuietly(500, TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FindUsages.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FindUsages.java
@@ -111,6 +111,8 @@ public class FindUsages {
   public void clickOnIconNodeInFindUsagesPanel(String nameNode) {
     seleniumWebDriverHelper.waitAndClick(
         By.xpath(format(Locators.FIND_USAGES_ICON_NODE, nameNode)));
+
+    // wait after clicking because sometimes after quick click on nodes they do not close
     WaitUtils.sleepQuietly(500, TimeUnit.MILLISECONDS);
   }
 
@@ -122,6 +124,8 @@ public class FindUsages {
   public void selectNodeInFindUsagesByDoubleClick(String node) {
     seleniumWebDriverHelper.moveCursorToAndDoubleClick(
         By.xpath(format(Locators.FIND_USAGES_NODE, node)));
+
+    // wait after double click because sometimes after quick clicking on nodes they do not close
     WaitUtils.sleepQuietly(500, TimeUnit.MILLISECONDS);
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FindUsages.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FindUsages.java
@@ -109,11 +109,11 @@ public class FindUsages {
    * @param nameNode is name of the node
    */
   public void clickOnIconNodeInFindUsagesPanel(String nameNode) {
+    // we need to wait a little to avoid node closing after quick clicking
+    WaitUtils.sleepQuietly(500, TimeUnit.MILLISECONDS);
+
     seleniumWebDriverHelper.waitAndClick(
         By.xpath(format(Locators.FIND_USAGES_ICON_NODE, nameNode)));
-
-    // wait after clicking because sometimes after quick click on nodes they do not close
-    WaitUtils.sleepQuietly(500, TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -122,11 +122,11 @@ public class FindUsages {
    * @param node is the name of the node
    */
   public void selectNodeInFindUsagesByDoubleClick(String node) {
+    // we need to wait a little to avoid node closing after quick clicking
+    WaitUtils.sleepQuietly(500, TimeUnit.MILLISECONDS);
+
     seleniumWebDriverHelper.moveCursorToAndDoubleClick(
         By.xpath(format(Locators.FIND_USAGES_NODE, node)));
-
-    // wait after double click because sometimes after quick clicking on nodes they do not close
-    WaitUtils.sleepQuietly(500, TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.miscellaneous;
 
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_USAGES;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
@@ -23,7 +24,6 @@ import static org.openqa.selenium.Keys.ENTER;
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
@@ -38,7 +38,7 @@ import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev */
 public class FindUsagesBaseOperationTest {
-  private static final String PROJECT_NAME = NameGenerator.generate("project", 4);
+  private static final String PROJECT_NAME = generate("project", 4);
 
   private static final String EXPECTED_TEXT =
       "Usages of numGuessByUser [3 occurrences]\n"
@@ -67,85 +67,83 @@ public class FindUsagesBaseOperationTest {
           + "30:    if (numGuessByUser != null && numGuessByUser.equals(secretNum)) {\n"
           + "34:    else if (numGuessByUser != null) {";
 
-  @Inject private FindUsages findUsages;
-  @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
-  @Inject private ProjectExplorer projectExplorer;
-  @Inject private CodenvyEditor editor;
   @Inject private Menu menu;
   @Inject private Loader loader;
-  @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private Events events;
+  @Inject private CodenvyEditor editor;
+  @Inject private FindUsages findUsages;
+  @Inject private TestWorkspace workspace;
+  @Inject private ProjectExplorer projectExplorer;
+  @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
     URL resource = getClass().getResource("/projects/guess-project");
     testProjectServiceClient.importProject(
         workspace.getId(), Paths.get(resource.toURI()), PROJECT_NAME, MAVEN_SPRING);
+
     ide.open(workspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
   }
 
   @Test
   public void checkFindUsagesBaseOperation() {
-    ide.waitOpenedWorkspaceIsReadyToUse();
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByVisibleNameInExplorer("AppController.java");
 
-    // Check basic operations of the 'find usages' panel
+    // check basic operations of the 'find usages' panel
     editor.selectTabByName("AppController");
     editor.goToCursorPositionVisible(27, 17);
     menu.runCommand(ASSISTANT, FIND_USAGES);
     loader.waitOnClosed();
     findUsages.waitFindUsagesPanelIsOpen();
+    findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
+    findUsages.waitSelectedElementInFindUsagesPanel("numGuessByUser");
+
+    // Switch to the Events panel and check that the FindUsages panel is not visible
+    findUsages.waitFindUsagesPanelIsOpen();
     events.clickEventLogBtn();
+    events.waitOpened();
     findUsages.waitFindUsagesPanelIsClosed();
+
+    // Switch to the FindUsages panel and check its expected content
     findUsages.clickFindUsagesIcon();
     findUsages.waitFindUsagesPanelIsOpen();
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
     findUsages.waitSelectedElementInFindUsagesPanel("numGuessByUser");
 
-    // Check basic operations of the 'find usages' panel
-    editor.selectTabByName("AppController");
-    editor.goToCursorPositionVisible(27, 17);
-    menu.runCommand(ASSISTANT, FIND_USAGES);
-    loader.waitOnClosed();
-    findUsages.waitFindUsagesPanelIsOpen();
-    findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
-    findUsages.waitSelectedElementInFindUsagesPanel("numGuessByUser");
-
-    // Check nodes in the 'find usages' panel by 'double click' and click on the icon node
+    // Check nodes in the FindUsages panel by 'double click' and click on the icon node
     findUsages.clickOnIconNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
 
     findUsages.selectNodeInFindUsagesByDoubleClick(PROJECT_NAME);
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
-
     findUsages.selectNodeInFindUsagesByDoubleClick("org.eclipse.qa.examples");
+    findUsages.waitExpectedTextInFindUsagesPanel("AppController");
     findUsages.selectNodeInFindUsagesByDoubleClick("AppController");
+    findUsages.waitExpectedTextInFindUsagesPanel(
+        "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.selectNodeInFindUsagesByDoubleClick(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
-    findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT_1);
+    findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
 
-    findUsages.clickOnIconNodeInFindUsagesPanel("AppController");
-    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
-
-    findUsages.clickOnIconNodeInFindUsagesPanel("AppController");
-    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
-
-    findUsages.clickOnIconNodeInFindUsagesPanel("AppController");
     findUsages.clickOnIconNodeInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
-    findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT_2);
+    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
+    findUsages.clickOnIconNodeInFindUsagesPanel("AppController");
+    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
+    findUsages.clickOnIconNodeInFindUsagesPanel("org.eclipse.qa.examples");
+    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(
+        "handleRequest(HttpServletRequest, HttpServletResponse)");
 
-    // Check nodes in the 'find usages' panel by 'Enter'
+    // Check nodes in the FindUsages panel by 'Enter' button
     findUsages.selectNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
-
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
-
     findUsages.selectNodeInFindUsagesPanel("org.eclipse.qa.examples");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.selectNodeInFindUsagesPanel("AppController");
@@ -154,37 +152,30 @@ public class FindUsagesBaseOperationTest {
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT_1);
-
     findUsages.selectNodeInFindUsagesPanel("AppController");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
-
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
-
     findUsages.selectNodeInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT_2);
 
-    // Check nodes in the 'find usages' panel by keyboard
+    // Check nodes in the FindUsages panel by keyboard
     findUsages.selectNodeInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_LEFT.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
-
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_RIGHT.toString());
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT_2);
-
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_UP.toString());
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_UP.toString());
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_UP.toString());
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_LEFT.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
-
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_RIGHT.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
-
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_DOWN.toString());
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_RIGHT.toString());
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_DOWN.toString());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
@@ -114,7 +114,7 @@ public class FindUsagesBaseOperationTest {
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
     findUsages.waitSelectedElementInFindUsagesPanel("numGuessByUser");
 
-    // Check nodes in the FindUsages panel by 'double click' and click
+    // Check nodes in the FindUsages panel by 'double click'
     findUsages.selectNodeInFindUsagesByDoubleClick(PROJECT_NAME);
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
     findUsages.selectNodeInFindUsagesByDoubleClick(PROJECT_NAME);
@@ -127,6 +127,8 @@ public class FindUsagesBaseOperationTest {
     findUsages.selectNodeInFindUsagesByDoubleClick(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
+
+    // Check nodes in the FindUsages panel by click on node icon
     findUsages.clickOnIconNodeInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
@@ -93,7 +93,7 @@ public class FindUsagesBaseOperationTest {
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByVisibleNameInExplorer("AppController.java");
 
-    // Check basic operations of the FindUsages panel
+    // Check basic operations of the Find Usages panel
     editor.selectTabByName("AppController");
     editor.goToCursorPositionVisible(27, 17);
     menu.runCommand(ASSISTANT, FIND_USAGES);
@@ -102,22 +102,21 @@ public class FindUsagesBaseOperationTest {
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
     findUsages.waitSelectedElementInFindUsagesPanel("numGuessByUser");
 
-    // Switch to the Events panel and check that the FindUsages panel is not visible
+    // Switch to the Events panel and check that the Find Usages panel is not visible
     findUsages.waitFindUsagesPanelIsOpen();
     events.clickEventLogBtn();
     events.waitOpened();
     findUsages.waitFindUsagesPanelIsClosed();
 
-    // Switch to the FindUsages panel and check its expected content
+    // Switch to the Find Usages panel and check its expected content
     findUsages.clickFindUsagesIcon();
     findUsages.waitFindUsagesPanelIsOpen();
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
     findUsages.waitSelectedElementInFindUsagesPanel("numGuessByUser");
 
-    // Check nodes in the FindUsages panel by 'double click' and click on the icon node
-    findUsages.clickOnIconNodeInFindUsagesPanel(PROJECT_NAME);
+    // Check nodes in the FindUsages panel by 'double click' and click
+    findUsages.selectNodeInFindUsagesByDoubleClick(PROJECT_NAME);
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
-
     findUsages.selectNodeInFindUsagesByDoubleClick(PROJECT_NAME);
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
     findUsages.selectNodeInFindUsagesByDoubleClick("org.eclipse.qa.examples");
@@ -128,7 +127,6 @@ public class FindUsagesBaseOperationTest {
     findUsages.selectNodeInFindUsagesByDoubleClick(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
-
     findUsages.clickOnIconNodeInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
@@ -138,7 +136,7 @@ public class FindUsagesBaseOperationTest {
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
 
-    // Check nodes in the FindUsages panel by 'Enter' button
+    // Check nodes in the Find Usages panel by 'Enter' button
     findUsages.selectNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
@@ -162,7 +160,7 @@ public class FindUsagesBaseOperationTest {
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT_2);
 
-    // Check nodes in the FindUsages panel by keyboard
+    // Check nodes in the Find Usages panel by keyboard
     findUsages.selectNodeInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ARROW_LEFT.toString());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
@@ -114,7 +114,7 @@ public class FindUsagesBaseOperationTest {
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
     findUsages.waitSelectedElementInFindUsagesPanel("numGuessByUser");
 
-    // Check nodes in the FindUsages panel by 'double click'
+    // Check nodes in the Find Usages panel by 'double click'
     findUsages.selectNodeInFindUsagesByDoubleClick(PROJECT_NAME);
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
     findUsages.selectNodeInFindUsagesByDoubleClick(PROJECT_NAME);
@@ -128,7 +128,7 @@ public class FindUsagesBaseOperationTest {
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT);
 
-    // Check nodes in the FindUsages panel by click on node icon
+    // Check nodes in the Find Usages panel by click on node icon
     findUsages.clickOnIconNodeInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
@@ -93,7 +93,7 @@ public class FindUsagesBaseOperationTest {
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByVisibleNameInExplorer("AppController.java");
 
-    // check basic operations of the 'find usages' panel
+    // Check basic operations of the FindUsages panel
     editor.selectTabByName("AppController");
     editor.goToCursorPositionVisible(27, 17);
     menu.runCommand(ASSISTANT, FIND_USAGES);


### PR DESCRIPTION
### What does this PR do?
This PR reworks use steps in **FindUsagesBaseOperationTest** selenium test in part that checks working with the "**Find Usages**" panel by clicks. Also were added timeout after every click on node.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11171