### PR TITLE
Selenium: stabilize selenium tests, adapt NewWorkspacePageTest test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -156,6 +156,7 @@ public class NewWorkspace {
     JAVA_DEBIAN("java-debian"),
     KOTLIN("kotlin-default"),
     NODE("node-default"),
+    NODEJS_AND_POSTGRES("nodejs-postgres"),
     OPENSHIFT_SQL("openshift-sql"),
     PHP("php-default"),
     PHP_GAE("php-gae"),

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -38,6 +38,7 @@ import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.J
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_OPENSHIFT;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.KOTLIN;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.NODE;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.NODEJS_AND_POSTGRES;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.PHP;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.PYTHON;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.RAILS;
@@ -207,10 +208,18 @@ public class NewWorkspacePageTest {
           SPRING_BOOT);
 
   private static final List<NewWorkspace.Stack> EXPECTED_OPENSHIFT_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL_THEIA_ON_KUBERNETES, JAVA_THEIA_ON_KUBERNETES, JAVA_THEIA_OPENSHIFT);
+      asList(
+          JAVA_MYSQL_THEIA_ON_KUBERNETES,
+          JAVA_THEIA_ON_KUBERNETES,
+          JAVA_THEIA_OPENSHIFT,
+          NODEJS_AND_POSTGRES);
 
   private static final List<NewWorkspace.Stack> EXPECTED_K8S_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL_THEIA_ON_KUBERNETES, JAVA_THEIA_ON_KUBERNETES, JAVA_THEIA_OPENSHIFT);
+      asList(
+          JAVA_MYSQL_THEIA_ON_KUBERNETES,
+          JAVA_THEIA_ON_KUBERNETES,
+          JAVA_THEIA_OPENSHIFT,
+          NODEJS_AND_POSTGRES);
 
   private static final List<NewWorkspace.Stack> EXPECTED_DOCKER_MULTI_MACHINE_STACKS =
       asList(JAVA_MYSQL, JAVA_MYSQL_CENTOS, JAVA_THEIA_DOCKER);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewPackageFromContextMenuTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewPackageFromContextMenuTest.java
@@ -22,6 +22,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -43,6 +44,7 @@ public class CreateNewPackageFromContextMenuTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
@@ -55,6 +57,8 @@ public class CreateNewPackageFromContextMenuTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/types/RenameTypeTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.RENAME;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 
 import com.google.inject.Inject;
 import java.io.IOException;
