### PR TITLE
Send URI instead of path to ls on didChangeWatchedFiles

### DIFF
--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerAbstractFileWatcher.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/LanguageServerAbstractFileWatcher.java
@@ -78,7 +78,7 @@ class LanguageServerAbstractFileWatcher implements Consumer<Path> {
           .put(
               pathMatcher,
               path -> {
-                FileEvent fileEvent = new FileEvent(path.toString(), fileChangeType);
+                FileEvent fileEvent = new FileEvent(path.toUri().toString(), fileChangeType);
                 List<FileEvent> changes = ImmutableList.of(fileEvent);
                 DidChangeWatchedFilesParams params = new DidChangeWatchedFilesParams(changes);
                 WorkspaceService service = languageServer.getWorkspaceService();


### PR DESCRIPTION
### What does this PR do?
Fixes didChangeWatchedFiles call to send proper uri's to langauges servers instead of paths.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11660

