### PR TITLE
Selenium: Change the 'waitNode()' method in the 'AssistantFindPanel'

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/AssistantFindPanel.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/AssistantFindPanel.java
@@ -12,7 +12,7 @@
 package org.eclipse.che.selenium.pageobject;
 
 import static java.util.Arrays.asList;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.AssistantFindPanel.Locators.ACTION_NODE_ID_PATTERN;
 import static org.eclipse.che.selenium.pageobject.AssistantFindPanel.Locators.ALL_ACTIONS_XPATH;
 import static org.eclipse.che.selenium.pageobject.AssistantFindPanel.Locators.PANEL_ID;
@@ -113,7 +113,7 @@ public class AssistantFindPanel {
                   }
                   return false;
                 }),
-        ELEMENT_TIMEOUT_SEC,
+        WIDGET_TIMEOUT_SEC * 2,
         StaleElementReferenceException.class);
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/AssistantFindPanel.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/AssistantFindPanel.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.pageobject;
 
 import static java.util.Arrays.asList;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.AssistantFindPanel.Locators.ACTION_NODE_ID_PATTERN;
 import static org.eclipse.che.selenium.pageobject.AssistantFindPanel.Locators.ALL_ACTIONS_XPATH;
 import static org.eclipse.che.selenium.pageobject.AssistantFindPanel.Locators.PANEL_ID;
@@ -23,6 +24,7 @@ import java.util.Collection;
 import java.util.List;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
 @Singleton
@@ -100,15 +102,19 @@ public class AssistantFindPanel {
   }
 
   public void waitNode(String expectedText) {
-    seleniumWebDriverHelper.waitSuccessCondition(
-        driver -> {
-          for (int i = 0; i < getActionNodesCount(); i++) {
-            if (isActionNodeContainsText(i, expectedText)) {
-              return true;
-            }
-          }
-          return false;
-        });
+    seleniumWebDriverHelper.waitNoExceptions(
+        () ->
+            seleniumWebDriverHelper.waitSuccessCondition(
+                driver -> {
+                  for (int i = 0; i < getActionNodesCount(); i++) {
+                    if (isActionNodeContainsText(i, expectedText)) {
+                      return true;
+                    }
+                  }
+                  return false;
+                }),
+        ELEMENT_TIMEOUT_SEC,
+        StaleElementReferenceException.class);
   }
 
   public void waitAllNodes(String... expectedNodesText) {


### PR DESCRIPTION
### What does this PR do?
* Rework the _waitNode_() in the _AssistantFindPanel_ using the _waitNoExceptions()_
from the _SeleniumWebDriverHelper_ to avoid unexpected _StaleElementReferenceException_

### What issues does this PR fix or reference?
#11730