### PR TITLE
Che-theia: adding @theia/cli to dependencies so it is available in production mode

### DIFF
--- a/dockerfiles/theia/src/package.json
+++ b/dockerfiles/theia/src/package.json
@@ -37,9 +37,7 @@
         "@theia/typescript": "latest",
         "@theia/userstorage": "latest",
         "@theia/variable-resolver": "latest",
-        "@theia/workspace": "latest"
-    },
-    "devDependencies": {
+        "@theia/workspace": "latest",
         "@theia/cli": "latest"
     }
 }


### PR DESCRIPTION
step 1 to avoid issue when running hosted instance:
```
yarn run v1.10.1
error Command "theia" not found.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
