### PR TITLE
Add attributes to Che 7 plugin meta; make URL field not mandatory

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/PluginMetaRetriever.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/PluginMetaRetriever.java
@@ -225,7 +225,6 @@ public class PluginMetaRetriever {
         meta.getName(), CHE_PLUGIN_OBJECT_ERROR, id, version, "Name is missing.");
     requireNotNullNorEmpty(
         meta.getType(), CHE_PLUGIN_OBJECT_ERROR, id, version, "Type is missing.");
-    requireNotNullNorEmpty(meta.getUrl(), CHE_PLUGIN_OBJECT_ERROR, id, version, "URL is missing.");
   }
 
   @VisibleForTesting

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.api.workspace.server.wsplugins.model;
 
+import java.util.HashMap;
+
 /** @author Oleksandr Garagatyi */
 public class PluginMeta {
   private String name = null;
@@ -21,6 +23,7 @@ public class PluginMeta {
   private String description = null;
   private String icon = null;
   private String url = null;
+  private HashMap<String, String> attributes = new HashMap<>();
 
   public PluginMeta name(String name) {
     this.name = name;
@@ -92,5 +95,17 @@ public class PluginMeta {
 
   public String getDescription() {
     return description;
+  }
+
+  public HashMap<String, String> getAttributes() {
+    if (attributes == null) {
+      attributes = new HashMap<>();
+    }
+    return attributes;
+  }
+
+  public PluginMeta attributes(HashMap<String, String> attributes) {
+    this.attributes = attributes;
+    return this;
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
@@ -23,7 +23,7 @@ public class PluginMeta {
   private String description = null;
   private String icon = null;
   private String url = null;
-  private HashMap<String, String> attributes = new HashMap<>();
+  private Map<String, String> attributes = new HashMap<>();
 
   public PluginMeta name(String name) {
     this.name = name;
@@ -97,14 +97,14 @@ public class PluginMeta {
     return description;
   }
 
-  public HashMap<String, String> getAttributes() {
+  public Map<String, String> getAttributes() {
     if (attributes == null) {
       attributes = new HashMap<>();
     }
     return attributes;
   }
 
-  public PluginMeta attributes(HashMap<String, String> attributes) {
+  public PluginMeta attributes(Map<String, String> attributes) {
     this.attributes = attributes;
     return this;
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.workspace.server.wsplugins.model;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /** @author Oleksandr Garagatyi */
 public class PluginMeta {


### PR DESCRIPTION
### What does this PR do?
Add attributes to Che 7 plugin meta; make URL field not mandatory.
This is needed for implementation of VS Code extension broker.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
