### PR TITLE
Fixed `exec`, `terminal` sidecars

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -49,6 +49,7 @@ import org.eclipse.che.api.workspace.server.WorkspaceStatusCache;
 import org.eclipse.che.api.workspace.server.hc.ServersCheckerFactory;
 import org.eclipse.che.api.workspace.server.spi.provision.InstallerConfigProvisioner;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
+import org.eclipse.che.api.workspace.server.spi.provision.MachineNameProvisioner;
 import org.eclipse.che.api.workspace.server.spi.provision.ProjectsVolumeForWsAgentProvisioner;
 import org.eclipse.che.api.workspace.server.spi.provision.env.AgentAuthEnableEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.CheApiEnvVarProvider;
@@ -165,6 +166,7 @@ public class WsMasterModule extends AbstractModule {
     internalEnvironmentProvisioners.addBinding().to(InstallerConfigProvisioner.class);
     internalEnvironmentProvisioners.addBinding().to(EnvVarEnvironmentProvisioner.class);
     internalEnvironmentProvisioners.addBinding().to(ProjectsVolumeForWsAgentProvisioner.class);
+    internalEnvironmentProvisioners.addBinding().to(MachineNameProvisioner.class);
 
     Multibinder<EnvVarProvider> envVarProviders =
         Multibinder.newSetBinder(binder(), EnvVarProvider.class);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.api.workspace.server.spi.environment;
 
-import static org.eclipse.che.api.workspace.shared.Constants.CHE_MACHINE_NAME_ENV_VAR;
-
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,8 +28,6 @@ import org.eclipse.che.api.installer.server.exception.InstallerException;
 import org.eclipse.che.api.installer.shared.model.Installer;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Creates a valid instance of InternalEnvironment.
@@ -48,8 +44,6 @@ import org.slf4j.LoggerFactory;
  * @author Sergii Leshchenko
  */
 public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(InternalEnvironmentFactory.class);
 
   private final InstallerRegistry installerRegistry;
   private final RecipeRetriever recipeRetriever;
@@ -101,8 +95,6 @@ public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> 
       } catch (InstallerException e) {
         throw new InfrastructureException(e);
       }
-
-      machineConfig.getEnv().put(CHE_MACHINE_NAME_ENV_VAR, machineEntry.getKey());
 
       machines.put(
           machineEntry.getKey(),

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/MachineNameProvisioner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/MachineNameProvisioner.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.spi.provision;
+
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_MACHINE_NAME_ENV_VAR;
+
+import java.util.Map.Entry;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+
+/**
+ * Provisions environment variable with machine name into each machine.
+ *
+ * @author Sergii Leshchenko
+ */
+public class MachineNameProvisioner implements InternalEnvironmentProvisioner {
+
+  @Override
+  public void provision(RuntimeIdentity id, InternalEnvironment internalEnvironment)
+      throws InfrastructureException {
+    for (Entry<String, InternalMachineConfig> machineEntry :
+        internalEnvironment.getMachines().entrySet()) {
+      machineEntry.getValue().getEnv().put(CHE_MACHINE_NAME_ENV_VAR, machineEntry.getKey());
+    }
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactoryTest.java
@@ -16,7 +16,6 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
-import static org.eclipse.che.api.workspace.shared.Constants.CHE_MACHINE_NAME_ENV_VAR;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -60,8 +59,6 @@ import org.testng.annotations.Test;
  */
 @Listeners(MockitoTestNGListener.class)
 public class InternalEnvironmentFactoryTest {
-
-  public static final long RAM_LIMIT = 3072;
 
   @Mock private InstallerRegistry installerRegistry;
   @Mock private RecipeRetriever recipeRetriever;
@@ -116,27 +113,6 @@ public class InternalEnvironmentFactoryTest {
     verify(environmentFactory).doCreate(any(), machinesCaptor.capture(), any());
     Map<String, InternalMachineConfig> internalMachines = machinesCaptor.getValue();
     assertEquals(internalMachines.get("machine").getInstallers(), installersToRetrieve);
-  }
-
-  @Test
-  public void shouldAddMachineNameToEnvironmentVariablesDuringInternalEnvironmentCreation()
-      throws Exception {
-    // given
-    MachineConfigImpl machineConfig = new MachineConfigImpl().withEnv(new HashMap<>());
-    EnvironmentImpl env =
-        new EnvironmentImpl(
-            null, ImmutableMap.of("machine1", machineConfig, "machine2", machineConfig));
-
-    // when
-    environmentFactory.create(env);
-
-    // then
-    verify(environmentFactory).doCreate(any(), machinesCaptor.capture(), any());
-    Map<String, InternalMachineConfig> internalMachines = machinesCaptor.getValue();
-    assertEquals(
-        internalMachines.get("machine1").getEnv().get(CHE_MACHINE_NAME_ENV_VAR), "machine1");
-    assertEquals(
-        internalMachines.get("machine2").getEnv().get(CHE_MACHINE_NAME_ENV_VAR), "machine2");
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
It contains two different fixes that are needed to make `exec` and `terminal` sidecars working with sidecars containers on local OCP when oauth provider is configured:
1. Previously, role bindings were created with a wrong service account names `che-workspace-exec` and `che-workspace-view`. This PR fixes name to right one which is `che-workspace` and replaces `create if doesn't exist` with `create or replace` to update wrong create role bindings.
2. `exec`/`terminal` sidecar matches container to Che Machine by `WORKSPACE_ID` label in pod and `CHE_MACHINE_NAME` environment variable in container. But previously Che Server provisioned `CHE_MACHINE_NAME` env var into machines that are described in a recipe. Now, all machines(including those ones that are provided by Che Plugins) will be provisioned with `CHE_MACHINE_NAME` env var.

### What issues does this PR fix or reference?
It fixes changes introduced in https://github.com/eclipse/che/pull/11199.
https://github.com/eclipse/che/issues/10991

#### Release Notes
N/A

#### Docs PR
N/A