### PR TITLE
Add log warning for using less than minimal workspace idle timeout

### DIFF
--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManager.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManager.java
@@ -46,11 +46,11 @@ import org.slf4j.LoggerFactory;
  */
 @Singleton
 public class WorkspaceActivityManager {
+  public static final long MINIMAL_TIMEOUT = 300_000L;
 
   private static final Logger LOG = LoggerFactory.getLogger(WorkspaceActivityManager.class);
 
   private static final String ACTIVITY_CHECKER = "activity-checker";
-  private static final long MINIMAL_TIMEOUT = 300_000L;
 
   private final long defaultTimeout;
   private final WorkspaceActivityDao activityDao;
@@ -71,9 +71,9 @@ public class WorkspaceActivityManager {
     this.defaultTimeout = timeout;
     if (timeout < MINIMAL_TIMEOUT) {
       LOG.warn(
-          "Default workspace idle timeout has a value of less than "
+          "Value of property \"che.limits.workspace.idle.timeout\" is below recommended minimum ("
               + TimeUnit.MILLISECONDS.toMinutes(MINIMAL_TIMEOUT)
-              + " minutes.");
+              + " minutes). This may cause problems with workspace components startup and can cause premature workspace shutdown.");
     }
 
     this.workspaceEventsSubscriber =
@@ -117,14 +117,6 @@ public class WorkspaceActivityManager {
   public void update(String wsId, long activityTime) {
     try {
       long timeout = getIdleTimeout(wsId);
-      if (timeout < MINIMAL_TIMEOUT) {
-        LOG.warn(
-            "Workspace '"
-                + wsId
-                + "' idle timeout has a value of less than "
-                + TimeUnit.MILLISECONDS.toMinutes(MINIMAL_TIMEOUT)
-                + " minutes.");
-      }
       if (timeout > 0) {
         activityDao.setExpiration(new WorkspaceExpiration(wsId, activityTime + timeout));
       }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManager.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManager.java
@@ -73,7 +73,7 @@ public class WorkspaceActivityManager {
       LOG.warn(
           "Value of property \"che.limits.workspace.idle.timeout\" is below recommended minimum ("
               + TimeUnit.MILLISECONDS.toMinutes(MINIMAL_TIMEOUT)
-              + " minutes). This may cause problems with workspace components startup and can cause premature workspace shutdown.");
+              + " minutes). This may cause problems with workspace components startup and/or premature workspace shutdown.");
     }
 
     this.workspaceEventsSubscriber =


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Log warning if the timeout value for workpace idling is being set to less than minimal.
Minimal time is  5 minutes, which should be enough to start average workspace.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11853
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
