### PR TITLE
Switch log message we wait for in LS tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/constant/TestCommandsConstants.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/constant/TestCommandsConstants.java
@@ -28,6 +28,4 @@ public interface TestCommandsConstants {
   String START_APACHE_COMMAND = "start apache";
   String STOP_APACHE_COMMAND = "stop apache";
   String RESTART_APACHE_COMMAND = "restart apache";
-  String FINISH_LANGUAGE_SERVER_INITIALIZATION_MESSAGE =
-      "Finished language servers initialization, file path";
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/ApacheCamelFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/ApacheCamelFileEditingTest.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.selenium.languageserver;
 
-import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.GO_TO_SYMBOL;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.CONSOLE_JAVA_SIMPLE;
@@ -39,7 +38,7 @@ public class ApacheCamelFileEditingTest {
   private static final String CAMEL_FILE_NAME = "camel.xml";
   private static final String PATH_TO_CAMEL_FILE = PROJECT_NAME + "/" + CAMEL_FILE_NAME;
   private static final String LS_INIT_MESSAGE =
-      format("Finished language servers initialization, file path '/%s'", PATH_TO_CAMEL_FILE);
+      "Initialized language server 'org.eclipse.che.plugin.camel.server.languageserver'";
   private static final String[] EXPECTED_GO_TO_SYMBOL_ALTERNATIVES = {
     "<no id>symbols (2)", "<no id>"
   };

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/TypeScriptEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/TypeScriptEditingTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.selenium.languageserver;
 
 import static java.lang.String.format;
-import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.FINISH_LANGUAGE_SERVER_INITIALIZATION_MESSAGE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_DEFINITION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_PROJECT_SYMBOL;
@@ -94,7 +93,7 @@ public class TypeScriptEditingTest {
     projectExplorer.waitVisibleItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
     projectExplorer.openItemByPath(PATH_TO_GREETER_FILE);
-    consoles.waitExpectedTextIntoConsole(FINISH_LANGUAGE_SERVER_INITIALIZATION_MESSAGE);
+    consoles.waitExpectedTextIntoConsole(INITIALIZE_LANG_SERVER_MESSAGE);
   }
 
   @Test
@@ -127,10 +126,6 @@ public class TypeScriptEditingTest {
 
   @Test(priority = 2, alwaysRun = true)
   public void checkMainFeaturesTypeScriptLS() {
-    String initTypeScriptLanguageServerMessage =
-        format("Finished language servers initialization, file path '/%s'", PATH_TO_GREETER_FILE);
-
-    consoles.waitExpectedTextIntoConsole(initTypeScriptLanguageServerMessage);
     checkCodeValidation();
     checkCodeAssistant();
     checkGoToDefinition();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/YamlFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/YamlFileEditingTest.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.selenium.languageserver;
 
-import static java.lang.String.format;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.GO_TO_SYMBOL;
@@ -54,7 +53,7 @@ public class YamlFileEditingTest {
   private static final String YAML_FILE_NAME = "openshift.yaml";
   private static final String PATH_TO_YAML_FILE = PROJECT_NAME + "/" + YAML_FILE_NAME;
   private static final String LS_INIT_MESSAGE =
-      format("Finished language servers initialization, file path '/%s'", PATH_TO_YAML_FILE);
+      "Initialized language server 'org.eclipse.che.plugin.yaml.server.languageserver'";
   private static final List<String> EXPECTED_GO_TO_SYMBOL_ALTERNATIVES =
       Arrays.asList("apiVersionsymbols (194)", "kind", "metadata");
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/csharp/CSharpFileAdvancedOperationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/csharp/CSharpFileAdvancedOperationsTest.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.selenium.languageserver.csharp;
 
-import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.FINISH_LANGUAGE_SERVER_INITIALIZATION_MESSAGE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_DEFINITION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.GO_TO_SYMBOL;
@@ -48,6 +47,9 @@ public class CSharpFileAdvancedOperationsTest {
 
   private static final String PATH_TO_DOT_NET_FILE = PROJECT_NAME + "/Hello.cs";
 
+  private final String LANGUAGE_SERVER_INIT_MESSAGE =
+      "Initialized language server 'org.eclipse.che.plugin.csharp.languageserver";
+
   @InjectTestWorkspace(template = WorkspaceTemplate.UBUNTU_LSP)
   private TestWorkspace workspace;
 
@@ -76,7 +78,7 @@ public class CSharpFileAdvancedOperationsTest {
     // after opening the file we are checking initializing message from LS and than check, that
     // dependencies have been added properly in this case
     // folders obj and bin should appear in the Project tree
-    consoles.waitExpectedTextIntoConsole(FINISH_LANGUAGE_SERVER_INITIALIZATION_MESSAGE);
+    consoles.waitExpectedTextIntoConsole(LANGUAGE_SERVER_INIT_MESSAGE);
     projectExplorer.waitItem(PROJECT_NAME + "/obj");
     projectExplorer.waitItem(PROJECT_NAME + "/bin");
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCamelStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCamelStackTest.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.selenium.stack;
 
-import static java.lang.String.format;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.CONSOLE_JAVA_SIMPLE;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.CAMEL_SPRINGBOOT;
@@ -41,7 +40,7 @@ public class CreateWorkspaceFromCamelStackTest {
   private static final String CAMEL_FILE_NAME = "camel.xml";
   private static final String PATH_TO_CAMEL_FILE = PROJECT_NAME + "/" + CAMEL_FILE_NAME;
   private static final String LS_INIT_MESSAGE =
-      format("Finished language servers initialization, file path '/%s'", PATH_TO_CAMEL_FILE);
+      "Initialized language server 'org.eclipse.che.plugin.camel.server.languageserver'";
 
   @Inject private Ide ide;
   @Inject private Dashboard dashboard;


### PR DESCRIPTION
### What does this PR do?
Waits for a different startup message before running LS related tesets

### What issues does this PR fix or reference?
Fix Wait Conditions for LS Startup #11393
