### PR TITLE
Properly handle no-environment in workspace config from UD

### DIFF
--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
@@ -307,7 +307,7 @@ export class FactoryInformationController {
    * @returns {any}
    */
   getRecipe(): string {
-    if (this.copyOriginFactory && this.copyOriginFactory.workspace) {
+    if (this.copyOriginFactory && this.copyOriginFactory.workspace && this.copyOriginFactory.workspace.defaultEnv) {
       let environement = this.copyOriginFactory.workspace.environments[this.copyOriginFactory.workspace.defaultEnv];
       return environement.recipe.location || environement.recipe.content;
     }

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
@@ -120,7 +120,7 @@
     </che-label-container>
 
     <!--Workspace RAM-->
-    <che-label-container che-label-name="RAM">
+    <che-label-container che-label-name="RAM" ng-if="factoryInformationController.copyOriginFactory.workspace.defaultEnv">
       <ng-form name="factoryInformationController.factoryInformationForm">
         <div data-ng-repeat="(environmentKey, environmentValue) in factoryInformationController.copyOriginFactory.workspace.environments">
           <span ng-if="factoryInformationController.getObjectKeys(factoryInformationController.copyOriginFactory.workspace.environments).length > 1"

--- a/dashboard/src/app/factories/list-factories/factory-item/factory-item.controller.ts
+++ b/dashboard/src/app/factories/list-factories/factory-item/factory-item.controller.ts
@@ -62,7 +62,7 @@ export class FactoryItemController {
    * @returns {string} display value of memory limit
    */
   getMemoryLimit(): string {
-    if (!this.factory.workspace) {
+    if (!this.factory.workspace || !this.factory.workspace.defaultEnv) {
       return '-';
     }
 

--- a/dashboard/src/app/stacks/stack-details/stack-validation.service.ts
+++ b/dashboard/src/app/stacks/stack-details/stack-validation.service.ts
@@ -77,8 +77,8 @@ export class StackValidationService {
    * @returns {IValidation}
    */
   getWorkspaceConfigValidation(workspaceConfig: che.IWorkspaceConfig): che.IValidation {
-    let mandatoryKeys: Array<string> = ['name', 'environments', 'defaultEnv'];
-    let additionalKeys: Array<string> = ['commands', 'projects', 'description', 'links', 'attributes'];
+    let mandatoryKeys: Array<string> = ['name', 'environments'];
+    let additionalKeys: Array<string> = ['commands', 'projects', 'description', 'links', 'attributes', 'defaultEnv'];
     let validKeys: Array<string> = mandatoryKeys.concat(additionalKeys);
     let errors: Array<string> = [];
     let isValid: boolean = true;
@@ -113,7 +113,7 @@ export class StackValidationService {
           errors = errors.concat(environmentValidation.errors);
         }
       });
-      if (!workspaceEnvironments[workspaceConfig.defaultEnv]) {
+      if (keys && keys.length > 0 && !workspaceEnvironments[workspaceConfig.defaultEnv]) {
         isValid = false;
         errors.push('Can\'t find default environment in environments.');
       }

--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.controller.ts
@@ -199,7 +199,7 @@ export class CreateWorkspaceController {
     this.stack = this.stackSelectorSvc.getStackById(stackId);
     this.workspaceConfig = angular.copy(this.stack.workspaceConfig);
 
-    if (!this.stack.workspaceConfig) {
+    if (!this.stack.workspaceConfig || !this.stack.workspaceConfig.defaultEnv) {
       this.memoryByMachine = {};
       this.stackMachines = [];
       return;

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.controller.ts
@@ -18,6 +18,7 @@ import {StackSelectorSvc} from './stack-selector.service';
 import {CheBranding} from '../../../../components/branding/che-branding.factory';
 import {ConfirmDialogService} from '../../../../components/service/confirm-dialog/confirm-dialog.service';
 import {CheWorkspace} from '../../../../components/api/workspace/che-workspace.factory';
+import {CheRecipeTypes} from '../../../../components/api/recipe/che-recipe-types';
 
 /**
  * @ngdoc controller
@@ -222,7 +223,7 @@ export class StackSelectorController {
       }
 
       this.stackMachines[stack.id] = [];
-      if (stack.workspaceConfig) {
+      if (stack.workspaceConfig && stack.workspaceConfig.defaultEnv) {
         // get machines memory limits
         const defaultEnv = stack.workspaceConfig.defaultEnv,
           environment = stack.workspaceConfig.environments[defaultEnv],
@@ -253,6 +254,10 @@ export class StackSelectorController {
 
     // for quickstart do not show stacks based on unsupported recipe types
     this.stacksByScope[StackSelectorScope.QUICK_START] = this.stacksByScope[StackSelectorScope.QUICK_START].filter((stack: che.IStack) => {
+      if (!stack.workspaceConfig.defaultEnv) {
+        return this.supportedRecipeTypes.indexOf(CheRecipeTypes.NOENVIRONMENT) !== -1;
+      }
+      
       const defaultEnvName = stack.workspaceConfig.defaultEnv,
         defaultEnv = stack.workspaceConfig.environments[defaultEnvName],
         recipeType = defaultEnv.recipe.type;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -282,11 +282,14 @@ export class WorkspaceDetailsController {
     if (this.newName !== config.name) {
       this.newName = config.name;
     }
-    if (!config.environments[config.defaultEnv]) {
+
+    if (config.defaultEnv && config.environments[config.defaultEnv]) {
+      this.workspaceImportedRecipe = config.environments[config.defaultEnv].recipe;
+    } else if (Object.keys(config.environments).length > 0) {
       return;
     }
+
     this.workspaceDetails.config = config;
-    this.workspaceImportedRecipe = config.environments[config.defaultEnv].recipe;
     this.checkEditMode();
   }
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.controller.ts
@@ -119,6 +119,7 @@ export class WorkspaceMachinesController {
     this.cheEnvironmentRegistry = cheEnvironmentRegistry;
 
     this.absUrl = $location.absUrl().split('?')[0];
+    this.machines = [];
     this.cheListHelper = cheListHelperFactory.getHelper(MACHINE_LIST_HELPER_ID);
 
     this.updateData(this.workspaceDetails);
@@ -137,7 +138,7 @@ export class WorkspaceMachinesController {
    * @returns {boolean}
    */
   isScalable(): boolean {
-    return this.cheRecipeService.isScalable(this.environment.recipe);
+    return this.environment ? this.cheRecipeService.isScalable(this.environment.recipe) : false;
   }
 
   /**
@@ -161,6 +162,7 @@ export class WorkspaceMachinesController {
       return;
     }
     this.environmentManager = this.cheEnvironmentRegistry.getEnvironmentManager(this.environment.recipe.type);
+
     this.machines = this.environmentManager.getMachines(this.environment);
     this.environment = this.environmentManager.getEnvironment(this.environment, this.machines);
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.html
@@ -12,7 +12,10 @@
 
 -->
 <md-content flex layout="column" md-theme="maincontent-theme" class="workspace-machines">
-  <div class="warning-message" ng-hide="workspaceMachinesController.isScalable()">
+  <div class="che-list-empty" ng-if="workspaceMachinesController.machines.length === 0">
+    <span>There are no machines to display.</span>
+  </div>
+  <div class="warning-message" ng-hide="workspaceMachinesController.isScalable() || workspaceMachinesController.machines.length === 0">
     <span>Add another machine by changing the environment type to <b>compose</b> or <b>openshift</b></span>
   </div>
   <che-list-header che-add-button-title="Add machine"

--- a/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.controller.ts
@@ -118,7 +118,7 @@ export class WorkspaceDetailsSshCtrl {
     });
 
     let defaultEnv : string = this.workspace.config.defaultEnv;
-    let machines : any = this.workspace.config.environments[defaultEnv].machines;
+    let machines : any = defaultEnv ? this.workspace.config.environments[defaultEnv].machines : [];
     let machineNames : Array<string> = Object.keys(machines);
     this.machineSshAgents.length = 0;
     machineNames.forEach((machineName: string) => {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-ssh/workspace-details-ssh.html
@@ -15,8 +15,10 @@
   <md-progress-linear md-mode="indeterminate"
                       ng-show="workspaceDetailsSshCtrl.isLoading"></md-progress-linear>
 </div>
-<md-content flex class="workspace-ssh-content">
-
+<div class="che-list-empty" ng-if="!workspaceDetailsSshCtrl.workspace.config.defaultEnv">
+  <span>There are no machines to display.</span>
+</div>
+<md-content flex class="workspace-ssh-content" ng-if="workspaceDetailsSshCtrl.workspace.config.defaultEnv">
   <div layout="row" flex class="workspace-ssh-content-invalid-notification" ng-if="workspaceDetailsSshCtrl.workspace.status !== 'RUNNING'">
     <i class="fa fa-info-circle"></i>
     <div>Workspace is not running. SSH connections are unavailable.</div>

--- a/dashboard/src/app/workspaces/workspaces.service.ts
+++ b/dashboard/src/app/workspaces/workspaces.service.ts
@@ -46,7 +46,7 @@ export class WorkspacesService {
     envName = envName || workspace.config.defaultEnv;
 
     const supportedRecipeTypes = this.cheWorkspace.getSupportedRecipeTypes(),
-      envRecipeType = workspace.config.environments[envName].recipe.type;
+      envRecipeType = envName ? workspace.config.environments[envName].recipe.type : 'no-environment';
 
     return supportedRecipeTypes.indexOf(envRecipeType) !== -1;
   }

--- a/dashboard/src/components/api/environment/che-environment-manager.factory.ts
+++ b/dashboard/src/components/api/environment/che-environment-manager.factory.ts
@@ -19,6 +19,7 @@ import {ComposeEnvironmentManager} from './compose-environment-manager';
 import {OpenshiftEnvironmentManager} from './openshift-environment-manager';
 import {DefaultEnvironmentManager} from './default-environment-manager';
 import {KubernetesEnvironmentManager} from './kubernetes-environment-manager';
+import { NoEnvironmentManager } from './no-environment-manager';
 
 export class CheEnvironmentManager {
 
@@ -51,6 +52,8 @@ export class CheEnvironmentManager {
         return new KubernetesEnvironmentManager(this.$log);
       case CheRecipeTypes.OPENSHIFT:
         return new OpenshiftEnvironmentManager(this.$log);
+      case CheRecipeTypes.NOENVIRONMENT:
+        return new NoEnvironmentManager(this.$log);  
       default:
         return new DefaultEnvironmentManager(this.$log, environmentType);
     }

--- a/dashboard/src/components/api/environment/no-environment-manager.ts
+++ b/dashboard/src/components/api/environment/no-environment-manager.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import {EnvironmentManager} from './environment-manager';
+import {IEnvironmentManagerMachine} from './environment-manager-machine';
+import {DockerimageParser, IDockerimage} from './docker-image-parser';
+import {CheRecipeTypes} from '../recipe/che-recipe-types';
+
+/**
+ * This is the implementation of empty environment manager.
+ *
+ * The recipe type is <code>dockerimage</code>. This environment can contain only an image.
+ * Machine is described by image and in machines attribute of the environment (machine configs).
+ * The machine configs contain memoryLimitBytes in attributes, servers and agent.
+ * Environment variables can not be set.
+ *
+ * @author Ann Shumilova
+ */
+export class NoEnvironmentManager extends EnvironmentManager {
+  
+  parseRecipe(content: string) {
+    this.$log.error('EnvironmentManager: cannot parse recipe.');
+  }
+  
+  stringifyRecipe(recipeObj: any): string {
+    this.$log.error('EnvironmentManager: cannot stringify a recipe.');
+    return null;
+  }
+
+  constructor($log: ng.ILogService) {
+    super($log);
+  }
+
+  get type(): string {
+    return null;
+  }
+
+  /**
+   * Create a new default machine.
+   * @param {che.IWorkspaceEnvironment} environment
+   * @param {string} image
+   * @return {IEnvironmentManagerMachine}
+   */
+  createMachine(environment: che.IWorkspaceEnvironment, image?: string): IEnvironmentManagerMachine {
+    this.$log.error('EnvironmentManager: cannot create a new machine.');
+    return null;
+  }
+
+  /**
+   * Add machine.
+   *
+   * @param {che.IWorkspaceEnvironment} environment
+   * @param {IEnvironmentManagerMachine} machine
+   *
+   * @return {che.IWorkspaceEnvironment}
+   */
+  addMachine(environment: che.IWorkspaceEnvironment, machine: IEnvironmentManagerMachine): che.IWorkspaceEnvironment {
+    this.$log.error('EnvironmentManager: cannot add machine.');
+    return null;
+  }
+
+  /**
+   * Retrieves the list of machines.
+   *
+   * @param {che.IWorkspaceEnvironment} environment environment's configuration
+   * @param {any=} runtime runtime of an active environment
+   * @returns {IEnvironmentManagerMachine[]} list of machines defined in environment
+   */
+  getMachines(environment: che.IWorkspaceEnvironment, runtime?: any): IEnvironmentManagerMachine[] {
+    this.$log.error('EnvironmentManager: cannot get machines.');
+
+    return null;
+  }
+
+  /**
+   * Provides the environment configuration based on machines format.
+   *
+   * @param {che.IWorkspaceEnvironment} environment origin of the environment to be edited
+   * @param {IEnvironmentManagerMachine[]} machines the list of machines
+   * @returns {che.IWorkspaceEnvironment} environment's configuration
+   */
+  getEnvironment(environment: che.IWorkspaceEnvironment, machines: IEnvironmentManagerMachine[]): che.IWorkspaceEnvironment {
+    this.$log.error('EnvironmentManager: cannot get environment.');
+
+    return null;
+  }
+
+  /**
+   * Returns a dockerimage.
+   *
+   * @param {IEnvironmentManagerMachine} machine
+   * @returns {{image: string}}
+   */
+  getSource(machine: IEnvironmentManagerMachine): any {
+    this.$log.error('EnvironmentManager: cannot get source.');
+    return null;
+  }
+
+  /**
+   * Updates machine's image
+   *
+   * @param {IEnvironmentManagerMachine} machine
+   * @param {String} image
+   */
+  setSource(machine: IEnvironmentManagerMachine, image: string): void {
+    this.$log.error('EnvironmentManager: cannot set source.');
+  }
+
+}

--- a/dashboard/src/components/api/recipe/che-recipe-types.ts
+++ b/dashboard/src/components/api/recipe/che-recipe-types.ts
@@ -38,13 +38,18 @@ class CheRecipeTypesStatic {
     return 'openshift';
   }
 
+  static get NOENVIRONMENT(): string {
+    return 'no-environment';
+  }
+
   static getValues(): Array<string> {
     return [
       CheRecipeTypesStatic.DOCKERFILE,
       CheRecipeTypesStatic.DOCKERIMAGE,
       CheRecipeTypesStatic.COMPOSE,
       CheRecipeTypesStatic.KUBERNETES,
-      CheRecipeTypesStatic.OPENSHIFT
+      CheRecipeTypesStatic.OPENSHIFT,
+      CheRecipeTypesStatic.NOENVIRONMENT
     ];
   }
 

--- a/dashboard/src/components/api/workspace/che-workspace.factory.ts
+++ b/dashboard/src/components/api/workspace/che-workspace.factory.ts
@@ -37,6 +37,7 @@ interface ICHELicenseResource<T> extends ng.resource.IResourceClass<T> {
   deleteProject: any;
   stopWorkspace: any;
   startWorkspace: any;
+  startWorkspaceWithNoEnvironment: any;
   startTemporaryWorkspace: any;
   addCommand: any;
   getSettings: () => ng.resource.IResource<IWorkspaceSettings>;
@@ -141,6 +142,7 @@ export class CheWorkspace {
         deleteProject: {method: 'DELETE', url: '/api/workspace/:workspaceId/project/:path'},
         stopWorkspace: {method: 'DELETE', url: '/api/workspace/:workspaceId/runtime'},
         startWorkspace: {method: 'POST', url: '/api/workspace/:workspaceId/runtime?environment=:envName'},
+        startWorkspaceWithNoEnvironment: {method: 'POST', url: '/api/workspace/:workspaceId/runtime'},
         startTemporaryWorkspace: {method: 'POST', url: '/api/workspace/runtime?temporary=true'},
         addCommand: {method: 'POST', url: '/api/workspace/:workspaceId/command'},
         getSettings: {method: 'GET', url: '/api/workspace/settings'}
@@ -534,16 +536,16 @@ export class CheWorkspace {
   /**
    * Starts the given workspace by specifying the ID and the environment name
    * @param workspaceId the workspace ID
-   * @param envName the name of the environment
+   * @param envName the name of the environment (optional)
    * @returns {ng.IPromise<any>} promise
    */
-  startWorkspace(workspaceId: string, envName: string): ng.IPromise<any> {
+  startWorkspace(workspaceId: string, envName?: string): ng.IPromise<any> {
     const workspacePromisesKey = 'startWorkspace' + workspaceId;
     if (this.workspacePromises.has(workspacePromisesKey)) {
       return this.workspacePromises.get(workspacePromisesKey);
     }
 
-    const promise = this.remoteWorkspaceAPI.startWorkspace({workspaceId: workspaceId, envName: envName}, {}).$promise;
+    const promise = envName ? this.remoteWorkspaceAPI.startWorkspace({workspaceId: workspaceId, envName: envName}, {}).$promise : this.remoteWorkspaceAPI.startWorkspaceWithNoEnvironment({workspaceId: workspaceId}, {}).$promise;
     this.workspacePromises.set(workspacePromisesKey, promise);
     promise.finally(() => {
       this.workspacePromises.delete(workspacePromisesKey);

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -168,6 +168,7 @@ declare namespace che {
       COMPOSE: string;
       KUBERNETES: string;
       OPENSHIFT: string;
+      NOENVIRONMENT: string;
       getValues(): Array<string>;
     }
   }


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Handles the no-environment in UD. When workspace has no default environment set and no environments defined - the UD has to allow to work with such workspace - create stacks, create workspace, create and accept factory. 

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
