### PR TITLE
Added publishing of plugin broker logs as runtime logs

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -200,7 +200,7 @@ public class WsMasterModule extends AbstractModule {
         .asEagerSingleton();
     bind(org.eclipse.che.api.workspace.server.event.InstallerLogJsonRpcMessenger.class)
         .asEagerSingleton();
-    bind(org.eclipse.che.api.workspace.server.event.MachineLogJsonRpcMessenger.class)
+    bind(org.eclipse.che.api.workspace.server.event.RuntimeLogJsonRpcMessenger.class)
         .asEagerSingleton();
 
     bind(org.eclipse.che.security.oauth.OAuthAuthenticatorProvider.class)

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -507,7 +507,7 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.1.0
+che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.2.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/dashboard/src/app/factories/load-factory/load-factory.controller.ts
+++ b/dashboard/src/app/factories/load-factory/load-factory.controller.ts
@@ -443,7 +443,7 @@ export class LoadFactoryController {
   getDisplayMachineLog(log: any): string {
     log = angular.fromJson(log);
     if (angular.isObject(log)) {
-      return '[' + log.machineName + '] ' + log.text;
+      return (log.machineName ? '[' + log.machineName + '] ' : '') + log.text;
     } else {
       return log;
     }

--- a/dashboard/src/components/api/json-rpc/che-json-rpc-master-api.ts
+++ b/dashboard/src/components/api/json-rpc/che-json-rpc-master-api.ts
@@ -14,7 +14,7 @@ import {CheJsonRpcApiClient} from './che-json-rpc-api-service';
 import {ICommunicationClient} from './json-rpc-client';
 
 enum MasterChannels {
-  ENVIRONMENT_OUTPUT = <any>'machine/log',
+  ENVIRONMENT_OUTPUT = <any>'runtime/log',
   ENVIRONMENT_STATUS = <any>'machine/statusChanged',
   WS_AGENT_OUTPUT = <any>'installer/log',
   WORKSPACE_STATUS = <any>'workspace/statusChanged',

--- a/deploy/openshift/ocp.sh
+++ b/deploy/openshift/ocp.sh
@@ -318,6 +318,7 @@ parse_args() {
            ;;
            --no-pull)
                export IMAGE_PULL_POLICY=IfNotPresent
+               export CHE_WORKSPACE_PLUGIN__BROKER_PULL__POLICY=IfNotPresent
                shift
            ;;
            --rolling)

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsMasterJsonRpcInitializer.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/jsonrpc/WsMasterJsonRpcInitializer.java
@@ -19,8 +19,8 @@ import static org.eclipse.che.api.workspace.shared.Constants.ERROR_MESSAGE_ATTRI
 import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_ENVIRONMENT_STATUS_CHANNEL;
-import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.RUNTIME_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_EXEC_AGENT_HTTP_REFERENCE;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_TERMINAL_REFERENCE;
@@ -157,7 +157,7 @@ public class WsMasterJsonRpcInitializer {
         WS_MASTER_JSON_RPC_ENDPOINT_ID, MACHINE_STATUS_CHANGED_METHOD, scope);
     subscriptionManagerClient.subscribe(
         WS_MASTER_JSON_RPC_ENDPOINT_ID, SERVER_STATUS_CHANGED_METHOD, scope);
-    subscriptionManagerClient.subscribe(WS_MASTER_JSON_RPC_ENDPOINT_ID, MACHINE_LOG_METHOD, scope);
+    subscriptionManagerClient.subscribe(WS_MASTER_JSON_RPC_ENDPOINT_ID, RUNTIME_LOG_METHOD, scope);
     subscriptionManagerClient.subscribe(
         WS_MASTER_JSON_RPC_ENDPOINT_ID, INSTALLER_LOG_METHOD, scope);
     subscriptionManagerClient.subscribe(
@@ -174,7 +174,7 @@ public class WsMasterJsonRpcInitializer {
     subscriptionManagerClient.unSubscribe(
         WS_MASTER_JSON_RPC_ENDPOINT_ID, SERVER_STATUS_CHANGED_METHOD, scope);
     subscriptionManagerClient.unSubscribe(
-        WS_MASTER_JSON_RPC_ENDPOINT_ID, MACHINE_LOG_METHOD, scope);
+        WS_MASTER_JSON_RPC_ENDPOINT_ID, RUNTIME_LOG_METHOD, scope);
     subscriptionManagerClient.unSubscribe(
         WS_MASTER_JSON_RPC_ENDPOINT_ID, INSTALLER_LOG_METHOD, scope);
     subscriptionManagerClient.unSubscribe(

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
@@ -1325,6 +1325,11 @@ public class ProcessesPanelPresenter extends BasePresenter
   public void printMachineOutput(final String machineName, final String text) {
     // Create a temporary machine node to display outputs.
 
+    if (machineName == null) {
+      // runtime log. Should not be printed as machine output
+      return;
+    }
+
     if (!consoles.containsKey(machineName)) {
       provideMachineNode(machineName, true, false);
     }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/events/RuntimeLogHandler.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/events/RuntimeLogHandler.java
@@ -11,24 +11,24 @@
  */
 package org.eclipse.che.ide.workspace.events;
 
-import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_LOG_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.RUNTIME_LOG_METHOD;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
-import org.eclipse.che.api.workspace.shared.dto.event.MachineLogEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.RuntimeLogEvent;
 import org.eclipse.che.ide.processes.panel.EnvironmentOutputEvent;
 
 @Singleton
-class MachineLogHandler {
+class RuntimeLogHandler {
 
   @Inject
-  MachineLogHandler(RequestHandlerConfigurator configurator, EventBus eventBus) {
+  RuntimeLogHandler(RequestHandlerConfigurator configurator, EventBus eventBus) {
     configurator
         .newConfiguration()
-        .methodName(MACHINE_LOG_METHOD)
-        .paramsAsDto(MachineLogEvent.class)
+        .methodName(RUNTIME_LOG_METHOD)
+        .paramsAsDto(RuntimeLogEvent.class)
         .noResult()
         .withBiConsumer(
             (endpointId, log) ->

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/events/WorkspaceEventsModule.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/workspace/events/WorkspaceEventsModule.java
@@ -23,6 +23,6 @@ public class WorkspaceEventsModule extends AbstractGinModule {
 
     bind(InstallerLogHandler.class).asEagerSingleton();
     bind(InstallerStatusEventHandler.class).asEagerSingleton();
-    bind(MachineLogHandler.class).asEagerSingleton();
+    bind(RuntimeLogHandler.class).asEagerSingleton();
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/logs/MachineLoggersFactory.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/logs/MachineLoggersFactory.java
@@ -21,7 +21,7 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.DtoConverter;
-import org.eclipse.che.api.workspace.shared.dto.event.MachineLogEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.RuntimeLogEvent;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.infrastructure.docker.client.LogMessage;
 import org.eclipse.che.infrastructure.docker.client.MessageProcessor;
@@ -102,7 +102,7 @@ public class MachineLoggersFactory {
     }
   }
 
-  /** Forms new instance of {@link MachineLogEvent} and publish it via {@link EventService}. */
+  /** Forms new instance of {@link RuntimeLogEvent} and publish it via {@link EventService}. */
   private class MachineLogsBiConsumer implements BiConsumer<String, String> {
 
     private final String machineName;
@@ -116,7 +116,7 @@ public class MachineLoggersFactory {
     @Override
     public void accept(String stream, String text) {
       eventService.publish(
-          DtoFactory.newDto(MachineLogEvent.class)
+          DtoFactory.newDto(RuntimeLogEvent.class)
               .withRuntimeId(DtoConverter.asDto(runtime))
               .withStream(stream)
               .withText(text)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -772,7 +772,7 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
             machines.getMachines(getContext().getIdentity()).entrySet()) {
           final KubernetesMachineImpl machine = entry.getValue();
           if (machine.getPodName().equals(podName)) {
-            eventPublisher.sendMachineLogEnvent(
+            eventPublisher.sendMachineLogEvent(
                 entry.getKey(),
                 event.getMessage(),
                 event.getCreationTimeStamp(),

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
@@ -29,7 +29,7 @@ import org.eclipse.che.api.workspace.server.DtoConverter;
 import org.eclipse.che.api.workspace.server.bootstrap.AbstractBootstrapper;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
-import org.eclipse.che.api.workspace.shared.dto.event.MachineLogEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.RuntimeLogEvent;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesMachineImpl;
@@ -143,7 +143,7 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
     final BiConsumer<String, String> outputConsumer =
         (stream, text) ->
             eventService.publish(
-                DtoFactory.newDto(MachineLogEvent.class)
+                DtoFactory.newDto(RuntimeLogEvent.class)
                     .withRuntimeId(runtimeIdentityDto)
                     .withStream(stream)
                     .withText(text)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/RuntimeEventsPublisher.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/RuntimeEventsPublisher.java
@@ -19,8 +19,8 @@ import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.DtoConverter;
-import org.eclipse.che.api.workspace.shared.dto.event.MachineLogEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.RuntimeLogEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.RuntimeStatusEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.ServerStatusEvent;
 import org.eclipse.che.dto.server.DtoFactory;
@@ -96,10 +96,10 @@ public class RuntimeEventsPublisher {
             .withServerUrl(serverUrl));
   }
 
-  public void sendMachineLogEnvent(
+  public void sendMachineLogEvent(
       String machineName, String text, String time, RuntimeIdentity runtimeId) {
     eventService.publish(
-        DtoFactory.newDto(MachineLogEvent.class)
+        DtoFactory.newDto(RuntimeLogEvent.class)
             .withMachineName(machineName)
             .withRuntimeId(DtoConverter.asDto(runtimeId))
             .withText(text)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerEvent.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerEvent.java
@@ -13,9 +13,10 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.events;
 
 import com.google.common.annotations.Beta;
 import java.util.List;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
 import org.eclipse.che.api.workspace.shared.dto.BrokerStatus;
-import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.BrokerStatusChangedEvent;
 
 /**
  * Event sent by a plugin broker with results of broker invocation.
@@ -30,7 +31,7 @@ import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
 @Beta
 public class BrokerEvent {
   private BrokerStatus status;
-  private String workspaceId;
+  private RuntimeIdentity runtimeId;
   private String error;
   private List<ChePlugin> tooling;
 
@@ -40,7 +41,7 @@ public class BrokerEvent {
   public BrokerEvent(BrokerStatusChangedEvent resultEvent, List<ChePlugin> tooling) {
     this.error = resultEvent.getError();
     this.status = resultEvent.getStatus();
-    this.workspaceId = resultEvent.getWorkspaceId();
+    this.runtimeId = resultEvent.getRuntimeId();
     this.tooling = tooling;
   }
 
@@ -53,12 +54,12 @@ public class BrokerEvent {
     return this;
   }
 
-  public String getWorkspaceId() {
-    return workspaceId;
+  public RuntimeIdentity getRuntimeId() {
+    return runtimeId;
   }
 
-  public BrokerEvent withWorkspaceId(String workspaceId) {
-    this.workspaceId = workspaceId;
+  public BrokerEvent withRuntimeId(RuntimeIdentity runtimeId) {
+    this.runtimeId = runtimeId;
     return this;
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerService.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerService.java
@@ -22,10 +22,14 @@ import java.util.List;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
-import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.BrokerLogEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.BrokerStatusChangedEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.RuntimeLogEvent;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.dto.server.DtoFactory;
 import org.slf4j.Logger;
 
 /**
@@ -44,6 +48,7 @@ public class BrokerService {
 
   public static final String BROKER_RESULT_METHOD = "broker/result";
   public static final String BROKER_STATUS_CHANGED_METHOD = "broker/statusChanged";
+  public static final String BROKER_LOG_METHOD = "broker/log";
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final EventService eventService;
@@ -68,12 +73,28 @@ public class BrokerService {
         .paramsAsDto(BrokerStatusChangedEvent.class)
         .noResult()
         .withConsumer(this::handle);
+
+    requestHandler
+        .newConfiguration()
+        .methodName(BROKER_LOG_METHOD)
+        .paramsAsDto(BrokerLogEvent.class)
+        .noResult()
+        .withConsumer(this::handle);
+  }
+
+  private void handle(BrokerLogEvent brokerLogEvent) {
+    eventService.publish(
+        DtoFactory.newDto(RuntimeLogEvent.class)
+            .withRuntimeId(brokerLogEvent.getRuntimeId())
+            .withText(brokerLogEvent.getText())
+            .withTime(brokerLogEvent.getTime()));
   }
 
   private void handle(BrokerStatusChangedEvent event) {
     // Tooling has fields that can't be parsed by DTO and JSON_RPC framework works with DTO only
     String encodedTooling = event.getTooling();
-    if (event.getStatus() == null || event.getWorkspaceId() == null) {
+    RuntimeIdentity runtimeId = event.getRuntimeId();
+    if (event.getStatus() == null || runtimeId == null || runtimeId.getWorkspaceId() == null) {
       LOG.error("Broker event skipped due to illegal content: {}", event);
       return;
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListener.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListener.java
@@ -42,7 +42,8 @@ public class BrokerStatusListener implements EventSubscriber<BrokerEvent> {
 
   @Override
   public void onEvent(BrokerEvent event) {
-    if (!workspaceId.equals(event.getWorkspaceId())) {
+    if (event.getRuntimeId() == null
+        || !workspaceId.equals(event.getRuntimeId().getWorkspaceId())) {
       return;
     }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -99,8 +99,8 @@ import org.eclipse.che.api.workspace.server.spi.RuntimeStartInterruptedException
 import org.eclipse.che.api.workspace.server.spi.StateException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
-import org.eclipse.che.api.workspace.shared.dto.event.MachineLogEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.RuntimeLogEvent;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime.MachineLogsPublisher;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapper;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
@@ -478,15 +478,15 @@ public class KubernetesInternalRuntimeTest {
             "image pulled",
             EVENT_CREATION_TIMESTAMP,
             getCurrentTimestampWithOneHourShiftAhead());
-    final ArgumentCaptor<MachineLogEvent> captor = ArgumentCaptor.forClass(MachineLogEvent.class);
+    final ArgumentCaptor<RuntimeLogEvent> captor = ArgumentCaptor.forClass(RuntimeLogEvent.class);
 
     internalRuntime.doStartMachine(kubernetesServerResolver);
     logsPublisher.handle(out1);
     logsPublisher.handle(out2);
 
     verify(eventService, atLeastOnce()).publish(captor.capture());
-    final ImmutableList<MachineLogEvent> machineLogs =
-        ImmutableList.of(asMachineLogEvent(out1), asMachineLogEvent(out2));
+    final ImmutableList<RuntimeLogEvent> machineLogs =
+        ImmutableList.of(asRuntimeLogEvent(out1), asRuntimeLogEvent(out2));
 
     assertTrue(captor.getAllValues().containsAll(machineLogs));
   }
@@ -837,8 +837,8 @@ public class KubernetesInternalRuntimeTest {
     return event;
   }
 
-  private static MachineLogEvent asMachineLogEvent(PodEvent event) {
-    return newDto(MachineLogEvent.class)
+  private static RuntimeLogEvent asRuntimeLogEvent(PodEvent event) {
+    return newDto(RuntimeLogEvent.class)
         .withRuntimeId(DtoConverter.asDto(IDENTITY))
         .withText(event.getMessage())
         .withTime(event.getCreationTimeStamp())

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
@@ -49,7 +50,20 @@ public class BrokerStatusListenerTest {
   @Test
   public void shouldDoNothingIfEventWithForeignWorkspaceIdIsReceived() {
     // given
-    BrokerEvent event = new BrokerEvent().withWorkspaceId("foreignWorkspace");
+    BrokerEvent event =
+        new BrokerEvent().withRuntimeId(new RuntimeIdentityImpl("foreignWorkspace", null, null));
+
+    // when
+    brokerStatusListener.onEvent(event);
+
+    // then
+    verifyNoMoreInteractions(finishFuture);
+  }
+
+  @Test
+  public void shouldDoNothingIfEventWithoutRuntimeIdentityIsReceived() {
+    // given
+    BrokerEvent event = new BrokerEvent().withRuntimeId(null);
 
     // when
     brokerStatusListener.onEvent(event);
@@ -63,7 +77,7 @@ public class BrokerStatusListenerTest {
     // given
     BrokerEvent event =
         new BrokerEvent()
-            .withWorkspaceId(WORKSPACE_ID)
+            .withRuntimeId(new RuntimeIdentityImpl(WORKSPACE_ID, null, null))
             .withStatus(BrokerStatus.DONE)
             .withTooling(emptyList());
 
@@ -79,7 +93,7 @@ public class BrokerStatusListenerTest {
     // given
     BrokerEvent event =
         new BrokerEvent()
-            .withWorkspaceId(WORKSPACE_ID)
+            .withRuntimeId(new RuntimeIdentityImpl(WORKSPACE_ID, null, null))
             .withStatus(BrokerStatus.DONE)
             .withTooling(null);
 
@@ -95,7 +109,7 @@ public class BrokerStatusListenerTest {
     // given
     BrokerEvent event =
         new BrokerEvent()
-            .withWorkspaceId(WORKSPACE_ID)
+            .withRuntimeId(new RuntimeIdentityImpl(WORKSPACE_ID, null, null))
             .withStatus(BrokerStatus.FAILED)
             .withError("error");
 

--- a/multiuser/permission/che-multiuser-permission-infra-kubernetes/src/main/java/org/eclipse/che/multiuser/permission/workspace/infra/kubernetes/BrokerServicePermissionFilter.java
+++ b/multiuser/permission/che-multiuser-permission-infra-kubernetes/src/main/java/org/eclipse/che/multiuser/permission/workspace/infra/kubernetes/BrokerServicePermissionFilter.java
@@ -18,7 +18,8 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerManager;
-import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
+import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
+import org.eclipse.che.api.workspace.shared.dto.event.BrokerStatusChangedEvent;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.multiuser.api.permission.server.jsonrpc.JsonRpcPermissionsFilterAdapter;
@@ -44,7 +45,11 @@ public class BrokerServicePermissionFilter extends JsonRpcPermissionsFilterAdapt
     switch (method) {
       case BROKER_STATUS_CHANGED_METHOD:
       case BROKER_RESULT_METHOD:
-        workspaceId = ((BrokerStatusChangedEvent) params[0]).getWorkspaceId();
+        RuntimeIdentityDto runtimeId = ((BrokerStatusChangedEvent) params[0]).getRuntimeId();
+        if (runtimeId == null || runtimeId.getWorkspaceId() == null) {
+          throw new ForbiddenException("Workspace id must be specified");
+        }
+        workspaceId = runtimeId.getWorkspaceId();
         break;
       default:
         throw new ForbiddenException("Unknown method is configured to be filtered.");

--- a/multiuser/permission/che-multiuser-permission-infra-kubernetes/src/test/java/org/eclipse/che/multiuser/permission/workspace/infra/kubernetes/BrokerServicePermissionFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-infra-kubernetes/src/test/java/org/eclipse/che/multiuser/permission/workspace/infra/kubernetes/BrokerServicePermissionFilterTest.java
@@ -18,7 +18,8 @@ import static org.mockito.Mockito.when;
 
 import org.eclipse.che.api.core.ForbiddenException;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerManager;
-import org.eclipse.che.api.workspace.shared.dto.BrokerStatusChangedEvent;
+import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
+import org.eclipse.che.api.workspace.shared.dto.event.BrokerStatusChangedEvent;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.dto.server.DtoFactory;
@@ -78,7 +79,9 @@ public class BrokerServicePermissionFilterTest {
 
     // when
     permissionFilter.doAccept(
-        method, DtoFactory.newDto(BrokerStatusChangedEvent.class).withWorkspaceId("ws123"));
+        method,
+        DtoFactory.newDto(BrokerStatusChangedEvent.class)
+            .withRuntimeId(DtoFactory.newDto(RuntimeIdentityDto.class).withWorkspaceId("ws123")));
   }
 
   @Test(dataProvider = "coveredMethods")
@@ -89,7 +92,9 @@ public class BrokerServicePermissionFilterTest {
 
     // when
     permissionFilter.doAccept(
-        method, DtoFactory.newDto(BrokerStatusChangedEvent.class).withWorkspaceId("ws123"));
+        method,
+        DtoFactory.newDto(BrokerStatusChangedEvent.class)
+            .withRuntimeId(DtoFactory.newDto(RuntimeIdentityDto.class).withWorkspaceId("ws123")));
   }
 
   @Test(
@@ -98,7 +103,9 @@ public class BrokerServicePermissionFilterTest {
   public void shouldThrowExceptionIfUnknownMethodIsInvoking() throws Exception {
     // when
     permissionFilter.doAccept(
-        "unknown", DtoFactory.newDto(BrokerStatusChangedEvent.class).withWorkspaceId("ws123"));
+        "unknown",
+        DtoFactory.newDto(BrokerStatusChangedEvent.class)
+            .withRuntimeId(DtoFactory.newDto(RuntimeIdentityDto.class).withWorkspaceId("ws123")));
   }
 
   @DataProvider

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspaceRemoteSubscriptionPermissionFilter.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspaceRemoteSubscriptionPermissionFilter.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_LOG_METHO
 import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.RUNTIME_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STATUS_CHANGED_METHOD;
 
@@ -45,6 +46,7 @@ public class WorkspaceRemoteSubscriptionPermissionFilter
         WORKSPACE_STATUS_CHANGED_METHOD,
         MACHINE_STATUS_CHANGED_METHOD,
         SERVER_STATUS_CHANGED_METHOD,
+        RUNTIME_LOG_METHOD,
         MACHINE_LOG_METHOD,
         INSTALLER_LOG_METHOD,
         INSTALLER_STATUS_CHANGED_METHOD,

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspaceRemoteSubscriptionPermissionFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/filters/WorkspaceRemoteSubscriptionPermissionFilterTest.java
@@ -16,8 +16,10 @@ import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_LOG_METHO
 import static org.eclipse.che.api.workspace.shared.Constants.INSTALLER_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.MACHINE_STATUS_CHANGED_METHOD;
+import static org.eclipse.che.api.workspace.shared.Constants.RUNTIME_LOG_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.SERVER_STATUS_CHANGED_METHOD;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_STATUS_CHANGED_METHOD;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
@@ -65,15 +67,17 @@ public class WorkspaceRemoteSubscriptionPermissionFilterTest {
     permissionFilter.register(permissionManager);
 
     // then
-    permissionManager.registerCheck(
-        permissionFilter,
-        WORKSPACE_STATUS_CHANGED_METHOD,
-        MACHINE_STATUS_CHANGED_METHOD,
-        SERVER_STATUS_CHANGED_METHOD,
-        MACHINE_LOG_METHOD,
-        INSTALLER_LOG_METHOD,
-        INSTALLER_STATUS_CHANGED_METHOD,
-        BOOTSTRAPPER_STATUS_CHANGED_METHOD);
+    verify(permissionManager)
+        .registerCheck(
+            permissionFilter,
+            WORKSPACE_STATUS_CHANGED_METHOD,
+            MACHINE_STATUS_CHANGED_METHOD,
+            SERVER_STATUS_CHANGED_METHOD,
+            RUNTIME_LOG_METHOD,
+            MACHINE_LOG_METHOD,
+            INSTALLER_LOG_METHOD,
+            INSTALLER_STATUS_CHANGED_METHOD,
+            BOOTSTRAPPER_STATUS_CHANGED_METHOD);
   }
 
   @Test(

--- a/workspace-loader/src/json-rpc/che-json-rpc-master-api.ts
+++ b/workspace-loader/src/json-rpc/che-json-rpc-master-api.ts
@@ -14,7 +14,7 @@ import {CheJsonRpcApiClient} from './che-json-rpc-api-service';
 import { ICommunicationClient, CODE_REQUEST_TIMEOUT, CommunicationClientEvent } from './json-rpc-client';
 
 enum MasterChannels {
-  ENVIRONMENT_OUTPUT = <any>'machine/log',
+  ENVIRONMENT_OUTPUT = <any>'runtime/log',
   ENVIRONMENT_STATUS = <any>'machine/statusChanged',
   WS_AGENT_OUTPUT = <any>'installer/log',
   WORKSPACE_STATUS = <any>'workspace/statusChanged'

--- a/wsmaster/che-core-api-logger/src/main/java/org/eclipse/che/api/logger/ErrorRuntimeLogEventLogger.java
+++ b/wsmaster/che-core-api-logger/src/main/java/org/eclipse/che/api/logger/ErrorRuntimeLogEventLogger.java
@@ -18,31 +18,31 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.core.notification.EventSubscriber;
 import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
-import org.eclipse.che.api.workspace.shared.dto.event.MachineLogEvent;
+import org.eclipse.che.api.workspace.shared.dto.event.RuntimeLogEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The goal of this class is to catch all MachineLogEvent events from error stream and dump them to
+ * The goal of this class is to catch all RuntimeLogEvent events from error stream and dump them to
  * slf4j log.
  */
 @Singleton
-public class ErrorMachineLogEventLogger implements EventSubscriber<MachineLogEvent> {
+public class ErrorRuntimeLogEventLogger implements EventSubscriber<RuntimeLogEvent> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ErrorMachineLogEventLogger.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ErrorRuntimeLogEventLogger.class);
 
   @Inject
   public void subscribe(EventService eventService) {
-    eventService.subscribe(this, MachineLogEvent.class);
+    eventService.subscribe(this, RuntimeLogEvent.class);
   }
 
   @Override
-  public void onEvent(MachineLogEvent event) {
+  public void onEvent(RuntimeLogEvent event) {
     if ("stderr".equalsIgnoreCase(event.getStream()) && !isNullOrEmpty(event.getText())) {
       RuntimeIdentityDto identity = event.getRuntimeId();
       LOG.error(
-          "Machine `{}` error from owner=`{}` env=`{}` workspace=`{}` text=`{}` time=`{}`",
-          event.getMachineName(),
+          "{} error from owner=`{}` env=`{}` workspace=`{}` text=`{}` time=`{}`",
+          event.getMachineName() != null ? "Machine `" + event.getMachineName() + "`" : "Runtime",
           identity.getOwnerId(),
           identity.getEnvName(),
           identity.getWorkspaceId(),

--- a/wsmaster/che-core-api-logger/src/main/java/org/eclipse/che/api/logger/deploy/LoggerModule.java
+++ b/wsmaster/che-core-api-logger/src/main/java/org/eclipse/che/api/logger/deploy/LoggerModule.java
@@ -13,13 +13,13 @@ package org.eclipse.che.api.logger.deploy;
 
 import com.google.inject.AbstractModule;
 import org.eclipse.che.api.logger.ErrorInstallerLogEventLogger;
-import org.eclipse.che.api.logger.ErrorMachineLogEventLogger;
+import org.eclipse.che.api.logger.ErrorRuntimeLogEventLogger;
 
 public class LoggerModule extends AbstractModule {
   @Override
   protected void configure() {
     bind(org.eclipse.che.api.logger.LoggerService.class);
     bind(ErrorInstallerLogEventLogger.class).asEagerSingleton();
-    bind(ErrorMachineLogEventLogger.class).asEagerSingleton();
+    bind(ErrorRuntimeLogEventLogger.class).asEagerSingleton();
   }
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -133,7 +133,16 @@ public final class Constants {
   public static final String WORKSPACE_STATUS_CHANGED_METHOD = "workspace/statusChanged";
   public static final String MACHINE_STATUS_CHANGED_METHOD = "machine/statusChanged";
   public static final String SERVER_STATUS_CHANGED_METHOD = "server/statusChanged";
-  public static final String MACHINE_LOG_METHOD = "machine/log";
+
+  public static final String RUNTIME_LOG_METHOD = "runtime/log";
+
+  /**
+   * JSON RPC methods for listening to machine logs.
+   *
+   * @deprecated use {@link #RUNTIME_LOG_METHOD} instead
+   */
+  @Deprecated public static final String MACHINE_LOG_METHOD = "machine/log";
+
   public static final String INSTALLER_LOG_METHOD = "installer/log";
   public static final String INSTALLER_STATUS_CHANGED_METHOD = "installer/statusChanged";
   public static final String BOOTSTRAPPER_STATUS_CHANGED_METHOD = "bootstrapper/statusChanged";

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/BrokerLogEvent.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/BrokerLogEvent.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.shared.dto.event;
+
+import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
+import org.eclipse.che.dto.shared.DTO;
+
+/** @author Sergii Leshchenko */
+@DTO
+public interface BrokerLogEvent {
+
+  /** Returns the contents of the log event. */
+  String getText();
+
+  void setText(String text);
+
+  BrokerLogEvent withText(String text);
+
+  /** Returns runtime identity. */
+  RuntimeIdentityDto getRuntimeId();
+
+  void setRuntimeId(RuntimeIdentityDto runtimeId);
+
+  BrokerLogEvent withRuntimeId(RuntimeIdentityDto runtimeId);
+
+  /** Returns time in format '2017-06-27T17:11:09.306+03:00' */
+  String getTime();
+
+  void setTime(String time);
+
+  BrokerLogEvent withTime(String time);
+}

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/BrokerStatusChangedEvent.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/BrokerStatusChangedEvent.java
@@ -9,8 +9,10 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.api.workspace.shared.dto;
+package org.eclipse.che.api.workspace.shared.dto.event;
 
+import org.eclipse.che.api.workspace.shared.dto.BrokerStatus;
+import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
 import org.eclipse.che.dto.shared.DTO;
 
 /**
@@ -29,10 +31,10 @@ public interface BrokerStatusChangedEvent {
 
   BrokerStatusChangedEvent withStatus(BrokerStatus status);
 
-  /** ID of a workspace this event is related to. */
-  String getWorkspaceId();
+  /** Returns identity of runtime to which broker belongs t. */
+  RuntimeIdentityDto getRuntimeId();
 
-  BrokerStatusChangedEvent withWorkspaceId(String workspaceId);
+  BrokerStatusChangedEvent withRuntimeId(RuntimeIdentityDto runtimeId);
 
   /**
    * Error message that explains the reason of the broker process failure.

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/RuntimeLogEvent.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/event/RuntimeLogEvent.java
@@ -12,50 +12,56 @@
 package org.eclipse.che.api.workspace.shared.dto.event;
 
 import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.dto.shared.DTO;
 
 /**
- * Defines event format for machine logs.
+ * Defines event format for runtime logs.
  *
- * @author Anton Korneta
- * @deprecated use {@link RuntimeLogEvent} instead
+ * @author Sergii Leshchenko
  */
 @DTO
-@Deprecated
-public interface MachineLogEvent {
+public interface RuntimeLogEvent {
 
   /** Returns the contents of the log event. */
   String getText();
 
   void setText(String text);
 
-  MachineLogEvent withText(String text);
-
-  /** Returns the name of the machine that produces the logs. */
-  String getMachineName();
-
-  void setMachineName(String machineName);
-
-  MachineLogEvent withMachineName(String machineName);
+  RuntimeLogEvent withText(String text);
 
   /** Returns runtime identity. */
   RuntimeIdentityDto getRuntimeId();
 
   void setRuntimeId(RuntimeIdentityDto runtimeId);
 
-  MachineLogEvent withRuntimeId(RuntimeIdentityDto runtimeId);
+  RuntimeLogEvent withRuntimeId(RuntimeIdentityDto runtimeId);
+
+  /**
+   * Returns the name of the machine that produces the logs.
+   *
+   * <p>May return null when log is produced by process which doesn't belong to any particular
+   * machine.
+   */
+  @Nullable
+  String getMachineName();
+
+  void setMachineName(String machineName);
+
+  RuntimeLogEvent withMachineName(String machineName);
 
   /** Returns time in format '2017-06-27T17:11:09.306+03:00' */
   String getTime();
 
   void setTime(String time);
 
-  MachineLogEvent withTime(String time);
+  RuntimeLogEvent withTime(String time);
 
   /** Returns standard streams, if present otherwise, null will be returned. */
+  @Nullable
   String getStream();
 
   void setStream(String stream);
 
-  MachineLogEvent withStream(String stream);
+  RuntimeLogEvent withStream(String stream);
 }


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is adding publishing of plugin broker logs as runtime logs.
To achieve it there are several commits:
- Introduced new event `RuntimeLogEvent` instead of `MachineLogEvent`. New event can be used to publish machine related log or machine independent log (like Plugin Broker). There is optional field `machineName` that indicates whether the event is machine related;
- Add RuntimeId to plugin broker events instead of workspace id field. It is needed to publish `PluginBrokerEvent` as `RuntimeLogEvent`;
- Make Che Server listen to broker log and republish it as runtime log;
- Make Workspace Loader listen to runtime log instead of machine log;
- Adapt GWT IDE to RuntimeLogEvent changes;

Dashboard is not adapted and it still uses deprecated `machine/log` JSON RPC method. A separated issue will be created for it.

Here is an example of how:

Workspace Loader displays Plugin Broker logs
![screenshot_20181001_155728](https://user-images.githubusercontent.com/5887312/46289944-27005e00-c593-11e8-995e-da4159fc72f0.png)

Dashboard displays Plugin Broker logs
![screenshot_20181003_154415](https://user-images.githubusercontent.com/5887312/46411064-7ecdcf00-c723-11e8-8fb6-ea75621b8e1c.png)

#### Minor improvements
- to make plugin broker testing easier there is commit that sets Plugin Broker pull policy according to parameter;

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11069


#### Release Notes
N/A


#### Docs PR
N/A