@@ -192,7 +193,7 @@ public class RenameTypeTest {
     askDialog.clickOkBtn();
     askDialog.waitFormToClose();
     refactorPanel.waitRefactorPreviewFormIsClosed();
-    projectExplorer.waitItem(pathToCurrentPackage + "/B.java", 6);
+    projectExplorer.waitItem(pathToCurrentPackage + "/B.java", ELEMENT_TIMEOUT_SEC);
     editor.waitTextIntoEditor(contentFromOutB);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCamelStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCamelStackTest.java
@@ -12,23 +12,14 @@
 package org.eclipse.che.selenium.stack;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.project.ProjectTemplates.CONSOLE_JAVA_SIMPLE;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.CAMEL_SPRINGBOOT;
 
 import com.google.inject.Inject;
-import java.net.URL;
-import java.nio.file.Paths;
-import org.eclipse.che.api.core.model.workspace.Workspace;
-import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
-import org.eclipse.che.selenium.languageserver.ApacheCamelFileEditingTest;
-import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
-import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.testng.annotations.AfterClass;
@@ -38,9 +29,6 @@ import org.testng.annotations.Test;
 public class CreateWorkspaceFromCamelStackTest {
 
   private static final String WORKSPACE_NAME = generate("workspaceCamel", 4);
-  private static final String PROJECT_NAME = "project-for-camel-ls";
-  private static final String CAMEL_FILE_NAME = "camel.xml";
-  private static final String PATH_TO_CAMEL_FILE = PROJECT_NAME + "/" + CAMEL_FILE_NAME;
   private static final String LS_INIT_MESSAGE =
       "Initialized language server 'org.eclipse.che.plugin.camel.server.languageserver'";
 
@@ -48,12 +36,8 @@ public class CreateWorkspaceFromCamelStackTest {
   @Inject private Dashboard dashboard;
   @Inject private DefaultTestUser defaultTestUser;
   @Inject private CreateWorkspaceHelper createWorkspaceHelper;
-  @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
-  @Inject private ProjectExplorer projectExplorer;
-  @Inject private CodenvyEditor editor;
   @Inject private Consoles consoles;
-  @Inject private TestProjectServiceClient testProjectServiceClient;
 
   // it is used to read workspace logs on test failure
   private TestWorkspace testWorkspace;
@@ -69,7 +53,7 @@ public class CreateWorkspaceFromCamelStackTest {
   }
 
   @Test
-  public void createWorkspaceFromCamelStackTest() throws Exception {
+  public void createWorkspaceFromCamelStackTest() {
     // store info about created workspace to make SeleniumTestHandler.captureTestWorkspaceLogs()
     // possible to read logs in case of test failure
     testWorkspace =
@@ -78,24 +62,7 @@ public class CreateWorkspaceFromCamelStackTest {
 
     ide.switchToIdeAndWaitWorkspaceIsReadyToUse();
 
-    checkLanguageServerInitialized();
-  }
-
-  private void checkLanguageServerInitialized() throws Exception {
-    URL resource = ApacheCamelFileEditingTest.class.getResource("/projects/project-for-camel-ls");
-
     consoles.selectProcessByTabName("dev-machine");
     consoles.waitExpectedTextIntoConsole(LS_INIT_MESSAGE);
-
-    Workspace ws = workspaceServiceClient.getByName(WORKSPACE_NAME, defaultTestUser.getName());
-    testProjectServiceClient.importProject(
-        ws.getId(), Paths.get(resource.toURI()), PROJECT_NAME, CONSOLE_JAVA_SIMPLE);
-    notificationsPopupPanel.waitPopupPanelsAreClosed();
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
-
-    projectExplorer.waitAndSelectItem(PROJECT_NAME);
-    projectExplorer.openItemByPath(PROJECT_NAME);
-    projectExplorer.openItemByPath(PATH_TO_CAMEL_FILE);
-    editor.waitTabIsPresent(CAMEL_FILE_NAME);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4Test.java
@@ -69,9 +69,7 @@ public class JavaTestPluginJunit4Test {
   @Inject private Loader loader;
   @Inject private NotificationsPopupPanel notifications;
   @Inject private Menu menu;
-
   @Inject private TestWorkspace ws;
-
   @Inject private Ide ide;
   @Inject private Consoles consoles;
   @Inject private CodenvyEditor editor;
@@ -93,11 +91,14 @@ public class JavaTestPluginJunit4Test {
         ProjectTemplates.CONSOLE_JAVA_SIMPLE);
 
     ide.open(ws);
-    loader.waitOnClosed();
+    ide.waitOpenedWorkspaceIsReadyToUse();
+
     projectExplorer.waitItem(JUNIT4_PROJECT);
-    projectExplorer.quickExpandWithJavaScript();
-    runCompileCommandByPallete(compileCommand);
+    consoles.waitJDTLSProjectResolveFinishedMessage(JUNIT4_PROJECT);
     notifications.waitProgressPopupPanelClose();
+    projectExplorer.quickExpandWithJavaScript();
+
+    runCompileCommandByPallete(compileCommand);
   }
 
   private void runCompileCommandByPallete(CompileCommand compileCommand) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/theia/TheiaBuildPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/theia/TheiaBuildPluginTest.java
@@ -115,7 +115,7 @@ public class TheiaBuildPluginTest {
     theiaIde.waitNotificationDisappearance(expectedYaomanMessage, UPDATING_PROJECT_TIMEOUT_SEC);
 
     // build plugin
-    openTerminal("File", "Open Terminal in specific container", "ws/theia-ide");
+    openTerminalByProposal("ws/theia-ide");
     theiaTerminal.waitTab(wsTheiaIdeTerminalTitle);
     theiaTerminal.clickOnTab(wsTheiaIdeTerminalTitle);
     theiaTerminal.performCommand(goToDirectoryCommand);
@@ -244,6 +244,13 @@ public class TheiaBuildPluginTest {
     theiaIde.runMenuCommand(topMenuCommand, commandName);
 
     theiaProposalForm.waitSearchField();
+    theiaProposalForm.waitProposal(proposalText);
+    theiaProposalForm.clickOnProposal(proposalText);
+    theiaProposalForm.waitFormDisappearance();
+  }
+
+  private void openTerminalByProposal(String proposalText) {
+    theiaIde.pressKeyCombination(Keys.LEFT_CONTROL, "`");
     theiaProposalForm.waitProposal(proposalText);
     theiaProposalForm.clickOnProposal(proposalText);
     theiaProposalForm.waitFormDisappearance();

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -254,7 +254,6 @@
           <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterWorkspaceRestartTest"/>
           <class name="org.eclipse.che.selenium.theia.Che7PreviewStackStartTest"/>
           <class name="org.eclipse.che.selenium.stack.CreateWorkspaceFromBlankStackTest"/>
-          <class name="org.eclipse.che.selenium.stack.CreateWorkspaceFromCamelStackTest"/>
           <class name="org.eclipse.che.selenium.stack.CreateWorkspaceFromJavaStackTest"/>
           <class name="org.eclipse.che.selenium.stack.CreateWorkspaceFromPythonStackTest"/>
           <class name="org.eclipse.che.selenium.stack.CreateWorkspaceFromJavaMySqlStackTest"/>


### PR DESCRIPTION
### What does this PR do?
This PR:
- adapt **NewWorkspacePageTest** test according to adding new ```Nodejs and Postgres``` stack;
- add checking that java language server if fully initialized before working with a project in **CreateNewPackageFromContextMenuTest** and **JavaTestPluginJunit4Test** tests;
- increase timeout for checking that a file was renamed in **RenameTypeTest**(sometimes 6 sec isn't enough);
- not check working with project in **CreateWorkspaceFromCamelStackTest** test(```ApacheCamel``` stack doesn't have project samples);
- remove **CreateWorkspaceFromCamelStackTest** test from ```CheSuite.xml``` test suite(this test already every day starts on ```stacks``` CI job).