### PR TITLE
Added 1-second delay between installer commands in the test 

### DIFF
--- a/agents/go-agents/bootstrapper/booter/booter_test.go
+++ b/agents/go-agents/bootstrapper/booter/booter_test.go
@@ -47,7 +47,7 @@ var (
 		ID:          "test-installer-3",
 		Description: "Installer for testing",
 		Version:     "1.0",
-		Script:      "printf \"1\n\" && printf \"error\" >&2 && exit 1",
+		Script:      "printf \"1\n\" && sleep 1 && printf \"error\" >&2 && exit 1",
 	}
 )
 


### PR DESCRIPTION

### What does this PR do?
What: Added 1-second delay between installer commands in the test to avoid racing error between stdout log pumper and stderr pumper.

In the test we have a command ```printf \"1\n\" && sleep 1 && printf \"error\" >&2 && exit 1```, and we check that first we receive 1 in stdout, then we receive 'error' in stderror and command exited with status 1. To get this two events we have two goroutines that are pumping stdout and stderr channels.
The distance between events is a hundredth of a second
```
2018/10/25 09:14:05 OnStdout. 1 at 2018-10-25T09:14:05.098357+03:00
2018/10/25 09:14:06 OnStderr. error at 2018-10-25T09:14:06.10633+03:00
```
Since we have no obligation of the order between stdout and stderro, I've changed this test to make sure events are distinct in time.
```
2018/10/25 09:15:53 OnStdout. 1 at 2018-10-25T09:15:53.177569+03:00
2018/10/25 09:15:53 OnStderr. error at 2018-10-25T09:15:53.178326+03:00
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10914

#### Release Notes
n/a

#### Docs PR
n/a