### PR TITLE
Selenium: fix unstable selenium tests, add info about known issues

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ProjectExplorer.java
@@ -550,7 +550,8 @@ public class ProjectExplorer {
           waitItemIsSelected(path);
         },
         (EXPECTED_MESS_IN_CONSOLE_SEC + ELEMENT_TIMEOUT_SEC) * 2,
-        NoSuchElementException.class);
+        NoSuchElementException.class,
+        TimeoutException.class);
 
     seleniumWebDriverHelper.waitNoExceptions(
         () -> {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
@@ -133,6 +133,10 @@ public class TheiaIde {
     seleniumWebDriverHelper.waitInvisibility(By.xpath(notificationMessage), timeout);
   }
 
+  public void waitNotificationPanelClosed() {
+    seleniumWebDriverHelper.waitInvisibility(By.className("theia-Notification"));
+  }
+
   public void waitTheiaIde() {
     seleniumWebDriverHelper.waitVisibility(theiaIde, PREPARING_WS_TIMEOUT_SEC);
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -48,6 +48,8 @@ public class CreateAndDeleteProjectsTest {
   private static final String WORKSPACE = generate("workspace", 4);
   private static final String SECOND_WEB_JAVA_SPRING_PROJECT_NAME = WEB_JAVA_SPRING + "-1";
 
+  private String dashboardWindow;
+
   @Inject private Dashboard dashboard;
   @Inject private WorkspaceProjects workspaceProjects;
   @Inject private WorkspaceDetails workspaceDetails;
@@ -79,7 +81,7 @@ public class CreateAndDeleteProjectsTest {
   }
 
   @Test
-  public void createAndDeleteProjectTest() {
+  public void createProjectTest() {
     dashboard.waitDashboardToolbarTitle();
     dashboard.selectWorkspacesItemOnDashboard();
     workspaces.clickOnAddWorkspaceBtn();
@@ -107,7 +109,7 @@ public class CreateAndDeleteProjectsTest {
     testWorkspace = testWorkspaceProvider.getWorkspace(WORKSPACE, defaultTestUser);
 
     // switch to the IDE and wait for workspace is ready to use
-    String dashboardWindow = seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
+    dashboardWindow = seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     toastLoader.waitToastLoaderAndClickStartButton();
     ide.waitOpenedWorkspaceIsReadyToUse();
 
@@ -120,6 +122,10 @@ public class CreateAndDeleteProjectsTest {
     explorer.waitDefinedTypeOfFolder(CONSOLE_JAVA_SIMPLE, PROJECT_FOLDER);
     explorer.waitDefinedTypeOfFolder(WEB_JAVA_SPRING, PROJECT_FOLDER);
     notificationsPopupPanel.waitPopupPanelsAreClosed();
+  }
+
+  @Test
+  public void deleteProjectsFromDashboardTest() {
 
     // delete projects from workspace details page
     switchToWindow(dashboardWindow);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -124,10 +124,8 @@ public class CreateAndDeleteProjectsTest {
     notificationsPopupPanel.waitPopupPanelsAreClosed();
   }
 
-  @Test
+  @Test(priority = 1)
   public void deleteProjectsFromDashboardTest() {
-
-    // delete projects from workspace details page
     switchToWindow(dashboardWindow);
     dashboard.selectWorkspacesItemOnDashboard();
     workspaces.selectWorkspaceItemName(WORKSPACE);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
@@ -270,7 +270,7 @@ public class ContextMenuEditorTest {
     editor.closeFileByNameWithSaving("ModelAndView.class");
   }
 
-  @Test(priority = 6, alwaysRun = true)
+  @Test(priority = 6, alwaysRun = true, groups = UNDER_REPAIR)
   public void checkRefactoring() {
     final String editorTabName = "Test1";
     final String renamedEditorTabName = "Zclass";
@@ -295,7 +295,7 @@ public class ContextMenuEditorTest {
       editor.waitTabIsPresent(editorTabName);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11697");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11697");
     }
 
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/Test1.java");
@@ -311,7 +311,7 @@ public class ContextMenuEditorTest {
       editor.waitTabIsPresent(renamedEditorTabName);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11697");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11697");
     }
     editor.waitTextIntoEditor("public class Zclass");
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/Zclass.java");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/GolangFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/GolangFileEditingTest.java
@@ -210,7 +210,7 @@ public class GolangFileEditingTest {
       editor.waitTextElementsActiveLine("if k == 1");
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/10524");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11907");
     }
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/csharp/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/csharp/CSharpFileEditingTest.java
@@ -99,7 +99,7 @@ public class CSharpFileEditingTest {
     }
   }
 
-  public void checkCodeValidation() {
+  private void checkCodeValidation() {
     editor.goToCursorPositionVisible(24, 12);
     for (int i = 0; i < 9; i++) {
       editor.typeTextIntoEditor(BACK_SPACE.toString());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/GenericsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/GenericsTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.refactor.types;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
@@ -44,6 +45,7 @@ import org.testng.annotations.Test;
  *
  * @author Musienko Maxim
  */
+@Test(groups = UNDER_REPAIR)
 public class GenericsTest {
   private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
@@ -104,7 +106,7 @@ public class GenericsTest {
       assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11779");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11779");
     }
 
     editor.waitTextIntoEditor(contentFromOutB);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.refactor.types;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
@@ -47,6 +48,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = UNDER_REPAIR)
 public class RenameTypeTest {
   private static final Logger LOG = LoggerFactory.getLogger(RenameTypeTest.class);
   private static final String PROJECT_NAME = generate("project", 4);
@@ -200,7 +202,7 @@ public class RenameTypeTest {
       editor.waitTextIntoEditor(contentFromOutB);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11779");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11779");
     }
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestAnnotationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestAnnotationsTest.java
@@ -16,6 +16,7 @@ import static java.nio.charset.Charset.forName;
 import static java.nio.file.Files.readAllLines;
 import static java.nio.file.Paths.get;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
@@ -41,6 +42,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = UNDER_REPAIR)
 public class TestAnnotationsTest {
   private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
@@ -102,7 +104,7 @@ public class TestAnnotationsTest {
       editor.waitTextIntoEditor(contentFromInB);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11779");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11779");
     }
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestEnumerationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestEnumerationsTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.refactor.types;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
@@ -40,6 +41,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = UNDER_REPAIR)
 public class TestEnumerationsTest {
   private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
@@ -97,7 +99,7 @@ public class TestEnumerationsTest {
       assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11779");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11779");
     }
 
     editor.waitTextIntoEditor(contentFromOutB);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCamelStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCamelStackTest.java
@@ -27,6 +27,7 @@ import org.eclipse.che.selenium.languageserver.ApacheCamelFileEditingTest;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
+import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
@@ -47,6 +48,7 @@ public class CreateWorkspaceFromCamelStackTest {
   @Inject private Dashboard dashboard;
   @Inject private DefaultTestUser defaultTestUser;
   @Inject private CreateWorkspaceHelper createWorkspaceHelper;
+  @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private CodenvyEditor editor;
@@ -88,6 +90,7 @@ public class CreateWorkspaceFromCamelStackTest {
     Workspace ws = workspaceServiceClient.getByName(WORKSPACE_NAME, defaultTestUser.getName());
     testProjectServiceClient.importProject(
         ws.getId(), Paths.get(resource.toURI()), PROJECT_NAME, CONSOLE_JAVA_SIMPLE);
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
 
     projectExplorer.waitAndSelectItem(PROJECT_NAME);
     projectExplorer.openItemByPath(PROJECT_NAME);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaDockerStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaDockerStackTest.java
@@ -69,6 +69,7 @@ public class CreateWorkspaceFromJavaTheiaDockerStackTest {
     theiaIde.waitTheiaIde();
     theiaIde.waitTheiaIdeTopPanel();
     theiaIde.waitLoaderInvisibility();
+    theiaIde.waitNotificationPanelClosed();
 
     // run 'About' command from 'Help' menu
     theiaIde.runMenuCommand("Help", "About");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaOpenshiftStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaOpenshiftStackTest.java
@@ -69,6 +69,7 @@ public class CreateWorkspaceFromJavaTheiaOpenshiftStackTest {
     theiaIde.waitTheiaIde();
     theiaIde.waitTheiaIdeTopPanel();
     theiaIde.waitLoaderInvisibility();
+    theiaIde.waitNotificationPanelClosed();
 
     // run 'About' command from 'Help' menu
     theiaIde.runMenuCommand("Help", "About");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsCons
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.BUILD_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.RUN_GOAL;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.NODE;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -32,6 +33,7 @@ import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -139,7 +141,12 @@ public class CreateWorkspaceFromNodeStackTest {
     seleniumWebDriver.navigate().refresh();
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     ide.waitOpenedWorkspaceIsReadyToUse();
-    consoles.waitPreviewUrlIsPresent();
+
+    try {
+      consoles.waitPreviewUrlIsPresent();
+    } catch (TimeoutException ex) {
+      fail("Known random failure https://github.com/eclipse/che/issues/11419", ex);
+    }
 
     consoles.checkWebElementVisibilityAtPreviewPage(textOnPreviewPage);
 


### PR DESCRIPTION
### What does this PR do?
This PR:
- add info about known #11419 issue to ```CreateWorkspaceFromNodeStackTest``` test
- change ```CreateAndDeleteProjectsTest``` selenium test to check project deleting in separate method
- change #11779 issues status from random to permanent failure in selenium tests from ```refactor.types``` package 
- change #11697 issue status from random to permanent failure in ```ContextMenuEditorTest``` selenium test
- change info about known issue in ```GolangFileEditingTest``` test from #10524 to #11907.
- check that all notification are closed after workspace is started in ```CreateWorkspaceFromJavaTheiaDockerStackTest``` test

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11419