### PR TITLE
[Selenium] Fix of unexpected fails of "AutocompleteProposalJavaDocTest", "ShowHintsCommandTest", "DownloadProjectTest", "CheckRestoringSplitEditorTest" selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.editor;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_JAVA_MULTIMODULE;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.TabActionLocator.SPIT_HORISONTALLY;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.TabActionLocator.SPLIT_VERTICALLY;
@@ -97,7 +98,7 @@ public class CheckRestoringSplitEditorTest {
     seleniumWebDriver.navigate().refresh();
     projectExplorer.waitItem(PROJECT_NAME);
     loader.waitOnClosed();
-    projectExplorer.waitVisibilityByName(javaClassName);
+    projectExplorer.waitVisibilityByName(javaClassName, WIDGET_TIMEOUT_SEC);
 
     notificationsPopupPanel.waitPopupPanelsAreClosed();
     checkSplitdEditorAfterRefreshing(

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
@@ -82,7 +82,7 @@ public class CheckRestoringSplitEditorTest {
   }
 
   @Test
-  public void checkRestoringStateSplittedEditor() throws IOException, Exception {
+  public void checkRestoringStateSplitEditor() throws IOException, Exception {
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
     splitEditorAndOpenFiles();
@@ -101,15 +101,15 @@ public class CheckRestoringSplitEditorTest {
     projectExplorer.waitVisibilityByName(javaClassName, WIDGET_TIMEOUT_SEC);
 
     notificationsPopupPanel.waitPopupPanelsAreClosed();
-    checkSplitdEditorAfterRefreshing(
+    checkSplitEditorAfterRefreshing(
         1, javaClassTab, expectedTextFromEditor.get(0), cursorPositionForJavaFile);
-    checkSplitdEditorAfterRefreshing(
+    checkSplitEditorAfterRefreshing(
         2, readmeFileName, expectedTextFromEditor.get(1).trim(), cursorPositionForReadMeFile);
-    checkSplitdEditorAfterRefreshing(
+    checkSplitEditorAfterRefreshing(
         3, pomFileTab, expectedTextFromEditor.get(2).trim(), cursorPositionForPomFile);
   }
 
-  private void checkSplitdEditorAfterRefreshing(
+  private void checkSplitEditorAfterRefreshing(
       int numOfEditor,
       String nameOfEditorTab,
       String expectedTextAfterRefresh,

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.selenium.editor.autocomplete;
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.CUSTOM;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.io.IOException;
@@ -31,6 +32,7 @@ import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -99,16 +101,8 @@ public class AutocompleteProposalJavaDocTest {
 
   @Test
   public void shouldDisplayJavaDocOfClassMethod() throws Exception {
-    // when
-    editor.waitActive();
-    loader.waitOnClosed();
-    editor.goToCursorPositionVisible(31, 30);
-    editor.launchAutocompleteAndWaitContainer();
-    editor.selectCompositeAutocompleteProposal(
-        "concat(String part1, String part2, char divider) : String App");
-
-    // then
-    editor.waitProposalDocumentationHTML(
+    // given
+    final String expectedJavadocHtmlText =
         "<p><strong>Deprecated</strong>  <em>As of version 1.0, use <a href=\"jdt://contents/commons-lang-2.6.jar/org.apache.commons.lang/StringUtils.class?=app/%5C/home%5C/user%5C/.m2%5C/repository%5C/commons-lang%5C/commons-lang%5C/2.6%5C/commons-lang-2.6.jar%3Corg.apache.commons.lang%28StringUtils.class#3169\">org.apache.commons.lang.StringUtils.join(Object [], char)</a></em></p>\n"
             + "<p>Returns concatination of two strings into one divided by special symbol.</p>\n"
             + "<ul>\n"
@@ -132,7 +126,23 @@ public class AutocompleteProposalJavaDocTest {
             + "<li><a href=\"jdt://contents/rt.jar/java.lang/NullPointerException.class?=app/%5C/usr%5C/lib%5C/jvm%5C/java-8-openjdk-amd64%5C/jre%5C/lib%5C/rt.jar%3Cjava.lang%28NullPointerException.class#53\">NullPointerException</a> - if one of the part has null value.</li>\n"
             + "</ul>\n"
             + "</li>\n"
-            + "</ul>\n");
+            + "</ul>\n";
+
+    // when
+    editor.waitActive();
+    loader.waitOnClosed();
+    editor.goToCursorPositionVisible(31, 30);
+    editor.launchAutocompleteAndWaitContainer();
+    editor.selectCompositeAutocompleteProposal(
+        "concat(String part1, String part2, char divider) : String App");
+
+    // then
+    try {
+      editor.waitProposalDocumentationHTML(expectedJavadocHtmlText);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known random failure https://github.com/eclipse/che/issues/11743");
+    }
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/ShowHintsCommandTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/ShowHintsCommandTest.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.selenium.editor.autocomplete;
 
+import static org.testng.Assert.fail;
+
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
@@ -25,6 +27,7 @@ import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
@@ -93,7 +96,13 @@ public class ShowHintsCommandTest {
     editor.waitMarkerInPosition(MarkerLocator.ERROR, 34);
     editor.goToCursorPositionVisible(33, 16);
     editor.callShowHintsPopUp();
-    editor.waitShowHintsPopUpOpened();
+    try {
+      editor.waitShowHintsPopUpOpened();
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11747", ex);
+    }
+
     editor.waitExpTextIntoShowHintsPopUp(TEXT_IN_POP_UP_1);
     editor.typeTextIntoEditor(Keys.ESCAPE.toString());
     editor.waitShowHintsPopUpClosed();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DownloadProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DownloadProjectTest.java
@@ -84,8 +84,7 @@ public class DownloadProjectTest {
         ProjectTemplates.MAVEN_SPRING);
 
     ide.open(workspace);
-    consoles.waitJDTLSProjectResolveFinishedMessage(TEST_PROJECT_1);
-    consoles.waitJDTLSProjectResolveFinishedMessage(TEST_PROJECT_2);
+    consoles.waitJDTLSProjectResolveFinishedMessage(TEST_PROJECT_1, TEST_PROJECT_2);
     projectExplorer.waitProjectExplorer();
     loader.waitOnClosed();
   }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix of unexpected fails of "AutocompleteProposalJavaDocTest", "ShowHintsCommandTest", "DownloadProjectTest", "CheckRestoringSplitEditorTest" selenium tests

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/11741
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
