### PR TITLE
Add workspace name and namespace as environment variable

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -64,8 +64,8 @@ import org.eclipse.che.api.workspace.server.spi.provision.env.ProjectsRootEnvVar
 import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceAgentJavaOptsEnvVariableProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceIdEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceMavenServerJavaOptsEnvVariableProvider;
-import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceNamespaceNameEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceNameEnvVarProvider;
+import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceNamespaceNameEnvVarProvider;
 import org.eclipse.che.api.workspace.server.stack.StackLoader;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
 import org.eclipse.che.api.workspace.server.wsplugins.ChePluginsApplier;

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -64,6 +64,8 @@ import org.eclipse.che.api.workspace.server.spi.provision.env.ProjectsRootEnvVar
 import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceAgentJavaOptsEnvVariableProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceIdEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceMavenServerJavaOptsEnvVariableProvider;
+import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceNamespaceNameEnvVarProvider;
+import org.eclipse.che.api.workspace.server.spi.provision.env.WorkspaceNameEnvVarProvider;
 import org.eclipse.che.api.workspace.server.stack.StackLoader;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
 import org.eclipse.che.api.workspace.server.wsplugins.ChePluginsApplier;
@@ -175,6 +177,8 @@ public class WsMasterModule extends AbstractModule {
     envVarProviders.addBinding().to(CheApiExternalEnvVarProvider.class);
     envVarProviders.addBinding().to(MachineTokenEnvVarProvider.class);
     envVarProviders.addBinding().to(WorkspaceIdEnvVarProvider.class);
+    envVarProviders.addBinding().to(WorkspaceNamespaceNameEnvVarProvider.class);
+    envVarProviders.addBinding().to(WorkspaceNameEnvVarProvider.class);
 
     envVarProviders.addBinding().to(JavaOptsEnvVariableProvider.class);
     envVarProviders.addBinding().to(MavenOptsEnvVariableProvider.class);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.spi.provision.env;
+
+import javax.inject.Inject;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
+import org.eclipse.che.commons.lang.Pair;
+
+/**
+ * Provides environment variable with workspace name
+ *
+ * @author Sergii Kabashniuk
+ */
+public class WorkspaceNameEnvVarProvider implements EnvVarProvider {
+
+  /** Env variable for workspace name */
+  public static final String CHE_WORKSPACE_NAME = "CHE_WORKSPACE_NAME";
+
+  private final WorkspaceDao workspaceDao;
+
+  @Inject
+  public WorkspaceNameEnvVarProvider(WorkspaceDao workspaceDao) {
+    this.workspaceDao = workspaceDao;
+  }
+
+  @Override
+  public Pair<String, String> get(RuntimeIdentity runtimeIdentity) throws InfrastructureException {
+    try {
+      WorkspaceImpl workspace = workspaceDao.get(runtimeIdentity.getWorkspaceId());
+      return Pair.of(CHE_WORKSPACE_NAME, workspace.getConfig().getName());
+    } catch (NotFoundException | ServerException e) {
+      throw new InfrastructureException(
+          "Not able to get workspace name for workspace with id "
+              + runtimeIdentity.getWorkspaceId(),
+          e);
+    }
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNamespaceNameEnvVarProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNamespaceNameEnvVarProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.spi.provision.env;
+
+import javax.inject.Inject;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
+import org.eclipse.che.commons.lang.Pair;
+
+/**
+ * Provides environment variable with workspace namespace
+ *
+ * @author Sergii Kabashniuk
+ */
+public class WorkspaceNamespaceNameEnvVarProvider implements EnvVarProvider {
+
+  /** Env variable for workspace name */
+  public static final String CHE_WORKSPACE_NAMESPACE = "CHE_WORKSPACE_NAMESPACE";
+
+  private final WorkspaceDao workspaceDao;
+
+  @Inject
+  public WorkspaceNamespaceNameEnvVarProvider(WorkspaceDao workspaceDao) {
+    this.workspaceDao = workspaceDao;
+  }
+
+  @Override
+  public Pair<String, String> get(RuntimeIdentity runtimeIdentity) throws InfrastructureException {
+    try {
+      WorkspaceImpl workspace = workspaceDao.get(runtimeIdentity.getWorkspaceId());
+      return Pair.of(CHE_WORKSPACE_NAMESPACE, workspace.getNamespace());
+    } catch (NotFoundException | ServerException e) {
+      throw new InfrastructureException(
+          "Not able to get workspace namespace for workspace with id "
+              + runtimeIdentity.getWorkspaceId(),
+          e);
+    }
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProviderTest.java
@@ -47,7 +47,6 @@ public class WorkspaceNameEnvVarProviderTest {
   public void shouldReturnNameVar()
       throws NotFoundException, ServerException, InfrastructureException {
     // given
-
     when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
     doReturn(workspace).when(workspaceDao).get(Mockito.eq("ws-id111"));
     when(workspace.getConfig()).thenReturn(config);
@@ -55,6 +54,7 @@ public class WorkspaceNameEnvVarProviderTest {
 
     // when
     Pair<String, String> actual = provider.get(runtimeIdentity);
+
     // then
     assertEquals(actual.first, WorkspaceNameEnvVarProvider.CHE_WORKSPACE_NAME);
     assertEquals(actual.second, "ws-name");
@@ -67,14 +67,11 @@ public class WorkspaceNameEnvVarProviderTest {
   public void shouldWrapNotFoundExceptionException()
       throws NotFoundException, ServerException, InfrastructureException {
     // given
-
     when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
     doThrow(new NotFoundException("Some message")).when(workspaceDao).get(Mockito.eq("ws-id111"));
 
     // when
     provider.get(runtimeIdentity);
-    // then
-
   }
 
   @Test(
@@ -89,7 +86,5 @@ public class WorkspaceNameEnvVarProviderTest {
 
     // when
     provider.get(runtimeIdentity);
-    // then
-
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProviderTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.spi.provision.env;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
+import org.eclipse.che.commons.lang.Pair;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class WorkspaceNameEnvVarProviderTest {
+
+  @Mock WorkspaceDao workspaceDao;
+  @Mock WorkspaceImpl workspace;
+  @Mock WorkspaceConfigImpl config;
+  @Mock RuntimeIdentity runtimeIdentity;
+  WorkspaceNameEnvVarProvider provider;
+
+  @BeforeMethod
+  public void setup() {
+    provider = new WorkspaceNameEnvVarProvider(workspaceDao);
+  }
+
+  @Test
+  public void shouldReturnNameVar()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
+    doReturn(workspace).when(workspaceDao).get(Mockito.eq("ws-id111"));
+    when(workspace.getConfig()).thenReturn(config);
+    when(config.getName()).thenReturn("ws-name");
+
+    // when
+    Pair<String, String> actual = provider.get(runtimeIdentity);
+    // then
+    assertEquals(actual.first, WorkspaceNameEnvVarProvider.CHE_WORKSPACE_NAME);
+    assertEquals(actual.second, "ws-name");
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Not able to get workspace name for workspace with id ws-id111")
+  public void shouldWrapNotFoundExceptionException()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
+    doThrow(new NotFoundException("Some message")).when(workspaceDao).get(Mockito.eq("ws-id111"));
+
+    // when
+    provider.get(runtimeIdentity);
+    // then
+
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Not able to get workspace name for workspace with id ws-id111")
+  public void shouldWrapServerExceptionException()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
+    doThrow(new ServerException("Some message")).when(workspaceDao).get(Mockito.eq("ws-id111"));
+
+    // when
+    provider.get(runtimeIdentity);
+    // then
+
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProviderTest.java
@@ -11,7 +11,9 @@
  */
 package org.eclipse.che.api.workspace.server.spi.provision.env;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import org.eclipse.che.api.core.NotFoundException;

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNamespaceEnvVarProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNamespaceEnvVarProviderTest.java
@@ -45,13 +45,13 @@ public class WorkspaceNamespaceEnvVarProviderTest {
   public void shouldReturnNamespaceVar()
       throws NotFoundException, ServerException, InfrastructureException {
     // given
-
     when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
     doReturn(workspace).when(workspaceDao).get(Mockito.eq("ws-id111"));
     when(workspace.getNamespace()).thenReturn("ws-namespace");
 
     // when
     Pair<String, String> actual = provider.get(runtimeIdentity);
+
     // then
     assertEquals(actual.first, WorkspaceNamespaceNameEnvVarProvider.CHE_WORKSPACE_NAMESPACE);
     assertEquals(actual.second, "ws-namespace");
@@ -64,14 +64,11 @@ public class WorkspaceNamespaceEnvVarProviderTest {
   public void shouldWrapNotFoundExceptionException()
       throws NotFoundException, ServerException, InfrastructureException {
     // given
-
     when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
     doThrow(new NotFoundException("Some message")).when(workspaceDao).get(Mockito.eq("ws-id111"));
 
     // when
     provider.get(runtimeIdentity);
-    // then
-
   }
 
   @Test(
@@ -86,7 +83,5 @@ public class WorkspaceNamespaceEnvVarProviderTest {
 
     // when
     provider.get(runtimeIdentity);
-    // then
-
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNamespaceEnvVarProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNamespaceEnvVarProviderTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server.spi.provision.env;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
+import org.eclipse.che.commons.lang.Pair;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class WorkspaceNamespaceEnvVarProviderTest {
+
+  @Mock WorkspaceDao workspaceDao;
+  @Mock WorkspaceImpl workspace;
+  @Mock RuntimeIdentity runtimeIdentity;
+  WorkspaceNamespaceNameEnvVarProvider provider;
+
+  @BeforeMethod
+  public void setup() {
+    provider = new WorkspaceNamespaceNameEnvVarProvider(workspaceDao);
+  }
+
+  @Test
+  public void shouldReturnNamespaceVar()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
+    doReturn(workspace).when(workspaceDao).get(Mockito.eq("ws-id111"));
+    when(workspace.getNamespace()).thenReturn("ws-namespace");
+
+    // when
+    Pair<String, String> actual = provider.get(runtimeIdentity);
+    // then
+    assertEquals(actual.first, WorkspaceNamespaceNameEnvVarProvider.CHE_WORKSPACE_NAMESPACE);
+    assertEquals(actual.second, "ws-namespace");
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Not able to get workspace namespace for workspace with id ws-id111")
+  public void shouldWrapNotFoundExceptionException()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
+    doThrow(new NotFoundException("Some message")).when(workspaceDao).get(Mockito.eq("ws-id111"));
+
+    // when
+    provider.get(runtimeIdentity);
+    // then
+
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Not able to get workspace namespace for workspace with id ws-id111")
+  public void shouldWrapServerExceptionException()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
+    doThrow(new ServerException("Some message")).when(workspaceDao).get(Mockito.eq("ws-id111"));
+
+    // when
+    provider.get(runtimeIdentity);
+    // then
+
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNamespaceEnvVarProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNamespaceEnvVarProviderTest.java
@@ -11,7 +11,9 @@
  */
 package org.eclipse.che.api.workspace.server.spi.provision.env;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import org.eclipse.che.api.core.NotFoundException;


### PR DESCRIPTION
### What does this PR do?
Add workspace name and namespace as an environment variable.
This will all to not make additional calls to ws master for tools that needed this data on startup.
![2018-10-16 11 39 41](https://user-images.githubusercontent.com/1614429/47004750-e8de6f00-d13a-11e8-827e-bef80593aa5f.png)


### What issues does this PR fix or reference?
Need for https://github.com/eclipse/che/issues/11453

#### Release Notes
n/a

#### Docs PR
n/a