### PR TITLE
Selenium: Correct the 'openItemByPath()' to avoid the 'NoSuchElementException'

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -541,10 +541,14 @@ public class ProjectExplorer {
    */
   public void openItemByPath(String path) {
     Actions action = actionsFactory.createAction(seleniumWebDriver);
-    waitAndSelectItem(path);
 
     seleniumWebDriverHelper.waitNoExceptions(
-        () -> waitItemIsSelected(path), LOAD_PAGE_TIMEOUT_SEC, NoSuchElementException.class);
+        () -> {
+          waitAndSelectItem(path);
+          waitItemIsSelected(path);
+        },
+        LOAD_PAGE_TIMEOUT_SEC,
+        NoSuchElementException.class);
 
     seleniumWebDriverHelper.waitNoExceptions(
         () -> {


### PR DESCRIPTION
### What does this PR do?
* Correct the _'openItemByPath()'_ in the _ProjectExplorer_ to avoid the '_NoSuchElementException_'

### What issues does this PR fix or reference?
#11373