### PR TITLE
Temporary disable refactoring rename operation in go extension

### DIFF
--- a/plugins/plugin-golang/che-plugin-golang-lang-ide/pom.xml
+++ b/plugins/plugin-golang/che-plugin-golang-lang-ide/pom.xml
@@ -33,6 +33,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-gwt</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-ide-api</artifactId>
         </dependency>
         <dependency>

--- a/plugins/plugin-golang/che-plugin-golang-lang-ide/pom.xml
+++ b/plugins/plugin-golang/che-plugin-golang-lang-ide/pom.xml
@@ -45,6 +45,14 @@
             <classifier>sources</classifier>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.plugin</groupId>
+            <artifactId>che-plugin-languageserver-ide</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.lsp4j</groupId>
+            <artifactId>org.eclipse.lsp4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.vectomatic</groupId>
             <artifactId>lib-gwt-svg</artifactId>
         </dependency>

--- a/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
+++ b/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
@@ -12,9 +12,15 @@
 package org.eclipse.che.plugin.golang.ide;
 
 import com.google.inject.Inject;
+import com.google.web.bindery.event.shared.EventBus;
+import org.eclipse.che.ide.api.editor.editorconfig.TextEditorConfiguration;
+import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.extension.Extension;
 import org.eclipse.che.ide.api.icon.Icon;
 import org.eclipse.che.ide.api.icon.IconRegistry;
+import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
+import org.eclipse.che.ide.api.parts.PartPresenter;
+import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorConfiguration;
 
 /** @author Eugene Ivantsov */
 @Extension(title = "Golang")
@@ -26,5 +32,19 @@ public class GolangExtension {
   private void prepareActions(GolangResources resources, IconRegistry iconRegistry) {
     iconRegistry.registerIcon(
         new Icon(GOLANG_CATEGORY + ".samples.category.icon", resources.golangIcon()));
+  }
+
+  // TODO(vzhukovskyi): fix for https://github.com/eclipse/che/issues/11907, has to be removed when issue is resolved
+  @Inject
+  private void temporaryDisableRenameAction(EventBus eventBus) {
+    eventBus.addHandler(ActivePartChangedEvent.TYPE, event -> {
+      PartPresenter activePart = event.getActivePart();
+      if (activePart instanceof TextEditor) {
+        TextEditorConfiguration configuration = ((TextEditor) activePart).getConfiguration();
+        if (configuration instanceof LanguageServerEditorConfiguration) {
+          ((LanguageServerEditorConfiguration) configuration).getServerCapabilities().setRenameProvider(false);
+        }
+      }
+    });
   }
 }

--- a/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
+++ b/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
@@ -45,6 +45,16 @@ public class GolangExtension {
             return;
           }
 
+          if (!"go"
+              .equals(
+                  ((TextEditor) activePart)
+                      .getEditorInput()
+                      .getFile()
+                      .getLocation()
+                      .getFileExtension())) {
+            return;
+          }
+
           TextEditorConfiguration configuration = ((TextEditor) activePart).getConfiguration();
           if (!(configuration instanceof LanguageServerEditorConfiguration)) {
             return;

--- a/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
+++ b/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
@@ -34,17 +34,25 @@ public class GolangExtension {
         new Icon(GOLANG_CATEGORY + ".samples.category.icon", resources.golangIcon()));
   }
 
-  // TODO(vzhukovskyi): fix for https://github.com/eclipse/che/issues/11907, has to be removed when issue is resolved
+  // TODO(vzhukovskyi): has to be removed when https://github.com/eclipse/che/issues/11907 resolved
   @Inject
   private void temporaryDisableRenameAction(EventBus eventBus) {
-    eventBus.addHandler(ActivePartChangedEvent.TYPE, event -> {
-      PartPresenter activePart = event.getActivePart();
-      if (activePart instanceof TextEditor) {
-        TextEditorConfiguration configuration = ((TextEditor) activePart).getConfiguration();
-        if (configuration instanceof LanguageServerEditorConfiguration) {
-          ((LanguageServerEditorConfiguration) configuration).getServerCapabilities().setRenameProvider(false);
-        }
-      }
-    });
+    eventBus.addHandler(
+        ActivePartChangedEvent.TYPE,
+        event -> {
+          PartPresenter activePart = event.getActivePart();
+          if (!(activePart instanceof TextEditor)) {
+            return;
+          }
+
+          TextEditorConfiguration configuration = ((TextEditor) activePart).getConfiguration();
+          if (!(configuration instanceof LanguageServerEditorConfiguration)) {
+            return;
+          }
+
+          ((LanguageServerEditorConfiguration) configuration)
+              .getServerCapabilities()
+              .setRenameProvider(false);
+        });
   }
 }

--- a/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
+++ b/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.plugin.golang.ide;
 
+import static org.eclipse.che.plugin.golang.shared.Constants.GOLANG_FILE_EXT;
+
 import com.google.inject.Inject;
 import com.google.web.bindery.event.shared.EventBus;
 import org.eclipse.che.ide.api.editor.editorconfig.TextEditorConfiguration;
@@ -21,8 +23,6 @@ import org.eclipse.che.ide.api.icon.IconRegistry;
 import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorConfiguration;
-
-import static org.eclipse.che.plugin.golang.shared.Constants.GOLANG_FILE_EXT;
 
 /** @author Eugene Ivantsov */
 @Extension(title = "Golang")
@@ -47,13 +47,12 @@ public class GolangExtension {
             return;
           }
 
-          if (!GOLANG_FILE_EXT
-              .equals(
-                  ((TextEditor) activePart)
-                      .getEditorInput()
-                      .getFile()
-                      .getLocation()
-                      .getFileExtension())) {
+          if (!GOLANG_FILE_EXT.equals(
+              ((TextEditor) activePart)
+                  .getEditorInput()
+                  .getFile()
+                  .getLocation()
+                  .getFileExtension())) {
             return;
           }
 

--- a/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
+++ b/plugins/plugin-golang/che-plugin-golang-lang-ide/src/main/java/org/eclipse/che/plugin/golang/ide/GolangExtension.java
@@ -22,6 +22,8 @@ import org.eclipse.che.ide.api.parts.ActivePartChangedEvent;
 import org.eclipse.che.ide.api.parts.PartPresenter;
 import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorConfiguration;
 
+import static org.eclipse.che.plugin.golang.shared.Constants.GOLANG_FILE_EXT;
+
 /** @author Eugene Ivantsov */
 @Extension(title = "Golang")
 public class GolangExtension {
@@ -45,7 +47,7 @@ public class GolangExtension {
             return;
           }
 
-          if (!"go"
+          if (!GOLANG_FILE_EXT
               .equals(
                   ((TextEditor) activePart)
                       .getEditorInput()


### PR DESCRIPTION
### What does this PR do?
This changes proposal according to https://github.com/eclipse/che/issues/11907 provide temporary fix that checks opened file in editor and if the current file has .go extension, then refactoring feature _rename_ will be unavailable. This method has to be removed when refactoring rename operation will be resolved by library (go) provider.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#11907 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A