### PR TITLE
Selenium: quick fix for selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Refactor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Refactor.java
@@ -15,6 +15,7 @@ import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.Refactor.Locators.ERROR_CONTAINER_OF_COMPILATION_FORM;
 import static org.eclipse.che.selenium.pageobject.Refactor.Locators.EXPAND_ITEM_ICON;
 import static org.eclipse.che.selenium.pageobject.Refactor.Locators.FLAG_ITEM;
@@ -68,6 +69,7 @@ public class Refactor {
   private final WebDriverWait redrawUiElementWait;
   private final WebDriverWait loadPageWait;
   private final WebDriverWait elementWait;
+  private final WebDriverWait widgetTimeout;
   private final ProjectExplorer projectExplorer;
   private final NotificationsPopupPanel notifications;
 
@@ -82,6 +84,7 @@ public class Refactor {
     this.redrawUiElementWait = new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
     this.loadPageWait = new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC);
     this.elementWait = new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC);
+    this.widgetTimeout = new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC);
     this.projectExplorer = projectExplorer;
     this.notifications = notifications;
     PageFactory.initElements(seleniumWebDriver, this);
@@ -246,7 +249,7 @@ public class Refactor {
   /** wait the 'Rename Method' form is closed */
   public void waitRenameMethodFormIsClosed() {
     try {
-      elementWait.until(invisibilityOfElementLocated(By.xpath(RENAME_METHOD_FORM)));
+      widgetTimeout.until(invisibilityOfElementLocated(By.xpath(RENAME_METHOD_FORM)));
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
       fail("Known issue: https://github.com/eclipse/che/issues/10784", ex);

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Refactor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/Refactor.java
@@ -13,9 +13,9 @@ package org.eclipse.che.selenium.pageobject;
 
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.Refactor.Locators.ERROR_CONTAINER_OF_COMPILATION_FORM;
 import static org.eclipse.che.selenium.pageobject.Refactor.Locators.EXPAND_ITEM_ICON;
 import static org.eclipse.che.selenium.pageobject.Refactor.Locators.FLAG_ITEM;
@@ -46,14 +46,13 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.textToBePresentI
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOf;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfAllElementsLocatedBy;
 import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -65,26 +64,27 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 public class Refactor {
 
   private final SeleniumWebDriver seleniumWebDriver;
+  private final SeleniumWebDriverHelper seleniumWebDriverHelper;
   private final Loader loader;
   private final WebDriverWait redrawUiElementWait;
   private final WebDriverWait loadPageWait;
   private final WebDriverWait elementWait;
-  private final WebDriverWait widgetTimeout;
   private final ProjectExplorer projectExplorer;
   private final NotificationsPopupPanel notifications;
 
   @Inject
   public Refactor(
       SeleniumWebDriver seleniumWebDriver,
+      SeleniumWebDriverHelper seleniumWebDriverHelper,
       Loader loader,
       ProjectExplorer projectExplorer,
       NotificationsPopupPanel notifications) {
     this.seleniumWebDriver = seleniumWebDriver;
+    this.seleniumWebDriverHelper = seleniumWebDriverHelper;
     this.loader = loader;
     this.redrawUiElementWait = new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
     this.loadPageWait = new WebDriverWait(seleniumWebDriver, LOAD_PAGE_TIMEOUT_SEC);
     this.elementWait = new WebDriverWait(seleniumWebDriver, ELEMENT_TIMEOUT_SEC);
-    this.widgetTimeout = new WebDriverWait(seleniumWebDriver, WIDGET_TIMEOUT_SEC);
     this.projectExplorer = projectExplorer;
     this.notifications = notifications;
     PageFactory.initElements(seleniumWebDriver, this);
@@ -248,12 +248,7 @@ public class Refactor {
 
   /** wait the 'Rename Method' form is closed */
   public void waitRenameMethodFormIsClosed() {
-    try {
-      widgetTimeout.until(invisibilityOfElementLocated(By.xpath(RENAME_METHOD_FORM)));
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known issue: https://github.com/eclipse/che/issues/10784", ex);
-    }
+    seleniumWebDriverHelper.waitInvisibility(By.xpath(RENAME_METHOD_FORM), LOADER_TIMEOUT_SEC);
   }
 
   /** wait the 'Rename Field' form is open */

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -154,6 +154,7 @@ public class NewWorkspace {
     GO("go-default"),
     JAVA_CENTOS("java-centos"),
     JAVA_THEIA_DOCKER("simple-theia-docker"),
+    JAVA_THEIA_ON_KUBERNETES("java-theia-kubernetes"),
     JAVA_THEIA_OPENSHIFT("java-theia-openshift"),
     JAVA_MYSQL_CENTOS("java-centos-mysql"),
     JAVA_DEBIAN("java-debian"),

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -32,6 +32,7 @@ import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.J
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_MYSQL;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_MYSQL_CENTOS;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_DOCKER;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_ON_KUBERNETES;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_OPENSHIFT;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.KOTLIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.NODE;
@@ -84,6 +85,7 @@ public class NewWorkspacePageTest {
           CHE_7_PREVIEW,
           ECLIPSE_CHE,
           GO,
+          JAVA_THEIA_ON_KUBERNETES,
           JAVA_THEIA_OPENSHIFT,
           NODE,
           PHP,
@@ -100,6 +102,7 @@ public class NewWorkspacePageTest {
           CHE_7_PREVIEW,
           ECLIPSE_CHE,
           GO,
+          JAVA_THEIA_ON_KUBERNETES,
           NODE,
           PHP,
           PYTHON,
@@ -197,13 +200,28 @@ public class NewWorkspacePageTest {
           SPRING_BOOT);
 
   private static final List<NewWorkspace.Stack> EXPECTED_OPENSHIFT_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS, JAVA_THEIA_DOCKER);
+      asList(
+          JAVA_MYSQL,
+          JAVA_THEIA_ON_KUBERNETES,
+          JAVA_THEIA_OPENSHIFT,
+          JAVA_MYSQL_CENTOS,
+          JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack> EXPECTED_K8S_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS, JAVA_THEIA_DOCKER);
+      asList(
+          JAVA_MYSQL,
+          JAVA_THEIA_ON_KUBERNETES,
+          JAVA_THEIA_OPENSHIFT,
+          JAVA_MYSQL_CENTOS,
+          JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack> EXPECTED_DOCKER_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL, JAVA_THEIA_OPENSHIFT, JAVA_MYSQL_CENTOS, JAVA_THEIA_DOCKER);
+      asList(
+          JAVA_MYSQL,
+          JAVA_THEIA_ON_KUBERNETES,
+          JAVA_THEIA_OPENSHIFT,
+          JAVA_MYSQL_CENTOS,
+          JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack>
       EXPECTED_OPENSHIFT_QUICK_START_STACKS_REVERSE_ORDER =
@@ -215,6 +233,7 @@ public class NewWorkspacePageTest {
               PHP,
               NODE,
               JAVA_THEIA_OPENSHIFT,
+              JAVA_THEIA_ON_KUBERNETES,
               GO,
               ECLIPSE_CHE,
               CHE_7_PREVIEW,
@@ -230,6 +249,7 @@ public class NewWorkspacePageTest {
           PYTHON,
           PHP,
           NODE,
+          JAVA_THEIA_ON_KUBERNETES,
           GO,
           ECLIPSE_CHE,
           CHE_7_PREVIEW,

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/methods/RenameVirtualMethodsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/methods/RenameVirtualMethodsTest.java
@@ -163,7 +163,13 @@ public class RenameVirtualMethodsTest {
     // need for validation on server side
     WaitUtils.sleepQuietly(2);
     refactor.clickOkButtonRefactorForm();
-    refactor.waitRenameMethodFormIsClosed();
+
+    try {
+      refactor.waitRenameMethodFormIsClosed();
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue: https://github.com/eclipse/che/issues/10784", ex);
+    }
   }
 
   private void doRefactorByWizardWithClosingWarnMess(
@@ -176,7 +182,13 @@ public class RenameVirtualMethodsTest {
     askDialog.waitFormToOpen();
     askDialog.clickOkBtn();
     askDialog.waitFormToClose();
-    refactor.waitRenameMethodFormIsClosed();
+
+    try {
+      refactor.waitRenameMethodFormIsClosed();
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known issue: https://github.com/eclipse/che/issues/10784", ex);
+    }
   }
 
   private void prepareProjectForRefactor(int cursorPositionLine, int cursorPositionChar) {

--- a/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
+++ b/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
@@ -18,7 +18,7 @@ tests.webdriverlogs_dir=target/site/webdriver-logs
 tests.tmp_dir=/tmp
 
 # Che workspace parameters
-che.workspace_agent_dev_inactive_stop_timeout_ms=300000
+che.workspace_agent_dev_inactive_stop_timeout_ms=420000
 che.workspace.activity_check_scheduler_period_s=60
 
 # Workspace default size

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -99,7 +99,6 @@
           <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithRootFolderTest"/>
           <class name="org.eclipse.che.selenium.factory.CheckFactoryWithSparseCheckoutTest"/>
           <class name="org.eclipse.che.selenium.filewatcher.EditFilesWithTabsTest"/>
-          <class name="org.eclipse.che.selenium.filewatcher.RefactoringFeatureTest"/>
           <class name="org.eclipse.che.selenium.filewatcher.RemoveFilesWithActiveTabs"/>
           <class name="org.eclipse.che.selenium.filewatcher.UpdateFilesWithoutIDE"/>
           <class name="org.eclipse.che.selenium.factory.CreateNamedFactoryFromDashboardTest"/>
@@ -140,7 +139,6 @@
           <class name="org.eclipse.che.selenium.miscellaneous.CheckMacrosFeatureTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.CheckRestoringWorkspaceAfterStoppingWsAgentProcessTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.ConvertToProjectFromConfigurationTest"/>
-          <class name="org.eclipse.che.selenium.miscellaneous.ConvertToMavenProjectTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.DialogAboutTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.FileStructureBaseOperationTest"/>
           <class name="org.eclipse.che.selenium.miscellaneous.FileStructureByKeyboardTest"/>


### PR DESCRIPTION
### What does this PR do?
This PR:
- update expected stacks list in **NewWorkspacePageTest** selenium test according to https://github.com/eclipse/che/pull/11661;
- increase timeout for checking that 'Refactor rename' form is closed(it maybe fix https://github.com/eclipse/che/issues/10784 issue);
- set **che.workspace_agent_dev_inactive_stop_timeout_ms property** to 420000 ms;
- remove **ConvertToMavenProjectTest** and **RefactoringFeatureTest** selenium tests from **CheSuite** test suite.
