### PR TITLE
Fail workspace start if registry not configured and ws.next plugins requested

### DIFF
--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -47,7 +47,7 @@ public final class Constants {
   /**
    * Property name for Che plugin registry url. Key name of api workspace/settings method results.
    */
-  public static final String CHE_WORKSPACE_PLUGIN_REGISTRY_ULR =
+  public static final String CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY =
       "che.workspace.plugin_registry_url";
 
   /** Name for environment variable of machine name */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -18,7 +18,7 @@ import static java.util.stream.Collectors.toList;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
-import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PLUGIN_REGISTRY_ULR;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
@@ -101,7 +101,7 @@ public class WorkspaceService extends Service {
       WorkspaceManager workspaceManager,
       MachineTokenProvider machineTokenProvider,
       WorkspaceLinksGenerator linksGenerator,
-      @Named(CHE_WORKSPACE_PLUGIN_REGISTRY_ULR) @Nullable String pluginRegistryUrl) {
+      @Named(CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY) @Nullable String pluginRegistryUrl) {
     this.apiEndpoint = apiEndpoint;
     this.cheWorkspaceAutoStart = cheWorkspaceAutoStart;
     this.workspaceManager = workspaceManager;

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/PluginMetaRetrieverTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/PluginMetaRetrieverTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server;
+
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.wsplugins.PluginMetaRetriever;
+import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
+import org.eclipse.che.api.workspace.shared.Constants;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Angel Misevski <amisevsk@redhat.com> */
+@Listeners(MockitoTestNGListener.class)
+public class PluginMetaRetrieverTest {
+
+  private static final String REGISTRY_ATTRIBUTE = "plugin-registry";
+
+  @Test(dataProvider = "pluginMetaRetrieverWithAndWithoutRegistry")
+  public void shouldReturnEmptyListWhenAttributesNull(PluginMetaRetriever retriever)
+      throws Exception {
+
+    Collection<PluginMeta> metas = retriever.get(null);
+
+    assertTrue(
+        metas.isEmpty(), "PluginMetaRetriever should return empty list when attributes is null");
+  }
+
+  @Test(dataProvider = "pluginMetaRetrieverWithAndWithoutRegistry")
+  public void shouldReturnEmptyListWhenNoPluginsOrEditors(PluginMetaRetriever retriever)
+      throws Exception {
+    Map<String, String> attributes = Collections.emptyMap();
+
+    Collection<PluginMeta> metas = retriever.get(attributes);
+
+    assertTrue(
+        metas.isEmpty(), "PluginMetaRetriever should return empty list when attributes is empty");
+  }
+
+  @Test(dataProvider = "pluginMetaRetrieverWithAndWithoutRegistry")
+  public void shouldReturnEmptyListWhenPluginsValueEmpty(PluginMetaRetriever retriever)
+      throws Exception {
+    Map<String, String> attributes =
+        ImmutableMap.<String, String>builder()
+            .put(Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE, "")
+            .build();
+
+    Collection<PluginMeta> metas = retriever.get(attributes);
+
+    assertTrue(
+        metas.isEmpty(),
+        "PluginMetaRetriever should return empty list when plugins value is empty");
+  }
+
+  @Test(dataProvider = "pluginMetaRetrieverWithAndWithoutRegistry")
+  public void shouldReturnEmptyListWhenEditorValueEmpty(PluginMetaRetriever retriever)
+      throws Exception {
+    Map<String, String> attributes =
+        ImmutableMap.<String, String>builder()
+            .put(Constants.WORKSPACE_TOOLING_EDITOR_ATTRIBUTE, "")
+            .build();
+
+    Collection<PluginMeta> metas = retriever.get(attributes);
+
+    assertTrue(
+        metas.isEmpty(), "PluginMetaRetriever should return empty list when editor value is empty");
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void shouldThrowExceptionWhenPluginsNotEmptyAndRegistryNotDefined() throws Exception {
+    PluginMetaRetriever pluginMetaRetriever = new PluginMetaRetriever(REGISTRY_ATTRIBUTE);
+    Map<String, String> attributes =
+        ImmutableMap.<String, String>builder()
+            .put(Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE, "plugin1")
+            .build();
+
+    pluginMetaRetriever.get(attributes);
+
+    fail(
+        "PluginMetaRetriever should throw Exception when attributes includes "
+            + "plugins and no registry is defined");
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void shouldThrowExceptionWhenEditorNotEmptyAndRegistryNotDefined() throws Exception {
+    PluginMetaRetriever pluginMetaRetriever = new PluginMetaRetriever(REGISTRY_ATTRIBUTE);
+    Map<String, String> attributes =
+        ImmutableMap.<String, String>builder()
+            .put(Constants.WORKSPACE_TOOLING_EDITOR_ATTRIBUTE, "editor")
+            .build();
+
+    pluginMetaRetriever.get(attributes);
+
+    fail(
+        "PluginMetaRetriever should throw Exception when attributes includes "
+            + "editor and no registry is defined");
+  }
+
+  @DataProvider
+  public Object[][] pluginMetaRetrieverWithAndWithoutRegistry() {
+    return new Object[][] {
+      {new PluginMetaRetriever(REGISTRY_ATTRIBUTE)}, {new PluginMetaRetriever(null)}
+    };
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Fails workspace start if user tries to start workspace with ws.next plugins/editor in Che deployment not configured with plugin registry.

Notes:
- Note: since commit e53b34b2b1, `che.workspace.plugin_registry_url` has default value in `che.properties`, so not configuring plugin registry is pretty hard unless you manually set env var to `NULL`
- If the property is set but registry is not present / url is invalid, an exception is already thrown (due to http error)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11124