### PR TITLE
Move Che Theia to 3100 port

### DIFF
--- a/dockerfiles/theia/Dockerfile
+++ b/dockerfiles/theia/Dockerfile
@@ -72,7 +72,7 @@ ENV USE_LOCAL_GIT=true \
     LOCAL_GIT_DIRECTORY=/usr \
     GIT_EXEC_PATH=/usr/libexec/git-core
 
-EXPOSE 3000 3030
+EXPOSE 3100 3130
 
 # Install sudo
 # Install Java for java extension

--- a/dockerfiles/theia/e2e/cypress/integration/theia/commands.spec.ts
+++ b/dockerfiles/theia/e2e/cypress/integration/theia/commands.spec.ts
@@ -10,7 +10,7 @@
 
 context('Check Extensions are installed', () => {
   before(() => {
-    cy.visit('http://localhost:3000');
+    cy.visit('http://localhost:3100');
 
     // maybe it's possible to wait for an element being displayed/hidden
     cy.wait(10000);

--- a/dockerfiles/theia/e2e/cypress/integration/theia/typescript.spec.ts
+++ b/dockerfiles/theia/e2e/cypress/integration/theia/typescript.spec.ts
@@ -10,7 +10,7 @@
 
 context('TypeScript', () => {
     before(() => {
-        cy.visit('http://localhost:3000');
+        cy.visit('http://localhost:3100');
 
         // maybe it's possible to wait for an element being displayed/hidden
         cy.wait(10000);

--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -35,7 +35,7 @@ if [ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /de
 fi
 
 if [ -z "$THEIA_PORT" ]; then
-    export THEIA_PORT=3000
+    export THEIA_PORT=3100
 else
     # Parse THEIA_PORT env var in case it has weird value, such as tcp://10.108.137.206:3000
     theia_port_number_regexp='^[0-9]+$'

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -20,7 +20,7 @@
                     "type": "ide"
                   },
                   "protocol": "http",
-                  "port": "3000",
+                  "port": "3100",
                   "path": "/"
                 },
                 "theia-dev": {
@@ -28,7 +28,7 @@
                     "type": "ide-dev"
                   },
                   "protocol": "http",
-                  "port": "3030"
+                  "port": "3130"
                 }
               },
               "installers": [],
@@ -96,7 +96,7 @@
               "servers": {
                 "theia": {
                   "protocol": "http",
-                  "port": "3000",
+                  "port": "3100",
                   "path": "/",
                   "attributes": {
                     "type": "ide",
@@ -106,7 +106,7 @@
                 },
                 "theia-dev": {
                   "protocol": "http",
-                  "port": "3030",
+                  "port": "3130",
                   "attributes": {
                     "type": "ide-dev"
                   }
@@ -184,7 +184,7 @@
               "servers": {
                 "theia": {
                   "protocol": "http",
-                  "port": "3000",
+                  "port": "3100",
                   "path": "/",
                   "attributes": {
                     "type": "ide",
@@ -194,7 +194,7 @@
                 },
                 "theia-dev": {
                   "protocol": "http",
-                  "port": "3030",
+                  "port": "3130",
                   "attributes": {
                     "type": "ide-dev"
                   }


### PR DESCRIPTION
### What does this PR do?
Moves Che Theia from 3000 port to 3100 port. This is done because many other application (especially nodejs apps) use 3000 port which brings inconveniences while using Theia in workspace.
Also, to be consistent, Che Theia Hosted Instance is moved to 3130 port.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12074

#### Release Notes
Che Theia moved from 3000 to 3100 port.
Che Theia Hosted Instance moved from 3030 to 3130 port.