### PR TITLE
Fix git when it is being used from the Theia terminal

### DIFF
--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -69,6 +69,7 @@ trap 'responsible_shutdown' SIGHUP SIGTERM SIGINT
 
 # run che
 cd ${HOME}
+export LD_LIBRARY_PATH=/opt/rh/httpd24/root/usr/lib64
 node_modules/.bin/theia start /projects --hostname=0.0.0.0 --port=${THEIA_PORT} &
 
 PID=$!


### PR DESCRIPTION
when using git from the terminal within the theia container we get:

```
sh-4.2$ git clone https://github.com/eclipse/che-theia-factory-extension.git
Cloning into 'che-theia-factory-extension'...
git-remote-https: error while loading shared libraries: libcurl-httpd24.so.4: cannot open shared object file: No such file or directory
sh-4.2$
```
This patch is adding the library path to be used