### PR TITLE
Made Workspace Loader listen to installer output and print it

### DIFF
--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -313,6 +313,8 @@ export class WorkspaceLoader {
         return new Promise((resolve, reject) => {
             masterApi.subscribeEnvironmentOutput(this.workspace.id,
                 (message: any) => this.onEnvironmentOutput(message.text));
+            masterApi.subscribeInstallerOutput(this.workspace.id,
+                 (message: any) => this.onEnvironmentOutput(message.text));
             masterApi.subscribeWorkspaceStatus(this.workspace.id,
                 (message: any) => {
                     if (message.error) {

--- a/workspace-loader/src/json-rpc/che-json-rpc-master-api.ts
+++ b/workspace-loader/src/json-rpc/che-json-rpc-master-api.ts
@@ -16,7 +16,7 @@ import { ICommunicationClient, CODE_REQUEST_TIMEOUT, CommunicationClientEvent } 
 enum MasterChannels {
   ENVIRONMENT_OUTPUT = <any>'runtime/log',
   ENVIRONMENT_STATUS = <any>'machine/statusChanged',
-  WS_AGENT_OUTPUT = <any>'installer/log',
+  INSTALLER_OUTPUT = <any>'installer/log',
   WORKSPACE_STATUS = <any>'workspace/statusChanged'
 }
 const SUBSCRIBE: string = 'subscribe';
@@ -172,8 +172,8 @@ export class CheJsonRpcMasterApi {
    * @param workspaceId workspace's id
    * @param callback callback to process event
    */
-  subscribeWsAgentOutput(workspaceId: string, callback: Function): void {
-    this.subscribe(MasterChannels.WS_AGENT_OUTPUT, workspaceId, callback);
+  subscribeInstallerOutput(workspaceId: string, callback: Function): void {
+    this.subscribe(MasterChannels.INSTALLER_OUTPUT, workspaceId, callback);
   }
 
   /**
@@ -182,8 +182,8 @@ export class CheJsonRpcMasterApi {
    * @param workspaceId workspace's id
    * @param callback callback to process event
    */
-  unSubscribeWsAgentOutput(workspaceId: string, callback: Function): void {
-    this.unsubscribe(MasterChannels.WS_AGENT_OUTPUT, workspaceId, callback);
+  unSubscribeInstallerOutput(workspaceId: string, callback: Function): void {
+    this.unsubscribe(MasterChannels.INSTALLER_OUTPUT, workspaceId, callback);
   }
 
   /**

--- a/workspace-loader/test/test.spec.ts
+++ b/workspace-loader/test/test.spec.ts
@@ -261,6 +261,7 @@ describe('Workspace Loader', () => {
                 return Promise.resolve({
                     addListener: () => { },
                     subscribeEnvironmentOutput: () => { },
+                    subscribeInstallerOutput: () => { },
                     subscribeWorkspaceStatus: (workspaceId, callback) => {
                         statusChangeCallback = callback;
                     }
@@ -391,6 +392,7 @@ describe('Workspace Loader', () => {
                 return Promise.resolve({
                     addListener: () => { },
                     subscribeEnvironmentOutput: () => {},
+                    subscribeInstallerOutput: () => {},
                     subscribeWorkspaceStatus: () => {}
                 });
             });
@@ -467,6 +469,7 @@ describe('Workspace Loader', () => {
                 return Promise.resolve({
                     addListener: () => { },
                     subscribeEnvironmentOutput: () => { },
+                    subscribeInstallerOutput: () => { },
                     subscribeWorkspaceStatus: (workspaceId, callback) => {
                         statusChangeCallback = callback;
                     }


### PR DESCRIPTION
### What does this PR do?
Makes Workspace Loader listen to installer output and print it.
![screenshot_20181128_122048](https://user-images.githubusercontent.com/5887312/49145317-2cb2bf80-f308-11e8-887a-adfd84ec5325.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11572

#### Release Notes
N/A

#### Docs PR
N/A