### PR TITLE
Selenium: adapt selenium tests after merging JDT.LS branch in master

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -610,7 +610,7 @@ public class Consoles {
 
     waitTabNameProcessIsPresent(commandName);
     waitProcessInProcessConsoleTree(commandName);
-    waitExpectedTextIntoConsole(expectedMessageInTerminal, PREPARING_WS_TIMEOUT_SEC);
+    waitExpectedTextIntoConsole(expectedMessageInTerminal, APPLICATION_START_TIMEOUT_SEC);
   }
 
   public void closeProcessTabWithAskDialog(String tabName) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Consoles.java
@@ -14,6 +14,7 @@ package org.eclipse.che.selenium.pageobject;
 import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
@@ -67,6 +68,7 @@ public class Consoles {
   private final WebDriverWait redrawDriverWait;
   private final WebDriverWait loadPageDriverWait;
   private final WebDriverWait updateProjDriverWait;
+  private final WebDriverWait appStartDriverWait;
   private final ProjectExplorer projectExplorer;
   private final AskDialog askDialog;
   private final SeleniumWebDriverHelper seleniumWebDriverHelper;
@@ -141,6 +143,7 @@ public class Consoles {
     redrawDriverWait = new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
     loadPageDriverWait = new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC);
     updateProjDriverWait = new WebDriverWait(seleniumWebDriver, UPDATING_PROJECT_TIMEOUT_SEC);
+    appStartDriverWait = new WebDriverWait(seleniumWebDriver, APPLICATION_START_TIMEOUT_SEC);
     PageFactory.initElements(seleniumWebDriver, this);
   }
 
