### PR TITLE
Shows icons specific to visibility in "file structure" window.

### DIFF
--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/inject/JavaGinModule.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/inject/JavaGinModule.java
@@ -123,6 +123,9 @@ public class JavaGinModule extends AbstractGinModule {
         GinMapBinder.newMapBinder(binder(), String.class, FqnProvider.class);
     fqnProviders.addBinding("maven").to(JavaFqnProvider.class);
 
+    install(
+        new GinFactoryModuleBuilder()
+            .build(org.eclipse.che.ide.ext.java.client.navigation.filestructure.NodeFactory.class));
     install(new GinFactoryModuleBuilder().build(JavaNodeFactory.class));
     install(
         new GinFactoryModuleBuilder()

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/ElementSelectionDelegate.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/ElementSelectionDelegate.java
@@ -9,7 +9,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.plugin.languageserver.ide.filestructure;
+package org.eclipse.che.ide.ext.java.client.navigation.filestructure;
 
 /**
  * Interface to signal selection of an element

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructurePresenter.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructurePresenter.java
@@ -21,7 +21,6 @@ import org.eclipse.che.ide.ext.java.dto.DtoClientImpls;
 import org.eclipse.che.ide.util.loging.Log;
 import org.eclipse.che.jdt.ls.extension.api.dto.ExtendedSymbolInformation;
 import org.eclipse.che.jdt.ls.extension.api.dto.FileStructureCommandParameters;
-import org.eclipse.che.plugin.languageserver.ide.filestructure.ElementSelectionDelegate;
 import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.che.plugin.languageserver.ide.util.OpenFileInEditorHelper;
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructureTree.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructureTree.java
@@ -9,7 +9,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.plugin.languageserver.ide.filestructure;
+package org.eclipse.che.ide.ext.java.client.navigation.filestructure;
 
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.Event;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructureView.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructureView.java
@@ -9,7 +9,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.plugin.languageserver.ide.filestructure;
+package org.eclipse.che.ide.ext.java.client.navigation.filestructure;
 
 import static org.eclipse.che.ide.ui.smartTree.SelectionModel.Mode.SINGLE;
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructureView.ui.xml
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructureView.ui.xml
@@ -12,6 +12,6 @@
 
 -->
 <ui:UiBinder xmlns:ui='urn:ui:com.google.gwt.uibinder'
-             xmlns:g="urn:import:org.eclipse.che.plugin.languageserver.ide.filestructure">
+             xmlns:g="urn:import:org.eclipse.che.ide.ext.java.client.navigation.filestructure">
     <g:FileStructureTree ui:field="tree" debugId="file-structure-mainPanel" />
 </ui:UiBinder>

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructureWindow.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/FileStructureWindow.java
@@ -35,9 +35,6 @@ import org.eclipse.che.ide.util.input.CharCodeWithModifiers;
 import org.eclipse.che.ide.util.input.SignalEvent;
 import org.eclipse.che.ide.util.input.SignalEventUtils;
 import org.eclipse.che.jdt.ls.extension.api.dto.ExtendedSymbolInformation;
-import org.eclipse.che.plugin.languageserver.ide.filestructure.ElementSelectionDelegate;
-import org.eclipse.che.plugin.languageserver.ide.filestructure.FileStructureView;
-import org.eclipse.che.plugin.languageserver.ide.filestructure.NodeFactory;
 
 /**
  * A window showing a java specific file structure

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/NodeFactory.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/NodeFactory.java
@@ -9,7 +9,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.plugin.languageserver.ide.filestructure;
+package org.eclipse.che.ide.ext.java.client.navigation.filestructure;
 
 import org.eclipse.che.jdt.ls.extension.api.dto.ExtendedSymbolInformation;
 

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/SymbolNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/SymbolNode.java
@@ -17,13 +17,13 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.eclipse.che.api.promises.client.Promise;
 import org.eclipse.che.api.promises.client.PromiseProvider;
+import org.eclipse.che.ide.ext.java.client.util.SymbolIcons;
 import org.eclipse.che.ide.ui.smartTree.data.AbstractTreeNode;
 import org.eclipse.che.ide.ui.smartTree.data.HasAction;
 import org.eclipse.che.ide.ui.smartTree.data.Node;
 import org.eclipse.che.ide.ui.smartTree.presentation.HasNewPresentation;
 import org.eclipse.che.ide.ui.smartTree.presentation.NewNodePresentation;
 import org.eclipse.che.jdt.ls.extension.api.dto.ExtendedSymbolInformation;
-import org.eclipse.che.plugin.languageserver.ide.navigation.symbol.SymbolKindHelper;
 
 /**
  * A node presenting {@link ExtendedSymbolInformation} objects
@@ -31,18 +31,18 @@ import org.eclipse.che.plugin.languageserver.ide.navigation.symbol.SymbolKindHel
  * @author Thomas Mäder
  */
 public class SymbolNode extends AbstractTreeNode implements HasNewPresentation, HasAction {
-  private SymbolKindHelper symbolHelper;
+  private SymbolIcons symbolIcons;
   private PromiseProvider promiseProvider;
   private ElementSelectionDelegate<ExtendedSymbolInformation> delegate;
   private ExtendedSymbolInformation symbol;
 
   @Inject
   public SymbolNode(
-      SymbolKindHelper symbolHelper,
+      SymbolIcons symbolHelper,
       PromiseProvider promiseProvider,
       @Assisted ElementSelectionDelegate<ExtendedSymbolInformation> delegate,
       @Assisted ExtendedSymbolInformation symbol) {
-    this.symbolHelper = symbolHelper;
+    this.symbolIcons = symbolHelper;
     this.promiseProvider = promiseProvider;
     this.delegate = delegate;
     this.symbol = symbol;
@@ -64,7 +64,7 @@ public class SymbolNode extends AbstractTreeNode implements HasNewPresentation, 
         symbol
             .getChildren()
             .stream()
-            .map(child -> new SymbolNode(symbolHelper, promiseProvider, delegate, child))
+            .map(child -> new SymbolNode(symbolIcons, promiseProvider, delegate, child))
             .collect(Collectors.toList()));
   }
 
@@ -72,7 +72,7 @@ public class SymbolNode extends AbstractTreeNode implements HasNewPresentation, 
   public NewNodePresentation getPresentation() {
     String name = symbol.getInfo().getName();
     return new NewNodePresentation.Builder()
-        .withIcon(symbolHelper.getIcon(symbol.getInfo().getKind()))
+        .withIcon(symbolIcons.get(symbol))
         .withNodeText(name)
         .build();
   }

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/SymbolNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/SymbolNode.java
@@ -38,11 +38,11 @@ public class SymbolNode extends AbstractTreeNode implements HasNewPresentation, 
 
   @Inject
   public SymbolNode(
-      SymbolIcons symbolHelper,
+      SymbolIcons symbolIcons,
       PromiseProvider promiseProvider,
       @Assisted ElementSelectionDelegate<ExtendedSymbolInformation> delegate,
       @Assisted ExtendedSymbolInformation symbol) {
-    this.symbolIcons = symbolHelper;
+    this.symbolIcons = symbolIcons;
     this.promiseProvider = promiseProvider;
     this.delegate = delegate;
     this.symbol = symbol;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/SymbolNode.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/navigation/filestructure/SymbolNode.java
@@ -9,7 +9,7 @@
  * Contributors:
  *   Red Hat, Inc. - initial API and implementation
  */
-package org.eclipse.che.plugin.languageserver.ide.filestructure;
+package org.eclipse.che.ide.ext.java.client.navigation.filestructure;
 
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/util/SymbolIcons.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/util/SymbolIcons.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.ide.ext.java.client.util;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.eclipse.che.ide.ext.java.client.JavaResources;
+import org.eclipse.che.jdt.ls.extension.api.Visibility;
+import org.eclipse.che.jdt.ls.extension.api.dto.ExtendedSymbolInformation;
+import org.eclipse.lsp4j.SymbolKind;
+import org.vectomatic.dom.svg.ui.SVGResource;
+
+public class SymbolIcons {
+  private static final Map<Visibility, Map<SymbolKind, SVGResource>> resources;
+
+  static {
+    resources =
+        map(
+            put(
+                Visibility.PUBLIC,
+                map(
+                    put(SymbolKind.Package, JavaResources.INSTANCE.packageItem()),
+                    put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem()),
+                    put(SymbolKind.Method, JavaResources.INSTANCE.publicMethod()),
+                    put(SymbolKind.Field, JavaResources.INSTANCE.publicField()),
+                    put(SymbolKind.Constructor, JavaResources.INSTANCE.publicMethod()),
+                    put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem()),
+                    put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem()),
+                    put(SymbolKind.Field, JavaResources.INSTANCE.publicField()),
+                    put(SymbolKind.Constant, JavaResources.INSTANCE.publicField()),
+                    put(SymbolKind.EnumMember, JavaResources.INSTANCE.publicField()))),
+            put(
+                Visibility.PROTECTED,
+                map(
+                    put(SymbolKind.Package, JavaResources.INSTANCE.packageItem()),
+                    put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem()),
+                    put(SymbolKind.Method, JavaResources.INSTANCE.protectedMethod()),
+                    put(SymbolKind.Field, JavaResources.INSTANCE.protectedField()),
+                    put(SymbolKind.Constructor, JavaResources.INSTANCE.protectedMethod()),
+                    put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem()),
+                    put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem()),
+                    put(SymbolKind.Field, JavaResources.INSTANCE.protectedField()),
+                    put(SymbolKind.Constant, JavaResources.INSTANCE.protectedField()),
+                    put(SymbolKind.EnumMember, JavaResources.INSTANCE.protectedField()))),
+            put(
+                Visibility.PACKAGE,
+                map(
+                    put(SymbolKind.Package, JavaResources.INSTANCE.packageItem()),
+                    put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem()),
+                    put(SymbolKind.Method, JavaResources.INSTANCE.defaultMethod()),
+                    put(SymbolKind.Field, JavaResources.INSTANCE.defaultField()),
+                    put(SymbolKind.Constructor, JavaResources.INSTANCE.defaultMethod()),
+                    put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem()),
+                    put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem()),
+                    put(SymbolKind.Field, JavaResources.INSTANCE.defaultField()),
+                    put(SymbolKind.Constant, JavaResources.INSTANCE.defaultField()),
+                    put(SymbolKind.EnumMember, JavaResources.INSTANCE.defaultField()))),
+            put(
+                Visibility.PRIVATE,
+                map(
+                    put(SymbolKind.Package, JavaResources.INSTANCE.packageItem()),
+                    put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem()),
+                    put(SymbolKind.Method, JavaResources.INSTANCE.privateMethod()),
+                    put(SymbolKind.Field, JavaResources.INSTANCE.privateField()),
+                    put(SymbolKind.Constructor, JavaResources.INSTANCE.privateMethod()),
+                    put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem()),
+                    put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem()),
+                    put(SymbolKind.Field, JavaResources.INSTANCE.privateField()),
+                    put(SymbolKind.Constant, JavaResources.INSTANCE.privateField()),
+                    put(SymbolKind.EnumMember, JavaResources.INSTANCE.privateField()))));
+  }
+
+  public SVGResource get(ExtendedSymbolInformation symbol) {
+    Visibility visiblity = symbol.getVisiblity();
+    return resources
+        .get(visiblity == null ? Visibility.PACKAGE : visiblity)
+        .get(symbol.getInfo().getKind());
+  }
+
+  private static <K, V> Consumer<Map<K, V>> put(K key, V value) {
+    return new Consumer<Map<K, V>>() {
+
+      @Override
+      public void accept(Map<K, V> map) {
+        map.put(key, value);
+      }
+    };
+  }
+
+  @SafeVarargs
+  private static <K, V> Map<K, V> map(Consumer<Map<K, V>>... entries) {
+    HashMap<K, V> result = new HashMap<>(entries.length);
+    for (Consumer<Map<K, V>> entry : entries) {
+      entry.accept(result);
+    }
+    return result;
+  }
+}

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/util/SymbolIcons.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/util/SymbolIcons.java
@@ -11,9 +11,8 @@
  */
 package org.eclipse.che.ide.ext.java.client.util;
 
