### PR TITLE
Make Theia sidecar/stack secure, add an ability to use new JWT auth on a per-workspace basis

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -99,7 +99,9 @@
                   "port": "3000",
                   "path": "/",
                   "attributes": {
-                    "type": "ide"
+                    "type": "ide",
+                    "cookiesAuthEnabled": "true",
+                    "secure": "true"
                   }
                 },
                 "theia-dev": {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -131,15 +131,14 @@ public class KubernetesInfraModule extends AbstractModule {
 
     install(new JpaKubernetesRuntimeCacheModule());
 
+    bind(SecureServerExposerFactoryProvider.class)
+        .to(new TypeLiteral<SecureServerExposerFactoryProvider<KubernetesEnvironment>>() {});
+
     MapBinder<String, ChePluginsApplier> chePluginsAppliers =
         MapBinder.newMapBinder(binder(), String.class, ChePluginsApplier.class);
     chePluginsAppliers
         .addBinding(KubernetesEnvironment.TYPE)
         .to(KubernetesPluginsToolingApplier.class);
-
-    bind(new TypeLiteral<SecureServerExposerFactory<KubernetesEnvironment>>() {})
-        .toProvider(
-            new TypeLiteral<SecureServerExposerFactoryProvider<KubernetesEnvironment>>() {});
 
     MapBinder<String, SecureServerExposerFactory<KubernetesEnvironment>>
         secureServerExposerFactories =

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriter.java
@@ -27,6 +27,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.Configurati
  * @author Alexander Garagatyi
  */
 public class RestartPolicyRewriter implements ConfigurationProvisioner {
+  public static final int RESTART_POLICY_SET_TO_NEVER = 4104;
+
   static final String DEFAULT_RESTART_POLICY = "Never";
 
   @Override
@@ -48,7 +50,7 @@ public class RestartPolicyRewriter implements ConfigurationProvisioner {
           format(
               "Restart policy '%s' for pod '%s' is rewritten with %s",
               restartPolicy, podName, DEFAULT_RESTART_POLICY);
-      env.addWarning(new WarningImpl(101, warnMsg));
+      env.addWarning(new WarningImpl(RESTART_POLICY_SET_TO_NEVER, warnMsg));
     }
     podSpec.setRestartPolicy(DEFAULT_RESTART_POLICY);
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/server/ServersConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/server/ServersConverter.java
@@ -56,7 +56,7 @@ public class ServersConverter<T extends KubernetesEnvironment>
   @Override
   public void provision(T k8sEnv, RuntimeIdentity identity) throws InfrastructureException {
     SecureServerExposer<T> secureServerExposer =
-        secureServerExposerFactoryProvider.get().create(identity);
+        secureServerExposerFactoryProvider.get(k8sEnv).create(identity);
 
     for (Pod podConfig : k8sEnv.getPods().values()) {
       final PodSpec podSpec = podConfig.getSpec();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/server/ServersConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/server/ServersConverter.java
@@ -27,7 +27,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.Configurati
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.KubernetesServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposer;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider;
 
 /**
  * Converts {@link ServerConfig} to Kubernetes related objects to add a server into Kubernetes
@@ -42,20 +42,21 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureS
 public class ServersConverter<T extends KubernetesEnvironment>
     implements ConfigurationProvisioner<T> {
 
-  private final SecureServerExposerFactory<T> secureServerExposerFactory;
   private final ExternalServerExposerStrategy<T> externalServerExposerStrategy;
+  private final SecureServerExposerFactoryProvider<T> secureServerExposerFactoryProvider;
 
   @Inject
   public ServersConverter(
-      SecureServerExposerFactory<T> secureServerExposerFactory,
-      ExternalServerExposerStrategy<T> externalServerExposerStrategy) {
-    this.secureServerExposerFactory = secureServerExposerFactory;
+      ExternalServerExposerStrategy<T> externalServerExposerStrategy,
+      SecureServerExposerFactoryProvider<T> secureServerExposerFactoryProvider) {
     this.externalServerExposerStrategy = externalServerExposerStrategy;
+    this.secureServerExposerFactoryProvider = secureServerExposerFactoryProvider;
   }
 
   @Override
   public void provision(T k8sEnv, RuntimeIdentity identity) throws InfrastructureException {
-    SecureServerExposer<T> secureServerExposer = secureServerExposerFactory.create(identity);
+    SecureServerExposer<T> secureServerExposer =
+        secureServerExposerFactoryProvider.get().create(identity);
 
     for (Pod podConfig : k8sEnv.getPods().values()) {
       final PodSpec podSpec = podConfig.getSpec();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/SecureServerExposerFactoryProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/SecureServerExposerFactoryProvider.java
@@ -16,19 +16,27 @@ import static java.lang.String.format;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
+import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
 /**
- * Provides implementation of {@link SecureServerExposerFactory} according to configuration property
- * with name `che.server.secure_exposer`.
+ * Provides implementation of {@link SecureServerExposerFactory} according to workspace config
+ * attribute with name `che.server.secure_exposer` if it is present and contains bound
+ * implementation key or configuration property with name `che.server.secure_exposer` otherwise.
  *
  * @author Sergii Leshchenko
  * @author Oleksandr Garagatyi
  */
 public class SecureServerExposerFactoryProvider<T extends KubernetesEnvironment> {
-  private static final String SECURE_EXPOSER_IMPL_PROPERTY = "che.server.secure_exposer";
+  public static final int UNKNOWN_SECURE_SERVER_EXPOSER_CONFIGURED_IN_WS = 4105;
 
+  public static final String SECURE_EXPOSER_IMPL_PROPERTY = "che.server.secure_exposer";
+  public static final String UNKNOWN_EXPOSER_ERROR_TEMPLATE =
+      "Unknown secure servers exposer '%s' is configured in workspace. Currently supported: %s.";
+
+  private final Map<String, SecureServerExposerFactory<T>> factories;
+  private final String unknownExposerErrorTemplate;
   private final SecureServerExposerFactory<T> serverExposerFactory;
 
   @Inject
@@ -43,13 +51,28 @@ public class SecureServerExposerFactoryProvider<T extends KubernetesEnvironment>
               "Unknown secure servers exposer '%s' is configured. Currently supported: %s.",
               serverExposer, knownExposers));
     }
+    this.unknownExposerErrorTemplate = format(UNKNOWN_EXPOSER_ERROR_TEMPLATE, "%s", knownExposers);
+    this.factories = factories;
   }
 
   /**
    * Creates instance of {@link SecureServerExposerFactory} that will expose secure servers of
-   * Kubernetes environment for runtime with the specified runtime identity.
+   * provided Kubernetes environment for runtime with the specified runtime identity.
    */
-  public SecureServerExposerFactory<T> get() {
+  public SecureServerExposerFactory<T> get(T k8sEnv) {
+    String envExposerImpl = k8sEnv.getAttributes().get(SECURE_EXPOSER_IMPL_PROPERTY);
+    if (envExposerImpl != null) {
+      if (factories.containsKey(envExposerImpl)) {
+        return factories.get(envExposerImpl);
+      }
+      k8sEnv
+          .getWarnings()
+          .add(
+              new WarningImpl(
+                  UNKNOWN_SECURE_SERVER_EXPOSER_CONFIGURED_IN_WS,
+                  format(unknownExposerErrorTemplate, envExposerImpl)));
+    }
+
     return this.serverExposerFactory;
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriterTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpol
 import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter.DEFAULT_RESTART_POLICY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter.RESTART_POLICY_SET_TO_NEVER;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -65,7 +66,7 @@ public class RestartPolicyRewriterTest {
         k8sEnv.getPods().get(TEST_POD_NAME).getSpec().getRestartPolicy(), DEFAULT_RESTART_POLICY);
     verifyWarnings(
         new WarningImpl(
-            101,
+            RESTART_POLICY_SET_TO_NEVER,
             format(
                 "Restart policy '%s' for pod '%s' is rewritten with %s",
                 ALWAYS_RESTART_POLICY, TEST_POD_NAME, DEFAULT_RESTART_POLICY)));

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/SecureServerExposerFactoryProviderTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/SecureServerExposerFactoryProviderTest.java
@@ -11,10 +11,17 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.secure;
 
+import static java.lang.String.format;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider.SECURE_EXPOSER_IMPL_PROPERTY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider.UNKNOWN_EXPOSER_ERROR_TEMPLATE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider.UNKNOWN_SECURE_SERVER_EXPOSER_CONFIGURED_IN_WS;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
+import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.mockito.Mock;
@@ -26,26 +33,33 @@ import org.testng.annotations.Test;
 /** @author Sergii Leshchenko */
 @Listeners(MockitoTestNGListener.class)
 public class SecureServerExposerFactoryProviderTest {
+  private static final String EXPOSER1 = "exposer1";
+  private static final String EXPOSER2 = "exposer2";
+  private static final String NON_EXISTING_EXPOSER = "non-existing";
+
   @Mock private SecureServerExposerFactory<KubernetesEnvironment> secureServerExposer1;
   @Mock private SecureServerExposerFactory<KubernetesEnvironment> secureServerExposer2;
 
   private Map<String, SecureServerExposerFactory<KubernetesEnvironment>> factories;
+  private KubernetesEnvironment kubernetesEnvironment;
 
   @BeforeMethod
   public void setUp() {
     factories = new HashMap<>();
-    factories.put("exposer1", secureServerExposer1);
-    factories.put("exposer2", secureServerExposer2);
+    factories.put(EXPOSER1, secureServerExposer1);
+    factories.put(EXPOSER2, secureServerExposer2);
+    kubernetesEnvironment = KubernetesEnvironment.builder().build();
   }
 
   @Test
   public void shouldReturnConfiguredSecureServerExposer() {
     // given
     SecureServerExposerFactoryProvider<KubernetesEnvironment> factoryProvider =
-        new SecureServerExposerFactoryProvider<>("exposer1", factories);
+        new SecureServerExposerFactoryProvider<>(EXPOSER1, factories);
 
     // when
-    SecureServerExposerFactory<KubernetesEnvironment> factory = factoryProvider.get();
+    SecureServerExposerFactory<KubernetesEnvironment> factory =
+        factoryProvider.get(kubernetesEnvironment);
 
     // then
     assertSame(factory, secureServerExposer1);
@@ -57,6 +71,44 @@ public class SecureServerExposerFactoryProviderTest {
           "Unknown secure servers exposer 'non-existing' is configured. Currently supported: exposer1, exposer2.")
   public void shouldThrowAnExceptionIfConfiguredSecureServerWasNotFound() {
     // given
-    new SecureServerExposerFactoryProvider<>("non-existing", factories);
+    new SecureServerExposerFactoryProvider<>(NON_EXISTING_EXPOSER, factories);
+  }
+
+  @Test
+  public void shouldAddWarningIfSecureServerConfiguredInEnvironmentWasNotFound() {
+    // given
+    SecureServerExposerFactoryProvider<KubernetesEnvironment> factoryProvider =
+        new SecureServerExposerFactoryProvider<>(EXPOSER1, factories);
+    kubernetesEnvironment.setAttributes(
+        ImmutableMap.of(SECURE_EXPOSER_IMPL_PROPERTY, NON_EXISTING_EXPOSER));
+    WarningImpl expectedWarning =
+        new WarningImpl(
+            UNKNOWN_SECURE_SERVER_EXPOSER_CONFIGURED_IN_WS,
+            format(
+                UNKNOWN_EXPOSER_ERROR_TEMPLATE,
+                NON_EXISTING_EXPOSER,
+                String.join(", ", factories.keySet())));
+
+    SecureServerExposerFactory<KubernetesEnvironment> factory =
+        factoryProvider.get(kubernetesEnvironment);
+
+    // then
+    assertSame(factory, secureServerExposer1);
+    assertEquals(kubernetesEnvironment.getWarnings().size(), 1);
+    assertEquals(kubernetesEnvironment.getWarnings().get(0), expectedWarning);
+  }
+
+  @Test
+  public void shouldReturnSecureServerExposerConfiguredInEnvironment() {
+    // given
+    SecureServerExposerFactoryProvider<KubernetesEnvironment> factoryProvider =
+        new SecureServerExposerFactoryProvider<>(EXPOSER1, factories);
+    kubernetesEnvironment.setAttributes(ImmutableMap.of(SECURE_EXPOSER_IMPL_PROPERTY, EXPOSER2));
+
+    SecureServerExposerFactory<KubernetesEnvironment> factory =
+        factoryProvider.get(kubernetesEnvironment);
+
+    // then
+    assertSame(factory, secureServerExposer2);
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/SecureServerExposerFactoryProviderTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/SecureServerExposerFactoryProviderTest.java
@@ -54,13 +54,9 @@ public class SecureServerExposerFactoryProviderTest {
   @Test(
       expectedExceptions = ConfigurationException.class,
       expectedExceptionsMessageRegExp =
-          "Unknown secure servers exposer is configured 'non-existing'. Currently supported: exposer1, exposer2.")
+          "Unknown secure servers exposer 'non-existing' is configured. Currently supported: exposer1, exposer2.")
   public void shouldThrowAnExceptionIfConfiguredSecureServerWasNotFound() {
     // given
-    SecureServerExposerFactoryProvider<KubernetesEnvironment> factoryProvider =
-        new SecureServerExposerFactoryProvider<>("non-existing", factories);
-
-    // when
-    factoryProvider.get();
+    new SecureServerExposerFactoryProvider<>("non-existing", factories);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -111,8 +111,8 @@ public class OpenShiftInfraModule extends AbstractModule {
         MapBinder.newMapBinder(binder(), String.class, ChePluginsApplier.class);
     pluginsAppliers.addBinding(OpenShiftEnvironment.TYPE).to(KubernetesPluginsToolingApplier.class);
 
-    bind(new TypeLiteral<SecureServerExposerFactory<OpenShiftEnvironment>>() {})
-        .toProvider(new TypeLiteral<SecureServerExposerFactoryProvider<OpenShiftEnvironment>>() {});
+    bind(SecureServerExposerFactoryProvider.class)
+        .to(new TypeLiteral<SecureServerExposerFactoryProvider<OpenShiftEnvironment>>() {});
 
     MapBinder<String, SecureServerExposerFactory<OpenShiftEnvironment>>
         secureServerExposerFactories =

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
@@ -49,7 +49,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory
  */
 public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<OpenShiftEnvironment> {
 
-  static final int ROUTE_IGNORED_WARNING_CODE = 4100;
+  static final int ROUTE_IGNORED_WARNING_CODE = 5100;
   static final String ROUTES_IGNORED_WARNING_MESSAGE =
       "Routes specified in OpenShift recipe are ignored. "
           + "To expose ports please define servers in machine configuration.";

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -36,6 +36,8 @@ import org.eclipse.che.commons.annotation.Nullable;
  */
 public abstract class InternalRuntime<T extends RuntimeContext> {
 
+  public static final int MALFORMED_SERVER_URL_FOUND = 1100;
+
   private final T context;
   private final URLRewriter urlRewriter;
   private final List<Warning> warnings;
@@ -232,7 +234,10 @@ public abstract class InternalRuntime<T extends RuntimeContext> {
                       urlRewriter.rewriteURL(identity, machineName, name, incomingServer.getUrl()));
           outgoing.put(name, server);
         } catch (InfrastructureException e) {
-          warnings.add(new WarningImpl(101, "Malformed URL for " + name + " : " + e.getMessage()));
+          warnings.add(
+              new WarningImpl(
+                  MALFORMED_SERVER_URL_FOUND,
+                  "Malformed URL for " + name + " : " + e.getMessage()));
         }
       }
     }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/InternalRuntimeTest.java
@@ -480,7 +480,8 @@ public class InternalRuntimeTest {
     List<WarningImpl> expectedWarnings = new ArrayList<>();
     expectedWarnings.add(
         new WarningImpl(
-            101, "Malformed URL for " + badServerName + " : " + badServerRewritingExcMessage));
+            InternalRuntime.MALFORMED_SERVER_URL_FOUND,
+            "Malformed URL for " + badServerName + " : " + badServerRewritingExcMessage));
     doReturn(internalMachines).when(internalRuntime).getInternalMachines();
     doThrow(new InfrastructureException(badServerRewritingExcMessage))
         .when(urlRewriter)


### PR DESCRIPTION
### What does this PR do?
**This PR is designed to be reviewed in a commit-by-commit manner.** The scope of each commit is very limited to the purpose described in its message. 

**Description of why:**
In sidecar-based workspaces with Theia sidecar, we can not use current security mechanism. To overcome it Che platform team implemented JWTProxy based implementation. We can switch these implementations for the whole Che, but this is not enough in a case when old workspaces are mostly used but sidecar-based workspaces evaluation is needed. Since JWTProxy based auth wasn't tested well enough as it is a non-default option I decided to switch only sidecar-based workspaces to it. 

**Description of what:**
Adds an ability to enable workspace security implementation on a per-workspace basis.
Enables JWTProxy based security to sidecar-based workspaces if authentication is enabled in Che.
Adds `secure` and `cookiesAuthEnabled` attributes to Theia stacks, so they are secure on a multiuser Che in contrast to the current state in master.
Adds other small fixes, such as fixing warning codes for workspace starting components.  

**Description of how:**
In **ServersConverter** I used **SecureServerExposerFactoryProvider** to create **SecureServerExposerFactory** directly and removed its binding from the DI container. 
Then I added an argument to the **get()** method of the provider. It accepts **KubernetesEnvironment** as an argument. The provider now does the deccision on what security implementation should be used not just by checking global Che property but also by looking at KuberneterEnvironment attributes **KuberneterEnvironment.getAttributes()**. When attribute **che.server.secure_exposer** is present in the environment and contains bound implementation the provider uses this implementation instead of the globally configured with the property with the same name. If there is no attribute or implementation not found the provider falls back to the globally configured implementation. 
Then in **che.server.secure_exposer** I added code that adds attribute **che.server.secure_exposer** with value  **jwtproxy** if authentication is enabled in Che.

**How to test it:**
Prerequsites:
Theia will work in secure sidecar-based workspaces only after applying this [PR](https://github.com/ws-skeleton/che-editor-theia/pull/7) and populating it to your che-plugin-registry instance and applying [PR](https://github.com/eclipse/che-plugin-broker/pull/11) to the plugin broker.  

1. Start Che in multiuser mode.
1. Create and start sidecar-based workspace.
1. Create and start regular Che 6 workspace, but add attribute **che.server.secure_exposer** with value  **jwtproxy** to workspace config attributes.
1. Create workspace from Theia stack.
1. All 3 workspaces from the previous steps are secured with JWTProxy instead of being completely unsecure as it is in master branch.

### What issues does this PR fix or reference?
To vitness working sidecar-based Theia secured in multi-user Che PRs need to be merged:
 https://github.com/eclipse/che-plugin-broker/pull/11
https://github.com/ws-skeleton/che-editor-theia/pull/7
Fixes https://github.com/redhat-developer/rh-che/issues/853

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
