### PR TITLE
Fix exception message during factory update with duplicate name

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
@@ -57,7 +57,9 @@ public class JpaFactoryDao implements FactoryDao {
     try {
       doCreate(factory);
     } catch (DuplicateKeyException ex) {
-      throw new ConflictException(ex.getLocalizedMessage());
+      throw new ConflictException(format(
+          "Factory with name '%s' already exists",
+          factory.getName()));
     } catch (IntegrityConstraintViolationException ex) {
       throw new ConflictException(
           "Could not create factory with creator that refers on non-existent user");
@@ -75,7 +77,7 @@ public class JpaFactoryDao implements FactoryDao {
       return new FactoryImpl(doUpdate(update));
     } catch (DuplicateKeyException ex) {
       throw new ConflictException(format(
-          "Factory with name '%s' already exist in namespace",
+          "Factory with name '%s' already exists",
           update.getName()));
     } catch (RuntimeException ex) {
       throw new ServerException(ex.getLocalizedMessage(), ex);

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
+import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
@@ -73,7 +74,9 @@ public class JpaFactoryDao implements FactoryDao {
     try {
       return new FactoryImpl(doUpdate(update));
     } catch (DuplicateKeyException ex) {
-      throw new ConflictException(ex.getLocalizedMessage());
+      throw new ConflictException(format(
+          "Factory with name '%s' already exist in namespace",
+          update.getName()));
     } catch (RuntimeException ex) {
       throw new ServerException(ex.getLocalizedMessage(), ex);
     }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
@@ -27,7 +27,6 @@ import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.persistence.EntityManager;
-import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
@@ -57,9 +56,8 @@ public class JpaFactoryDao implements FactoryDao {
     try {
       doCreate(factory);
     } catch (DuplicateKeyException ex) {
-      throw new ConflictException(format(
-          "Factory with name '%s' already exists",
-          factory.getName()));
+      throw new ConflictException(
+          format("Factory with name '%s' already exists", factory.getName()));
     } catch (IntegrityConstraintViolationException ex) {
       throw new ConflictException(
           "Could not create factory with creator that refers on non-existent user");
@@ -76,9 +74,8 @@ public class JpaFactoryDao implements FactoryDao {
     try {
       return new FactoryImpl(doUpdate(update));
     } catch (DuplicateKeyException ex) {
-      throw new ConflictException(format(
-          "Factory with name '%s' already exists",
-          update.getName()));
+      throw new ConflictException(
+          format("Factory with name '%s' already exists", update.getName()));
     } catch (RuntimeException ex) {
       throw new ServerException(ex.getLocalizedMessage(), ex);
     }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/jpa/JpaFactoryDao.java
@@ -57,7 +57,7 @@ public class JpaFactoryDao implements FactoryDao {
       doCreate(factory);
     } catch (DuplicateKeyException ex) {
       throw new ConflictException(
-          format("Factory with name '%s' already exists", factory.getName()));
+          format("Factory with name '%s' already exists for current user", factory.getName()));
     } catch (IntegrityConstraintViolationException ex) {
       throw new ConflictException(
           "Could not create factory with creator that refers on non-existent user");
@@ -75,7 +75,7 @@ public class JpaFactoryDao implements FactoryDao {
       return new FactoryImpl(doUpdate(update));
     } catch (DuplicateKeyException ex) {
       throw new ConflictException(
-          format("Factory with name '%s' already exists", update.getName()));
+          format("Factory with name '%s' already exists for current user", update.getName()));
     } catch (RuntimeException ex) {
       throw new ServerException(ex.getLocalizedMessage(), ex);
     }

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
@@ -127,7 +127,8 @@ public class FactoryDaoTest {
 
   @Test(
       expectedExceptions = ConflictException.class,
-      expectedExceptionsMessageRegExp = "Factory with name 'factoryName0' already exists")
+      expectedExceptionsMessageRegExp =
+          "Factory with name 'factoryName0' already exists for current user")
   public void shouldThrowConflictExceptionWhenCreatingFactoryWithExistingNameAndUserId()
       throws Exception {
     final FactoryImpl factory = createFactory(10, users[0].getId());
@@ -171,7 +172,8 @@ public class FactoryDaoTest {
 
   @Test(
       expectedExceptions = ConflictException.class,
-      expectedExceptionsMessageRegExp = "Factory with name 'factoryName1' already exists")
+      expectedExceptionsMessageRegExp =
+          "Factory with name 'factoryName1' already exists for current user")
   public void shouldThrowConflictExceptionWhenUpdateFactoryWithExistingNameAndUserId()
       throws Exception {
     final FactoryImpl update = factories[0];

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
@@ -125,7 +125,7 @@ public class FactoryDaoTest {
     factoryDao.create(factory);
   }
 
-  @Test(expectedExceptions = ConflictException.class)
+  @Test(expectedExceptions = ConflictException.class, expectedExceptionsMessageRegExp = "Factory with name 'factoryName0' already exists")
   public void shouldThrowConflictExceptionWhenCreatingFactoryWithExistingNameAndUserId()
       throws Exception {
     final FactoryImpl factory = createFactory(10, users[0].getId());
@@ -167,7 +167,7 @@ public class FactoryDaoTest {
     assertEquals(factoryDao.getById(update.getId()), update);
   }
 
-  @Test(expectedExceptions = ConflictException.class, expectedExceptionsMessageRegExp = "Factory with name 'factoryName1' already exist in namespace")
+  @Test(expectedExceptions = ConflictException.class, expectedExceptionsMessageRegExp = "Factory with name 'factoryName1' already exists")
   public void shouldThrowConflictExceptionWhenUpdateFactoryWithExistingNameAndUserId()
       throws Exception {
     final FactoryImpl update = factories[0];

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
@@ -125,7 +125,9 @@ public class FactoryDaoTest {
     factoryDao.create(factory);
   }
 
-  @Test(expectedExceptions = ConflictException.class, expectedExceptionsMessageRegExp = "Factory with name 'factoryName0' already exists")
+  @Test(
+      expectedExceptions = ConflictException.class,
+      expectedExceptionsMessageRegExp = "Factory with name 'factoryName0' already exists")
   public void shouldThrowConflictExceptionWhenCreatingFactoryWithExistingNameAndUserId()
       throws Exception {
     final FactoryImpl factory = createFactory(10, users[0].getId());
@@ -167,7 +169,9 @@ public class FactoryDaoTest {
     assertEquals(factoryDao.getById(update.getId()), update);
   }
 
-  @Test(expectedExceptions = ConflictException.class, expectedExceptionsMessageRegExp = "Factory with name 'factoryName1' already exists")
+  @Test(
+      expectedExceptions = ConflictException.class,
+      expectedExceptionsMessageRegExp = "Factory with name 'factoryName1' already exists")
   public void shouldThrowConflictExceptionWhenUpdateFactoryWithExistingNameAndUserId()
       throws Exception {
     final FactoryImpl update = factories[0];

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/spi/tck/FactoryDaoTest.java
@@ -167,7 +167,7 @@ public class FactoryDaoTest {
     assertEquals(factoryDao.getById(update.getId()), update);
   }
 
-  @Test(expectedExceptions = ConflictException.class)
+  @Test(expectedExceptions = ConflictException.class, expectedExceptionsMessageRegExp = "Factory with name 'factoryName1' already exist in namespace")
   public void shouldThrowConflictExceptionWhenUpdateFactoryWithExistingNameAndUserId()
       throws Exception {
     final FactoryImpl update = factories[0];


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Display short exception of conflict exception that occurs in FactoryDao
when attempting to create/update factory with name of another factory that belongs to that user
![screenshot from 2018-10-16 17-02-13](https://user-images.githubusercontent.com/5712744/47022364-02e17700-d166-11e8-8164-19daf2ee9546.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11605
