### PR TITLE
[Selenium] Get rid of "StaleElementReferenceException" in the "TheiaEditor#getEditorText()" method

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaEditor.java
@@ -107,10 +107,10 @@ public class TheiaEditor {
     final int editorLinesCount =
         seleniumWebDriverHelper.waitVisibilityOfAllElements(By.xpath(EDITOR_LINE_XPATH)).size();
 
-    List<Integer> linesCoordinates = getEditorLinesPixelCoordinates(editorLinesCount);
+    List<Integer> linePixelCoordinates = getEditorLinePixelCoordinates(editorLinesCount);
 
     List<String> linesText =
-        linesCoordinates
+        linePixelCoordinates
             .stream()
             .map(
                 linePixelCoordinate -> {
@@ -132,7 +132,7 @@ public class TheiaEditor {
     return format(EDITOR_LINE_BY_INDEX_XPATH_TEMPLATE, lineIndex);
   }
 
-  private List<Integer> getEditorLinesPixelCoordinates(int editorLinesCount) {
+  private List<Integer> getEditorLinePixelCoordinates(int editorLinesCount) {
     List<Integer> result = new ArrayList<>();
 
     for (int i = 1; i <= editorLinesCount; i++) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaEditor.java
@@ -103,12 +103,14 @@ public class TheiaEditor {
 
   public List<String> getEditorText() {
     // In this realization each line element will be found exactly before using
-    // This realization allows as to avoid "StaleElementReferenceException"
+    // This realization allows us to avoid "StaleElementReferenceException"
     final int editorLinesCount =
         seleniumWebDriverHelper.waitVisibilityOfAllElements(By.xpath(EDITOR_LINE_XPATH)).size();
 
     List<Integer> linesCoordinates = getEditorLinesPixelCoordinates(editorLinesCount);
 
+    // should be sorted by coordinates because found lines may be mixed by indexes
+    // and don't match with their expected places
     linesCoordinates.sort((first, second) -> first - second);
 
     List<String> linesText =

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaEditor.java
@@ -109,10 +109,6 @@ public class TheiaEditor {
 
     List<Integer> linesCoordinates = getEditorLinesPixelCoordinates(editorLinesCount);
 
-    // should be sorted by coordinates because found lines may be mixed by indexes
-    // and don't match with their expected places
-    linesCoordinates.sort((first, second) -> first - second);
-
     List<String> linesText =
         linesCoordinates
             .stream()
@@ -147,6 +143,9 @@ public class TheiaEditor {
       result.add(linePixelCoordinate);
     }
 
+    // should be sorted by coordinates because found lines may be mixed by indexes
+    // and don't match with their expected places
+    result.sort((first, second) -> first - second);
     return result;
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaEditor.java
@@ -15,11 +15,14 @@ import static java.lang.String.format;
 import static java.lang.String.join;
 import static java.util.Arrays.asList;
 import static org.eclipse.che.selenium.pageobject.theia.TheiaEditor.Locators.ACTIVE_LINE_XPATH;
+import static org.eclipse.che.selenium.pageobject.theia.TheiaEditor.Locators.EDITOR_LINE_BY_INDEX_XPATH_TEMPLATE;
+import static org.eclipse.che.selenium.pageobject.theia.TheiaEditor.Locators.EDITOR_LINE_BY_PIXEL_COORDINATES_XPATH_TEMPLATE;
 import static org.eclipse.che.selenium.pageobject.theia.TheiaEditor.Locators.EDITOR_LINE_XPATH;
 import static org.eclipse.che.selenium.pageobject.theia.TheiaEditor.Locators.EDITOR_TAB_XPATH_TEMPLATE;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
@@ -46,6 +49,9 @@ public class TheiaEditor {
         "//div[@data-mode-id='plaintext']//span[@class='mtk1']/parent::span/parent::div";
     String ACTIVE_LINE_XPATH =
         "//div[@data-mode-id='plaintext']//div[contains(@class, 'monaco-editor') and contains(@class, 'focused')]";
+    String EDITOR_LINE_BY_INDEX_XPATH_TEMPLATE = "(" + EDITOR_LINE_XPATH + ")[%s]";
+    String EDITOR_LINE_BY_PIXEL_COORDINATES_XPATH_TEMPLATE =
+        "//div[@data-mode-id='plaintext']//div[contains(@style, 'top:%spx;')]//span[@class='mtk1']/parent::span/parent::div";
   }
 
   public void waitActiveEditor() {
@@ -96,18 +102,50 @@ public class TheiaEditor {
   }
 
   public List<String> getEditorText() {
-    List<WebElement> editorLinesElements =
-        seleniumWebDriverHelper.waitVisibilityOfAllElements(By.xpath(EDITOR_LINE_XPATH));
+    // In this realization each line element will be found exactly before using
+    // This realization allows as to avoid "StaleElementReferenceException"
+    final int editorLinesCount =
+        seleniumWebDriverHelper.waitVisibilityOfAllElements(By.xpath(EDITOR_LINE_XPATH)).size();
 
-    editorLinesElements.sort(
-        (firstElement, secondElement) ->
-            getEditorLinePixelCoordinate(firstElement)
-                - getEditorLinePixelCoordinate(secondElement));
+    List<Integer> linesCoordinates = getEditorLinesPixelCoordinates(editorLinesCount);
 
-    return editorLinesElements
-        .stream()
-        .map(element -> seleniumWebDriverHelper.waitVisibilityAndGetText(element))
-        .collect(Collectors.toList());
+    linesCoordinates.sort((first, second) -> first - second);
+
+    List<String> linesText =
+        linesCoordinates
+            .stream()
+            .map(
+                linePixelCoordinate -> {
+                  String lineByPixelCoordinatesXpath =
+                      getEditorLineByPixelCoordinateXpath(linePixelCoordinate);
+                  return seleniumWebDriverHelper.waitVisibilityAndGetText(
+                      By.xpath(lineByPixelCoordinatesXpath));
+                })
+            .collect(Collectors.toList());
+
+    return linesText;
+  }
+
+  private String getEditorLineByPixelCoordinateXpath(int pixelCoordinate) {
+    return format(EDITOR_LINE_BY_PIXEL_COORDINATES_XPATH_TEMPLATE, pixelCoordinate);
+  }
+
+  private String getEditorLineByIndexXpath(int lineIndex) {
+    return format(EDITOR_LINE_BY_INDEX_XPATH_TEMPLATE, lineIndex);
+  }
+
+  private List<Integer> getEditorLinesPixelCoordinates(int editorLinesCount) {
+    List<Integer> result = new ArrayList<>();
+
+    for (int i = 1; i <= editorLinesCount; i++) {
+      String editorLineXpath = getEditorLineByIndexXpath(i);
+      int linePixelCoordinate =
+          getEditorLinePixelCoordinate(
+              seleniumWebDriverHelper.waitVisibility(By.xpath(editorLineXpath)));
+      result.add(linePixelCoordinate);
+    }
+
+    return result;
   }
 
   public String getEditorTextAsString() {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Get rid of "StaleElementReferenceException" in the "TheiaEditor#getEditorText()" method

### What issues does this PR fix or reference?
Fix failed "BuildTheiaPluginTest" selenium test in
https://ci.codenvycorp.com/view/qa-nightly/job/che-integration-tests-multiuser-master-ocp/381/Selenium_20tests_20report/
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
