### PR TITLE
Replaced ws.next sample stack with a Che7 preview stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks-images/type-che7.svg
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks-images/type-che7.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 254.1 293.5"
+   style="enable-background:new 0 0 254.1 293.5;"
+   xml:space="preserve"
+   sodipodi:docname="type-che7.svg"
+   inkscape:version="0.92.2 5c3e80d, 2017-08-06"><metadata
+     id="metadata132"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+     id="defs130"><filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter202"><feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix200"
+         result="fbSourceGraphic" /><feColorMatrix
+         result="fbSourceGraphicAlpha"
+         in="fbSourceGraphic"
+         values="0 0 0 -1 0 0 0 0 -1 0 0 0 0 -1 0 0 0 0 1 0"
+         id="feColorMatrix208" /><feColorMatrix
+         id="feColorMatrix210"
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         in="fbSourceGraphic" /></filter><filter
+       style="color-interpolation-filters:sRGB;"
+       inkscape:label="Greyscale"
+       id="filter206"><feColorMatrix
+         values="0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0.21 0.72 0.072 0 0 0 0 0 1 0 "
+         id="feColorMatrix204" /></filter></defs><sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="915"
+     inkscape:window-height="830"
+     id="namedview128"
+     showgrid="false"
+     inkscape:zoom="0.80408859"
+     inkscape:cx="127.05"
+     inkscape:cy="146.75"
+     inkscape:window-x="1161"
+     inkscape:window-y="364"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="Layer_1" /><style
+     type="text/css"
+     id="style119">
+	.st0{fill:#525C86;}
+	.st1{fill:#FDB940;}
+</style><g
+     id="g125"
+     style="filter:url(#filter206)"><polygon
+       class="st0"
+       points="0,128.7 0,220.1 127.1,293.5 254.1,220.1 254.1,128.7 127.1,202.1  "
+       id="polygon121" /><polygon
+       class="st1"
+       points="127.1,0 0,73.4 0,164.7 127.1,91.4 175,119 254.1,73.4  "
+       id="polygon123" /></g><text
+     xml:space="preserve"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;filter:url(#filter202)"
+     x="132.33806"
+     y="217.98831"
+     id="text198"><tspan
+       sodipodi:role="line"
+       x="132.33806"
+       y="217.98831"
+       id="tspan196"><tspan
+         x="132.33806"
+         y="217.98831"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:192px;font-family:'DIN Alternate';-inkscape-font-specification:'DIN Alternate Bold';text-align:center;text-anchor:middle"
+         id="tspan194">7</tspan></tspan></text>
+</svg>

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -164,16 +164,40 @@
     }
   },
   {
-    "id": "wsnext-helloworld-openshift",
+    "id": "che7-preview",
     "creator": "ide",
-    "name": "Workspace Next HelloWorld example on OpenShift",
-    "description": "Example of a Theia Hello World plug-in + Theia plug-in (openshift)",
+    "name": "Che 7 Preview",
+    "description": "Workspace.next sidecars and Theia as IDE",
     "scope": "general",
     "tags": [
       "ws.next",
-      "Theia"
+      "Theia",
+      "Java",
+      "JDK",
+      "Node.JS",
+      "NPM",
+      "Yeoman"
+    ],
+    "components": [
+      {
+        "name": "Centos",
+        "version": "7"
+      },
+      {
+        "name": "OpenJDK",
+        "version": "1.8.0_181"
+      },
+      {
+        "name": "NodeJS",
+        "version": "8.12.0"
+      },
+      {
+        "name": "NPM",
+        "version": "6.4.1"
+      }
     ],
     "workspaceConfig": {
+      "name": "che7",
       "defaultEnv": "default",
       "environments": {
         "default": {
@@ -198,64 +222,14 @@
         }
       },
       "projects": [],
-      "name": "skeleton",
       "attributes": {
-        "editor": "org.eclipse.che.editor.theia:1.0.0",
-        "plugins": "che-dummy-plugin:0.0.1,che-machine-exec-plugin:0.0.1"
+        "editor": "org.eclipse.che.editor.theia:1.0.0"
       },
       "commands": [],
       "links": []
     },
     "stackIcon": {
-      "name": "type-theia.svg",
-      "mediaType": "image/svg+xml"
-    }
-  },
-  {
-    "id": "wsnext-service-openshift",
-    "creator": "ide",
-    "name": "Workspace Next REST Service Example on OpenShift",
-    "description": "Example of a Theia REST Service plug-in + REST server container + Theia plug-in (openshift)",
-    "scope": "general",
-    "tags": [
-      "ws.next",
-      "Theia"
-    ],
-    "workspaceConfig": {
-      "defaultEnv": "default",
-      "environments": {
-        "default": {
-          "machines": {
-            "ws/dev": {
-              "attributes": {},
-              "servers": {},
-              "volumes": {
-                "projects": {
-                  "path": "/projects"
-                }
-              },
-              "installers": [],
-              "env": {}
-            }
-          },
-          "recipe": {
-            "type": "openshift",
-            "content": "---\nkind: List\nitems:\n-\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n  spec:\n    containers:\n      -\n        image: eclipse/che-dev:nightly\n        name: dev",
-            "contentType": "application/x-yaml"
-          }
-        }
-      },
-      "projects": [],
-      "name": "skeleton",
-      "attributes": {
-        "editor": "org.eclipse.che.editor.theia:1.0.0",
-        "plugins": "che-service-plugin:0.0.1,che-machine-exec-plugin:0.0.1"
-      },
-      "commands": [],
-      "links": []
-    },
-    "stackIcon": {
-      "name": "type-theia.svg",
+      "name": "type-che7.svg",
       "mediaType": "image/svg+xml"
     }
   },


### PR DESCRIPTION
### What does this PR do?

Replace the HelloWorld workspace.next stacks with a Che 7 preview stack


### What issues does this PR fix or reference?

#10644

#### Release Notes

Introduced Che 7 preview stack with sidecar plugins support and Theia as IDE
