### PR TITLE
Use latest plugin brokers

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -516,8 +516,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.4.0
-che.workspace.plugin_broker.theia_remote.image=wsskeleton/che-plugin-broker:theia-broker
+che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.5.0
+che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.1.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -516,8 +516,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.5.0
-che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.1.0
+che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.5.1
+che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.5.1
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -180,7 +180,7 @@ public class KubernetesInfraModule extends AbstractModule {
         .addBinding("Che Editor")
         .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.image")));
     pluginBrokers
-        .addBinding("Theia remote plugin")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.theia_remote.image")));
+        .addBinding("Theia plugin")
+        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.theia.image")));
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/ServerServiceBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/ServerServiceBuilder.java
@@ -63,7 +63,7 @@ public class ServerServiceBuilder {
         new io.fabric8.kubernetes.api.model.ServiceBuilder();
     return builder
         .withNewMetadata()
-        .withName(name.replace("/", "-"))
+        .withName(name.replace("/", "-").toLowerCase())
         .withAnnotations(
             Annotations.newSerializer()
                 .servers(serversConfigs)

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -157,7 +157,7 @@ public class OpenShiftInfraModule extends AbstractModule {
         .addBinding("Che Editor")
         .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.image")));
     pluginBrokers
-        .addBinding("Theia remote plugin")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.theia_remote.image")));
+        .addBinding("Theia plugin")
+        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.theia.image")));
   }
 }


### PR DESCRIPTION
### What does this PR do?
Changes brokers configuration to use the latest version of Che plugin broker and Theia plugin broker instead of Theia remote plugin broker. 

### What issues does this PR fix or reference?
Depends on https://github.com/eclipse/che/issues/12140
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
