### PR TITLE
Don't stop workspace recovery when error is encountered

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -531,7 +531,7 @@ public class WorkspaceRuntimes {
       return;
     } catch (InfrastructureException e) {
       LOG.error(
-          "An error occurred while attempted to recover runtimes using infrastructure '{}'. Reason: '{}'",
+          "An error occurred while attempting to get runtime identities for infrastructure '{}'. Reason: '{}'",
           infrastructure.getName(),
           e.getMessage());
       return;
@@ -542,7 +542,7 @@ public class WorkspaceRuntimes {
         recoverOne(infrastructure, identity);
       } catch (ServerException | ConflictException e) {
         LOG.error(
-            "An error occurred while attempted to recover runtimes using infrastructure '{}'. Reason: '{}'",
+            "An error occurred while attempting to recover runtimes using infrastructure '{}'. Reason: '{}'",
             infrastructure.getName(),
             e.getMessage());
       }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -523,23 +523,29 @@ public class WorkspaceRuntimes {
       LOG.warn("Recovery of the workspaces is rejected.");
       return;
     }
+    Set<RuntimeIdentity> identities;
     try {
-      for (RuntimeIdentity identity : infrastructure.getIdentities()) {
-        recoverOne(infrastructure, identity);
-      }
-    } catch (UnsupportedOperationException x) {
+      identities = infrastructure.getIdentities();
+    } catch (UnsupportedOperationException e) {
       LOG.warn("Not recoverable infrastructure: '{}'", infrastructure.getName());
-    } catch (InternalInfrastructureException x) {
-      LOG.error(
-          format(
-              "An error occurred while attempted to recover runtimes using infrastructure '%s'",
-              infrastructure.getName()),
-          x);
-    } catch (ConflictException | ServerException | InfrastructureException x) {
+      return;
+    } catch (InfrastructureException e) {
       LOG.error(
           "An error occurred while attempted to recover runtimes using infrastructure '{}'. Reason: '{}'",
           infrastructure.getName(),
-          x.getMessage());
+          e.getMessage());
+      return;
+    }
+
+    for (RuntimeIdentity identity : identities) {
+      try {
+        recoverOne(infrastructure, identity);
+      } catch (ServerException | ConflictException e) {
+        LOG.error(
+            "An error occurred while attempted to recover runtimes using infrastructure '{}'. Reason: '{}'",
+            infrastructure.getName(),
+            e.getMessage());
+      }
     }
   }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -188,6 +188,64 @@ public class WorkspaceRuntimesTest {
   }
 
   @Test
+  public void runtimeRecoveryContinuesThroughException() throws Exception {
+    // Given
+    RuntimeIdentityImpl identity1 = new RuntimeIdentityImpl("workspace1", "env1", "owner1");
+    RuntimeIdentityImpl identity2 = new RuntimeIdentityImpl("workspace2", "env2", "owner2");
+    RuntimeIdentityImpl identity3 = new RuntimeIdentityImpl("workspace3", "env3", "owner3");
+    Set<RuntimeIdentity> identities =
+        ImmutableSet.<RuntimeIdentity>builder()
+            .add(identity1)
+            .add(identity2)
+            .add(identity3)
+            .build();
+    doReturn(identities).when(infrastructure).getIdentities();
+
+    mockWorkspace(identity1);
+    mockWorkspace(identity2);
+    mockWorkspace(identity3);
+    when(statuses.get(anyString())).thenReturn(WorkspaceStatus.STARTING);
+
+    RuntimeContext context1 = mockContext(identity1);
+    when(context1.getRuntime())
+        .thenReturn(new TestInternalRuntime(context1, emptyMap(), WorkspaceStatus.STARTING));
+    doReturn(context1).when(infrastructure).prepare(eq(identity1), any());
+    RuntimeContext context2 = mockContext(identity1);
+    when(context2.getRuntime())
+        .thenReturn(new TestInternalRuntime(context2, emptyMap(), WorkspaceStatus.STARTING));
+    doReturn(context2).when(infrastructure).prepare(eq(identity2), any());
+    RuntimeContext context3 = mockContext(identity1);
+    when(context3.getRuntime())
+        .thenReturn(new TestInternalRuntime(context3, emptyMap(), WorkspaceStatus.STARTING));
+    doReturn(context3).when(infrastructure).prepare(eq(identity3), any());
+
+    InternalEnvironment internalEnvironment = mock(InternalEnvironment.class);
+    doReturn(internalEnvironment).when(testEnvFactory).create(any(Environment.class));
+
+    // Want to fail recovery of identity2
+    doThrow(new InfrastructureException("oops!"))
+        .when(infrastructure)
+        .prepare(eq(identity2), any(InternalEnvironment.class));
+
+    // When
+    runtimes.recover();
+
+    // Then
+    verify(infrastructure).prepare(identity1, internalEnvironment);
+    verify(infrastructure).prepare(identity2, internalEnvironment);
+    verify(infrastructure).prepare(identity3, internalEnvironment);
+
+    WorkspaceImpl workspace1 = new WorkspaceImpl(identity1.getWorkspaceId(), null, null);
+    runtimes.injectRuntime(workspace1);
+    assertNotNull(workspace1.getRuntime());
+    assertEquals(workspace1.getStatus(), WorkspaceStatus.STARTING);
+    WorkspaceImpl workspace3 = new WorkspaceImpl(identity3.getWorkspaceId(), null, null);
+    runtimes.injectRuntime(workspace3);
+    assertNotNull(workspace3.getRuntime());
+    assertEquals(workspace3.getStatus(), WorkspaceStatus.STARTING);
+  }
+
+  @Test
   public void attributesIsSetWhenRuntimeAbnormallyStopped() throws Exception {
     String error = "Some kind of error happened";
     EventService localEventService = new EventService();


### PR DESCRIPTION
Fix issue where encountering an exception while recovering workspaces on startup prevents recovery of further workspaces.

### What does this PR do?
Fix issue where encountering an exception while recovering workspaces on startup prevents recovery of further workspaces.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11445

### Testing
1. Start Che multiuser on minishift
2. Start a few workspaces
3. Scale Che server down to 0
4. modify postgres database to set `owner_id` to 0 for some workspace in table `che_k8s_runtime`
5. restart Che server
logs contain something like:
```
2018-10-02 20:41:56,358[ost-startStop-1]  [ERROR] [o.e.c.a.w.s.WorkspaceRuntimes 544]   - An error occurred while attempted to recover runtimes using infrastructure 'openshift'. Reason: 'Couldn't recover runtime 'workspace3ob15dnpujw9eamy:default'. Error: The user `0` doesn't have the required `use` permission for workspace `workspace3ob15dnpujw9eamy`'
2018-10-02 20:41:57,647[ost-startStop-1]  [INFO ] [o.e.c.a.w.s.WorkspaceRuntimes 590]   - Successfully recovered workspace runtime 'workspacekvgznl4cdef4u8r7'
2018-10-02 20:41:57,739[ost-startStop-1]  [INFO ] [o.e.c.a.w.s.WorkspaceRuntimes 590]   - Successfully recovered workspace runtime 'workspacec7tt9hc681m1uvr7'
```
and workspaces that can be recovered are. Workspace that had `owner_id` modified is listed as "not running" in Che, and deployment is not cleaned up, but there's not much we can do there.

Additionally, this will allow logging of all recovery errors, so this could be used to better track recovery bugs.