### PR TITLE
Change access modifiers of debug config classes for reusing code

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/AbstractDebugConfig.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/AbstractDebugConfig.java
@@ -12,17 +12,17 @@
 package org.eclipse.che.selenium.pageobject.debug;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.pageobject.debug.AbstractDebugConfig.Locators.DEBUG_CONFIGURATION_WIDGET_ID;
 
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 /**
  * @author Dmytro Nochevnov
@@ -30,11 +30,14 @@ import org.openqa.selenium.support.ui.WebDriverWait;
  */
 @Singleton
 public abstract class AbstractDebugConfig {
+  private SeleniumWebDriverHelper seleniumWebDriverHelper;
 
   protected final SeleniumWebDriver seleniumWebDriver;
 
-  public AbstractDebugConfig(SeleniumWebDriver seleniumWebDriver) {
+  public AbstractDebugConfig(
+      SeleniumWebDriver seleniumWebDriver, SeleniumWebDriverHelper seleniumWebDriverHelper) {
     this.seleniumWebDriver = seleniumWebDriver;
+    this.seleniumWebDriverHelper = seleniumWebDriverHelper;
     PageFactory.initElements(seleniumWebDriver, this);
   }
 
@@ -53,9 +56,11 @@ public abstract class AbstractDebugConfig {
     String REMOVE_CONFIG_BUTTON_XPATH_TEMPLATE = CONFIG_ITEM_XPATH_TEMPLATE + "/span/span[1]";
 
     String DELETE_CONFIGURATION_DIALOG_TITLE_XPATH = "//div[text()='Delete Configuration']";
+
+    String DEBUG_BUTTON_ID = "window-edit-debug-configurations-debug";
   }
 
-  @FindBy(id = Locators.DEBUG_CONFIGURATION_WIDGET_ID)
+  @FindBy(id = DEBUG_CONFIGURATION_WIDGET_ID)
   WebElement debugConfigurationsView;
 
   @FindBy(xpath = Locators.NAME_OF_DEBUG_CONFIG_FIELD_XPATH)
@@ -63,6 +68,9 @@ public abstract class AbstractDebugConfig {
 
   @FindBy(id = Locators.DEBUG_CONFIG_CLOSE_BTN_XPATH)
   WebElement configCloseBtn;
+
+  @FindBy(id = Locators.DEBUG_BUTTON_ID)
+  WebElement debugButton;
 
   @FindBy(xpath = Locators.DEBUG_CONFIG_SAVE_BTN_XPATH)
   WebElement configSaveBtn;
@@ -72,16 +80,13 @@ public abstract class AbstractDebugConfig {
 
   /** Wait opening of the Debug configuration widget */
   public void waitDebugConfigurationIsOpened() {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOf(debugConfigurationsView));
+    seleniumWebDriverHelper.waitVisibility(debugConfigurationsView, REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
   }
 
   /** Wait closing of the Debug configuration widget */
   public void waitDebugConfigurationIsClosed() {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(
-            ExpectedConditions.invisibilityOfElementLocated(
-                By.id(Locators.DEBUG_CONFIGURATION_WIDGET_ID)));
+    seleniumWebDriverHelper.waitInvisibility(
+        By.id(DEBUG_CONFIGURATION_WIDGET_ID), REDRAW_UI_ELEMENTS_TIMEOUT_SEC);
   }
 
   /**
@@ -91,28 +96,19 @@ public abstract class AbstractDebugConfig {
    */
   public void removeConfig(String configName) {
     String configItemXpath = String.format(Locators.CONFIG_ITEM_XPATH_TEMPLATE, configName);
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(configItemXpath)))
-        .click();
+    seleniumWebDriverHelper.waitAndClick(By.xpath(configItemXpath));
 
     String removeConfigButtonXpath =
         String.format(Locators.REMOVE_CONFIG_BUTTON_XPATH_TEMPLATE, configName);
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.xpath(removeConfigButtonXpath)))
-        .click();
+    seleniumWebDriverHelper.waitAndClick(By.xpath(removeConfigButtonXpath));
 
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOf(deleteConfigurationDialogTitle));
+    seleniumWebDriverHelper.waitVisibility(deleteConfigurationDialogTitle);
 
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOfElementLocated(By.id(AskDialog.OK_BTN_ID)))
-        .click();
+    seleniumWebDriverHelper.waitAndClick(By.id(AskDialog.OK_BTN_ID));
 
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.invisibilityOfElementLocated(By.id(AskDialog.OK_BTN_ID)));
+    seleniumWebDriverHelper.waitInvisibility(By.id(AskDialog.OK_BTN_ID));
 
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.invisibilityOfElementLocated(By.xpath(configItemXpath)));
+    seleniumWebDriverHelper.waitInvisibility(By.xpath(configItemXpath));
 
     close();
   }
