### PR TITLE
Selenium: quick fix for CheckStoppingWsByTimeoutTest test

### DIFF
--- a/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
+++ b/selenium/che-selenium-test/src/test/resources/conf/selenium.properties
@@ -18,7 +18,7 @@ tests.webdriverlogs_dir=target/site/webdriver-logs
 tests.tmp_dir=/tmp
 
 # Che workspace parameters
-che.workspace_agent_dev_inactive_stop_timeout_ms=420000
+che.workspace_agent_dev_inactive_stop_timeout_ms=500000
 che.workspace.activity_check_scheduler_period_s=60
 
 # Workspace default size


### PR DESCRIPTION
### What does this PR do?
This PR increases value of "**che.workspace_agent_dev_inactive_stop_timeout_ms**" property from 420000 ms to 500000 ms to fix **CheckStoppingWsByTimeoutTest** selenium test.
