### PR TITLE
Reuse the Dashboard Keycloak instance in IDE frames when possible

### DIFF
--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/IDE.html
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/IDE.html
@@ -62,6 +62,11 @@
              */
             this.loadKeycloakSettings = function() {
                 var msg = "Cannot load keycloak settings. This is normal for single-user mode.";
+                if (window.parent && window.parent['_keycloak']) {
+                    window['_keycloak'] = window.parent['_keycloak'];
+                    Loader.startLoading();
+                    return;
+                }
                 
                 try {
                     var request = new XMLHttpRequest();

--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.js
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.js
@@ -19,7 +19,7 @@ class KeycloakLoader {
         return new Promise((resolve, reject) => {
             if (window.parent && window.parent['_keycloak']) {
                 window['_keycloak'] = window.parent['_keycloak'];
-                resolve(window.parent['_keycloak']);
+                resolve(window['_keycloak']);
                 return;
             }
             try {

--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.js
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/loader.js
@@ -17,6 +17,11 @@ class KeycloakLoader {
         const msg = "Cannot load keycloak settings. This is normal for single-user mode.";
 
         return new Promise((resolve, reject) => {
+            if (window.parent && window.parent['_keycloak']) {
+                window['_keycloak'] = window.parent['_keycloak'];
+                resolve(window.parent['_keycloak']);
+                return;
+            }
             try {
                 const request = new XMLHttpRequest();
 

--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -28,6 +28,11 @@ export class KeycloakLoader {
         const msg = "Cannot load keycloak settings. This is normal for single-user mode.";
 
         return new Promise((resolve, reject) => {
+            if (window.parent && window.parent['_keycloak']) {
+                window['_keycloak'] = window.parent['_keycloak'];
+                resolve(window.parent['_keycloak']);
+                return;
+            }
             try {
                 const request = new XMLHttpRequest();
 

--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -30,7 +30,7 @@ export class KeycloakLoader {
         return new Promise((resolve, reject) => {
             if (window.parent && window.parent['_keycloak']) {
                 window['_keycloak'] = window.parent['_keycloak'];
-                resolve(window.parent['_keycloak']);
+                resolve(window['_keycloak']);
                 return;
             }
             try {


### PR DESCRIPTION
### What does this PR do?

This PR allows reusing the Dashboard Keycloak instance in IDE frames when possible (=> when the IDE window is opened as a frame in the Dashboard window).

This avoids performing one or even (in some cases) 2 authentication flows before the real IDE loading,
and this decreases the overall IDE loading process by 5 seconds or more.

(5-6 seconds out of 10-12s in my case)

### What issues does this PR fix or reference?

This is a first step in some more general work around optimizing the IDE loading in OSIO: https://github.com/redhat-developer/rh-che/issues/1013
