### PR TITLE
Fix failed test due to the wrong mock reset

### DIFF
--- a/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/ProfileServiceTest.java
+++ b/wsmaster/che-core-api-user/src/test/java/org/eclipse/che/api/user/server/ProfileServiceTest.java
@@ -83,7 +83,8 @@ public class ProfileServiceTest {
         .when(linksInjector.injectLinks(any(), any()))
         .thenAnswer(inv -> inv.getArguments()[0]);
 
-    when(profileManager.getById(SUBJECT.getUserId()))
+    lenient()
+        .when(profileManager.getById(SUBJECT.getUserId()))
         .thenReturn(new ProfileImpl(SUBJECT.getUserId()));
   }
 


### PR DESCRIPTION
### What does this PR do?
Fixes fails of  
org.eclipse.che.api.user.server.ProfileServiceTest.shouldNotUpdateSpecifiedProfileAttributesIfNothingtest in some cases due to the wrong mock reset.

### What issues does this PR fix or reference?
n/a


#### Release Notes
n/a


#### Docs PR
n/a