### PR TITLE
Only deploy metrics ingress if metrics are enabled.

### DIFF
--- a/deploy/kubernetes/helm/che/templates/metrics-ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/metrics-ingress.yaml
@@ -15,6 +15,8 @@
 {{- printf "grafana-%s.%s" .Release.Namespace .Values.global.ingressDomain }}
 {{- end }}
 
+{{- if .Values.global.metricsEnabled }}
+
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -54,3 +56,5 @@ spec:
         backend:
           serviceName: che-grafana
           servicePort: 80
+
+{{- end }}


### PR DESCRIPTION
### What does this PR do?

The `che-metrics-ingress` is now only deployed using the Che Helm chart when metrics are enabled (by setting the `global.metricsEnabled` property to true).

### What issues does this PR fix or reference?

#12191 
