### PR TITLE
Selenium: Rework the 'waitGitDeletionMarkerInPosition()' to avoid unexpected 'stale element exception'

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
@@ -913,13 +913,14 @@ public class CodenvyEditor {
    * @param line line's number where the marker should be displayed
    */
   public void waitGitDeletionMarkerInPosition(int line) {
-    webDriverWaitFactory
-        .get(REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            (ExpectedCondition<Boolean>)
+    seleniumWebDriverHelper.waitNoExceptions(
+        () ->
+            seleniumWebDriverHelper.waitSuccessCondition(
                 webDriver ->
                     "git-change-marker deletion"
-                        .equals(getListGitMarkers().get(line).getAttribute("class")));
+                        .equals(getListGitMarkers().get(line).getAttribute("class")),
+                REDRAW_UI_ELEMENTS_TIMEOUT_SEC),
+        StaleElementReferenceException.class);
   }
 
   /**


### PR DESCRIPTION
### What does this PR do?
* Rework the _waitGitDeletionMarkerInPosition()_ in the _CodenvyEditor_ using the _waitNoExceptions()_
from the _SeleniumWebDriverHelper_ to avoid unexpected _StaleElementReferenceException_

 
### What issues does this PR fix or reference?
#11317