### PR TITLE
Added dirigible server to liveness probes list

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -137,7 +137,7 @@ che.workspace.activity_check_scheduler_delay_s=180
 che.workspace.server.ping_success_threshold=1
 
 # List of servers names which require liveness probes
-che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia,jupyter
+che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia,jupyter,dirigible
 
 ### TEMPLATES
 # Folder that contains JSON files with code templates and samples


### PR DESCRIPTION
### What does this PR do?
After pr https://github.com/eclipse/che-plugin-registry/pull/54 introduced new Che Editor.
This pr is adding dirigible to liveness probes checklist. Server configured here https://github.com/dirigiblelabs/dirigible-che-editor-plugin/blob/master/etc/che-plugin.yaml#L9

### What issues does this PR fix or reference?



#### Release Notes
n/a

#### Docs PR
n/a