### PR TITLE
Make sure we update local projects when importing or on startup

### DIFF
--- a/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
+++ b/plugins/plugin-java/che-plugin-java-server/src/main/java/org/eclipse/che/plugin/java/languageserver/JavaLanguageServerExtensionService.java
@@ -982,11 +982,18 @@ public class JavaLanguageServerExtensionService {
    * Returns all nested projects starting from the given path.
    *
    * @param rootPath the root project path
+   * @throws TimeoutException
+   * @throws ExecutionException
+   * @throws InterruptedException
+   * @throws JsonSyntaxException
    */
-  public List<String> getMavenProjects(String rootPath) {
+  public List<String> getMavenProjects(String rootPath, int timeout, TimeUnit unit)
+      throws JsonSyntaxException, InterruptedException, ExecutionException, TimeoutException {
     Type type = new TypeToken<ArrayList<String>>() {}.getType();
-    List<String> projectsUri =
-        doGetList(Commands.GET_MAVEN_PROJECTS_COMMAND, singletonList(prefixURI(rootPath)), type);
+
+    CompletableFuture<Object> result =
+        executeCommand(Commands.GET_MAVEN_PROJECTS_COMMAND, singletonList(prefixURI(rootPath)));
+    List<String> projectsUri = gson.fromJson(gson.toJson(result.get(timeout, unit)), type);
     return removePrefixUri(projectsUri);
   }
 


### PR DESCRIPTION
### What does this PR do?
Increases the wait time when synchronizing maven projects with the local projects after importing a new project considerably. Also, synchronize root projects with jdt.ls after the LS has finished initializing.

### What issues does this PR fix or reference?
[JDT LS] Maven submodules and packages are not recognized in the Che project after importing #11537
