### PR TITLE
Fix exception handling in permissions DAO

### DIFF
--- a/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/spi/jpa/JpaMemberDao.java
+++ b/multiuser/api/che-multiuser-api-organization/src/main/java/org/eclipse/che/multiuser/organization/spi/jpa/JpaMemberDao.java
@@ -179,13 +179,16 @@ public class JpaMemberDao extends AbstractJpaPermissionsDao<MemberImpl> implemen
   }
 
   @Override
-  protected MemberImpl getEntity(String userId, String instanceId) throws NotFoundException {
+  protected MemberImpl getEntity(String userId, String instanceId)
+      throws NotFoundException, ServerException {
     try {
       return doGet(userId, instanceId);
     } catch (NoResultException e) {
       throw new NotFoundException(
           String.format(
               "Membership of user %s in organization %s was not found", userId, instanceId));
+    } catch (RuntimeException e) {
+      throw new ServerException(e.getMessage(), e);
     }
   }
 

--- a/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jpa/AbstractJpaPermissionsDao.java
+++ b/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jpa/AbstractJpaPermissionsDao.java
@@ -58,7 +58,6 @@ public abstract class AbstractJpaPermissionsDao<T extends AbstractPermissions>
   }
 
   @Override
-  @Transactional
   public boolean exists(String userId, String instanceId, String action) throws ServerException {
     requireNonNull(userId, "User identifier required");
     requireNonNull(action, "Action name required");
@@ -97,7 +96,8 @@ public abstract class AbstractJpaPermissionsDao<T extends AbstractPermissions>
    * Parameters {@code userId} and {@code instanceId} are the same to {@link #get(String, String)}
    * method parameters.
    */
-  protected abstract T getEntity(String userId, String instanceId) throws NotFoundException;
+  protected abstract T getEntity(String userId, String instanceId)
+      throws NotFoundException, ServerException;
 
   @Transactional
   protected Optional<T> doCreate(T permissions) throws ServerException {

--- a/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jpa/JpaSystemPermissionsDao.java
+++ b/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/jpa/JpaSystemPermissionsDao.java
@@ -100,12 +100,16 @@ public class JpaSystemPermissionsDao extends AbstractJpaPermissionsDao<SystemPer
 
   @Override
   protected SystemPermissionsImpl getEntity(String userId, String instanceId)
-      throws NotFoundException {
-    final List<SystemPermissionsImpl> existent = doGetByUser(userId);
-    if (existent.isEmpty()) {
-      throw new NotFoundException(format("System permissions for user '%s' not found", userId));
+      throws NotFoundException, ServerException {
+    try {
+      final List<SystemPermissionsImpl> existent = doGetByUser(userId);
+      if (existent.isEmpty()) {
+        throw new NotFoundException(format("System permissions for user '%s' not found", userId));
+      }
+      return existent.get(0);
+    } catch (RuntimeException e) {
+      throw new ServerException(e.getMessage(), e);
     }
-    return existent.get(0);
   }
 
   @Transactional

--- a/multiuser/permission/che-multiuser-permission-workspace/pom.xml
+++ b/multiuser/permission/che-multiuser-permission-workspace/pom.xml
@@ -26,6 +26,10 @@
     </properties>
     <dependencies>
         <dependency>
+            <groupId>aopalliance</groupId>
+            <artifactId>aopalliance</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaStackPermissionsDao.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaStackPermissionsDao.java
@@ -105,12 +105,14 @@ public class JpaStackPermissionsDao extends AbstractJpaPermissionsDao<StackPermi
 
   @Override
   protected StackPermissionsImpl getEntity(String userId, String instanceId)
-      throws NotFoundException {
+      throws NotFoundException, ServerException {
     try {
       return doGet(userId, instanceId);
     } catch (NoResultException e) {
       throw new NotFoundException(
           format("Permissions on stack '%s' of user '%s' was not found.", instanceId, userId));
+    } catch (RuntimeException e) {
+      throw new ServerException(e.getMessage(), e);
     }
   }
 

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaWorkerDao.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaWorkerDao.java
@@ -82,11 +82,7 @@ public class JpaWorkerDao extends AbstractJpaPermissionsDao<WorkerImpl> implemen
       throws ServerException, NotFoundException {
     requireNonNull(instanceId, "Workspace identifier required");
     requireNonNull(userId, "User identifier required");
-    try {
-      return new WorkerImpl(getEntity(wildcardToNull(userId), instanceId));
-    } catch (RuntimeException x) {
-      throw new ServerException(x.getLocalizedMessage(), x);
-    }
+    return new WorkerImpl(getEntity(wildcardToNull(userId), instanceId));
   }
 
   @Override
@@ -128,12 +124,15 @@ public class JpaWorkerDao extends AbstractJpaPermissionsDao<WorkerImpl> implemen
   }
 
   @Override
-  protected WorkerImpl getEntity(String userId, String instanceId) throws NotFoundException {
+  protected WorkerImpl getEntity(String userId, String instanceId)
+      throws NotFoundException, ServerException {
     try {
       return doGet(userId, instanceId);
     } catch (NoResultException e) {
       throw new NotFoundException(
           format("Worker of workspace '%s' with id '%s' was not found.", instanceId, userId));
+    } catch (RuntimeException e) {
+      throw new ServerException(e.getMessage(), e);
     }
   }
 

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaWorkerDao.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaWorkerDao.java
@@ -82,7 +82,11 @@ public class JpaWorkerDao extends AbstractJpaPermissionsDao<WorkerImpl> implemen
       throws ServerException, NotFoundException {
     requireNonNull(instanceId, "Workspace identifier required");
     requireNonNull(userId, "User identifier required");
-    return new WorkerImpl(getEntity(wildcardToNull(userId), instanceId));
+    try {
+      return new WorkerImpl(getEntity(wildcardToNull(userId), instanceId));
+    } catch (RuntimeException x) {
+      throw new ServerException(x.getLocalizedMessage(), x);
+    }
   }
 
   @Override

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/EntityManagerExceptionInterceptor.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/EntityManagerExceptionInterceptor.java
@@ -11,13 +11,18 @@
  */
 package org.eclipse.che.multiuser.permission.workspace.server.spi.jpa;
 
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import javax.persistence.EntityManager;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 
 public class EntityManagerExceptionInterceptor implements MethodInterceptor {
+  @Inject Provider<EntityManager> emf;
 
   @Override
   public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+    emf.get().getTransaction().setRollbackOnly();
     throw new RuntimeException("Database exception");
   }
 }

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/EntityManagerExceptionInterceptor.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/EntityManagerExceptionInterceptor.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.workspace.server.spi.jpa;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+public class EntityManagerExceptionInterceptor implements MethodInterceptor {
+
+  @Override
+  public Object invoke(MethodInvocation methodInvocation) throws Throwable {
+    throw new RuntimeException("Database exception");
+  }
+}

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaWorkerDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaWorkerDaoTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.workspace.server.spi.jpa;
+
+import static org.eclipse.che.multiuser.api.permission.server.AbstractPermissionsDomain.SET_PERMISSIONS;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.persistence.EntityManager;
+import org.eclipse.che.account.shared.model.Account;
+import org.eclipse.che.account.spi.AccountImpl;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
+import org.eclipse.che.multiuser.permission.workspace.server.jpa.WorkspaceTckModule;
+import org.eclipse.che.multiuser.permission.workspace.server.model.impl.WorkerImpl;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class JpaWorkerDaoTest {
+
+  private JpaWorkerDao workerDao;
+  private EntityManager manager;
+  private TckResourcesCleaner tckResourcesCleaner;
+
+  @BeforeMethod
+  private void setUpManager() {
+    final Injector injector = Guice.createInjector(new WorkspaceTckModule());
+    manager = injector.getInstance(EntityManager.class);
+    workerDao = injector.getInstance(JpaWorkerDao.class);
+    tckResourcesCleaner = injector.getInstance(TckResourcesCleaner.class);
+  }
+
+  @AfterMethod
+  private void cleanup() {
+    manager.getTransaction().begin();
+    final List<Object> entities = new ArrayList<>();
+    entities.addAll(manager.createQuery("SELECT w FROM Worker w").getResultList());
+    entities.addAll(manager.createQuery("SELECT w FROM Workspace w").getResultList());
+    entities.addAll(manager.createQuery("SELECT u FROM Usr u").getResultList());
+    entities.addAll(manager.createQuery("SELECT a FROM Account a").getResultList());
+    for (Object entity : entities) {
+      manager.remove(entity);
+    }
+    manager.getTransaction().commit();
+    tckResourcesCleaner.clean();
+  }
+
+  @Test
+  public void shouldSuccesfullyCheckExistingPersmission() throws Exception {
+    final Account account = new AccountImpl("accountId", "namespace", "test");
+    final WorkspaceImpl workspace = new WorkspaceImpl("workspaceId", account, null);
+
+    // Persist the account
+    manager.getTransaction().begin();
+    manager.persist(account);
+    manager.getTransaction().commit();
+    manager.clear();
+
+    // Persist the workspace
+    manager.getTransaction().begin();
+    manager.persist(workspace);
+    manager.getTransaction().commit();
+    manager.clear();
+    final UserImpl user = new UserImpl("user0", "user0@com.com", "usr0");
+    // Persist the user
+    manager.getTransaction().begin();
+    manager.persist(user);
+    manager.getTransaction().commit();
+    manager.clear();
+
+    // Persist the worker
+    WorkerImpl worker =
+        new WorkerImpl("workspaceId", "user0", Collections.singletonList(SET_PERMISSIONS));
+    manager.getTransaction().begin();
+    manager.persist(worker);
+    manager.getTransaction().commit();
+    manager.clear();
+
+    assertTrue(workerDao.exists("user0", "workspaceId", SET_PERMISSIONS));
+  }
+}

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaWorkerDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/JpaWorkerDaoTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.multiuser.permission.workspace.server.spi.jpa;
 
 import static org.eclipse.che.multiuser.api.permission.server.AbstractPermissionsDomain.SET_PERMISSIONS;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Guice;
@@ -28,7 +27,6 @@ import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.commons.test.tck.TckResourcesCleaner;
 import org.eclipse.che.multiuser.permission.workspace.server.jpa.WorkspaceTckModule;
 import org.eclipse.che.multiuser.permission.workspace.server.model.impl.WorkerImpl;
-import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
- remove `@Transactional` from `exist` method
- in impementations of getEntity() rethrow RuntimeException as ServerException, which is intended to be defined in a rollbackOn of methods that invoke it
- added JPA Test to test handling of previously failing case (rolling back transaction)
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11601
