### PR TITLE
Update the theia yeoman generator to the latest version

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -112,7 +112,7 @@ RUN useradd -u 1000 -G users,wheel,root -d ${HOME} --shell /bin/bash theia \
        done \
     && cat /etc/passwd | sed s#root:x.*#root:x:\${USER_ID}:\${GROUP_ID}::\${HOME}:/bin/bash#g > ${HOME}/passwd.template \
     && cat /etc/group | sed s#root:x:0:#root:x:0:0,\${USER_ID}:#g > ${HOME}/group.template \
-    && npm install -g yo @theia/generator-plugin \
+    && npm install -g yo @theia/generator-plugin@0.0.1-1540209403 \
     && mkdir -p ${HOME}/.config/insight-nodejs/ \
     && chmod -R 777 ${HOME}/.config/ \
     # Defines the root /node_modules as the folder to use by yarn


### PR DESCRIPTION
### What does this PR do?
Fix issue with "null" message displayed when using theia yeoman generator inside the theia yeoman plug-in (wrong path, was relative instead of absolute)

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
N/A

Change-Id: I5b1a47582184d90ba99bd2f0475f44230d435e3a
Signed-off-by: Florent BENOIT <fbenoit@redhat.com>

