### PR TITLE
Fix NPE when no signature help is available

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/signature/SignatureInfoImpl.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/signature/SignatureInfoImpl.java
@@ -41,6 +41,9 @@ class SignatureInfoImpl implements SignatureInfo {
   public Optional<String> getDocumentation() {
     Either<String, MarkupContent> doc = dto.getDocumentation();
     // both markdown and plain text are ok.
+    if (doc == null) {
+      return Optional.absent();
+    }
     return Optional.fromNullable(doc.isLeft() ? doc.getLeft() : doc.getRight().getValue());
   }
 


### PR DESCRIPTION
### What does this PR do?
Fixes NPE when no documentation for a method in signature help is available.

### What issues does this PR fix or reference?
Show argument hints functionality doesn't display "No documentation found" in the case with absence "javadoc" #11503
