### PR TITLE
The PVC cleaning on workspace deletion is done in the wrong condition

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleaner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleaner.java
@@ -52,7 +52,7 @@ public class WorkspacePVCCleaner {
 
   @Inject
   public void subscribe(EventService eventService) {
-    if (pvcEnabled && !namespaceFactory.isPredefined())
+    if (pvcEnabled && namespaceFactory.isPredefined())
       eventService.subscribe(
           event -> {
             final Workspace workspace = event.getWorkspace();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleanerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleanerTest.java
@@ -50,7 +50,7 @@ public class WorkspacePVCCleanerTest {
 
   @BeforeMethod
   public void setUp() {
-    when(namespaceFactory.isPredefined()).thenReturn(false);
+    when(namespaceFactory.isPredefined()).thenReturn(true);
     workspacePVCCleaner = new WorkspacePVCCleaner(true, namespaceFactory, pvcStrategy);
   }
 
@@ -64,8 +64,8 @@ public class WorkspacePVCCleanerTest {
   }
 
   @Test
-  public void testDoNotSubscribesCleanerWhenPVCEnabledAndNamespaceIsPredefined() {
-    when(namespaceFactory.isPredefined()).thenReturn(true);
+  public void testDoNotSubscribesCleanerWhenPVCEnabledAndNamespaceIsNotPredefined() {
+    when(namespaceFactory.isPredefined()).thenReturn(false);
     workspacePVCCleaner = spy(new WorkspacePVCCleaner(false, namespaceFactory, pvcStrategy));
 
     workspacePVCCleaner.subscribe(eventService);


### PR DESCRIPTION
### What does this PR do?

The PVC cleaning on workspace deletion was done in the wrong condition: it was only done when each workspace is created in its own new Kubernetes namespace, through it seems it should be precisely the contrary.
This PR fixes this buggy behavior that also impacts the OSIO namespace PVC cleaning.

### What issues does this PR fix or reference?

This is a fix for issue
https://github.com/redhat-developer/rh-che/issues/1026 (PVC is not
cleaned when workspace is deleted)
