### PR TITLE
Set k8s memory request wherever we set limit

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
@@ -28,7 +28,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SecurityCon
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitRequestProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.ServersConverter;
 
@@ -53,7 +53,7 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
     private ServersConverter<KubernetesEnvironment> serversConverter;
     private EnvVarsConverter envVarsConverter;
     private RestartPolicyRewriter restartPolicyRewriter;
-    private RamLimitProvisioner ramLimitProvisioner;
+    private RamLimitRequestProvisioner ramLimitProvisioner;
     private InstallerServersPortProvisioner installerServersPortProvisioner;
     private LogsVolumeMachineProvisioner logsVolumeMachineProvisioner;
     private SecurityContextProvisioner securityContextProvisioner;
@@ -71,7 +71,7 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
         EnvVarsConverter envVarsConverter,
         RestartPolicyRewriter restartPolicyRewriter,
         WorkspaceVolumesStrategy volumesStrategy,
-        RamLimitProvisioner ramLimitProvisioner,
+        RamLimitRequestProvisioner ramLimitProvisioner,
         InstallerServersPortProvisioner installerServersPortProvisioner,
         LogsVolumeMachineProvisioner logsVolumeMachineProvisioner,
         SecurityContextProvisioner securityContextProvisioner,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
-import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolume;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolumeMount;
@@ -24,7 +23,6 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodStatus;
-import io.fabric8.kubernetes.api.model.Quantity;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -40,6 +38,7 @@ import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SecurityContextProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -214,9 +213,10 @@ public class PVCSubPathHelper {
             .withCommand(command)
             .withVolumeMounts(newVolumeMount(pvcName, JOB_MOUNT_PATH, null))
             .withNewResources()
-            .withLimits(singletonMap("memory", new Quantity(jobMemoryLimit)))
             .endResources()
             .build();
+    Containers.addRamLimit(container, jobMemoryLimit);
+    Containers.addRamRequest(container, jobMemoryLimit);
     return new PodBuilder()
         .withNewMetadata()
         .withName(podName)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisioner.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram;
 
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_REQUEST_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Names.machineName;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -25,11 +26,12 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.Configurati
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
 
 /**
- * Sets Ram limit to Kubernetes machine.
+ * Sets or overrides Kubernetes container RAM limit and request if corresponding attributes are
+ * present in machine corresponding to the container.
  *
  * @author Anton Korneta
  */
-public class RamLimitProvisioner implements ConfigurationProvisioner {
+public class RamLimitRequestProvisioner implements ConfigurationProvisioner {
 
   @Override
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
@@ -42,6 +44,10 @@ public class RamLimitProvisioner implements ConfigurationProvisioner {
         String memoryLimitAttribute = attributes.get(MEMORY_LIMIT_ATTRIBUTE);
         if (memoryLimitAttribute != null) {
           Containers.addRamLimit(container, Long.parseLong(memoryLimitAttribute));
+        }
+        String memoryRequestAttribute = attributes.get(MEMORY_REQUEST_ATTRIBUTE);
+        if (memoryRequestAttribute != null) {
+          Containers.addRamRequest(container, Long.parseLong(memoryRequestAttribute));
         }
       }
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/Containers.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/Containers.java
@@ -101,4 +101,19 @@ public class Containers {
     container.setResources(
         resourceBuilder.addToRequests("memory", new Quantity(String.valueOf(ramRequest))).build());
   }
+
+  /**
+   * Sets given RAM request in kubernetes notion to specified container. Note if the container
+   * already contains a RAM request, it will be overridden, other resources won't be affected.
+   */
+  public static void addRamRequest(Container container, String limitInK8sNotion) {
+    final ResourceRequirementsBuilder resourceBuilder;
+    if (container.getResources() != null) {
+      resourceBuilder = new ResourceRequirementsBuilder(container.getResources());
+    } else {
+      resourceBuilder = new ResourceRequirementsBuilder();
+    }
+    container.setResources(
+        resourceBuilder.addToRequests("memory", new Quantity(limitInK8sNotion)).build());
+  }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/K8sContainerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/K8sContainerResolver.java
@@ -78,6 +78,7 @@ public class K8sContainerResolver {
               memoryLimit, e.getMessage()));
     }
     Containers.addRamLimit(container, memoryLimit);
+    Containers.addRamRequest(container, memoryLimit);
   }
 
   private List<ContainerPort> getContainerPorts() {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
@@ -25,7 +25,6 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import java.util.Arrays;
@@ -44,6 +43,7 @@ import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
 
 /**
  * Creates {@link KubernetesEnvironment} with everything needed to deploy Plugin broker.
@@ -143,9 +143,10 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
             .withVolumeMounts(new VolumeMount(CONF_FOLDER + "/", BROKER_VOLUME, true, null))
             .withEnv(envVars.stream().map(this::asEnvVar).collect(toList()))
             .withNewResources()
-            .withLimits(singletonMap("memory", new Quantity("250Mi")))
             .endResources()
             .build();
+    Containers.addRamLimit(container, "250Mi");
+    Containers.addRamRequest(container, "250Mi");
     return new PodBuilder()
         .withNewMetadata()
         .withName(podName)

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisionerTest.java
@@ -28,7 +28,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SecurityCon
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitRequestProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.ServersConverter;
 import org.mockito.InOrder;
@@ -54,7 +54,7 @@ public class KubernetesEnvironmentProvisionerTest {
   @Mock private EnvVarsConverter envVarsProvisioner;
   @Mock private ServersConverter<KubernetesEnvironment> serversProvisioner;
   @Mock private RestartPolicyRewriter restartPolicyRewriter;
-  @Mock private RamLimitProvisioner ramLimitProvisioner;
+  @Mock private RamLimitRequestProvisioner ramLimitProvisioner;
   @Mock private LogsVolumeMachineProvisioner logsVolumeMachineProvisioner;
   @Mock private SecurityContextProvisioner securityContextProvisioner;
   @Mock private PodTerminationGracePeriodProvisioner podTerminationGracePeriodProvisioner;

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/ContainersTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/ContainersTest.java
@@ -154,4 +154,16 @@ public class ContainersTest {
       {"10G", null},
     };
   }
+
+  @Test(dataProvider = "k8sNotionRamLimitProvider")
+  public void testAddContainerRamRequestInK8sNotion(
+      String ramRequest, ResourceRequirements resources) {
+    when(container.getResources()).thenReturn(resources);
+
+    Containers.addRamRequest(container, ramRequest);
+
+    verify(container).setResources(resourceCaptor.capture());
+    ResourceRequirements captured = resourceCaptor.getValue();
+    assertEquals(captured.getRequests().get("memory").getAmount(), ramRequest);
+  }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/K8sContainerResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/K8sContainerResolverTest.java
@@ -86,7 +86,7 @@ public class K8sContainerResolverTest {
   }
 
   @Test(dataProvider = "memLimitResourcesProvider")
-  public void shouldProvisionSidecarMemoryLimit(
+  public void shouldProvisionSidecarMemoryLimitAndRequest(
       String sidecarMemLimit, ResourceRequirements resources) throws Exception {
     cheContainer.setMemoryLimit(sidecarMemLimit);
 
@@ -100,9 +100,9 @@ public class K8sContainerResolverTest {
     return new Object[][] {
       {"", null},
       {null, null},
-      {"123456789", toK8sResources("123456789")},
-      {"1Ki", toK8sResources("1Ki")},
-      {"100M", toK8sResources("100M")},
+      {"123456789", toK8sLimitRequestResources("123456789")},
+      {"1Ki", toK8sLimitRequestResources("1Ki")},
+      {"100M", toK8sLimitRequestResources("100M")},
     };
   }
 
@@ -115,8 +115,11 @@ public class K8sContainerResolverTest {
     resolver.resolve();
   }
 
-  private static ResourceRequirements toK8sResources(String memLimit) {
-    return new ResourceRequirementsBuilder().addToLimits("memory", new Quantity(memLimit)).build();
+  private static ResourceRequirements toK8sLimitRequestResources(String memLimit) {
+    return new ResourceRequirementsBuilder()
+        .addToLimits("memory", new Quantity(memLimit))
+        .addToRequests("memory", new Quantity(memLimit))
+        .build();
   }
 
   private List<EnvVar> toSidecarEnvVars(Map<String, String> envVars) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -26,7 +26,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ProxySettin
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitRequestProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.ServersConverter;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
@@ -51,7 +51,7 @@ public class OpenShiftEnvironmentProvisioner
   private final ServersConverter<OpenShiftEnvironment> serversConverter;
   private final EnvVarsConverter envVarsConverter;
   private final RestartPolicyRewriter restartPolicyRewriter;
-  private final RamLimitProvisioner ramLimitProvisioner;
+  private final RamLimitRequestProvisioner ramLimitProvisioner;
   private final InstallerServersPortProvisioner installerServersPortProvisioner;
   private final LogsVolumeMachineProvisioner logsVolumeMachineProvisioner;
   private final PodTerminationGracePeriodProvisioner podTerminationGracePeriodProvisioner;
@@ -68,7 +68,7 @@ public class OpenShiftEnvironmentProvisioner
       EnvVarsConverter envVarsConverter,
       RestartPolicyRewriter restartPolicyRewriter,
       WorkspaceVolumesStrategy volumesStrategy,
-      RamLimitProvisioner ramLimitProvisioner,
+      RamLimitRequestProvisioner ramLimitProvisioner,
       InstallerServersPortProvisioner installerServersPortProvisioner,
       LogsVolumeMachineProvisioner logsVolumeMachineProvisioner,
       PodTerminationGracePeriodProvisioner podTerminationGracePeriodProvisioner,

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -23,7 +23,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.PodTerminat
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ProxySettingsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitRequestProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.ServersConverter;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
@@ -53,7 +53,7 @@ public class OpenShiftEnvironmentProvisionerTest {
   @Mock private EnvVarsConverter envVarsProvisioner;
   @Mock private ServersConverter<OpenShiftEnvironment> serversProvisioner;
   @Mock private RestartPolicyRewriter restartPolicyRewriter;
-  @Mock private RamLimitProvisioner ramLimitProvisioner;
+  @Mock private RamLimitRequestProvisioner ramLimitProvisioner;
   @Mock private LogsVolumeMachineProvisioner logsVolumeMachineProvisioner;
   @Mock private PodTerminationGracePeriodProvisioner podTerminationGracePeriodProvisioner;
   @Mock private ImagePullSecretProvisioner imagePullSecretProvisioner;


### PR DESCRIPTION
### What does this PR do?
**Why:**
On some infras, default memory request for a container is set. If we try to create a container without memory request set but with memory limit set to a value that is lower than the default (k8s, not Che) memory request pod specification is considered as broken by k8s. 

**What:**
I added setting of memory request at the same places where we are already setting memory limit.  

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11382

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
