### PR TITLE
Adapt jdt.ls as a lsp editor when opening locations

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
@@ -310,7 +310,7 @@ public class ContextMenuEditorTest {
     fileStructure.waitFileStructureFormIsClosed();
     editor.typeTextIntoEditor(Keys.ARROW_LEFT.toString());
     editor.waitTextElementsActiveLine("handleRequest");
-    editor.waitSpecifiedValueForLineAndChar(26, 24);
+    editor.waitSpecifiedValueForLineAndChar(26, 3);
   }
 
   @Test(priority = 8)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/OpenDeclarationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/OpenDeclarationTest.java
@@ -135,8 +135,7 @@ public class OpenDeclarationTest {
     editor.goToCursorPositionVisible(31, 12);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("ModelAndView.class");
-    editor.waitTextElementsActiveLine("ModelAndView");
-    editor.waitSpecifiedValueForLineAndChar(44, 14);
+    editor.waitSpecifiedValueForLineAndChar(44, 26);
     editor.closeFileByNameWithSaving("ModelAndView.class");
 
     // Check go to method
@@ -144,14 +143,12 @@ public class OpenDeclarationTest {
     editor.goToCursorPositionVisible(44, 16);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("ModelAndView.class");
-    editor.waitTextElementsActiveLine("addObject");
-    editor.waitSpecifiedValueForLineAndChar(226, 22);
+    editor.waitSpecifiedValueForLineAndChar(226, 31);
 
     // Check go to inner method
     editor.goToCursorPositionVisible(227, 9);
     editor.typeTextIntoEditor(Keys.F4.toString());
     editor.waitTabIsPresent("ModelAndView.class");
-    editor.waitTextElementsActiveLine("getModelMap()");
-    editor.waitSpecifiedValueForLineAndChar(203, 18);
+    editor.waitSpecifiedValueForLineAndChar(203, 29);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/TypeScriptEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/TypeScriptEditingTest.java
@@ -121,7 +121,7 @@ public class TypeScriptEditingTest {
     menu.runCommand(ASSISTANT, FIND_PROJECT_SYMBOL);
     assistantFindPanel.typeToInputField("testPrint");
     assistantFindPanel.clickOnActionNodeWithTextContains("testPrint");
-    editor.waitCursorPosition(23, 6);
+    editor.waitCursorPosition(26, 6);
   }
 
   @Test(priority = 2, alwaysRun = true)
@@ -249,6 +249,6 @@ public class TypeScriptEditingTest {
     editor.goToPosition(25, 20);
     menu.runCommand(ASSISTANT, FIND_DEFINITION);
     editor.waitActiveTabFileName("testPrint.ts");
-    editor.waitCursorPosition(15, 1);
+    editor.waitCursorPosition(15, 6);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureCodeEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureCodeEditorTest.java
@@ -76,22 +76,19 @@ public class FileStructureCodeEditorTest {
     fileStructure.waitFileStructureFormIsOpen(JAVA_FILE_NAME);
     fileStructure.selectItemInFileStructureByDoubleClick("getInstance():Company");
     fileStructure.waitFileStructureFormIsClosed();
-    editor.waitTextElementsActiveLine("getInstance");
-    editor.waitSpecifiedValueForLineAndChar(41, 27);
+    editor.waitSpecifiedValueForLineAndChar(41, 38);
 
     menu.runCommand(ASSISTANT, FILE_STRUCTURE);
     fileStructure.waitFileStructureFormIsOpen(JAVA_FILE_NAME);
     fileStructure.selectItemInFileStructureByEnter("INSTANCE");
     fileStructure.waitFileStructureFormIsClosed();
-    editor.waitTextElementsActiveLine("INSTANCE");
-    editor.waitSpecifiedValueForLineAndChar(25, 38);
+    editor.waitSpecifiedValueForLineAndChar(25, 46);
 
     menu.runCommand(ASSISTANT, FILE_STRUCTURE);
     fileStructure.waitFileStructureFormIsOpen(JAVA_FILE_NAME);
     fileStructure.selectItemInFileStructureByEnter("getId():double");
     fileStructure.waitFileStructureFormIsClosed();
-    editor.waitTextElementsActiveLine("getId");
-    editor.waitSpecifiedValueForLineAndChar(37, 23);
+    editor.waitSpecifiedValueForLineAndChar(37, 28);
 
     // check new elements in the 'file structure' form
     editor.setCursorToLine(20);


### PR DESCRIPTION
### What does this PR do?
Adapts some tests to the fixed behaviour of lsp editors when opening locations. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11431
