### PR TITLE
Correct initialize orion hover provider

### DIFF
--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionHoverRegistrant.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/OrionHoverRegistrant.java
@@ -15,9 +15,8 @@ import com.google.gwt.core.client.JsArrayString;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 import com.google.inject.Singleton;
-import org.eclipse.che.api.promises.client.Operation;
-import org.eclipse.che.api.promises.client.OperationException;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionCodeEditWidgetOverlay;
+import org.eclipse.che.ide.editor.orion.client.jso.OrionServiceRegistrationOverlay;
 import org.eclipse.che.ide.editor.orion.client.jso.OrionServiceRegistryOverlay;
 
 /** @author Evgen Vidolob */
@@ -26,6 +25,7 @@ public class OrionHoverRegistrant {
 
   private final Provider<OrionCodeEditWidgetOverlay> codeEditWidgetProvider;
   private final EditorInitializePromiseHolder editorModule;
+  private OrionServiceRegistrationOverlay hoverRegistration = null;
 
   @Inject
   public OrionHoverRegistrant(
@@ -39,20 +39,23 @@ public class OrionHoverRegistrant {
     editorModule
         .getInitializerPromise()
         .then(
-            new Operation<Void>() {
-              @Override
-              public void apply(Void arg) throws OperationException {
-                registerHover(
-                    codeEditWidgetProvider.get().getServiceRegistry(), contentTypes, handler);
+            ignored -> {
+              if (null != hoverRegistration) {
+                hoverRegistration.doUnregister();
+                hoverRegistration = null;
               }
+
+              hoverRegistration =
+                  registerHover(
+                      codeEditWidgetProvider.get().getServiceRegistry(), contentTypes, handler);
             });
   }
 
-  private final native void registerHover(
+  private final native OrionServiceRegistrationOverlay registerHover(
       OrionServiceRegistryOverlay serviceRegistry,
       JsArrayString contentTypes,
       OrionHoverHandler handler) /*-{
-        serviceRegistry.registerService("orion.edit.hover", {
+        return serviceRegistry.registerService("orion.edit.hover", {
             computeHoverInfo: function (editorContext, context) {
                 return handler.@OrionHoverHandler::computeHover(*)(context);
             }

--- a/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionServiceRegistrationOverlay.java
+++ b/ide/che-core-orion-editor/src/main/java/org/eclipse/che/ide/editor/orion/client/jso/OrionServiceRegistrationOverlay.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.editor.orion.client.jso;
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * JavaScript overlay over Orion Service Registration.
+ *
+ * @author Vladyslav Zhukovskyi
+ */
+public class OrionServiceRegistrationOverlay extends JavaScriptObject {
+
+  protected OrionServiceRegistrationOverlay() {}
+
+  public final native void doUnregister() /*-{
+    this.unregister();
+  }-*/;
+}


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds correct initialization of orion hover provider. The problem was in initialization mechanism, editor was initialized with odd hover provider each time when workspace started.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#10117 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A
