### PR TITLE
Selenium: Change the timeout in the 'openItemByPath()' from the 'ProjectExplorer'

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -547,7 +547,7 @@ public class ProjectExplorer {
           waitAndSelectItem(path);
           waitItemIsSelected(path);
         },
-        LOAD_PAGE_TIMEOUT_SEC,
+        (EXPECTED_MESS_IN_CONSOLE_SEC + ELEMENT_TIMEOUT_SEC) * 2,
         NoSuchElementException.class);
 
     seleniumWebDriverHelper.waitNoExceptions(


### PR DESCRIPTION
### What does this PR do?
* Change the timeout in the _openItemByPath()_  from the _ProjectExplorer_ to avoid the _'NoSuchElementException'_

### What issues does this PR fix or reference?
#11373
