### PR TITLE
Fix MetricsServer deployment

### DIFF
--- a/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/MetricsServer.java
+++ b/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/MetricsServer.java
@@ -15,6 +15,7 @@ import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.exporter.HTTPServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -39,6 +40,7 @@ public class MetricsServer {
     this.metricsPort = metricsPort;
   }
 
+  @PostConstruct
   public void startServer() throws IOException {
     this.server = new HTTPServer(new InetSocketAddress(metricsPort), collectorRegistry, true);
     LOG.info("Metrics server started at port {} successfully ", metricsPort);


### PR DESCRIPTION
### What does this PR do?
In my "last minute commit" I've moved inject annotation from method to constructor. And looks like forget or made a mistake during testing. This PR fixes MetricsServer deployment
![15 18 50](https://user-images.githubusercontent.com/1614429/49224434-19782080-f3ea-11e8-85b2-731349c63dc8.png)
![15 18 43](https://user-images.githubusercontent.com/1614429/49224435-1a10b700-f3ea-11e8-8cc1-93ff83b2e917.png)


### What issues does this PR fix or reference?

n/a


#### Release Notes

n/a

#### Docs PR

n/a