### PR TITLE
[WIP]Distintiguish between workspace start and update.

### DIFF
--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -57,9 +57,21 @@ public final class Constants {
    * Workspace#getAttributes}
    */
   public static final String CREATED_ATTRIBUTE_NAME = "created";
+
   /**
-   * Describes time when workspace was last updated or started. Should be set/read from {@link
-   * Workspace#getAttributes}
+   * Describes the time when the workspace was last started. Note that this is not reset when the
+   * workspace is stopped so that the last running time of a stopped workspace can be determined.
+   *
+   * <p>Should be set/read from {@link Workspace#getAttributes()}.
+   */
+  public static final String STARTED_ATTRIBUTE_NAME = "started";
+
+  /**
+   * Describes time when workspace was last updated. Before Che 6.16.0 this attribute also marked a
+   * workspace start, but since 6.16.0 this is tracked separately by the {@link
+   * #STARTED_ATTRIBUTE_NAME started} attribute.
+   *
+   * <p>Should be set/read from {@link Workspace#getAttributes}
    */
   public static final String UPDATED_ATTRIBUTE_NAME = "updated";
   /**

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -19,6 +19,7 @@ import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 import static org.eclipse.che.api.workspace.shared.Constants.CREATED_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.ERROR_MESSAGE_ATTRIBUTE_NAME;
+import static org.eclipse.che.api.workspace.shared.Constants.STARTED_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.STOPPED_ABNORMALLY_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.STOPPED_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.UPDATED_ATTRIBUTE_NAME;
@@ -357,7 +358,7 @@ public class WorkspaceManager {
       WorkspaceImpl workspace, @Nullable String envName, Map<String, String> options)
       throws ConflictException, NotFoundException, ServerException {
     String env = getValidatedEnvironmentName(workspace, envName);
-    workspace.getAttributes().put(UPDATED_ATTRIBUTE_NAME, Long.toString(currentTimeMillis()));
+    workspace.getAttributes().put(STARTED_ATTRIBUTE_NAME, Long.toString(currentTimeMillis()));
     workspaceDao.update(workspace);
     runtimes
         .startAsync(workspace, env, firstNonNull(options, Collections.emptyMap()))

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -21,6 +21,7 @@ import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.CREATED_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.ERROR_MESSAGE_ATTRIBUTE_NAME;
+import static org.eclipse.che.api.workspace.shared.Constants.STARTED_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.STOPPED_ABNORMALLY_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.STOPPED_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.UPDATED_ATTRIBUTE_NAME;
@@ -344,7 +345,11 @@ public class WorkspaceManagerTest {
     workspace.getAttributes().put("new attribute", "attribute");
     when(workspaceDao.update(any())).thenAnswer(inv -> inv.getArguments()[0]);
 
+    assertNull(workspace.getAttributes().get(UPDATED_ATTRIBUTE_NAME));
+
     workspaceManager.updateWorkspace(workspace.getId(), workspace);
+
+    assertNotNull(workspace.getAttributes().get(UPDATED_ATTRIBUTE_NAME));
 
     verify(workspaceDao).update(workspace);
   }
@@ -386,7 +391,7 @@ public class WorkspaceManagerTest {
         workspace.getId(), workspace.getConfig().getDefaultEnv(), emptyMap());
 
     verify(runtimes).startAsync(workspace, workspace.getConfig().getDefaultEnv(), emptyMap());
-    assertNotNull(workspace.getAttributes().get(UPDATED_ATTRIBUTE_NAME));
+    assertNotNull(workspace.getAttributes().get(STARTED_ATTRIBUTE_NAME));
   }
 
   @Test

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.16.0/1__add_last_started_workspace_attribute.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/6.16.0/1__add_last_started_workspace_attribute.sql
@@ -1,0 +1,19 @@
+--
+-- Copyright (c) 2012-2018 Red Hat, Inc.
+-- This program and the accompanying materials are made
+-- available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+--
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+-- A workspace can be merely created and not started and therefore the code doesn't assume that
+-- a 'started' attribute exists. Therefore it is OK for us to create a started attribute only for
+-- the currently running workspaces. For those there is a certain probability that the last update
+-- was indeed the actual start of the workspace, not its update.
+INSERT INTO workspace_attributes (workspace_id, attributes, attribute_key)
+  SELECT a.workspace_id, a.attributes, 'started' FROM workspace_attributes a, che_k8s_runtime r
+  WHERE r.workspace_id = a.workspace_id AND r.status <> 'STOPPED' AND a.attribute_key = 'updated';


### PR DESCRIPTION
### What does this PR do?
This makes the server store the timestamp of a workspace start as a separate attribute. Before start and update of a workspace were both tracked by a single attribute called "updated".

This PR will enable us to track the long running workspaces in #12091.

Not sure about the impact of this change. Is this part of the public API? It seems to have been part of the contract forever.

### What issues does this PR fix or reference?

#12091 

#### Release Notes

The start time of a workspace is now stored as "started" attribute of a workspace. The "updated" attribute now only contains the timestamp of the last update of the workspace.
