### PR TITLE
Adapt "open declaration" tests to behaviour of LSP editors

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
@@ -1811,13 +1811,22 @@ public class CodenvyEditor {
    * @param charPosition char's number where cursor is expected
    */
   public void waitSpecifiedValueForLineAndChar(final int linePosition, final int charPosition) {
+    int[] lastPos = new int[] {-1, -1};
     webDriverWaitFactory
         .get()
+        .withMessage(
+            () -> {
+              return String.format(
+                  "Expected (%d, %d), but was (%d, %d)",
+                  linePosition, charPosition, lastPos[0], lastPos[1]);
+            })
         .until(
             (ExpectedCondition<Boolean>)
-                webDriver ->
-                    (getPositionVisible() == linePosition)
-                        && (getPositionOfChar() == charPosition));
+                webDriver -> {
+                  lastPos[0] = getPositionVisible();
+                  lastPos[1] = getPositionOfChar();
+                  return (lastPos[0] == linePosition) && (lastPos[1] == charPosition);
+                });
   }
 
   /**

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0087Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0087Test.java
@@ -64,6 +64,6 @@ public class Eclipse0087Test {
     editor.goToCursorPositionVisible(13, 45);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("Myclass0087");
-    editor.waitSpecifiedValueForLineAndChar(14, 14);
+    editor.waitSpecifiedValueForLineAndChar(14, 25);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0091Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0091Test.java
@@ -61,6 +61,6 @@ public class Eclipse0091Test {
     editor.goToCursorPositionVisible(14, 5);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("MyAnnot");
-    editor.waitSpecifiedValueForLineAndChar(14, 19);
+    editor.waitSpecifiedValueForLineAndChar(14, 26);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0093Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0093Test.java
@@ -63,6 +63,6 @@ public class Eclipse0093Test {
     editor.goToCursorPositionVisible(18, 26);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("MyEnum");
-    editor.waitSpecifiedValueForLineAndChar(15, 3);
+    editor.waitSpecifiedValueForLineAndChar(15, 19);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0097Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0097Test.java
@@ -62,6 +62,6 @@ public class Eclipse0097Test {
     editor.goToCursorPositionVisible(14, 31);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("Key");
-    editor.waitSpecifiedValueForLineAndChar(14, 14);
+    editor.waitSpecifiedValueForLineAndChar(14, 17);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0114Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0114Test.java
@@ -66,6 +66,6 @@ public class Eclipse0114Test {
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("Test");
     editor.waitActive();
-    editor.waitSpecifiedValueForLineAndChar(15, 9);
+    editor.waitSpecifiedValueForLineAndChar(15, 15);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0115Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0115Test.java
@@ -62,6 +62,6 @@ public class Eclipse0115Test {
     editor.waitMarkerInPosition(WARNING, 15);
     editor.goToCursorPositionVisible(33, 14);
     editor.typeTextIntoEditor(Keys.F4.toString());
-    editor.waitSpecifiedValueForLineAndChar(36, 24);
+    editor.waitSpecifiedValueForLineAndChar(36, 29);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0119Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0119Test.java
@@ -62,6 +62,6 @@ public class Eclipse0119Test {
     editor.goToCursorPositionVisible(16, 28);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("Collections");
-    editor.waitSpecifiedValueForLineAndChar(15, 35);
+    editor.waitSpecifiedValueForLineAndChar(15, 44);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0120Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0120Test.java
@@ -58,6 +58,6 @@ public class Eclipse0120Test {
     editor.goToCursorPositionVisible(17, 42);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("Collections");
-    editor.waitSpecifiedValueForLineAndChar(15, 35);
+    editor.waitSpecifiedValueForLineAndChar(15, 44);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0121Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0121Test.java
@@ -62,6 +62,6 @@ public class Eclipse0121Test {
     editor.goToCursorPositionVisible(16, 43);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("Collections");
-    editor.waitSpecifiedValueForLineAndChar(15, 35);
+    editor.waitSpecifiedValueForLineAndChar(15, 44);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0122Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/opendeclaration/Eclipse0122Test.java
@@ -61,6 +61,6 @@ public class Eclipse0122Test {
     editor.waitActive();
     editor.goToCursorPositionVisible(16, 24);
     editor.typeTextIntoEditor(Keys.F4.toString());
-    editor.waitSpecifiedValueForLineAndChar(15, 16);
+    editor.waitSpecifiedValueForLineAndChar(15, 19);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Adapts opendeclaration package of selenium tests to the fact that the Java editor now is a LSP editor and as such behaves the same in "open declaration".
Also, added code to print expected and actual values when checking for editor position

### What issues does this PR fix or reference?
Partial fix of: 
https://github.com/eclipse/che/issues/11431
