### PR TITLE
Selenium: not check that CHE_MACHINE_NAME variable exists in 'Environment variables' tab

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
@@ -33,7 +33,6 @@ import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.EditMachineForm;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetailsMachines;
-import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceEnvVariables;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceInstallers;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceServers;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
@@ -68,7 +67,6 @@ public class WorkspaceDetailsMachineActionsTest {
   @Inject private WorkspaceInstallers workspaceInstallers;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private WorkspaceServers workspaceServers;
-  @Inject private WorkspaceEnvVariables workspaceEnvVariables;
 
   @BeforeMethod
   public void setup() throws Exception {
@@ -221,7 +219,6 @@ public class WorkspaceDetailsMachineActionsTest {
   public void checkMachineSettings() {
     final String installerName = "Exec";
     final String serverName = "tomcat8";
-    final String envVariable = "CHE_MACHINE_NAME";
 
     // check the "Installers" link
     waitMachineListItemAndClickOnSettingsButton();
@@ -234,13 +231,6 @@ public class WorkspaceDetailsMachineActionsTest {
     waitMachineListItemAndClickOnSettingsButton();
     workspaceDetailsMachines.clickOnServersLink();
     workspaceServers.checkServerName(serverName);
-
-    seleniumWebDriver.navigate().back();
-
-    // Check the "Environment Variables" link
-    waitMachineListItemAndClickOnSettingsButton();
-    workspaceDetailsMachines.clickOnEnvironmentVariablesLink();
-    workspaceEnvVariables.checkEnvVariableExists(envVariable);
 
     seleniumWebDriver.navigate().back();
 


### PR DESCRIPTION
### What does this PR do?
This PR removes checking that "CHE_MACHINE_NAME" variable exists in 'Environment variables' tab according to changes from https://github.com/eclipse/che/pull/11432.

![selection_136](https://user-images.githubusercontent.com/7760565/46412434-3ca68c80-c727-11e8-8835-74f2b4a9e909.png)
