### PR TITLE
Add tracking of STARTING/STOPPING recovered k8s/OS runtimes

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -188,22 +188,22 @@
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
-                          <execution>
-                            <id>install-yarn</id>
-                            <phase>compile</phase>
-                            <goals>
-                              <goal>run</goal>
-                            </goals>
-                            <configuration>
-                              <target>
-                                <!-- install yarn -->
-                                <exec dir="${basedir}" executable="npm" failonerror="true">
-                                  <arg value="install" />
-                                  <arg value="yarn" />
-                                </exec>
-                              </target>
-                            </configuration>
-                          </execution>
+                            <execution>
+                                <id>install-yarn</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- install yarn -->
+                                        <exec dir="${basedir}" executable="npm" failonerror="true">
+                                            <arg value="install" />
+                                            <arg value="yarn" />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
                             <execution>
                                 <id>build-dashboard</id>
                                 <phase>compile</phase>

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -796,6 +796,9 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
 
     @Override
     public void handle(Action action, Pod pod) {
+      eventPublisher.sendAbnormalStoppingEvent(
+          getContext().getIdentity(),
+          format("Pod '%s' was abnormally stopped", pod.getMetadata().getName()));
       // Cancels workspace servers probes if any
       probeScheduler.cancel(getContext().getIdentity().getWorkspaceId());
       if (pod.getStatus() != null && POD_STATUS_PHASE_FAILED.equals(pod.getStatus().getPhase())) {
@@ -804,9 +807,9 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
         } catch (InfrastructureException ex) {
           LOG.error("Kubernetes environment stop failed cause '{}'", ex.getMessage());
         } finally {
-          eventPublisher.sendRuntimeStoppedEvent(
-              format("Pod '%s' was abnormally stopped", pod.getMetadata().getName()),
-              getContext().getIdentity());
+          eventPublisher.sendAbnormalStoppedEvent(
+              getContext().getIdentity(),
+              format("Pod '%s' was abnormally stopped", pod.getMetadata().getName()));
         }
       }
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesRuntimeContext.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesRuntimeContext.java
@@ -81,7 +81,7 @@ public class KubernetesRuntimeContext<T extends KubernetesEnvironment> extends R
             namespaceFactory.create(workspaceId, runtimeState.getNamespace()),
             getEnvironment().getWarnings());
 
