### PR TITLE
[Selenium] Fix unexpected fail of "MacrosCommandsEditorTest" selenium test

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/MacrosCommandsEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/MacrosCommandsEditorTest.java
@@ -123,7 +123,6 @@ public class MacrosCommandsEditorTest {
       "${server.terminal}",
       "${server.tomcat8-debug}",
       "${server.tomcat8}",
-      "${server.wsagent-debug}",
       "${server.wsagent/http}",
       "${server.wsagent/ws}"
     };


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix unexpected fail of "MacrosCommandsEditorTest" selenium test. 
Remove deprecated macros from expected macros list. The "wsagent/debug" was turned off by default in this PR https://github.com/eclipse/che/pull/11475




### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/11497
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
