### PR TITLE
Selenium: fix unstable selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/DocumentationPage.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/DocumentationPage.java
@@ -33,11 +33,16 @@ public class DocumentationPage {
   }
 
   public interface Locators {
-    String PAGE_TITLE_CLASS_NAME = "post-title-main";
+    String PAGE_TITLE_CLASS_NAME = "projectTitle";
   }
 
   public String getTitle() {
     return seleniumWebDriverHelper.waitVisibilityAndGetText(
         By.className(PAGE_TITLE_CLASS_NAME), LOADER_TIMEOUT_SEC);
+  }
+
+  public void waitTitle(String title) {
+    seleniumWebDriverHelper.waitTextContains(
+        By.className(PAGE_TITLE_CLASS_NAME), title, LOADER_TIMEOUT_SEC);
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -274,6 +274,9 @@ public class NewWorkspace {
 
   public void clickOnIncrementMemoryButton(String machineName) {
     seleniumWebDriverHelper.waitAndClick(By.xpath(format(INCREMENT_MEMORY_BUTTON, machineName)));
+
+    // we need to wait a little to avoid quick clicking on this button
+    WaitUtils.sleepQuietly(1);
   }
 
   public void clickAndHoldIncrementMemoryButton(String machineName, int holdingTimeout) {
@@ -300,6 +303,9 @@ public class NewWorkspace {
 
   public void clickOnDecrementMemoryButton(String machineName) {
     seleniumWebDriverHelper.waitAndClick(By.xpath(format(DECREMENT_MEMORY_BUTTON, machineName)));
+
+    // we need to wait a little to avoid quick clicking on this button
+    WaitUtils.sleepQuietly(1);
   }
 
   public double getRAM(String machineName) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -274,9 +274,6 @@ public class NewWorkspace {
 
   public void clickOnIncrementMemoryButton(String machineName) {
     seleniumWebDriverHelper.waitAndClick(By.xpath(format(INCREMENT_MEMORY_BUTTON, machineName)));
-
-    // we need to wait a little to avoid quick clicking on this button
-    WaitUtils.sleepQuietly(1);
   }
 
   public void clickAndHoldIncrementMemoryButton(String machineName, int holdingTimeout) {
@@ -303,9 +300,6 @@ public class NewWorkspace {
 
   public void clickOnDecrementMemoryButton(String machineName) {
     seleniumWebDriverHelper.waitAndClick(By.xpath(format(DECREMENT_MEMORY_BUTTON, machineName)));
-
-    // we need to wait a little to avoid quick clicking on this button
-    WaitUtils.sleepQuietly(1);
   }
 
   public double getRAM(String machineName) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateWorkspaceTest.java
@@ -25,6 +25,7 @@ import static org.testng.Assert.assertTrue;
 import com.google.inject.Inject;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.selenium.core.TestGroup;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
@@ -103,7 +104,11 @@ public class CreateWorkspaceTest {
     newWorkspace.clickOnIncrementMemoryButton(machineName);
     assertEquals(newWorkspace.getRAM(machineName), 2.1);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
+
+    // we need to wait a little to avoid quick clicking on this button
+    WaitUtils.sleepQuietly(1);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
+    WaitUtils.sleepQuietly(1);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
     assertEquals(newWorkspace.getRAM(machineName), 1.8);
 
@@ -138,7 +143,11 @@ public class CreateWorkspaceTest {
     newWorkspace.clickOnIncrementMemoryButton(machineName);
     assertEquals(newWorkspace.getRAM(machineName), 2.1);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
+
+    // we need to wait a little to avoid quick clicking on this button
+    WaitUtils.sleepQuietly(1);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
+    WaitUtils.sleepQuietly(1);
     newWorkspace.clickOnDecrementMemoryButton(machineName);
     assertEquals(newWorkspace.getRAM(machineName), 1.8);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/WorkspacesListTest.java
@@ -53,7 +53,7 @@ public class WorkspacesListTest {
   private static final int JAVA_WS_MB = 3072;
   private static final int BLANK_WS_PROJECTS_COUNT = 0;
   private static final int JAVA_WS_PROJECTS_COUNT = 1;
-  private static final String EXPECTED_DOCUMENTATION_PAGE_TITLE = "What Is a Che Workspace?";
+  private static final String EXPECTED_DOCUMENTATION_PAGE_TITLE = "Eclipse Che Documentation";
   private static final String EXPECTED_JAVA_PROJECT_NAME = "web-java-spring";
   private static final String NEWEST_CREATED_WORKSPACE_NAME = "just-created-workspace";
   private static final int EXPECTED_SORTED_WORKSPACES_COUNT = 1;
@@ -286,7 +286,7 @@ public class WorkspacesListTest {
     seleniumWebDriverHelper.waitOpenedSomeWin();
     seleniumWebDriverHelper.switchToNextWindow(mainWindow);
 
-    assertEquals(EXPECTED_DOCUMENTATION_PAGE_TITLE, documentationPage.getTitle());
+    documentationPage.waitTitle(EXPECTED_DOCUMENTATION_PAGE_TITLE);
 
     seleniumWebDriver.close();
     seleniumWebDriver.switchTo().window(mainWindow);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/RunToCursorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/RunToCursorTest.java
@@ -73,7 +73,10 @@ public class RunToCursorTest {
     commandsPalette.openCommandPalette();
     commandsPalette.startCommandByDoubleClick("build");
     projectExplorer.quickExpandWithJavaScript();
+
+    projectExplorer.waitItem(PROJECT + "/src/App.class");
     projectExplorer.openItemByPath(PROJECT + "/src/App.java");
+    editor.waitActive();
     editor.setBreakpoint(15);
     debugPanel.openDebugPanel();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckOnValidAndInvalidPackageNameTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckOnValidAndInvalidPackageNameTest.java
@@ -22,6 +22,7 @@ import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -44,6 +45,7 @@ public class CheckOnValidAndInvalidPackageNameTest {
   @Inject private TestWorkspace testWorkspace;
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
+  @Inject private Consoles console;
   @Inject private Loader loader;
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private TestProjectServiceClient testProjectServiceClient;
@@ -67,6 +69,7 @@ public class CheckOnValidAndInvalidPackageNameTest {
     createPackageByPath(PROJECT_NAME + PATH_TO_JAVA_FOLDER, packageName);
 
     projectExplorer.waitVisibilityByName(packageName);
+    console.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
     projectExplorer.openItemByVisibleNameInExplorer(packageName);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCamelStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCamelStackTest.java
@@ -91,6 +91,7 @@ public class CreateWorkspaceFromCamelStackTest {
     testProjectServiceClient.importProject(
         ws.getId(), Paths.get(resource.toURI()), PROJECT_NAME, CONSOLE_JAVA_SIMPLE);
     notificationsPopupPanel.waitPopupPanelsAreClosed();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
 
     projectExplorer.waitAndSelectItem(PROJECT_NAME);
     projectExplorer.openItemByPath(PROJECT_NAME);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/theia/TheiaBuildPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/theia/TheiaBuildPluginTest.java
@@ -115,7 +115,7 @@ public class TheiaBuildPluginTest {
     theiaIde.waitNotificationDisappearance(expectedYaomanMessage, UPDATING_PROJECT_TIMEOUT_SEC);
 
     // build plugin
-    openTerminal("File", "Open new multi-machine terminal", "ws/theia-ide");
+    openTerminal("File", "Open Terminal in specific container", "ws/theia-ide");
     theiaTerminal.waitTab(wsTheiaIdeTerminalTitle);
     theiaTerminal.clickOnTab(wsTheiaIdeTerminalTitle);
     theiaTerminal.performCommand(goToDirectoryCommand);


### PR DESCRIPTION
### What does this PR do?
This PR:
- add checking that java language server if fully initialized before working with a project in ```CheckOnValidAndInvalidPackageNameTest``` and ```CreateWorkspaceFromCamelStackTest``` tests;
- add timeout for 1 second after every clicking on change RAM button in ```NewWorspace``` page object to avoid fast clicking on buttons;
- fix expected locator on "Che Documentation" page ```DocumentationPage``` page object;
- fix expected menu item name for starting a new terminal in ```TheiaBuildPluginTest``` test;
- wait that expected file is visible in Project Explorer in ```RunToCursorTest``` test.
