### PR TITLE
Include activity tracker extension into default Theia image

### DIFF
--- a/dockerfiles/theia/src/extensions.json
+++ b/dockerfiles/theia/src/extensions.json
@@ -61,6 +61,13 @@
             "folder": "che-theia-task-extension",
             "checkoutTo": "master",
             "type": "git"
+        },
+        {
+            "name": "@eclipse-che/theia-activity-tracker",
+            "source": "https://github.com/eclipse/che-theia-activity-tracker.git",
+            "folder": "che-theia-activity-tracker",
+            "checkoutTo": "master",
+            "type": "git"
         }
     ]
 }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds activity tracker extension into Theia image.
The extension is needed for workspace stop prevention. It doesn't save or collect any data at all, it even doesn't distinguish between activity types. Only the fact of any activity matters.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11267