-import java.util.HashMap;
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
-import java.util.function.Consumer;
 import org.eclipse.che.ide.ext.java.client.JavaResources;
 import org.eclipse.che.jdt.ls.extension.api.Visibility;
 import org.eclipse.che.jdt.ls.extension.api.dto.ExtendedSymbolInformation;
@@ -25,59 +24,64 @@ public class SymbolIcons {
 
   static {
     resources =
-        map(
-            put(
+        new ImmutableMap.Builder<Visibility, Map<SymbolKind, SVGResource>>()
+            .put(
                 Visibility.PUBLIC,
-                map(
-                    put(SymbolKind.Package, JavaResources.INSTANCE.packageItem()),
-                    put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem()),
-                    put(SymbolKind.Method, JavaResources.INSTANCE.publicMethod()),
-                    put(SymbolKind.Field, JavaResources.INSTANCE.publicField()),
-                    put(SymbolKind.Constructor, JavaResources.INSTANCE.publicMethod()),
-                    put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem()),
-                    put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem()),
-                    put(SymbolKind.Field, JavaResources.INSTANCE.publicField()),
-                    put(SymbolKind.Constant, JavaResources.INSTANCE.publicField()),
-                    put(SymbolKind.EnumMember, JavaResources.INSTANCE.publicField()))),
-            put(
+                new ImmutableMap.Builder<SymbolKind, SVGResource>()
+                    .put(SymbolKind.Package, JavaResources.INSTANCE.packageItem())
+                    .put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem())
+                    .put(SymbolKind.Method, JavaResources.INSTANCE.publicMethod())
+                    .put(SymbolKind.Field, JavaResources.INSTANCE.publicField())
+                    .put(SymbolKind.Constructor, JavaResources.INSTANCE.publicMethod())
+                    .put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem())
+                    .put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem())
+                    .put(SymbolKind.Field, JavaResources.INSTANCE.publicField())
+                    .put(SymbolKind.Constant, JavaResources.INSTANCE.publicField())
+                    .put(SymbolKind.EnumMember, JavaResources.INSTANCE.publicField())
+                    .build())
+            .put(
                 Visibility.PROTECTED,
-                map(
-                    put(SymbolKind.Package, JavaResources.INSTANCE.packageItem()),
-                    put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem()),
-                    put(SymbolKind.Method, JavaResources.INSTANCE.protectedMethod()),
-                    put(SymbolKind.Field, JavaResources.INSTANCE.protectedField()),
-                    put(SymbolKind.Constructor, JavaResources.INSTANCE.protectedMethod()),
-                    put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem()),
-                    put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem()),
-                    put(SymbolKind.Field, JavaResources.INSTANCE.protectedField()),
-                    put(SymbolKind.Constant, JavaResources.INSTANCE.protectedField()),
-                    put(SymbolKind.EnumMember, JavaResources.INSTANCE.protectedField()))),
-            put(
+                new ImmutableMap.Builder<SymbolKind, SVGResource>()
+                    .put(SymbolKind.Package, JavaResources.INSTANCE.packageItem())
+                    .put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem())
+                    .put(SymbolKind.Method, JavaResources.INSTANCE.protectedMethod())
+                    .put(SymbolKind.Field, JavaResources.INSTANCE.protectedField())
+                    .put(SymbolKind.Constructor, JavaResources.INSTANCE.protectedMethod())
+                    .put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem())
+                    .put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem())
+                    .put(SymbolKind.Field, JavaResources.INSTANCE.protectedField())
+                    .put(SymbolKind.Constant, JavaResources.INSTANCE.protectedField())
+                    .put(SymbolKind.EnumMember, JavaResources.INSTANCE.protectedField())
+                    .build())
+            .put(
                 Visibility.PACKAGE,
-                map(
-                    put(SymbolKind.Package, JavaResources.INSTANCE.packageItem()),
-                    put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem()),
-                    put(SymbolKind.Method, JavaResources.INSTANCE.defaultMethod()),
-                    put(SymbolKind.Field, JavaResources.INSTANCE.defaultField()),
-                    put(SymbolKind.Constructor, JavaResources.INSTANCE.defaultMethod()),
-                    put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem()),
-                    put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem()),
-                    put(SymbolKind.Field, JavaResources.INSTANCE.defaultField()),
-                    put(SymbolKind.Constant, JavaResources.INSTANCE.defaultField()),
-                    put(SymbolKind.EnumMember, JavaResources.INSTANCE.defaultField()))),
-            put(
+                new ImmutableMap.Builder<SymbolKind, SVGResource>()
+                    .put(SymbolKind.Package, JavaResources.INSTANCE.packageItem())
+                    .put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem())
+                    .put(SymbolKind.Method, JavaResources.INSTANCE.defaultMethod())
+                    .put(SymbolKind.Field, JavaResources.INSTANCE.defaultField())
+                    .put(SymbolKind.Constructor, JavaResources.INSTANCE.defaultMethod())
+                    .put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem())
+                    .put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem())
+                    .put(SymbolKind.Field, JavaResources.INSTANCE.defaultField())
+                    .put(SymbolKind.Constant, JavaResources.INSTANCE.defaultField())
+                    .put(SymbolKind.EnumMember, JavaResources.INSTANCE.defaultField())
+                    .build())
+            .put(
                 Visibility.PRIVATE,
-                map(
-                    put(SymbolKind.Package, JavaResources.INSTANCE.packageItem()),
-                    put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem()),
-                    put(SymbolKind.Method, JavaResources.INSTANCE.privateMethod()),
-                    put(SymbolKind.Field, JavaResources.INSTANCE.privateField()),
-                    put(SymbolKind.Constructor, JavaResources.INSTANCE.privateMethod()),
-                    put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem()),
-                    put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem()),
-                    put(SymbolKind.Field, JavaResources.INSTANCE.privateField()),
-                    put(SymbolKind.Constant, JavaResources.INSTANCE.privateField()),
-                    put(SymbolKind.EnumMember, JavaResources.INSTANCE.privateField()))));
+                new ImmutableMap.Builder<SymbolKind, SVGResource>()
+                    .put(SymbolKind.Package, JavaResources.INSTANCE.packageItem())
+                    .put(SymbolKind.Class, JavaResources.INSTANCE.svgClassItem())
+                    .put(SymbolKind.Method, JavaResources.INSTANCE.privateMethod())
+                    .put(SymbolKind.Field, JavaResources.INSTANCE.privateField())
+                    .put(SymbolKind.Constructor, JavaResources.INSTANCE.privateMethod())
+                    .put(SymbolKind.Enum, JavaResources.INSTANCE.enumItem())
+                    .put(SymbolKind.Interface, JavaResources.INSTANCE.interfaceItem())
+                    .put(SymbolKind.Field, JavaResources.INSTANCE.privateField())
+                    .put(SymbolKind.Constant, JavaResources.INSTANCE.privateField())
+                    .put(SymbolKind.EnumMember, JavaResources.INSTANCE.privateField())
+                    .build())
+            .build();
   }
 
   public SVGResource get(ExtendedSymbolInformation symbol) {
@@ -85,24 +89,5 @@ public class SymbolIcons {
     return resources
         .get(visiblity == null ? Visibility.PACKAGE : visiblity)
         .get(symbol.getInfo().getKind());
-  }
-
-  private static <K, V> Consumer<Map<K, V>> put(K key, V value) {
-    return new Consumer<Map<K, V>>() {
-
-      @Override
-      public void accept(Map<K, V> map) {
-        map.put(key, value);
-      }
-    };
-  }
-
-  @SafeVarargs
-  private static <K, V> Map<K, V> map(Consumer<Map<K, V>>... entries) {
-    HashMap<K, V> result = new HashMap<>(entries.length);
-    for (Consumer<Map<K, V>> entry : entries) {
-      entry.accept(result);
-    }
-    return result;
   }
 }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/inject/LanguageServerGinModule.java
