### PR TITLE
Selenium: fix unstable selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -41,7 +41,6 @@ import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.webdriver.WebDriverWaitFactory;
 import org.openqa.selenium.By;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -525,24 +524,19 @@ public class Consoles {
     waitPreviewUrlIsPresent();
     waitPreviewUrlIsResponsive(10);
 
-    // wait for 2 sec to prevent "Application is not available" error
-    WaitUtils.sleepQuietly(2);
+    // wait for 5 sec to prevent "Application is not available" error
+    WaitUtils.sleepQuietly(5);
     clickOnPreviewUrl();
 
     seleniumWebDriverHelper.switchToNextWindow(currentWindow);
 
     try {
       seleniumWebDriverHelper.waitVisibility(webElement, LOADER_TIMEOUT_SEC);
-    } catch (TimeoutException ex) {
-      // Switch to IDE frame if webElement was not found on Application page
+    } finally {
       seleniumWebDriver.close();
       seleniumWebDriver.switchTo().window(currentWindow);
       seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     }
-
-    seleniumWebDriver.close();
-    seleniumWebDriver.switchTo().window(currentWindow);
-    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
   }
 
   // Start command from project context menu and check expected message in Console

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -41,6 +41,7 @@ import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.webdriver.WebDriverWaitFactory;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebDriverException;
 import org.openqa.selenium.WebElement;
@@ -530,7 +531,14 @@ public class Consoles {
 
     seleniumWebDriverHelper.switchToNextWindow(currentWindow);
 
-    seleniumWebDriverHelper.waitVisibility(webElement, LOADER_TIMEOUT_SEC);
+    try {
+      seleniumWebDriverHelper.waitVisibility(webElement, LOADER_TIMEOUT_SEC);
+    } catch (TimeoutException ex) {
+      // Switch to IDE frame if webElement was not found on Application page
+      seleniumWebDriver.close();
+      seleniumWebDriver.switchTo().window(currentWindow);
+      seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
+    }
 
     seleniumWebDriver.close();
     seleniumWebDriver.switchTo().window(currentWindow);

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FileStructure.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FileStructure.java
@@ -169,6 +169,9 @@ public class FileStructure {
    * @param item is the name of the item
    */
   public void selectItemInFileStructure(String item) {
+    // we need to wait a little to avoid quick clicking on nodes
+    WaitUtils.sleepQuietly(1);
+
     seleniumWebDriverHelper.waitNoExceptions(
         () -> selectItem(item), StaleElementReferenceException.class);
   }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
@@ -75,7 +75,9 @@ public class EditMachineForm {
   }
 
   public void clickOnRecipeForm() {
-    seleniumWebDriverHelper.waitAndClick(By.xpath(RECIPE_EDITOR_TEXT_XPATH));
+    seleniumWebDriverHelper.waitNoExceptions(
+        () -> seleniumWebDriverHelper.waitAndClick(By.xpath(RECIPE_EDITOR_TEXT_XPATH)),
+        StaleElementReferenceException.class);
   }
 
   public void typeToRecipe(String text) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
@@ -114,6 +114,16 @@ public class WorkspaceDetailsMachineActionsTest {
     checkEditOfMachineName("FROM " + IMAGE_NAME + "\n");
   }
 
+  @Test(groups = {OPENSHIFT, K8S, OSIO})
+  public void checkRamSectionOpenshift() {
+    checkRamSection(IMAGE_NAME);
+  }
+
+  @Test(groups = DOCKER)
+  public void checkRamSectionDocker() {
+    checkRamSection("FROM " + IMAGE_NAME + "\n");
+  }
+
   private void checkEditOfMachineName(String expectedRecipeText) {
     // check default values
     workspaceDetailsMachines.clickOnEditButton(MACHINE_NAME);
@@ -148,8 +158,7 @@ public class WorkspaceDetailsMachineActionsTest {
     editMachineForm.waitSaveButtonDisabling();
   }
 
-  @Test
-  public void checkRamSection() {
+  public void checkRamSection(String expectedRecipeText) {
     // check machine name editing
     workspaceDetailsMachines.clickOnEditButton(MACHINE_NAME);
     editMachineForm.waitForm();
@@ -198,7 +207,7 @@ public class WorkspaceDetailsMachineActionsTest {
     editMachineForm.waitFormInvisibility();
     workspaceDetailsMachines.clickOnEditButton(MACHINE_NAME);
     editMachineForm.waitForm();
-    waitRecipeText(IMAGE_NAME);
+    waitRecipeText(expectedRecipeText);
 
     // check saving of the changes
     editMachineForm.typeRam(CHANGED_RAM_SIZE);


### PR DESCRIPTION
### What does this PR do?
This PR:
- ignore **StaleElementReferenceException** exception while clicking on **EditMachine** window(**EditMachineForm** page object);
- add timeout for 1 second before selecting node by click in **FileStructure** form to avoid quick clicking on nodes(**FileStructure** page object);
- close application page and return to IDE page if expected web element on application page was not found(**Consoles** page object).