### PR TITLE
On workspace creation - open IDE by default, allow RAM < 0.5

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.controller.ts
@@ -121,6 +121,11 @@ export class CreateWorkspaceController {
   private pluginRegistry: string;
 
   /**
+   * Property for displaying or hidding the plugins list.
+   */
+  private displayPlugins: boolean;
+
+  /**
    * Default constructor that is using resource injection
    */
   constructor($mdDialog: ng.material.IDialogService,
@@ -159,25 +164,26 @@ export class CreateWorkspaceController {
     // when stacks selector is rendered
     // and default stack is selected
     this.hideLoader = false;
+    this.displayPlugins = false;
 
     // header toolbar
     // dropdown button config
     this.headerCreateButtonConfig = {
       mainAction: {
-        title: 'Create',
-        type: 'button',
-        action: () => {
-          this.createWorkspace().then((workspace: che.IWorkspace) => {
-            this.createWorkspaceSvc.redirectToDetails(workspace);
-          });
-        }
-      },
-      otherActions: [{
-        title: 'Open in IDE',
+        title: 'Create & Open',
         type: 'button',
         action: () => {
           this.createWorkspace().then((workspace: che.IWorkspace) => {
             this.createWorkspaceSvc.redirectToIDE(workspace);
+          });
+        }
+      },
+      otherActions: [{
+        title: 'Create & Proceed Editing',
+        type: 'button',
+        action: () => {
+          this.createWorkspace().then((workspace: che.IWorkspace) => {
+            this.createWorkspaceSvc.redirectToDetails(workspace);
           });
         },
         orderNumber: 1
@@ -198,6 +204,7 @@ export class CreateWorkspaceController {
 
     this.stack = this.stackSelectorSvc.getStackById(stackId);
     this.workspaceConfig = angular.copy(this.stack.workspaceConfig);
+    this.displayPlugins = this.isPluginDefined();
 
     if (!this.stack.workspaceConfig || !this.stack.workspaceConfig.defaultEnv) {
       this.memoryByMachine = {};
@@ -392,6 +399,23 @@ export class CreateWorkspaceController {
         this.createWorkspaceSvc.redirectToDetails(workspace);
       });
     });
+  }
+
+  /**
+   * Creates a workspace and redirects to the IDE.
+   */
+  createWorkspaceAndOpenIDE(): void {
+    this.createWorkspace().then((workspace: che.IWorkspace) => {
+      this.createWorkspaceSvc.redirectToIDE(workspace);
+    });
+  }
+
+  isPluginDefined(): boolean {
+    if (this.workspaceConfig && this.workspaceConfig.attributes) {
+      return Object.keys(this.workspaceConfig.attributes).indexOf('editor') >= 0 || Object.keys(this.workspaceConfig.attributes).indexOf('plugins') >= 0;
+    }
+
+    return false;
   }
 
 }

--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.html
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.html
@@ -76,7 +76,7 @@
     <!-- Plugin selector -->
     <che-label-container che-label-name="Plugins"
                          che-label-description="Choose plugins for your workspace."
-                         ng-if="createWorkspaceController.pluginRegistry" >
+                         ng-if="createWorkspaceController.pluginRegistry && createWorkspaceController.displayPlugins" >
       <workspace-plugins workspace-config="createWorkspaceController.workspaceConfig"
                          plugin-registry-location="createWorkspaceController.pluginRegistry">
       </workspace-plugins>
@@ -85,8 +85,8 @@
     <che-label-container>
       <che-button-save-flat class="create-workspace-footer-button"
                             name="saveButton"
-                            che-button-title="Create"
-                            ng-click="createWorkspaceController.createWorkspaceAndShowDialog($event)"
+                            che-button-title="Create & Open"
+                            ng-click="createWorkspaceController.createWorkspaceAndOpenIDE()"
                             ng-disabled="createWorkspaceController.isCreateButtonDisabled()"></che-button-save-flat>
     </che-label-container>
 

--- a/dashboard/src/app/workspaces/create-workspace/ram-settings/ram-settings-machine-item/ram-settings-machine-item.html
+++ b/dashboard/src/app/workspaces/create-workspace/ram-settings/ram-settings-machine-item/ram-settings-machine-item.html
@@ -32,9 +32,9 @@
         <ng-form name="ramAmountForm">
           <che-number-spinner che-form="ramAmountForm"
                               che-name="memory"
-                              che-step="0.5"
+                              che-step="0.1"
                               che-tofixed="1"
-                              che-minvalue="0.5"
+                              che-minvalue="0.1"
                               che-maxvalue="100"
                               che-unit="GB"
                               id="machine-{{ramSettingsMachineItemController.machineName}}-ram"

--- a/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/stack-selector/stack-selector.controller.ts
@@ -248,12 +248,8 @@ export class StackSelectorController {
   buildStacksListsByScope(): void {
     const scopes = StackSelectorScope.values();
 
-    scopes.forEach((scope: StackSelectorScope) => {
-      this.stacksByScope[scope] = this.$filter('stackScopeFilter')(this.stacks, scope, this.stackMachines);
-    });
-
     // for quickstart do not show stacks based on unsupported recipe types
-    this.stacksByScope[StackSelectorScope.QUICK_START] = this.stacksByScope[StackSelectorScope.QUICK_START].filter((stack: che.IStack) => {
+    this.stacks = this.stacks.filter((stack: che.IStack) => {
       if (!stack.workspaceConfig.defaultEnv) {
         return this.supportedRecipeTypes.indexOf(CheRecipeTypes.NOENVIRONMENT) !== -1;
       }
@@ -261,7 +257,13 @@ export class StackSelectorController {
       const defaultEnvName = stack.workspaceConfig.defaultEnv,
         defaultEnv = stack.workspaceConfig.environments[defaultEnvName],
         recipeType = defaultEnv.recipe.type;
+
       return this.supportedRecipeTypes.indexOf(recipeType) !== -1;
+    });
+
+
+    scopes.forEach((scope: StackSelectorScope) => {
+      this.stacksByScope[scope] = this.$filter('stackScopeFilter')(this.stacks, scope, this.stackMachines);
     });
   }
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/machine-item/workspace-machine-item.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/machine-item/workspace-machine-item.html
@@ -28,9 +28,9 @@
           <ng-form name="ramAmountForm">
             <che-number-spinner che-form="ramAmountForm"
                                 che-name="memory"
-                                che-step="0.5"
+                                che-step="0.1"
                                 che-tofixed="1"
-                                che-minvalue="0.5"
+                                che-minvalue="0.1"
                                 che-maxvalue="100"
                                 che-unit="GB"
                                 id="machine-{{machine.name}}-ram"

--- a/dashboard/src/app/workspaces/workspace-ram-slider/che-workspace-ram-allocation-slider.html
+++ b/dashboard/src/app/workspaces/workspace-ram-slider/che-workspace-ram-allocation-slider.html
@@ -15,7 +15,7 @@
     </div>
     <div layout="column" layout-align="center start" class="slider-input">
       <md-input-container>
-        <input type="number" min="0.5" max="100" step="0.5"
+        <input type="number" min="0.1" max="100" step="0.1"
                ng-model="cheWorkspaceRamAllocationSliderController.inputVal"
                aria-label="Amount of RAM"
                ng-change="cheWorkspaceRamAllocationSliderController.onChange()"/>

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -14,13 +14,11 @@ package org.eclipse.che.selenium.pageobject.dashboard;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.ALL_BUTTON_ID;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.BOTTOM_CREATE_BUTTON_XPATH;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.CREATE_STACK_DIALOG_FORM_XPATH;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.DECREMENT_MEMORY_BUTTON;
-import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.EDIT_WORKSPACE_DIALOG_BUTTON;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.ERROR_MESSAGE;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.FILTERS_INPUT_TAGS_XPATH;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.FILTERS_INPUT_TAG_XPATH_TEMPLATE;
@@ -28,15 +26,14 @@ import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locator
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.FILTER_SUGGESTION_BUTTON;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.INCREMENT_MEMORY_BUTTON;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.MULTI_MACHINE_BUTTON_ID;
-import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.OPEN_IN_IDE_DIALOG_BUTTON;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.ORGANIZATIONS_LIST_ID;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.QUICK_START_BUTTON_ID;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.SINGLE_MACHINE_BUTTON_ID;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.STACK_ROW_XPATH;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.TOOLBAR_TITLE_ID;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.TOP_CREATE_BUTTON_XPATH;
-import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.WORKSPACE_CREATED_DIALOG;
-import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.WORKSPACE_CREATED_DIALOG_CLOSE_BUTTON_XPATH;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.TOP_DROPDOWN_BUTTON_XPATH;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Locators.TOP_EDIT_BUTTON_XPATH;
 import static org.openqa.selenium.Keys.BACK_SPACE;
 
 import com.google.inject.Inject;
@@ -112,11 +109,6 @@ public class NewWorkspace {
     String INCREMENT_MEMORY_BUTTON =
         "//*[@id='machine-%s-ram']//button[@aria-label='Increment memory']";
     String MACHINE_RAM_VALUE = "//*[@id='machine-%s-ram']//input";
-    String WORKSPACE_CREATED_DIALOG = "//md-dialog/che-popup[@title='Workspace Is Created']";
-    String WORKSPACE_CREATED_DIALOG_CLOSE_BUTTON_XPATH =
-        "//md-dialog/che-popup[@title='Workspace Is Created']//i";
-    String EDIT_WORKSPACE_DIALOG_BUTTON = "//che-button-primary//span[text()='Edit']";
-    String OPEN_IN_IDE_DIALOG_BUTTON = "//che-button-default//span[text()='Open In IDE']";
     String ORGANIZATIONS_LIST_ID = "namespace-selector";
     String ORGANIZATION_ITEM = "//md-menu-item[text()='%s']";
     String FILTERS_INPUT_TAGS_XPATH = "//div[@class='md-chip-content']";
@@ -126,6 +118,8 @@ public class NewWorkspace {
 
     // buttons
     String TOP_CREATE_BUTTON_XPATH = "//button[@name='split-button']";
+    String TOP_DROPDOWN_BUTTON_XPATH = "//button[@name='dropdown-toggle']";
+    String TOP_EDIT_BUTTON_XPATH = "//span[text()='Create & Proceed Editing']";
     String BOTTOM_CREATE_BUTTON_XPATH = "//che-button-save-flat/button[@name='saveButton']";
     String ALL_BUTTON_ID = "all-stacks-button";
     String QUICK_START_BUTTON_ID = "quick-start-button";
@@ -213,6 +207,15 @@ public class NewWorkspace {
 
   @FindBy(xpath = BOTTOM_CREATE_BUTTON_XPATH)
   WebElement bottomCreateWorkspaceButton;
+
+  @FindBy(xpath = TOP_CREATE_BUTTON_XPATH)
+  WebElement topCreateWorkspaceButton;
+
+  @FindBy(xpath = TOP_DROPDOWN_BUTTON_XPATH)
+  WebElement topDropdownButton;
+
+  @FindBy(xpath = TOP_EDIT_BUTTON_XPATH)
+  WebElement topEditWorkspaceButton;
 
   @FindBy(xpath = Locators.SEARCH_INPUT)
   WebElement searchInput;
@@ -560,40 +563,15 @@ public class NewWorkspace {
     seleniumWebDriverHelper.waitAndClick(selectMultiMachineStacksTab);
   }
 
-  public void waitWorkspaceCreatedDialogIsVisible() {
-    testWebElementRenderChecker.waitElementIsRendered(
-        By.xpath(WORKSPACE_CREATED_DIALOG), ELEMENT_TIMEOUT_SEC);
-  }
-
-  public void closeWorkspaceCreatedDialog() {
-    seleniumWebDriverHelper.waitAndClick(By.xpath(WORKSPACE_CREATED_DIALOG_CLOSE_BUTTON_XPATH));
-  }
-
-  public void waitWorkspaceCreatedDialogDisappearance() {
-    seleniumWebDriverHelper.waitInvisibility(
-        By.xpath(WORKSPACE_CREATED_DIALOG), ELEMENT_TIMEOUT_SEC);
-  }
-
-  public void clickOnEditWorkspaceButton() {
-    seleniumWebDriverHelper.waitAndClick(
-        By.xpath(EDIT_WORKSPACE_DIALOG_BUTTON), ELEMENT_TIMEOUT_SEC);
-  }
-
-  public void clickOnOpenInIDEButton() {
-    seleniumWebDriverHelper.waitAndClick(By.xpath(OPEN_IN_IDE_DIALOG_BUTTON), ELEMENT_TIMEOUT_SEC);
-  }
-
   public void clickOnCreateButtonAndOpenInIDE() {
     seleniumWebDriverHelper.waitAndClick(bottomCreateWorkspaceButton);
-    waitWorkspaceCreatedDialogIsVisible();
-    clickOnOpenInIDEButton();
   }
 
   public void clickOnCreateButtonAndEditWorkspace() {
-    waitBottomCreateWorkspaceButtonEnabled();
-    seleniumWebDriverHelper.waitAndClick(bottomCreateWorkspaceButton);
-    waitWorkspaceCreatedDialogIsVisible();
-    clickOnEditWorkspaceButton();
+    waitTopCreateButton();
+
+    seleniumWebDriverHelper.waitAndClick(topDropdownButton);
+    seleniumWebDriverHelper.waitAndClick(topEditWorkspaceButton);
   }
 
   public void clickOnBottomCreateButton() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateWorkspaceTest.java
@@ -12,8 +12,11 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.BLANK;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.CHE_7_PREVIEW;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_MYSQL;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_MYSQL_CENTOS;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_MYSQL_THEIA_ON_KUBERNETES;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.WEB_JAVA_SPRING;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -21,6 +24,7 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.selenium.core.TestGroup;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
@@ -87,8 +91,8 @@ public class CreateWorkspaceTest {
     newWorkspace.waitBottomCreateWorkspaceButtonEnabled();
   }
 
-  @Test
-  public void checkMachines() {
+  @Test(groups = TestGroup.DOCKER)
+  public void checkMachinesDocker() {
     String machineName = "dev-machine";
 
     // change the RAM number by the increment and decrement buttons
@@ -97,33 +101,68 @@ public class CreateWorkspaceTest {
     assertTrue(newWorkspace.isMachineExists(machineName));
     assertEquals(newWorkspace.getRAM(machineName), 2.0);
     newWorkspace.clickOnIncrementMemoryButton(machineName);
-    assertEquals(newWorkspace.getRAM(machineName), 2.5);
+    assertEquals(newWorkspace.getRAM(machineName), 2.1);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
-    assertEquals(newWorkspace.getRAM(machineName), 1.0);
+    assertEquals(newWorkspace.getRAM(machineName), 1.8);
 
     // type number of memory in the RAM field
     newWorkspace.setMachineRAM(machineName, 5.0);
     assertEquals(newWorkspace.getRAM(machineName), 5.0);
 
     // check the RAM section of the Java-MySql stack(with two machines)
-    newWorkspace.selectStack(JAVA_MYSQL);
+    newWorkspace.selectStack(JAVA_MYSQL_CENTOS);
     assertTrue(newWorkspace.isMachineExists("db"));
     assertTrue(newWorkspace.isMachineExists(machineName));
     newWorkspace.clickOnDecrementMemoryButton(machineName);
     newWorkspace.clickOnDecrementMemoryButton("db");
-    assertEquals(newWorkspace.getRAM(machineName), 1.5);
-    assertEquals(newWorkspace.getRAM("db"), 0.5);
+    assertEquals(newWorkspace.getRAM(machineName), 1.9);
+    assertEquals(newWorkspace.getRAM("db"), 0.9);
     newWorkspace.clickOnDecrementMemoryButton("db");
-    assertEquals(newWorkspace.getRAM("db"), 0.5);
+    assertEquals(newWorkspace.getRAM("db"), 0.8);
     newWorkspace.setMachineRAM(machineName, 100.0);
     newWorkspace.clickOnIncrementMemoryButton(machineName);
     assertEquals(newWorkspace.getRAM(machineName), 100.0);
   }
 
-  @Test
-  public void checkFiltersStacksFeature() {
+  @Test(groups = {TestGroup.OPENSHIFT})
+  public void checkMachinesOpenshift() {
+    String machineName = "dev-machine";
+
+    // change the RAM number by the increment and decrement buttons
+    newWorkspace.clickOnAllStacksTab();
+    newWorkspace.selectStack(JAVA);
+    assertTrue(newWorkspace.isMachineExists(machineName));
+    assertEquals(newWorkspace.getRAM(machineName), 2.0);
+    newWorkspace.clickOnIncrementMemoryButton(machineName);
+    assertEquals(newWorkspace.getRAM(machineName), 2.1);
+    newWorkspace.clickOnDecrementMemoryButton(machineName);
+    newWorkspace.clickOnDecrementMemoryButton(machineName);
+    newWorkspace.clickOnDecrementMemoryButton(machineName);
+    assertEquals(newWorkspace.getRAM(machineName), 1.8);
+
+    // type number of memory in the RAM field
+    newWorkspace.setMachineRAM(machineName, 5.0);
+    assertEquals(newWorkspace.getRAM(machineName), 5.0);
+
+    // check the RAM section of 'MySQL with Theia IDE on Kubernetes' stack(with two machines)
+    newWorkspace.selectStack(JAVA_MYSQL_THEIA_ON_KUBERNETES);
+    assertTrue(newWorkspace.isMachineExists("web/mysql"));
+    assertTrue(newWorkspace.isMachineExists("web/dev"));
+    newWorkspace.clickOnDecrementMemoryButton("web/dev");
+    newWorkspace.clickOnDecrementMemoryButton("web/mysql");
+    assertEquals(newWorkspace.getRAM("web/dev"), 0.4);
+    assertEquals(newWorkspace.getRAM("web/mysql"), 0.2);
+    newWorkspace.clickOnDecrementMemoryButton("web/mysql");
+    assertEquals(newWorkspace.getRAM("web/mysql"), 0.1);
+    newWorkspace.setMachineRAM("web/dev", 100.0);
+    newWorkspace.clickOnIncrementMemoryButton("web/dev");
+    assertEquals(newWorkspace.getRAM("web/dev"), 100.0);
+  }
+
+  @Test(groups = TestGroup.DOCKER)
+  public void checkFiltersStacksFeatureDocker() {
 
     // filter stacks by 'java' value and check filtered stacks list
     newWorkspace.clickOnAllStacksTab();
@@ -147,18 +186,37 @@ public class CreateWorkspaceTest {
     newWorkspace.clickOnAllStacksTab();
     newWorkspace.clickOnFiltersButton();
     newWorkspace.clearSuggestions();
-    newWorkspace.typeToFiltersInput("java 1");
+    newWorkspace.typeToFiltersInput("java");
     newWorkspace.chooseFilterSuggestionByPlusButton("JAVA 1.8, TOMCAT 8, MYSQL 5.7");
     assertTrue(newWorkspace.isStackVisible(JAVA_MYSQL));
     newWorkspace.clickOnSingleMachineTab();
     assertFalse(newWorkspace.isStackVisible(JAVA_MYSQL));
-
-    newWorkspace.clickOnFiltersButton();
-    newWorkspace.clearSuggestions();
   }
 
-  @Test
-  public void checkSearchStackFeature() {
+  @Test(groups = {TestGroup.OPENSHIFT})
+  public void checkFiltersStacksFeatureOpenshift() {
+
+    // filter stacks by 'java' value and check filtered stacks list
+    newWorkspace.clickOnAllStacksTab();
+    newWorkspace.clickOnFiltersButton();
+    newWorkspace.typeToFiltersInput("java");
+    newWorkspace.chooseFilterSuggestionByPlusButton("JAVA");
+    assertTrue(newWorkspace.isStackVisible(JAVA));
+    assertFalse(newWorkspace.isStackVisible(JAVA_MYSQL));
+    newWorkspace.clickOnMultiMachineTab();
+    assertFalse(newWorkspace.isStackVisible(JAVA));
+
+    // filter stacks by 'blank' value and check filtered stacks list
+    newWorkspace.clickOnSingleMachineTab();
+    newWorkspace.clickOnFiltersButton();
+    newWorkspace.clearSuggestions();
+    newWorkspace.typeToFiltersInput("blank");
+    newWorkspace.chooseFilterSuggestionByPlusButton("BLANK");
+    assertTrue(newWorkspace.isStackVisible(BLANK));
+  }
+
+  @Test(groups = TestGroup.DOCKER)
+  public void checkSearchStackFeatureDocker() {
 
     // search stacks with 'java' value
     newWorkspace.typeToSearchInput("java");
@@ -177,6 +235,35 @@ public class CreateWorkspaceTest {
     assertTrue(newWorkspace.isStackVisible(JAVA_MYSQL));
 
     // search stacks with 'blank' value
+    newWorkspace.typeToSearchInput("blank");
+    assertTrue(newWorkspace.isStackVisible(BLANK));
+    newWorkspace.clickOnMultiMachineTab();
+    assertFalse(newWorkspace.isStackVisible(BLANK));
+
+    newWorkspace.clearTextInSearchInput();
+  }
+
+  @Test(groups = {TestGroup.OPENSHIFT})
+  public void checkSearchStackFeatureOpenshift() {
+
+    // search stacks with 'java' value
+    newWorkspace.typeToSearchInput("java");
+    newWorkspace.clickOnSingleMachineTab();
+    assertTrue(newWorkspace.isStackVisible(JAVA));
+    assertFalse(newWorkspace.isStackVisible(JAVA_MYSQL_THEIA_ON_KUBERNETES));
+    newWorkspace.clickOnAllStacksTab();
+    assertTrue(newWorkspace.isStackVisible(JAVA_MYSQL_THEIA_ON_KUBERNETES));
+    newWorkspace.clearTextInSearchInput();
+
+    // search stacks with 'mysql' value
+    newWorkspace.typeToSearchInput("che 7");
+    newWorkspace.clickOnAllStacksTab();
+    assertTrue(newWorkspace.isStackVisible(CHE_7_PREVIEW));
+    newWorkspace.clickOnMultiMachineTab();
+    assertFalse(newWorkspace.isStackVisible(CHE_7_PREVIEW));
+
+    // search stacks with 'blank' value
+    newWorkspace.clickOnSingleMachineTab();
     newWorkspace.typeToSearchInput("blank");
     assertTrue(newWorkspace.isStackVisible(BLANK));
     newWorkspace.clickOnMultiMachineTab();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -65,8 +65,8 @@ public class NewWorkspacePageTest {
   private static final String EXPECTED_WORKSPACE_NAME_PREFIX = "wksp-";
   private static final String MACHINE_NAME = "dev-machine";
   private static final double MAX_RAM_VALUE = 100.0;
-  private static final double MIN_RAM_VALUE = 0.5;
-  private static final double RAM_CHANGE_STEP = 0.5;
+  private static final double MIN_RAM_VALUE = 0.1;
+  private static final double RAM_CHANGE_STEP = 0.1;
   private static final String JDK_SUGGESTION_TITLE = "JDK";
   private static final String JAVA_SUGGESTION_TITLE = "JAVA";
   private static final String JAVA_1_8_SUGGESTION_TITLE = "JAVA 1.8";
@@ -195,8 +195,6 @@ public class NewWorkspacePageTest {
           CENTOS_NODEJS,
           CENTOS_WILDFLY_SWARM,
           CEYLON_WITH_JAVA_JAVASCRIPT,
-          CHE_7_PREVIEW,
-          CHE_7_PREVIEW_DEV,
           ECLIPSE_CHE,
           ECLIPSE_VERTX,
           GO,
@@ -209,31 +207,13 @@ public class NewWorkspacePageTest {
           SPRING_BOOT);
 
   private static final List<NewWorkspace.Stack> EXPECTED_OPENSHIFT_MULTI_MACHINE_STACKS =
-      asList(
-          JAVA_MYSQL,
-          JAVA_MYSQL_THEIA_ON_KUBERNETES,
-          JAVA_THEIA_ON_KUBERNETES,
-          JAVA_THEIA_OPENSHIFT,
-          JAVA_MYSQL_CENTOS,
-          JAVA_THEIA_DOCKER);
+      asList(JAVA_MYSQL_THEIA_ON_KUBERNETES, JAVA_THEIA_ON_KUBERNETES, JAVA_THEIA_OPENSHIFT);
 
   private static final List<NewWorkspace.Stack> EXPECTED_K8S_MULTI_MACHINE_STACKS =
-      asList(
-          JAVA_MYSQL,
-          JAVA_MYSQL_THEIA_ON_KUBERNETES,
-          JAVA_THEIA_ON_KUBERNETES,
-          JAVA_THEIA_OPENSHIFT,
-          JAVA_MYSQL_CENTOS,
-          JAVA_THEIA_DOCKER);
+      asList(JAVA_MYSQL_THEIA_ON_KUBERNETES, JAVA_THEIA_ON_KUBERNETES, JAVA_THEIA_OPENSHIFT);
 
   private static final List<NewWorkspace.Stack> EXPECTED_DOCKER_MULTI_MACHINE_STACKS =
-      asList(
-          JAVA_MYSQL,
-          JAVA_MYSQL_THEIA_ON_KUBERNETES,
-          JAVA_THEIA_ON_KUBERNETES,
-          JAVA_THEIA_OPENSHIFT,
-          JAVA_MYSQL_CENTOS,
-          JAVA_THEIA_DOCKER);
+      asList(JAVA_MYSQL, JAVA_MYSQL_CENTOS, JAVA_THEIA_DOCKER);
 
   private static final List<NewWorkspace.Stack>
       EXPECTED_OPENSHIFT_QUICK_START_STACKS_REVERSE_ORDER =

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsMachineActionsTest.java
@@ -53,7 +53,7 @@ public class WorkspaceDetailsMachineActionsTest {
   private static final String MAX_VALID_RAM_VALUE = "100";
   private static final String NOT_EXISTED_IMAGE = NameGenerator.generate("wrong/image", 5);
   private static final String CHANGED_RAM_SIZE = "7";
-  private static final String MIN_VALID_RAM_VALUE = "0.5";
+  private static final String MIN_VALID_RAM_VALUE = "0.1";
 
   @Inject private Dashboard dashboard;
   @Inject private Workspaces workspaces;
@@ -172,8 +172,8 @@ public class WorkspaceDetailsMachineActionsTest {
     editMachineForm.waitRamFieldText(MIN_VALID_RAM_VALUE);
 
     seleniumWebDriverHelper.sendKeys(ARROW_UP.toString());
-    editMachineForm.waitRamFieldText("1");
-    editMachineForm.waitSliderRamValue("1 GB");
+    editMachineForm.waitRamFieldText("0.2");
+    editMachineForm.waitSliderRamValue("0.2 GB");
 
     // check RAM behavior with more than max valid value
     editMachineForm.typeRam(TOO_BIG_RAM_SIZE);
@@ -194,8 +194,8 @@ public class WorkspaceDetailsMachineActionsTest {
     seleniumWebDriverHelper.sendKeys(ARROW_DOWN.toString());
     editMachineForm.waitValidNameHighlighting();
     editMachineForm.waitSaveButtonEnabling();
-    editMachineForm.waitRamFieldText("99.5");
-    editMachineForm.waitSliderRamValue("99.5 GB");
+    editMachineForm.waitRamFieldText("99.9");
+    editMachineForm.waitSliderRamValue("99.9 GB");
 
     // check restoring of default values after clicking on "Cancel" button
     editMachineForm.typeRam("4");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsMachinesRamTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/details/WorkspaceDetailsMachinesRamTest.java
@@ -31,7 +31,7 @@ public class WorkspaceDetailsMachinesRamTest {
   private static final String IMAGE_NAME = "eclipse/ubuntu_jdk8";
   private static final String EXPECTED_RAM_VALUE = "2";
   private static final String MAX_RAM_VALID_VALUE = "100";
-  private static final String MIN_RAM_VALID_VALUE = "0.5";
+  private static final String MIN_RAM_VALID_VALUE = "0.1";
   private static final String SUCCESS_NOTIFICATION_MESSAGE = "Workspace updated.";
 
   @Inject private Dashboard dashboard;
@@ -81,7 +81,7 @@ public class WorkspaceDetailsMachinesRamTest {
 
     workspaceDetailsMachines.clickOnDecrementRamButton(MACHINE_NAME);
     workspaceDetailsMachines.waitValidRamHighlighting(MACHINE_NAME);
-    workspaceDetailsMachines.waitRamAmount(MACHINE_NAME, "99.5");
+    workspaceDetailsMachines.waitRamAmount(MACHINE_NAME, "99.9");
 
     workspaceDetailsMachines.typeRamAmount(MACHINE_NAME, MIN_RAM_VALID_VALUE);
     workspaceDetailsMachines.waitValidRamHighlighting(MACHINE_NAME);
@@ -92,7 +92,7 @@ public class WorkspaceDetailsMachinesRamTest {
     workspaceDetailsMachines.waitValidRamHighlighting(MACHINE_NAME);
 
     workspaceDetailsMachines.clickOnIncrementRamButton(MACHINE_NAME);
-    workspaceDetailsMachines.waitRamAmount(MACHINE_NAME, "1");
+    workspaceDetailsMachines.waitRamAmount(MACHINE_NAME, "0.2");
     workspaceDetailsMachines.waitValidRamHighlighting(MACHINE_NAME);
 
     workspaceDetailsMachines.typeRamAmount(MACHINE_NAME, "3");


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
1. Plugins list on workspace creation is visible only if Che7 stack is selected
2. Add ability to set the RAM less then 512MB
3. Filter all stacks for worskpace creation by supported infrastructure (unsupported ones won't be shown now in the "All" tab as well)
4. "Create & Open" buttons - by default perform workspace creation and opening in IDE, the popup with choices to open IDE or Edit won't be shown; at the top - there is button to "Create & Proceed Editing"
5. Selenium test fixes due to changes in workspace creation flow

![ezgif com-video-to-gif 4](https://user-images.githubusercontent.com/1611939/49433151-f23e9c00-f7b9-11e8-9219-b153c1464ac3.gif)
![ezgif com-video-to-gif 5](https://user-images.githubusercontent.com/1611939/49433173-02ef1200-f7ba-11e8-989f-9687c849aee3.gif)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11788

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

