### PR TITLE
Add property to control ping interval in ServersChecker

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -136,6 +136,9 @@ che.workspace.activity_check_scheduler_delay_s=180
 # Note: the property is common for all servers e.g. workspace agent, terminal, exec etc.
 che.workspace.server.ping_success_threshold=1
 
+# Interval, in milliseconds, between successive pings to workspace server.
+che.workspace.server.ping_interval_milliseconds=3000
+
 # List of servers names which require liveness probes
 che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia,jupyter,dirigible
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServersChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServersChecker.java
@@ -47,6 +47,7 @@ public class ServersChecker {
   private final Map<String, ? extends Server> servers;
   private final MachineTokenProvider machineTokenProvider;
   private final int serverPingSuccessThreshold;
+  private final long serverPingIntervalMillis;
   private final Set<String> livenessProbes;
 
   private Timer timer;
@@ -66,6 +67,7 @@ public class ServersChecker {
       @Assisted Map<String, ? extends Server> servers,
       MachineTokenProvider machineTokenProvider,
       @Named("che.workspace.server.ping_success_threshold") int serverPingSuccessThreshold,
+      @Named("che.workspace.server.ping_interval_milliseconds") long serverPingInterval,
       @Named("che.workspace.server.liveness_probes") String[] livenessProbes) {
     this.runtimeIdentity = runtimeIdentity;
     this.machineName = machineName;
@@ -73,6 +75,7 @@ public class ServersChecker {
     this.timer = new Timer("ServersChecker", true);
     this.machineTokenProvider = machineTokenProvider;
     this.serverPingSuccessThreshold = serverPingSuccessThreshold;
+    this.serverPingIntervalMillis = serverPingInterval;
     this.livenessProbes =
         Arrays.stream(livenessProbes).map(String::trim).collect(Collectors.toSet());
   }
@@ -211,10 +214,10 @@ public class ServersChecker {
           url,
           machineName,
           serverRef,
-          3,
-          180,
+          serverPingIntervalMillis,
+          TimeUnit.SECONDS.toMillis(180),
           serverPingSuccessThreshold,
-          TimeUnit.SECONDS,
+          TimeUnit.MILLISECONDS,
           timer,
           token);
     }
@@ -223,10 +226,10 @@ public class ServersChecker {
         url,
         machineName,
         serverRef,
-        3,
-        180,
+        serverPingIntervalMillis,
+        TimeUnit.SECONDS.toMillis(180),
         serverPingSuccessThreshold,
-        TimeUnit.SECONDS,
+        TimeUnit.MILLISECONDS,
         timer,
         token);
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
@@ -57,6 +57,7 @@ public class ServersCheckerTest {
   private static final String WORKSPACE_ID = "ws123";
   private static final String USER_ID = "0000-0000-0007";
   private static final int SERVER_PING_SUCCESS_THRESHOLD = 1;
+  private static final long SERVER_PING_INTERVAL_MILLIS = 3000;
 
   @Mock private Consumer<String> readinessHandler;
   @Mock private MachineTokenProvider machineTokenProvider;
@@ -91,6 +92,7 @@ public class ServersCheckerTest {
                 servers,
                 machineTokenProvider,
                 SERVER_PING_SUCCESS_THRESHOLD,
+                SERVER_PING_INTERVAL_MILLIS,
                 CONFIGURED_SERVERS));
     when(checker.doCreateChecker(any(URL.class), anyString(), anyString()))
         .thenReturn(connectionChecker);


### PR DESCRIPTION
### What does this PR do?
Add property `che.workspace.server.ping_interval_milliseconds` to control ping interval (default 3000ms) when checking whether servers are running during workspace start.

### What issues does this PR fix or reference?
The current implementation causes a built-in delay when starting workspaces, as a 3 second interval is quite significant. As an example, in my testing, if I reduce the ping interval to 500 milliseconds, it takes ~2-3 seconds for the Theia server in a Che 7 workspace to be marked as running. With the current implementation, this time is consistently double (6+ seconds). 

### Docs PR
Not sure if necessary but happy to add if needed.