### PR TITLE
Provide a way to annotate rest endpoint functions to enable Machine Auth

### DIFF
--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthorized.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthorized.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.machine.authentication.server;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares that a method can be invoked using machine token signed requests.
+ *
+ * @author David Festal (dfestal@redhat.com)
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MachineAuthorized {}

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenAccessFilter.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineTokenAccessFilter.java
@@ -15,6 +15,7 @@ import static java.util.Arrays.asList;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import java.lang.reflect.Method;
 import javax.ws.rs.Path;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.commons.env.EnvironmentContext;
@@ -50,10 +51,15 @@ public class MachineTokenAccessFilter extends CheMethodInvokerFilter {
     if (!(EnvironmentContext.getCurrent().getSubject() instanceof MachineTokenAuthorizedSubject)) {
       return;
     }
-    if (!allowedMethodsByPath
+    if (allowedMethodsByPath
         .get(genericMethodResource.getParentResource().getPathValue().getPath())
         .contains(genericMethodResource.getMethod().getName())) {
-      throw new ForbiddenException("This operation cannot be performed using machine token.");
+      return;
     }
+    Method method = genericMethodResource.getMethod();
+    if (method != null && method.isAnnotationPresent(MachineAuthorized.class)) {
+      return;
+    }
+    throw new ForbiddenException("This operation cannot be performed using machine token.");
   }
 }


### PR DESCRIPTION
### What does this PR do?

This PR allows extends the newly-added mechanism that limits the scope of allowed operations with machine token to workspace related ones only.

We should be able to provide, in a custom assembly for example, additional wsmaster endpoints that would be considered as workspace-related.
This is a strong requirement to enable updating RhChe to upstrea Che 6.12.0 version.
For more details about the RhChe case, see [this comment](https://github.com/redhat-developer/rh-che/pull/902#issuecomment-424645862)

The proposed solution defines a `MachineAuthorized` annotation that can be added on an new REST endpoint method, so that it would support Machine-token-based authentication coming from agent requests. 

### What issues does this PR fix or reference?

This is a pre-requisite for issue https://github.com/redhat-developer/rh-che/issues/927

### Was this tested ?

This was tested in the context of RhChe built on `6.12.0-SNAPSHOT` upstream version