### PR TITLE
Prevent duplication of command in context menu after update meta information

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/name/NamePage.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/editor/page/name/NamePage.java
@@ -71,6 +71,8 @@ public class NamePage extends AbstractCommandEditorPage implements NamePageView.
 
   @Override
   public void onNameChanged(String name) {
+    name = name.trim();
+
     editedCommand.setName(name);
 
     notifyDirtyStateChanged();

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandActionManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandActionManager.java
@@ -196,7 +196,7 @@ public class ExecuteCommandActionManager {
       }
 
       // remove action group if it's empty
-      DefaultActionGroup goalPopUpGroup = goalPopUpGroups.remove(goalId);
+      DefaultActionGroup goalPopUpGroup = goalPopUpGroups.get(goalId);
 
       if (goalPopUpGroup != null) {
         goalPopUpGroup.remove(commandAction);

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandActionManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandActionManager.java
@@ -199,10 +199,6 @@ public class ExecuteCommandActionManager {
 
       if (goalPopUpGroup != null) {
         goalPopUpGroup.remove(commandAction);
-
-        if (goalPopUpGroup.getChildrenCount() == 0) {
-          removeAction(goalPopUpGroup);
-        }
       }
     }
   }

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandActionManager.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/ExecuteCommandActionManager.java
@@ -195,7 +195,6 @@ public class ExecuteCommandActionManager {
         goalId = goalRegistry.getDefaultGoal().getId();
       }
 
-      // remove action group if it's empty
       DefaultActionGroup goalPopUpGroup = goalPopUpGroups.get(goalId);
 
       if (goalPopUpGroup != null) {

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/GoalPopUpGroup.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/command/execute/GoalPopUpGroup.java
@@ -55,7 +55,11 @@ class GoalPopUpGroup extends DefaultActionGroup {
 
   @Override
   public void update(ActionEvent e) {
-    e.getPresentation().setText(commandGoal.getId() + " (" + getChildrenCount() + ")");
+    if (getChildrenCount() > 0) {
+      e.getPresentation().setText(commandGoal.getId() + " (" + getChildrenCount() + ")");
+    } else {
+      e.getPresentation().setEnabledAndVisible(false);
+    }
   }
 
   private SVGResource getCommandGoalIcon() {

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/NameUtils.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/util/NameUtils.java
@@ -23,7 +23,7 @@ public class NameUtils {
   private static RegExp FILE_NAME = RegExp.compile("^((?![*:\\/\\\\\"?<>|\0]).)+$");
   private static RegExp FOLDER_NAME = FILE_NAME;
   private static RegExp PROJECT_NAME = RegExp.compile("^[A-Za-z0-9_\\-\\.]+$");
-  private static RegExp COMMAND_NAME = FILE_NAME;
+  private static RegExp COMMAND_NAME = RegExp.compile("^((?![*\\/\\\\\"?<>|\0]).)+$");
 
   private NameUtils() {}
 

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/NameUtilsTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/NameUtilsTest.java
@@ -32,6 +32,8 @@ public class NameUtilsTest {
   private static String[] INVALID_FILENAMES =
       new String[] {"\0", "a/b", "/", "\\", "*", "?", "|", "<", ">", "I<3Math.png", ""};
 
+  private static String[] VALID_COMMAND_NAMES = new String[] {"build", "project: build"};
+
   @Test(dataProvider = "ValidFilenames")
   public void validFilenamesShouldGetValidated(String validFilename) {
     assertTrue(validFilename + " is supposed to be valid", NameUtils.checkFileName(validFilename));
@@ -56,6 +58,12 @@ public class NameUtilsTest {
         NameUtils.checkFileName(invalidFolderName));
   }
 
+  @Test(dataProvider = "ValidCommandNames")
+  public void validCommandNamesShouldGetValidated(String validCommandName) {
+    assertTrue(
+        validCommandName + " is supposed to be valid", NameUtils.checkFileName(validCommandName));
+  }
+
   @Test
   public void getFileExtension() {
     assertEquals("txt", NameUtils.getFileExtension("123.txt"));
@@ -71,6 +79,11 @@ public class NameUtilsTest {
   @DataProvider(name = "InvalidFilenames")
   public Object[][] getInvalidFilenames() {
     return toDataProviderData(INVALID_FILENAMES);
+  }
+
+  @DataProvider(name = "ValidCommandNames")
+  public Object[][] getValidCommandNames() {
+    return toDataProviderData(VALID_COMMAND_NAMES);
   }
 
   private Object[][] toDataProviderData(String[] strings) {

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/NameUtilsTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/NameUtilsTest.java
@@ -61,7 +61,8 @@ public class NameUtilsTest {
   @Test(dataProvider = "ValidCommandNames")
   public void validCommandNamesShouldGetValidated(String validCommandName) {
     assertTrue(
-        validCommandName + " is supposed to be valid", NameUtils.isValidCommandName(validCommandName));
+        validCommandName + " is supposed to be valid",
+        NameUtils.isValidCommandName(validCommandName));
   }
 
   @Test

--- a/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/NameUtilsTest.java
+++ b/ide/commons-gwt/src/test/java/org/eclipse/che/ide/util/NameUtilsTest.java
@@ -61,7 +61,7 @@ public class NameUtilsTest {
   @Test(dataProvider = "ValidCommandNames")
   public void validCommandNamesShouldGetValidated(String validCommandName) {
     assertTrue(
-        validCommandName + " is supposed to be valid", NameUtils.checkFileName(validCommandName));
+        validCommandName + " is supposed to be valid", NameUtils.isValidCommandName(validCommandName));
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds few fix related to edit command name. First fix prevent saving command name with trailing whitespaces. Second fix adds backward compatibility to allow char `:` in command names. Third fix prevent command duplication after update operation.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#4940 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
