### PR TITLE
Exclude E2E tests which failed permanently from default test execution

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitCompareTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/GitCompareTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.git;
 
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Edit.DELETE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Edit.EDIT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Git.ADD_TO_INDEX;
@@ -207,7 +208,7 @@ public class GitCompareTest {
     git.closeGroupGitCompareForm();
   }
 
-  @Test(priority = 3)
+  @Test(priority = 3, groups = UNDER_REPAIR)
   public void checkCompareWithRevision() {
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitAndSelectItem(PATH_TO_APP_CONTROLLER);
@@ -235,7 +236,7 @@ public class GitCompareTest {
       git.waitExpTextIntoCompareLeftEditor("//change content from compare editor");
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11791");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11791");
     }
 
     git.clickOnGitCompareCloseButton();
@@ -244,7 +245,7 @@ public class GitCompareTest {
       askDialog.confirmAndWaitClosed();
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11769");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11769");
     }
 
     git.waitGitCompareFormIsClosed();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/GolangFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/GolangFileEditingTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.languageserver;
 
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_DEFINITION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_PROJECT_SYMBOL;
@@ -207,7 +208,7 @@ public class GolangFileEditingTest {
     editor.clickOnCloseFileIcon("print.go");
   }
 
-  @Test(priority = 1)
+  @Test(priority = 1, groups = UNDER_REPAIR)
   public void checkRenameFeature() {
     projectExplorer.openItemByPath(PROJECT_NAME + "/towers.go");
     editor.waitTabIsPresent("towers.go");
@@ -220,7 +221,7 @@ public class GolangFileEditingTest {
       editor.waitTextElementsActiveLine("if k == 1");
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/10524");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/10524");
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
It excludes next E2E tests which failed permanently from default test execution:
- GolangFileEditingTest.checkRenameFeature()
- GitCompareTest.checkCompareWithRevision()

### What issues does this PR fix or reference?
#11688