### PR TITLE
Factory plugin

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -106,6 +106,7 @@ RUN useradd -u 1000 -G users,wheel,root -d ${HOME} --shell /bin/bash theia \
     && mkdir /default-theia-plugins \
     # Download yeoman generator plug-in
     && curl -L -o /default-theia-plugins/theia_yeoman_plugin.theia https://github.com/eclipse/theia-yeoman-plugin/releases/download/untagged-04f28ee329e479cc465b/theia_yeoman_plugin.theia \
+    && curl -L -o /default-theia-plugins/eclipse_che_theia_factory_plugin.theia https://github.com/eclipse/che-theia-factory-extension/releases/download/untagged-856bf351cc3b4bcc335a/eclipse_che_theia_factory_plugin.theia \
     && for f in "${HOME}" "/etc/passwd" "/etc/group /node_modules /default-theia-plugins /projects"; do\
            sudo chgrp -R 0 ${f} && \
            sudo chmod -R g+rwX ${f}; \

--- a/dockerfiles/theia/src/extensions.json
+++ b/dockerfiles/theia/src/extensions.json
@@ -22,13 +22,6 @@
             "type": "git"
         },
         {
-            "name": "@eclipse-che/theia-factory-extension",
-            "source": "https://github.com/eclipse/che-theia-factory-extension.git",
-            "folder": "che-theia-factory",
-            "checkoutTo": "extension",
-            "type": "git"
-        },
-        {
             "name": "@eclipse-che/theia-dashboard-extension",
             "source": "https://github.com/eclipse/che-theia-dashboard-extension.git",
             "folder": "theia-dashboard-extension",


### PR DESCRIPTION
### What does this PR do?
- Removes the legacy Che-Theia factory extension.
- Includes the che-theia-factory plugin.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11249

#### Release Notes
Che-theia clones projects that are defined in the workspace definition.
Che-theia performs factory cloning and execute post loading actions.
