### PR TITLE
Create a parent /node_modules folder and add setting for yarn to use that parent folder

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -74,7 +74,7 @@ RUN find ${HOME} -exec sh -c "chgrp 0 {}; chmod g+rwX {}" \;
 ###
 # Runtime Image
 #
-FROM centos
+FROM centos as runtime
 ENV USE_LOCAL_GIT=true \
     HOME=/home/theia
 
@@ -94,7 +94,9 @@ RUN yum install -y rh-git29 scl-utils sudo java-1.8.0-openjdk-devel bzip2 && \
 RUN useradd -u 1000 -G users,wheel,root -d ${HOME} --shell /bin/bash theia \
     && usermod -p "*" theia \
     && echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
-    && for f in "${HOME}" "/etc/passwd" "/etc/group"; do\
+    # Create root node_modules in order to not use node_modules in each project folder
+    && mkdir /node_modules \
+    && for f in "${HOME}" "/etc/passwd" "/etc/group /node_modules"; do\
            sudo chgrp -R 0 ${f} && \
            sudo chmod -R g+rwX ${f}; \
        done \
@@ -103,6 +105,8 @@ RUN useradd -u 1000 -G users,wheel,root -d ${HOME} --shell /bin/bash theia \
     && npm install -g yo @theia/generator-plugin \
     && mkdir -p ${HOME}/.config/insight-nodejs/ \
     && chmod -R 777 ${HOME}/.config/ \
+    # Defines the root /node_modules as the folder to use by yarn
+    && echo '"--*.modules-folder" "/node_modules"' > $HOME/.yarnrc \
     # use typescript globally (to have tsc/typescript working)
     && npm install -g typescript@2.9.2 \
     # Disable the statistics for yeoman

--- a/dockerfiles/theia/e2e/src/docker-run.sh
+++ b/dockerfiles/theia/e2e/src/docker-run.sh
@@ -13,5 +13,5 @@ sleep 10s
 rm -rf /home/cypress/cypress/videos
 
 # Run tests
-cd /home/cypress && ./node_modules/.bin/cypress run
+cd /home/cypress && /node_modules/.bin/cypress run
  


### PR DESCRIPTION
### What does this PR do?
Create a parent /node_modules folder and add setting for yarn to use that parent folder
then, any /projects/* items will use that parent folder to store dependencies and avoid to use current folder
it will avoid any big I/O operations on the /projects folder

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A


#### Docs PR
N/A

Change-Id: I9fee5963808607b93dcc592456845fb5a3d73e4a
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>
