### PR TITLE
Do not show warning about low timeout value, if it is set to less than 0

### DIFF
--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManager.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManager.java
@@ -69,7 +69,7 @@ public class WorkspaceActivityManager {
     this.eventService = eventService;
     this.activityDao = activityDao;
     this.defaultTimeout = timeout;
-    if (timeout < MINIMAL_TIMEOUT) {
+    if (timeout > 0 && timeout < MINIMAL_TIMEOUT) {
       LOG.warn(
           "Value of property \"che.limits.workspace.idle.timeout\" is below recommended minimum ("
               + TimeUnit.MILLISECONDS.toMinutes(MINIMAL_TIMEOUT)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Follow up https://github.com/eclipse/che/pull/11878 fix to low workspace low timeout warning that occurs on non-positive values (disabled timeout)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11853
