### PR TITLE
Remove unneeded listening of PluginBrokers Pod events

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
@@ -66,7 +66,7 @@ public class DeployBroker extends BrokerPhase {
 
   @Override
   public List<ChePlugin> execute() throws InfrastructureException {
-    LOG.debug("Starting brokers deployment for workspace '{}'", workspaceId);
+    LOG.debug("Starting brokers pod for workspace '{}'", workspaceId);
     KubernetesDeployments deployments = namespace.deployments();
     try {
       // Creates config map that can inject Che tooling plugins meta files into a Che plugin
@@ -85,23 +85,21 @@ public class DeployBroker extends BrokerPhase {
         namespace.deployments().watchEvents(unrecoverableEventListener);
       }
 
-      Pod barePod = deployments.create(pluginBrokerPod);
+      deployments.create(pluginBrokerPod);
 
-      deployments.waitRunningAsync(barePod.getMetadata().getName());
-      LOG.debug("Brokers deployment finished for workspace '{}'", workspaceId);
+      LOG.debug("Brokers pod is created for workspace '{}'", workspaceId);
       return nextPhase.execute();
     } finally {
       namespace.deployments().stopWatch();
       try {
         deployments.delete();
       } catch (InfrastructureException e) {
-        LOG.error("Broker deployment removal failed. Error: " + e.getLocalizedMessage(), e);
+        LOG.error("Brokers pod removal failed. Error: " + e.getLocalizedMessage(), e);
       }
       try {
         namespace.configMaps().delete();
       } catch (InfrastructureException ex) {
-        LOG.error(
-            "Broker deployment config map removal failed. Error: " + ex.getLocalizedMessage(), ex);
+        LOG.error("Brokers config map removal failed. Error: " + ex.getLocalizedMessage(), ex);
       }
     }
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBrokerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBrokerTest.java
@@ -100,7 +100,6 @@ public class DeployBrokerTest {
     assertSame(result, plugins);
     verify(k8sConfigMaps).create(configMap);
     verify(k8sDeployments).create(pod);
-    verify(k8sDeployments).waitRunningAsync(PLUGIN_BROKER_POD_NAME);
 
     verify(k8sDeployments).stopWatch();
     verify(k8sDeployments).delete();


### PR DESCRIPTION
### What does this PR do?
This PR removes unneeded listening of PluginBrokers Pod events.
`Deployments#waitRunningAsync` is designed to return CompetableFuture which client should use it to get a result of waiting. `DeployBroker` class do nothing with returned completable future, so unneeded HTTP calls are done and redundant WebSocket connection is established.

I tried to fix `PluginBroker` phase to wait until PluginBroker Pod is really `RUNNING` but there are some issues like:
- if plugin broker pod contains two containers - plugin broker pod status will be RUNNING even when one of a container is completed or failed.
- if plugin broker pod contain one container - plugin broker pod status will be `Succeeded` if a broker container is completed or failed. 
Made changes are available here https://github.com/sleshchenko/che/commit/71f44375f61f67a03b96d5e4a019b983c99df86b
So, there are use cases when it would work correctly and when it works incorrectly. Ideally, `waitRunningAsync` should be redesigned to track containers statuses instead of Pod status, but there are tricky things with auto restarting of containers.

I think the simplest solution is just to remove waiting for PluginBrokers pod to be RUNNING and on next phase wait for PluginBrokers results.

### What issues does this PR fix or reference?
It is related to https://github.com/eclipse/che/pull/11344
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A