@@ -137,20 +133,26 @@ public abstract class AbstractDebugConfig {
   void createConfigWithoutClosingDialog(String configName) {
     waitDebugConfigurationIsOpened();
     expandDebugCategory();
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOf(nameFieldOfDebugConf));
+    seleniumWebDriverHelper.waitVisibility(nameFieldOfDebugConf);
     nameFieldOfDebugConf.clear();
     nameFieldOfDebugConf.sendKeys(configName);
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOf(configSaveBtn))
-        .click();
+    clickOnSaveBtn();
   }
 
   /** Expand the debugger type icon '+' */
-  abstract void expandDebugCategory();
+  public abstract void expandDebugCategory();
 
-  void close() {
-    configCloseBtn.click();
+  protected void clickOnSaveBtn() {
+    seleniumWebDriverHelper.waitAndClick(configSaveBtn);
+  }
+
+  protected void close() {
+    seleniumWebDriverHelper.waitAndClick(configCloseBtn);
+    waitDebugConfigurationIsClosed();
+  }
+
+  protected void clickOnDebugAndWaitClosing() {
+    seleniumWebDriverHelper.waitAndClick(debugButton);
     waitDebugConfigurationIsClosed();
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/AbstractDebugConfig.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/AbstractDebugConfig.java
@@ -97,19 +97,13 @@ public abstract class AbstractDebugConfig {
   public void removeConfig(String configName) {
     String configItemXpath = String.format(Locators.CONFIG_ITEM_XPATH_TEMPLATE, configName);
     seleniumWebDriverHelper.waitAndClick(By.xpath(configItemXpath));
-
     String removeConfigButtonXpath =
         String.format(Locators.REMOVE_CONFIG_BUTTON_XPATH_TEMPLATE, configName);
     seleniumWebDriverHelper.waitAndClick(By.xpath(removeConfigButtonXpath));
-
     seleniumWebDriverHelper.waitVisibility(deleteConfigurationDialogTitle);
-
     seleniumWebDriverHelper.waitAndClick(By.id(AskDialog.OK_BTN_ID));
-
     seleniumWebDriverHelper.waitInvisibility(By.id(AskDialog.OK_BTN_ID));
-
     seleniumWebDriverHelper.waitInvisibility(By.xpath(configItemXpath));
-
     close();
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/CppDebugConfig.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/CppDebugConfig.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRA
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -31,8 +32,9 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 public class CppDebugConfig extends AbstractDebugConfig {
 
   @Inject
-  public CppDebugConfig(SeleniumWebDriver seleniumWebDriver) {
-    super(seleniumWebDriver);
+  public CppDebugConfig(
+      SeleniumWebDriver seleniumWebDriver, SeleniumWebDriverHelper seleniumWebDriverHelper) {
+    super(seleniumWebDriver, seleniumWebDriverHelper);
     PageFactory.initElements(seleniumWebDriver, this);
   }
 
@@ -75,7 +77,7 @@ public class CppDebugConfig extends AbstractDebugConfig {
   }
 
   @Override
-  void expandDebugCategory() {
+  public void expandDebugCategory() {
     new WebDriverWait(seleniumWebDriver, ATTACHING_ELEM_TO_DOM_SEC)
         .until(ExpectedConditions.visibilityOf(debugCategoryExpandIcon))
         .click();

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/JavaDebugConfig.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/JavaDebugConfig.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ATTAC
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -28,10 +29,10 @@ import org.openqa.selenium.support.ui.WebDriverWait;
  */
 @Singleton
 public class JavaDebugConfig extends AbstractDebugConfig {
-
   @Inject
-  public JavaDebugConfig(SeleniumWebDriver seleniumWebDriver) {
-    super(seleniumWebDriver);
+  public JavaDebugConfig(
+      SeleniumWebDriver seleniumWebDriver, SeleniumWebDriverHelper seleniumWebDriverHelper) {
+    super(seleniumWebDriver, seleniumWebDriverHelper);
     PageFactory.initElements(seleniumWebDriver, this);
   }
 
@@ -50,7 +51,7 @@ public class JavaDebugConfig extends AbstractDebugConfig {
   }
 
   @Override
-  void expandDebugCategory() {
+  public void expandDebugCategory() {
     new WebDriverWait(seleniumWebDriver, ATTACHING_ELEM_TO_DOM_SEC)
         .until(ExpectedConditions.visibilityOf(debugCategoryExpandIcon))
         .click();

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/NodeJsDebugConfig.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/NodeJsDebugConfig.java
@@ -11,17 +11,13 @@
  */
 package org.eclipse.che.selenium.pageobject.debug;
 
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ATTACHING_ELEM_TO_DOM_SEC;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
-
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-import org.openqa.selenium.support.ui.WebDriverWait;
 
 /**
  * @author Dmytro Nochevnov
@@ -30,9 +26,13 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 @Singleton
 public class NodeJsDebugConfig extends AbstractDebugConfig {
 
+  private SeleniumWebDriverHelper seleniumWebDriverHelper;
+
   @Inject
-  public NodeJsDebugConfig(SeleniumWebDriver seleniumWebDriver) {
-    super(seleniumWebDriver);
+  public NodeJsDebugConfig(
+      SeleniumWebDriver seleniumWebDriver, SeleniumWebDriverHelper seleniumWebDriverHelper) {
+    super(seleniumWebDriver, seleniumWebDriverHelper);
+    this.seleniumWebDriverHelper = seleniumWebDriverHelper;
     PageFactory.initElements(seleniumWebDriver, this);
   }
 
@@ -62,16 +62,25 @@ public class NodeJsDebugConfig extends AbstractDebugConfig {
    * @param pathToNodeJsFile the defined path
    */
   public void setPathToScriptForNodeJs(String pathToNodeJsFile) {
-    new WebDriverWait(seleniumWebDriver, REDRAW_UI_ELEMENTS_TIMEOUT_SEC)
-        .until(ExpectedConditions.visibilityOf(scriptNodeJsField))
-        .clear();
+    seleniumWebDriverHelper.waitVisibility(scriptNodeJsField).clear();
     scriptNodeJsField.sendKeys(pathToNodeJsFile);
   }
 
   @Override
-  void expandDebugCategory() {
-    new WebDriverWait(seleniumWebDriver, ATTACHING_ELEM_TO_DOM_SEC)
-        .until(ExpectedConditions.visibilityOf(debugCategoryExpandIcon))
-        .click();
+  public void expandDebugCategory() {
+    seleniumWebDriverHelper.waitAndClick(debugCategoryExpandIcon);
+  }
+
+  public void saveConfiguration() {
+    clickOnSaveBtn();
+  }
+
+  public void saveConfigurationAndclose() {
+    saveConfiguration();
+    close();
+  }
+
+  public void clickOnDebugButtonAndWaitClosing() {
+    clickOnDebugAndWaitClosing();
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/PhpDebugConfig.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/debug/PhpDebugConfig.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRA
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
+import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -32,8 +33,9 @@ import org.openqa.selenium.support.ui.WebDriverWait;
 public class PhpDebugConfig extends AbstractDebugConfig {
 
   @Inject
-  public PhpDebugConfig(SeleniumWebDriver seleniumWebDriver) {
-    super(seleniumWebDriver);
+  public PhpDebugConfig(
+      SeleniumWebDriver seleniumWebDriver, SeleniumWebDriverHelper seleniumWebDriverHelper) {
+    super(seleniumWebDriver, seleniumWebDriverHelper);
     PageFactory.initElements(seleniumWebDriver, this);
   }
 
@@ -106,7 +108,7 @@ public class PhpDebugConfig extends AbstractDebugConfig {
   }
 
   @Override
-  void expandDebugCategory() {
+  public void expandDebugCategory() {
     new WebDriverWait(seleniumWebDriver, ATTACHING_ELEM_TO_DOM_SEC)
         .until(ExpectedConditions.visibilityOf(debugCategoryExpandIcon))
         .click();


### PR DESCRIPTION
### What does this PR do?
* Change access modifiers in some methods for using this one in other tests
* Apply selenium helper to `AbstractDebugConfig` class change depended classes
@dmytro-ndp, @Ohrimenko1988, @SkorikSergey 