### PR TITLE
drop codenvy nexus repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1970,11 +1970,6 @@
             <name>central public snapshots</name>
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
-        <repository>
-            <id>codenvy-public-repo</id>
-            <name>codenvy public</name>
-            <url>https://maven.codenvycorp.com/content/groups/public/</url>
-        </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>


### PR DESCRIPTION
since all che artifacts moved to maven central we should stop using Codenvy nexus.
