### PR TITLE
Change Centos Nodejs stack Run Command

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2021,7 +2021,7 @@
             "goal": "Run",
             "previewUrl": "${server.8080/tcp}"
           },
-          "commandLine": "cd ${current.project.path} && scl enable rh-nodejs6 'node app.js'"
+          "commandLine": "cd ${current.project.path} && scl enable rh-nodejs6 'node .'"
         }
       ],
       "projects": [],


### PR DESCRIPTION
### What does this PR do?
Change the default run command for `centos nodejs` stack from `node app.js` (which will work only if the entry point of the project is app.js) to `node .` (which will work for all nodejs projects which have a `main` section defined in `package.json` file. The `main` section defines the entry point.

Related to https://github.com/redhat-developer/rh-che/pull/1078

### What issues does this PR fix or reference?
 N/A
