### PR TITLE
Make Che Server depending on plugin broker image tag instead of latest

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -504,7 +504,7 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.image=eclipse/che-plugin-broker:latest
+che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.1.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
### What does this PR do?
Make Che Server depending on plugin broker image tag instead of latest version.

It is needed because there may be breaking changes in plugin broker which requires adaptation of Che Server code. And in this case even when two PRs (Che Server and Plugin Broker) are merged in the same time, `nightly` Che Server image will be broker until new image won't be rebuilt because of dependency on `latest` Plugin Broker.

When Che Server depends on tagged Plugin Broker, then PR with adaptation of Che Server will provide needed tag of Plugin Broker.

### What issues does this PR fix or reference?
It is needed before merging of https://github.com/eclipse/che-plugin-broker/pull/12