### PR TITLE
Fields are declared at the top of the class

### DIFF
--- a/plugins/plugin-zend-debugger/che-plugin-zend-debugger-server/src/main/java/org/eclipse/che/plugin/zdb/server/connection/ZendDbgConnection.java
+++ b/plugins/plugin-zend-debugger/che-plugin-zend-debugger-server/src/main/java/org/eclipse/che/plugin/zdb/server/connection/ZendDbgConnection.java
@@ -52,6 +52,17 @@ import org.eclipse.che.plugin.zdb.server.exceptions.ZendDbgTimeoutException;
  */
 public class ZendDbgConnection {
 
+  private EngineConnectionRunnable engineConnectionRunnable;
+  private ExecutorService engineConnectionRunnableExecutor;
+  private EngineMessageRunnable engineMessageRunnable;
+  private ExecutorService engineMessageRunnableExecutor;
+  private Map<Integer, EngineSyncResponse<IDbgEngineResponse>> engineSyncResponses =
+      new HashMap<>();
+  private final ZendDbgSettings debugSettings;
+  private IEngineMessageHandler engineMessageHandler;
+  private int debugRequestId = 1000;
+  private boolean isConnected = false;
+
   private final class EngineConnectionRunnable implements Runnable {
 
     private ServerSocket debugSocket;
@@ -244,17 +255,6 @@ public class ZendDbgConnection {
 
     <T extends IDbgClientResponse> T handleRequest(IDbgEngineRequest<T> request);
   }
-
-  private EngineConnectionRunnable engineConnectionRunnable;
-  private ExecutorService engineConnectionRunnableExecutor;
-  private EngineMessageRunnable engineMessageRunnable;
-  private ExecutorService engineMessageRunnableExecutor;
-  private Map<Integer, EngineSyncResponse<IDbgEngineResponse>> engineSyncResponses =
-      new HashMap<>();
-  private final ZendDbgSettings debugSettings;
-  private IEngineMessageHandler engineMessageHandler;
-  private int debugRequestId = 1000;
-  private boolean isConnected = false;
 
   /**
    * Constructs a new DebugConnectionThread with a given Socket.


### PR DESCRIPTION
According to Java Code Patterns : 
Fields should be declared at the top of the class, before any method declarations, constructors, initializers or inner classes.

### What does this PR do?
This is PR enhances code readability and uses Java code patterns.




