### PR TITLE
Selenium: Correct the method 'waitAndSelectItemByName()' in the 'ProjectExplorer'

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -500,7 +500,10 @@ public class ProjectExplorer {
    * @param name item's visible name
    */
   public void waitAndSelectItemByName(String name) {
-    waitVisibilityByName(name).click();
+    seleniumWebDriverHelper.waitNoExceptions(
+        () -> waitVisibilityByName(name).click(),
+        ELEMENT_TIMEOUT_SEC,
+        StaleElementReferenceException.class);
   }
 
   /**
@@ -581,7 +584,7 @@ public class ProjectExplorer {
 
   private void openItemByVisibleName(String name) {
 
-    waitVisibilityByName(name).click();
+    waitAndSelectItemByName(name);
     waitItemSelectedByName(name);
     actionsFactory
         .createAction(seleniumWebDriver)


### PR DESCRIPTION
### What does this PR do?
* Correct the waitAndSelectItemByName() in the ProjectExplorer to avoid the unexpected 'stale element reference' exception
* It allows to increase the reliability of the _ImportWizardFormTest_ selenium test when it runs on the CI job

### What issues does this PR fix or reference?
#11558