### PR TITLE
Fail workspace validation if config contains both ws.next plugins and installers

### DIFF
--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
@@ -324,6 +324,28 @@ public class WorkspaceValidatorTest {
     wsValidator.validateConfig(config);
   }
 
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp = ".*([pP]lugin.*[iI]nstaller|[iI]nstaller.*[pP]lugin).*")
+  public void shouldFailValidationIfBothPluginsAndInstallersPresent() throws Exception {
+    // createConfig creates config with one installer by default
+    final WorkspaceConfigDto config = createConfig();
+    config.getAttributes().put(WorkspaceValidator.PLUGINS_ATTRIBUTE, "plugin1");
+
+    wsValidator.validateConfig(config);
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp = ".*([pP]lugin.*[iI]nstaller|[iI]nstaller.*[pP]lugin).*")
+  public void shouldFailValidationIfBothEditorAndInstallersPresent() throws Exception {
+    // createConfig creates config with one installer by default
+    final WorkspaceConfigDto config = createConfig();
+    config.getAttributes().put(WorkspaceValidator.EDITOR_ATTRIBUTE, "editor1");
+
+    wsValidator.validateConfig(config);
+  }
+
   private static WorkspaceConfigDto createConfig() {
     final WorkspaceConfigDto workspaceConfigDto =
         newDto(WorkspaceConfigDto.class).withName("ws-name").withDefaultEnv("dev-env");

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.api.workspace.shared.dto.CommandDto;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.MachineConfigDto;
@@ -330,7 +331,7 @@ public class WorkspaceValidatorTest {
   public void shouldFailValidationIfBothPluginsAndInstallersPresent() throws Exception {
     // createConfig creates config with one installer by default
     final WorkspaceConfigDto config = createConfig();
-    config.getAttributes().put(WorkspaceValidator.PLUGINS_ATTRIBUTE, "plugin1");
+    config.getAttributes().put(Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE, "plugin1");
 
     wsValidator.validateConfig(config);
   }
@@ -341,7 +342,7 @@ public class WorkspaceValidatorTest {
   public void shouldFailValidationIfBothEditorAndInstallersPresent() throws Exception {
     // createConfig creates config with one installer by default
     final WorkspaceConfigDto config = createConfig();
-    config.getAttributes().put(WorkspaceValidator.EDITOR_ATTRIBUTE, "editor1");
+    config.getAttributes().put(Constants.WORKSPACE_TOOLING_EDITOR_ATTRIBUTE, "editor1");
 
     wsValidator.validateConfig(config);
   }


### PR DESCRIPTION
### What does this PR do?
Checks if a workspace config contains both ws.next config options (editor, plugins) and installers during validation.

One potential shortcoming of the way this is currently implemented is that validation only occurs on creation/modification, so existing workspace with the issue will continue to launch. @garagatyi is this something we should also fix, or no?

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11259
