### PR TITLE
CRW-2 Should Che depend on the latest...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <che.dashboard.version>6.16.0-SNAPSHOT</che.dashboard.version>
         <che.docs.version>6.16.0-SNAPSHOT</che.docs.version>
         <che.lib.version>6.16.0-SNAPSHOT</che.lib.version>
-        <che.ls.jdt.version>0.0.2</che.ls.jdt.version>
+        <che.ls.jdt.version>0.0.3-SNAPSHOT</che.ls.jdt.version>
         <che.version>6.16.0-SNAPSHOT</che.version>
         <specification.version>1.0-beta2</specification.version>
     </properties>


### PR DESCRIPTION
Should Che depend on the latest che.ls.jdt.version = 0.0.3-SNAPSHOT ?

Change-Id: I8bbb8264c6f518938be9dec15e5e935b3d56b605
Signed-off-by: nickboldt <nboldt@redhat.com>