### PR TITLE
CHE-11697: Remove redundant synchronize call

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorFileStatusNotificationOperation.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorFileStatusNotificationOperation.java
@@ -13,7 +13,6 @@ package org.eclipse.che.ide.editor;
 
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.NOT_EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.SUCCESS;
-import static org.eclipse.che.ide.api.resources.ResourceDelta.REMOVED;
 
 import com.google.web.bindery.event.shared.EventBus;
 import java.util.List;
@@ -30,7 +29,6 @@ import org.eclipse.che.ide.api.editor.EditorAgent;
 import org.eclipse.che.ide.api.editor.EditorPartPresenter;
 import org.eclipse.che.ide.api.editor.events.FileContentUpdateEvent;
 import org.eclipse.che.ide.api.notification.NotificationManager;
-import org.eclipse.che.ide.api.resources.ExternalResourceDelta;
 import org.eclipse.che.ide.resource.Path;
 import org.eclipse.che.ide.util.loging.Log;
 
@@ -111,12 +109,10 @@ public class EditorFileStatusNotificationOperation
         {
           Log.debug(getClass(), "Received removed file event status: " + stringPath);
 
-          final Path path = Path.valueOf(stringPath);
-          appContext.getWorkspaceRoot().synchronize(new ExternalResourceDelta(path, path, REMOVED));
           if (notificationManager != null && !deletedFilesController.remove(stringPath)) {
             notificationManager.notify(
                 "External operation", "File '" + name + "' is removed", SUCCESS, NOT_EMERGE_MODE);
-            closeOpenedEditor(path);
+            closeOpenedEditor(Path.valueOf(stringPath));
           }
 
           break;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Removes redundant `synchronize()` call.
One is already called from `ProjectTreeChangeHandler`:
https://github.com/eclipse/che/blob/0ec95375e0f4e9c3452b49a2439a5f6000b6998e/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/resources/ProjectTreeChangeHandler.java#L253

### What issues does this PR fix or reference?
fixes #11697

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Fixes bug when editor's tab closes after refactoring on slow network connection.

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A