### PR TITLE
CHE-11408: Disable probes of Che master when debug is enabled

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -336,6 +336,8 @@ if [ "${CHE_DEBUG_SERVER}" == "true" ]; then
   ${OC_BINARY}  expose service che-debug
   NodePort=$(oc get service che-debug -o jsonpath='{.spec.ports[0].nodePort}')
   printInfo "Remote wsmaster debugging URL: ${CLUSTER_IP}:${NodePort}"
+  printInfo "Removing liveness and readiness probes from Che deployment"
+  oc set probe dc/che --remove --readiness --liveness
 fi
 }
 


### PR DESCRIPTION
### What does this PR do?
Remove readiness/liveness probes from Che deployment when debug is
enabled.
This allows debugging Che master for a long period of time without
Che container being killed because of unresponsive probes.


### What issues does this PR fix or reference?
Fixes #11408 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
