### PR TITLE
Made PVC Strategies wait until PVCs are bound during preparing

### DIFF
--- a/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
+++ b/core/commons/che-core-commons-logback/src/main/java/org/eclipse/che/commons/logback/EnvironmentVariablesLogLevelPropagator.java
@@ -18,6 +18,7 @@ import ch.qos.logback.classic.spi.LoggerContextListener;
 import ch.qos.logback.core.spi.ContextAwareBase;
 import ch.qos.logback.core.spi.LifeCycle;
 import java.util.Arrays;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class searches environment variable CHE_LOGGER_CONFIG Value of this variable is expected in such
@@ -29,15 +30,17 @@ import java.util.Arrays;
  */
 public class EnvironmentVariablesLogLevelPropagator extends ContextAwareBase
     implements LoggerContextListener, LifeCycle {
+  private static final org.slf4j.Logger LOG =
+      LoggerFactory.getLogger(EnvironmentVariablesLogLevelPropagator.class);
 
   private boolean isStarted;
 
   @Override
   public void start() {
-
     String config = System.getenv("CHE_LOGGER_CONFIG");
     if (config != null && !config.isEmpty()) {
       Arrays.stream(config.split(",")).map(String::trim).forEach(this::setLoggerLevel);
+      LOG.info("The following Che Logger Config is applied: {}", config);
     }
     isStarted = true;
   }

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -49,7 +49,7 @@ global:
   # Service account name that will be mounted to workspaces pods
   # Note that:
   # if `cheWorkspacesNamespace` is configured then service account with configured name will be created by helm chart during deploying Che
-  # if `cheWorkspacesNamespace` is empty then Che Server creates new namespace for each workspace and creates configured SA exists there
+  # if `cheWorkspacesNamespace` is empty then Che Server creates new namespace for each workspace and ensures that configured SA exists there
   cheWorkspaceServiceAccount: "che-workspace"
   workspaceIdleTimeout: "-1"
   log:

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -165,7 +165,8 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
 
       // Tooling side car provisioner should be applied before other provisioners
       // because new machines may be provisioned there
-      toolingProvisioner.provision(context.getIdentity(), context.getEnvironment());
+      toolingProvisioner.provision(
+          context.getIdentity(), startSynchronizer, context.getEnvironment());
 
       startSynchronizer.checkFailure();
 
@@ -182,7 +183,8 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
 
       LOG.debug("Provisioning of workspace '{}' completed.", workspaceId);
 
-      volumesStrategy.prepare(context.getEnvironment(), workspaceId);
+      volumesStrategy.prepare(
+          context.getEnvironment(), workspaceId, startSynchronizer.getStartTimeoutMillis());
 
       startSynchronizer.checkFailure();
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -239,7 +239,7 @@ public class KubernetesDeployments {
    * @param name name of pod or deployment containing pod that should be watched
    * @param timeoutMin waiting timeout in minutes
    * @param predicate predicate to perform state check
-   * @return pod that satisifes the specified predicate
+   * @return pod that satisfies the specified predicate
    * @throws InfrastructureException when specified timeout is reached
    * @throws InfrastructureException when {@link Thread} is interrupted while waiting
    * @throws InfrastructureException when any other exception occurs

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPersistentVolumeClaims.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPersistentVolumeClaims.java
@@ -13,13 +13,23 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
 import static java.util.stream.Collectors.toSet;
 
+import io.fabric8.kubernetes.api.model.DoneablePersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.Resource;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 
@@ -30,6 +40,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastruct
  * @author Sergii Leshchenko
  */
 public class KubernetesPersistentVolumeClaims {
+
+  public static final String PVC_BOUND_PHASE = "Bound";
 
   private final String namespace;
   private final String workspaceId;
@@ -135,6 +147,94 @@ public class KubernetesPersistentVolumeClaims {
           .delete();
     } catch (KubernetesClientException e) {
       throw new KubernetesInfrastructureException(e);
+    }
+  }
+
+  /**
+   * Waits until persistent volume claim state is bound.
+   *
+   * @param name name of persistent volume claim that should be watched
+   * @param timeoutMillis waiting timeout in milliseconds
+   * @return persistent volume claim that satisfies the specified predicate
+   * @throws InfrastructureException when specified timeout is reached
+   * @throws InfrastructureException when {@link Thread} is interrupted while waiting
+   * @throws InfrastructureException when any other exception occurs
+   */
+  public PersistentVolumeClaim waitBound(String name, long timeoutMillis)
+      throws InfrastructureException {
+    return wait(name, timeoutMillis, pvc -> pvc.getStatus().getPhase().equals(PVC_BOUND_PHASE));
+  }
+
+  /**
+   * Waits until persistent volume claim state will suit for specified predicate.
+   *
+   * @param name name of persistent volume claim that should be watched
+   * @param timeoutMillis waiting timeout in milliseconds
+   * @param predicate predicate to perform state check
+   * @return persistent volume claim that satisfies the specified predicate
+   * @throws InfrastructureException when specified timeout is reached
+   * @throws InfrastructureException when {@link Thread} is interrupted while waiting
+   * @throws InfrastructureException when any other exception occurs
+   */
+  public PersistentVolumeClaim wait(
+      String name, long timeoutMillis, Predicate<PersistentVolumeClaim> predicate)
+      throws InfrastructureException {
+    CompletableFuture<PersistentVolumeClaim> future = new CompletableFuture<>();
+    Watch watch = null;
+    try {
+      Resource<PersistentVolumeClaim, DoneablePersistentVolumeClaim> pvcResource =
+          clientFactory
+              .create(workspaceId)
+              .persistentVolumeClaims()
+              .inNamespace(namespace)
+              .withName(name);
+
+      watch =
+          pvcResource.watch(
+              new Watcher<PersistentVolumeClaim>() {
+                @Override
+                public void eventReceived(Action action, PersistentVolumeClaim pvc) {
+                  if (predicate.test(pvc)) {
+                    future.complete(pvc);
+                  }
+                }
+
+                @Override
+                public void onClose(KubernetesClientException cause) {
+                  future.completeExceptionally(
+                      new InfrastructureException(
+                          "Waiting for persistent volume claim '" + name + "' was interrupted"));
+                }
+              });
+
+      PersistentVolumeClaim actualPvc = pvcResource.get();
+      if (predicate.test(actualPvc)) {
+        return actualPvc;
+      }
+      try {
+        return future.get(timeoutMillis, TimeUnit.MILLISECONDS);
+      } catch (ExecutionException e) {
+        // May happen only if WebSocket Connection is closed before needed event received.
+        // Throw internal exception because there may be some cluster/network issues that admin
+        // should take a look.
+        throw new InternalInfrastructureException(e.getCause().getMessage(), e);
+      } catch (TimeoutException e) {
+        // May happen when PVC is not bound in the time.
+        // Throw internal exception because there may be some cluster configuration/performance
+        // issues that admin should take a look.
+        throw new InternalInfrastructureException(
+            "Waiting for persistent volume claim '" + name + "' reached timeout");
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new InfrastructureException(
+            "Waiting for persistent volume claim '" + name + "' was interrupted");
+      }
+    } catch (KubernetesClientException e) {
+      throw new KubernetesInfrastructureException(e);
+    } finally {
+      if (watch != null) {
+        watch.close();
+      }
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
@@ -132,7 +132,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
   }
 
   @Override
-  public void prepare(KubernetesEnvironment k8sEnv, String workspaceId)
+  public void prepare(KubernetesEnvironment k8sEnv, String workspaceId, long timeoutMillis)
       throws InfrastructureException {
     if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
       return;
@@ -149,7 +149,10 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
             (String[])
                 pvc.getAdditionalProperties().remove(format(SUBPATHS_PROPERTY_FMT, workspaceId));
         if (!existing.contains(pvc.getMetadata().getName())) {
+          LOG.debug("Creating PVC for workspace '{}'", workspaceId);
           pvcs.create(pvc);
+          LOG.debug("Waiting PVC for workspace '{}' to be bound", workspaceId);
+          pvcs.waitBound(pvc.getMetadata().getName(), timeoutMillis);
         }
         if (preCreateDirs && subpaths != null) {
           pvcSubPathHelper.createDirs(workspaceId, subpaths);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspaceVolumesStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspaceVolumesStrategy.java
@@ -41,9 +41,11 @@ public interface WorkspaceVolumesStrategy extends ConfigurationProvisioner {
    *
    * @param k8sEnv Kubernetes environment that changes as a result of preparation
    * @param workspaceId the workspace identifier for which volumes will be prepared
+   * @param timeoutMillis timeout in milliseconds
    * @throws InfrastructureException when any error while preparation occurs
    */
-  void prepare(KubernetesEnvironment k8sEnv, String workspaceId) throws InfrastructureException;
+  void prepare(KubernetesEnvironment k8sEnv, String workspaceId, long timeoutMillis)
+      throws InfrastructureException;
 
   /**
    * Cleanups workspace backed up data in a strategy specific way.

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
@@ -23,6 +23,7 @@ import org.eclipse.che.api.workspace.server.wsplugins.ChePluginsApplier;
 import org.eclipse.che.api.workspace.server.wsplugins.PluginMetaRetriever;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
 import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility;
 import org.slf4j.Logger;
@@ -56,7 +57,8 @@ public class SidecarToolingProvisioner<E extends KubernetesEnvironment> {
   }
 
   @Beta
-  public void provision(RuntimeIdentity id, E environment) throws InfrastructureException {
+  public void provision(RuntimeIdentity id, StartSynchronizer startSynchronizer, E environment)
+      throws InfrastructureException {
 
     Collection<PluginMeta> pluginsMeta = pluginMetaRetriever.get(environment.getAttributes());
     if (pluginsMeta.isEmpty()) {
@@ -71,7 +73,8 @@ public class SidecarToolingProvisioner<E extends KubernetesEnvironment> {
     }
 
     boolean isEphemeral = EphemeralWorkspaceUtility.isEphemeral(environment.getAttributes());
-    List<ChePlugin> chePlugins = pluginBrokerManager.getTooling(id, pluginsMeta, isEphemeral);
+    List<ChePlugin> chePlugins =
+        pluginBrokerManager.getTooling(id, startSynchronizer, pluginsMeta, isEphemeral);
 
     pluginsApplier.apply(environment, chePlugins);
     if (isEphemeral) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/PrepareStorage.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/PrepareStorage.java
@@ -15,6 +15,7 @@ import com.google.common.annotations.Beta;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
+import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 
@@ -31,19 +32,23 @@ public class PrepareStorage extends BrokerPhase {
   private final String workspaceId;
   private final KubernetesEnvironment brokerEnvironment;
   private final WorkspaceVolumesStrategy volumesStrategy;
+  private final StartSynchronizer startSynchronizer;
 
   public PrepareStorage(
       String workspaceId,
       KubernetesEnvironment brokerEnvironment,
-      WorkspaceVolumesStrategy volumesStrategy) {
+      WorkspaceVolumesStrategy volumesStrategy,
+      StartSynchronizer startSynchronizer) {
     this.workspaceId = workspaceId;
     this.brokerEnvironment = brokerEnvironment;
     this.volumesStrategy = volumesStrategy;
+    this.startSynchronizer = startSynchronizer;
   }
 
   @Override
   public List<ChePlugin> execute() throws InfrastructureException {
-    volumesStrategy.prepare(brokerEnvironment, workspaceId);
+    volumesStrategy.prepare(
+        brokerEnvironment, workspaceId, startSynchronizer.getStartTimeoutMillis());
 
     return nextPhase.execute();
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -312,7 +312,7 @@ public class KubernetesInternalRuntimeTest {
 
     internalRuntime.internalStart(emptyMap());
 
-    verify(toolingProvisioner).provision(IDENTITY, k8sEnv);
+    verify(toolingProvisioner).provision(IDENTITY, startSynchronizer, k8sEnv);
     verify(internalEnvironmentProvisioner).provision(IDENTITY, k8sEnv);
     verify(kubernetesEnvironmentProvisioner).provision(k8sEnv, IDENTITY);
     verify(deployments).deploy(any());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
@@ -48,6 +48,7 @@ public class SidecarToolingProvisionerTest {
   private static final String RECIPE_TYPE = "TestingRecipe";
   private static final String PLUGIN_META_NAME = "TestPluginMeta";
 
+  @Mock private StartSynchronizer startSynchronizer;
   @Mock private KubernetesBrokerInitContainerApplier<KubernetesEnvironment> brokerApplier;
   @Mock private PluginMetaRetriever pluginMetaRetriever;
   @Mock private PluginBrokerManager<KubernetesEnvironment> brokerManager;
@@ -91,7 +92,7 @@ public class SidecarToolingProvisionerTest {
 
   @Test
   public void shouldNotAddInitContainerWhenWorkspaceIsNotEphemeral() throws Exception {
-    provisioner.provision(runtimeId, nonEphemeralEnvironment);
+    provisioner.provision(runtimeId, startSynchronizer, nonEphemeralEnvironment);
 
     verify(chePluginsApplier, times(1)).apply(any(), any());
     verify(brokerApplier, times(0)).apply(any(), any(), any());
@@ -99,7 +100,7 @@ public class SidecarToolingProvisionerTest {
 
   @Test
   public void shouldIncludeInitContainerWhenWorkspaceIsEphemeral() throws Exception {
-    provisioner.provision(runtimeId, ephemeralEnvironment);
+    provisioner.provision(runtimeId, startSynchronizer, ephemeralEnvironment);
 
     verify(chePluginsApplier, times(1)).apply(any(), any());
     verify(brokerApplier, times(1)).apply(any(), any(), any());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -254,10 +254,11 @@ public class CommonPVCStrategyTest {
     when(pvc.getAdditionalProperties()).thenReturn(subPaths);
     doNothing().when(pvcSubPathHelper).createDirs(WORKSPACE_ID, WORKSPACE_SUBPATHS);
 
-    commonPVCStrategy.prepare(k8sEnv, WORKSPACE_ID);
+    commonPVCStrategy.prepare(k8sEnv, WORKSPACE_ID, 100);
 
     verify(pvcs).get();
     verify(pvcs).create(pvc);
+    verify(pvcs).waitBound(PVC_NAME, 100);
     verify(pvcSubPathHelper).createDirs(any(), any());
   }
 
@@ -267,7 +268,7 @@ public class CommonPVCStrategyTest {
         .thenReturn(singletonMap(PVC_NAME, mock(PersistentVolumeClaim.class)));
     doThrow(InfrastructureException.class).when(pvcs).get();
 
-    commonPVCStrategy.prepare(k8sEnv, WORKSPACE_ID);
+    commonPVCStrategy.prepare(k8sEnv, WORKSPACE_ID, 100);
   }
 
   @Test(expectedExceptions = InfrastructureException.class)
@@ -277,7 +278,7 @@ public class CommonPVCStrategyTest {
     when(pvcs.get()).thenReturn(emptyList());
     doThrow(InfrastructureException.class).when(pvcs).create(any());
 
-    commonPVCStrategy.prepare(k8sEnv, WORKSPACE_ID);
+    commonPVCStrategy.prepare(k8sEnv, WORKSPACE_ID, 100);
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -224,9 +224,10 @@ public class UniqueWorkspacePVCStrategyTest {
     when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(uniqueName, pvc));
     doReturn(pvc).when(pvcs).create(any());
 
-    strategy.prepare(k8sEnv, WORKSPACE_ID);
+    strategy.prepare(k8sEnv, WORKSPACE_ID, 100);
 
     verify(pvcs).create(any());
+    verify(pvcs).waitBound(uniqueName, 100);
   }
 
   @Test(expectedExceptions = InfrastructureException.class)
@@ -235,7 +236,7 @@ public class UniqueWorkspacePVCStrategyTest {
     when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(PVC_NAME_PREFIX, pvc));
     doThrow(InfrastructureException.class).when(pvcs).create(any(PersistentVolumeClaim.class));
 
-    strategy.prepare(k8sEnv, WORKSPACE_ID);
+    strategy.prepare(k8sEnv, WORKSPACE_ID, 100);
   }
 
   @Test

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/pom.xml
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/pom.xml
@@ -56,14 +56,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-languageserver</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-api-project</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
@@ -91,6 +83,11 @@
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-assistedinject</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-languageserver</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is making PVC Strategies wait until PVCs are bound during preparing. It prevents an unrecoverable event happening when PVCs binding is slow.

Also, this PR contains the following minor changes:
* Fix dependencies scope. 
   * Remove duplicated dependency declaration for che-core-api-project to
avoid warning message during maven build
    * Change scope of che-core-api-languageserver dependency to `test` to fix
issue while building Che without compiling of tests
* Add info message about applied logger config

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11848

#### Release Notes
N/A

#### Docs PR
N/A