### PR TITLE
Add sample for nodejs postgres stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2369,7 +2369,7 @@
     "description": "Nodejs stack with Postgres",
     "scope": "advanced",
     "tags": [
-      "node.js",
+      "nodejs-postgres",
       "npm",
       "postgres"
     ],

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -597,6 +597,42 @@
     ]
   },
   {
+    "name": "nodejs-crud-sample",
+    "displayName": "Nodejs Postgres Sample",
+    "path": "/nodejs-crud",
+    "description": "Express app with Postgres database",
+    "projectType": "node-js",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "javascript"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/nodeshift-starters/nodejs-rest-http-crud.git",
+      "parameters": {}
+    },
+    "commands": [
+      {
+        "name": "install dependencies",
+        "type": "custom",
+        "commandLine": "cd ${current.project.path} \nnpm install",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Build"
+        }
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "nodejs-postgres"
+    ]
+  },
+  {
     "name": "web-nodejs-simple",
     "displayName": "web-nodejs-simple",
     "path": "/web-nodejs-simple",


### PR DESCRIPTION
### What does this PR do?
Add https://github.com/nodeshift-starters/nodejs-rest-http-crud to the list of samples for nodejs-postgres stack

Note: I have intentionally not added the run command for this sample. The nodejs-postgres stack already has the correct Run command.


Signed-off-by: Ibrahim Jarif <jarifibrahim@gmail.com>

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/12194
