### PR TITLE
Add integrity validations for devfile service

### DIFF
--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
@@ -17,6 +17,10 @@ public class Constants {
 
   public static final String CURRENT_SPEC_VERSION = "0.0.1";
 
+  public static final String EDITOR_TOOL_TYPE = "cheEditor";
+
+  public static final String PLUGIN_TOOL_TYPE = "chePlugin";
+
   /**
    * Workspace attribute which contains comma-separated list of mappings of tool id to its name
    * Example value:

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
@@ -51,7 +51,7 @@ public class DevfileConverter {
               wsConfig.getName()));
     }
 
-    Devfile devFile =
+    Devfile devfile =
         new Devfile().withSpecVersion(CURRENT_SPEC_VERSION).withName(wsConfig.getName());
 
     // Manage projects
@@ -59,7 +59,7 @@ public class DevfileConverter {
     wsConfig
         .getProjects()
         .forEach(projectConfig -> projects.add(projectConfigToDevProject(projectConfig)));
-    devFile.setProjects(projects);
+    devfile.setProjects(projects);
 
     // Manage commands
     Map<String, String> toolsIdToName = parseTools(wsConfig);
@@ -67,7 +67,7 @@ public class DevfileConverter {
     wsConfig
         .getCommands()
         .forEach(command -> commands.add(commandImplToDevCommand(command, toolsIdToName)));
-    devFile.setCommands(commands);
+    devfile.setCommands(commands);
 
     // Manage tools
     List<Tool> tools = new ArrayList<>();
@@ -91,27 +91,27 @@ public class DevfileConverter {
         }
       }
     }
-    devFile.setTools(tools);
-    return devFile;
+    devfile.setTools(tools);
+    return devfile;
   }
 
-  public WorkspaceConfigImpl devFileToWorkspaceConfig(Devfile devFile)
+  public WorkspaceConfigImpl devFileToWorkspaceConfig(Devfile devfile)
       throws DevfileFormatException {
-    validateCurrentVersion(devFile);
+    validateCurrentVersion(devfile);
     WorkspaceConfigImpl config = new WorkspaceConfigImpl();
 
-    config.setName(devFile.getName());
+    config.setName(devfile.getName());
 
     // Manage projects
     List<ProjectConfigImpl> projects = new ArrayList<>();
-    devFile.getProjects().forEach(project -> projects.add(devProjectToProjectConfig(project)));
+    devfile.getProjects().forEach(project -> projects.add(devProjectToProjectConfig(project)));
     config.setProjects(projects);
 
     // Manage tools
     Map<String, String> attributes = new HashMap<>();
     StringJoiner pluginsStringJoiner = new StringJoiner(",");
     StringJoiner toolIdToNameMappingStringJoiner = new StringJoiner(",");
-    for (Tool tool : devFile.getTools()) {
+    for (Tool tool : devfile.getTools()) {
       switch (tool.getType()) {
         case "cheEditor":
           attributes.put(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE, tool.getId());
@@ -135,9 +135,9 @@ public class DevfileConverter {
 
     // Manage commands
     List<CommandImpl> commands = new ArrayList<>();
-    devFile
+    devfile
         .getCommands()
-        .forEach(command -> commands.addAll(devCommandToCommandImpls(devFile, command)));
+        .forEach(command -> commands.addAll(devCommandToCommandImpls(devfile, command)));
     config.setCommands(commands);
     return config;
   }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
@@ -17,6 +17,8 @@ import static java.lang.String.format;
 import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DIRECTORY_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.Constants.ALIASES_WORKSPACE_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.devfile.server.Constants.CURRENT_SPEC_VERSION;
+import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_EDITOR_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE;
 
@@ -76,7 +78,7 @@ public class DevfileConverter {
         String editorId = entry.getValue();
         Tool editorTool =
             new Tool()
-                .withType("cheEditor")
+                .withType(EDITOR_TOOL_TYPE)
                 .withId(editorId)
                 .withName(toolsIdToName.getOrDefault(editorId, editorId));
         tools.add(editorTool);
@@ -85,7 +87,7 @@ public class DevfileConverter {
           Tool pluginTool =
               new Tool()
                   .withId(pluginId)
-                  .withType("chePlugin")
+                  .withType(PLUGIN_TOOL_TYPE)
                   .withName(toolsIdToName.getOrDefault(pluginId, pluginId));
           tools.add(pluginTool);
         }
@@ -113,10 +115,10 @@ public class DevfileConverter {
     StringJoiner toolIdToNameMappingStringJoiner = new StringJoiner(",");
     for (Tool tool : devfile.getTools()) {
       switch (tool.getType()) {
-        case "cheEditor":
+        case EDITOR_TOOL_TYPE:
           attributes.put(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE, tool.getId());
           break;
-        case "chePlugin":
+        case PLUGIN_TOOL_TYPE:
           pluginsStringJoiner.add(tool.getId());
           break;
         default:

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
@@ -49,7 +49,7 @@ public class DevfileIntegrityValidator {
    * </pre>
    *
    * @param devfile input devfile
-   * @throws DevfileFormatException is some of the checks is failed
+   * @throws DevfileFormatException if some of the checks is failed
    */
   public void validateDevfile(Devfile devfile) throws DevfileFormatException {
     validateProjects(devfile);

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
@@ -13,6 +13,8 @@ package org.eclipse.che.api.devfile.server;
 
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
+import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -37,8 +39,12 @@ import org.eclipse.che.api.devfile.model.Tool;
  * </pre>
  */
 @Singleton
-public class DevfileIntegrityValidator {
+class DevfileIntegrityValidator {
 
+  /**
+   * Checks than name may contain only letters, digits, symbols _.- and does not starts with
+   * non-word character.
+   */
   private static final Pattern PROJECT_NAME_PATTERN = Pattern.compile("^[\\w\\d]+[\\w\\d_.-]*$");
 
   void validateDevfile(Devfile devfile) throws DevfileFormatException {
@@ -55,7 +61,7 @@ public class DevfileIntegrityValidator {
         throw new DevfileFormatException(format("Duplicate tool name found:'%s'", tool.getName()));
       }
       switch (tool.getType()) {
-        case "cheEditor":
+        case EDITOR_TOOL_TYPE:
           if (editorTool != null) {
             throw new DevfileFormatException(
                 format(
@@ -64,7 +70,7 @@ public class DevfileIntegrityValidator {
           }
           editorTool = tool;
           break;
-        case "chePlugin":
+        case PLUGIN_TOOL_TYPE:
           break;
         default:
           throw new DevfileFormatException(
@@ -108,7 +114,7 @@ public class DevfileIntegrityValidator {
       if (!PROJECT_NAME_PATTERN.matcher(project.getName()).matches()) {
         throw new DevfileFormatException(
             format(
-                "Invalid project name found:'%s'. Name must contain only Latin letters,\n"
+                "Invalid project name found:'%s'. Name must contain only Latin letters,"
                     + "digits or these following special characters ._-",
                 project.getName()));
       }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.devfile.server;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+import javax.inject.Singleton;
+import org.eclipse.che.api.devfile.model.Action;
+import org.eclipse.che.api.devfile.model.Command;
+import org.eclipse.che.api.devfile.model.Devfile;
+import org.eclipse.che.api.devfile.model.Project;
+import org.eclipse.che.api.devfile.model.Tool;
+
+/**
+ * Validates devfile logical integrity. Performs the following checks:
+ *
+ * <pre>
+ * <ul>
+ *   <li>All listed items (projects, tools, commands) have unique names</li>
+ *   <li>There is only one tool of type cheEditor</li>
+ *   <li>All tools exists which are referenced/required by command actions</li>
+ *   <li>Project names conforms naming rules</>
+ * </ul>
+ * </pre>
+ */
+@Singleton
+public class DevfileIntegrityValidator {
+
+  private static final Pattern PROJECT_NAME_PATTERN = Pattern.compile("^[\\w\\d]+[\\w\\d_.-]*$");
+
+  void validateDevfile(Devfile devfile) throws DevfileFormatException {
+    validateProjects(devfile);
+    Set<String> toolNames = validateTools(devfile);
+    validateCommands(devfile, toolNames);
+  }
+
+  private Set<String> validateTools(Devfile devfile) throws DevfileFormatException {
+    Set<String> existingNames = new HashSet<>();
+    Tool editorTool = null;
+    for (Tool tool : devfile.getTools()) {
+      if (!existingNames.add(tool.getName())) {
+        throw new DevfileFormatException(format("Duplicate tool name found:'%s'", tool.getName()));
+      }
+      switch (tool.getType()) {
+        case "cheEditor":
+          if (editorTool != null) {
+            throw new DevfileFormatException(
+                format(
+                    "Multiple editor tools found: '%s', '%s'",
+                    editorTool.getName(), tool.getName()));
+          }
+          editorTool = tool;
+          break;
+        case "chePlugin":
+          break;
+        default:
+          throw new DevfileFormatException(
+              format("Unsupported tool '%s' type provided:'%s'", tool.getName(), tool.getType()));
+      }
+    }
+    return existingNames;
+  }
+
+  private void validateCommands(Devfile devfile, Set<String> toolNames)
+      throws DevfileFormatException {
+    Set<String> existingNames = new HashSet<>();
+    for (Command command : devfile.getCommands()) {
+      if (!existingNames.add(command.getName())) {
+        throw new DevfileFormatException(
+            format("Duplicate command name found:'%s'", command.getName()));
+      }
+      Set<String> nonexistingToolActions =
+          command
+              .getActions()
+              .stream()
+              .map(Action::getTool)
+              .filter(t -> !toolNames.contains(t))
+              .collect(toSet());
+      if (!nonexistingToolActions.isEmpty()) {
+        throw new DevfileFormatException(
+            format(
+                "Found actions which refers to non-existing tools in command '%s':'%s'",
+                command.getName(), String.join(",", nonexistingToolActions)));
+      }
+    }
+  }
+
+  private void validateProjects(Devfile devfile) throws DevfileFormatException {
+    Set<String> existingNames = new HashSet<>();
+    for (Project project : devfile.getProjects()) {
+      if (!existingNames.add(project.getName())) {
+        throw new DevfileFormatException(
+            format("Duplicate project name found:'%s'", project.getName()));
+      }
+      if (!PROJECT_NAME_PATTERN.matcher(project.getName()).matches()) {
+        throw new DevfileFormatException(
+            format(
+                "Invalid project name found:'%s'. Name must contain only Latin letters,\n"
+                    + "digits or these following special characters ._-",
+                project.getName()));
+      }
+    }
+  }
+}

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
@@ -48,8 +48,7 @@ public class DevfileIntegrityValidator {
    * </ul>
    * </pre>
    *
-   * param devfile input devfile
-   *
+   * @param devfile input devfile
    * @throws DevfileFormatException is some of the checks is failed
    */
   public void validateDevfile(Devfile devfile) throws DevfileFormatException {

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
@@ -92,18 +92,18 @@ public class DevfileIntegrityValidator {
         throw new DevfileFormatException(
             format("Duplicate command name found:'%s'", command.getName()));
       }
-      Set<String> nonexistingToolActions =
+      Set<String> nonExistingToolActions =
           command
               .getActions()
               .stream()
               .map(Action::getTool)
               .filter(t -> !toolNames.contains(t))
               .collect(toSet());
-      if (!nonexistingToolActions.isEmpty()) {
+      if (!nonExistingToolActions.isEmpty()) {
         throw new DevfileFormatException(
             format(
-                "Found actions which refers to non-existing tools in command '%s':'%s'",
-                command.getName(), String.join(",", nonexistingToolActions)));
+                "Found actions which refer to non-existing tools in command '%s':'%s'",
+                command.getName(), String.join(",", nonExistingToolActions)));
       }
     }
   }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
@@ -32,7 +32,7 @@ import org.eclipse.che.api.devfile.model.Tool;
  *   <li>All listed items (projects, tools, commands) have unique names</li>
  *   <li>There is only one tool of type cheEditor</li>
  *   <li>All tools exists which are referenced/required by command actions</li>
- *   <li>Project names conforms naming rules<li/>
+ *   <li>Project names conforms naming rules</li>
  * </ul>
  * </pre>
  */

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
@@ -26,20 +26,9 @@ import org.eclipse.che.api.devfile.model.Devfile;
 import org.eclipse.che.api.devfile.model.Project;
 import org.eclipse.che.api.devfile.model.Tool;
 
-/**
- * Validates devfile logical integrity. Performs the following checks:
- *
- * <pre>
- * <ul>
- *   <li>All listed items (projects, tools, commands) have unique names</li>
- *   <li>There is only one tool of type cheEditor</li>
- *   <li>All tools exists which are referenced/required by command actions</li>
- *   <li>Project names conforms naming rules</li>
- * </ul>
- * </pre>
- */
+/** Validates devfile logical integrity. */
 @Singleton
-class DevfileIntegrityValidator {
+public class DevfileIntegrityValidator {
 
   /**
    * Checks than name may contain only letters, digits, symbols _.- and does not starts with
@@ -47,7 +36,23 @@ class DevfileIntegrityValidator {
    */
   private static final Pattern PROJECT_NAME_PATTERN = Pattern.compile("^[\\w\\d]+[\\w\\d_.-]*$");
 
-  void validateDevfile(Devfile devfile) throws DevfileFormatException {
+  /**
+   * Performs the following checks:
+   *
+   * <pre>
+   * <ul>
+   *   <li>All listed items (projects, tools, commands) have unique names</li>
+   *   <li>There is only one tool of type cheEditor</li>
+   *   <li>All tools exists which are referenced/required by command actions</li>
+   *   <li>Project names conforms naming rules</li>
+   * </ul>
+   * </pre>
+   *
+   * param devfile input devfile
+   *
+   * @throws DevfileFormatException is some of the checks is failed
+   */
+  public void validateDevfile(Devfile devfile) throws DevfileFormatException {
     validateProjects(devfile);
     Set<String> toolNames = validateTools(devfile);
     validateCommands(devfile, toolNames);

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidator.java
@@ -32,7 +32,7 @@ import org.eclipse.che.api.devfile.model.Tool;
  *   <li>All listed items (projects, tools, commands) have unique names</li>
  *   <li>There is only one tool of type cheEditor</li>
  *   <li>All tools exists which are referenced/required by command actions</li>
- *   <li>Project names conforms naming rules</>
+ *   <li>Project names conforms naming rules<li/>
  * </ul>
  * </pre>
  */

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileService.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileService.java
@@ -58,6 +58,7 @@ public class DevfileService extends Service {
 
   private WorkspaceLinksGenerator linksGenerator;
   private DevfileSchemaValidator schemaValidator;
+  private DevfileIntegrityValidator integrityValidator;
   private DevfileSchemaProvider schemaCachedProvider;
   private WorkspaceManager workspaceManager;
   private ObjectMapper objectMapper;
@@ -67,10 +68,12 @@ public class DevfileService extends Service {
   public DevfileService(
       WorkspaceLinksGenerator linksGenerator,
       DevfileSchemaValidator schemaValidator,
+      DevfileIntegrityValidator integrityValidator,
       DevfileSchemaProvider schemaCachedProvider,
       WorkspaceManager workspaceManager) {
     this.linksGenerator = linksGenerator;
     this.schemaValidator = schemaValidator;
+    this.integrityValidator = integrityValidator;
     this.schemaCachedProvider = schemaCachedProvider;
     this.workspaceManager = workspaceManager;
     this.objectMapper = new ObjectMapper(new YAMLFactory());
@@ -136,6 +139,7 @@ public class DevfileService extends Service {
     try {
       JsonNode parsed = schemaValidator.validateBySchema(data, verbose);
       devFile = objectMapper.treeToValue(parsed, Devfile.class);
+      integrityValidator.validateDevfile(devFile);
       workspaceConfig = devfileConverter.devFileToWorkspaceConfig(devFile);
     } catch (IOException e) {
       throw new ServerException(e.getMessage());

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidatorTest.java
@@ -49,7 +49,7 @@ public class DevfileIntegrityValidatorTest {
 
   @Test(
       expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp = "Duplicate tool name found:'.*'")
+      expectedExceptionsMessageRegExp = "Duplicate tool name found:'mvn-stack'")
   public void shouldThrowExceptionOnDuplicateToolName() throws Exception {
     Devfile broken = copyOf(initialDevfile);
     broken.getTools().add(new Tool().withName(initialDevfile.getTools().get(0).getName()));
@@ -59,7 +59,7 @@ public class DevfileIntegrityValidatorTest {
 
   @Test(
       expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp = "Multiple editor tools found: '.*', '.*'")
+      expectedExceptionsMessageRegExp = "Multiple editor tools found: 'theia-ide', 'editor-2'")
   public void shouldThrowExceptionOnMultipleEditors() throws Exception {
     Devfile broken = copyOf(initialDevfile);
     broken.getTools().add(new Tool().withName("editor-2").withType("cheEditor"));
@@ -69,7 +69,7 @@ public class DevfileIntegrityValidatorTest {
 
   @Test(
       expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp = "Duplicate command name found:'.*'")
+      expectedExceptionsMessageRegExp = "Duplicate command name found:'build'")
   public void shouldThrowExceptionOnDuplicateCommandName() throws Exception {
     Devfile broken = copyOf(initialDevfile);
     broken.getCommands().add(new Command().withName(initialDevfile.getCommands().get(0).getName()));
@@ -80,7 +80,7 @@ public class DevfileIntegrityValidatorTest {
   @Test(
       expectedExceptions = DevfileFormatException.class,
       expectedExceptionsMessageRegExp =
-          "Found actions which refers to non-existing tools in command '.*':'no_such_tool'")
+          "Found actions which refers to non-existing tools in command 'build':'no_such_tool'")
   public void shouldThrowExceptionOnUnexistingCommandActionTool() throws Exception {
     Devfile broken = copyOf(initialDevfile);
     broken.getCommands().get(0).getActions().add(new Action().withTool("no_such_tool"));
@@ -90,7 +90,7 @@ public class DevfileIntegrityValidatorTest {
 
   @Test(
       expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp = "Duplicate project name found:'.*'")
+      expectedExceptionsMessageRegExp = "Duplicate project name found:'petclinic'")
   public void shouldThrowExceptionOnDuplicateProjectName() throws Exception {
     Devfile broken = copyOf(initialDevfile);
     broken.getProjects().add(new Project().withName(initialDevfile.getProjects().get(0).getName()));
@@ -101,7 +101,7 @@ public class DevfileIntegrityValidatorTest {
   @Test(
       expectedExceptions = DevfileFormatException.class,
       expectedExceptionsMessageRegExp =
-          "Invalid project name found:'.*'. Name must contain only Latin letters,\\n"
+          "Invalid project name found:'.*'. Name must contain only Latin letters,"
               + "digits or these following special characters ._-")
   public void shouldThrowExceptionOnInvalidProjectName() throws Exception {
     Devfile broken = copyOf(initialDevfile);

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidatorTest.java
@@ -132,11 +132,20 @@ public class DevfileIntegrityValidatorTest {
     result.setTools(tools);
     List<Command> commands = new ArrayList<>();
     for (Command command : source.getCommands()) {
+      List<Action> actions = new ArrayList<>();
+      for (Action action : command.getActions()) {
+        actions.add(
+            new Action()
+                .withCommand(action.getCommand())
+                .withTool(action.getTool())
+                .withType(action.getType())
+                .withWorkdir(action.getWorkdir()));
+      }
       commands.add(
           new Command()
               .withName(command.getName())
               .withAttributes(command.getAttributes())
-              .withActions(new ArrayList<>(command.getActions())));
+              .withActions(actions));
     }
     result.setCommands(commands);
     return result;

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidatorTest.java
@@ -80,7 +80,7 @@ public class DevfileIntegrityValidatorTest {
   @Test(
       expectedExceptions = DevfileFormatException.class,
       expectedExceptionsMessageRegExp =
-          "Found actions which refers to non-existing tools in command 'build':'no_such_tool'")
+          "Found actions which refer to non-existing tools in command 'build':'no_such_tool'")
   public void shouldThrowExceptionOnUnexistingCommandActionTool() throws Exception {
     Devfile broken = copyOf(initialDevfile);
     broken.getCommands().get(0).getActions().add(new Action().withTool("no_such_tool"));

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileIntegrityValidatorTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.devfile.server;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.che.api.devfile.model.Action;
+import org.eclipse.che.api.devfile.model.Command;
+import org.eclipse.che.api.devfile.model.Devfile;
+import org.eclipse.che.api.devfile.model.Project;
+import org.eclipse.che.api.devfile.model.Source;
+import org.eclipse.che.api.devfile.model.Tool;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.testng.reporters.Files;
+
+public class DevfileIntegrityValidatorTest {
+
+  private ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
+
+  private Devfile initialDevfile;
+
+  private DevfileIntegrityValidator integrityValidator;
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    integrityValidator = new DevfileIntegrityValidator();
+    String devFileYamlContent =
+        Files.readFile(getClass().getClassLoader().getResourceAsStream("devfile.yaml"));
+    initialDevfile = objectMapper.readValue(devFileYamlContent, Devfile.class);
+  }
+
+  @Test
+  public void shouldValidateCorrectDevfile() throws Exception {
+    // when
+    integrityValidator.validateDevfile(initialDevfile);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp = "Duplicate tool name found:'.*'")
+  public void shouldThrowExceptionOnDuplicateToolName() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getTools().add(new Tool().withName(initialDevfile.getTools().get(0).getName()));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp = "Multiple editor tools found: '.*', '.*'")
+  public void shouldThrowExceptionOnMultipleEditors() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getTools().add(new Tool().withName("editor-2").withType("cheEditor"));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp = "Duplicate command name found:'.*'")
+  public void shouldThrowExceptionOnDuplicateCommandName() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getCommands().add(new Command().withName(initialDevfile.getCommands().get(0).getName()));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Found actions which refers to non-existing tools in command '.*':'no_such_tool'")
+  public void shouldThrowExceptionOnUnexistingCommandActionTool() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getCommands().get(0).getActions().add(new Action().withTool("no_such_tool"));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp = "Duplicate project name found:'.*'")
+  public void shouldThrowExceptionOnDuplicateProjectName() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getProjects().add(new Project().withName(initialDevfile.getProjects().get(0).getName()));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Invalid project name found:'.*'. Name must contain only Latin letters,\\n"
+              + "digits or these following special characters ._-")
+  public void shouldThrowExceptionOnInvalidProjectName() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getProjects().get(0).setName("./" + initialDevfile.getProjects().get(0).getName());
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  private Devfile copyOf(Devfile source) {
+    Devfile result = new Devfile();
+    result.setName(source.getName());
+    result.setSpecVersion(source.getSpecVersion());
+    List<Project> projects = new ArrayList<>();
+    for (Project project : source.getProjects()) {
+      projects.add(
+          new Project()
+              .withName(project.getName())
+              .withSource(
+                  new Source()
+                      .withType(project.getSource().getType())
+                      .withLocation(project.getSource().getType())));
+    }
+    result.setProjects(projects);
+    List<Tool> tools = new ArrayList<>();
+    for (Tool tool : source.getTools()) {
+      tools.add(new Tool().withId(tool.getId()).withName(tool.getName()).withType(tool.getType()));
+    }
+    result.setTools(tools);
+    List<Command> commands = new ArrayList<>();
+    for (Command command : source.getCommands()) {
+      commands.add(
+          new Command()
+              .withName(command.getName())
+              .withAttributes(command.getAttributes())
+              .withActions(new ArrayList<>(command.getActions())));
+    }
+    result.setCommands(commands);
+    return result;
+  }
+}

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileServiceTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileServiceTest.java
@@ -64,6 +64,7 @@ public class DevfileServiceTest {
 
   @Mock private WorkspaceManager workspaceManager;
   @Mock private EnvironmentContext environmentContext;
+  @Mock private DevfileIntegrityValidator integrityValidator;
   private DevfileSchemaProvider schemaProvider = new DevfileSchemaProvider();
   private DevfileSchemaValidator validator;
 
@@ -76,10 +77,11 @@ public class DevfileServiceTest {
   private DevfileService devFileService;
 
   @BeforeMethod
-  public void initService() throws IOException {
+  public void initService() {
     this.validator = spy(new DevfileSchemaValidator(schemaProvider));
     this.devFileService =
-        new DevfileService(linksGenerator, validator, schemaProvider, workspaceManager);
+        new DevfileService(
+            linksGenerator, validator, integrityValidator, schemaProvider, workspaceManager);
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Adds validator for devfile logical integrity. It performs the following checks:
 -All listed items (projects, tools, commands) have unique names</li>
 -There is only one tool of type cheEditor</li>
 -All tools exists which are referenced/required by command actions</li>
 -Project names conforms naming rules

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12079



#### Release Notes
N/A


#### Docs PR
N/A