### PR TITLE
Ensure plugin broker works with ephemeral workspaces

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
@@ -104,7 +104,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     final String workspaceId = identity.getWorkspaceId();
-    if (EphemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
+    if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
       ephemeralWorkspaceAdapter.provision(k8sEnv, identity);
       return;
     }
@@ -117,7 +117,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
       List<Container> containers = new ArrayList<>();
       containers.addAll(podSpec.getContainers());
       containers.addAll(podSpec.getInitContainers());
-      for (Container container : podSpec.getContainers()) {
+      for (Container container : containers) {
         String machineName = Names.machineName(pod, container);
         InternalMachineConfig machineConfig = k8sEnv.getMachines().get(machineName);
         addMachineVolumes(workspaceId, subPaths, pod, container, machineConfig.getVolumes());
@@ -134,7 +134,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
   @Override
   public void prepare(KubernetesEnvironment k8sEnv, String workspaceId)
       throws InfrastructureException {
-    if (EphemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
+    if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
       return;
     }
     final Collection<PersistentVolumeClaim> claims = k8sEnv.getPersistentVolumeClaims().values();
@@ -161,7 +161,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
 
   @Override
   public void cleanup(Workspace workspace) throws InfrastructureException {
-    if (EphemeralWorkspaceAdapter.isEphemeral(workspace)) {
+    if (EphemeralWorkspaceUtility.isEphemeral(workspace)) {
       return;
     }
     String workspaceId = workspace.getId();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
-import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolumeMount;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
 
@@ -25,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.inject.Singleton;
-import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
@@ -45,38 +43,6 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 @Singleton
 public class EphemeralWorkspaceAdapter {
   private static final String EPHEMERAL_VOLUME_NAME_PREFIX = "ephemeral-che-workspace-";
-
-  /**
-   * @param workspace
-   * @return true if workspace config contains `persistVolumes` attribute which is set to false. In
-   *     this case regardless of the PVC strategy, workspace volumes would be created as `emptyDir`.
-   *     When a workspace Pod is removed for any reason, the data in the `emptyDir` volume is
-   *     deleted forever
-   */
-  public static boolean isEphemeral(Workspace workspace) {
-    return isEphemeral(workspace.getConfig().getAttributes());
-  }
-
-  /**
-   * @param workspaceAttributes
-   * @return true if `persistVolumes` attribute exists and set to 'false'. In this case regardless
-   *     of the PVC strategy, workspace volumes would be created as `emptyDir`. When a workspace Pod
-   *     is removed for any reason, the data in the `emptyDir` volume is deleted forever
-   */
-  public static boolean isEphemeral(Map<String, String> workspaceAttributes) {
-    String persistVolumes = workspaceAttributes.get(PERSIST_VOLUMES_ATTRIBUTE);
-    return "false".equals(persistVolumes);
-  }
-
-  /**
-   * Change workspace attributes such that future calls to {@link
-   * EphemeralWorkspaceAdapter#isEphemeral} will return true.
-   *
-   * @param workspaceAttributes
-   */
-  public static void makeEphemeral(Map<String, String> workspaceAttributes) {
-    workspaceAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");
-  }
 
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceUtility.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceUtility.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
+
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+
+public class EphemeralWorkspaceUtility {
+
+  /**
+   * @param workspaceAttributes
+   * @return true if `persistVolumes` attribute exists and set to 'false'. In this case regardless
+   *     of the PVC strategy, workspace volumes would be created as `emptyDir`. When a workspace Pod
+   *     is removed for any reason, the data in the `emptyDir` volume is deleted forever
+   */
+  public static boolean isEphemeral(Map<String, String> workspaceAttributes) {
+    String persistVolumes = workspaceAttributes.get(PERSIST_VOLUMES_ATTRIBUTE);
+    return "false".equals(persistVolumes);
+  }
+
+  /**
+   * @param workspace
+   * @return true if workspace config contains `persistVolumes` attribute which is set to false. In
+   *     this case regardless of the PVC strategy, workspace volumes would be created as `emptyDir`.
+   *     When a workspace Pod is removed for any reason, the data in the `emptyDir` volume is
+   *     deleted forever
+   */
+  public static boolean isEphemeral(Workspace workspace) {
+    return isEphemeral(workspace.getConfig().getAttributes());
+  }
+
+  /**
+   * Change workspace attributes such that future calls to {@link isEphemeral} will return true.
+   *
+   * @param workspaceAttributes
+   */
+  public static void makeEphemeral(Map<String, String> workspaceAttributes) {
+    workspaceAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
@@ -94,7 +94,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     final String workspaceId = identity.getWorkspaceId();
-    if (EphemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
+    if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
       ephemeralWorkspaceAdapter.provision(k8sEnv, identity);
       return;
     }
@@ -124,7 +124,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
   @Override
   public void prepare(KubernetesEnvironment k8sEnv, String workspaceId)
       throws InfrastructureException {
-    if (EphemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
+    if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
       return;
     }
     if (!k8sEnv.getPersistentVolumeClaims().isEmpty()) {
@@ -190,7 +190,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
 
   @Override
   public void cleanup(Workspace workspace) throws InfrastructureException {
-    if (EphemeralWorkspaceAdapter.isEphemeral(workspace)) {
+    if (EphemeralWorkspaceUtility.isEphemeral(workspace)) {
       return;
     }
     String workspaceId = workspace.getId();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
@@ -25,8 +25,10 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.inject.Inject;
@@ -92,7 +94,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     final String workspaceId = identity.getWorkspaceId();
-    if (ephemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
+    if (EphemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
       ephemeralWorkspaceAdapter.provision(k8sEnv, identity);
       return;
     }
@@ -107,7 +109,10 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
                 .getByLabel(CHE_WORKSPACE_ID_LABEL, workspaceId));
     for (Pod pod : k8sEnv.getPods().values()) {
       final PodSpec podSpec = pod.getSpec();
-      for (Container container : podSpec.getContainers()) {
+      List<Container> containers = new ArrayList<>();
+      containers.addAll(podSpec.getContainers());
+      containers.addAll(podSpec.getInitContainers());
+      for (Container container : containers) {
         final String machineName = Names.machineName(pod, container);
         Map<String, Volume> volumes = k8sEnv.getMachines().get(machineName).getVolumes();
         addMachineVolumes(workspaceId, claims, volumeName2PVC, pod, container, volumes);
@@ -119,7 +124,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
   @Override
   public void prepare(KubernetesEnvironment k8sEnv, String workspaceId)
       throws InfrastructureException {
-    if (ephemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
+    if (EphemeralWorkspaceAdapter.isEphemeral(k8sEnv.getAttributes())) {
       return;
     }
     if (!k8sEnv.getPersistentVolumeClaims().isEmpty()) {
@@ -185,7 +190,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
 
   @Override
   public void cleanup(Workspace workspace) throws InfrastructureException {
-    if (ephemeralWorkspaceAdapter.isEphemeral(workspace)) {
+    if (EphemeralWorkspaceAdapter.isEphemeral(workspace)) {
       return;
     }
     String workspaceId = workspace.getId();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
@@ -37,13 +37,13 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphase
  * @author Angel Misevski
  */
 @Beta
-public class KubernetesBrokerInitContainerApplier<Environment extends KubernetesEnvironment> {
+public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironment> {
 
-  private final BrokerEnvironmentFactory<Environment> brokerEnvironmentFactory;
+  private final BrokerEnvironmentFactory<E> brokerEnvironmentFactory;
 
   @Inject
   public KubernetesBrokerInitContainerApplier(
-      BrokerEnvironmentFactory<Environment> brokerEnvironmentFactory) {
+      BrokerEnvironmentFactory<E> brokerEnvironmentFactory) {
     this.brokerEnvironmentFactory = brokerEnvironmentFactory;
   }
 
@@ -63,7 +63,7 @@ public class KubernetesBrokerInitContainerApplier<Environment extends Kubernetes
       throws InfrastructureException {
 
     KubernetesEnvironment kubernetesEnvironment = (KubernetesEnvironment) workspaceEnvironment;
-    Environment brokerEnvironment =
+    E brokerEnvironment =
         brokerEnvironmentFactory.create(pluginsMeta, runtimeID, new BrokersResult());
 
     Map<String, Pod> workspacePods = kubernetesEnvironment.getPods();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
@@ -50,23 +50,15 @@ public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironmen
   /**
    * Apply plugin broker as init container to workspace environment. Workspace environment will have
    * broker's configmap, machines, and volumes added in addition to the init container
-   *
-   * @param workspaceEnvironment
-   * @param runtimeID
-   * @param pluginsMeta
-   * @throws InfrastructureException
    */
   public void apply(
-      InternalEnvironment workspaceEnvironment,
-      RuntimeIdentity runtimeID,
-      Collection<PluginMeta> pluginsMeta)
+      E workspaceEnvironment, RuntimeIdentity runtimeID, Collection<PluginMeta> pluginsMeta)
       throws InfrastructureException {
 
-    KubernetesEnvironment kubernetesEnvironment = (KubernetesEnvironment) workspaceEnvironment;
     E brokerEnvironment =
         brokerEnvironmentFactory.create(pluginsMeta, runtimeID, new BrokersResult());
 
-    Map<String, Pod> workspacePods = kubernetesEnvironment.getPods();
+    Map<String, Pod> workspacePods = workspaceEnvironment.getPods();
     if (workspacePods.size() != 1) {
       throw new InfrastructureException(
           "Che plugins tooling configuration can be applied to a workspace with one pod only.");
@@ -88,12 +80,12 @@ public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironmen
         throw new InfrastructureException(
             String.format("Could not find machine for broker container %s", container.getName()));
       }
-      kubernetesEnvironment
+      workspaceEnvironment
           .getMachines()
           .put(Names.machineName(workspacePod, container), brokerMachine);
     }
 
-    kubernetesEnvironment.getConfigMaps().putAll(brokerEnvironment.getConfigMaps());
+    workspaceEnvironment.getConfigMaps().putAll(brokerEnvironment.getConfigMaps());
     workspacePod.getSpec().setInitContainers(brokerPod.getSpec().getContainers());
     workspacePod.getSpec().getVolumes().addAll(brokerPod.getSpec().getVolumes());
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
+
+import com.google.common.annotations.Beta;
+import com.google.inject.Inject;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Pod;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory;
+
+/**
+ * Given a {@link InternalEnvironment} representing a workspace, adds the plugin broker as an init
+ * container to the workspace Pod. This is necessary if the workspace is created using emptyDir
+ * volumes (to allow the broker to add files to the workspace pod's volumes).
+ *
+ * <p>This API is in <b>Beta</b> and is subject to changes or removal.
+ *
+ * @author Angel Misevski
+ */
+@Beta
+public class KubernetesBrokerInitContainerApplier<Environment extends KubernetesEnvironment> {
+
+  private final BrokerEnvironmentFactory<Environment> brokerEnvironmentFactory;
+
+  @Inject
+  public KubernetesBrokerInitContainerApplier(
+      BrokerEnvironmentFactory<Environment> brokerEnvironmentFactory) {
+    this.brokerEnvironmentFactory = brokerEnvironmentFactory;
+  }
+
+  /**
+   * Apply plugin broker as init container to workspace environment. Workspace environment will have
+   * broker's configmap, machines, and volumes added in addition to the init container
+   *
+   * @param workspaceEnvironment
+   * @param runtimeID
+   * @param pluginsMeta
+   * @throws InfrastructureException
+   */
+  public void apply(
+      InternalEnvironment workspaceEnvironment,
+      RuntimeIdentity runtimeID,
+      Collection<PluginMeta> pluginsMeta)
+      throws InfrastructureException {
+
+    KubernetesEnvironment kubernetesEnvironment = (KubernetesEnvironment) workspaceEnvironment;
+    Environment brokerEnvironment =
+        brokerEnvironmentFactory.create(pluginsMeta, runtimeID, new BrokersResult());
+
+    Map<String, Pod> workspacePods = kubernetesEnvironment.getPods();
+    if (workspacePods.size() != 1) {
+      throw new InfrastructureException(
+          "Che plugins tooling configuration can be applied to a workspace with one pod only.");
+    }
+    Pod workspacePod = workspacePods.values().iterator().next();
+
+    Map<String, Pod> brokerPods = brokerEnvironment.getPods();
+    if (brokerPods.size() != 1) {
+      throw new InfrastructureException("Broker environment must have only one Pod.");
+    }
+    Pod brokerPod = brokerPods.values().iterator().next();
+
+    // Add broker machines to workspace environment so that the init containers can be provisioned.
+    List<Container> brokerContainers = brokerPod.getSpec().getContainers();
+    for (Container container : brokerContainers) {
+      InternalMachineConfig brokerMachine =
+          brokerEnvironment.getMachines().get(Names.machineName(brokerPod, container));
+      if (brokerMachine == null) {
+        throw new InfrastructureException(
+            String.format("Could not find machine for broker container %s", container.getName()));
+      }
+      kubernetesEnvironment
+          .getMachines()
+          .put(Names.machineName(workspacePod, container), brokerMachine);
+    }
+
+    kubernetesEnvironment.getConfigMaps().putAll(brokerEnvironment.getConfigMaps());
+    workspacePod.getSpec().setInitContainers(brokerPod.getSpec().getContainers());
+    workspacePod.getSpec().getVolumes().addAll(brokerPod.getSpec().getVolumes());
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/PluginBrokerManager.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/PluginBrokerManager.java
@@ -25,7 +25,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironment
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceAdapter;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListenerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory;
@@ -95,7 +95,7 @@ public class PluginBrokerManager<E extends KubernetesEnvironment> {
 
     E brokerEnvironment = brokerEnvironmentFactory.create(pluginsMeta, runtimeID, brokersResult);
     if (isEphemeral) {
-      EphemeralWorkspaceAdapter.makeEphemeral(brokerEnvironment.getAttributes());
+      EphemeralWorkspaceUtility.makeEphemeral(brokerEnvironment.getAttributes());
     }
     environmentProvisioner.provision(brokerEnvironment, runtimeID);
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/PluginBrokerManager.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/PluginBrokerManager.java
@@ -25,6 +25,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironment
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceAdapter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListenerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory;
@@ -84,7 +85,8 @@ public class PluginBrokerManager<E extends KubernetesEnvironment> {
    * <p>This API is in <b>Beta</b> and is subject to changes or removal.
    */
   @Beta
-  public List<ChePlugin> getTooling(RuntimeIdentity runtimeID, Collection<PluginMeta> pluginsMeta)
+  public List<ChePlugin> getTooling(
+      RuntimeIdentity runtimeID, Collection<PluginMeta> pluginsMeta, boolean isEphemeral)
       throws InfrastructureException {
 
     String workspaceId = runtimeID.getWorkspaceId();
@@ -92,6 +94,9 @@ public class PluginBrokerManager<E extends KubernetesEnvironment> {
     BrokersResult brokersResult = new BrokersResult();
 
     E brokerEnvironment = brokerEnvironmentFactory.create(pluginsMeta, runtimeID, brokersResult);
+    if (isEphemeral) {
+      EphemeralWorkspaceAdapter.makeEphemeral(brokerEnvironment.getAttributes());
+    }
     environmentProvisioner.provision(brokerEnvironment, runtimeID);
 
     ListenBrokerEvents listenBrokerEvents = getListenEventPhase(workspaceId, brokersResult);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
@@ -24,7 +24,7 @@ import org.eclipse.che.api.workspace.server.wsplugins.PluginMetaRetriever;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
 import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceAdapter;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +70,7 @@ public class SidecarToolingProvisioner<E extends KubernetesEnvironment> {
           "Sidecar tooling configuration is not supported with environment type " + recipeType);
     }
 
-    boolean isEphemeral = EphemeralWorkspaceAdapter.isEphemeral(environment.getAttributes());
+    boolean isEphemeral = EphemeralWorkspaceUtility.isEphemeral(environment.getAttributes());
     List<ChePlugin> chePlugins = pluginBrokerManager.getTooling(id, pluginsMeta, isEphemeral);
 
     pluginsApplier.apply(environment, chePlugins);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesBrokerInitContainerApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesBrokerInitContainerApplierTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACHINE_NAME_ANNOTATION_FMT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Volume;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesBrokerInitContainerApplier;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link KubernetesBrokerInitContainerApplier}.
+ *
+ * @author Angel Misevski
+ */
+@Listeners(MockitoTestNGListener.class)
+public class KubernetesBrokerInitContainerApplierTest {
+
+  private static final String WORKSPACE_POD_NAME = "workspacePod";
+  private static final String WORKSPACE_MACHINE_NAME = "workspaceMachine";
+  private static final String WORKSPACE_CONTAINER_NAME = "workspaceContainer";
+
+  private static final String BROKER_POD_NAME = "brokerPod";
+  private static final String BROKER_MACHINE_NAME = "brokerMachine";
+  private static final String BROKER_CONTAINER_NAME = "brokerContainer";
+  private static final String BROKER_CONFIGMAP_NAME = "brokerConfigMap";
+
+  @Mock private BrokerEnvironmentFactory<KubernetesEnvironment> brokerEnvironmentFactory;
+  @Mock private RuntimeIdentity runtimeID;
+  @Mock private Collection<PluginMeta> pluginsMeta;
+
+  // Broker Environment mocks
+  @Mock private KubernetesEnvironment brokerEnvironment;
+  @Mock private Pod brokerPod;
+  @Mock private Container brokerContainer;
+  @Mock private InternalMachineConfig brokerMachine;
+  @Mock private Map<String, InternalMachineConfig> brokerMachines;
+  @Mock private ConfigMap brokerConfigMap;
+  @Mock private Volume brokerVolume;
+  private PodSpec brokerPodSpec;
+
+  // Workspace Environment mocks
+  @Mock private KubernetesEnvironment workspaceEnvironment;
+  @Mock private Pod workspacePod;
+  @Mock private Map<String, InternalMachineConfig> workspaceMachines;
+  private PodSpec workspacePodSpec;
+  private Map<String, ConfigMap> workspaceConfigMaps;
+
+  private KubernetesBrokerInitContainerApplier<KubernetesEnvironment> applier;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    // Workspace mocking
+    doReturn(ImmutableMap.of(WORKSPACE_POD_NAME, workspacePod))
+        .when(workspaceEnvironment)
+        .getPods();
+    doReturn(workspaceMachines).when(workspaceEnvironment).getMachines();
+    workspacePodSpec = new PodSpec();
+    doReturn(workspacePodSpec).when(workspacePod).getSpec();
+    workspaceConfigMaps = new HashMap<>();
+    doReturn(workspaceConfigMaps).when(workspaceEnvironment).getConfigMaps();
+
+    // Broker mocking
+    doReturn(brokerEnvironment).when(brokerEnvironmentFactory).create(any(), any(), any());
+    doReturn(ImmutableMap.of(BROKER_POD_NAME, brokerPod)).when(brokerEnvironment).getPods();
+    brokerPodSpec = new PodSpec();
+    brokerPodSpec.setContainers(ImmutableList.of(brokerContainer));
+    brokerPodSpec.setVolumes(ImmutableList.of(brokerVolume));
+    doReturn(brokerPodSpec).when(brokerPod).getSpec();
+    doReturn(brokerMachines).when(brokerEnvironment).getMachines();
+    doReturn(brokerMachine).when(brokerMachines).get(any());
+    doReturn(ImmutableMap.of(BROKER_CONFIGMAP_NAME, brokerConfigMap))
+        .when(brokerEnvironment)
+        .getConfigMaps();
+
+    // Mocks necessary to make Names.machineName(pod, container) work
+    ObjectMeta workspacePodMetadata = mock(ObjectMeta.class);
+    doReturn(workspacePodMetadata).when(workspacePod).getMetadata();
+    doReturn(
+            ImmutableMap.of(
+                String.format(MACHINE_NAME_ANNOTATION_FMT, WORKSPACE_CONTAINER_NAME),
+                WORKSPACE_MACHINE_NAME))
+        .when(workspacePodMetadata)
+        .getAnnotations();
+    ObjectMeta brokerPodMetadata = mock(ObjectMeta.class);
+    doReturn(brokerPodMetadata).when(brokerPod).getMetadata();
+    doReturn(
+            ImmutableMap.of(
+                String.format(MACHINE_NAME_ANNOTATION_FMT, BROKER_CONTAINER_NAME),
+                BROKER_MACHINE_NAME))
+        .when(brokerPodMetadata)
+        .getAnnotations();
+
+    applier = new KubernetesBrokerInitContainerApplier<>(brokerEnvironmentFactory);
+  }
+
+  @Test
+  public void shouldAddBrokerMachineToWorkspaceEnvironment() throws Exception {
+    applier.apply(workspaceEnvironment, runtimeID, pluginsMeta);
+
+    verify(workspaceMachines).put(Names.machineName(workspacePod, brokerContainer), brokerMachine);
+  }
+
+  @Test
+  public void shouldAddBrokerConfigMapsToWorkspaceEnvironment() throws Exception {
+    applier.apply(workspaceEnvironment, runtimeID, pluginsMeta);
+
+    assertTrue(workspaceConfigMaps.get(BROKER_CONFIGMAP_NAME).equals(brokerConfigMap));
+  }
+
+  @Test
+  public void shouldAddBrokerAsInitContainerOnWorkspacePod() throws Exception {
+    applier.apply(workspaceEnvironment, runtimeID, pluginsMeta);
+
+    List<Container> initContainers = workspacePod.getSpec().getInitContainers();
+    assertEquals(initContainers.size(), 1);
+    assertEquals(initContainers.iterator().next(), brokerContainer);
+  }
+
+  @Test
+  public void shouldAddBrokerVolumesToWorkspacePod() throws Exception {
+    applier.apply(workspaceEnvironment, runtimeID, pluginsMeta);
+
+    List<Volume> workspaceVolumes = workspacePodSpec.getVolumes();
+    assertEquals(workspaceVolumes.size(), 1);
+    assertEquals(workspaceVolumes.iterator().next(), brokerVolume);
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.wsplugins.ChePluginsApplier;
+import org.eclipse.che.api.workspace.server.wsplugins.PluginMetaRetriever;
+import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesBrokerInitContainerApplier;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.PluginBrokerManager;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.SidecarToolingProvisioner;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link SidecarToolingProvisioner}.
+ *
+ * @author Angel Misevski
+ */
+@Listeners(MockitoTestNGListener.class)
+public class SidecarToolingProvisionerTest {
+
+  private static final String RECIPE_TYPE = "TestingRecipe";
+  private static final String PLUGIN_META_NAME = "TestPluginMeta";
+
+  @Mock private KubernetesBrokerInitContainerApplier<KubernetesEnvironment> brokerApplier;
+  @Mock private PluginMetaRetriever pluginMetaRetriever;
+  @Mock private PluginBrokerManager<KubernetesEnvironment> brokerManager;
+  @Mock private KubernetesEnvironment nonEphemeralEnvironment;
+  @Mock private KubernetesEnvironment ephemeralEnvironment;
+  @Mock private RuntimeIdentity runtimeId;
+  @Mock private ChePluginsApplier chePluginsApplier;
+
+  private static Map<String, String> environmentAttributesBase =
+      ImmutableMap.of(
+          "editor", "org.eclipse.che.editor.theia:1.0.0",
+          "plugins", "che-machine-exec-plugin:0.0.1");
+
+  private Collection<PluginMeta> pluginsMeta =
+      ImmutableList.of(new PluginMeta().name(PLUGIN_META_NAME));
+
+  private SidecarToolingProvisioner<KubernetesEnvironment> provisioner;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    Map<String, ChePluginsApplier> workspaceNextAppliers =
+        ImmutableMap.of(RECIPE_TYPE, chePluginsApplier);
+    Map<String, String> ephemeralEnvironmentAttributes = new HashMap<>(environmentAttributesBase);
+    EphemeralWorkspaceUtility.makeEphemeral(ephemeralEnvironmentAttributes);
+    Map<String, String> nonEphemeralEnvironmentAttributes =
+        new HashMap<>(environmentAttributesBase);
+
+    lenient().doReturn(RECIPE_TYPE).when(nonEphemeralEnvironment).getType();
+    lenient().doReturn(RECIPE_TYPE).when(ephemeralEnvironment).getType();
+    lenient()
+        .doReturn(nonEphemeralEnvironmentAttributes)
+        .when(nonEphemeralEnvironment)
+        .getAttributes();
+    lenient().doReturn(ephemeralEnvironmentAttributes).when(ephemeralEnvironment).getAttributes();
+    doReturn(pluginsMeta).when(pluginMetaRetriever).get(any());
+
+    provisioner =
+        new SidecarToolingProvisioner<>(
+            workspaceNextAppliers, brokerApplier, pluginMetaRetriever, brokerManager);
+  }
+
+  @Test
+  public void shouldNotAddInitContainerWhenWorkspaceIsNotEphemeral() throws Exception {
+    provisioner.provision(runtimeId, nonEphemeralEnvironment);
+
+    verify(chePluginsApplier, times(1)).apply(any(), any());
+    verify(brokerApplier, times(0)).apply(any(), any(), any());
+  }
+
+  @Test
+  public void shouldIncludeInitContainerWhenWorkspaceIsEphemeral() throws Exception {
+    provisioner.provision(runtimeId, ephemeralEnvironment);
+
+    verify(chePluginsApplier, times(1)).apply(any(), any());
+    verify(brokerApplier, times(1)).apply(any(), any(), any());
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
@@ -163,6 +164,10 @@ public class CommonPVCStrategyTest {
     mockName(pod, POD_NAME);
     mockName(pod2, POD_NAME_2);
     when(workspace.getId()).thenReturn(WORKSPACE_ID);
+    Map<String, String> workspaceAttributes = new HashMap<>();
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    when(workspace.getConfig()).thenReturn(workspaceConfig);
+    when(workspaceConfig.getAttributes()).thenReturn(workspaceAttributes);
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
@@ -147,6 +148,10 @@ public class UniqueWorkspacePVCStrategyTest {
     mockName(pod2, POD_NAME_2);
 
     lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+    Map<String, String> workspaceAttributes = new HashMap<>();
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceAttributes);
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Changes necessary to make plugin broker work correctly when a workspace is marked as ephemeral. This is done by making the broker run as an init container on ephemeral workspaces, so that any volume-related actions are reflected in the workspace's emptyDir volumes.

Detailed changes:
- Slight changes to `EphemeralWorkspaceAdapter`: 1. Make ephemeral workspace check methods static to allow them to be used elsewhere, and 2. add method to "make" a workspace ephemeral, so that all attribute management happens in one place.
- Modify PVC strategies to account for init containers. For `EphemeralWorkspaceAdapter` this is necessary, as otherwise the `/plugins` directory cannot be mounted. I've also included this change for the common and unique strategies, although it doesn't do anything at the moment (since no init containers are added in the non-ephemeral case).
- Apply plugin broker as init container if workspace is ephemeral

### What issues does this PR fix or reference?
#11554 

#### Release Notes
Allow Che 7 workspaces to run as ephermal (emptyDir) containers on Kubernetes/OpenShift.