### PR TITLE
Changes required for 6.14.2 version

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -136,6 +136,9 @@ che.workspace.activity_check_scheduler_delay_s=180
 # Note: the property is common for all servers e.g. workspace agent, terminal, exec etc.
 che.workspace.server.ping_success_threshold=1
 
+# Interval, in milliseconds, between successive pings to workspace server.
+che.workspace.server.ping_interval_milliseconds=3000
+
 # List of servers names which require liveness probes
 che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia,jupyter,dirigible
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesClientFactory.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.utils.HttpClientUtils;
+import io.fabric8.kubernetes.client.utils.ImpersonatorInterceptor;
 import io.fabric8.kubernetes.client.utils.Utils;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -196,7 +197,11 @@ public class KubernetesClientFactory {
         httpClient.newBuilder().authenticator(Authenticator.NONE).build();
     OkHttpClient.Builder builder = clientHttpClient.newBuilder();
     builder.interceptors().clear();
-    clientHttpClient = builder.addInterceptor(buildKubernetesInterceptor(config)).build();
+    clientHttpClient =
+        builder
+            .addInterceptor(buildKubernetesInterceptor(config))
+            .addInterceptor(new ImpersonatorInterceptor(config))
+            .build();
 
     return new UnclosableKubernetesClient(clientHttpClient, config);
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServersChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServersChecker.java
@@ -47,6 +47,7 @@ public class ServersChecker {
   private final Map<String, ? extends Server> servers;
   private final MachineTokenProvider machineTokenProvider;
   private final int serverPingSuccessThreshold;
+  private final long serverPingIntervalMillis;
   private final Set<String> livenessProbes;
 
   private Timer timer;
@@ -66,6 +67,7 @@ public class ServersChecker {
       @Assisted Map<String, ? extends Server> servers,
       MachineTokenProvider machineTokenProvider,
       @Named("che.workspace.server.ping_success_threshold") int serverPingSuccessThreshold,
+      @Named("che.workspace.server.ping_interval_milliseconds") long serverPingInterval,
       @Named("che.workspace.server.liveness_probes") String[] livenessProbes) {
     this.runtimeIdentity = runtimeIdentity;
     this.machineName = machineName;
@@ -73,6 +75,7 @@ public class ServersChecker {
     this.timer = new Timer("ServersChecker", true);
     this.machineTokenProvider = machineTokenProvider;
     this.serverPingSuccessThreshold = serverPingSuccessThreshold;
+    this.serverPingIntervalMillis = serverPingInterval;
     this.livenessProbes =
         Arrays.stream(livenessProbes).map(String::trim).collect(Collectors.toSet());
   }
@@ -211,10 +214,10 @@ public class ServersChecker {
           url,
           machineName,
           serverRef,
-          3,
-          180,
+          serverPingIntervalMillis,
+          TimeUnit.SECONDS.toMillis(180),
           serverPingSuccessThreshold,
-          TimeUnit.SECONDS,
+          TimeUnit.MILLISECONDS,
           timer,
           token);
     }
@@ -223,10 +226,10 @@ public class ServersChecker {
         url,
         machineName,
         serverRef,
-        3,
-        180,
+        serverPingIntervalMillis,
+        TimeUnit.SECONDS.toMillis(180),
         serverPingSuccessThreshold,
-        TimeUnit.SECONDS,
+        TimeUnit.MILLISECONDS,
         timer,
         token);
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
@@ -57,6 +57,7 @@ public class ServersCheckerTest {
   private static final String WORKSPACE_ID = "ws123";
   private static final String USER_ID = "0000-0000-0007";
   private static final int SERVER_PING_SUCCESS_THRESHOLD = 1;
+  private static final long SERVER_PING_INTERVAL_MILLIS = 3000;
 
   @Mock private Consumer<String> readinessHandler;
   @Mock private MachineTokenProvider machineTokenProvider;
@@ -91,6 +92,7 @@ public class ServersCheckerTest {
                 servers,
                 machineTokenProvider,
                 SERVER_PING_SUCCESS_THRESHOLD,
+                SERVER_PING_INTERVAL_MILLIS,
                 CONFIGURED_SERVERS));
     when(checker.doCreateChecker(any(URL.class), anyString(), anyString()))
         .thenReturn(connectionChecker);


### PR DESCRIPTION
### What does this PR do?
Changes required for 6.14.2 version:

Add property `che.workspace.server.ping_interval_milliseconds` to
control ping interval when checking that servers are running during
workspace start.

- https://github.com/eclipse/che/commit/f96c81f21745ed465e7fd3cea5db089f362c3265

Adding 'ImpersonatorInterceptor' during creation of KubernetesClient

- https://github.com/eclipse/che/commit/35faf112046a87c66792fa5a92d5df18e60ac64d

### What issues does this PR fix or reference?

<!-- #### Changelog -->
Add property `che.workspace.server.ping_interval_milliseconds` to
control ping interval when checking that servers are running during
workspace start.

Adding 'ImpersonatorInterceptor' during creation of KubernetesClient


#### Release Notes
Add property `che.workspace.server.ping_interval_milliseconds` to
control ping interval when checking that servers are running during
workspace start.

Adding 'ImpersonatorInterceptor' during creation of KubernetesClient

#### Docs PR
N/A
