### PR TITLE
Don't put new line in the editor when going to a line by number

### DIFF
--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/choice/ChoiceDialogViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/choice/ChoiceDialogViewImpl.java
@@ -63,6 +63,7 @@ public class ChoiceDialogViewImpl extends Window implements ChoiceDialogView {
 
   @Override
   public void onEnterPress(NativeEvent evt) {
+    evt.preventDefault();
     delegate.onEnterClicked();
   }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/confirm/ConfirmDialogViewImpl.java
@@ -58,6 +58,7 @@ public class ConfirmDialogViewImpl extends Window implements ConfirmDialogView {
 
   @Override
   public void onEnterPress(NativeEvent evt) {
+    evt.preventDefault();
     delegate.onEnterClicked();
   }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/input/InputDialogViewImpl.java
@@ -68,6 +68,7 @@ public class InputDialogViewImpl extends Window implements InputDialogView {
 
   @Override
   public void onEnterPress(NativeEvent evt) {
+    evt.preventDefault();
     delegate.onEnterClicked();
   }
 

--- a/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/message/MessageDialogViewImpl.java
+++ b/ide/che-core-ide-ui/src/main/java/org/eclipse/che/ide/ui/dialogs/message/MessageDialogViewImpl.java
@@ -69,6 +69,7 @@ public class MessageDialogViewImpl extends Window implements MessageDialogView {
 
   @Override
   public void onEnterPress(NativeEvent evt) {
+    evt.preventDefault();
     delegate.accepted();
   }
 


### PR DESCRIPTION
Signed-off-by: Artem Zatsarynnyi <azatsary@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Prevents adding new line in the editor when closing 'Go to line' window with Enter key.

### What issues does this PR fix or reference?
#10982 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
