### PR TITLE
Fixed case when Find References feature displays incorrect line positions

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/location/OpenLocationViewImpl.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/location/OpenLocationViewImpl.java
@@ -82,13 +82,13 @@ public class OpenLocationViewImpl extends BaseView<OpenLocationView.ActionDelega
       presentation.setPresentableText(location.getUri());
       presentation.setInfoText(
           "From:"
-              + location.getRange().getStart().getLine()
+              + (location.getRange().getStart().getLine() + 1)
               + ":"
-              + location.getRange().getStart().getCharacter()
+              + (location.getRange().getStart().getCharacter() + 1)
               + " To:"
-              + location.getRange().getEnd().getLine()
+              + (location.getRange().getEnd().getLine() + 1)
               + ":"
-              + location.getRange().getEnd().getCharacter());
+              + (location.getRange().getEnd().getCharacter() + 1));
     }
 
     @Override


### PR DESCRIPTION
Related issue: https://github.com/eclipse/che/issues/10698

The problem is that IDE editor and language server differently interprets intervals.