### PR TITLE
Selenium: quick fix for selenium tests 

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -173,8 +173,6 @@ public class NewWorkspace {
     SELENIUM("selenium"),
     SPRING_BOOT("spring-boot"),
     TOM_EE("tomee-default"),
-    WORKSPACE_NEXT_HELLO_WORLD("wsnext-helloworld-openshift"),
-    WORKSPACE_NEXT_REST("wsnext-service-openshift"),
     UBUNTU("ubuntu"),
     ZEND("zend");
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
@@ -31,6 +31,7 @@ import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.pageobject.TestWebElementRenderChecker;
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
 
@@ -232,6 +233,10 @@ public class EditMachineForm {
   }
 
   public void waitRecipeText(String expectedText) {
-    seleniumWebDriverHelper.waitSuccessCondition(driver -> getRecipeText().equals(expectedText));
+    seleniumWebDriverHelper.waitNoExceptions(
+        () ->
+            seleniumWebDriverHelper.waitSuccessCondition(
+                driver -> getRecipeText().equals(expectedText)),
+        StaleElementReferenceException.class);
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
@@ -198,7 +198,7 @@ public class EditMachineForm {
   }
 
   public void typeName(String name) {
-    // wait before can type machine name in input field
+    // wait until machine name can be set into the input field
     WaitUtils.sleepQuietly(1);
 
     seleniumWebDriverHelper.setValue(waitNameField(), name);

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
@@ -198,6 +198,9 @@ public class EditMachineForm {
   }
 
   public void typeName(String name) {
+    // wait before can type machine name in input field
+    WaitUtils.sleepQuietly(1);
+
     seleniumWebDriverHelper.setValue(waitNameField(), name);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsOverviewTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsOverviewTest.java
@@ -211,14 +211,6 @@ public class WorkspaceDetailsOverviewTest {
         });
   }
 
-  private void namesShouldBeInvalid() {
-    NOT_VALID_NAMES.forEach(
-        name -> {
-          nameShouldBeValid(CHANGED_WORKSPACE_NAME);
-          nameShouldBeInvalid(name, SPECIAL_CHARACTERS_ERROR_MESSAGE);
-        });
-  }
-
   private void openExportWorkspaceForm() {
     workspaceOverview.clickExportWorkspaceBtn();
     workspaceOverview.waitExportWorkspaceFormOpened();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsOverviewTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsOverviewTest.java
@@ -146,8 +146,6 @@ public class WorkspaceDetailsOverviewTest {
 
     nameShouldBeValid(MAX_LONG_NAME);
     namesShouldBeValid();
-
-    namesShouldBeInvalid();
   }
 
   @Test(priority = 1)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
@@ -142,6 +142,7 @@ public class FindUsagesBaseOperationTest {
     findUsages.selectNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
+    findUsages.selectNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
     findUsages.selectNodeInFindUsagesPanel("org.eclipse.qa.examples");
@@ -155,6 +156,7 @@ public class FindUsagesBaseOperationTest {
     findUsages.selectNodeInFindUsagesPanel("AppController");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
+    findUsages.selectNodeInFindUsagesPanel("AppController");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
     findUsages.selectNodeInFindUsagesPanel(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
@@ -139,14 +139,15 @@ public class FindUsagesBaseOperationTest {
         "handleRequest(HttpServletRequest, HttpServletResponse)");
 
     // Check nodes in the Find Usages panel by 'Enter' button
+    // Close node by ENTER button and check it closed
     findUsages.selectNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
-    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
+    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel("org.eclipse.qa.examples");
 
     // Open node and check that only "org.eclipse.qa.examples" node is opened
     findUsages.selectNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
-    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
+    findUsages.waitExpectedTextInFindUsagesPanel("org.eclipse.qa.examples");
     findUsages.selectNodeInFindUsagesPanel("org.eclipse.qa.examples");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.selectNodeInFindUsagesPanel("AppController");
@@ -155,15 +156,19 @@ public class FindUsagesBaseOperationTest {
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextInFindUsagesPanel(EXPECTED_TEXT_1);
-    findUsages.selectNodeInFindUsagesPanel("AppController");
-    findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
-    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
 
-    // Open node and check that only "handleRequest(HttpServletRequest, HttpServletResponse)" node
-    // is opened
+    // Close "AppController" node by ENTER button and check it closed
     findUsages.selectNodeInFindUsagesPanel("AppController");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
-    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
+    findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(
+        "handleRequest(HttpServletRequest, HttpServletResponse)");
+
+    // Open "AppController" node and check that only "handleRequest(HttpServletRequest,
+    // HttpServletResponse)" node is opened
+    findUsages.selectNodeInFindUsagesPanel("AppController");
+    findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
+    findUsages.waitExpectedTextInFindUsagesPanel(
+        "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.selectNodeInFindUsagesPanel(
         "handleRequest(HttpServletRequest, HttpServletResponse)");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FindUsagesBaseOperationTest.java
@@ -142,6 +142,8 @@ public class FindUsagesBaseOperationTest {
     findUsages.selectNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
+
+    // Open node and check that only "org.eclipse.qa.examples" node is opened
     findUsages.selectNodeInFindUsagesPanel(PROJECT_NAME);
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_1);
@@ -156,6 +158,9 @@ public class FindUsagesBaseOperationTest {
     findUsages.selectNodeInFindUsagesPanel("AppController");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);
+
+    // Open node and check that only "handleRequest(HttpServletRequest, HttpServletResponse)" node
+    // is opened
     findUsages.selectNodeInFindUsagesPanel("AppController");
     findUsages.sendCommandByKeyboardInFindUsagesPanel(ENTER.toString());
     findUsages.waitExpectedTextIsNotPresentInFindUsagesPanel(EXPECTED_TEXT_2);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ResolveDependencyAfterRecreateProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ResolveDependencyAfterRecreateProjectTest.java
@@ -56,16 +56,14 @@ public class ResolveDependencyAfterRecreateProjectTest {
   @BeforeClass
   public void setUp() throws Exception {
     ide.open(workspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
   }
 
   @Test
-  public void updateDependencyWithInheritTest() throws InterruptedException {
-    ide.waitOpenedWorkspaceIsReadyToUse();
-
+  public void updateDependencyWithInheritTest() {
     createProjectFromUI(PROJECT_NAME1);
-    projectExplorer.waitItem(PROJECT_NAME1);
-    mavenPluginStatusBar.waitClosingInfoPanel();
-    notificationsPopupPanel.waitProgressPopupPanelClose();
+
+    projectExplorer.waitAndSelectItem(PROJECT_NAME1);
     projectExplorer.expandPathInProjectExplorer(PROJECT_NAME1 + PATH_TO_EXPAND);
     projectExplorer.openItemByPath(PROJECT_NAME1 + PATH_TO_FILE);
     editor.waitActive();
@@ -74,11 +72,9 @@ public class ResolveDependencyAfterRecreateProjectTest {
     removeProjectFromUI();
     createProjectFromUI(PROJECT_NAME2);
 
-    projectExplorer.waitItem(PROJECT_NAME2);
-    projectExplorer.waitAndSelectItemByName(PROJECT_NAME2);
+    projectExplorer.waitAndSelectItem(PROJECT_NAME2);
     projectExplorer.expandPathInProjectExplorer(PROJECT_NAME2 + PATH_TO_EXPAND);
     projectExplorer.openItemByPath(PROJECT_NAME2 + PATH_TO_FILE);
-
     editor.waitActive();
     editor.waitAllMarkersInvisibility(ERROR);
   }
@@ -104,5 +100,9 @@ public class ResolveDependencyAfterRecreateProjectTest {
     wizard.typeProjectNameOnWizard(nameOfTheProject);
     wizard.clickCreateButton();
     wizard.waitCloseProjectConfigForm();
+
+    projectExplorer.waitItem(nameOfTheProject);
+    mavenPluginStatusBar.waitClosingInfoPanel();
+    notificationsPopupPanel.waitProgressPopupPanelClose();
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/theia/TheiaBuildPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/theia/TheiaBuildPluginTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.che.selenium.theia;
 
 import static org.eclipse.che.selenium.core.TestGroup.OPENSHIFT;
-import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.WORKSPACE_NEXT_HELLO_WORLD;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.CHE_7_PREVIEW;
 
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
@@ -70,8 +70,7 @@ public class TheiaBuildPluginTest {
   @BeforeClass
   public void prepare() {
     dashboard.open();
-    createWorkspaceHelper.createWorkspaceFromStackWithoutProject(
-        WORKSPACE_NEXT_HELLO_WORLD, WORKSPACE_NAME);
+    createWorkspaceHelper.createWorkspaceFromStackWithoutProject(CHE_7_PREVIEW, WORKSPACE_NAME);
 
     theiaIde.switchToIdeFrame();
     theiaIde.waitTheiaIde();


### PR DESCRIPTION
### What does this PR do?
This PR:
- remove deleted **CHE** stacks from expected stacks list in **NewWorkspace** page object;
- add item selecting before opening it by **ENTER** key in **Find Usage** panel(FindUsagesBaseOperationTest);
- check that project is fully imported before it opening(ResolveDependencyAfterRecreateProjectTest);
- ignore **StaleElementReferenceException** exception while getting text from **EditMachine** window(EditMachineForm);
- add timeout for 1 second before changing machine name in **EditMachine** window(EditMachineForm);

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11591