### PR TITLE
Added PerWorkspace PVC strategy

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -397,14 +397,18 @@ che.infra.kubernetes.pvc.enabled=true
 #
 # Supported strategies:
 # - 'common'
-#        PVC with name that is configured by 'che.infra.kubernetes.pvc.name'
-#        property will be used for storing workspaces data of each workspace
-#        in an OpenShift project.
+#        All workspaces in the same Kubernetes Namespace will reuse the same PVC.
+#        Name of PVC may be configured with 'che.infra.kubernetes.pvc.name'.
 #        Existing PVC will be used or new one will be created if it doesn't exist.
 #
 # - 'unique'
-#        PVC with name that is evaluated as '{che.infra.kubernetes.pvc.name} + '-' + {generated_8_chars}'
-#        will be used for storing of workspaces data.
+#        Separate PVC for each workspace's volume will be used.
+#        Name of PVC is evaluated as '{che.infra.kubernetes.pvc.name} + '-' + {generated_8_chars}'.
+#        Existing PVC will be used or a new one will be created if it doesn't exist.
+#
+# - 'per-workspace'
+#        Separate PVC for each workspace will be used.
+#        Name of PVC is evaluated as '{che.infra.kubernetes.pvc.name} + '-' + {WORKSPACE_ID}'.
 #        Existing PVC will be used or a new one will be created if it doesn't exist.
 che.infra.kubernetes.pvc.strategy=common
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes;
 
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.COMMON_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.PerWorkspacePVCStrategy.PER_WORKSPACE_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.UniqueWorkspacePVCStrategy.UNIQUE_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.DefaultHostIngressExternalServerExposer.DEFAULT_HOST_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostIngressExternalServerExposer.MULTI_HOST_STRATEGY;
@@ -42,6 +43,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.RemoveNamespaceOnWorkspaceRemove;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.PerWorkspacePVCStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.UniqueWorkspacePVCStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspacePVCCleaner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumeStrategyProvider;
@@ -99,6 +101,7 @@ public class KubernetesInfraModule extends AbstractModule {
     MapBinder<String, WorkspaceVolumesStrategy> volumesStrategies =
         MapBinder.newMapBinder(binder(), String.class, WorkspaceVolumesStrategy.class);
     volumesStrategies.addBinding(COMMON_STRATEGY).to(CommonPVCStrategy.class);
+    volumesStrategies.addBinding(PER_WORKSPACE_STRATEGY).to(PerWorkspacePVCStrategy.class);
     volumesStrategies.addBinding(UNIQUE_STRATEGY).to(UniqueWorkspacePVCStrategy.class);
     bind(WorkspaceVolumesStrategy.class).toProvider(WorkspaceVolumeStrategyProvider.class);
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
@@ -29,6 +29,8 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Allows to create ephemeral workspaces (with no PVC attached) based on workspace config
@@ -42,10 +44,13 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
  */
 @Singleton
 public class EphemeralWorkspaceAdapter {
+  private static final Logger LOG = LoggerFactory.getLogger(CommonPVCStrategy.class);
+
   private static final String EPHEMERAL_VOLUME_NAME_PREFIX = "ephemeral-che-workspace-";
 
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
+    LOG.debug("Provisioning PVC strategy for workspace '{}'", identity.getWorkspaceId());
     for (Pod pod : k8sEnv.getPods().values()) {
       PodSpec podSpec = pod.getSpec();
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
@@ -11,78 +11,38 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
-import static java.lang.String.format;
-import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newPVC;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolume;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolumeMount;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
 
 import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Workspace;
-import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
-import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
- * Provides common PVC per each workspace in one Kubernetes namespace.
+ * Provides common PVC per each workspace.
  *
  * <p>Names for PVCs are evaluated as: '{configured_prefix}' + '-' +'{workspaceId}' to avoid naming
  * collisions inside of one Kubernetes namespace.
  *
- * <p>This strategy uses subpaths for resolving backed up data paths collisions. <br>
- * Subpaths evaluated as following: '{workspace data folder}'. Workspace data folder it's a
- * configured path where workspace projects, logs or any other data located, this path may contain a
- * machine name when conflicts can occur e.g. two identical agents inside different machines produce
+ * <p>This strategy uses subpaths to do the same as {@link CommonPVCStrategy} does and make easier
+ * data migration if it will be needed.<br>
+ * Subpaths have the following format: '{workspaceId}/{volumeName}'.<br>
+ * Note that logs volume has the special format: '{workspaceId}/{volumeName}/{machineName}'. It is
+ * done in this way to avoid conflicts e.g. two identical agents inside different machines produce
  * the same log file.
  *
- * @author Anton Korneta
- * @author Alexander Garagatyi
+ * @author Sergii Leshchenko
  * @author Masaki Muranaka
  */
-public class PerWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
+public class PerWorkspacePVCStrategy extends CommonPVCStrategy {
 
-  private static final Logger LOG = LoggerFactory.getLogger(PerWorkspacePVCStrategy.class);
   public static final String PER_WORKSPACE_STRATEGY = "per-workspace";
 
-  /**
-   * The additional property name with the wildcard reserved for workspace id. Formatted property
-   * with the real workspace id is used to get workspace subpaths directories. The value of this
-   * property represents the String array of subpaths that are used to create folders in PV with
-   * user rights. Note that the value would not be stored and it is removed before PVC creation.
-   */
-  static final String SUBPATHS_PROPERTY_FMT = "che.workspace.%s.subpaths";
-
-  private final boolean preCreateDirs;
-  private final String pvcQuantity;
-  private final String pvcName;
-  private final String pvcAccessMode;
-  private final PVCSubPathHelper pvcSubPathHelper;
   private final KubernetesNamespaceFactory factory;
-  private final EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
+  private final String pvcNamePrefix;
 
   @Inject
   public PerWorkspacePVCStrategy(
@@ -93,77 +53,21 @@ public class PerWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
       PVCSubPathHelper pvcSubPathHelper,
       KubernetesNamespaceFactory factory,
       EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter) {
-    this.pvcName = pvcName;
-    this.pvcQuantity = pvcQuantity;
-    this.pvcAccessMode = pvcAccessMode;
-    this.preCreateDirs = preCreateDirs;
-    this.pvcSubPathHelper = pvcSubPathHelper;
+    super(
+        pvcName,
+        pvcQuantity,
+        pvcAccessMode,
+        preCreateDirs,
+        pvcSubPathHelper,
+        factory,
+        ephemeralWorkspaceAdapter);
+    this.pvcNamePrefix = pvcName;
     this.factory = factory;
-    this.ephemeralWorkspaceAdapter = ephemeralWorkspaceAdapter;
   }
 
   @Override
-  public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
-      throws InfrastructureException {
-    final String workspaceId = identity.getWorkspaceId();
-    if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
-      ephemeralWorkspaceAdapter.provision(k8sEnv, identity);
-      return;
-    }
-    LOG.debug("Provisioning PVC strategy for workspace '{}'", workspaceId);
-    final Set<String> subPaths = new HashSet<>();
-    final String pvcName = getPVCName(workspaceId);
-    final PersistentVolumeClaim pvc = newPVC(pvcName, pvcAccessMode, pvcQuantity);
-    putLabel(pvc, CHE_WORKSPACE_ID_LABEL, workspaceId);
-    k8sEnv.getPersistentVolumeClaims().put(pvcName, pvc);
-    for (Pod pod : k8sEnv.getPods().values()) {
-      PodSpec podSpec = pod.getSpec();
-      List<Container> containers = new ArrayList<>();
-      containers.addAll(podSpec.getContainers());
-      containers.addAll(podSpec.getInitContainers());
-      for (Container container : containers) {
-        String machineName = Names.machineName(pod, container);
-        InternalMachineConfig machineConfig = k8sEnv.getMachines().get(machineName);
-        addMachineVolumes(workspaceId, subPaths, pod, container, machineConfig.getVolumes());
-      }
-    }
-    if (preCreateDirs && !subPaths.isEmpty()) {
-      pvc.setAdditionalProperty(
-          format(SUBPATHS_PROPERTY_FMT, workspaceId),
-          subPaths.toArray(new String[subPaths.size()]));
-    }
-    LOG.debug("PVC strategy provisioning done for workspace '{}'", workspaceId);
-  }
-
-  @Override
-  public void prepare(KubernetesEnvironment k8sEnv, String workspaceId, long timeoutMillis)
-      throws InfrastructureException {
-    if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
-      return;
-    }
-    final Collection<PersistentVolumeClaim> claims = k8sEnv.getPersistentVolumeClaims().values();
-    if (!claims.isEmpty()) {
-      LOG.debug("Preparing PVC started for workspace '{}'", workspaceId);
-      final KubernetesNamespace namespace = factory.create(workspaceId);
-      final KubernetesPersistentVolumeClaims pvcs = namespace.persistentVolumeClaims();
-      final Set<String> existing =
-          pvcs.get().stream().map(p -> p.getMetadata().getName()).collect(toSet());
-      for (PersistentVolumeClaim pvc : claims) {
-        final String[] subpaths =
-            (String[])
-                pvc.getAdditionalProperties().remove(format(SUBPATHS_PROPERTY_FMT, workspaceId));
-        if (!existing.contains(pvc.getMetadata().getName())) {
-          LOG.debug("Creating PVC for workspace '{}'", workspaceId);
-          pvcs.create(pvc);
-          LOG.debug("Waiting PVC for workspace '{}' to be bound", workspaceId);
-          pvcs.waitBound(pvc.getMetadata().getName(), timeoutMillis);
-        }
-        if (preCreateDirs && subpaths != null) {
-          pvcSubPathHelper.createDirs(workspaceId, subpaths);
-        }
-      }
-      LOG.debug("Preparing PVC done for workspace '{}'", workspaceId);
-    }
+  protected String getCommonPVCName(RuntimeIdentity identity) {
+    return pvcNamePrefix + '-' + identity.getWorkspaceId();
   }
 
   @Override
@@ -176,48 +80,5 @@ public class PerWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
         .create(workspaceId)
         .persistentVolumeClaims()
         .delete(ImmutableMap.of(CHE_WORKSPACE_ID_LABEL, workspaceId));
-  }
-
-  private void addMachineVolumes(
-      String workspaceId,
-      Set<String> subPaths,
-      Pod pod,
-      Container container,
-      Map<String, Volume> volumes) {
-    if (volumes.isEmpty()) {
-      return;
-    }
-    final String pvcName = getPVCName(workspaceId);
-    for (Entry<String, Volume> volumeEntry : volumes.entrySet()) {
-      String volumePath = volumeEntry.getValue().getPath();
-      String subPath =
-          getVolumeSubPath(workspaceId, volumeEntry.getKey(), Names.machineName(pod, container));
-      subPaths.add(subPath);
-
-      container.getVolumeMounts().add(newVolumeMount(pvcName, volumePath, subPath));
-      addVolumeIfNeeded(pod.getSpec(), pvcName);
-    }
-  }
-
-  private void addVolumeIfNeeded(PodSpec podSpec, String pvcName) {
-    if (podSpec.getVolumes().stream().noneMatch(volume -> volume.getName().equals(pvcName))) {
-      podSpec.getVolumes().add(newVolume(pvcName, pvcName));
-    }
-  }
-
-  /** Get sub-path for particular volume in a particular workspace */
-  private String getVolumeSubPath(String workspaceId, String volumeName, String machineName) {
-    // logs must be located inside the folder related to the machine because few machines can
-    // contain the identical agents and in this case, a conflict is possible.
-    if (LOGS_VOLUME_NAME.equals(volumeName)) {
-      return volumeName + '/' + machineName;
-    }
-    // this path should correlate with path returned by method getWorkspaceSubPath
-    // because this logic is used to correctly cleanup sub-paths related to a workspace
-    return volumeName;
-  }
-
-  private String getPVCName(String workspaceId) {
-    return this.pvcName + "-" + workspaceId;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toSet;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newPVC;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolume;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolumeMount;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides common PVC per each workspace in one Kubernetes namespace.
+ *
+ * <p>Names for PVCs are evaluated as: '{configured_prefix}' + '-' +'{workspaceId}' to avoid naming
+ * collisions inside of one Kubernetes namespace.
+ *
+ * <p>This strategy uses subpaths for resolving backed up data paths collisions. <br>
+ * Subpaths evaluated as following: '{workspace data folder}'. Workspace data folder it's a
+ * configured path where workspace projects, logs or any other data located, this path may contain a
+ * machine name when conflicts can occur e.g. two identical agents inside different machines produce
+ * the same log file.
+ *
+ * @author Anton Korneta
+ * @author Alexander Garagatyi
+ * @author Masaki Muranaka
+ */
+public class PerWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PerWorkspacePVCStrategy.class);
+  public static final String PER_WORKSPACE_STRATEGY = "per-workspace";
+
+  /**
+   * The additional property name with the wildcard reserved for workspace id. Formatted property
+   * with the real workspace id is used to get workspace subpaths directories. The value of this
+   * property represents the String array of subpaths that are used to create folders in PV with
+   * user rights. Note that the value would not be stored and it is removed before PVC creation.
+   */
+  static final String SUBPATHS_PROPERTY_FMT = "che.workspace.%s.subpaths";
+
+  private final boolean preCreateDirs;
+  private final String pvcQuantity;
+  private final String pvcName;
+  private final String pvcAccessMode;
+  private final PVCSubPathHelper pvcSubPathHelper;
+  private final KubernetesNamespaceFactory factory;
+  private final EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
+
+  @Inject
+  public PerWorkspacePVCStrategy(
+      @Named("che.infra.kubernetes.pvc.name") String pvcName,
+      @Named("che.infra.kubernetes.pvc.quantity") String pvcQuantity,
+      @Named("che.infra.kubernetes.pvc.access_mode") String pvcAccessMode,
+      @Named("che.infra.kubernetes.pvc.precreate_subpaths") boolean preCreateDirs,
+      PVCSubPathHelper pvcSubPathHelper,
+      KubernetesNamespaceFactory factory,
+      EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter) {
+    this.pvcName = pvcName;
+    this.pvcQuantity = pvcQuantity;
+    this.pvcAccessMode = pvcAccessMode;
+    this.preCreateDirs = preCreateDirs;
+    this.pvcSubPathHelper = pvcSubPathHelper;
+    this.factory = factory;
+    this.ephemeralWorkspaceAdapter = ephemeralWorkspaceAdapter;
+  }
+
+  @Override
+  public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+    final String workspaceId = identity.getWorkspaceId();
+    if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
+      ephemeralWorkspaceAdapter.provision(k8sEnv, identity);
+      return;
+    }
+    LOG.debug("Provisioning PVC strategy for workspace '{}'", workspaceId);
+    final Set<String> subPaths = new HashSet<>();
+    final String pvcName = getPVCName(workspaceId);
+    final PersistentVolumeClaim pvc = newPVC(pvcName, pvcAccessMode, pvcQuantity);
+    putLabel(pvc, CHE_WORKSPACE_ID_LABEL, workspaceId);
+    k8sEnv.getPersistentVolumeClaims().put(pvcName, pvc);
+    for (Pod pod : k8sEnv.getPods().values()) {
+      PodSpec podSpec = pod.getSpec();
+      List<Container> containers = new ArrayList<>();
+      containers.addAll(podSpec.getContainers());
+      containers.addAll(podSpec.getInitContainers());
+      for (Container container : containers) {
+        String machineName = Names.machineName(pod, container);
+        InternalMachineConfig machineConfig = k8sEnv.getMachines().get(machineName);
+        addMachineVolumes(workspaceId, subPaths, pod, container, machineConfig.getVolumes());
+      }
+    }
+    if (preCreateDirs && !subPaths.isEmpty()) {
+      pvc.setAdditionalProperty(
+          format(SUBPATHS_PROPERTY_FMT, workspaceId),
+          subPaths.toArray(new String[subPaths.size()]));
+    }
+    LOG.debug("PVC strategy provisioning done for workspace '{}'", workspaceId);
+  }
+
+  @Override
+  public void prepare(KubernetesEnvironment k8sEnv, String workspaceId, long timeoutMillis)
+      throws InfrastructureException {
+    if (EphemeralWorkspaceUtility.isEphemeral(k8sEnv.getAttributes())) {
+      return;
+    }
+    final Collection<PersistentVolumeClaim> claims = k8sEnv.getPersistentVolumeClaims().values();
+    if (!claims.isEmpty()) {
+      LOG.debug("Preparing PVC started for workspace '{}'", workspaceId);
+      final KubernetesNamespace namespace = factory.create(workspaceId);
+      final KubernetesPersistentVolumeClaims pvcs = namespace.persistentVolumeClaims();
+      final Set<String> existing =
+          pvcs.get().stream().map(p -> p.getMetadata().getName()).collect(toSet());
+      for (PersistentVolumeClaim pvc : claims) {
+        final String[] subpaths =
+            (String[])
+                pvc.getAdditionalProperties().remove(format(SUBPATHS_PROPERTY_FMT, workspaceId));
+        if (!existing.contains(pvc.getMetadata().getName())) {
+          LOG.debug("Creating PVC for workspace '{}'", workspaceId);
+          pvcs.create(pvc);
+          LOG.debug("Waiting PVC for workspace '{}' to be bound", workspaceId);
+          pvcs.waitBound(pvc.getMetadata().getName(), timeoutMillis);
+        }
+        if (preCreateDirs && subpaths != null) {
+          pvcSubPathHelper.createDirs(workspaceId, subpaths);
+        }
+      }
+      LOG.debug("Preparing PVC done for workspace '{}'", workspaceId);
+    }
+  }
+
+  @Override
+  public void cleanup(Workspace workspace) throws InfrastructureException {
+    if (EphemeralWorkspaceUtility.isEphemeral(workspace)) {
+      return;
+    }
+    final String workspaceId = workspace.getId();
+    factory
+        .create(workspaceId)
+        .persistentVolumeClaims()
+        .delete(ImmutableMap.of(CHE_WORKSPACE_ID_LABEL, workspaceId));
+  }
+
+  private void addMachineVolumes(
+      String workspaceId,
+      Set<String> subPaths,
+      Pod pod,
+      Container container,
+      Map<String, Volume> volumes) {
+    if (volumes.isEmpty()) {
+      return;
+    }
+    final String pvcName = getPVCName(workspaceId);
+    for (Entry<String, Volume> volumeEntry : volumes.entrySet()) {
+      String volumePath = volumeEntry.getValue().getPath();
+      String subPath =
+          getVolumeSubPath(workspaceId, volumeEntry.getKey(), Names.machineName(pod, container));
+      subPaths.add(subPath);
+
+      container.getVolumeMounts().add(newVolumeMount(pvcName, volumePath, subPath));
+      addVolumeIfNeeded(pod.getSpec(), pvcName);
+    }
+  }
+
+  private void addVolumeIfNeeded(PodSpec podSpec, String pvcName) {
+    if (podSpec.getVolumes().stream().noneMatch(volume -> volume.getName().equals(pvcName))) {
+      podSpec.getVolumes().add(newVolume(pvcName, pvcName));
+    }
+  }
+
+  /** Get sub-path for particular volume in a particular workspace */
+  private String getVolumeSubPath(String workspaceId, String volumeName, String machineName) {
+    // logs must be located inside the folder related to the machine because few machines can
+    // contain the identical agents and in this case, a conflict is possible.
+    if (LOGS_VOLUME_NAME.equals(volumeName)) {
+      return volumeName + '/' + machineName;
+    }
+    // this path should correlate with path returned by method getWorkspaceSubPath
+    // because this logic is used to correctly cleanup sub-paths related to a workspace
+    return volumeName;
+  }
+
+  private String getPVCName(String workspaceId) {
+    return this.pvcName + "-" + workspaceId;
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
@@ -47,21 +47,27 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provides a unique PVC for each workspace.
+ * Provides a unique PVC for each volume of a workspace.
  *
  * <p>Names for PVCs are evaluated as: '{configured_prefix}' + '-' +'{generated_8_chars}' to avoid
  * naming collisions inside of one Kubernetes namespace.
  *
- * <p>Note that for this strategy count of simultaneously running workspaces and workspaces with
- * backed up data is always the same and equal to the count of available PVCs in Kubernetes
- * namespace.
+ * <p>Note that for this strategy count of simultaneously used volumes by workspaces is always the
+ * same and equal to the count of available PVCs in Kubernetes namespace.
  *
  * <p>The usage of PVCs for this strategy is next: one PVC per volume, but for volumes that are
  * provided by Che there a small exception: <br>
  * - when the workspace contains few machines that are placed in separated pods and relies on the
  * same volume then, for each of the pods' the separate PVC would be provided.
  *
- * <p>Cleanup of backed up data is performed by removing of PVC related to the workspace but when
+ * <p>This strategy uses subpaths to do the same as {@link CommonPVCStrategy} does and make easier
+ * data migration if it will be needed.<br>
+ * Subpaths have the following format: '{workspaceId}/{volumeName}'.<br>
+ * Note that logs volume has the special format: '{workspaceId}/{volumeName}/{machineName}'. It is
+ * done in this way to avoid conflicts e.g. two identical agents inside different machines produce
+ * the same log file.
+ *
+ * <p>Cleanup of backed up data is performed by removing of PVCs related to the workspace but when
  * the volume or machine name is changed then related PVC would not be removed.
  *
  * @author Anton Korneta

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
@@ -1,0 +1,313 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static java.lang.String.format;
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.SUBPATHS_PROPERTY_FMT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link PerWorkspacePVCStrategy}
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class PerWorkspacePVCStrategyTest {
+
+  private static final String WORKSPACE_ID = "workspace123";
+  private static final String PVC_NAME_PREFIX = "che-claim";
+  private static final String PVC_NAME = PVC_NAME_PREFIX + '-' + WORKSPACE_ID;
+  private static final String POD_NAME = "main";
+  private static final String POD_NAME_2 = "second";
+  private static final String CONTAINER_NAME = "app";
+  private static final String CONTAINER_NAME_2 = "db";
+  private static final String CONTAINER_NAME_3 = "app2";
+  private static final String MACHINE_1_NAME = POD_NAME + '/' + CONTAINER_NAME;
+  private static final String MACHINE_2_NAME = POD_NAME + '/' + CONTAINER_NAME_2;
+  private static final String MACHINE_3_NAME = POD_NAME_2 + '/' + CONTAINER_NAME_3;
+  private static final String PVC_QUANTITY = "10Gi";
+  private static final String PVC_ACCESS_MODE = "RWO";
+  private static final String VOLUME_1_NAME = "vol1";
+  private static final String VOLUME_2_NAME = "vol2";
+
+  private static final String[] WORKSPACE_SUBPATHS = {"/projects", "/logs"};
+
+  private static final RuntimeIdentity IDENTITY =
+      new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");
+
+  @Mock private Pod pod;
+  @Mock private Pod pod2;
+  @Mock private PodSpec podSpec;
+  @Mock private PodSpec podSpec2;
+  @Mock private Container container;
+  @Mock private Container container2;
+  @Mock private Container container3;
+  @Mock private KubernetesEnvironment k8sEnv;
+  @Mock private PVCSubPathHelper pvcSubPathHelper;
+  @Mock private KubernetesNamespaceFactory factory;
+  @Mock private KubernetesNamespace k8sNamespace;
+  @Mock private KubernetesPersistentVolumeClaims pvcs;
+  @Mock private Workspace workspace;
+  @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
+
+  private PerWorkspacePVCStrategy perWorkspaceStratefy;
+
+  @BeforeMethod
+  public void setup() throws Exception {
+    perWorkspaceStratefy =
+        new PerWorkspacePVCStrategy(
+            PVC_NAME_PREFIX,
+            PVC_QUANTITY,
+            PVC_ACCESS_MODE,
+            true,
+            pvcSubPathHelper,
+            factory,
+            ephemeralWorkspaceAdapter);
+
+    Map<String, InternalMachineConfig> machines = new HashMap<>();
+    InternalMachineConfig machine1 = mock(InternalMachineConfig.class);
+    Map<String, Volume> volumes1 = new HashMap<>();
+    volumes1.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
+    volumes1.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
+    lenient().when(machine1.getVolumes()).thenReturn(volumes1);
+    machines.put(MACHINE_1_NAME, machine1);
+
+    InternalMachineConfig machine2 = mock(InternalMachineConfig.class);
+    Map<String, Volume> volumes2 = new HashMap<>();
+    volumes2.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
+    lenient().when(machine2.getVolumes()).thenReturn(volumes2);
+    machines.put(MACHINE_2_NAME, machine2);
+
+    InternalMachineConfig machine3 = mock(InternalMachineConfig.class);
+    Map<String, Volume> volumes3 = new HashMap<>();
+    volumes3.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
+    lenient().when(machine3.getVolumes()).thenReturn(volumes3);
+    machines.put(MACHINE_3_NAME, machine3);
+    lenient().when(k8sEnv.getMachines()).thenReturn(machines);
+
+    Map<String, Pod> pods = new HashMap<>();
+    pods.put(POD_NAME, pod);
+    pods.put(POD_NAME_2, pod2);
+    lenient().when(k8sEnv.getPods()).thenReturn(pods);
+
+    lenient().when(pod.getSpec()).thenReturn(podSpec);
+    lenient().when(pod2.getSpec()).thenReturn(podSpec2);
+    lenient().when(podSpec.getContainers()).thenReturn(asList(container, container2));
+    lenient().when(podSpec2.getContainers()).thenReturn(singletonList(container3));
+    lenient().when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
+    lenient().when(podSpec2.getVolumes()).thenReturn(new ArrayList<>());
+    lenient().when(container.getName()).thenReturn(CONTAINER_NAME);
+    lenient().when(container2.getName()).thenReturn(CONTAINER_NAME_2);
+    lenient().when(container3.getName()).thenReturn(CONTAINER_NAME_3);
+    lenient().when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
+    lenient().when(container2.getVolumeMounts()).thenReturn(new ArrayList<>());
+    lenient().when(container3.getVolumeMounts()).thenReturn(new ArrayList<>());
+
+    lenient().doNothing().when(pvcSubPathHelper).execute(any(), any(), any());
+    lenient().when(k8sEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
+    lenient()
+        .when(pvcSubPathHelper.removeDirsAsync(anyString(), any(String.class)))
+        .thenReturn(CompletableFuture.completedFuture(null));
+    lenient().when(factory.create(WORKSPACE_ID)).thenReturn(k8sNamespace);
+    lenient().when(k8sNamespace.persistentVolumeClaims()).thenReturn(pvcs);
+
+    mockName(pod, POD_NAME);
+    mockName(pod2, POD_NAME_2);
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+    Map<String, String> workspaceAttributes = new HashMap<>();
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceAttributes);
+  }
+
+  @Test
+  public void testProvisionVolumesIntoKubernetesEnvironment() throws Exception {
+    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
+
+    perWorkspaceStratefy.provision(k8sEnv, IDENTITY);
+
+    // 2 volumes in machine1
+    verify(container, times(2)).getVolumeMounts();
+    verify(container2).getVolumeMounts();
+    verify(container3).getVolumeMounts();
+    // 1 addition + 3 checks because there are 3 volumes in pod
+    verify(podSpec, times(4)).getVolumes();
+    // 1 addition + 1 check
+    verify(podSpec2, times(2)).getVolumes();
+    assertFalse(podSpec.getVolumes().isEmpty());
+    assertFalse(podSpec2.getVolumes().isEmpty());
+    assertFalse(container.getVolumeMounts().isEmpty());
+    assertFalse(container2.getVolumeMounts().isEmpty());
+    assertFalse(container3.getVolumeMounts().isEmpty());
+    assertFalse(k8sEnv.getPersistentVolumeClaims().isEmpty());
+    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(PVC_NAME));
+  }
+
+  @Test
+  public void testReplacePVCWhenItsAlreadyInKubernetesEnvironment() throws Exception {
+    final Map<String, PersistentVolumeClaim> claims = new HashMap<>();
+    final PersistentVolumeClaim provisioned = mock(PersistentVolumeClaim.class);
+    claims.put(PVC_NAME, provisioned);
+    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(claims);
+
+    perWorkspaceStratefy.provision(k8sEnv, IDENTITY);
+
+    assertNotEquals(k8sEnv.getPersistentVolumeClaims().get(PVC_NAME), provisioned);
+  }
+
+  @Test
+  public void testProvisionVolumesWithSubpathsIntoKubernetesEnvironment() throws Exception {
+    perWorkspaceStratefy.provision(k8sEnv, IDENTITY);
+
+    final Map<String, PersistentVolumeClaim> actual = k8sEnv.getPersistentVolumeClaims();
+    assertFalse(actual.isEmpty());
+    assertTrue(actual.containsKey(PVC_NAME));
+    Set<String> subpaths =
+        Arrays.stream(
+                (String[])
+                    actual
+                        .get(PVC_NAME)
+                        .getAdditionalProperties()
+                        .get(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID)))
+            .collect(Collectors.toSet());
+    assertEquals(subpaths.size(), 2);
+    assertTrue(subpaths.contains(expectedVolumeDir(VOLUME_1_NAME)));
+    assertTrue(subpaths.contains(expectedVolumeDir(VOLUME_2_NAME)));
+  }
+
+  @Test
+  public void testDoNotAddsSubpathsWhenPreCreationIsNotNeeded() throws Exception {
+    perWorkspaceStratefy =
+        new PerWorkspacePVCStrategy(
+            PVC_NAME_PREFIX,
+            PVC_QUANTITY,
+            PVC_ACCESS_MODE,
+            false,
+            pvcSubPathHelper,
+            factory,
+            ephemeralWorkspaceAdapter);
+
+    perWorkspaceStratefy.provision(k8sEnv, IDENTITY);
+
+    final Map<String, PersistentVolumeClaim> actual = k8sEnv.getPersistentVolumeClaims();
+    assertFalse(actual.isEmpty());
+    assertTrue(actual.containsKey(PVC_NAME));
+    assertFalse(
+        actual
+            .get(PVC_NAME)
+            .getAdditionalProperties()
+            .containsKey(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID)));
+  }
+
+  @Test
+  public void testCreatesPVCWithSubpathsOnPrepare() throws Exception {
+    final PersistentVolumeClaim pvc = mockName(mock(PersistentVolumeClaim.class), PVC_NAME);
+    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(PVC_NAME, pvc));
+    final Map<String, Object> subPaths = new HashMap<>();
+    subPaths.put(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID), WORKSPACE_SUBPATHS);
+    when(pvc.getAdditionalProperties()).thenReturn(subPaths);
+    doNothing().when(pvcSubPathHelper).createDirs(WORKSPACE_ID, WORKSPACE_SUBPATHS);
+
+    perWorkspaceStratefy.prepare(k8sEnv, WORKSPACE_ID, 100);
+
+    verify(pvcs).get();
+    verify(pvcs).create(pvc);
+    verify(pvcs).waitBound(PVC_NAME, 100);
+    verify(pvcSubPathHelper).createDirs(any(), any());
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwsInfrastructureExceptionWhenFailedToGetExistingPVCs() throws Exception {
+    when(k8sEnv.getPersistentVolumeClaims())
+        .thenReturn(singletonMap(PVC_NAME, mock(PersistentVolumeClaim.class)));
+    doThrow(InfrastructureException.class).when(pvcs).get();
+
+    perWorkspaceStratefy.prepare(k8sEnv, WORKSPACE_ID, 100);
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwsInfrastructureExceptionWhenPVCCreationFailed() throws Exception {
+    final PersistentVolumeClaim claim = mockName(mock(PersistentVolumeClaim.class), PVC_NAME);
+    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(PVC_NAME, claim));
+    when(pvcs.get()).thenReturn(emptyList());
+    doThrow(InfrastructureException.class).when(pvcs).create(any());
+
+    perWorkspaceStratefy.prepare(k8sEnv, WORKSPACE_ID, 100);
+  }
+
+  @Test
+  public void testCleanup() throws Exception {
+    perWorkspaceStratefy.cleanup(workspace);
+
+    verify(pvcs).delete(ImmutableMap.of(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID));
+  }
+
+  static <T extends HasMetadata> T mockName(T obj, String name) {
+    final ObjectMeta objectMeta = mock(ObjectMeta.class);
+    lenient().when(obj.getMetadata()).thenReturn(objectMeta);
+    lenient().when(objectMeta.getName()).thenReturn(name);
+    return obj;
+  }
+
+  private static String expectedVolumeDir(String volumeName) {
+    return WORKSPACE_ID + '/' + volumeName;
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.openshift;
 
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.COMMON_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.PerWorkspacePVCStrategy.PER_WORKSPACE_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.UniqueWorkspacePVCStrategy.UNIQUE_STRATEGY;
 
 import com.google.inject.AbstractModule;
@@ -41,6 +42,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.PerWorkspacePVCStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.UniqueWorkspacePVCStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspacePVCCleaner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumeStrategyProvider;
@@ -95,6 +97,7 @@ public class OpenShiftInfraModule extends AbstractModule {
     MapBinder<String, WorkspaceVolumesStrategy> volumesStrategies =
         MapBinder.newMapBinder(binder(), String.class, WorkspaceVolumesStrategy.class);
     volumesStrategies.addBinding(COMMON_STRATEGY).to(CommonPVCStrategy.class);
+    volumesStrategies.addBinding(PER_WORKSPACE_STRATEGY).to(PerWorkspacePVCStrategy.class);
     volumesStrategies.addBinding(UNIQUE_STRATEGY).to(UniqueWorkspacePVCStrategy.class);
     bind(WorkspaceVolumesStrategy.class).toProvider(WorkspaceVolumeStrategyProvider.class);
 


### PR DESCRIPTION
### What does this PR do?
Added PerWorkspace PVC strategy which allows configuring Che Server to use new PVC per each workspace (but not each volume as Common PVC strategy does).
It also contains several documentation fixes for `common` and `unique` PVC strategies.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12165
https://github.com/eclipse/che/issues/12024

#### Release Notes
Added an ability to configure `perWorkspace` PVC strategy. Che Server will use a separate PV for each workspace in this case.

#### Docs PR
https://github.com/eclipse/che-docs/pull/636
