### PR TITLE
Selenium: remove info about known #11779 and #11697 issues

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
@@ -270,7 +270,7 @@ public class ContextMenuEditorTest {
     editor.closeFileByNameWithSaving("ModelAndView.class");
   }
 
-  @Test(priority = 6, alwaysRun = true, groups = UNDER_REPAIR)
+  @Test(priority = 6, alwaysRun = true)
   public void checkRefactoring() {
     final String editorTabName = "Test1";
     final String renamedEditorTabName = "Zclass";
@@ -291,12 +291,7 @@ public class ContextMenuEditorTest {
     refactor.clickOkButtonRefactorForm();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
-    try {
-      editor.waitTabIsPresent(editorTabName);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/11697");
-    }
+    editor.waitTabIsPresent(editorTabName);
 
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/Test1.java");
     editor.goToCursorPositionVisible(14, 15);
@@ -307,12 +302,7 @@ public class ContextMenuEditorTest {
     editor.typeTextIntoEditor(renamedEditorTabName);
     editor.typeTextIntoEditor(Keys.ENTER.toString());
     loader.waitOnClosed();
-    try {
-      editor.waitTabIsPresent(renamedEditorTabName);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/11697");
-    }
+    editor.waitTabIsPresent(renamedEditorTabName);
     editor.waitTextIntoEditor("public class Zclass");
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/Zclass.java");
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/GenericsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/GenericsTest.java
@@ -12,12 +12,10 @@
 package org.eclipse.che.selenium.refactor.types;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -36,7 +34,6 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -45,7 +42,6 @@ import org.testng.annotations.Test;
  *
  * @author Musienko Maxim
  */
-@Test(groups = UNDER_REPAIR)
 public class GenericsTest {
   private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
@@ -101,14 +97,7 @@ public class GenericsTest {
         "Found potential matches. Please review changes on the preview page.");
     askDialog.waitFormToClose();
     projectExplorer.waitItem(pathToCurrentPackage + "/B.java");
-
-    try {
-      assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/11779");
-    }
-
+    assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
     editor.waitTextIntoEditor(contentFromOutB);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -12,11 +12,9 @@
 package org.eclipse.che.selenium.refactor.types;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.io.IOException;
@@ -38,7 +36,6 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriverException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +45,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
-@Test(groups = UNDER_REPAIR)
 public class RenameTypeTest {
   private static final Logger LOG = LoggerFactory.getLogger(RenameTypeTest.class);
   private static final String PROJECT_NAME = generate("project", 4);
@@ -197,12 +193,6 @@ public class RenameTypeTest {
     askDialog.waitFormToClose();
     refactorPanel.waitRefactorPreviewFormIsClosed();
     projectExplorer.waitItem(pathToCurrentPackage + "/B.java", 6);
-
-    try {
-      editor.waitTextIntoEditor(contentFromOutB);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/11779");
-    }
+    editor.waitTextIntoEditor(contentFromOutB);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestAnnotationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestAnnotationsTest.java
@@ -16,11 +16,9 @@ import static java.nio.charset.Charset.forName;
 import static java.nio.file.Files.readAllLines;
 import static java.nio.file.Paths.get;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
-import static org.testng.Assert.fail;
 
 import com.google.common.base.Joiner;
 import com.google.inject.Inject;
@@ -37,12 +35,10 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
-@Test(groups = UNDER_REPAIR)
 public class TestAnnotationsTest {
   private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
@@ -99,13 +95,7 @@ public class TestAnnotationsTest {
     askDialog.clickOkBtn();
     askDialog.waitFormToClose();
     projectExplorer.waitItem(pathToCurrentPackage + "/B.java");
-
-    try {
-      editor.waitTextIntoEditor(contentFromInB);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/11779");
-    }
+    editor.waitTextIntoEditor(contentFromInB);
   }
 
   private void setFieldsForTest(String nameCurrentTest) throws Exception {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestEnumerationsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/TestEnumerationsTest.java
@@ -12,12 +12,10 @@
 package org.eclipse.che.selenium.refactor.types;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -36,12 +34,10 @@ import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
-@Test(groups = UNDER_REPAIR)
 public class TestEnumerationsTest {
   private static final String PROJECT_NAME = generate("project", 4);
   private static final String PATH_TO_PACKAGE_IN_CHE_PREFIX =
@@ -94,14 +90,7 @@ public class TestEnumerationsTest {
     askDialog.clickOkBtn();
     askDialog.waitFormToClose();
     projectExplorer.waitItem(pathToCurrentPackage + "/B.java");
-
-    try {
-      assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/11779");
-    }
-
+    assertEquals(editor.getVisibleTextFromEditor(), contentFromOutB);
     editor.waitTextIntoEditor(contentFromOutB);
   }
 


### PR DESCRIPTION
### What does this PR do?
This PR removes info about known #11697 and #11779 issues in selenium tests from ```refactor``` package. These issues were resolved by https://github.com/eclipse/che/pull/12073.

