### PR TITLE
CHE-11457: switch github-extension to tag

### DIFF
--- a/dockerfiles/theia/src/extensions.json
+++ b/dockerfiles/theia/src/extensions.json
@@ -4,7 +4,7 @@
             "name": "github-extension",
             "source": "https://github.com/eclipse/che-theia-github-plugin",
             "folder": "github-extension",
-            "checkoutTo": "master",
+            "checkoutTo": "0.0.1",
             "type": "git"
         },
         {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Checkout che-theia-github-plugin to tag with extension. Master of the extension's repository is going to contain theia plugin instead of extension.

### What issues does this PR fix or reference?
#11457 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
