### PR TITLE
Use `bash` instead of `sh`.

### DIFF
--- a/dockerfiles/action/build.sh
+++ b/dockerfiles/action/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/base/build.sh
+++ b/dockerfiles/base/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/bats/build.sh
+++ b/dockerfiles/bats/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2012-2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/che/build.sh
+++ b/dockerfiles/che/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/cli/build.sh
+++ b/dockerfiles/cli/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made
@@ -25,5 +25,5 @@ fi
 build
 
 if ! skip_tests; then
-  sh "${base_dir}"/test.sh "$@"
+  bash "${base_dir}"/test.sh "$@"
 fi

--- a/dockerfiles/cli/test.sh
+++ b/dockerfiles/cli/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2012-2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/dev/build.sh
+++ b/dockerfiles/dev/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/dir/build.sh
+++ b/dockerfiles/dir/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/init/build.sh
+++ b/dockerfiles/init/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/ip/build.sh
+++ b/dockerfiles/ip/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2016-2017 Red Hat, Inc.
 # This program and the accompanying materials are made
@@ -15,5 +15,5 @@ init --name:ip "$@"
 build
 
 if ! skip_tests; then
-  sh "${base_dir}"/test.sh "$@"
+  bash "${base_dir}"/test.sh "$@"
 fi

--- a/dockerfiles/ip/run.sh
+++ b/dockerfiles/ip/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/ip/test.sh
+++ b/dockerfiles/ip/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/keycloak/build.sh
+++ b/dockerfiles/keycloak/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/lib/build.sh
+++ b/dockerfiles/lib/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/mount/build.sh
+++ b/dockerfiles/mount/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/mount/entrypoint.sh
+++ b/dockerfiles/mount/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/postgres/build.sh
+++ b/dockerfiles/postgres/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/postgres/init-debug.sh
+++ b/dockerfiles/postgres/init-debug.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2012-2018 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/test/build.sh
+++ b/dockerfiles/test/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2017 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0

--- a/dockerfiles/theia/build.sh
+++ b/dockerfiles/theia/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made

--- a/dockerfiles/theia/e2e/build.sh
+++ b/dockerfiles/theia/e2e/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
@@ -12,5 +12,5 @@ base_dir=$(cd "$(dirname "$0")"; pwd)
 init --name:theia-e2e "$@"
 build
 if ! skip_tests; then
-  sh "${base_dir}"/test.sh "$@"
+  bash "${base_dir}"/test.sh "$@"
 fi

--- a/dockerfiles/theia/e2e/test.sh
+++ b/dockerfiles/theia/e2e/test.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0


### PR DESCRIPTION
### What does this PR do?

Replaces some `sh` to `bash`.

Because `sh` is not linked to `bash` on some distributions like Ubuntu.

### What issues does this PR fix or reference?

Will fix #10041 

#### Release Notes

N/A

#### Docs PR

N/A