-    runtime.scheduleServersCheckers();
+    runtime.scheduleRuntimeStateChecks();
 
     return runtime;
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeHangingDetector.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeHangingDetector.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.Map;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.WorkspaceSharedPool;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.RuntimeEventsPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tracks STARTING/STOPPING runtimes and forcibly stop them if they did not change status before a
+ * timeout is reached.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class RuntimeHangingDetector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RuntimeHangingDetector.class);
+
+  private Timer timeouts;
+
+  private final WorkspaceSharedPool workspaceSharedPool;
+  private final RuntimeEventsPublisher eventPublisher;
+  private final Map<String, WaitStatusChangedTask> workspaceId2Task;
+
+  @Inject
+  public RuntimeHangingDetector(
+      RuntimeEventsPublisher eventPublisher, WorkspaceSharedPool workspaceSharedPool) {
+    this.workspaceSharedPool = workspaceSharedPool;
+    this.eventPublisher = eventPublisher;
+    this.workspaceId2Task = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Schedules a task to check whether the specified runtime changed its status from {@link
+   * WorkspaceStatus#STARTING} after the specified timeout and if it didn't change then runtime
+   * start will be interrupted.
+   *
+   * <p>MUST be invoked after recovering of {@link WorkspaceStatus#STARTING} runtime to track it and
+   * avoid hanging.
+   *
+   * <p>{@link #stopTracking(RuntimeIdentity)} MUST be invoked if start is normally interrupted or
+   * became RUNNING before timeout.
+   *
+   * @param runtime runtime to track
+   * @param timeoutMin timeout before which runtime should change its state
+   */
+  public synchronized void trackStarting(KubernetesInternalRuntime runtime, long timeoutMin) {
+    String workspaceId = runtime.getContext().getIdentity().getWorkspaceId();
+    WaitStatusChangedTask waitStartingChangedTask =
+        new WaitStatusChangedTask(
+            runtime, WorkspaceStatus.STARTING, this::handleHangingStartingRuntime);
+
+    LOG.debug(
+        "Registered a task to check runtime '{}' to become RUNNING OR STOPPED after {} minutes",
+        workspaceId,
+        timeoutMin);
+    workspaceId2Task.put(workspaceId, waitStartingChangedTask);
+    getTimer().schedule(waitStartingChangedTask, TimeUnit.MINUTES.toMillis(timeoutMin));
+  }
+
+  private void handleHangingStartingRuntime(KubernetesInternalRuntime runtime) {
+    RuntimeIdentity runtimeId = runtime.getContext().getIdentity();
+    try {
+      eventPublisher.sendAbnormalStoppingEvent(
+          runtimeId, "Workspace is not started in time. Trying interrupt runtime start");
+      runtime.stop(emptyMap());
+      eventPublisher.sendAbnormalStoppedEvent(runtimeId, "Workspace start reached timeout");
+      LOG.info(
+          "Start of hanging runtime '{}:{}:{}' is interrupted",
+          runtimeId.getWorkspaceId(),
+          runtimeId.getEnvName(),
+          runtimeId.getOwnerId());
+    } catch (InfrastructureException e) {
+      LOG.error(
+          "Error occurred during start interruption of hanging runtime '{}:{}:{}'. Error: {}",
+          runtimeId.getWorkspaceId(),
+          runtimeId.getEnvName(),
+          runtimeId.getOwnerId(),
+          e.getMessage(),
+          e);
+    }
+  }
+
+  /**
+   * Schedules a task to check whether the specified runtime changed its status from {@link
+   * WorkspaceStatus#STOPPING} after the specified timeout and if it didn't change then runtime will
+   * be stopped forcibly.
+   *
+   * <p>MUST be invoked after recovering of {@link WorkspaceStatus#STOPPING} runtime to track it and
+   * avoid hanging.
+   *
+   * <p>{@link #stopTracking(RuntimeIdentity)} MUST be invoked if stop is normally finished before
+   * timeout.
+   *
+   * @param runtime runtime to track
+   * @param timeoutMin timeout before which runtime should change its state
+   */
+  public synchronized void trackStopping(KubernetesInternalRuntime runtime, long timeoutMin) {
+    String workspaceId = runtime.getContext().getIdentity().getWorkspaceId();
+    WaitStatusChangedTask waitStoppingChangedTask =
+        new WaitStatusChangedTask(
+            runtime, WorkspaceStatus.STOPPING, this::handleHangingStoppingRuntime);
+
+    LOG.debug(
+        "Registered a task to check workspace {} to become STOPPED after {} minutes",
+        workspaceId,
+        timeoutMin);
+    workspaceId2Task.put(workspaceId, waitStoppingChangedTask);
+    getTimer().schedule(waitStoppingChangedTask, TimeUnit.MINUTES.toMillis(timeoutMin));
+  }
+
+  private void handleHangingStoppingRuntime(KubernetesInternalRuntime runtime) {
+    RuntimeIdentity runtimeId = runtime.getContext().getIdentity();
+    try {
+      eventPublisher.sendAbnormalStoppingEvent(
+          runtimeId, "Workspace is not stopped in time. Trying to stop it forcibly");
+      runtime.internalStop(emptyMap());
+      runtime.markStopped();
+      eventPublisher.sendAbnormalStoppedEvent(runtimeId, "Workspace stop reached timeout");
+      LOG.info(
+          "Runtime '{}:{}:{}' is not stopped in time. Stopped it forcibly",
+          runtimeId.getWorkspaceId(),
+          runtimeId.getEnvName(),
+          runtimeId.getOwnerId());
+    } catch (InfrastructureException e) {
+      LOG.error(
+          "Error occurred during forcibly stopping of hanging runtime '{}:{}:{}'. Error: {}",
+          runtimeId.getWorkspaceId(),
+          runtimeId.getEnvName(),
+          runtimeId.getOwnerId(),
+          e.getMessage(),
+          e);
+    }
+  }
+
+  /**
+   * Stop tracking of runtime it is was registered before, otherwise do nothing.
+   *
+   * @param runtimeId identifier of runtime that should not be tracked anymore
+   */
+  public synchronized void stopTracking(RuntimeIdentity runtimeId) {
+    TimerTask timerTask = workspaceId2Task.remove(runtimeId.getWorkspaceId());
+    if (timerTask != null) {
+      LOG.debug("Tracking task for workspace {} is canceled", runtimeId.getWorkspaceId());
+      timerTask.cancel();
+
+      if (workspaceId2Task.isEmpty()) {
+        timeouts.cancel();
+        timeouts = null;
+      }
+    }
+  }
+
+  private Timer getTimer() {
+    if (timeouts == null) {
+      timeouts = new Timer("TrackRuntimesStatuses", true);
+    }
+    return timeouts;
+  }
+
+  private class WaitStatusChangedTask extends TimerTask {
+
+    private final KubernetesInternalRuntime runtime;
+    private final WorkspaceStatus trackedStatus;
+    private final Consumer<KubernetesInternalRuntime> failureCallback;
+
+    private WaitStatusChangedTask(
+        KubernetesInternalRuntime runtime,
+        WorkspaceStatus trackedStatus,
+        Consumer<KubernetesInternalRuntime> failureCallback) {
+      this.runtime = runtime;
+      this.trackedStatus = trackedStatus;
+      this.failureCallback = failureCallback;
+    }
+
+    @Override
+    public void run() {
+      String workspaceId = runtime.getContext().getIdentity().getWorkspaceId();
+      workspaceId2Task.remove(workspaceId);
+      if (getRuntimeStatus(runtime) == trackedStatus) {
+        LOG.debug(
+            "Timeout is reached but workspace with id '{}' is still {}.",
+            workspaceId,
+            trackedStatus);
+
+        workspaceSharedPool.execute(() -> failureCallback.accept(runtime));
+      } else {
+        LOG.debug(
+            "Timeout is reached and workspace with id '{}' is not anymore",
+            workspaceId,
+            trackedStatus);
+      }
+    }
+  }
+
+  private WorkspaceStatus getRuntimeStatus(KubernetesInternalRuntime runtime) {
+    try {
+      return runtime.getStatus();
+    } catch (InfrastructureException e) {
+      return null;
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesIngresses.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesIngresses.java
@@ -63,7 +63,7 @@ public class KubernetesIngresses {
     }
   }
 
-  public Ingress wait(String name, int timeoutMin, Predicate<Ingress> predicate)
+  public Ingress wait(String name, long timeout, TimeUnit timeoutUnit, Predicate<Ingress> predicate)
       throws InfrastructureException {
     CompletableFuture<Ingress> future = new CompletableFuture<>();
     Watch watch = null;
@@ -102,7 +102,7 @@ public class KubernetesIngresses {
         return actualIngress;
       }
       try {
-        return future.get(timeoutMin, TimeUnit.MINUTES);
+        return future.get(timeout, timeoutUnit);
       } catch (ExecutionException e) {
         throw new InfrastructureException(e.getCause().getMessage(), e);
       } catch (TimeoutException e) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/RuntimeEventsPublisher.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/RuntimeEventsPublisher.java
@@ -19,18 +19,16 @@ import org.eclipse.che.api.core.model.workspace.runtime.Server;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.DtoConverter;
+import org.eclipse.che.api.workspace.server.event.RuntimeAbnormalStoppedEvent;
+import org.eclipse.che.api.workspace.server.event.RuntimeAbnormalStoppingEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.RuntimeLogEvent;
-import org.eclipse.che.api.workspace.shared.dto.event.RuntimeStatusEvent;
 import org.eclipse.che.api.workspace.shared.dto.event.ServerStatusEvent;
 import org.eclipse.che.dto.server.DtoFactory;
 
 /** @author Anton Korneta */
 @Singleton
 public class RuntimeEventsPublisher {
-
-  private static final String RUNTIME_STOPPED_STATE = "STOPPED";
-  private static final String RUNTIME_RUNNING_STATE = "RUNNING";
 
   private final EventService eventService;
 
@@ -64,16 +62,6 @@ public class RuntimeEventsPublisher {
             .withError(message));
   }
 
-  public void sendRuntimeStoppedEvent(String errorMsg, RuntimeIdentity runtimeId) {
-    eventService.publish(
-        DtoFactory.newDto(RuntimeStatusEvent.class)
-            .withIdentity(DtoConverter.asDto(runtimeId))
-            .withStatus(RUNTIME_STOPPED_STATE)
-            .withPrevStatus(RUNTIME_RUNNING_STATE)
-            .withFailed(true)
-            .withError(errorMsg));
-  }
-
   public void sendServerStatusEvent(
       String machineName, String serverName, Server server, RuntimeIdentity runtimeId) {
     eventService.publish(
@@ -104,5 +92,13 @@ public class RuntimeEventsPublisher {
             .withRuntimeId(DtoConverter.asDto(runtimeId))
             .withText(text)
             .withTime(time));
+  }
+
+  public void sendAbnormalStoppedEvent(RuntimeIdentity runtimeId, String reason) {
+    eventService.publish(new RuntimeAbnormalStoppedEvent(runtimeId, reason));
+  }
+
+  public void sendAbnormalStoppingEvent(RuntimeIdentity runtimeId, String reason) {
+    eventService.publish(new RuntimeAbnormalStoppingEvent(runtimeId, reason));
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -20,8 +20,8 @@ import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.STA
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_ORIGINAL_NAME_LABEL;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
@@ -218,7 +218,7 @@ public class KubernetesInternalRuntimeTest {
     runtimeStatesCache = new MapBasedRuntimeStateCache();
     machinesCache = new MapBasedMachinesCache();
 
-    startSynchronizer = spy(new StartSynchronizer(eventService, IDENTITY));
+    startSynchronizer = spy(new StartSynchronizer(eventService, 5, IDENTITY));
     when(startSynchronizerFactory.create(any())).thenReturn(startSynchronizer);
 
     internalRuntime =
@@ -291,7 +291,7 @@ public class KubernetesInternalRuntimeTest {
     final Map<String, Ingress> allIngresses = ImmutableMap.of(INGRESS_NAME, ingress);
     when(services.create(any())).thenAnswer(a -> a.getArguments()[0]);
     when(ingresses.create(any())).thenAnswer(a -> a.getArguments()[0]);
-    when(ingresses.wait(any(), anyInt(), any())).thenReturn(ingress);
+    when(ingresses.wait(anyString(), anyLong(), any(), any())).thenReturn(ingress);
     when(deployments.deploy(any())).thenAnswer(a -> a.getArguments()[0]);
     when(k8sEnv.getServices()).thenReturn(allServices);
     when(k8sEnv.getIngresses()).thenReturn(allIngresses);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -188,6 +188,7 @@ public class KubernetesInternalRuntimeTest {
   @Mock private WorkspaceProbes workspaceProbes;
   @Mock private KubernetesServerResolver kubernetesServerResolver;
   @Mock private InternalEnvironmentProvisioner internalEnvironmentProvisioner;
+  @Mock private RuntimeHangingDetector runtimeHangingDetector;
 
   @Mock
   private KubernetesEnvironmentProvisioner<KubernetesEnvironment> kubernetesEnvironmentProvisioner;
@@ -240,6 +241,7 @@ public class KubernetesInternalRuntimeTest {
             ImmutableSet.of(internalEnvironmentProvisioner),
             kubernetesEnvironmentProvisioner,
             toolingProvisioner,
+            runtimeHangingDetector,
             context,
             namespace,
             emptyList());
@@ -263,6 +265,7 @@ public class KubernetesInternalRuntimeTest {
             ImmutableSet.of(internalEnvironmentProvisioner),
             kubernetesEnvironmentProvisioner,
             toolingProvisioner,
+            runtimeHangingDetector,
             context,
             namespace,
             emptyList());
@@ -451,6 +454,7 @@ public class KubernetesInternalRuntimeTest {
 
     internalRuntime.internalStop(emptyMap());
 
+    verify(runtimeHangingDetector).stopTracking(IDENTITY);
     verify(namespace).cleanUp();
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/StartSynchronizerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/StartSynchronizerTest.java
@@ -50,7 +50,7 @@ public class StartSynchronizerTest {
   @BeforeMethod
   public void setUp() {
     runtimeId = new RuntimeIdentityImpl("workspace123", "envName", "ownerId");
-    startSynchronizer = new StartSynchronizer(eventService, runtimeId);
+    startSynchronizer = new StartSynchronizer(eventService, 5, runtimeId);
   }
 
   @Test
@@ -168,7 +168,7 @@ public class StartSynchronizerTest {
   public void shouldInterruptStartWhenStoppingEventIsPublished() throws Exception {
     // given
     EventService eventService = new EventService();
-    StartSynchronizer localStartSynchronizer = new StartSynchronizer(eventService, runtimeId);
+    StartSynchronizer localStartSynchronizer = new StartSynchronizer(eventService, 5, runtimeId);
     localStartSynchronizer.start();
 
     // when
@@ -182,7 +182,7 @@ public class StartSynchronizerTest {
   public void shouldCompleteStartWhenStoppedEventIsPublished() {
     // given
     EventService eventService = new EventService();
-    StartSynchronizer localStartSynchronizer = new StartSynchronizer(eventService, runtimeId);
+    StartSynchronizer localStartSynchronizer = new StartSynchronizer(eventService, 5, runtimeId);
     localStartSynchronizer.start();
 
     // when

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -31,6 +31,7 @@ import org.eclipse.che.api.workspace.server.hc.probe.WorkspaceProbesFactory;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime;
+import org.eclipse.che.workspace.infrastructure.kubernetes.RuntimeHangingDetector;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapperFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
@@ -73,6 +74,7 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
       Set<InternalEnvironmentProvisioner> internalEnvironmentProvisioners,
       OpenShiftEnvironmentProvisioner kubernetesEnvironmentProvisioner,
       SidecarToolingProvisioner<OpenShiftEnvironment> toolingProvisioner,
+      RuntimeHangingDetector runtimeHangingDetector,
       @Assisted OpenShiftRuntimeContext context,
       @Assisted OpenShiftProject project,
       @Assisted List<Warning> warnings) {
@@ -94,6 +96,7 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
         internalEnvironmentProvisioners,
         kubernetesEnvironmentProvisioner,
         toolingProvisioner,
+        runtimeHangingDetector,
         context,
         project,
         warnings);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftRuntimeContext.java
@@ -74,7 +74,7 @@ public class OpenShiftRuntimeContext extends KubernetesRuntimeContext<OpenShiftE
             projectFactory.create(workspaceId, runtimeState.getNamespace()),
             getEnvironment().getWarnings());
 
-    runtime.scheduleServersCheckers();
+    runtime.scheduleRuntimeStateChecks();
 
     return runtime;
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -68,6 +68,7 @@ import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
 import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.RuntimeHangingDetector;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.bootstrapper.KubernetesBootstrapper;
@@ -142,6 +143,7 @@ public class OpenShiftInternalRuntimeTest {
   @Mock private OpenShiftEnvironmentProvisioner kubernetesEnvironmentProvisioner;
   @Mock private SidecarToolingProvisioner<OpenShiftEnvironment> toolingProvisioner;
   @Mock private UnrecoverablePodEventListenerFactory unrecoverablePodEventListenerFactory;
+  @Mock private RuntimeHangingDetector runtimeHangingDetector;
 
   @Captor private ArgumentCaptor<MachineStatusEvent> machineStatusEventCaptor;
 
@@ -176,6 +178,7 @@ public class OpenShiftInternalRuntimeTest {
             ImmutableSet.of(internalEnvironmentProvisioner),
             kubernetesEnvironmentProvisioner,
             toolingProvisioner,
+            runtimeHangingDetector,
             context,
             project,
             emptyList());
@@ -199,6 +202,7 @@ public class OpenShiftInternalRuntimeTest {
             ImmutableSet.of(internalEnvironmentProvisioner),
             kubernetesEnvironmentProvisioner,
             toolingProvisioner,
+            runtimeHangingDetector,
             context,
             project,
             emptyList());

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -595,7 +595,7 @@ public class WorkspaceRuntimes {
 
       long finishTime = System.currentTimeMillis();
       LOG.info(
-          "All runtimes is recovered inished in {} seconds.",
+          "All runtimes have been recovered in {} seconds.",
           TimeUnit.MILLISECONDS.toSeconds(finishTime - startTime));
     }
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -815,7 +815,7 @@ public class WorkspaceRuntimes {
           publishWorkspaceStatusEvent(
               workspaceId,
               STOPPED,
-              RUNNING,
+              status,
               "Error occurs on workspace runtime stop. Error: " + event.getError());
           setAbnormalStopAttributes(workspaceId, event.getError());
         }
@@ -832,7 +832,8 @@ public class WorkspaceRuntimes {
       } catch (NotFoundException | ServerException | ConflictException e) {
         LOG.warn(
             format(
-                "Cannot set error status of the workspace %s. Error is: %s", workspaceId, error));
+                "Cannot set error status of the workspace %s. Error status is: %s. Cause: %s",
+                workspaceId, error, e.getMessage()));
       }
     }
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/RuntimeAbnormalStoppedEvent.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/RuntimeAbnormalStoppedEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.event;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+
+/**
+ * Should be propagated after Infrastructure stopped a runtime because of any fatal error.
+ *
+ * @author Sergii Leshchenko
+ */
+public class RuntimeAbnormalStoppedEvent {
+
+  private RuntimeIdentity runtimeId;
+  private String reason;
+
+  public RuntimeAbnormalStoppedEvent(RuntimeIdentity runtimeId, String reason) {
+    this.runtimeId = runtimeId;
+    this.reason = reason;
+  }
+
+  public RuntimeIdentity getIdentity() {
+    return runtimeId;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/RuntimeAbnormalStoppingEvent.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/event/RuntimeAbnormalStoppingEvent.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.event;
+
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+
+/**
+ * Should be propagated before Infrastructure stops a runtime because of any fatal error.
+ *
+ * @author Sergii Leshchenko
+ */
+public class RuntimeAbnormalStoppingEvent {
+
+  private RuntimeIdentity runtimeId;
+  private String reason;
+
+  public RuntimeAbnormalStoppingEvent(RuntimeIdentity runtimeId, String reason) {
+    this.runtimeId = runtimeId;
+    this.reason = reason;
+  }
+
+  public RuntimeIdentity getIdentity() {
+    return runtimeId;
+  }
+
+  public String getReason() {
+    return reason;
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -49,6 +49,8 @@ import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.event.RuntimeAbnormalStoppedEvent;
+import org.eclipse.che.api.workspace.server.event.RuntimeAbnormalStoppingEvent;
 import org.eclipse.che.api.workspace.server.hc.probe.ProbeScheduler;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.MachineImpl;
@@ -65,7 +67,6 @@ import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironmentFactory;
 import org.eclipse.che.api.workspace.shared.dto.RuntimeIdentityDto;
-import org.eclipse.che.api.workspace.shared.dto.event.RuntimeStatusEvent;
 import org.eclipse.che.core.db.DBInitializer;
 import org.eclipse.che.dto.server.DtoFactory;
 import org.mockito.ArgumentCaptor;
@@ -272,23 +273,54 @@ public class WorkspaceRuntimesTest {
     when(context.getRuntime()).thenReturn(new TestInternalRuntime(context));
     when(statuses.remove(anyString())).thenReturn(WorkspaceStatus.RUNNING);
 
-    RuntimeStatusEvent event =
-        DtoFactory.newDto(RuntimeStatusEvent.class)
-            .withIdentity(identity)
-            .withFailed(true)
-            .withError(error);
+    RuntimeAbnormalStoppedEvent event = new RuntimeAbnormalStoppedEvent(identity, error);
     localRuntimes.recoverOne(infrastructure, identity);
     ArgumentCaptor<WorkspaceImpl> captor = ArgumentCaptor.forClass(WorkspaceImpl.class);
 
     // when
     localEventService.publish(event);
 
-    // than
+    // then
     verify(workspaceDao, atLeastOnce()).update(captor.capture());
     WorkspaceImpl ws = captor.getAllValues().get(captor.getAllValues().size() - 1);
     assertNotNull(ws.getAttributes().get(STOPPED_ATTRIBUTE_NAME));
     assertTrue(Boolean.valueOf(ws.getAttributes().get(STOPPED_ABNORMALLY_ATTRIBUTE_NAME)));
     assertEquals(ws.getAttributes().get(ERROR_MESSAGE_ATTRIBUTE_NAME), error);
+  }
+
+  @Test
+  public void stoppingStatusIsSetWhenRuntimeAbnormallyStopping() throws Exception {
+    String error = "Some kind of error happened";
+    EventService localEventService = new EventService();
+    WorkspaceRuntimes localRuntimes =
+        new WorkspaceRuntimes(
+            localEventService,
+            ImmutableMap.of(TEST_ENVIRONMENT_TYPE, testEnvFactory),
+            infrastructure,
+            sharedPool,
+            workspaceDao,
+            dbInitializer,
+            probeScheduler,
+            statuses,
+            lockService);
+    localRuntimes.init();
+    RuntimeIdentityDto identity =
+        DtoFactory.newDto(RuntimeIdentityDto.class)
+            .withWorkspaceId("workspace123")
+            .withEnvName("my-env")
+            .withOwnerId("myId");
+    mockWorkspace(identity);
+    RuntimeContext context = mockContext(identity);
+    when(context.getRuntime()).thenReturn(new TestInternalRuntime(context));
+
+    RuntimeAbnormalStoppingEvent event = new RuntimeAbnormalStoppingEvent(identity, error);
+    localRuntimes.recoverOne(infrastructure, identity);
+
+    // when
+    localEventService.publish(event);
+
+    // then
+    verify(statuses).replace("workspace123", WorkspaceStatus.STOPPING);
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
**Major changes**
Add tracking of STARTING/STOPPING recovered k8s/OS runtimes and stop them if operation is not finished in time.

Move start timeout to StartSynchronizer.
It allows considering ingress wait timeout as part of start timeout
instead of considering them as non-related timeouts

**Minor changes**
Fix WorkspaceRuntimes error logging and status change propagation

Fix propagating of TimeoutException 
Since timeout exception has no message in this particular case
user saw `Workspace failed to start. Cause: null` when timeout exception
occurred. Now TimeoutException is wrapped in InfrastructureException with
meaningful message and it is much clear what happened

Formatted pom.xml in dashboard module

Introduced RuntimeAbnormalStopping and RuntimeAbnormalStopped events

Fix logging when error occurred during stopping of workspace

### How it works

https://youtu.be/3ZEPot4MJ90

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11364

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
