### PR TITLE
Fix 'Go to line' for 'Git Compare' widget

### DIFF
--- a/plugins/plugin-orion/che-plugin-orion-compare/src/main/java/org/eclipse/che/ide/orion/compare/CompareInitializer.java
+++ b/plugins/plugin-orion/che-plugin-orion-compare/src/main/java/org/eclipse/che/ide/orion/compare/CompareInitializer.java
@@ -14,8 +14,10 @@ package org.eclipse.che.ide.orion.compare;
 import com.google.gwt.core.client.Callback;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.user.client.Command;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -111,7 +113,7 @@ public class CompareInitializer {
 
     @Override
     public void accepted(String value) {
-      acceptedNative(value);
+      Scheduler.get().scheduleDeferred((Command) () -> acceptedNative(value));
     }
 
     private native void acceptedNative(String value) /*-{


### PR DESCRIPTION
### What does this PR do?
When user uses 'Go to line' feature Input Dialog is displayed.
We close dialog and try to set cursor for given position when user enters line number and click 'OK' button. At this step an editor loses focus.
So, I propose to execute setting of given position as deferred command.
It allows to set cursor position when dialog is closed after the browser event loop returns.

### What issues does this PR fix or reference?
#11791 

Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>