### PR TITLE
Fix importing a project from Git VCS with a branch that contains slash symbol

### DIFF
--- a/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
+++ b/wsagent/che-core-git-impl-jgit/src/main/java/org/eclipse/che/git/impl/jgit/JGitConnection.java
@@ -412,15 +412,14 @@ class JGitConnection implements GitConnection {
                 .map(Branch::getDisplayName)
                 .collect(Collectors.toList());
         if (!localBranches.contains(name)) {
-          List<Branch> remoteBranchesWithGivenName =
-              branchList(LIST_REMOTE)
-                  .stream()
-                  .filter(
-                      branch -> {
-                        String branchName = branch.getName();
-                        return name.equals(branchName.substring(branchName.lastIndexOf("/") + 1));
-                      })
-                  .collect(Collectors.toList());
+          List<Branch> remoteBranchesWithGivenName = new ArrayList<>();
+          for (Branch branch : branchList(LIST_REMOTE)) {
+            String branchNameWithoutRefs = branch.getName().replaceFirst("refs/remotes/", "");
+            String branchNameWithoutRemote = cleanRemoteName(branchNameWithoutRefs);
+            if (name.equals(branchNameWithoutRemote)) {
+              remoteBranchesWithGivenName.add(branch);
+            }
+          }
           if (remoteBranchesWithGivenName.size() > 1) {
             throw new GitException(
                 String.format(ERROR_CHECKOUT_BRANCH_NAME_EXISTS_IN_SEVERAL_REMOTES, name));


### PR DESCRIPTION

Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix importing a project from Git VCS with a branch that contains slash symbol. See #11012 for details.

### What issues does this PR fix or reference?
Closes #11012

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
