### PR TITLE
Remove redundant <version> elements.

### DIFF
--- a/agents/pom.xml
+++ b/agents/pom.xml
@@ -21,7 +21,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-agents-parent</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Agents Parent</name>
     <modules>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -22,7 +22,6 @@
     </parent>
     <groupId>org.eclipse.che</groupId>
     <artifactId>che-assembly-parent</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che IDE :: Parent</name>
     <modules>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,6 @@
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-parent</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Core Parent</name>
     <modules>

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -22,7 +22,6 @@
     </parent>
     <groupId>org.eclipse.che.dashboard</groupId>
     <artifactId>che-dashboard-war</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>Che Dashboard :: Web App</name>
     <inceptionYear>2015</inceptionYear>

--- a/dockerfiles/pom.xml
+++ b/dockerfiles/pom.xml
@@ -22,7 +22,6 @@
     </parent>
     <groupId>org.eclipse.che.dockerfiles</groupId>
     <artifactId>che-dockerfiles-parent</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Dockerfiles</name>
     <inceptionYear>2018</inceptionYear>

--- a/dockerfiles/theia/pom.xml
+++ b/dockerfiles/theia/pom.xml
@@ -21,7 +21,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>che-dockerfiles-theia</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Dockerfiles :: Theia</name>
     <inceptionYear>2018</inceptionYear>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -22,7 +22,6 @@
     </parent>
     <groupId>org.eclipse.che.plugin</groupId>
     <artifactId>che-plugin-parent</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Plugin :: Parent</name>
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
     </parent>
     <groupId>org.eclipse.che</groupId>
     <artifactId>che-parent</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Parent</name>
     <modules>

--- a/workspace-loader/pom.xml
+++ b/workspace-loader/pom.xml
@@ -22,7 +22,6 @@
     </parent>
     <groupId>org.eclipse.che.workspace.loader</groupId>
     <artifactId>che-workspace-loader</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Workspace Loader :: Web App</name>
     <inceptionYear>2018</inceptionYear>

--- a/wsagent/pom.xml
+++ b/wsagent/pom.xml
@@ -22,7 +22,6 @@
     </parent>
     <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-agent-parent</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Agent Parent</name>
     <modules>

--- a/wsmaster/pom.xml
+++ b/wsmaster/pom.xml
@@ -21,7 +21,6 @@
         <relativePath>../core/pom.xml</relativePath>
     </parent>
     <artifactId>che-master-parent</artifactId>
-    <version>6.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Master Parent</name>
     <modules>


### PR DESCRIPTION
### What does this PR do?

Remove redundant <version> elements in POM files.
They may be harmless. But some IDE like Eclipse reports them as an warning.

### What issues does this PR fix or reference?

None.
