### PR TITLE
Overwrite styles for the quick fix popups to respect the light theme

### DIFF
--- a/ide/che-core-orion-editor/src/main/resources/org/eclipse/che/ide/editor/orion/client/orion-codenvy-theme.css
+++ b/ide/che-core-orion-editor/src/main/resources/org/eclipse/che/ide/editor/orion/client/orion-codenvy-theme.css
@@ -158,57 +158,96 @@
     border-right: 5px solid transparent;
 }
 
+/* Overwrite default styles for text view tooltip */
+
 .textviewTooltip {
-    font-family: "Open Sans", sans-serif;
-    font-size: 11px;
-    background-color: completionPopupBackgroundColor;
-    color: completionPopupItemTextColor;
-    padding-left: 10px;
-    padding-right: 10px;
-    padding-top: 5px;
-    padding-bottom: 7px !important;
+    font-family: "Open Sans", sans-serif !important;
+    font-size: 11px !important;
+    background-color: completionPopupBackgroundColor !important;
+    color: completionPopupItemTextColor !important;
+    padding: 8px !important;
+
+    box-sizing: content-box !important;
+    border-radius: 3px !important;
+    z-index: 101 !important;
+    position: fixed !important;
+    overflow: hidden !important;
 
     border: 1px solid completionPopupBorderColor;
     box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.5);
-    line-height: 14px;
-    cursor: default;
-    outline: none;
 }
 
-.textviewTooltip em {
-    line-height: 20px;
+.textviewTooltip a {
+    color: #7CC7FF !important;
 }
-
+.textviewTooltip h3 {
+    -webkit-margin-before: 0 !important;
+    margin-top: 0 !important;
+}
+.textviewTooltip p:first-of-type {
+    -webkit-margin-before: 0 !important;
+    margin-top: 0 !important;
+    -webkit-margin-after: 0 !important;
+    margin-bottom: 0 !important;
+}
+.textviewTooltip p {
+    word-wrap: break-word !important;
+}
+.textviewTooltip multi_anno {
+    font-style: normal !important;
+    font-weight: bold !important;
+}
+.textviewTooltip span {
+    vertical-align: baseline !important;
+}
 .textviewTooltip .tooltipRow {
-    display: block;
-    position: relative;
+    display: table-row !important;
 }
-
 .textviewTooltip .tooltipImage {
-    display: table-cell;
-    vertical-align: top;
-    padding-top: 1px;
-    width: 18px;
+    display: inline-block !important;
+    vertical-align: middle !important;
+    padding: 1px !important;
 }
-
-.textviewTooltip .tooltipImage {
-    margin-left: 0px;
-}
-
 .textviewTooltip .tooltipTitle {
-    display: table-cell;
-    max-width: 400px;
-    text-overflow: ellipsis;
-    overflow-x: hidden;
+    padding-left: 3px !important;
+    vertical-align: middle !important;
 }
+.textviewTooltip .hoverTooltipTitle {
+    font-weight: normal !important;
+}
+.textviewTooltip .quickFixList {
+    margin-top: 5px !important;
+}
+.textviewTooltip .commandButton {
+    border: 1px solid completionPopupBorderColor !important;
+    background-color: inherit !important;
+    color: completionPopupItemTextColor !important;
+}
+.textviewTooltip .commandButton:not(.dropdownTrigger){
+    text-transform: initial !important;
+}
+.textviewTooltip .commandList > li {
+    margin: 0 !important;
+}
+.textviewTooltip .quickfixAllParameter {
+    margin-bottom: 4px !important;
+    vertical-align: middle !important;
+    font-weight: normal !important;
+    font-family: "HelveticaNeue", "Helvetica Neue", "HelveticaNeueRoman", "HelveticaNeue-Roman", "Helvetica Neue Roman", 'TeXGyreHerosRegular', "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif !important;
+}
+.textViewTooltipOnFocus {
+    resize: both !important;
+    overflow: auto !important;
+}
+.textViewTooltipOnHover {
+    overflow: auto !important;
+}
+
+/* End of overwrite default styles for text view tooltip */
 
 .tooltipTheme.textview {
     background-color: InfoBackground !important;
     color: InfoText !important;
-}
-
-.textViewTooltipOnHover {
-    overflow: auto;
 }
 
 .orionCodenvy .textViewFind {


### PR DESCRIPTION
### What does this PR do?
This changes proposal provide correct overwrite predefined styles for the quick fix popups which are provided by orin editor. Now we'll be able to use quick fix popups in light theme, because button are not invisible anymore:

<img width="226" alt="2018-12-12 18 56 41" src="https://user-images.githubusercontent.com/1968177/49886421-42fd6700-fe42-11e8-952c-626d7b983fde.png">
<img width="157" alt="2018-12-12 18 58 51" src="https://user-images.githubusercontent.com/1968177/49886423-4395fd80-fe42-11e8-820d-f627ff1d4459.png">
<img width="224" alt="2018-12-12 18 59 42" src="https://user-images.githubusercontent.com/1968177/49886424-4395fd80-fe42-11e8-828a-1555bcf22b65.png">
<img width="154" alt="2018-12-12 19 00 29" src="https://user-images.githubusercontent.com/1968177/49886425-4395fd80-fe42-11e8-8e3f-2d96e32e32de.png">

@apupier take a look on it.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#10342 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A
