### PR TITLE
Display notification with error instead of dialog window

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/CoreLocalizationConstant.java
@@ -229,6 +229,21 @@ public interface CoreLocalizationConstant extends Messages {
   @Key("projectWizard.saveButtonText")
   String projectWizardSaveButtonText();
 
+  @Key("projectWizard.updateProject")
+  String projectWizardUpdateProject(String projectName);
+
+  @Key("projectWizard.createProject.failed")
+  String projectWizardCreateProjectFailed();
+
+  @Key("projectWizard.importProject.failed")
+  String projectWizardImportProjectFailed();
+
+  @Key("projectWizard.updateProject.failed")
+  String projectWizardUpdateProjectFailed();
+
+  @Key("projectWizard.defaultErrorTitle")
+  String projectWizardDefaultErrorTitle();
+
   @Key("format.name")
   String formatName();
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/ProjectWizard.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/ProjectWizard.java
@@ -12,6 +12,11 @@
 package org.eclipse.che.ide.projecttype.wizard;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.FLOAT_MODE;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.PROGRESS;
+import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
 import static org.eclipse.che.ide.api.project.type.wizard.ProjectWizardMode.CREATE;
 import static org.eclipse.che.ide.api.project.type.wizard.ProjectWizardMode.IMPORT;
 import static org.eclipse.che.ide.api.project.type.wizard.ProjectWizardMode.UPDATE;
@@ -27,10 +32,13 @@ import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseError;
 import org.eclipse.che.api.workspace.shared.dto.CommandDto;
+import org.eclipse.che.ide.CoreLocalizationConstant;
 import org.eclipse.che.ide.api.app.AppContext;
 import org.eclipse.che.ide.api.command.CommandImpl;
 import org.eclipse.che.ide.api.command.CommandImpl.ApplicableContext;
 import org.eclipse.che.ide.api.command.CommandManager;
+import org.eclipse.che.ide.api.notification.NotificationManager;
+import org.eclipse.che.ide.api.notification.StatusNotification;
 import org.eclipse.che.ide.api.project.MutableProjectConfig;
 import org.eclipse.che.ide.api.project.type.wizard.ProjectWizardMode;
 import org.eclipse.che.ide.api.resources.Container;
@@ -52,19 +60,26 @@ public class ProjectWizard extends AbstractWizard<MutableProjectConfig> {
   private static final String PROJECT_PATH_MACRO_REGEX = "\\$\\{current.project.path\\}";
 
   private final ProjectWizardMode mode;
-  private final AppContext appContext;
-  private final CommandManager commandManager;
+
+  private AppContext appContext;
+  private CommandManager commandManager;
+  private NotificationManager notificationManager;
+  private CoreLocalizationConstant localizedConstant;
 
   @Inject
   public ProjectWizard(
       @Assisted MutableProjectConfig dataObject,
       @Assisted ProjectWizardMode mode,
       AppContext appContext,
-      CommandManager commandManager) {
+      CommandManager commandManager,
+      NotificationManager notificationManager,
+      CoreLocalizationConstant localizedConstant) {
     super(dataObject);
     this.mode = mode;
     this.appContext = appContext;
     this.commandManager = commandManager;
+    this.notificationManager = notificationManager;
+    this.localizedConstant = localizedConstant;
 
     context.put(WIZARD_MODE_KEY, mode.toString());
     context.put(PROJECT_NAME_KEY, dataObject.getName());
@@ -95,12 +110,32 @@ public class ProjectWizard extends AbstractWizard<MutableProjectConfig> {
 
                 final Container container = optContainer.get();
                 if (container.getResourceType() == PROJECT) {
+                  StatusNotification notification =
+                      notificationManager.notify(
+                          localizedConstant.projectWizardUpdateProject(dataObject.getName()),
+                          null,
+                          PROGRESS,
+                          FLOAT_MODE);
+
                   ((Project) container)
                       .update()
                       .withBody(dataObject)
                       .send()
-                      .then(onComplete(callback))
-                      .catchError(onFailure(callback));
+                      .then(
+                          project -> {
+                            notification.setStatus(SUCCESS);
+                            callback.onCompleted();
+                          })
+                      .catchError(
+                          error -> {
+                            String errorMessage = error.getMessage();
+                            if (!isNullOrEmpty(errorMessage)) {
+                              notification.setContent(errorMessage);
+                            }
+
+                            notification.setStatus(FAIL);
+                            callback.onFailure(error.getCause());
+                          });
                 } else if (container.getResourceType() == FOLDER) {
                   ((Folder) container)
                       .toProject()
@@ -169,6 +204,34 @@ public class ProjectWizard extends AbstractWizard<MutableProjectConfig> {
   }
 
   private Operation<PromiseError> onFailure(final CompleteCallback callback) {
-    return error -> callback.onFailure(error.getCause());
+    return error -> {
+      String title;
+      switch (mode) {
+        case CREATE:
+          title = localizedConstant.projectWizardCreateProjectFailed();
+          break;
+
+        case IMPORT:
+          title = localizedConstant.projectWizardImportProjectFailed();
+          break;
+
+        case UPDATE:
+          title = localizedConstant.projectWizardUpdateProjectFailed();
+          break;
+
+        default:
+          title = localizedConstant.projectWizardDefaultErrorTitle();
+      }
+
+      Throwable throwable = error.getCause();
+      String errorMessage =
+          throwable != null && !isNullOrEmpty(throwable.getLocalizedMessage())
+              ? throwable.getLocalizedMessage()
+              : "";
+
+      notificationManager.notify(title, errorMessage, FAIL, FLOAT_MODE);
+
+      callback.onFailure(throwable);
+    };
   }
 }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/ProjectWizard.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/ProjectWizard.java
@@ -221,6 +221,7 @@ public class ProjectWizard extends AbstractWizard<MutableProjectConfig> {
 
         default:
           title = localizedConstant.projectWizardDefaultErrorTitle();
+          break;
       }
 
       Throwable throwable = error.getCause();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/presenter/ProjectWizardPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/projecttype/wizard/presenter/ProjectWizardPresenter.java
@@ -39,7 +39,6 @@ import org.eclipse.che.ide.projecttype.wizard.ProjectWizardFactory;
 import org.eclipse.che.ide.projecttype.wizard.ProjectWizardRegistry;
 import org.eclipse.che.ide.projecttype.wizard.categoriespage.CategoriesPagePresenter;
 import org.eclipse.che.ide.resource.Path;
-import org.eclipse.che.ide.ui.dialogs.DialogFactory;
 
 /**
  * Presenter for project wizard.
@@ -61,7 +60,6 @@ public class ProjectWizardPresenter
   private final ProjectWizardFactory projectWizardFactory;
   private final ProjectWizardRegistry wizardRegistry;
   private final Provider<CategoriesPagePresenter> categoriesPageProvider;
-  private final DialogFactory dialogFactory;
   private final Map<ProjectTypeDto, ProjectWizard> wizardsCache;
   private CategoriesPagePresenter categoriesPage;
   private ProjectWizard wizard;
@@ -75,13 +73,11 @@ public class ProjectWizardPresenter
       ProjectWizardView view,
       ProjectWizardFactory projectWizardFactory,
       ProjectWizardRegistry wizardRegistry,
-      Provider<CategoriesPagePresenter> categoriesPageProvider,
-      DialogFactory dialogFactory) {
+      Provider<CategoriesPagePresenter> categoriesPageProvider) {
     this.view = view;
     this.projectWizardFactory = projectWizardFactory;
     this.wizardRegistry = wizardRegistry;
     this.categoriesPageProvider = categoriesPageProvider;
-    this.dialogFactory = dialogFactory;
     wizardsCache = new HashMap<>();
     view.setDelegate(this);
   }
@@ -114,7 +110,6 @@ public class ProjectWizardPresenter
 
           @Override
           public void onFailure(Throwable e) {
-            dialogFactory.createMessageDialog("Error", e.getMessage(), null).show();
             view.setLoaderVisibility(false);
           }
         });

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/ide/CoreLocalizationConstant.properties
@@ -24,6 +24,12 @@ projectWizard.titleText = Project Configuration
 projectWizard.defaultSaveButtonText = Create
 projectWizard.saveButtonText = Save
 
+projectWizard.updateProject = Update project \"{0}\"
+projectWizard.createProject.failed = Failed to create project
+projectWizard.importProject.failed = Failed to import project
+projectWizard.updateProject.failed = Failed to update project
+projectWizard.defaultErrorTitle = Error
+
 ############### Switching parts ######################
 action.switch.editor.displaying.title=Editor
 action.switch.editor.displaying.description=Switch Editor display mode


### PR DESCRIPTION
### What does this PR do?
Display notification with error instead of dialog window when some error is happened at creating/importing/updating project.
For example, for creating project:
Current behavior:
![create_old_behavior](https://user-images.githubusercontent.com/5676062/47296756-edfc5c00-d61b-11e8-8fd6-86e07484df9c.gif)

New behavior:
![new_create_error](https://user-images.githubusercontent.com/5676062/47296765-f2c11000-d61b-11e8-82bb-25600ecfb0ee.gif)

### What issues does this PR fix or reference?
#10515

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>