### PR TITLE
[WIP DO NOT MERGE] Change CORS filter configuration

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterServletModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterServletModule.java
@@ -44,7 +44,7 @@ public class WsMasterServletModule extends ServletModule {
             + "Origin,"
             + "Access-Control-Request-Method,"
             + "Access-Control-Request-Headers");
-    corsFilterParams.put("cors.support.credentials", "true");
+    corsFilterParams.put("cors.support.credentials", "false");
     // preflight cache is available for 10 minutes
     corsFilterParams.put("cors.preflight.maxage", "10");
     bind(CorsFilter.class).in(Singleton.class);

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterServletModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterServletModule.java
@@ -32,24 +32,6 @@ public class WsMasterServletModule extends ServletModule {
       install(new org.eclipse.che.core.tracing.web.TracingWebModule());
     }
 
-    final Map<String, String> corsFilterParams = new HashMap<>();
-    corsFilterParams.put("cors.allowed.origins", "*");
-    corsFilterParams.put(
-        "cors.allowed.methods", "GET," + "POST," + "HEAD," + "OPTIONS," + "PUT," + "DELETE");
-    corsFilterParams.put(
-        "cors.allowed.headers",
-        "Content-Type,"
-            + "X-Requested-With,"
-            + "accept,"
-            + "Origin,"
-            + "Access-Control-Request-Method,"
-            + "Access-Control-Request-Headers");
-    corsFilterParams.put("cors.support.credentials", "false");
-    // preflight cache is available for 10 minutes
-    corsFilterParams.put("cors.preflight.maxage", "10");
-    bind(CorsFilter.class).in(Singleton.class);
-
-    filter("/*").through(CorsFilter.class, corsFilterParams);
     filter("/*").through(RequestIdLoggerFilter.class);
 
     // Matching group SHOULD contain forward slash.

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/cors/CheCorsFilter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/cors/CheCorsFilter.java
@@ -70,8 +70,10 @@ public class CheCorsFilter implements Filter {
     private final Map<String, String> filterParams;
 
     public CheCorsFilterConfig() {
+      final String cheApi = System.getenv("CHE_API");
+      final String cheServerOrigin = cheApi.substring(0, cheApi.length() - 4);
       filterParams = new HashMap<>();
-      filterParams.put(PARAM_CORS_ALLOWED_ORIGINS, DEFAULT_ALLOWED_ORIGINS);
+      filterParams.put(PARAM_CORS_ALLOWED_ORIGINS, cheServerOrigin);
       filterParams.put(
           PARAM_CORS_ALLOWED_METHODS, "GET," + "POST," + "HEAD," + "OPTIONS," + "PUT," + "DELETE");
       filterParams.put(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

Introduced in latest Tomcat changes won't allow running CORS filter with configuration, where it allows requests from all origins and allows requests with credentials from clients. It requires to either disallow requests with credentials, or provide a list of allowed origins.



### What does this PR do?
Currently, CORS filters are installed on WS Master and WS Agent. 
- While on WS Agent, CORS is needed to allow make requests from browser to ws-agent, that is located on the other domain, as well it has to allow requests with credentials mode. In this PR it will configure workspace masters domain as allowed origin (infering it from CHE_API variable in WS Agent container).
- on WS Master currently CORS is disabled, as discussion goes on about related functionality to it.
