### PR TITLE
Added liveness probe for jupyter server

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -130,6 +130,9 @@ che.workspace.activity_check_scheduler_delay_s=180
 # Note: the property is common for all servers e.g. workspace agent, terminal, exec etc.
 che.workspace.server.ping_success_threshold=1
 
+# List of servers names which require liveness probes
+che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia
+
 ### TEMPLATES
 # Folder that contains JSON files with code templates and samples
 che.template.storage=${che.home}/templates

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -131,7 +131,7 @@ che.workspace.activity_check_scheduler_delay_s=180
 che.workspace.server.ping_success_threshold=1
 
 # List of servers names which require liveness probes
-che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia
+che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia,jupyter
 
 ### TEMPLATES
 # Folder that contains JSON files with code templates and samples

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
@@ -45,6 +45,12 @@ import org.testng.annotations.Test;
 /** @author Alexander Garagatyi */
 @Listeners(MockitoTestNGListener.class)
 public class ServersCheckerTest {
+  private static final String WSAGENT_HTTP_SERVER = "wsagent/http";
+  private static final String EXEC_AGENT_HTTP_SERVER = "exec-agent/http";
+  private static final String TERMINAL_SERVER = "terminal";
+
+  private static final String[] CONFIGURED_SERVERS =
+      new String[] {WSAGENT_HTTP_SERVER, EXEC_AGENT_HTTP_SERVER, TERMINAL_SERVER};
 
   private static final String MACHINE_NAME = "mach1";
   private static final String MACHINE_TOKEN = "machineToken";
@@ -66,9 +72,9 @@ public class ServersCheckerTest {
     servers = new HashMap<>();
     servers.putAll(
         ImmutableMap.of(
-            "wsagent/http", new ServerImpl().withUrl("http://localhost/api"),
-            "exec-agent/http", new ServerImpl().withUrl("http://localhost/exec-agent/process"),
-            "terminal", new ServerImpl().withUrl("http://localhost/terminal/pty")));
+            WSAGENT_HTTP_SERVER, new ServerImpl().withUrl("http://localhost/api"),
+            EXEC_AGENT_HTTP_SERVER, new ServerImpl().withUrl("http://localhost/exec-agent/process"),
+            TERMINAL_SERVER, new ServerImpl().withUrl("http://localhost/terminal/pty")));
 
     compFuture = new CompletableFuture<>();
 
@@ -84,7 +90,8 @@ public class ServersCheckerTest {
                 MACHINE_NAME,
                 servers,
                 machineTokenProvider,
-                SERVER_PING_SUCCESS_THRESHOLD));
+                SERVER_PING_SUCCESS_THRESHOLD,
+                CONFIGURED_SERVERS));
     when(checker.doCreateChecker(any(URL.class), anyString(), anyString()))
         .thenReturn(connectionChecker);
     when(machineTokenProvider.getToken(anyString(), anyString())).thenReturn(MACHINE_TOKEN);
@@ -141,12 +148,12 @@ public class ServersCheckerTest {
   }
 
   @Test(timeOut = 1000)
-  public void shouldNotCheckNotHardcodedServers() throws Exception {
+  public void shouldNotCheckNotConfiguredServers() throws Exception {
     servers.clear();
     servers.putAll(
         ImmutableMap.of(
             "wsagent/http", new ServerImpl().withUrl("http://localhost"),
-            "not-hardcoded", new ServerImpl().withUrl("http://localhost")));
+            "not-configured", new ServerImpl().withUrl("http://localhost")));
 
     checker.startAsync(readinessHandler);
     connectionChecker.getReportCompFuture().complete("test_ref");


### PR DESCRIPTION
### What does this PR do?
Since there is jypyter editor in plugin registry it is needed to have liveness probe for it.

Also, this PR moves list of servers which requires liveness probe to the configuration. It allows configuring new server if it is needed, like when custom plugin registry is used where new editor is available.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11383

#### Release Notes
N/A

#### Docs PR
N/A