### PR TITLE
Update python content to valid Python 3.x syntax (#11891)

### DIFF
--- a/plugins/plugin-python/che-plugin-python-lang-server/src/main/resources/files/default_python_content
+++ b/plugins/plugin-python/che-plugin-python-lang-server/src/main/resources/files/default_python_content
@@ -1,1 +1,1 @@
-print "Hello World!"
+print("Hello World!")


### PR DESCRIPTION
### What does this PR do?

Update the default python content to Python 3.x syntax:  print is now a function not a statement.

### What issues does this PR fix or reference?

#11891 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
