### PR TITLE
rh-che #1075: Adding 'ImpersonatorInterceptor' during creation of KubernetesClient

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
 import io.fabric8.kubernetes.client.utils.Utils;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -196,7 +197,11 @@ public class KubernetesClientFactory {
         httpClient.newBuilder().authenticator(Authenticator.NONE).build();
     OkHttpClient.Builder builder = clientHttpClient.newBuilder();
     builder.interceptors().clear();
-    clientHttpClient = builder.addInterceptor(buildKubernetesInterceptor(config)).build();
+    clientHttpClient =
+        builder
+            .addInterceptor(buildKubernetesInterceptor(config))
+            .addInterceptor(new ImpersonatorInterceptor(config))
+            .build();
 
     return new UnclosableKubernetesClient(clientHttpClient, config);
   }


### PR DESCRIPTION
### What does this PR do?
Adding 'ImpersonatorInterceptor' during creation of KubernetesClient
Currently `ImpersonatorInterceptor` is added only during creation of `OpenShiftClient`, but not `KubernetesClient`

https://github.com/eclipse/che/blob/44588aa775e77f629eb0a0052ac20d949ab8c7c3/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientFactory.java#L214

### What issues does this PR fix or reference?
https://github.com/redhat-developer/rh-che/issues/1075

#### Release Notes
Adding 'ImpersonatorInterceptor' during creation of KubernetesClient

#### Docs PR
N/A
