### PR TITLE
Different small changes for Che with SSL enabled

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -53,6 +53,7 @@ HELP="
 --rolling - Rolling update strategy (Recreate is the default one). With Rolling strategy Che server pvc and volume aren't created
 --debug - Deploy Che in a debug mode, create and expose debug route
 --image-che - Override default Che image. Example: --image-che=org/repo:tag. Tag is mandatory!
+--secure | -s - Deploy Che with SSL enabled
 ===================================
 ENV vars: this script automatically detect envs vars beginning with "CHE_" and passes them to Che deployments:
 CHE_IMAGE_REPO - Che server Docker image, defaults to "eclipse-che-server"

--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -460,7 +460,7 @@ ${CHE_VAR_ARRAY}"
         $OC_BINARY login -u "system:admin" > /dev/null
         KEYCLOAK_ROUTE=$($OC_BINARY get route/keycloak --namespace=${CHE_OPENSHIFT_PROJECT} -o=jsonpath={'.spec.host'})
         $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/oauth-client.yaml \
-          -p REDIRECT_URI="http://${KEYCLOAK_ROUTE}/auth/realms/che/broker/${OCP_IDENTITY_PROVIDER_ID}/endpoint" \
+          -p REDIRECT_URI="${HTTP_PROTOCOL}://${KEYCLOAK_ROUTE}/auth/realms/che/broker/${OCP_IDENTITY_PROVIDER_ID}/endpoint" \
           -p OCP_OAUTH_CLIENT_ID=${OCP_OAUTH_CLIENT_ID} \
           -p OCP_OAUTH_CLIENT_SECRET=${OCP_OAUTH_CLIENT_SECRET}
 

--- a/deploy/openshift/ocp.sh
+++ b/deploy/openshift/ocp.sh
@@ -252,6 +252,7 @@ parse_args() {
     --destroy - destroy ocp cluster
     --deploy-che - deploy che to ocp
     --project | -p - OpenShift namespace to deploy Che (defaults to eclipse-che). Example: --project=myproject
+    --secure | -s - Deploy Che with SSL enabled
     --multiuser - deploy Che in multiuser mode
     --postgres-debug - run PostgreSQL DB with Debug logging
     --no-pull - IfNotPresent pull policy for Che server deployment
@@ -338,6 +339,10 @@ parse_args() {
            --image-che=*)
                export CHE_IMAGE_REPO=$(echo "${i#*=}" | sed 's/:.*//')
                export CHE_IMAGE_TAG=$(echo "${i#*=}" | sed 's/.*://')
+               shift
+           ;;
+           -s | --secure)
+               export ENABLE_SSL=true
                shift
            ;;
            --remove-che)

--- a/deploy/openshift/templates/che-server-template.yaml
+++ b/deploy/openshift/templates/che-server-template.yaml
@@ -149,11 +149,11 @@ objects:
             value: "${CHE_WORKSPACE_SIDECAR_DEFAULT__MEMORY__LIMIT__MB}"
           - name: ROUTING_SUFFIX
             value: "${ROUTING_SUFFIX}"
-          - name: OPENSHIFT_IDENTITY_PROVIDER_CERTIFICATE
+          - name: CHE_SELF__SIGNED__CERT
             valueFrom:
               secretKeyRef:
                 key: ca.crt
-                name: openshift-identity-provider
+                name: self-signed-certificate
                 optional: true
           - name: CHE_WORKSPACE_PLUGIN__REGISTRY__URL
             value: "${CHE_WORKSPACE_PLUGIN__REGISTRY__URL}"

--- a/deploy/openshift/templates/multi/keycloak-template.yaml
+++ b/deploy/openshift/templates/multi/keycloak-template.yaml
@@ -58,11 +58,11 @@ objects:
             value: "${ROUTING_SUFFIX}"
           - name: CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD
             value: "${CHE_KEYCLOAK_ADMIN_REQUIRE_UPDATE_PASSWORD}"
-          - name: OPENSHIFT_IDENTITY_PROVIDER_CERTIFICATE
+          - name: CHE_SELF__SIGNED__CERT
             valueFrom:
               secretKeyRef:
                 key: ca.crt
-                name: openshift-identity-provider
+                name: self-signed-certificate
                 optional: true
           image: '${IMAGE_KEYCLOAK}:${KEYCLOAK_IMAGE_TAG}'
           command: ["/scripts/kc_realm_user.sh"]

--- a/deploy/openshift/templates/multi/openshift-certificate-secret.yaml
+++ b/deploy/openshift/templates/multi/openshift-certificate-secret.yaml
@@ -11,7 +11,7 @@
 kind: Template
 apiVersion: v1
 metadata:
-  name: openshift-identity-provider-certificate
+  name: self-signed-certificate
   annotations:
     description: Che
 objects:
@@ -21,12 +21,11 @@ objects:
       ${CERTIFICATE}
   kind: Secret
   metadata:
-    name: openshift-identity-provider
+    name: self-signed-certificate
     namespace: che
   type: Opaque
 parameters:
 - name: CERTIFICATE
   displayName: Openshift console certificate
 labels:
