### PR TITLE
Create parent dirs in zip import

### DIFF
--- a/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/fs/server/impl/ZipArchiver.java
+++ b/wsagent/che-core-api-project/src/main/java/org/eclipse/che/api/fs/server/impl/ZipArchiver.java
@@ -111,6 +111,7 @@ class ZipArchiver {
             }
           }
 
+          Files.createDirectories(path.getParent());
           if (zipEntry.isDirectory()) {
             Files.createDirectory(path);
           } else {


### PR DESCRIPTION
### What does this PR do?
Makes sure parent dirs are created before attempting to write to a file during zip import

### What issues does this PR fix or reference?
Zip Import Broken for Some Zips #11683

#### Release Notes
