### PR TITLE
Made changes needed for deploying secure Che with OAuth provider configured on Minishift

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -19,6 +19,9 @@
 # --------------
 # Print Che logo
 # --------------
+
+set -e
+
 export TERM=xterm
 
 echo

--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -305,6 +305,7 @@ wait_for_postgres() {
       printError "Deployment timeout. Aborting."
       exit 1
     fi
+    printInfo "Postgres successfully deployed"
 }
 
 wait_for_keycloak() {
@@ -327,6 +328,7 @@ wait_for_keycloak() {
       printError "Deployment timeout. Aborting."
       exit 1
     fi
+    printInfo "Keycloak successfully deployed"
 }
 
 wait_for_che() {
@@ -488,7 +490,9 @@ ${CHE_VAR_ARRAY}"
       wait_for_keycloak
 
       if [ "${SETUP_OCP_OAUTH}" == "true" ]; then
+        printInfo "Registering oAuth client in OpenShift"
         # register oAuth client in OpenShift
+        printInfo "Logging as \"system:admin\""
         $OC_BINARY login -u "system:admin" > /dev/null
         KEYCLOAK_ROUTE=$($OC_BINARY get route/keycloak --namespace=${CHE_OPENSHIFT_PROJECT} -o=jsonpath={'.spec.host'})
         $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/oauth-client.yaml \
@@ -497,6 +501,8 @@ ${CHE_VAR_ARRAY}"
           -p OCP_OAUTH_CLIENT_SECRET=${OCP_OAUTH_CLIENT_SECRET}
 
         # register OpenShift Identity Provider in Keycloak
+        printInfo "Registering oAuth client in Keycloak"
+        printInfo "Logging as \"${OPENSHIFT_USERNAME}\""
         $OC_BINARY login -u "${OPENSHIFT_USERNAME}" -p "${OPENSHIFT_PASSWORD}" > /dev/null
         KEYCLOAK_POD_NAME=$(${OC_BINARY} get pod --namespace=${CHE_OPENSHIFT_PROJECT} -l app=keycloak --no-headers | awk '{print $1}')
         ${OC_BINARY} exec ${KEYCLOAK_POD_NAME} -- /opt/jboss/keycloak/bin/kcadm.sh create identity-provider/instances -r che \

--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -500,7 +500,7 @@ ${CHE_VAR_ARRAY}"
         printInfo "Registering oAuth client in OpenShift"
         # register oAuth client in OpenShift
         printInfo "Logging as \"system:admin\""
-        $OC_BINARY login -u "system:admin" > /dev/null
+        $OC_BINARY login -u "system:admin"
         KEYCLOAK_ROUTE=$($OC_BINARY get route/keycloak --namespace=${CHE_OPENSHIFT_PROJECT} -o=jsonpath={'.spec.host'})
         $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/oauth-client.yaml \
           -p REDIRECT_URI="${HTTP_PROTOCOL}://${KEYCLOAK_ROUTE}/auth/realms/che/broker/${OCP_IDENTITY_PROVIDER_ID}/endpoint" \
@@ -510,7 +510,7 @@ ${CHE_VAR_ARRAY}"
         # register OpenShift Identity Provider in Keycloak
         printInfo "Registering oAuth client in Keycloak"
         printInfo "Logging as \"${OPENSHIFT_USERNAME}\""
-        $OC_BINARY login -u "${OPENSHIFT_USERNAME}" -p "${OPENSHIFT_PASSWORD}" > /dev/null
+        $OC_BINARY login -u "${OPENSHIFT_USERNAME}" -p "${OPENSHIFT_PASSWORD}"
         KEYCLOAK_POD_NAME=$(${OC_BINARY} get pod --namespace=${CHE_OPENSHIFT_PROJECT} -l app=keycloak --no-headers | awk '{print $1}')
         ${OC_BINARY} exec ${KEYCLOAK_POD_NAME} -- /opt/jboss/keycloak/bin/kcadm.sh create identity-provider/instances -r che \
           -s alias=${OCP_IDENTITY_PROVIDER_ID} \

--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -502,10 +502,11 @@ ${CHE_VAR_ARRAY}"
         printInfo "Logging as \"system:admin\""
         $OC_BINARY login -u "system:admin"
         KEYCLOAK_ROUTE=$($OC_BINARY get route/keycloak --namespace=${CHE_OPENSHIFT_PROJECT} -o=jsonpath={'.spec.host'})
-        $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/oauth-client.yaml \
+
+        $OC_BINARY process -f ${BASE_DIR}/templates/multi/oauth-client.yaml \
           -p REDIRECT_URI="${HTTP_PROTOCOL}://${KEYCLOAK_ROUTE}/auth/realms/che/broker/${OCP_IDENTITY_PROVIDER_ID}/endpoint" \
           -p OCP_OAUTH_CLIENT_ID=${OCP_OAUTH_CLIENT_ID} \
-          -p OCP_OAUTH_CLIENT_SECRET=${OCP_OAUTH_CLIENT_SECRET}
+          -p OCP_OAUTH_CLIENT_SECRET=${OCP_OAUTH_CLIENT_SECRET} | oc apply -f -
 
         # register OpenShift Identity Provider in Keycloak
         printInfo "Registering oAuth client in Keycloak"

--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -475,7 +475,14 @@ ${CHE_VAR_ARRAY}"
 
       if [ "${SETUP_OCP_OAUTH}" == "true" ]; then
         # create secret with OpenShift certificate
-        $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/openshift-certificate-secret.yaml -p CERTIFICATE="$(cat /var/lib/origin/openshift.local.config/master/ca.crt)"
+
+        if [[ -z ${OPENSHIFT_CERT} ]]; then
+          DEFAULT_OPENSHIFT_CERT_PATH=/var/lib/origin/openshift.local.config/master/ca.crt
+          export OPENSHIFT_CERT_PATH=${OPENSHIFT_CERT_PATH:-${DEFAULT_OPENSHIFT_CERT_PATH}}
+          OPENSHIFT_CERT="$(cat $OPENSHIFT_CERT_PATH)"
+        fi
+
+        $OC_BINARY new-app -f ${BASE_DIR}/templates/multi/openshift-certificate-secret.yaml -p CERTIFICATE="$OPENSHIFT_CERT"
       fi
 
       ${OC_BINARY} new-app -f ${BASE_DIR}/templates/multi/keycloak-template.yaml \


### PR DESCRIPTION
### What does this PR do?
There are several commits that improve deploying secure Che on Minishift or any other OpenShift cluster that is not local OCP:
* Add settings of `-e` mode in deploy_che.sh script
It is needed because previously any fatal error doesn't break the deploying process. As result, there is a message that Che is Deployed but actually, deployment may be is in inconsistency state.
* Add an ability to set up oauth provided from deploy_che.sh with the argument
There are a lot of missing default values for environment variable. This commit adds needed env vars with defaults and add respecting of `--setup-ocp-oauth` argument
* Add more info about current deploying state
Just few more message about current deploying state to make it clear of a user.
* Add an ability to specify self-signed certificate during deploying che
Previously certificate should be located in file `/var/lib/origin/openshift.local.config/master/ca.crt` and it works only for OCP on docker. Now there is an ability to specify certificate content with `OPENSHIFT_CERT` env var or path to cert file with `OPENSHIFT_CERT_PATH` env var
* Remove supressing output/input during execution
In case of deploying on minishift with self-signed certificate, `oc login ... > /dev/null` command hangs because of waiting approval that oc may trust self-signed certificate. So, `> /dev/null` is removed and now user is able to type `y` to allow trusting self-signed certificate
* Create or update oauth client instead of try to create a new one
Previously the only first deployment works because `oauth-client` is created at cluster scope, and the next tries fails with error `oauth client already exists`. Using of `oc apply` allows create or update if it exists.

I was not able to test it on minishift because of the following bug https://github.com/openshift/origin/issues/20716. I tested it by deploying Che with `deploy_che.sh` on Local OCP:
```bash
export OPENSHIFT_CERT=$(cat /var/lib/origin/openshift.local.config/master/ca.crt)
./deploy_che.sh --multiuser --no-pull --rolling --secure --setup-ocp-oauth
```

### What issues does this PR fix or reference?
It is related(but not needed) to https://github.com/eclipse/che/issues/10910.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A