### PR TITLE
Fix of conflict of seleniumhq 3.0.1 with guava 27.0.1-jre

### DIFF
--- a/selenium/pom.xml
+++ b/selenium/pom.xml
@@ -27,4 +27,19 @@
         <module>che-selenium-core</module>
         <module>che-selenium-test</module>
     </modules>
+
+    <properties>
+        <!-- fix of conflict of seleniumhq 3.0.1 with guava 27.0.1-jre (https://github.com/eclipse/che/issues/12184) -->
+        <com.google.guava.version>20.0</com.google.guava.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.google.guava</groupId>
+                <artifactId>guava</artifactId>
+                <version>${com.google.guava.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>


### PR DESCRIPTION
### What does this PR do?
It fixes dependency conflicts in E2E selenium tests after version of guava had been renewed from 20.0 to 27.0.1-jre ([PR](https://github.com/eclipse/che-parent/pull/93) which renewed dependencies and caused [dependence conflict in selenium tests project](https://gist.github.com/skabashnyuk/b0590d7061929a4bdc051bfa58ddca56)). The problem is selenium frameworks 3.0.1 depends on older version of guava:
```
[ERROR] warning: Supported source version 'RELEASE_6' from annotation processor 'org.jvnet.hudson.annotation_indexer.AnnotationProcessorImpl' less than -source '1.8'
/Users/sj/dev/src/redhat/che/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ConfigureClasspath.java:[109,8] error: reference to until is ambiguous
  both method until(Predicate<T>) in FluentWait and method <V>until(Function<? super T,V>) in FluentWait match
  where T,V are type-variables:
    T extends Object declared in class FluentWait
    V extends Object declared in method <V>until(Function<? super T,V>)
[ERROR] /Users/sj/dev/src/redhat/che/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/ConfigureClasspath.java:[119,8] error: reference to until is ambiguous
  both method until(Predicate<T>) in FluentWait and method <V>until(Function<? super T,V>) in FluentWait match
  where T,V are type-variables:
    T extends Object declared in class FluentWait
    V extends Object declared in method <V>until(Function<? super T,V>)
...
```

This changes just stick guave version to 20.0 for selenium tests only.
IMHO it doesn't make mush sense to spend time for upgrading selenium framework to version which compatible with guava 27.0.1-jre since we plan to migrate to Che 7.

### What issues does this PR fix or reference?
#12184