### PR TITLE
Fix memory request jwt

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisionerTest.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
 import java.util.Collections;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.spi.environment.MemoryAttributeProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -55,6 +56,7 @@ public class RamLimitRequestProvisionerTest {
   @Mock private RuntimeIdentity identity;
   @Mock private Pod pod;
   @Mock private InternalMachineConfig internalMachineConfig;
+  @Mock private MemoryAttributeProvisioner memoryAttributeProvisioner;
 
   @Captor private ArgumentCaptor<ResourceRequirements> resourceCaptor;
 
@@ -63,7 +65,7 @@ public class RamLimitRequestProvisionerTest {
 
   @BeforeMethod
   public void setup() {
-    ramProvisioner = new RamLimitRequestProvisioner();
+    ramProvisioner = new RamLimitRequestProvisioner(memoryAttributeProvisioner);
     container = new Container();
     container.setName(CONTAINER_NAME);
     when(k8sEnv.getPods()).thenReturn(of(POD_NAME, pod));


### PR DESCRIPTION
### What does this PR do?
**What:**
Set Memory request for JWT sidecar.
Ensure that all containers have a memory request is set and not
bigger than the memory limit.
**Why:**
When k8s/OS has a significant value of RAM request as default and Che doesn't set memory request and machine/sidecar RAM limit is lower we get an error from k8s/OS API about invalidness of pod spec since  RAM limit is lower than RAM request.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/11547
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
