### PR TITLE
Fix handling of workspace paths in find implementations

### DIFF
--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
@@ -591,7 +591,7 @@ public class JavaLanguageServerExtensionService {
   }
 
   public ImplementersResponseDto findImplementers(TextDocumentPositionParams params) {
-    params.getTextDocument().setUri(fixJdtUri(params.getTextDocument().getUri()));
+    params.getTextDocument().setUri(fixJdtUri(prefixURI(params.getTextDocument().getUri())));
     CompletableFuture<Object> result =
         executeCommand(FIND_IMPLEMENTERS_COMMAND, singletonList(params));
 


### PR DESCRIPTION
### What does this PR do?
Prefixes workspace paths to be a proper URI for jdt.ls use. The implementations widget will be shown if a java element can be found at the location given in the request, otherwise nothing happesn.


### What issues does this PR fix or reference?
[ JDT LS ] Implementation form is missed #11513