@@ -48,9 +48,6 @@ public class LanguageServerGinModule extends AbstractGinModule {
     install(new GinFactoryModuleBuilder().build(LanguageServerReconcileStrategyFactory.class));
     install(new GinFactoryModuleBuilder().build(LanguageServerSignatureHelpFactory.class));
     install(new GinFactoryModuleBuilder().build(RenameNodeFactory.class));
-    install(
-        new GinFactoryModuleBuilder()
-            .build(org.eclipse.che.plugin.languageserver.ide.filestructure.NodeFactory.class));
 
     bind(PublishDiagnosticsReceiver.class).asEagerSingleton();
     bind(ShowMessageJsonRpcReceiver.class).asEagerSingleton();

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <che.dashboard.version>6.14.0-SNAPSHOT</che.dashboard.version>
         <che.docs.version>6.14.0-SNAPSHOT</che.docs.version>
         <che.lib.version>6.14.0-SNAPSHOT</che.lib.version>
-        <che.ls.jdt.version>0.0.1</che.ls.jdt.version>
+        <che.ls.jdt.version>0.0.2-SNAPSHOT</che.ls.jdt.version>
         <che.version>6.14.0-SNAPSHOT</che.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>


### PR DESCRIPTION
### What does this PR do?
- Moved file structure stuff to java plugin (other LS's use different UI)
- Use Java-specific icons file structure

Companion PR: https://github.com/eclipse/che-ls-jdt/pull/87

### What issues does this PR fix or reference?
The "Navigate File Form" has difference if compare with upstream #11490

#### Release Notes
N/A