@@ -436,7 +439,7 @@ public class Consoles {
     }
     try {
 
-      updateProjDriverWait.until(
+      appStartDriverWait.until(
           (Predicate<WebDriver>)
               webdriver -> {
                 ArrayList<String> projectsCopy = new ArrayList<>(projectStrings);
@@ -473,7 +476,7 @@ public class Consoles {
   /**
    * wait expected text into 'Command console'
    *
-   * @param expectedText expected messaje in concole
+   * @param expectedText expected message in console
    * @param definedTimeout timeout in seconds defined with user
    */
   public void waitExpectedTextIntoConsole(String expectedText, int definedTimeout) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FileStructure.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/FileStructure.java
@@ -159,8 +159,12 @@ public class FileStructure {
    *
    * @param item is the name of the item
    */
-  public void selectItemInFileStructureByEnter(String item) {
-    seleniumWebDriverHelper.getAction().sendKeys(ENTER).perform();
+  public void selectAndOpenItemInFileStructureByEnter(String item) {
+    selectItemInFileStructure(item);
+
+    // we need to wait a little to avoid quick nodes opening
+    WaitUtils.sleepQuietly(1);
+    seleniumWebDriverHelper.sendKeys(ENTER.toString());
   }
 
   /**

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/EditMachineForm.java
@@ -123,6 +123,9 @@ public class EditMachineForm {
   }
 
   public void typeRam(String ramValue) {
+    // wait until ram can be set into input field
+    WaitUtils.sleepQuietly(1);
+
     seleniumWebDriverHelper.setValue(waitRamTextField(), ramValue);
   }
 
@@ -141,7 +144,7 @@ public class EditMachineForm {
     seleniumWebDriverHelper.waitSuccessCondition(driver -> isRamValueValid());
   }
 
-  public void waitInvalideRamFieldHighlighting() {
+  public void waitInvalidRamFieldHighlighting() {
     seleniumWebDriverHelper.waitSuccessCondition(driver -> !isRamValueValid());
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsOverviewTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsOverviewTest.java
@@ -114,6 +114,7 @@ public class WorkspaceDetailsOverviewTest {
     workspaces.clickOnAddWorkspaceBtn();
     newWorkspace.waitPageLoad();
     newWorkspace.typeWorkspaceName(WORKSPACE_NAME);
+    newWorkspace.clickOnAllStacksTab();
 
     selectStackAndCheckWorkspaceName(ANDROID);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureCodeEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureCodeEditorTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.selenium.miscellaneous;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FILE_STRUCTURE;
+import static org.openqa.selenium.Keys.ENTER;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -27,7 +28,6 @@ import org.eclipse.che.selenium.pageobject.FileStructure;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -80,22 +80,20 @@ public class FileStructureCodeEditorTest {
 
     menu.runCommand(ASSISTANT, FILE_STRUCTURE);
     fileStructure.waitFileStructureFormIsOpen(JAVA_FILE_NAME);
-    fileStructure.selectItemInFileStructure("INSTANCE");
-    fileStructure.selectItemInFileStructureByEnter("INSTANCE");
+    fileStructure.selectAndOpenItemInFileStructureByEnter("INSTANCE");
     fileStructure.waitFileStructureFormIsClosed();
     editor.waitSpecifiedValueForLineAndChar(25, 46);
 
     menu.runCommand(ASSISTANT, FILE_STRUCTURE);
     fileStructure.waitFileStructureFormIsOpen(JAVA_FILE_NAME);
-    fileStructure.selectItemInFileStructure("getId():double");
-    fileStructure.selectItemInFileStructureByEnter("getId():double");
+    fileStructure.selectAndOpenItemInFileStructureByEnter("getId():double");
     fileStructure.waitFileStructureFormIsClosed();
     editor.waitSpecifiedValueForLineAndChar(37, 28);
 
     // check new elements in the 'file structure' form
     editor.setCursorToLine(20);
     editor.waitActive();
-    editor.typeTextIntoEditor(Keys.ENTER.toString());
+    editor.typeTextIntoEditor(ENTER.toString());
     editor.typeTextIntoEditor(NEW_CONTENT);
     editor.waitTextIntoEditor(EXPECTED_TEXT);
     menu.runCommand(ASSISTANT, FILE_STRUCTURE);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ImplementationBaseOperationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/ImplementationBaseOperationsTest.java
@@ -11,15 +11,16 @@
  */
 package org.eclipse.che.selenium.miscellaneous;
 
+import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.IMPLEMENTATION_S;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SIMPLE;
-import static org.testng.Assert.fail;
+import static org.openqa.selenium.Keys.ARROW_LEFT;
+import static org.openqa.selenium.Keys.ENTER;
 
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
-import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
@@ -27,14 +28,12 @@ import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev on 12.01.16 */
 public class ImplementationBaseOperationsTest {
-  private static final String PROJECT_NAME = NameGenerator.generate("project", 5);
+  private static final String PROJECT_NAME = generate("project", 5);
   private static final String JAVA_FILE_NAME = "Company";
   private static final String ABSTRACT_CLASS_NAME = "Empl";
   private static final String INTERFACE_NAME = "Employee";
@@ -54,13 +53,13 @@ public class ImplementationBaseOperationsTest {
           + PROJECT_NAME
           + "/src/main/java/com/codenvy/qa/EmployeeHourlyWages.java)";
 
-  @Inject private TestWorkspace workspace;
   @Inject private Ide ide;
-  @Inject private ProjectExplorer projectExplorer;
-  @Inject private CodenvyEditor editor;
   @Inject private Menu menu;
-  @Inject private TestProjectServiceClient testProjectServiceClient;
   @Inject private Consoles consoles;
+  @Inject private CodenvyEditor editor;
+  @Inject private TestWorkspace workspace;
+  @Inject private ProjectExplorer projectExplorer;
+  @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
   public void setUp() throws Exception {
@@ -68,12 +67,12 @@ public class ImplementationBaseOperationsTest {
     testProjectServiceClient.importProject(
         workspace.getId(), Paths.get(resource.toURI()), PROJECT_NAME, MAVEN_SIMPLE);
     ide.open(workspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test
   public void checkImplementationInEditor() {
-    ide.waitOpenedWorkspaceIsReadyToUse();
     projectExplorer.openItemByPath(PROJECT_NAME);
     expandTReeProjectAndOpenClass(JAVA_FILE_NAME);
 
@@ -102,7 +101,8 @@ public class ImplementationBaseOperationsTest {
     editor.waitTextElementsActiveLine(ABSTRACT_CLASS_NAME);
     editor.launchImplementationFormByKeyboard();
     editor.waitActiveTabFileName("EmployeeFixedSalary");
-    editor.expectedNumberOfActiveLine(14);
+    editor.typeTextIntoEditor(ARROW_LEFT.toString());
+    editor.waitSpecifiedValueForLineAndChar(14, 14);
     editor.waitTextElementsActiveLine("EmployeeFixedSalary extends Empl");
     editor.clickOnCloseFileIcon("EmployeeFixedSalary");
     editor.waitActiveTabFileName(ABSTRACT_CLASS_NAME);
@@ -111,7 +111,8 @@ public class ImplementationBaseOperationsTest {
     editor.clickOnSelectedElementInEditor("toString");
     menu.runCommand(ASSISTANT, IMPLEMENTATION_S);
     editor.waitActiveTabFileName("EmployeeFixedSalary");
-    editor.expectedNumberOfActiveLine(39);
+    editor.typeTextIntoEditor(ARROW_LEFT.toString());
+    editor.waitSpecifiedValueForLineAndChar(39, 19);
     editor.waitTextElementsActiveLine("toString");
 
     // check the 'implementations' for interface
@@ -121,6 +122,8 @@ public class ImplementationBaseOperationsTest {
     editor.launchImplementationFormByKeyboard();
     editor.waitActiveTabFileName("EmployeeHourlyWages");
     editor.expectedNumberOfActiveLine(15);
+    editor.typeTextIntoEditor(ARROW_LEFT.toString());
+    editor.waitSpecifiedValueForLineAndChar(15, 14);
     editor.waitTextElementsActiveLine("EmployeeHourlyWages implements Employee");
     editor.clickOnCloseFileIcon("EmployeeHourlyWages");
     editor.waitActiveTabFileName(INTERFACE_NAME);
@@ -129,20 +132,17 @@ public class ImplementationBaseOperationsTest {
     editor.clickOnSelectedElementInEditor("toString");
     menu.runCommand(ASSISTANT, IMPLEMENTATION_S);
     editor.waitActiveTabFileName("EmployeeHourlyWages");
-    editor.expectedNumberOfActiveLine(59);
+    editor.typeTextIntoEditor(ARROW_LEFT.toString());
+    editor.waitSpecifiedValueForLineAndChar(59, 19);
     editor.waitTextElementsActiveLine("toString");
     editor.selectTabByName(INTERFACE_NAME);
     editor.goToCursorPositionVisible(16, 38);
     editor.waitTextElementsActiveLine("interface Employee extends Remote");
     menu.runCommand(ASSISTANT, IMPLEMENTATION_S);
-    try {
-      editor.waitImplementationFormIsOpen(GENERAL_INTERFACE_NAME);
-    } catch (TimeoutException e) {
-      fail("Known issue https://github.com/eclipse/che/issues/10857");
-    }
+    editor.waitImplementationFormIsOpen(GENERAL_INTERFACE_NAME);
 
     editor.waitTextInImplementationForm(LIST_IMPLEMENTATIONS);
-    editor.typeTextIntoEditor(Keys.ENTER.toString());
+    editor.typeTextIntoEditor(ENTER.toString());
     editor.waitImplementationFormIsClosed(GENERAL_INTERFACE_NAME);
     editor.waitActiveTabFileName(ABSTRACT_CLASS_NAME);
     editor.setCursorToLine(16);
@@ -152,7 +152,7 @@ public class ImplementationBaseOperationsTest {
     editor.waitImplementationFormIsOpen(GENERAL_INTERFACE_NAME);
     editor.waitTextInImplementationForm(LIST_IMPLEMENTATIONS);
     editor.selectImplementationByClick("EmployeeHourlyWages");
-    editor.typeTextIntoEditor(Keys.ENTER.toString());
+    editor.typeTextIntoEditor(ENTER.toString());
     editor.waitImplementationFormIsClosed(GENERAL_INTERFACE_NAME);
     editor.waitActiveTabFileName("EmployeeHourlyWages");
     editor.selectTabByName(INTERFACE_NAME);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCentosWildFlySwarmStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCentosWildFlySwarmStackTest.java
@@ -69,9 +69,10 @@ public class CreateWorkspaceFromCentosWildFlySwarmStackTest {
             CENTOS_WILDFLY_SWARM, WORKSPACE_NAME, PROJECT_NAME);
 
     ide.switchToIdeAndWaitWorkspaceIsReadyToUse();
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
 
     projectExplorer.waitProjectInitialization(PROJECT_NAME);
+
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test(priority = 1)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromEclipseVertxStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromEclipseVertxStackTest.java
@@ -83,11 +83,12 @@ public class CreateWorkspaceFromEclipseVertxStackTest {
             ECLIPSE_VERTX, WORKSPACE_NAME, projects);
 
     currentWindow = ide.switchToIdeAndWaitWorkspaceIsReadyToUse();
-    consoles.waitJDTLSProjectResolveFinishedMessage(
-        HEALTH_CHECKS_BOOSTER_PROJECT, HEALTH_HTTP_BOOSTER_PROJECT);
 
     projectExplorer.waitProjectInitialization(HEALTH_CHECKS_BOOSTER_PROJECT);
     projectExplorer.waitProjectInitialization(HEALTH_HTTP_BOOSTER_PROJECT);
+
+    consoles.waitJDTLSProjectResolveFinishedMessage(
+        HEALTH_CHECKS_BOOSTER_PROJECT, HEALTH_HTTP_BOOSTER_PROJECT);
   }
 
   @Test(priority = 1)

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromSpringBootStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromSpringBootStackTest.java
@@ -79,11 +79,12 @@ public class CreateWorkspaceFromSpringBootStackTest {
             SPRING_BOOT, WORKSPACE_NAME, projects);
 
     ide.switchToIdeAndWaitWorkspaceIsReadyToUse();
-    consoles.waitJDTLSProjectResolveFinishedMessage(
-        SPRING_BOOT_HEALTH_CHECK_PROJECT, SPRING_BOOT_HTTP_PROJECT);
 
     projectExplorer.waitProjectInitialization(SPRING_BOOT_HEALTH_CHECK_PROJECT);
     projectExplorer.waitProjectInitialization(SPRING_BOOT_HTTP_PROJECT);
+
+    consoles.waitJDTLSProjectResolveFinishedMessage(
+        SPRING_BOOT_HEALTH_CHECK_PROJECT, SPRING_BOOT_HTTP_PROJECT);
   }
 
   @Test(priority = 1)


### PR DESCRIPTION
### What does this PR do?
This PR adapt selenium tests according new behavior after merging **JDTLS** branch:
- fix checking Java language server initialization in **CreateWorkspaceFromCentosWildFlySwarmStackTest**,
**CreateWorkspaceFromEclipseVertxStackTest**, **CreateWorkspaceFromSpringBootStackTest** tests;
- add timeout for 1 second before selection item in **File Structure** form by ENTER;
- add checking cursor position of found element in **ImplementationBaseOperationsTest** test.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11663