### PR TITLE
Fix of signature help feature when typing '(' symbol

### DIFF
--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/signature/LanguageServerSignatureHelp.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/signature/LanguageServerSignatureHelp.java
@@ -62,7 +62,7 @@ public class LanguageServerSignatureHelp implements SignatureHelpProvider {
 
   @Override
   public Promise<Optional<SignatureHelp>> signatureHelp(Document document, int offset) {
-    TextDocumentPositionParams paramsDTO = helper.createTDPP(document, offset);
+    TextDocumentPositionParams paramsDTO = helper.createTDPP(document, offset + 1);
     Promise<org.eclipse.lsp4j.SignatureHelp> promise = client.signatureHelp(paramsDTO);
     return promise
         .then(
@@ -106,7 +106,8 @@ public class LanguageServerSignatureHelp implements SignatureHelpProvider {
                   new DocumentChangedHandler() {
                     @Override
                     public void onDocumentChanged(DocumentChangedEvent event) {
-                      if (triggerCharacters.contains(event.getText())) {
+                      String candidate = String.valueOf(event.getText().charAt(0));
+                      if (triggerCharacters.contains(candidate)) {
                         ((HandlesTextOperations) editor)
                             .doOperation(TextEditorOperations.SIGNATURE_HELP);
                       }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/signature/LanguageServerSignatureHelp.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/editor/signature/LanguageServerSignatureHelp.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.plugin.languageserver.ide.editor.signature;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
@@ -106,7 +108,13 @@ public class LanguageServerSignatureHelp implements SignatureHelpProvider {
                   new DocumentChangedHandler() {
                     @Override
                     public void onDocumentChanged(DocumentChangedEvent event) {
-                      String candidate = String.valueOf(event.getText().charAt(0));
+                      String eventText = event.getText();
+
+                      if (isNullOrEmpty(eventText)) {
+                        return;
+                      }
+
+                      String candidate = String.valueOf(eventText.charAt(0));
                       if (triggerCharacters.contains(candidate)) {
                         ((HandlesTextOperations) editor)
                             .doOperation(TextEditorOperations.SIGNATURE_HELP);


### PR DESCRIPTION
Related issue: https://github.com/eclipse/che/issues/10699

The cursor position that client was sending to a language server was incorrect and the signature help symbol filtering algorithm was not accurate enough.