-  app: keycloak
-  template: openshift-identity-provider-certificate
+  template: self-signed-certificate

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -283,9 +283,9 @@ init() {
 
 add_cert_to_truststore() {
 
-    if [ "${OPENSHIFT_IDENTITY_PROVIDER_CERTIFICATE}" != "" ]; then
+    if [ "${CHE_SELF__SIGNED__CERT}" != "" ]; then
         echo "Found a custom cert. Adding it to java trust store..."
-        echo "${OPENSHIFT_IDENTITY_PROVIDER_CERTIFICATE}" > /home/user/openshift.crt
+        echo "${CHE_SELF__SIGNED__CERT}" > /home/user/openshift.crt
         echo yes | keytool -keystore /home/user/openshift.jks -importcert -alias HOSTDOMAIN -file /home/user/openshift.crt -storepass minishift
         export JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=/home/user/openshift.jks -Djavax.net.ssl.trustStorePassword=minishift"
     fi

--- a/dockerfiles/keycloak/kc_realm_user.sh
+++ b/dockerfiles/keycloak/kc_realm_user.sh
@@ -33,8 +33,8 @@ if [ $KEYCLOAK_USER ] && [ $KEYCLOAK_PASSWORD ]; then
     /opt/jboss/keycloak/bin/add-user-keycloak.sh --user $KEYCLOAK_USER --password $KEYCLOAK_PASSWORD
 fi
 
-if [ "${OPENSHIFT_IDENTITY_PROVIDER_CERTIFICATE}" != "" ]; then
-    echo "${OPENSHIFT_IDENTITY_PROVIDER_CERTIFICATE}" > /scripts/openshift.cer
+if [ "${CHE_SELF__SIGNED__CERT}" != "" ]; then
+    echo "${CHE_SELF__SIGNED__CERT}" > /scripts/openshift.cer
     keytool -importcert -alias HOSTDOMAIN -keystore /scripts/openshift.jks -file /scripts/openshift.cer -storepass openshift -noprompt
     keytool -importkeystore -srckeystore $JAVA_HOME/jre/lib/security/cacerts -destkeystore /scripts/openshift.jks -srcstorepass changeit -deststorepass openshift
     /opt/jboss/keycloak/bin/jboss-cli.sh --file=/scripts/cli/add_openshift_certificate.cli && rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
@@ -105,6 +105,10 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
     injectBootstrapper();
 
     startSynchronizer.checkFailure();
+    LOG.debug(
+        "Bootstrapping {}:{}. Launching bootstrapper process",
+        runtimeIdentity,
+        kubernetesMachine.getName());
     exec(
         "sh",
         "-c",
@@ -158,6 +162,10 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
     exec(
         outputConsumer,
         "curl",
+        // -f, --fail          Fail silently (no output at all) on HTTP errors
+        // -s, --silent        Silent mode
+        // -S, --show-error    Show error even when -s is used
+        // -o, --output <file> Write to file instead of stdout
         "-fsSo",
         BOOTSTRAPPER_DIR + BOOTSTRAPPER_FILE,
         bootstrapperBinaryUrl);

--- a/selenium/che-selenium-test/src/test/resources/projects/nodejs-with-yaml/deployment.yaml
+++ b/selenium/che-selenium-test/src/test/resources/projects/nodejs-with-yaml/deployment.yaml
@@ -127,11 +127,11 @@ spec:
               value: http
             - name: ROUTING_SUFFIX
               value: 172.19.20.234.nip.io
-            - name: OPENSHIFT_IDENTITY_PROVIDER_CERTIFICATE
+            - name: CHE_SELF__SIGNED__CERT
               valueFrom:
                 secretKeyRef:
                   key: ca.crt
-                  name: openshift-identity-provider
+                  name: self-signed-certificate
                   optional: true
             - name: CHE_WORKSPACE_PLUGIN__REGISTRY__URL
               value: 'NULL'


### PR DESCRIPTION
### What does this PR do?
This PR contains small changes for Che with SSL enabled. I've separated this PR from my main self-signed related PR to make it easier to review. So it contains:
1. Fix creating of oauth client when SLL is enabled. Previously there was hardcoded `http`.
2. Setting environment variables before running deploys scripts is not convenient, so added parameter to ocp.sh to deploy Che with SSL enabled.
3. Discovered there is missing debug message on one `KubernetesBootstrapper` phase, so added it. Also, added a description of options that we used for `curl`.
4. Previously, configuring custom certificate for Che Server and Keycloak was done with `OPENSHIFT_IDENTITY_PROVIDER_CERTIFICATE` env var. I found this name a bit confusing. So renamed it to `CHE_SELF__SIGNED__CERT`.
5. Previously, Che Server java trust store was configured with empty trust store with the only one custom certificate, which breaks up Che 7 since it requires requesting external sources. So, my fixe creates new java trust store based on default one.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/10910

#### Release Notes
N/A

#### Docs PR
N/A