### PR TITLE
Correct the 'GitPullTest' related to unexpected stale element reference

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullTest.java
@@ -79,6 +79,7 @@ public class GitPullTest {
     prepareFilesForTest(jsFileName);
     prepareFilesForTest(htmlFileName);
     prepareFilesForTest(folderWithPlainFilesPath + "/" + readmeTxtFileName);
+    prepareFilesForTest(folderWithPlainFilesPath + "/README.md");
 
     testRepo.changeFileContent(jsFileName, currentTimeInMillis);
     testRepo.changeFileContent(htmlFileName, currentTimeInMillis);
@@ -103,7 +104,7 @@ public class GitPullTest {
         readmeTxtFileName,
         String.format("/%s/%s/%s", PROJECT_NAME, folderWithPlainFilesPath, readmeTxtFileName));
     checkPullAfterRemovingContent(
-        readmeTxtFileName,
+        "README.md",
         String.format("/%s/%s/%s", PROJECT_NAME, folderWithPlainFilesPath, "README.md"));
   }
 
@@ -127,7 +128,7 @@ public class GitPullTest {
 
   private void checkPullAfterRemovingContent(
       String tabNameOpenedFile, String pathToItemInProjectExplorer) {
-    editor.waitTextNotPresentIntoEditor(tabNameOpenedFile);
+    editor.waitTabIsNotPresent(tabNameOpenedFile);
     projectExplorer.waitLibrariesAreNotPresent(pathToItemInProjectExplorer);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitPullTest.java
@@ -70,6 +70,7 @@ public class GitPullTest {
     String jsFileName = "app.js";
     String htmlFileName = "file.html";
     String readmeTxtFileName = "readme-txt";
+    String readmeMdFileName = "README.md";
     String folderWithPlainFilesPath = "plain-files";
 
     String currentTimeInMillis = Long.toString(System.currentTimeMillis());
@@ -79,7 +80,7 @@ public class GitPullTest {
     prepareFilesForTest(jsFileName);
     prepareFilesForTest(htmlFileName);
     prepareFilesForTest(folderWithPlainFilesPath + "/" + readmeTxtFileName);
-    prepareFilesForTest(folderWithPlainFilesPath + "/README.md");
+    prepareFilesForTest(folderWithPlainFilesPath + "/" + readmeMdFileName);
 
     testRepo.changeFileContent(jsFileName, currentTimeInMillis);
     testRepo.changeFileContent(htmlFileName, currentTimeInMillis);
@@ -105,7 +106,7 @@ public class GitPullTest {
         String.format("/%s/%s/%s", PROJECT_NAME, folderWithPlainFilesPath, readmeTxtFileName));
     checkPullAfterRemovingContent(
         "README.md",
-        String.format("/%s/%s/%s", PROJECT_NAME, folderWithPlainFilesPath, "README.md"));
+        String.format("/%s/%s/%s", PROJECT_NAME, folderWithPlainFilesPath, readmeMdFileName));
   }
 
   private void performPull() {


### PR DESCRIPTION
### What does this PR do?
* Correct the selenium test _GitPullTest_ related to unexpected _'stale element reference'_ when the test runs on CI 
* We check that the expected text is not present in the editor after remove it on GitHub side, and performing git pull.
In fact we delete the folder with test files and as result after git pull these files are deleted from the editor and the project explorer.
On my opinion, we should check that test files are really delete from editor (the tab file names are not present), and to exclude the check of text unpresent in the editor.

### What issues does this PR fix or reference?
#11223