### PR TITLE
CRW-25 should we skip the selenium...

### DIFF
--- a/selenium/che-selenium-test/pom.xml
+++ b/selenium/che-selenium-test/pom.xml
@@ -264,6 +264,7 @@
                             <goal>integration-test</goal>
                         </goals>
                         <configuration>
+                            <skipITs>${skipIntegrationTests}</skipITs>
                             <trimStackTrace>false</trimStackTrace>
                             <!-- we need to set 'parallel=classes' to prevent unexpected destroy 
 								of test objects in case of execution the package of tests -->
@@ -390,6 +391,7 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <skipITs>false</skipITs>
                             <suiteXmlFiles>
                                 <suiteXmlFile>${runSuite}</suiteXmlFile>
                             </suiteXmlFiles>


### PR DESCRIPTION
CRW-25 should we skip the selenium integration tests if we're not using an integration profile? Skip them by default?

Change-Id: Idbf2ffdd445e1f8410b757a4ac527299ace10e5c
Signed-off-by: nickboldt <nboldt@redhat.com>