### PR TITLE
Split editors and plugins, and disable installers, when any plugin is selected

### DIFF
--- a/dashboard/src/app/index.styl
+++ b/dashboard/src/app/index.styl
@@ -240,14 +240,19 @@ md-tabs-wrapper
   z-index 1
   md-tab-item
     background-color inherit !important
-    .error-state
-      color $error-color !important
+    .error-state, .warning-state
       position absolute
       display inline-block
       font-size 14px
       margin-top 5px
       margin-left -15px
-
+    .error-state
+      color $error-color !important
+      
+    .warning-state
+      color $warning-color !important
+      margin-left -18px
+      
 .popover
   font-family 'Open Sans'
   font-size 12px

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -321,6 +321,10 @@ export class WorkspaceDetailsController {
       return `Current infrastructure doesn't support this workspace recipe type.`;
     }
 
+    if (this.isSwitchToPlugins()) {
+      return 'Installers and plugins are different concepts, which are not compatible between each others. Enabling plugins causes disabling all installers.';
+    } 
+
     if (failedTabs && failedTabs.length > 0) {
       const url = this.$location.absUrl().split('?')[0];
       let message = `<i class="error fa fa-exclamation-circle"
@@ -363,6 +367,7 @@ export class WorkspaceDetailsController {
 
     // message visibility
     this.editOverlayConfig.message.visible = !this.isSupported
+      || this.isSwitchToPlugins()
       || failedTabs.length > 0
       || this.unsavedChangesToApply
       || this.workspaceDetailsService.getRestartToApply(this.workspaceId);
@@ -525,5 +530,23 @@ export class WorkspaceDetailsController {
     });
 
     return tabs.some((tabKey: string) => this.checkFormsNotValid(tabKey));
+  }
+
+  /**
+   * Checks whether "plugins" were disabled in origin workspace config and are enabled now.
+   */
+  isSwitchToPlugins(): boolean {
+    let originEditor = this.originWorkspaceDetails.config.attributes['editor'] || '';
+    let originPlugins = this.originWorkspaceDetails.config.attributes['plugins'] || '';
+    return this.isPluginsEnabled() && (originEditor.length === 0 && originPlugins.length === 0);
+  }
+
+  /**
+   * Checks whether "plugins" are enabled in workspace config.
+   */
+  isPluginsEnabled(): boolean {
+    let editor = this.workspaceDetails.config.attributes['editor'] || '';
+    let plugins = this.workspaceDetails.config.attributes['plugins'] || '';
+    return (editor.length > 0 || plugins.length > 0);
   }
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
@@ -49,6 +49,7 @@ describe(`WorkspaceDetailsController >`, () => {
       'namespace': 'che',
       'status': 'RUNNING',
       'config': {
+        'attributes': {},
         'environments': {
           'default': {
             'recipe': {'type': 'dockerimage', 'content': 'eclipse/ubuntu_jdk8'},

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -71,6 +71,8 @@
     <!-- Installers tab -->
     <md-tab md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Installers);">
       <md-tab-label>
+        <i ng-show="workspaceDetailsController.isSwitchToPlugins()"
+          class="warning-state fa fa-exclamation-triangle" aria-hidden="true"></i>
         <span class="che-tab-label-title">Installers</span>
       </md-tab-label>
       <md-tab-body>
@@ -78,6 +80,7 @@
                               workspace-details="workspaceDetailsController.workspaceDetails"
                               on-change="workspaceDetailsController.checkEditMode(true)">
           <che-machine-agents selected-machine="machine"
+                              is-plugins-enabled="workspaceDetailsController.isPluginsEnabled()"
                               on-change="onChange()"></che-machine-agents>
         </che-machine-selector>
       </md-tab-body>

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.controller.ts
@@ -32,6 +32,7 @@ export class MachineAgentsController {
   static $inject = ['$scope', 'cheAgent', '$timeout', '$q'];
 
   onChange: Function;
+  isPluginsEnabled: boolean;
   agentOrderBy = 'name';
   agentItemsList: Array<IAgentItem>;
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.directive.ts
@@ -42,7 +42,8 @@ export class MachineAgents implements ng.IDirective {
     // scope values
     this.scope = {
       machine: '=selectedMachine',
-      onChange: '&'
+      onChange: '&',
+      isPluginsEnabled: '='
     };
   }
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.html
@@ -1,5 +1,13 @@
 <div class="che-machine-agents">
-  <div flex>
+  <div flex layout="row"
+        layout-align="start stretch"          
+        ng-if="machineAgentsController.isPluginsEnabled" class="warning-message">
+    <i class="fa fa-exclamation-triangle" aria-hidden="true"></i>
+    <div>Installers and plugins are different concepts, which are not compatible between each others.<br>
+      If you want to enable installers, you need to disable all the plugins already configured.<br>
+      Please note: Installers will be completely replaced by plugins in a near version.</div>
+  </div>
+  <div ng-if="!machineAgentsController.isPluginsEnabled" flex>
     <!-- Agents list header -->
     <div flex layout="column" md-theme="maincontent-theme">
       <che-list-header che-hide-header="!machineAgentsController.agentItemsList.length">

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-agents/machine-agents.styl
@@ -1,4 +1,13 @@
 .che-machine-agents
+  .warning-message
+    max-width 650px
+    color $label-secondary-color
+
+  .warning-message i
+    color $warning-color  
+    font-size 24px
+    margin auto 20px auto 0px
+
   margin-top 0
   .che-list-header
     .che-list-header-additional

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.html
@@ -1,5 +1,74 @@
 <md-progress-linear ng-show="workspacePluginsController.isLoading" md-mode="indeterminate"></md-progress-linear>
 <div flex layout="column" md-theme="maincontent-theme" class="plugins-page">
+  <che-list-header che-hide-header="workspacePluginsController.editors.length === 0">
+    <div flex="100"
+        layout="row"
+        layout-align="start stretch"
+        class="che-list-item-row">
+      <div layout="row" layout-align="center center" class="che-list-item-checkbox"></div>
+      <div flex layout="row" layout-align="start center" class="che-list-item-details">
+        <che-list-header-column flex="10" layout="column" layout-align="center start"
+                                che-sort-value="workspacePluginsController.pluginOrderBy"
+                                che-sort-item="isEnabled"
+                                che-column-title="Enable"></che-list-header-column>
+        <che-list-header-column flex="25" layout="column" layout-align="center start"
+                                che-sort-value="workspacePluginsController.pluginOrderBy"
+                                che-sort-item="name"
+                                che-column-title="Editor"></che-list-header-column>
+        <che-list-header-column flex="15" layout="column" layout-align="center start"
+                                che-column-title="Version"></che-list-header-column>
+        <che-list-header-column flex="50" layout="column" layout-align="center start"
+                                che-column-title="Description"></che-list-header-column>
+      </div>
+    </div>
+  </che-list-header>
+  <!-- editor list  -->
+  <che-list class="plugins-list" flex
+            ng-if="workspacePluginsController.editors && workspacePluginsController.editors.length > 0">
+    <div class="plugin-item"
+        ng-repeat="editor in workspacePluginsController.editors | orderBy:[workspacePluginsController.pluginOrderBy, 'name' ]">
+      <che-list-item flex>
+        <div flex="100"
+            layout="row"
+            layout-align="start stretch"
+            plugin-item-name="{{editor.name}}"
+            plugin-item-version="{{editor.version}}"
+            class="che-list-item-row">
+          <div layout="row" layout-align="center center" class="che-list-item-checkbox"></div>
+          <div flex layout="row" layout-align="start center">
+            <!-- isEnabled -->
+            <div flex="10">
+              <md-switch ng-model="editor.isEnabled"
+                        ng-change="workspacePluginsController.updatePlugin(editor)"
+                        aria-label="editor"
+                        plugin-switch="{{editor.name}}">
+              </md-switch>
+            </div>
+            <!-- Name -->
+            <div flex="25">
+              <span class="che-list-item-name" plugin-name="{{editor.name}}">{{editor.name}}</span>
+            </div>
+            <!-- Version -->
+            <div flex="15">
+              <span class="che-list-item-name" plugin-version="{{editor.version}}">{{editor.version}}</span>
+            </div>
+            <!-- Description -->
+            <div flex="50">
+              <span class="che-list-item-secondary" plugin-description="{{editor.description}}">{{editor.description}}</span>
+            </div>
+          </div>
+        </div>
+      </che-list-item>
+    </div>
+  </che-list>
+  <div class="che-list-empty">
+    <span ng-show="workspacePluginsController.editors.length === 0">
+      There are no editors.
+    </span>
+  </div>
+</div>
+<div class="plugin-page-separator"></div>
+<div flex layout="column" md-theme="maincontent-theme" class="plugins-page">
   <che-list-header-additional-parts>
     <div che-multi-transclude-part="che-list-add-button">
     </div>
@@ -12,9 +81,9 @@
 
   <che-list-header che-hide-header="workspacePluginsController.cheListHelper.visibleItemsNumber === 0">
     <div flex="100"
-         layout="row"
-         layout-align="start stretch"
-         class="che-list-item-row">
+        layout="row"
+        layout-align="start stretch"
+        class="che-list-item-row">
       <div layout="row" layout-align="center center" class="che-list-item-checkbox"></div>
       <div flex layout="row" layout-align="start center" class="che-list-item-details">
         <che-list-header-column flex="10" layout="column" layout-align="center start"
@@ -24,7 +93,7 @@
         <che-list-header-column flex="25" layout="column" layout-align="center start"
                                 che-sort-value="workspacePluginsController.pluginOrderBy"
                                 che-sort-item="name"
-                                che-column-title="Name"></che-list-header-column>
+                                che-column-title="Plugin"></che-list-header-column>
         <che-list-header-column flex="15" layout="column" layout-align="center start"
                                 che-column-title="Version"></che-list-header-column>
         <che-list-header-column flex="50" layout="column" layout-align="center start"
@@ -32,26 +101,26 @@
       </div>
     </div>
   </che-list-header>
-  <!-- plugins list  -->
+    <!-- plugins list  -->
   <che-list class="plugins-list" flex
             ng-if="workspacePluginsController.plugins && workspacePluginsController.plugins.length > 0">
     <div class="plugin-item"
-         ng-repeat="plugin in workspacePluginsController.cheListHelper.getVisibleItems() | orderBy:[workspacePluginsController.pluginOrderBy, 'name' ]">
+        ng-repeat="plugin in workspacePluginsController.cheListHelper.getVisibleItems() | orderBy:[workspacePluginsController.pluginOrderBy, 'name' ]">
       <che-list-item flex>
         <div flex="100"
-             layout="row"
-             layout-align="start stretch"
-             plugin-item-name="{{plugin.name}}"
-             plugin-item-version="{{plugin.version}}"
-             class="che-list-item-row">
+            layout="row"
+            layout-align="start stretch"
+            plugin-item-name="{{plugin.name}}"
+            plugin-item-version="{{plugin.version}}"
+            class="che-list-item-row">
           <div layout="row" layout-align="center center" class="che-list-item-checkbox"></div>
           <div flex layout="row" layout-align="start center">
             <!-- isEnabled -->
             <div flex="10">
               <md-switch ng-model="plugin.isEnabled"
-                         ng-change="workspacePluginsController.updatePlugin(plugin)"
-                         aria-label="plugin"
-                         plugin-switch="{{plugin.name}}">
+                        ng-change="workspacePluginsController.updatePlugin(plugin)"
+                        aria-label="plugin"
+                        plugin-switch="{{plugin.name}}">
               </md-switch>
             </div>
             <!-- Name -->

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.styl
@@ -1,6 +1,13 @@
 md-tab-content .plugins-page
   margin 0 25px
-  
+
+md-tab-content .plugins-page:first-of-type
+  margin-top 25px  
+
+md-tab-content .plugin-page-separator
+  margin-left 25px
+  margin-right 25px
+
 .plugins-page
   .che-list-header-additional-parts
       padding-left 0
@@ -53,3 +60,9 @@ md-tab-content .plugins-page
         .che-list-item-checkbox
           min-width 50px
           height inherit
+.plugin-page-separator
+  margin-top 40px
+  margin-bottom 10px
+  height 1px
+  background-color $list-separator-color
+


### PR DESCRIPTION

Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
1. Splits the plugins on: plugins and editors - for user to be able to differentiate.
![ezgif com-video-to-gif 2](https://user-images.githubusercontent.com/1611939/46734555-476b9f00-cc9c-11e8-9274-a254807e3db2.gif)


2. Disable installers, when plugin is selected with notifying user about that.
![ezgif com-video-to-gif 3](https://user-images.githubusercontent.com/1611939/46734566-4d618000-cc9c-11e8-98bc-af00de948a09.gif)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11401




