### PR TITLE
Add support for deployments and configmaps in k8s/OS recipes

### DIFF
--- a/dashboard/src/components/api/environment/kubernetes-environment-manager.spec.ts
+++ b/dashboard/src/components/api/environment/kubernetes-environment-manager.spec.ts
@@ -13,8 +13,8 @@
 
 import {KubernetesEnvironmentManager} from './kubernetes-environment-manager';
 import {IEnvironmentManagerMachine, IEnvironmentManagerMachineServer} from './environment-manager-machine';
-import {IPodList} from './kubernetes-environment-recipe-parser';
-import {IPodItem, IPodItemContainer} from './kubernetes-machine-recipe-parser';
+import {ISupportedItemList} from './kubernetes-environment-recipe-parser';
+import {IPodItem, IPodItemContainer, getPodItemOrNull, ISupportedListItem} from './kubernetes-machine-recipe-parser';
 import {CheRecipeTypes} from '../recipe/che-recipe-types';
 
 /**
@@ -104,11 +104,15 @@ describe('KubernetesEnvironmentManager', () => {
 
       let getEnvironmentSource = (environment: che.IWorkspaceEnvironment, machine: IEnvironmentManagerMachine): string => {
         const [podName, containerName] = machine.name.split(/\//);
-        const recipe: IPodList = jsyaml.load(environment.recipe.content);
-        const machinePodItem = recipe.items.find((machinePodItem: IPodItem) => {
+        const recipe: ISupportedItemList = jsyaml.load(environment.recipe.content);
+        const machinePodItem = getPodItemOrNull(recipe.items.find((item: ISupportedListItem) => {
+          const machinePodItem = getPodItemOrNull(item);
+          if (!machinePodItem) {
+            return false;
+          }
           const podItemName = machinePodItem.metadata.name ? machinePodItem.metadata.name : machinePodItem.metadata.generateName;
           return podItemName === podName;
-        });
+        }));
         const podContainer = machinePodItem.spec.containers.find((podContainer: IPodItemContainer) => {
           return podContainer.name === containerName;
         });
@@ -187,11 +191,16 @@ describe('KubernetesEnvironmentManager', () => {
       let getEnvironmentSource = (environment: che.IWorkspaceEnvironment, machine: IEnvironmentManagerMachine): string => {
         const podName = machine.recipe.metadata.name;
         const containerName = machine.recipe.spec.containers[0].name;
-        const recipe: IPodList = jsyaml.load(environment.recipe.content);
-        const machinePodItem = recipe.items.find((machinePodItem: IPodItem) => {
+        const recipe: ISupportedItemList = jsyaml.load(environment.recipe.content);
+        const machinePodItem = getPodItemOrNull(recipe.items.find((item: ISupportedListItem) => {
+          const machinePodItem = getPodItemOrNull(item);
+          if (!machinePodItem) {
+            return false;
+          }
           const podItemName = machinePodItem.metadata.name ? machinePodItem.metadata.name : machinePodItem.metadata.generateName;
           return podItemName === podName;
-        });
+        }));
+
         const podContainer = machinePodItem.spec.containers.find((podContainer: IPodItemContainer) => {
           return podContainer.name === containerName;
         });

--- a/dashboard/src/components/api/environment/kubernetes-environment-recipe-parser.ts
+++ b/dashboard/src/components/api/environment/kubernetes-environment-recipe-parser.ts
@@ -10,12 +10,12 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 'use strict';
-import {IPodItem, KubernetesMachineRecipeParser} from './kubernetes-machine-recipe-parser';
+import {ISupportedListItem, KubernetesMachineRecipeParser} from './kubernetes-machine-recipe-parser';
 import {IParser} from './parser';
 
-export interface IPodList {
+export interface ISupportedItemList {
   kind: string;
-  items: Array<IPodItem>;
+  items: Array<ISupportedListItem>;
 }
 
 /**
@@ -25,16 +25,16 @@ export interface IPodList {
  */
 export class KubernetesEnvironmentRecipeParser implements IParser {
   private machineRecipeParser = new KubernetesMachineRecipeParser();
-  private recipeByContent: Map<string, IPodList> = new Map();
+  private recipeByContent: Map<string, ISupportedItemList> = new Map();
   private recipeKeys: Array<string> = [];
 
   /**
    * Parses recipe content
    * @param content {string} recipe content
-   * @returns {IPodList} recipe object
+   * @returns {ISupportedItemList} recipe object
    */
-  parse(content: string): IPodList {
-    let recipe: IPodList;
+  parse(content: string): ISupportedItemList {
+    let recipe: ISupportedItemList;
     if (this.recipeByContent.has(content)) {
       recipe = angular.copy(this.recipeByContent.get(content));
       this.validate(recipe);
@@ -54,40 +54,40 @@ export class KubernetesEnvironmentRecipeParser implements IParser {
 
   /**
    * Dumps recipe object.
-   * @param recipe {IPodList} recipe object
+   * @param recipe {ISupportedItemList} recipe object
    * @returns {string} recipe content
    */
-  dump(recipe: IPodList): string {
+  dump(recipe: ISupportedItemList): string {
     return jsyaml.safeDump(recipe, {'indent': 1});
   }
 
   /**
    * Simple validation of recipe.
-   * @param recipe {IPodList}
+   * @param recipe {ISupportedItemList}
    */
-  private validate(recipe: IPodList): void {
+  private validate(recipe: ISupportedItemList): void {
     if (!recipe || !recipe.kind) {
       throw new TypeError(`Recipe should contain a 'kind' section.`);
     }
     if (recipe.kind.toLowerCase() !== 'list') {
       throw new TypeError(`Recipe 'kind' section should be equals 'list'.`);
     }
-    const podItems = recipe.items;
-    if (!podItems) {
-      throw new TypeError(`Recipe pod list should contain an 'items' section.`);
+    const items = recipe.items;
+    if (!items) {
+      throw new TypeError(`Recipe kubernetes list should contain an 'items' section.`);
     }
-    if (!angular.isArray(podItems) || podItems.length === 0) {
-      throw new TypeError(`Recipe pod list should contain at least one 'item'.`);
+    if (!angular.isArray(items) || items.length === 0) {
+      throw new TypeError(`Recipe kubernetes list should contain at least one 'item'.`);
     } else {
-      podItems.forEach((podItem: IPodItem) => {
-        if (!podItem) {
+      items.forEach((item: ISupportedListItem) => {
+        if (!item) {
           return;
         }
         // skip services
-        if (podItem.kind && podItem.kind.toLowerCase() === 'service') {
+        if (item.kind && item.kind.toLowerCase() === 'service') {
           return;
         }
-        this.machineRecipeParser.validate(podItem);
+        this.machineRecipeParser.validate(item);
       });
     }
   }

--- a/dashboard/src/components/api/environment/kubernetes-machine-recipe-parser.ts
+++ b/dashboard/src/components/api/environment/kubernetes-machine-recipe-parser.ts
@@ -13,15 +13,55 @@
 
 import {IParser} from './parser';
 
+export type ISupportedListItem = IPodItem | IDeploymentItem | IConfigMapItem;
+
+export function isDeploymentItem(item: ISupportedListItem): item is IDeploymentItem {
+  return (item.kind && item.kind.toLowerCase() === 'deployment');
+}
+
+export function isPodItem(item: ISupportedListItem): item is IPodItem {
+  return (item.kind && item.kind.toLowerCase() === 'pod');
+}
+
+export function isConfigMapItem(item: ISupportedListItem): item is IConfigMapItem {
+  return (item.kind && item.kind.toLowerCase() === 'configmap');
+}
+
+export function getPodItemOrNull(item: ISupportedListItem): IPodItem {
+  if (isDeploymentItem(item)) {
+    return item.spec.template;
+  } else if (isPodItem(item)) {
+    return item;
+  } else {
+    return null;
+  }
+}
+
+export interface IObjectMetadata {
+  name?: string;
+  generateName?: string;
+  annotations?: { [propName: string]: string };
+  labels?: { [propName: string ]: string };
+  [propName: string]: string | Object;
+}
+
+export interface IDeploymentItem {
+  apiVersion: string;
+  kind: string;
+  metadata: IObjectMetadata;
+  spec: {
+    replicas: number;
+    selector: {
+      matchLabels: { [propName: string]: string | Object };
+    }
+    template: IPodItem
+  };
+}
+
 export interface IPodItem {
   apiVersion: string;
   kind: string;
-  metadata: {
-    name?: string;
-    generateName?: string;
-    annotations?: { [propName: string]: string };
-    [propName: string]: string | Object;
-  };
+  metadata: IObjectMetadata;
   spec: { containers: Array<IPodItemContainer> };
   [propName: string]: string | Object;
 }
@@ -37,23 +77,30 @@ export interface IPodItemContainer {
   [propName: string]: string | Object;
 }
 
+export interface IConfigMapItem {
+  apiVersion: string;
+  kind: string;
+  metadata: IObjectMetadata;
+  data: { [propName: string]: string | Object };
+}
+
 /**
  * Wrapper for jsyaml and simple validator for kubernetes machine recipe.
  *
  *  @author Oleksii Orel
  */
 export class KubernetesMachineRecipeParser implements IParser {
-  private recipeByContent: Map<string, IPodItem> = new Map();
+  private recipeByContent: Map<string, ISupportedListItem> = new Map();
   private recipeKeys: Array<string> = [];
 
   /**
    * Parses recipe content
    *
    * @param content {string} recipe content
-   * @returns {IPodItem} recipe object
+   * @returns {ISupportedListItem} recipe object
    */
-  parse(content: string): IPodItem {
-    let recipe: IPodItem;
+  parse(content: string): ISupportedListItem {
+    let recipe: ISupportedListItem;
     if (this.recipeByContent.has(content)) {
       recipe = angular.copy(this.recipeByContent.get(content));
       this.validate(recipe);
@@ -74,47 +121,87 @@ export class KubernetesMachineRecipeParser implements IParser {
   /**
    * Dumps recipe object.
    *
-   * @param recipe {IPodItem} recipe object
+   * @param recipe {IPodItem | IDeploymentItem | IConfigMapItem} recipe object
    * @returns {string} recipe content
    */
-  dump(recipe: IPodItem): string {
+  dump(recipe: ISupportedListItem): string {
     return jsyaml.safeDump(recipe, {'indent': 1});
   }
 
-  /**
-   * Simple validation of machine recipe.
-   *
-   * @param recipe {IPodItem}
-   */
-  validate(recipe: IPodItem): void {
+  validate(recipe: ISupportedListItem ): void {
     if (!recipe || !recipe.kind) {
-      throw new TypeError(`Recipe should contain a 'kind' section.`);
-    }
-    if (recipe.kind.toLowerCase() !== 'pod') {
-      throw new TypeError(`Recipe 'kind' section should be equals 'pod'.`);
+      throw new TypeError(`Recipe item should contain a 'kind' section.`);
     }
     if (!recipe.apiVersion) {
-      throw new TypeError(`Recipe pod item should contain 'apiVersion' section.`);
+      throw new TypeError(`Recipe item should contain 'apiVersion' section`);
     }
-    if (!recipe.metadata) {
-      throw new TypeError(`Recipe pod item should contain 'metadata' section.`);
+    if (isDeploymentItem(recipe)) {
+      this.validateDeployment(<IDeploymentItem>recipe);
+    } else if (isPodItem(recipe)) {
+      this.validatePod(<IPodItem>recipe);
+    } else if (isConfigMapItem(recipe)) {
+      this.validateConfigMap(<IConfigMapItem>recipe);
     }
-    if (!recipe.metadata.name && !recipe.metadata.generateName) {
-      throw new TypeError(`Recipe pod item metadata should contain 'name' section.`);
+  }
+
+  /**
+   * Simple validation of Deployment recipe.
+   *
+   * @param deployment
+   */
+  validateDeployment(deployment: IDeploymentItem): void {
+    this.validateMetadata(deployment.metadata);
+    if (!deployment.spec) {
+      throw new TypeError(`Recipe deployment item should contain a 'spec' section.`);
     }
-    if (recipe.metadata.name && !this.testName(recipe.metadata.name)) {
-      throw new TypeError(`Recipe pod item container name should not contain special characters like dollar, etc.`);
+    const spec = deployment.spec;
+    if (!spec.replicas || spec.replicas !== 1) {
+      throw new TypeError(`Recipe deployment spec should contain replicas value equal to 1.`);
     }
-    if (!recipe.spec) {
+    if (!spec.template) {
+      throw new TypeError(`Recipe deployment spec should contain template section.`);
+    }
+    if (!spec.selector || !spec.selector.matchLabels) {
+      throw new TypeError(`Recipe deployment spec should contain selector section.`);
+    }
+    this.validatePod(spec.template);
+    // for the deployment to work, the matchlabels section needs to match the labels
+    // applied to the Pod.
+    const matchLabels = spec.selector.matchLabels;
+    const podLabels = spec.template.metadata.labels;
+    if (!podLabels) {
+      throw new TypeError(`Recipe deployment spec matchLabels must match pod labels.`);
+    }
+    for (const key of Object.keys(matchLabels)) {
+      if (matchLabels[key] !== podLabels[key]) {
+        throw new TypeError(`Recipe deployment matchLabels must match pod labels.`);
+      }
+    }
+    // since match labels are ANDed, we also need the same labels
+    for (const key of Object.keys(podLabels)) {
+      if (podLabels[key] !== matchLabels[key]) {
+        throw new TypeError(`Recipe deployment matchLabels must match pod labels.`);
+      }
+    }
+  }
+
+  /**
+   * Simple validation of Pod recipe.
+   *
+   * @param pod {IPodItem}
+   */
+  validatePod(pod: IPodItem): void {
+    this.validateMetadata(pod.metadata);
+    if (!pod.spec) {
       throw new TypeError(`Recipe pod item should contain 'spec' section.`);
     }
-    if (!recipe.spec.containers) {
+    if (!pod.spec.containers) {
       throw new TypeError(`Recipe pod item spec should contain 'containers' section.`);
     }
-    if (!angular.isArray(recipe.spec.containers) || recipe.spec.containers.length === 0) {
+    if (!angular.isArray(pod.spec.containers) || pod.spec.containers.length === 0) {
       throw new TypeError(`Recipe pod item spec containers should contain at least one 'container'.`);
     }
-    recipe.spec.containers.forEach((podItemContainer: IPodItemContainer) => {
+    pod.spec.containers.forEach((podItemContainer: IPodItemContainer) => {
       if (!podItemContainer) {
         return;
       }
@@ -128,7 +215,25 @@ export class KubernetesMachineRecipeParser implements IParser {
         throw new TypeError(`Recipe pod item container should contain 'image' section.`);
       }
     });
+  }
 
+  validateConfigMap(configMap: IConfigMapItem) {
+    this.validateMetadata(configMap.metadata);
+    if (!configMap.data) {
+      throw new TypeError(`Recipe config map item should contain data section.`);
+    }
+  }
+
+  validateMetadata(metadata: IObjectMetadata) {
+    if (!metadata) {
+      throw new TypeError(`Recipe item should contain 'metadata' section.`);
+    }
+    if (!metadata.name && !metadata.generateName) {
+      throw new TypeError(`Recipe item metadata should contain 'name' section.`);
+    }
+    if (metadata.name && !this.testName(metadata.name)) {
+      throw new TypeError(`Recipe item container name should not contain special characters like dollar, etc.`);
+    }
   }
 
   /**

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -718,9 +718,9 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
     final KubernetesEnvironment environment = getContext().getEnvironment();
     final Map<String, InternalMachineConfig> machineConfigs = environment.getMachines();
     final String workspaceId = getContext().getIdentity().getWorkspaceId();
-    LOG.debug("Begin pods creation for workspace '{}'", workspaceId);
+    LOG.info("Begin pods creation for workspace '{}'", workspaceId);
     for (Pod toCreate : environment.getPodsCopy().values()) {
-      startTracingContainersStartup(toCreate.getSpec(), toCreate.getMetadata());
+      startTracingContainersStartup(toCreate.getMetadata(), toCreate.getSpec());
       ObjectMeta toCreateMeta = toCreate.getMetadata();
       final Pod createdPod = namespace.deployments().deploy(toCreate);
       LOG.debug("Creating pod '{}' in workspace '{}'", toCreateMeta.getName(), workspaceId);
@@ -728,7 +728,7 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
     }
     for (Deployment toCreate : environment.getDeploymentsCopy().values()) {
       PodTemplateSpec template = toCreate.getSpec().getTemplate();
-      startTracingContainersStartup(template.getSpec(), template.getMetadata());
+      startTracingContainersStartup(template.getMetadata(), template.getSpec());
       ObjectMeta toCreateMeta = toCreate.getMetadata();
       final Pod createdPod = namespace.deployments().deploy(toCreate);
       LOG.debug("Creating deployment '{}' in workspace '{}'", toCreateMeta.getName(), workspaceId);
@@ -737,7 +737,7 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
       final ObjectMeta templateMeta = toCreate.getSpec().getTemplate().getMetadata();
       storeStartingMachine(createdPod, templateMeta, machineConfigs, serverResolver);
     }
-    LOG.debug("Pods creation finished in workspace '{}'", workspaceId);
+    LOG.info("Pods creation finished in workspace '{}'", workspaceId);
   }
 
   /** Puts createdPod in the {@code machines} map and sends the starting event for this machine */
@@ -766,7 +766,7 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
     }
   }
 
-  private void startTracingContainersStartup(PodSpec podSpec, ObjectMeta podMeta) {
+  private void startTracingContainersStartup(ObjectMeta podMeta, PodSpec podSpec) {
     if (tracer == null) {
       return;
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -21,14 +21,18 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.client.Watcher.Action;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -642,12 +646,14 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
     // namespace.pods().watch(new AbnormalStopHandler());
     namespace.deployments().watchEvents(new MachineLogsPublisher());
     if (unrecoverableEventListenerFactory.isConfigured()) {
-      Map<String, Pod> pods = getContext().getEnvironment().getPods();
+      Set<String> toWatch = new HashSet<>();
+      KubernetesEnvironment environment = getContext().getEnvironment();
+      toWatch.addAll(environment.getPodsCopy().keySet());
+      toWatch.addAll(environment.getDeploymentsCopy().keySet());
       namespace
           .deployments()
           .watchEvents(
-              unrecoverableEventListenerFactory.create(
-                  pods.keySet(), this::handleUnrecoverableEvent));
+              unrecoverableEventListenerFactory.create(toWatch, this::handleUnrecoverableEvent));
     }
 
     final KubernetesServerResolver serverResolver =
@@ -713,39 +719,57 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
     final Map<String, InternalMachineConfig> machineConfigs = environment.getMachines();
     final String workspaceId = getContext().getIdentity().getWorkspaceId();
     LOG.debug("Begin pods creation for workspace '{}'", workspaceId);
-    for (Pod toCreate : environment.getPods().values()) {
-      startTracingContainersStartup(toCreate);
+    for (Pod toCreate : environment.getPodsCopy().values()) {
+      startTracingContainersStartup(toCreate.getSpec(), toCreate.getMetadata());
+      ObjectMeta toCreateMeta = toCreate.getMetadata();
       final Pod createdPod = namespace.deployments().deploy(toCreate);
-      LOG.debug(
-          "Creating pod '{}' in workspace '{}'", toCreate.getMetadata().getName(), workspaceId);
-      final ObjectMeta podMetadata = createdPod.getMetadata();
-      for (Container container : createdPod.getSpec().getContainers()) {
-        String machineName = Names.machineName(toCreate, container);
-
-        LOG.debug("Creating machine '{}' in workspace '{}'", machineName, workspaceId);
-        machines.put(
-            getContext().getIdentity(),
-            new KubernetesMachineImpl(
-                workspaceId,
-                machineName,
-                podMetadata.getName(),
-                container.getName(),
-                MachineStatus.STARTING,
-                machineConfigs.get(machineName).getAttributes(),
-                serverResolver.resolve(machineName)));
-        eventPublisher.sendStartingEvent(machineName, getContext().getIdentity());
-      }
+      LOG.debug("Creating pod '{}' in workspace '{}'", toCreateMeta.getName(), workspaceId);
+      startMachines(createdPod, toCreateMeta, machineConfigs, serverResolver);
+    }
+    for (Deployment toCreate : environment.getDeploymentsCopy().values()) {
+      PodTemplateSpec template = toCreate.getSpec().getTemplate();
+      startTracingContainersStartup(template.getSpec(), template.getMetadata());
+      ObjectMeta toCreateMeta = toCreate.getMetadata();
+      final Pod createdPod = namespace.deployments().deploy(toCreate);
+      LOG.debug("Creating deployment '{}' in workspace '{}'", toCreateMeta.getName(), workspaceId);
+      startMachines(createdPod, toCreateMeta, machineConfigs, serverResolver);
     }
     LOG.debug("Pods creation finished in workspace '{}'", workspaceId);
   }
 
-  private void startTracingContainersStartup(Pod pod) {
+  /** Puts createdPod in the {@code machines} map and sends the starting event for this machine */
+  public void startMachines(
+      Pod createdPod,
+      ObjectMeta toCreateMeta,
+      Map<String, InternalMachineConfig> machineConfigs,
+      KubernetesServerResolver serverResolver)
+      throws InfrastructureException {
+    final String workspaceId = getContext().getIdentity().getWorkspaceId();
+    for (Container container : createdPod.getSpec().getContainers()) {
+      String machineName = Names.machineName(toCreateMeta, container);
+
+      LOG.debug("Creating machine '{}' in workspace '{}'", machineName, workspaceId);
+      machines.put(
+          getContext().getIdentity(),
+          new KubernetesMachineImpl(
+              workspaceId,
+              machineName,
+              createdPod.getMetadata().getName(),
+              container.getName(),
+              MachineStatus.STARTING,
+              machineConfigs.get(machineName).getAttributes(),
+              serverResolver.resolve(machineName)));
+      eventPublisher.sendStartingEvent(machineName, getContext().getIdentity());
+    }
+  }
+
+  private void startTracingContainersStartup(PodSpec podSpec, ObjectMeta podMeta) {
     if (tracer == null) {
       return;
     }
 
-    for (Container container : pod.getSpec().getContainers()) {
-      String machineName = Names.machineName(pod, container);
+    for (Container container : podSpec.getContainers()) {
+      String machineName = Names.machineName(podMeta, container);
 
       machineStartupTraces.put(
           machineName,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
@@ -73,8 +73,8 @@ public class Names {
   }
 
   /** Return pod name that will be unique for a whole namespace. */
-  public static String uniquePodName(String originalPodName, String workspaceId) {
-    return workspaceId + WORKSPACE_ID_PREFIX_SEPARATOR + originalPodName;
+  public static String uniqueResourceName(String originalResourceName, String workspaceId) {
+    return workspaceId + WORKSPACE_ID_PREFIX_SEPARATOR + originalResourceName;
   }
 
   /** Returns randomly generated name with given prefix. */

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
@@ -16,9 +16,11 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACHINE_NAME_ANNOTATION_FMT;
 
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import java.util.Map;
 import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Helps to work with Kubernetes objects names.
@@ -45,7 +47,15 @@ public class Names {
    * </pre>
    */
   public static String machineName(Pod pod, Container container) {
-    final Map<String, String> annotations = pod.getMetadata().getAnnotations();
+    return machineName(pod.getMetadata(), container);
+  }
+
+  public static String machineName(PodData podData, Container container) {
+    return machineName(podData.getMetadata(), container);
+  }
+
+  public static String machineName(ObjectMeta podMeta, Container container) {
+    final Map<String, String> annotations = podMeta.getAnnotations();
     final String machineName;
     final String containerName = container.getName();
     if (annotations != null
@@ -55,11 +65,11 @@ public class Names {
     }
 
     final String originalPodName;
-    final Map<String, String> labels = pod.getMetadata().getLabels();
+    final Map<String, String> labels = podMeta.getLabels();
     if (labels != null && (originalPodName = labels.get(CHE_ORIGINAL_NAME_LABEL)) != null) {
       return originalPodName + '/' + containerName;
     }
-    return pod.getMetadata().getName() + '/' + containerName;
+    return podMeta.getName() + '/' + containerName;
   }
 
   /** Return pod name that will be unique for a whole namespace. */

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
@@ -36,6 +36,24 @@ public class Names {
   /**
    * Returns machine name for the specified container in the specified pod.
    *
+   * <p>This is a convenience method for {@link #machineName(ObjectMeta, Container)}
+   */
+  public static String machineName(Pod pod, Container container) {
+    return machineName(pod.getMetadata(), container);
+  }
+
+  /**
+   * Returns machine name for the specified container in the specified pod.
+   *
+   * <p>This is a convenience method for {@link #machineName(ObjectMeta, Container)}
+   */
+  public static String machineName(PodData podData, Container container) {
+    return machineName(podData.getMetadata(), container);
+  }
+
+  /**
+   * Returns machine name for the specified container in the specified pod.
+   *
    * <p>Machine name is evaluated by the following algorithm:<br>
    *
    * <pre>
@@ -46,14 +64,6 @@ public class Names {
    * otherwise return podName + '/' + containerName as machine name
    * </pre>
    */
-  public static String machineName(Pod pod, Container container) {
-    return machineName(pod.getMetadata(), container);
-  }
-
-  public static String machineName(PodData podData, Container container) {
-    return machineName(podData.getMetadata(), container);
-  }
-
   public static String machineName(ObjectMeta podMeta, Container container) {
     final Map<String, String> annotations = podMeta.getAnnotations();
     final String machineName;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
@@ -31,10 +31,6 @@ public final class Warnings {
   public static final String SECRET_IGNORED_WARNING_MESSAGE =
       "Secrets specified in Kubernetes recipe are ignored.";
 
-  public static final int CONFIG_MAP_IGNORED_WARNING_CODE = 4103;
-  public static final String CONFIG_MAP_IGNORED_WARNING_MESSAGE =
-      "Config maps specified in Kubernetes recipe are ignored.";
-
   public static final int RESTART_POLICY_SET_TO_NEVER_WARNING_CODE = 4104;
   public static final String RESTART_POLICY_SET_TO_NEVER_WARNING_MESSAGE_FMT =
       "Restart policy '%s' for pod '%s' is rewritten with %s";

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
@@ -11,11 +11,16 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
 
+import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -37,6 +42,14 @@ public class KubernetesEnvironment extends InternalEnvironment {
   public static final String TYPE = "kubernetes";
 
   private final Map<String, Pod> pods;
+  private final Map<String, Deployment> deployments;
+  /**
+   * Stores abstracted spec and meta from either a deployment or pod.
+   *
+   * <p>{@link PodData}
+   */
+  private final Map<String, PodData> podData;
+
   private final Map<String, Service> services;
   private final Map<String, Ingress> ingresses;
   private final Map<String, PersistentVolumeClaim> persistentVolumeClaims;
@@ -61,7 +74,9 @@ public class KubernetesEnvironment extends InternalEnvironment {
   public KubernetesEnvironment(KubernetesEnvironment k8sEnv) {
     this(
         k8sEnv,
-        k8sEnv.getPods(),
+        k8sEnv.getPodsCopy(),
+        k8sEnv.getDeploymentsCopy(),
+        k8sEnv.getPodData(),
         k8sEnv.getServices(),
         k8sEnv.getIngresses(),
         k8sEnv.getPersistentVolumeClaims(),
@@ -72,6 +87,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
   protected KubernetesEnvironment(
       InternalEnvironment internalEnvironment,
       Map<String, Pod> pods,
+      Map<String, Deployment> deployments,
+      Map<String, PodData> podData,
       Map<String, Service> services,
       Map<String, Ingress> ingresses,
       Map<String, PersistentVolumeClaim> persistentVolumeClaims,
@@ -80,6 +97,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
     super(internalEnvironment);
     setType(TYPE);
     this.pods = pods;
+    this.deployments = deployments;
+    this.podData = podData;
     this.services = services;
     this.ingresses = ingresses;
     this.persistentVolumeClaims = persistentVolumeClaims;
@@ -92,6 +111,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
       Map<String, InternalMachineConfig> machines,
       List<Warning> warnings,
       Map<String, Pod> pods,
+      Map<String, Deployment> deployments,
+      Map<String, PodData> podData,
       Map<String, Service> services,
       Map<String, Ingress> ingresses,
       Map<String, PersistentVolumeClaim> persistentVolumeClaims,
@@ -100,6 +121,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
     super(internalRecipe, machines, warnings);
     setType(TYPE);
     this.pods = pods;
+    this.deployments = deployments;
+    this.podData = podData;
     this.services = services;
     this.ingresses = ingresses;
     this.persistentVolumeClaims = persistentVolumeClaims;
@@ -112,9 +135,43 @@ public class KubernetesEnvironment extends InternalEnvironment {
     return (KubernetesEnvironment) super.setType(type);
   }
 
-  /** Returns pods that should be created when environment starts. */
-  public Map<String, Pod> getPods() {
-    return pods;
+  /**
+   * Returns pods that should be created when environment starts.
+   *
+   * <p>Note: This map <b>should not</b> be changed, as it will only return pods and not
+   * deployments. If objects in the map need to be changed, see {@link #getPodData()}
+   */
+  public Map<String, Pod> getPodsCopy() {
+    return ImmutableMap.copyOf(pods);
+  }
+
+  /**
+   * Returns deployments that should be created when environment starts.
+   *
+   * <p>Note: This map <b>should not</b> be changed. If objects in the map need to be changed, see
+   * {@link #getPodData()}
+   */
+  public Map<String, Deployment> getDeploymentsCopy() {
+    return ImmutableMap.copyOf(deployments);
+  }
+
+  /**
+   * Returns {@link PodData} representing the metadata and pod spec of objects (pods or deployments)
+   * that should be created when environment starts. The data returned by this method represents all
+   * deployment and pod objects that form the workspace, and should be used when provisioning or
+   * performing any action that needs to see every object in the environment.
+   */
+  public Map<String, PodData> getPodData() {
+    return ImmutableMap.copyOf(podData);
+  }
+
+  /**
+   * Add a pod to the current environment. This method is necessary as the map returned by {@link
+   * #getPodsCopy()} is a copy. This method also adds the relevant data to {@link #getPodData()}.
+   */
+  public void addPod(String key, Pod pod) {
+    pods.put(key, pod);
+    podData.put(key, new PodData(pod.getSpec(), pod.getMetadata()));
   }
 
   /** Returns services that should be created when environment starts. */
@@ -146,6 +203,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
     protected final InternalEnvironment internalEnvironment;
 
     protected final Map<String, Pod> pods = new HashMap<>();
+    protected final Map<String, Deployment> deployments = new HashMap<>();
+    protected final Map<String, PodData> podData = new HashMap<>();
     protected final Map<String, Service> services = new HashMap<>();
     protected final Map<String, Ingress> ingresses = new HashMap<>();
     protected final Map<String, PersistentVolumeClaim> pvcs = new HashMap<>();
@@ -183,6 +242,25 @@ public class KubernetesEnvironment extends InternalEnvironment {
 
     public Builder setPods(Map<String, Pod> pods) {
       this.pods.putAll(pods);
+      pods.entrySet()
+          .forEach(
+              e -> {
+                Pod pod = e.getValue();
+                podData.put(e.getKey(), new PodData(pod.getSpec(), pod.getMetadata()));
+              });
+      return this;
+    }
+
+    public Builder setDeployments(Map<String, Deployment> deployments) {
+      this.deployments.putAll(deployments);
+      deployments
+          .entrySet()
+          .forEach(
+              e -> {
+                PodTemplateSpec podTemplate = e.getValue().getSpec().getTemplate();
+                podData.put(
+                    e.getKey(), new PodData(podTemplate.getSpec(), podTemplate.getMetadata()));
+              });
       return this;
     }
 
@@ -218,7 +296,49 @@ public class KubernetesEnvironment extends InternalEnvironment {
 
     public KubernetesEnvironment build() {
       return new KubernetesEnvironment(
-          internalEnvironment, pods, services, ingresses, pvcs, secrets, configMaps);
+          internalEnvironment,
+          pods,
+          deployments,
+          podData,
+          services,
+          ingresses,
+          pvcs,
+          secrets,
+          configMaps);
+    }
+  }
+
+  /**
+   * Abstraction of pod, since deployments store pod spec and meta within a PodSpecTemplate instead
+   * of a pod object. This class allows us to use one class to support passing of the relevant parts
+   * of a pod or deployment when it comes to provisioning.
+   *
+   * <p>The methods for accessing metadata and spec are identical to that of the Pod class (i.e.
+   * {@code getSpec()} and {@code getMetadata()}
+   */
+  public static class PodData {
+    private PodSpec podSpec;
+    private ObjectMeta podMeta;
+
+    public PodData(PodSpec podSpec, ObjectMeta podMeta) {
+      this.podSpec = podSpec;
+      this.podMeta = podMeta;
+    }
+
+    public PodSpec getSpec() {
+      return podSpec;
+    }
+
+    public void setSpec(PodSpec podSpec) {
+      this.podSpec = podSpec;
+    }
+
+    public ObjectMeta getMetadata() {
+      return podMeta;
+    }
+
+    public void setMetadata(ObjectMeta podMeta) {
+      this.podMeta = podMeta;
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
@@ -165,6 +165,9 @@ public class KubernetesEnvironment extends InternalEnvironment {
    *
    * <p>Note: This map <b>should not</b> be changed, as it will only return pods and not
    * deployments. If objects in the map need to be changed, see {@link #getPodsData()}
+   *
+   * <p>If pods need to be added to the environment, then {@link #addPod(Pod)} should be used
+   * instead.
    */
   public Map<String, Pod> getPodsCopy() {
     return ImmutableMap.copyOf(pods);
@@ -175,6 +178,9 @@ public class KubernetesEnvironment extends InternalEnvironment {
    *
    * <p>Note: This map <b>should not</b> be changed. If objects in the map need to be changed, see
    * {@link #getPodsData()}
+   *
+   * <p>If pods need to be added to the environment, then {@link #addPod(Pod)} should be used
+   * instead.
    */
   public Map<String, Deployment> getDeploymentsCopy() {
     return ImmutableMap.copyOf(deployments);
@@ -185,6 +191,9 @@ public class KubernetesEnvironment extends InternalEnvironment {
    * that should be created when environment starts. The data returned by this method represents all
    * deployment and pod objects that form the workspace, and should be used when provisioning or
    * performing any action that needs to see every object in the environment.
+   *
+   * <p>If pods need to be added to the environment, then {@link #addPod(Pod)} should be used
+   * instead.
    */
   public Map<String, PodData> getPodsData() {
     return ImmutableMap.copyOf(podData);
@@ -194,7 +203,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
    * Add a pod to the current environment. This method is necessary as the map returned by {@link
    * #getPodsCopy()} is a copy. This method also adds the relevant data to {@link #getPodsData()}.
    */
-  public void addPod(String podName, Pod pod) {
+  public void addPod(Pod pod) {
+    String podName = pod.getMetadata().getName();
     pods.put(podName, pod);
     podData.put(podName, new PodData(pod.getSpec(), pod.getMetadata()));
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
@@ -100,6 +101,7 @@ public class KubernetesEnvironmentFactory
         clientFactory.create().lists().load(new ByteArrayInputStream(content.getBytes())).get();
 
     Map<String, Pod> pods = new HashMap<>();
+    Map<String, Deployment> deployments = new HashMap<>();
     Map<String, Service> services = new HashMap<>();
     boolean isAnyIngressPresent = false;
     boolean isAnyPVCPresent = false;
@@ -109,6 +111,9 @@ public class KubernetesEnvironmentFactory
       if (object instanceof Pod) {
         Pod pod = (Pod) object;
         pods.put(pod.getMetadata().getName(), pod);
+      } else if (object instanceof Deployment) {
+        Deployment deployment = (Deployment) object;
+        deployments.put(deployment.getMetadata().getName(), deployment);
       } else if (object instanceof Service) {
         Service service = (Service) object;
         services.put(service.getMetadata().getName(), service);
@@ -158,6 +163,7 @@ public class KubernetesEnvironmentFactory
             .setMachines(machines)
             .setWarnings(warnings)
             .setPods(pods)
+            .setDeployments(deployments)
             .setServices(services)
             .setIngresses(new HashMap<>())
             .setPersistentVolumeClaims(new HashMap<>())

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidator.java
@@ -35,7 +35,8 @@ public class KubernetesEnvironmentValidator {
    * @throws ValidationException if the specified {@link KubernetesEnvironment} is invalid
    */
   public void validate(KubernetesEnvironment env) throws ValidationException {
-    checkArgument(!env.getPodsData().isEmpty(), "Environment should contain at least 1 pod");
+    checkArgument(
+        !env.getPodsData().isEmpty(), "Environment should contain at least 1 pod or deployment");
 
     Set<String> missingMachines = new HashSet<>(env.getMachines().keySet());
     for (PodData pod : env.getPodsData().values()) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidator.java
@@ -15,11 +15,11 @@ import static java.lang.String.format;
 
 import com.google.common.base.Joiner;
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.Pod;
 import java.util.HashSet;
 import java.util.Set;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Validates {@link KubernetesEnvironment}.
@@ -35,10 +35,10 @@ public class KubernetesEnvironmentValidator {
    * @throws ValidationException if the specified {@link KubernetesEnvironment} is invalid
    */
   public void validate(KubernetesEnvironment env) throws ValidationException {
-    checkArgument(!env.getPods().isEmpty(), "Environment should contain at least 1 pod");
+    checkArgument(!env.getPodData().isEmpty(), "Environment should contain at least 1 pod");
 
     Set<String> missingMachines = new HashSet<>(env.getMachines().keySet());
-    for (Pod pod : env.getPods().values()) {
+    for (PodData pod : env.getPodData().values()) {
       if (pod.getSpec() != null && pod.getSpec().getContainers() != null) {
         for (Container container : pod.getSpec().getContainers()) {
           missingMachines.remove(Names.machineName(pod, container));

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidator.java
@@ -35,10 +35,10 @@ public class KubernetesEnvironmentValidator {
    * @throws ValidationException if the specified {@link KubernetesEnvironment} is invalid
    */
   public void validate(KubernetesEnvironment env) throws ValidationException {
-    checkArgument(!env.getPodData().isEmpty(), "Environment should contain at least 1 pod");
+    checkArgument(!env.getPodsData().isEmpty(), "Environment should contain at least 1 pod");
 
     Set<String> missingMachines = new HashSet<>(env.getMachines().keySet());
-    for (PodData pod : env.getPodData().values()) {
+    for (PodData pod : env.getPodsData().values()) {
       if (pod.getSpec() != null && pod.getSpec().getContainers() != null) {
         for (Container container : pod.getSpec().getContainers()) {
           missingMachines.remove(Names.machineName(pod, container));

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -124,6 +124,10 @@ public class KubernetesDeployments {
    */
   public Pod deploy(Pod pod) throws InfrastructureException {
     putLabel(pod, CHE_WORKSPACE_ID_LABEL, workspaceId);
+    // Since we use the pod's metadata as the deployment's metadata
+    // This is used to identify the pod in CreateWatcher.
+    String originalName = pod.getMetadata().getName();
+    putLabel(pod, CHE_DEPLOYMENT_NAME_LABEL, originalName);
 
     ObjectMeta metadata = pod.getMetadata();
     PodSpec podSpec = pod.getSpec();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtil.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtil.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import java.util.HashMap;
 import java.util.Map;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Helps to work with Kubernetes objects.
@@ -45,6 +46,20 @@ public class KubernetesObjectUtil {
       target.setMetadata(metadata = new ObjectMeta());
     }
 
+    putLabel(target.getMetadata(), key, value);
+  }
+
+  public static void putLabel(PodData target, String key, String value) {
+    ObjectMeta metadata = target.getMetadata();
+
+    if (metadata == null) {
+      target.setMetadata(metadata = new ObjectMeta());
+    }
+
+    putLabel(metadata, key, value);
+  }
+
+  public static void putLabel(ObjectMeta metadata, String key, String value) {
     Map<String, String> labels = metadata.getLabels();
     if (labels == null) {
       metadata.setLabels(labels = new HashMap<>());

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtil.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtil.java
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import java.util.HashMap;
 import java.util.Map;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Helps to work with Kubernetes objects.
@@ -49,16 +48,7 @@ public class KubernetesObjectUtil {
     putLabel(target.getMetadata(), key, value);
   }
 
-  public static void putLabel(PodData target, String key, String value) {
-    ObjectMeta metadata = target.getMetadata();
-
-    if (metadata == null) {
-      target.setMetadata(metadata = new ObjectMeta());
-    }
-
-    putLabel(metadata, key, value);
-  }
-
+  /** Adds label to target Kubernetes object. */
   public static void putLabel(ObjectMeta metadata, String key, String value) {
     Map<String, String> labels = metadata.getLabels();
     if (labels == null) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
@@ -21,7 +21,6 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.Logs
 import com.google.inject.Inject;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,6 +39,7 @@ import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
@@ -128,7 +128,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
     String commonPVCName = getCommonPVCName(identity);
     final PersistentVolumeClaim pvc = newPVC(commonPVCName, pvcAccessMode, pvcQuantity);
     k8sEnv.getPersistentVolumeClaims().put(commonPVCName, pvc);
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (PodData pod : k8sEnv.getPodData().values()) {
       PodSpec podSpec = pod.getSpec();
       List<Container> containers = new ArrayList<>();
       containers.addAll(podSpec.getContainers());
@@ -198,7 +198,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
       String pvcName,
       String workspaceId,
       Set<String> subPaths,
-      Pod pod,
+      PodData pod,
       Container container,
       Map<String, Volume> volumes) {
     if (volumes.isEmpty()) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
@@ -128,7 +128,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
     String commonPVCName = getCommonPVCName(identity);
     final PersistentVolumeClaim pvc = newPVC(commonPVCName, pvcAccessMode, pvcQuantity);
     k8sEnv.getPersistentVolumeClaims().put(commonPVCName, pvc);
-    for (PodData pod : k8sEnv.getPodData().values()) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
       PodSpec podSpec = pod.getSpec();
       List<Container> containers = new ArrayList<>();
       containers.addAll(podSpec.getContainers());

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
@@ -15,7 +15,6 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.Kube
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
 
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import java.util.ArrayList;
@@ -29,6 +28,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +51,7 @@ public class EphemeralWorkspaceAdapter {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     LOG.debug("Provisioning PVC strategy for workspace '{}'", identity.getWorkspaceId());
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (PodData pod : k8sEnv.getPodData().values()) {
       PodSpec podSpec = pod.getSpec();
 
       // To ensure same volumes get mounted correctly in different containers, we need to track

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapter.java
@@ -51,7 +51,7 @@ public class EphemeralWorkspaceAdapter {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     LOG.debug("Provisioning PVC strategy for workspace '{}'", identity.getWorkspaceId());
-    for (PodData pod : k8sEnv.getPodData().values()) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
       PodSpec podSpec = pod.getSpec();
 
       // To ensure same volumes get mounted correctly in different containers, we need to track

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -136,7 +136,7 @@ public class PVCSubPathHelper {
     final String podName = jobName + '-' + workspaceId;
     final String[] command = buildCommand(commandBase, arguments);
     final Pod pod = newPod(podName, command);
-    securityContextProvisioner.provision(pod);
+    securityContextProvisioner.provision(pod.getSpec());
 
     KubernetesDeployments deployments = null;
     try {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
@@ -115,7 +115,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
                 .create(workspaceId)
                 .persistentVolumeClaims()
                 .getByLabel(CHE_WORKSPACE_ID_LABEL, workspaceId));
-    for (PodData pod : k8sEnv.getPodData().values()) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
       final PodSpec podSpec = pod.getSpec();
       List<Container> containers = new ArrayList<>();
       containers.addAll(podSpec.getContainers());

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
@@ -23,7 +23,6 @@ import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,6 +40,7 @@ import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
 import org.slf4j.Logger;
@@ -115,7 +115,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
                 .create(workspaceId)
                 .persistentVolumeClaims()
                 .getByLabel(CHE_WORKSPACE_ID_LABEL, workspaceId));
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (PodData pod : k8sEnv.getPodData().values()) {
       final PodSpec podSpec = pod.getSpec();
       List<Container> containers = new ArrayList<>();
       containers.addAll(podSpec.getContainers());
@@ -158,7 +158,7 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
       String workspaceId,
       Map<String, PersistentVolumeClaim> provisionedClaims,
       Map<String, PersistentVolumeClaim> existingVolumeName2PVC,
-      Pod pod,
+      PodData pod,
       Container container,
       Map<String, Volume> volumes)
       throws InfrastructureException {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisioner.java
@@ -81,7 +81,7 @@ public class CertificateProvisioner implements ConfigurationProvisioner<Kubernet
                 .withStringData(ImmutableMap.of(CA_CERT_FILE, certificate))
                 .build());
 
-    for (PodData pod : k8sEnv.getPodData().values()) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
       Optional<Volume> certVolume =
           pod.getSpec()
               .getVolumes()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisioner.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
@@ -30,6 +29,7 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Mount configured self-signed certificate as file in each workspace machines if configured.
@@ -81,7 +81,7 @@ public class CertificateProvisioner implements ConfigurationProvisioner<Kubernet
                 .withStringData(ImmutableMap.of(CA_CERT_FILE, certificate))
                 .build());
 
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (PodData pod : k8sEnv.getPodData().values()) {
       Optional<Volume> certVolume =
           pod.getSpec()
               .getVolumes()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ImagePullSecretProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ImagePullSecretProvisioner.java
@@ -94,7 +94,7 @@ public class ImagePullSecretProvisioner implements ConfigurationProvisioner<Kube
     k8sEnv.getSecrets().put(secret.getMetadata().getName(), secret);
 
     k8sEnv
-        .getPodData()
+        .getPodsData()
         .values()
         .forEach(p -> addImagePullSecret(secret.getMetadata().getName(), p.getSpec()));
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ImagePullSecretProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ImagePullSecretProvisioner.java
@@ -16,7 +16,7 @@ import com.google.gson.Gson;
 import com.google.gson.stream.JsonWriter;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import java.io.IOException;
@@ -93,7 +93,10 @@ public class ImagePullSecretProvisioner implements ConfigurationProvisioner<Kube
 
     k8sEnv.getSecrets().put(secret.getMetadata().getName(), secret);
 
-    k8sEnv.getPods().values().forEach(p -> addImagePullSecret(secret.getMetadata().getName(), p));
+    k8sEnv
+        .getPodData()
+        .values()
+        .forEach(p -> addImagePullSecret(secret.getMetadata().getName(), p.getSpec()));
   }
 
   /**
@@ -160,13 +163,12 @@ public class ImagePullSecretProvisioner implements ConfigurationProvisioner<Kube
     }
   }
 
-  private void addImagePullSecret(String secretName, Pod pod) {
-    List<LocalObjectReference> imagePullSecrets = pod.getSpec().getImagePullSecrets();
-    pod.getSpec()
-        .setImagePullSecrets(
-            ImmutableList.<LocalObjectReference>builder()
-                .add(new LocalObjectReferenceBuilder().withName(secretName).build())
-                .addAll(imagePullSecrets)
-                .build());
+  private void addImagePullSecret(String secretName, PodSpec podSpec) {
+    List<LocalObjectReference> imagePullSecrets = podSpec.getImagePullSecrets();
+    podSpec.setImagePullSecrets(
+        ImmutableList.<LocalObjectReference>builder()
+            .add(new LocalObjectReferenceBuilder().withName(secretName).build())
+            .addAll(imagePullSecrets)
+            .build());
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/InstallerServersPortProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/InstallerServersPortProvisioner.java
@@ -16,7 +16,6 @@ import static java.util.stream.Collectors.toList;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import io.fabric8.kubernetes.api.model.Pod;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -37,6 +36,7 @@ import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Fixes installers servers ports if conflicts are present.
@@ -76,7 +76,7 @@ public class InstallerServersPortProvisioner implements ConfigurationProvisioner
 
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (PodData pod : k8sEnv.getPodData().values()) {
       // it is needed to detect conflicts between all containers in a pod
       // because they use the same ports
       List<InternalMachineConfig> podMachines =

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/InstallerServersPortProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/InstallerServersPortProvisioner.java
@@ -76,7 +76,7 @@ public class InstallerServersPortProvisioner implements ConfigurationProvisioner
 
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
-    for (PodData pod : k8sEnv.getPodData().values()) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
       // it is needed to detect conflicts between all containers in a pod
       // because they use the same ports
       List<InternalMachineConfig> podMachines =

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java
@@ -46,7 +46,7 @@ public class PodTerminationGracePeriodProvisioner implements ConfigurationProvis
 
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
-    for (PodData pod : k8sEnv.getPodData().values()) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
       if (!isTerminationGracePeriodSet(pod.getSpec())) {
         pod.getSpec().setTerminationGracePeriodSeconds(graceTerminationPeriodSec);
       }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
-import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -19,6 +19,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Adds grace termination period to workspace pods.
@@ -45,8 +46,8 @@ public class PodTerminationGracePeriodProvisioner implements ConfigurationProvis
 
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
-    for (Pod pod : k8sEnv.getPods().values()) {
-      if (!isTerminationGracePeriodSet(pod)) {
+    for (PodData pod : k8sEnv.getPodData().values()) {
+      if (!isTerminationGracePeriodSet(pod.getSpec())) {
         pod.getSpec().setTerminationGracePeriodSeconds(graceTerminationPeriodSec);
       }
     }
@@ -57,7 +58,7 @@ public class PodTerminationGracePeriodProvisioner implements ConfigurationProvis
    * @return true if 'terminationGracePeriodSeconds' have been explicitly set in Kubernetes /
    *     OpenShift recipe, false otherwise
    */
-  private boolean isTerminationGracePeriodSet(final Pod pod) {
-    return pod.getSpec().getTerminationGracePeriodSeconds() != null;
+  private boolean isTerminationGracePeriodSet(final PodSpec podSpec) {
+    return podSpec.getTerminationGracePeriodSeconds() != null;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisioner.java
@@ -60,7 +60,7 @@ public class ProxySettingsProvisioner implements ConfigurationProvisioner {
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
     if (!proxyEnvVars.isEmpty()) {
-      for (PodData pod : k8sEnv.getPodData().values()) {
+      for (PodData pod : k8sEnv.getPodsData().values()) {
         pod.getSpec()
             .getContainers()
             .forEach(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ProxySettingsProvisioner.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.Pod;
 import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Inject;
@@ -22,6 +21,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Add proxy configuration to pod containers
@@ -60,7 +60,7 @@ public class ProxySettingsProvisioner implements ConfigurationProvisioner {
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
     if (!proxyEnvVars.isEmpty()) {
-      for (Pod pod : k8sEnv.getPods().values()) {
+      for (PodData pod : k8sEnv.getPodData().values()) {
         pod.getSpec()
             .getContainers()
             .forEach(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SecurityContextProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SecurityContextProvisioner.java
@@ -11,8 +11,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSecurityContextBuilder;
+import io.fabric8.kubernetes.api.model.PodSpec;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -38,13 +38,12 @@ public class SecurityContextProvisioner implements ConfigurationProvisioner<Kube
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     if (runAsUser != null) {
-      k8sEnv.getPods().values().forEach(this::provision);
+      k8sEnv.getPodData().values().forEach(p -> provision(p.getSpec()));
     }
   }
 
-  public void provision(Pod pod) {
-    pod.getSpec()
-        .setSecurityContext(
-            new PodSecurityContextBuilder().withRunAsUser(runAsUser).withFsGroup(fsGroup).build());
+  public void provision(PodSpec podSpec) {
+    podSpec.setSecurityContext(
+        new PodSecurityContextBuilder().withRunAsUser(runAsUser).withFsGroup(fsGroup).build());
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SecurityContextProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SecurityContextProvisioner.java
@@ -38,7 +38,7 @@ public class SecurityContextProvisioner implements ConfigurationProvisioner<Kube
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     if (runAsUser != null) {
-      k8sEnv.getPodData().values().forEach(p -> provision(p.getSpec()));
+      k8sEnv.getPodsData().values().forEach(p -> provision(p.getSpec()));
     }
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ServiceAccountProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ServiceAccountProvisioner.java
@@ -51,7 +51,7 @@ public class ServiceAccountProvisioner implements ConfigurationProvisioner {
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
     if (!isNullOrEmpty(serviceAccount)) {
-      for (PodData pod : k8sEnv.getPodData().values()) {
+      for (PodData pod : k8sEnv.getPodsData().values()) {
         pod.getSpec().setServiceAccountName(serviceAccount);
         pod.getSpec().setAutomountServiceAccountToken(true);
       }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ServiceAccountProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ServiceAccountProvisioner.java
@@ -13,7 +13,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 
-import io.fabric8.kubernetes.api.model.Pod;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -23,6 +22,7 @@ import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Sets the service account to workspace pods if configured.
@@ -51,7 +51,7 @@ public class ServiceAccountProvisioner implements ConfigurationProvisioner {
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
     if (!isNullOrEmpty(serviceAccount)) {
-      for (Pod pod : k8sEnv.getPods().values()) {
+      for (PodData pod : k8sEnv.getPodData().values()) {
         pod.getSpec().setServiceAccountName(serviceAccount);
         pod.getSpec().setAutomountServiceAccountToken(true);
       }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisioner.java
@@ -14,8 +14,8 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
 
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import javax.inject.Singleton;
@@ -26,6 +26,7 @@ import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Constants;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Makes names of Kubernetes pods and ingresses unique whole namespace by {@link Names}.
@@ -48,15 +49,14 @@ public class UniqueNamesProvisioner<T extends KubernetesEnvironment>
 
     TracingTags.WORKSPACE_ID.set(workspaceId);
 
-    final Set<Pod> pods = new HashSet<>(k8sEnv.getPods().values());
-    k8sEnv.getPods().clear();
-    for (Pod pod : pods) {
+    final Collection<PodData> podData = k8sEnv.getPodData().values();
+    for (PodData pod : podData) {
       final ObjectMeta podMeta = pod.getMetadata();
-      putLabel(pod, Constants.CHE_ORIGINAL_NAME_LABEL, podMeta.getName());
+      putLabel(podMeta, Constants.CHE_ORIGINAL_NAME_LABEL, podMeta.getName());
       final String podName = Names.uniquePodName(podMeta.getName(), workspaceId);
       podMeta.setName(podName);
-      k8sEnv.getPods().put(podName, pod);
     }
+
     final Set<Ingress> ingresses = new HashSet<>(k8sEnv.getIngresses().values());
     k8sEnv.getIngresses().clear();
     for (Ingress ingress : ingresses) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisioner.java
@@ -117,7 +117,12 @@ public class UniqueNamesProvisioner<T extends KubernetesEnvironment>
                 env -> {
                   ConfigMapKeySelector configMap = env.getValueFrom().getConfigMapKeyRef();
                   String originalName = configMap.getName();
-                  configMap.setName(configMapNameTranslation.get(originalName));
+                  // Since pods can reference configmaps that don't exist, we only change the name
+                  // if the configmap does exist to aid debugging recipes (otherwise message is just
+                  // null).
+                  if (configMapNameTranslation.containsKey(originalName)) {
+                    configMap.setName(configMapNameTranslation.get(originalName));
+                  }
                 });
       }
       if (container.getEnvFrom() != null) {
@@ -130,7 +135,9 @@ public class UniqueNamesProvisioner<T extends KubernetesEnvironment>
                 envFrom -> {
                   ConfigMapEnvSource configMapRef = envFrom.getConfigMapRef();
                   String originalName = configMapRef.getName();
-                  configMapRef.setName(configMapNameTranslation.get(originalName));
+                  if (configMapNameTranslation.containsKey(originalName)) {
+                    configMapRef.setName(configMapNameTranslation.get(originalName));
+                  }
                 });
       }
     }
@@ -144,7 +151,9 @@ public class UniqueNamesProvisioner<T extends KubernetesEnvironment>
               volume -> {
                 ConfigMapVolumeSource configMapVolume = volume.getConfigMap();
                 String originalName = configMapVolume.getName();
-                configMapVolume.setName(configMapNameTranslation.get(originalName));
+                if (configMapNameTranslation.containsKey(originalName)) {
+                  configMapVolume.setName(configMapNameTranslation.get(originalName));
+                }
               });
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverter.java
@@ -13,7 +13,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision.env;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.Pod;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -23,6 +22,7 @@ import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ConfigurationProvisioner;
 
 /**
@@ -39,7 +39,7 @@ public class EnvVarsConverter implements ConfigurationProvisioner {
 
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (PodData pod : k8sEnv.getPodData().values()) {
       for (Container container : pod.getSpec().getContainers()) {
         String machineName = Names.machineName(pod, container);
         InternalMachineConfig machineConf = k8sEnv.getMachines().get(machineName);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverter.java
@@ -39,7 +39,7 @@ public class EnvVarsConverter implements ConfigurationProvisioner {
 
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
-    for (PodData pod : k8sEnv.getPodData().values()) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
       for (Container container : pod.getSpec().getContainers()) {
         String machineName = Names.machineName(pod, container);
         InternalMachineConfig machineConf = k8sEnv.getMachines().get(machineName);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisioner.java
@@ -52,7 +52,7 @@ public class RamLimitRequestProvisioner implements ConfigurationProvisioner {
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
     final Map<String, InternalMachineConfig> machines = k8sEnv.getMachines();
-    for (PodData pod : k8sEnv.getPodData().values()) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
       for (Container container : pod.getSpec().getContainers()) {
         InternalMachineConfig machineConfig = machines.get(machineName(pod, container));
         memoryAttributeProvisioner.provision(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisioner.java
@@ -16,7 +16,6 @@ import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMO
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Names.machineName;
 
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.Pod;
 import java.util.Map;
 import javax.inject.Inject;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -26,6 +25,7 @@ import org.eclipse.che.api.workspace.server.spi.environment.MemoryAttributeProvi
 import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ConfigurationProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
 
@@ -52,7 +52,7 @@ public class RamLimitRequestProvisioner implements ConfigurationProvisioner {
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
     final Map<String, InternalMachineConfig> machines = k8sEnv.getMachines();
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (PodData pod : k8sEnv.getPodData().values()) {
       for (Container container : pod.getSpec().getContainers()) {
         InternalMachineConfig machineConfig = machines.get(machineName(pod, container));
         memoryAttributeProvisioner.provision(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriter.java
@@ -13,7 +13,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpol
 
 import static java.lang.String.format;
 
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
@@ -22,6 +21,7 @@ import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Warnings;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ConfigurationProvisioner;
 
 /**
@@ -40,7 +40,7 @@ public class RestartPolicyRewriter implements ConfigurationProvisioner {
 
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
-    for (Pod podConfig : k8sEnv.getPods().values()) {
+    for (PodData podConfig : k8sEnv.getPodData().values()) {
       final String podName = podConfig.getMetadata().getName();
       final PodSpec podSpec = podConfig.getSpec();
       rewriteRestartPolicy(podSpec, podName, k8sEnv);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriter.java
@@ -40,7 +40,7 @@ public class RestartPolicyRewriter implements ConfigurationProvisioner {
 
     TracingTags.WORKSPACE_ID.set(identity::getWorkspaceId);
 
-    for (PodData podConfig : k8sEnv.getPodData().values()) {
+    for (PodData podConfig : k8sEnv.getPodsData().values()) {
       final String podName = podConfig.getMetadata().getName();
       final PodSpec podSpec = podConfig.getSpec();
       rewriteRestartPolicy(podSpec, podName, k8sEnv);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/server/ServersConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/server/ServersConverter.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision.server;
 
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import java.util.Map;
 import javax.inject.Inject;
@@ -25,6 +24,7 @@ import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ConfigurationProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.KubernetesServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerStrategy;
@@ -64,7 +64,7 @@ public class ServersConverter<T extends KubernetesEnvironment>
     SecureServerExposer<T> secureServerExposer =
         secureServerExposerFactoryProvider.get(k8sEnv).create(identity);
 
-    for (Pod podConfig : k8sEnv.getPods().values()) {
+    for (PodData podConfig : k8sEnv.getPodData().values()) {
       final PodSpec podSpec = podConfig.getSpec();
       for (Container containerConfig : podSpec.getContainers()) {
         String machineName = Names.machineName(podConfig, containerConfig);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/server/ServersConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/server/ServersConverter.java
@@ -64,7 +64,7 @@ public class ServersConverter<T extends KubernetesEnvironment>
     SecureServerExposer<T> secureServerExposer =
         secureServerExposerFactoryProvider.get(k8sEnv).create(identity);
 
-    for (PodData podConfig : k8sEnv.getPodData().values()) {
+    for (PodData podConfig : k8sEnv.getPodsData().values()) {
       final PodSpec podSpec = podConfig.getSpec();
       for (Container containerConfig : podSpec.getContainers()) {
         String machineName = Names.machineName(podConfig, containerConfig);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposer.java
@@ -20,7 +20,6 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
@@ -38,6 +37,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Constants;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposer;
@@ -107,14 +107,14 @@ public class KubernetesServerExposer<T extends KubernetesEnvironment> {
   private final SecureServerExposer<T> secureServerExposer;
   private final String machineName;
   private final Container container;
-  private final Pod pod;
+  private final PodData pod;
   private final T k8sEnv;
 
   public KubernetesServerExposer(
       ExternalServerExposerStrategy<T> externalServerExposer,
       SecureServerExposer<T> secureServerExposer,
       String machineName,
-      Pod pod,
+      PodData pod,
       Container container,
       T k8sEnv) {
     this.externalServerExposer = externalServerExposer;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
@@ -213,7 +213,7 @@ public class JwtProxyProvisioner {
   private void ensureJwtProxyInjected(KubernetesEnvironment k8sEnv) throws InfrastructureException {
     if (!k8sEnv.getMachines().containsKey(JWT_PROXY_MACHINE_NAME)) {
       k8sEnv.getMachines().put(JWT_PROXY_MACHINE_NAME, createJwtProxyMachine());
-      k8sEnv.getPods().put(JWT_PROXY_POD_NAME, createJwtProxyPod());
+      k8sEnv.addPod(JWT_PROXY_POD_NAME, createJwtProxyPod());
 
       KeyPair keyPair;
       try {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
@@ -213,7 +213,7 @@ public class JwtProxyProvisioner {
   private void ensureJwtProxyInjected(KubernetesEnvironment k8sEnv) throws InfrastructureException {
     if (!k8sEnv.getMachines().containsKey(JWT_PROXY_MACHINE_NAME)) {
       k8sEnv.getMachines().put(JWT_PROXY_MACHINE_NAME, createJwtProxyMachine());
-      k8sEnv.addPod(JWT_PROXY_POD_NAME, createJwtProxyPod());
+      k8sEnv.addPod(createJwtProxyPod());
 
       KeyPair keyPair;
       try {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
@@ -58,14 +58,14 @@ public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironmen
     E brokerEnvironment =
         brokerEnvironmentFactory.create(pluginsMeta, runtimeID, new BrokersResult());
 
-    Map<String, PodData> workspacePods = workspaceEnvironment.getPodData();
+    Map<String, PodData> workspacePods = workspaceEnvironment.getPodsData();
     if (workspacePods.size() != 1) {
       throw new InfrastructureException(
           "Che plugins tooling configuration can be applied to a workspace with one pod only.");
     }
     PodData workspacePod = workspacePods.values().iterator().next();
 
-    Map<String, PodData> brokerPods = brokerEnvironment.getPodData();
+    Map<String, PodData> brokerPods = brokerEnvironment.getPodsData();
     if (brokerPods.size() != 1) {
       throw new InfrastructureException("Broker environment must have only one Pod.");
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
@@ -14,7 +14,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 import com.google.common.annotations.Beta;
 import com.google.inject.Inject;
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.Pod;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +24,7 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfi
 import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory;
 
 /**
@@ -58,18 +58,18 @@ public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironmen
     E brokerEnvironment =
         brokerEnvironmentFactory.create(pluginsMeta, runtimeID, new BrokersResult());
 
-    Map<String, Pod> workspacePods = workspaceEnvironment.getPods();
+    Map<String, PodData> workspacePods = workspaceEnvironment.getPodData();
     if (workspacePods.size() != 1) {
       throw new InfrastructureException(
           "Che plugins tooling configuration can be applied to a workspace with one pod only.");
     }
-    Pod workspacePod = workspacePods.values().iterator().next();
+    PodData workspacePod = workspacePods.values().iterator().next();
 
-    Map<String, Pod> brokerPods = brokerEnvironment.getPods();
+    Map<String, PodData> brokerPods = brokerEnvironment.getPodData();
     if (brokerPods.size() != 1) {
       throw new InfrastructureException("Broker environment must have only one Pod.");
     }
-    Pod brokerPod = brokerPods.values().iterator().next();
+    PodData brokerPod = brokerPods.values().iterator().next();
 
     // Add broker machines to workspace environment so that the init containers can be provisioned.
     List<Container> brokerContainers = brokerPod.getSpec().getContainers();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -127,7 +127,7 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
             .endSpec()
             .build();
 
-    kubernetesEnvironment.addPod(CHE_WORKSPACE_POD, pod);
+    kubernetesEnvironment.addPod(pod);
   }
 
   private void populateWorkspaceEnvVars(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -85,11 +85,11 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
 
     KubernetesEnvironment kubernetesEnvironment = (KubernetesEnvironment) internalEnvironment;
 
-    Map<String, PodData> pods = kubernetesEnvironment.getPodData();
+    Map<String, PodData> pods = kubernetesEnvironment.getPodsData();
     switch (pods.size()) {
       case 0:
         addToolingPod(kubernetesEnvironment);
-        pods = kubernetesEnvironment.getPodData();
+        pods = kubernetesEnvironment.getPodsData();
         break;
       case 1:
         break;
@@ -135,7 +135,7 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
 
     List<EnvVar> workspaceEnv = toK8sEnvVars(chePlugin.getWorkspaceEnv());
     kubernetesEnvironment
-        .getPodData()
+        .getPodsData()
         .values()
         .stream()
         .flatMap(pod -> pod.getSpec().getContainers().stream())

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
@@ -75,7 +75,7 @@ public class DeployBroker extends BrokerPhase {
         namespace.configMaps().create(configMap);
       }
 
-      Pod pluginBrokerPod = getPluginBrokerPod(brokerEnvironment.getPods());
+      Pod pluginBrokerPod = getPluginBrokerPod(brokerEnvironment.getPodsCopy());
 
       if (factory.isConfigured()) {
         UnrecoverablePodEventListener unrecoverableEventListener =

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesBrokerInitContainerApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesBrokerInitContainerApplierTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACH
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -80,14 +81,11 @@ public class KubernetesBrokerInitContainerApplierTest {
   @Mock private InternalMachineConfig brokerMachine;
   private Volume brokerVolume;
   private ConfigMap brokerConfigMap;
-  private KubernetesEnvironment brokerEnvironment;
-  private Pod brokerPod;
   private Container brokerContainer;
 
   // Workspace Environment mocks
   private KubernetesEnvironment workspaceEnvironment;
   private Pod workspacePod;
-  private Map<String, ConfigMap> workspaceConfigMaps;
 
   private KubernetesBrokerInitContainerApplier<KubernetesEnvironment> applier;
 
@@ -97,7 +95,7 @@ public class KubernetesBrokerInitContainerApplierTest {
     ObjectMeta workspacePodMeta =
         new ObjectMetaBuilder().withAnnotations(workspacePodAnnotations).build();
     workspacePod = new PodBuilder().withMetadata(workspacePodMeta).withSpec(new PodSpec()).build();
-    workspaceConfigMaps = new HashMap<>();
+    Map<String, ConfigMap> workspaceConfigMaps = new HashMap<>();
     workspaceEnvironment =
         KubernetesEnvironment.builder()
             .setPods(ImmutableMap.of(WORKSPACE_POD_NAME, workspacePod))
@@ -110,7 +108,7 @@ public class KubernetesBrokerInitContainerApplierTest {
         new ObjectMetaBuilder().withAnnotations(brokerPodAnnotations).build();
     brokerContainer = new ContainerBuilder().withName(BROKER_CONTAINER_NAME).build();
     brokerVolume = new VolumeBuilder().build();
-    brokerPod =
+    Pod brokerPod =
         new PodBuilder()
             .withMetadata(brokerPodMeta)
             .withNewSpec()
@@ -119,7 +117,7 @@ public class KubernetesBrokerInitContainerApplierTest {
             .endSpec()
             .build();
     brokerConfigMap = new ConfigMapBuilder().addToData(brokerConfigMapData).build();
-    brokerEnvironment =
+    KubernetesEnvironment brokerEnvironment =
         KubernetesEnvironment.builder()
             .setPods(ImmutableMap.of(BROKER_POD_NAME, brokerPod))
             .setConfigMaps(ImmutableMap.of(BROKER_CONFIGMAP_NAME, brokerConfigMap))
@@ -144,7 +142,7 @@ public class KubernetesBrokerInitContainerApplierTest {
 
     ConfigMap workspaceConfigMap = workspaceEnvironment.getConfigMaps().get(BROKER_CONFIGMAP_NAME);
     assertNotNull(workspaceConfigMap);
-    assertTrue(!workspaceConfigMap.getData().isEmpty());
+    assertFalse(workspaceConfigMap.getData().isEmpty());
     assertTrue(
         workspaceConfigMap
             .getData()

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesBrokerInitContainerApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesBrokerInitContainerApplierTest.java
@@ -14,19 +14,22 @@ package org.eclipse.che.workspace.infrastructure.kubernetes;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACHINE_NAME_ANNOTATION_FMT;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -54,77 +57,75 @@ public class KubernetesBrokerInitContainerApplierTest {
   private static final String WORKSPACE_POD_NAME = "workspacePod";
   private static final String WORKSPACE_MACHINE_NAME = "workspaceMachine";
   private static final String WORKSPACE_CONTAINER_NAME = "workspaceContainer";
+  private static final Map<String, String> workspacePodAnnotations =
+      ImmutableMap.of(
+          String.format(MACHINE_NAME_ANNOTATION_FMT, WORKSPACE_CONTAINER_NAME),
+          WORKSPACE_MACHINE_NAME);
 
   private static final String BROKER_POD_NAME = "brokerPod";
   private static final String BROKER_MACHINE_NAME = "brokerMachine";
   private static final String BROKER_CONTAINER_NAME = "brokerContainer";
   private static final String BROKER_CONFIGMAP_NAME = "brokerConfigMap";
+  private static final Map<String, String> brokerPodAnnotations =
+      ImmutableMap.of(
+          String.format(MACHINE_NAME_ANNOTATION_FMT, BROKER_CONTAINER_NAME), BROKER_MACHINE_NAME);
+  private static final Map<String, String> brokerConfigMapData =
+      ImmutableMap.of("brokerConfigKey", "brokerConfigValue");
 
   @Mock private BrokerEnvironmentFactory<KubernetesEnvironment> brokerEnvironmentFactory;
   @Mock private RuntimeIdentity runtimeID;
   @Mock private Collection<PluginMeta> pluginsMeta;
 
   // Broker Environment mocks
-  @Mock private KubernetesEnvironment brokerEnvironment;
-  @Mock private Pod brokerPod;
-  @Mock private Container brokerContainer;
   @Mock private InternalMachineConfig brokerMachine;
-  @Mock private Map<String, InternalMachineConfig> brokerMachines;
-  @Mock private ConfigMap brokerConfigMap;
-  @Mock private Volume brokerVolume;
-  private PodSpec brokerPodSpec;
+  private Volume brokerVolume;
+  private ConfigMap brokerConfigMap;
+  private KubernetesEnvironment brokerEnvironment;
+  private Pod brokerPod;
+  private Container brokerContainer;
 
   // Workspace Environment mocks
-  @Mock private KubernetesEnvironment workspaceEnvironment;
-  @Mock private Pod workspacePod;
-  @Mock private Map<String, InternalMachineConfig> workspaceMachines;
-  private PodSpec workspacePodSpec;
+  private KubernetesEnvironment workspaceEnvironment;
+  private Pod workspacePod;
   private Map<String, ConfigMap> workspaceConfigMaps;
 
   private KubernetesBrokerInitContainerApplier<KubernetesEnvironment> applier;
 
   @BeforeMethod
   public void setUp() throws Exception {
-    // Workspace mocking
-    doReturn(ImmutableMap.of(WORKSPACE_POD_NAME, workspacePod))
-        .when(workspaceEnvironment)
-        .getPods();
-    doReturn(workspaceMachines).when(workspaceEnvironment).getMachines();
-    workspacePodSpec = new PodSpec();
-    doReturn(workspacePodSpec).when(workspacePod).getSpec();
+    // Workspace env setup
+    ObjectMeta workspacePodMeta =
+        new ObjectMetaBuilder().withAnnotations(workspacePodAnnotations).build();
+    workspacePod = new PodBuilder().withMetadata(workspacePodMeta).withSpec(new PodSpec()).build();
     workspaceConfigMaps = new HashMap<>();
-    doReturn(workspaceConfigMaps).when(workspaceEnvironment).getConfigMaps();
+    workspaceEnvironment =
+        KubernetesEnvironment.builder()
+            .setPods(ImmutableMap.of(WORKSPACE_POD_NAME, workspacePod))
+            .setMachines(new HashMap<>())
+            .setConfigMaps(workspaceConfigMaps)
+            .build();
 
-    // Broker mocking
+    // Broker env setup
+    ObjectMeta brokerPodMeta =
+        new ObjectMetaBuilder().withAnnotations(brokerPodAnnotations).build();
+    brokerContainer = new ContainerBuilder().withName(BROKER_CONTAINER_NAME).build();
+    brokerVolume = new VolumeBuilder().build();
+    brokerPod =
+        new PodBuilder()
+            .withMetadata(brokerPodMeta)
+            .withNewSpec()
+            .withContainers(brokerContainer)
+            .withVolumes(brokerVolume)
+            .endSpec()
+            .build();
+    brokerConfigMap = new ConfigMapBuilder().addToData(brokerConfigMapData).build();
+    brokerEnvironment =
+        KubernetesEnvironment.builder()
+            .setPods(ImmutableMap.of(BROKER_POD_NAME, brokerPod))
+            .setConfigMaps(ImmutableMap.of(BROKER_CONFIGMAP_NAME, brokerConfigMap))
+            .setMachines(ImmutableMap.of(BROKER_MACHINE_NAME, brokerMachine))
+            .build();
     doReturn(brokerEnvironment).when(brokerEnvironmentFactory).create(any(), any(), any());
-    doReturn(ImmutableMap.of(BROKER_POD_NAME, brokerPod)).when(brokerEnvironment).getPods();
-    brokerPodSpec = new PodSpec();
-    brokerPodSpec.setContainers(ImmutableList.of(brokerContainer));
-    brokerPodSpec.setVolumes(ImmutableList.of(brokerVolume));
-    doReturn(brokerPodSpec).when(brokerPod).getSpec();
-    doReturn(brokerMachines).when(brokerEnvironment).getMachines();
-    doReturn(brokerMachine).when(brokerMachines).get(any());
-    doReturn(ImmutableMap.of(BROKER_CONFIGMAP_NAME, brokerConfigMap))
-        .when(brokerEnvironment)
-        .getConfigMaps();
-
-    // Mocks necessary to make Names.machineName(pod, container) work
-    ObjectMeta workspacePodMetadata = mock(ObjectMeta.class);
-    doReturn(workspacePodMetadata).when(workspacePod).getMetadata();
-    doReturn(
-            ImmutableMap.of(
-                String.format(MACHINE_NAME_ANNOTATION_FMT, WORKSPACE_CONTAINER_NAME),
-                WORKSPACE_MACHINE_NAME))
-        .when(workspacePodMetadata)
-        .getAnnotations();
-    ObjectMeta brokerPodMetadata = mock(ObjectMeta.class);
-    doReturn(brokerPodMetadata).when(brokerPod).getMetadata();
-    doReturn(
-            ImmutableMap.of(
-                String.format(MACHINE_NAME_ANNOTATION_FMT, BROKER_CONTAINER_NAME),
-                BROKER_MACHINE_NAME))
-        .when(brokerPodMetadata)
-        .getAnnotations();
 
     applier = new KubernetesBrokerInitContainerApplier<>(brokerEnvironmentFactory);
   }
@@ -133,14 +134,23 @@ public class KubernetesBrokerInitContainerApplierTest {
   public void shouldAddBrokerMachineToWorkspaceEnvironment() throws Exception {
     applier.apply(workspaceEnvironment, runtimeID, pluginsMeta);
 
-    verify(workspaceMachines).put(Names.machineName(workspacePod, brokerContainer), brokerMachine);
+    assertNotNull(workspaceEnvironment.getMachines());
+    assertTrue(workspaceEnvironment.getMachines().values().contains(brokerMachine));
   }
 
   @Test
   public void shouldAddBrokerConfigMapsToWorkspaceEnvironment() throws Exception {
     applier.apply(workspaceEnvironment, runtimeID, pluginsMeta);
 
-    assertTrue(workspaceConfigMaps.get(BROKER_CONFIGMAP_NAME).equals(brokerConfigMap));
+    ConfigMap workspaceConfigMap = workspaceEnvironment.getConfigMaps().get(BROKER_CONFIGMAP_NAME);
+    assertNotNull(workspaceConfigMap);
+    assertTrue(!workspaceConfigMap.getData().isEmpty());
+    assertTrue(
+        workspaceConfigMap
+            .getData()
+            .entrySet()
+            .stream()
+            .allMatch(e -> brokerConfigMap.getData().get(e.getKey()).equals(e.getValue())));
   }
 
   @Test
@@ -156,7 +166,7 @@ public class KubernetesBrokerInitContainerApplierTest {
   public void shouldAddBrokerVolumesToWorkspacePod() throws Exception {
     applier.apply(workspaceEnvironment, runtimeID, pluginsMeta);
 
-    List<Volume> workspaceVolumes = workspacePodSpec.getVolumes();
+    List<Volume> workspaceVolumes = workspacePod.getSpec().getVolumes();
     assertEquals(workspaceVolumes.size(), 1);
     assertEquals(workspaceVolumes.iterator().next(), brokerVolume);
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -279,10 +279,10 @@ public class KubernetesInternalRuntimeTest {
     when(services.create(any())).thenAnswer(a -> a.getArguments()[0]);
     when(ingresses.create(any())).thenAnswer(a -> a.getArguments()[0]);
     when(ingresses.wait(anyString(), anyLong(), any(), any())).thenReturn(ingress);
-    when(deployments.deploy(any())).thenAnswer(a -> a.getArguments()[0]);
+    when(deployments.deploy(any(Pod.class))).thenAnswer(a -> a.getArguments()[0]);
     when(k8sEnv.getServices()).thenReturn(allServices);
     when(k8sEnv.getIngresses()).thenReturn(allIngresses);
-    when(k8sEnv.getPods()).thenReturn(podsMap);
+    when(k8sEnv.getPodsCopy()).thenReturn(podsMap);
     when(k8sEnv.getCommands()).thenReturn(new ArrayList<>(singletonList(envCommand)));
 
     when(deployments.waitRunningAsync(any())).thenReturn(CompletableFuture.completedFuture(null));
@@ -376,7 +376,7 @@ public class KubernetesInternalRuntimeTest {
     verify(toolingProvisioner).provision(IDENTITY, startSynchronizer, k8sEnv);
     verify(internalEnvironmentProvisioner).provision(IDENTITY, k8sEnv);
     verify(kubernetesEnvironmentProvisioner).provision(k8sEnv, IDENTITY);
-    verify(deployments).deploy(any());
+    verify(deployments).deploy(any(Pod.class));
     verify(ingresses).create(any());
     verify(services).create(any());
     verify(secrets).create(any());
@@ -433,7 +433,7 @@ public class KubernetesInternalRuntimeTest {
 
     internalRuntime.start(emptyMap());
 
-    verify(deployments).deploy(any());
+    verify(deployments).deploy(any(Pod.class));
     verify(ingresses).create(any());
     verify(services).create(any());
     verify(namespace.deployments(), times(2)).watchEvents(any());
@@ -454,7 +454,7 @@ public class KubernetesInternalRuntimeTest {
 
     internalRuntime.start(emptyMap());
 
-    verify(deployments).deploy(any());
+    verify(deployments).deploy(any(Pod.class));
     verify(ingresses).create(any());
     verify(services).create(any());
     verify(namespace.deployments(), times(1)).watchEvents(any());
@@ -492,13 +492,13 @@ public class KubernetesInternalRuntimeTest {
     final Container container2 = mockContainer(CONTAINER_NAME_2, EXPOSED_PORT_2, INTERNAL_PORT);
     final ImmutableMap<String, Pod> allPods =
         ImmutableMap.of(WORKSPACE_POD_NAME, mockPod(ImmutableList.of(container1, container2)));
-    when(k8sEnv.getPods()).thenReturn(allPods);
+    when(k8sEnv.getPodsCopy()).thenReturn(allPods);
     doThrow(IllegalStateException.class).when(bootstrapper).bootstrapAsync();
 
     try {
       internalRuntime.start(emptyMap());
     } catch (Exception rethrow) {
-      verify(deployments).deploy(any());
+      verify(deployments).deploy(any(Pod.class));
       verify(ingresses).create(any());
       verify(services).create(any());
       verify(bootstrapper, atLeastOnce()).bootstrapAsync();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -53,12 +53,14 @@ import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.IntOrStringBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.api.model.extensions.IngressBackend;
 import io.fabric8.kubernetes.api.model.extensions.IngressRule;
@@ -211,6 +213,14 @@ public class KubernetesInternalRuntimeTest {
       ImmutableMap.of(
           WORKSPACE_POD_NAME,
           mockPod(
+              ImmutableList.of(
+                  mockContainer(CONTAINER_NAME_1, EXPOSED_PORT_1),
+                  mockContainer(CONTAINER_NAME_2, EXPOSED_PORT_2, INTERNAL_PORT))));
+
+  private final ImmutableMap<String, Deployment> deploymentsMap =
+      ImmutableMap.of(
+          WORKSPACE_POD_NAME,
+          mockDeployment(
               ImmutableList.of(
                   mockContainer(CONTAINER_NAME_1, EXPOSED_PORT_1),
                   mockContainer(CONTAINER_NAME_2, EXPOSED_PORT_2, INTERNAL_PORT))));
@@ -387,6 +397,86 @@ public class KubernetesInternalRuntimeTest {
     verifyOrderedEventsChains(
         new MachineStatusEvent[] {newEvent(M1_NAME, STARTING), newEvent(M1_NAME, RUNNING)},
         new MachineStatusEvent[] {newEvent(M2_NAME, STARTING), newEvent(M2_NAME, RUNNING)});
+    verify(serverCheckerFactory).create(IDENTITY, M1_NAME, emptyMap());
+    verify(serverCheckerFactory).create(IDENTITY, M2_NAME, emptyMap());
+    verify(serversChecker, times(2)).startAsync(any());
+    verify(namespace.deployments(), times(1)).stopWatch();
+  }
+
+  @Test
+  public void startKubernetesEnvironmentWithDeploymentsInsteadOfPods() throws Exception {
+    when(k8sEnv.getPodsCopy()).thenReturn(emptyMap());
+    when(k8sEnv.getDeploymentsCopy()).thenReturn(deploymentsMap);
+    when(k8sEnv.getSecrets()).thenReturn(ImmutableMap.of("secret", new Secret()));
+    when(k8sEnv.getConfigMaps()).thenReturn(ImmutableMap.of("configMap", new ConfigMap()));
+    when(deployments.deploy(any(Deployment.class)))
+        .thenAnswer(
+            a -> {
+              Deployment deployment = (Deployment) a.getArguments()[0];
+              return new PodBuilder()
+                  .withMetadata(deployment.getSpec().getTemplate().getMetadata())
+                  .withSpec(deployment.getSpec().getTemplate().getSpec())
+                  .build();
+            });
+
+    internalRuntime.start(emptyMap());
+
+    verify(toolingProvisioner).provision(IDENTITY, startSynchronizer, k8sEnv);
+    verify(internalEnvironmentProvisioner).provision(IDENTITY, k8sEnv);
+    verify(kubernetesEnvironmentProvisioner).provision(k8sEnv, IDENTITY);
+    verify(deployments).deploy(any(Deployment.class));
+    verify(ingresses).create(any());
+    verify(services).create(any());
+    verify(secrets).create(any());
+    verify(configMaps).create(any());
+    verify(namespace.deployments(), times(1)).watchEvents(any());
+    verify(bootstrapper, times(2)).bootstrapAsync();
+    verify(eventService, times(4)).publish(any());
+    verifyOrderedEventsChains(
+        new MachineStatusEvent[] {newEvent(M1_NAME, STARTING), newEvent(M1_NAME, RUNNING)},
+        new MachineStatusEvent[] {newEvent(M2_NAME, STARTING), newEvent(M2_NAME, RUNNING)});
+    verify(serverCheckerFactory).create(IDENTITY, M1_NAME, emptyMap());
+    verify(serverCheckerFactory).create(IDENTITY, M2_NAME, emptyMap());
+    verify(serversChecker, times(2)).startAsync(any());
+    verify(namespace.deployments(), times(1)).stopWatch();
+  }
+
+  @Test
+  public void startKubernetesEnvironmentWithDeploymentsAndPods() throws Exception {
+    when(k8sEnv.getDeploymentsCopy()).thenReturn(deploymentsMap);
+    when(k8sEnv.getSecrets()).thenReturn(ImmutableMap.of("secret", new Secret()));
+    when(k8sEnv.getConfigMaps()).thenReturn(ImmutableMap.of("configMap", new ConfigMap()));
+    when(deployments.deploy(any(Deployment.class)))
+        .thenAnswer(
+            a -> {
+              Deployment deployment = (Deployment) a.getArguments()[0];
+              return new PodBuilder()
+                  .withMetadata(deployment.getSpec().getTemplate().getMetadata())
+                  .withSpec(deployment.getSpec().getTemplate().getSpec())
+                  .build();
+            });
+
+    internalRuntime.start(emptyMap());
+
+    verify(toolingProvisioner).provision(IDENTITY, startSynchronizer, k8sEnv);
+    verify(internalEnvironmentProvisioner).provision(IDENTITY, k8sEnv);
+    verify(kubernetesEnvironmentProvisioner).provision(k8sEnv, IDENTITY);
+    verify(deployments).deploy(any(Deployment.class));
+    verify(deployments).deploy(any(Pod.class));
+    verify(ingresses).create(any());
+    verify(services).create(any());
+    verify(secrets).create(any());
+    verify(configMaps).create(any());
+    verify(namespace.deployments(), times(1)).watchEvents(any());
+    verify(bootstrapper, times(2)).bootstrapAsync();
+    verify(eventService, times(6)).publish(any());
+    verifyOrderedEventsChains(
+        new MachineStatusEvent[] {
+          newEvent(M1_NAME, STARTING), newEvent(M1_NAME, STARTING), newEvent(M1_NAME, RUNNING)
+        },
+        new MachineStatusEvent[] {
+          newEvent(M2_NAME, STARTING), newEvent(M2_NAME, STARTING), newEvent(M2_NAME, RUNNING)
+        });
     verify(serverCheckerFactory).create(IDENTITY, M1_NAME, emptyMap());
     verify(serverCheckerFactory).create(IDENTITY, M2_NAME, emptyMap());
     verify(serversChecker, times(2)).startAsync(any());
@@ -844,16 +934,45 @@ public class KubernetesInternalRuntimeTest {
   }
 
   private static Pod mockPod(List<Container> containers) {
-    final Pod pod = mock(Pod.class);
-    final PodSpec spec = mock(PodSpec.class);
-    mockName(WORKSPACE_POD_NAME, pod);
-    when(spec.getContainers()).thenReturn(containers);
-    when(pod.getSpec()).thenReturn(spec);
-    when(pod.getMetadata().getLabels())
-        .thenReturn(
-            ImmutableMap.of(
-                POD_SELECTOR, WORKSPACE_POD_NAME, CHE_ORIGINAL_NAME_LABEL, WORKSPACE_POD_NAME));
+    final Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName(WORKSPACE_POD_NAME)
+            .withLabels(
+                ImmutableMap.of(
+                    POD_SELECTOR, WORKSPACE_POD_NAME, CHE_ORIGINAL_NAME_LABEL, WORKSPACE_POD_NAME))
+            .endMetadata()
+            .withNewSpec()
+            .withContainers(containers)
+            .endSpec()
+            .build();
     return pod;
+  }
+
+  private static Deployment mockDeployment(List<Container> containers) {
+    final Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName(WORKSPACE_POD_NAME)
+            .withLabels(
+                ImmutableMap.of(
+                    POD_SELECTOR, WORKSPACE_POD_NAME, CHE_ORIGINAL_NAME_LABEL, WORKSPACE_POD_NAME))
+            .endMetadata()
+            .withNewSpec()
+            .withNewTemplate()
+            .withNewSpec()
+            .withContainers(containers)
+            .endSpec()
+            .withNewMetadata()
+            .withName(WORKSPACE_POD_NAME)
+            .withLabels(
+                ImmutableMap.of(
+                    POD_SELECTOR, WORKSPACE_POD_NAME, CHE_ORIGINAL_NAME_LABEL, WORKSPACE_POD_NAME))
+            .endMetadata()
+            .endTemplate()
+            .endSpec()
+            .build();
+    return deployment;
   }
 
   private static Service mockService() {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactoryTest.java
@@ -202,9 +202,9 @@ public class KubernetesEnvironmentFactoryTest {
     assertEquals(
         parsed.getPodsCopy().values().iterator().next().getMetadata().getName(),
         pod.getMetadata().getName());
-    assertEquals(parsed.getPodData().size(), 1);
+    assertEquals(parsed.getPodsData().size(), 1);
     assertEquals(
-        parsed.getPodData().values().iterator().next().getMetadata().getName(),
+        parsed.getPodsData().values().iterator().next().getMetadata().getName(),
         pod.getMetadata().getName());
   }
 
@@ -238,9 +238,9 @@ public class KubernetesEnvironmentFactoryTest {
     assertEquals(
         parsed.getDeploymentsCopy().values().iterator().next().getMetadata().getName(),
         deployment.getMetadata().getName());
-    assertEquals(parsed.getPodData().size(), 1);
+    assertEquals(parsed.getPodsData().size(), 1);
     assertEquals(
-        parsed.getPodData().values().iterator().next().getMetadata().getName(),
+        parsed.getPodsData().values().iterator().next().getMetadata().getName(),
         podTemplate.getMetadata().getName());
   }
 
@@ -277,10 +277,10 @@ public class KubernetesEnvironmentFactoryTest {
     final KubernetesEnvironment parsed =
         k8sEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
-    assertEquals(parsed.getPodData().size(), 2);
+    assertEquals(parsed.getPodsData().size(), 2);
     assertTrue(
         parsed
-            .getPodData()
+            .getPodsData()
             .values()
             .stream()
             .allMatch(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidatorTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -51,7 +52,7 @@ public class KubernetesEnvironmentValidatorTest {
       expectedExceptionsMessageRegExp = "Environment should contain at least 1 pod")
   public void shouldThrowExceptionWhenEnvDoesNotHaveAnyPods() throws Exception {
     // given
-    when(kubernetesEnvironment.getPods()).thenReturn(emptyMap());
+    when(kubernetesEnvironment.getPodData()).thenReturn(emptyMap());
 
     // when
     environmentValidator.validate(kubernetesEnvironment);
@@ -64,10 +65,12 @@ public class KubernetesEnvironmentValidatorTest {
   public void shouldThrowExceptionWhenMachineIsDeclaredButThereIsNotContainerInKubernetesRecipe()
       throws Exception {
     // given
+    String podName = "pod1";
     Pod pod = createPod("pod1", "main");
-    when(kubernetesEnvironment.getPods()).thenReturn(ImmutableMap.of("pod1", pod));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(kubernetesEnvironment.getPodData()).thenReturn(ImmutableMap.of(podName, podData));
     when(kubernetesEnvironment.getMachines())
-        .thenReturn(ImmutableMap.of("pod1/db", mock(InternalMachineConfig.class)));
+        .thenReturn(ImmutableMap.of(podName + "/db", mock(InternalMachineConfig.class)));
 
     // when
     environmentValidator.validate(kubernetesEnvironment);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidatorTest.java
@@ -52,7 +52,7 @@ public class KubernetesEnvironmentValidatorTest {
       expectedExceptionsMessageRegExp = "Environment should contain at least 1 pod")
   public void shouldThrowExceptionWhenEnvDoesNotHaveAnyPods() throws Exception {
     // given
-    when(kubernetesEnvironment.getPodData()).thenReturn(emptyMap());
+    when(kubernetesEnvironment.getPodsData()).thenReturn(emptyMap());
 
     // when
     environmentValidator.validate(kubernetesEnvironment);
@@ -68,7 +68,7 @@ public class KubernetesEnvironmentValidatorTest {
     String podName = "pod1";
     Pod pod = createPod("pod1", "main");
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    when(kubernetesEnvironment.getPodData()).thenReturn(ImmutableMap.of(podName, podData));
+    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of(podName, podData));
     when(kubernetesEnvironment.getMachines())
         .thenReturn(ImmutableMap.of(podName + "/db", mock(InternalMachineConfig.class)));
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidatorTest.java
@@ -49,7 +49,7 @@ public class KubernetesEnvironmentValidatorTest {
 
   @Test(
       expectedExceptions = ValidationException.class,
-      expectedExceptionsMessageRegExp = "Environment should contain at least 1 pod")
+      expectedExceptionsMessageRegExp = "Environment should contain at least 1 pod or deployment")
   public void shouldThrowExceptionWhenEnvDoesNotHaveAnyPods() throws Exception {
     // given
     when(kubernetesEnvironment.getPodsData()).thenReturn(emptyMap());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/convert/DockerImageEnvironmentConverterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/convert/DockerImageEnvironmentConverterTest.java
@@ -84,7 +84,7 @@ public class DockerImageEnvironmentConverterTest {
 
     final KubernetesEnvironment actual = converter.convert(dockerEnv);
 
-    assertEquals(pod, actual.getPods().values().iterator().next());
+    assertEquals(pod, actual.getPodsCopy().values().iterator().next());
     assertEquals(recipe, actual.getRecipe());
     assertEquals(machines, actual.getMachines());
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -161,7 +161,6 @@ public class CommonPVCStrategyTest {
     mockName(pod, POD_NAME);
     mockName(pod2, POD_NAME_2);
 
-    Map<String, Pod> pods = ImmutableMap.of(POD_NAME, pod, POD_NAME_2, pod);
     Map<String, PodData> podData =
         ImmutableMap.of(
             POD_NAME, new PodData(pod.getSpec(), pod.getMetadata()),

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -31,6 +31,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -50,6 +51,7 @@ import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
@@ -135,11 +137,6 @@ public class CommonPVCStrategyTest {
     machines.put(MACHINE_3_NAME, machine3);
     lenient().when(k8sEnv.getMachines()).thenReturn(machines);
 
-    Map<String, Pod> pods = new HashMap<>();
-    pods.put(POD_NAME, pod);
-    pods.put(POD_NAME_2, pod2);
-    lenient().when(k8sEnv.getPods()).thenReturn(pods);
-
     lenient().when(pod.getSpec()).thenReturn(podSpec);
     lenient().when(pod2.getSpec()).thenReturn(podSpec2);
     lenient().when(podSpec.getContainers()).thenReturn(asList(container, container2));
@@ -163,6 +160,14 @@ public class CommonPVCStrategyTest {
 
     mockName(pod, POD_NAME);
     mockName(pod2, POD_NAME_2);
+
+    Map<String, Pod> pods = ImmutableMap.of(POD_NAME, pod, POD_NAME_2, pod);
+    Map<String, PodData> podData =
+        ImmutableMap.of(
+            POD_NAME, new PodData(pod.getSpec(), pod.getMetadata()),
+            POD_NAME_2, new PodData(pod2.getSpec(), pod2.getMetadata()));
+    lenient().when(k8sEnv.getPodData()).thenReturn(podData);
+
     when(workspace.getId()).thenReturn(WORKSPACE_ID);
     Map<String, String> workspaceAttributes = new HashMap<>();
     WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -166,7 +166,7 @@ public class CommonPVCStrategyTest {
         ImmutableMap.of(
             POD_NAME, new PodData(pod.getSpec(), pod.getMetadata()),
             POD_NAME_2, new PodData(pod2.getSpec(), pod2.getMetadata()));
-    lenient().when(k8sEnv.getPodData()).thenReturn(podData);
+    lenient().when(k8sEnv.getPodsData()).thenReturn(podData);
 
     when(workspace.getId()).thenReturn(WORKSPACE_ID);
     Map<String, String> workspaceAttributes = new HashMap<>();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapterTest.java
@@ -38,6 +38,7 @@ import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -108,7 +109,8 @@ public class EphemeralWorkspaceAdapterTest {
   public void testEmptyDirVolumeMountsAdded() throws Exception {
     Container container = new Container();
     Pod pod = buildPod(POD_ID, container);
-    when(k8sEnv.getPods()).thenReturn(ImmutableMap.of(POD_ID, pod));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(k8sEnv.getPodData()).thenReturn(ImmutableMap.of(POD_ID, podData));
 
     ephemeralWorkspaceAdapter.provision(k8sEnv, runtimeIdentity);
 
@@ -123,7 +125,8 @@ public class EphemeralWorkspaceAdapterTest {
     Container container1 = new Container();
     Container container2 = new Container();
     Pod pod = buildPod(POD_ID, container1, container2);
-    when(k8sEnv.getPods()).thenReturn(ImmutableMap.of(POD_ID, pod));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(k8sEnv.getPodData()).thenReturn(ImmutableMap.of(POD_ID, podData));
 
     ephemeralWorkspaceAdapter.provision(k8sEnv, runtimeIdentity);
 
@@ -148,7 +151,8 @@ public class EphemeralWorkspaceAdapterTest {
     Container container2 = new Container();
     Container initContainer = new Container();
     Pod pod = buildPod(POD_ID, container1, container2);
-    when(k8sEnv.getPods()).thenReturn(ImmutableMap.of(POD_ID, pod));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(k8sEnv.getPodData()).thenReturn(ImmutableMap.of(POD_ID, podData));
     pod.getSpec().setInitContainers(ImmutableList.of(initContainer));
 
     ephemeralWorkspaceAdapter.provision(k8sEnv, runtimeIdentity);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceAdapterTest.java
@@ -110,7 +110,7 @@ public class EphemeralWorkspaceAdapterTest {
     Container container = new Container();
     Pod pod = buildPod(POD_ID, container);
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    when(k8sEnv.getPodData()).thenReturn(ImmutableMap.of(POD_ID, podData));
+    when(k8sEnv.getPodsData()).thenReturn(ImmutableMap.of(POD_ID, podData));
 
     ephemeralWorkspaceAdapter.provision(k8sEnv, runtimeIdentity);
 
@@ -126,7 +126,7 @@ public class EphemeralWorkspaceAdapterTest {
     Container container2 = new Container();
     Pod pod = buildPod(POD_ID, container1, container2);
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    when(k8sEnv.getPodData()).thenReturn(ImmutableMap.of(POD_ID, podData));
+    when(k8sEnv.getPodsData()).thenReturn(ImmutableMap.of(POD_ID, podData));
 
     ephemeralWorkspaceAdapter.provision(k8sEnv, runtimeIdentity);
 
@@ -152,7 +152,7 @@ public class EphemeralWorkspaceAdapterTest {
     Container initContainer = new Container();
     Pod pod = buildPod(POD_ID, container1, container2);
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    when(k8sEnv.getPodData()).thenReturn(ImmutableMap.of(POD_ID, podData));
+    when(k8sEnv.getPodsData()).thenReturn(ImmutableMap.of(POD_ID, podData));
     pod.getSpec().setInitContainers(ImmutableList.of(initContainer));
 
     ephemeralWorkspaceAdapter.provision(k8sEnv, runtimeIdentity);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
@@ -171,7 +171,7 @@ public class PerWorkspacePVCStrategyTest {
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
     PodData pod2Data = new PodData(pod2.getSpec(), pod2.getMetadata());
     lenient()
-        .when(k8sEnv.getPodData())
+        .when(k8sEnv.getPodsData())
         .thenReturn(ImmutableMap.of(POD_NAME, podData, POD_NAME_2, pod2Data));
 
     lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -47,6 +47,7 @@ import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
@@ -123,11 +124,6 @@ public class UniqueWorkspacePVCStrategyTest {
     machines.put(MACHINE_NAME_3, machine3);
     lenient().when(k8sEnv.getMachines()).thenReturn(machines);
 
-    Map<String, Pod> pods = new HashMap<>();
-    pods.put(POD_NAME, pod);
-    pods.put(POD_NAME_2, pod2);
-    lenient().when(k8sEnv.getPods()).thenReturn(pods);
-
     lenient().when(pod.getSpec()).thenReturn(podSpec);
     lenient().when(pod2.getSpec()).thenReturn(podSpec2);
     lenient().when(podSpec.getContainers()).thenReturn(asList(container, container2));
@@ -146,6 +142,12 @@ public class UniqueWorkspacePVCStrategyTest {
 
     mockName(pod, POD_NAME);
     mockName(pod2, POD_NAME_2);
+
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    PodData pod2Data = new PodData(pod2.getSpec(), pod2.getMetadata());
+    lenient()
+        .when(k8sEnv.getPodData())
+        .thenReturn(ImmutableMap.of(POD_NAME, podData, POD_NAME_2, pod2Data));
 
     lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
     Map<String, String> workspaceAttributes = new HashMap<>();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -146,7 +146,7 @@ public class UniqueWorkspacePVCStrategyTest {
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
     PodData pod2Data = new PodData(pod2.getSpec(), pod2.getMetadata());
     lenient()
-        .when(k8sEnv.getPodData())
+        .when(k8sEnv.getPodsData())
         .thenReturn(ImmutableMap.of(POD_NAME, podData, POD_NAME_2, pod2Data));
 
     lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisionerTest.java
@@ -107,14 +107,14 @@ public class CertificateProvisionerTest {
   @Test
   public void shouldAddVolumeAndVolumeMountsToPodsAndContainersInEnvironment() throws Exception {
     // given
-    k8sEnv.getPods().put("pod", createPod());
-    k8sEnv.getPods().put("pod2", createPod());
+    k8sEnv.addPod("pod", createPod());
+    k8sEnv.addPod("pod2", createPod());
 
     // when
     provisioner.provision(k8sEnv, runtimeId);
 
     // then
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (Pod pod : k8sEnv.getPodsCopy().values()) {
       verifyVolumeIsPresent(pod);
       for (Container container : pod.getSpec().getContainers()) {
         verifyVolumeMountIsPresent(container);
@@ -128,14 +128,14 @@ public class CertificateProvisionerTest {
           throws Exception {
     // given
     provisioner = new CertificateProvisioner("");
-    k8sEnv.getPods().put("pod", createPod());
-    k8sEnv.getPods().put("pod2", createPod());
+    k8sEnv.addPod("pod", createPod());
+    k8sEnv.addPod("pod2", createPod());
 
     // when
     provisioner.provision(k8sEnv, runtimeId);
 
     // then
-    for (Pod pod : k8sEnv.getPods().values()) {
+    for (Pod pod : k8sEnv.getPodsCopy().values()) {
       assertTrue(pod.getSpec().getVolumes().isEmpty());
       for (Container container : pod.getSpec().getContainers()) {
         assertTrue(container.getVolumeMounts().isEmpty());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisionerTest.java
@@ -107,8 +107,8 @@ public class CertificateProvisionerTest {
   @Test
   public void shouldAddVolumeAndVolumeMountsToPodsAndContainersInEnvironment() throws Exception {
     // given
-    k8sEnv.addPod("pod", createPod());
-    k8sEnv.addPod("pod2", createPod());
+    k8sEnv.addPod(createPod("pod"));
+    k8sEnv.addPod(createPod("pod2"));
 
     // when
     provisioner.provision(k8sEnv, runtimeId);
@@ -128,8 +128,8 @@ public class CertificateProvisionerTest {
           throws Exception {
     // given
     provisioner = new CertificateProvisioner("");
-    k8sEnv.addPod("pod", createPod());
-    k8sEnv.addPod("pod2", createPod());
+    k8sEnv.addPod(createPod("pod"));
+    k8sEnv.addPod(createPod("pod2"));
 
     // when
     provisioner.provision(k8sEnv, runtimeId);
@@ -162,9 +162,10 @@ public class CertificateProvisionerTest {
     assertEquals(volumeMount.getMountPath(), CERT_MOUNT_PATH);
   }
 
-  private Pod createPod() {
+  private Pod createPod(String podName) {
     return new PodBuilder()
         .withNewMetadata()
+        .withName(podName)
         .endMetadata()
         .withNewSpec()
         .withContainers(new ContainerBuilder().build(), new ContainerBuilder().build())

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ImagePullSecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ImagePullSecretProvisionerTest.java
@@ -75,9 +75,9 @@ public class ImagePullSecretProvisionerTest {
     when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
 
     k8sEnv = KubernetesEnvironment.builder().build();
-    k8sEnv.getPods().put("wksp", pod);
     when(pod.getSpec()).thenReturn(podSpec);
     when(podSpec.getImagePullSecrets()).thenReturn(ImmutableList.of(existingImagePullSecretRef));
+    k8sEnv.addPod("wksp", pod);
 
     when(credentialsProvider.getCredentials()).thenReturn(authConfigs);
     imagePullSecretProvisioner = new ImagePullSecretProvisioner(credentialsProvider);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ImagePullSecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/ImagePullSecretProvisionerTest.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import io.fabric8.kubernetes.api.model.LocalObjectReference;
 import io.fabric8.kubernetes.api.model.LocalObjectReferenceBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -75,9 +77,11 @@ public class ImagePullSecretProvisionerTest {
     when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
 
     k8sEnv = KubernetesEnvironment.builder().build();
+    ObjectMeta podMeta = new ObjectMetaBuilder().withName("wksp").build();
+    when(pod.getMetadata()).thenReturn(podMeta);
     when(pod.getSpec()).thenReturn(podSpec);
     when(podSpec.getImagePullSecrets()).thenReturn(ImmutableList.of(existingImagePullSecretRef));
-    k8sEnv.addPod("wksp", pod);
+    k8sEnv.addPod(pod);
 
     when(credentialsProvider.getCredentials()).thenReturn(authConfigs);
     imagePullSecretProvisioner = new ImagePullSecretProvisioner(credentialsProvider);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/InstallerServersPortProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/InstallerServersPortProvisionerTest.java
@@ -45,6 +45,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.InstallerServersPortProvisioner.ServersPorts;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -75,13 +76,15 @@ public class InstallerServersPortProvisionerTest {
       throws Exception {
     // given
     doNothing().when(portProvisioner).fixInstallersPortsConflicts(anyList());
-    when(k8sEnv.getPods())
+    Pod pod1 = createPod("pod1", "container1", "container2");
+    Pod pod2 = createPod("pod2", "container3");
+    when(k8sEnv.getPodData())
         .thenReturn(
             ImmutableMap.of(
                 "pod1",
-                createPod("pod1", "container1", "container2"),
+                new PodData(pod1.getSpec(), pod1.getMetadata()),
                 "pod2",
-                createPod("pod2", "container3")));
+                new PodData(pod2.getSpec(), pod2.getMetadata())));
 
     InternalMachineConfig machine1 = mock(InternalMachineConfig.class);
     InternalMachineConfig machine2 = mock(InternalMachineConfig.class);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/InstallerServersPortProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/InstallerServersPortProvisionerTest.java
@@ -78,7 +78,7 @@ public class InstallerServersPortProvisionerTest {
     doNothing().when(portProvisioner).fixInstallersPortsConflicts(anyList());
     Pod pod1 = createPod("pod1", "container1", "container2");
     Pod pod2 = createPod("pod2", "container3");
-    when(k8sEnv.getPodData())
+    when(k8sEnv.getPodsData())
         .thenReturn(
             ImmutableMap.of(
                 "pod1",

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisionerTest.java
@@ -17,11 +17,24 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvFromSource;
+import io.fabric8.kubernetes.api.model.EnvFromSourceBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
 import java.util.HashMap;
@@ -44,6 +57,10 @@ public class UniqueNamesProvisionerTest {
 
   private static final String WORKSPACE_ID = "workspace37";
   private static final String POD_NAME = "testPod";
+  private static final String DEPLOYMENT_NAME = "testDeployment";
+  private static final String CONFIGMAP_NAME = "testConfigMap";
+  private static final String CONFIGMAP_KEY = "testConfigMapKey";
+  private static final String CONFIGMAP_VALUE = "testConfigMapValue";
   private static final String INGRESS_NAME = "testIngress";
 
   @Mock private KubernetesEnvironment k8sEnv;
@@ -72,6 +89,174 @@ public class UniqueNamesProvisionerTest {
   }
 
   @Test
+  public void provideUniqueDeploymentsName() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    Deployment deployment = newDeployment();
+    doReturn(ImmutableMap.of(DEPLOYMENT_NAME, deployment)).when(k8sEnv).getDeploymentsCopy();
+
+    uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    ObjectMeta deploymentMetadata = deployment.getMetadata();
+    assertNotEquals(deploymentMetadata.getName(), DEPLOYMENT_NAME);
+    assertEquals(deploymentMetadata.getLabels().get(CHE_ORIGINAL_NAME_LABEL), DEPLOYMENT_NAME);
+  }
+
+  @Test
+  public void provideUniqueConfigMapName() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    ConfigMap configMap = newConfigMap();
+    doReturn(ImmutableMap.of(CONFIGMAP_NAME, configMap)).when(k8sEnv).getConfigMaps();
+
+    uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    ObjectMeta configMapMetadata = configMap.getMetadata();
+    assertNotEquals(configMapMetadata.getName(), CONFIGMAP_NAME);
+    assertEquals(configMapMetadata.getLabels().get(CHE_ORIGINAL_NAME_LABEL), CONFIGMAP_NAME);
+  }
+
+  @Test
+  public void rewritePodConfigMapEnv() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    ConfigMap configMap = newConfigMap();
+    doReturn(ImmutableMap.of(CONFIGMAP_NAME, configMap)).when(k8sEnv).getConfigMaps();
+
+    EnvVar envVar =
+        new EnvVarBuilder()
+            .withNewValueFrom()
+            .withNewConfigMapKeyRef()
+            .withName(CONFIGMAP_NAME)
+            .withKey(CONFIGMAP_KEY)
+            .endConfigMapKeyRef()
+            .endValueFrom()
+            .build();
+    Container container = new ContainerBuilder().withEnv(envVar).build();
+    Pod pod = newPod();
+    pod.getSpec().setContainers(ImmutableList.of(container));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodsData();
+
+    uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    String newConfigMapName = configMap.getMetadata().getName();
+    EnvVar newEnvVar = container.getEnv().iterator().next();
+    assertEquals(newEnvVar.getValueFrom().getConfigMapKeyRef().getName(), newConfigMapName);
+  }
+
+  @Test
+  public void doesNotRewritePodConfigMapEnvWhenNoConfigMap() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    EnvVar envVar =
+        new EnvVarBuilder()
+            .withNewValueFrom()
+            .withNewConfigMapKeyRef()
+            .withName(CONFIGMAP_NAME)
+            .withKey(CONFIGMAP_KEY)
+            .endConfigMapKeyRef()
+            .endValueFrom()
+            .build();
+    Container container = new ContainerBuilder().withEnv(envVar).build();
+    Pod pod = newPod();
+    pod.getSpec().setContainers(ImmutableList.of(container));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodsData();
+
+    uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    EnvVar newEnvVar = container.getEnv().iterator().next();
+    assertEquals(newEnvVar.getValueFrom().getConfigMapKeyRef().getName(), CONFIGMAP_NAME);
+  }
+
+  @Test
+  public void rewritePodConfigMapEnvFrom() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    ConfigMap configMap = newConfigMap();
+    doReturn(ImmutableMap.of(CONFIGMAP_NAME, configMap)).when(k8sEnv).getConfigMaps();
+
+    EnvFromSource envFrom =
+        new EnvFromSourceBuilder()
+            .withNewConfigMapRef()
+            .withName(CONFIGMAP_NAME)
+            .endConfigMapRef()
+            .build();
+    Container container = new ContainerBuilder().withEnvFrom(envFrom).build();
+    Pod pod = newPod();
+    pod.getSpec().setContainers(ImmutableList.of(container));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodsData();
+
+    uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    String newConfigMapName = configMap.getMetadata().getName();
+    EnvFromSource newEnvFromSource = container.getEnvFrom().iterator().next();
+    assertEquals(newEnvFromSource.getConfigMapRef().getName(), newConfigMapName);
+  }
+
+  @Test
+  public void doesNotRewritePodConfigMapEnvFromWhenNoConfigMap() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    EnvFromSource envFrom =
+        new EnvFromSourceBuilder()
+            .withNewConfigMapRef()
+            .withName(CONFIGMAP_NAME)
+            .endConfigMapRef()
+            .build();
+    Container container = new ContainerBuilder().withEnvFrom(envFrom).build();
+    Pod pod = newPod();
+    pod.getSpec().setContainers(ImmutableList.of(container));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodsData();
+
+    uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    EnvFromSource newEnvFromSource = container.getEnvFrom().iterator().next();
+    assertEquals(newEnvFromSource.getConfigMapRef().getName(), CONFIGMAP_NAME);
+  }
+
+  @Test
+  public void rewritePodConfigMapVolumes() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    ConfigMap configMap = newConfigMap();
+    doReturn(ImmutableMap.of(CONFIGMAP_NAME, configMap)).when(k8sEnv).getConfigMaps();
+
+    Volume volume =
+        new VolumeBuilder().withNewConfigMap().withName(CONFIGMAP_NAME).endConfigMap().build();
+    Pod pod = newPod();
+    pod.getSpec().setVolumes(ImmutableList.of(volume));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodsData();
+
+    uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    String newConfigMapName = configMap.getMetadata().getName();
+    Volume newVolume = pod.getSpec().getVolumes().iterator().next();
+    assertEquals(newVolume.getConfigMap().getName(), newConfigMapName);
+  }
+
+  @Test
+  public void doesNotRewritePodConfigMapVolumesWhenNoConfigMap() throws Exception {
+    when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    Volume volume =
+        new VolumeBuilder().withNewConfigMap().withName(CONFIGMAP_NAME).endConfigMap().build();
+    Pod pod = newPod();
+    pod.getSpec().setVolumes(ImmutableList.of(volume));
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodsData();
+
+    uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    Volume newVolume = pod.getSpec().getVolumes().iterator().next();
+    assertEquals(newVolume.getConfigMap().getName(), CONFIGMAP_NAME);
+  }
+
+  @Test
   public void provideUniqueIngressesNames() throws Exception {
     final HashMap<String, Ingress> ingresses = new HashMap<>();
     Ingress ingress = newIngress();
@@ -88,6 +273,32 @@ public class UniqueNamesProvisionerTest {
   private static Pod newPod() {
     return new PodBuilder()
         .withMetadata(new ObjectMetaBuilder().withName(POD_NAME).build())
+        .withNewSpec()
+        .endSpec()
+        .build();
+  }
+
+  private static Deployment newDeployment() {
+    return new DeploymentBuilder()
+        .withNewMetadata()
+        .withName(DEPLOYMENT_NAME)
+        .endMetadata()
+        .withNewSpec()
+        .withNewTemplate()
+        .withNewMetadata()
+        .withName(POD_NAME)
+        .endMetadata()
+        .endTemplate()
+        .endSpec()
+        .build();
+  }
+
+  private static ConfigMap newConfigMap() {
+    return new ConfigMapBuilder()
+        .withNewMetadata()
+        .withName(CONFIGMAP_NAME)
+        .endMetadata()
+        .withData(ImmutableMap.of(CONFIGMAP_KEY, CONFIGMAP_VALUE))
         .build();
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisionerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
+import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -26,6 +27,7 @@ import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
 import java.util.HashMap;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -57,10 +59,10 @@ public class UniqueNamesProvisionerTest {
   @Test
   public void provideUniquePodsNames() throws Exception {
     when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
-    final HashMap<String, Pod> pods = new HashMap<>();
+
     Pod pod = newPod();
-    pods.put(POD_NAME, pod);
-    doReturn(pods).when(k8sEnv).getPods();
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodData();
 
     uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisionerTest.java
@@ -62,7 +62,7 @@ public class UniqueNamesProvisionerTest {
 
     Pod pod = newPod();
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodData();
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(k8sEnv).getPodsData();
 
     uniqueNamesProvisioner.provision(k8sEnv, runtimeIdentity);
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisionerTest.java
@@ -30,6 +30,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.environment.MemoryAttributeProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
@@ -68,7 +69,6 @@ public class RamLimitRequestProvisionerTest {
     ramProvisioner = new RamLimitRequestProvisioner(memoryAttributeProvisioner);
     container = new Container();
     container.setName(CONTAINER_NAME);
-    when(k8sEnv.getPods()).thenReturn(of(POD_NAME, pod));
     when(k8sEnv.getMachines()).thenReturn(of(MACHINE_NAME, internalMachineConfig));
     when(internalMachineConfig.getAttributes())
         .thenReturn(
@@ -79,10 +79,9 @@ public class RamLimitRequestProvisionerTest {
                 RAM_REQUEST_ATTRIBUTE));
     final ObjectMeta podMetadata = mock(ObjectMeta.class);
     when(podMetadata.getName()).thenReturn(POD_NAME);
-    when(pod.getMetadata()).thenReturn(podMetadata);
     final PodSpec podSpec = mock(PodSpec.class);
     when(podSpec.getContainers()).thenReturn(Collections.singletonList(container));
-    when(pod.getSpec()).thenReturn(podSpec);
+    when(k8sEnv.getPodData()).thenReturn(of(POD_NAME, new PodData(podSpec, podMetadata)));
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisionerTest.java
@@ -20,7 +20,6 @@ import static org.testng.Assert.assertEquals;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
@@ -55,7 +54,6 @@ public class RamLimitRequestProvisionerTest {
 
   @Mock private KubernetesEnvironment k8sEnv;
   @Mock private RuntimeIdentity identity;
-  @Mock private Pod pod;
   @Mock private InternalMachineConfig internalMachineConfig;
   @Mock private MemoryAttributeProvisioner memoryAttributeProvisioner;
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/limits/ram/RamLimitRequestProvisionerTest.java
@@ -81,7 +81,7 @@ public class RamLimitRequestProvisionerTest {
     when(podMetadata.getName()).thenReturn(POD_NAME);
     final PodSpec podSpec = mock(PodSpec.class);
     when(podSpec.getContainers()).thenReturn(Collections.singletonList(container));
-    when(k8sEnv.getPodData()).thenReturn(of(POD_NAME, new PodData(podSpec, podMetadata)));
+    when(k8sEnv.getPodsData()).thenReturn(of(POD_NAME, new PodData(podSpec, podMetadata)));
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriterTest.java
@@ -34,6 +34,7 @@ import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -57,13 +58,13 @@ public class RestartPolicyRewriterTest {
 
   @Test
   public void rewritesRestartPolicyWhenItsDifferentWithDefaultOne() throws Exception {
-    when(k8sEnv.getPods())
-        .thenReturn(singletonMap(TEST_POD_NAME, newPod(TEST_POD_NAME, ALWAYS_RESTART_POLICY)));
+    Pod pod = newPod(TEST_POD_NAME, ALWAYS_RESTART_POLICY);
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(k8sEnv.getPodData()).thenReturn(singletonMap(TEST_POD_NAME, podData));
 
     restartPolicyRewriter.provision(k8sEnv, runtimeIdentity);
 
-    assertEquals(
-        k8sEnv.getPods().get(TEST_POD_NAME).getSpec().getRestartPolicy(), DEFAULT_RESTART_POLICY);
+    assertEquals(pod.getSpec().getRestartPolicy(), DEFAULT_RESTART_POLICY);
     verifyWarnings(
         new WarningImpl(
             RESTART_POLICY_SET_TO_NEVER_WARNING_CODE,

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/restartpolicy/RestartPolicyRewriterTest.java
@@ -60,7 +60,7 @@ public class RestartPolicyRewriterTest {
   public void rewritesRestartPolicyWhenItsDifferentWithDefaultOne() throws Exception {
     Pod pod = newPod(TEST_POD_NAME, ALWAYS_RESTART_POLICY);
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    when(k8sEnv.getPodData()).thenReturn(singletonMap(TEST_POD_NAME, podData));
+    when(k8sEnv.getPodsData()).thenReturn(singletonMap(TEST_POD_NAME, podData));
 
     restartPolicyRewriter.provision(k8sEnv, runtimeIdentity);
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposerTest.java
@@ -37,6 +37,7 @@ import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposer;
 import org.mockito.Mock;
@@ -86,12 +87,14 @@ public class KubernetesServerExposerTest {
 
     kubernetesEnvironment =
         KubernetesEnvironment.builder().setPods(ImmutableMap.of("pod", pod)).build();
+
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
     this.serverExposer =
         new KubernetesServerExposer<>(
             externalServerExposerStrategy,
             secureServerExposer,
             MACHINE_NAME,
-            pod,
+            podData,
             container,
             kubernetesEnvironment);
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisionerTest.java
@@ -131,7 +131,7 @@ public class JwtProxyProvisionerTest {
             + PUBLIC_KEY_FOOTER);
     assertNotNull(configMap.getData().get(JWT_PROXY_CONFIG_FILE));
 
-    Pod jwtProxyPod = k8sEnv.getPods().get("che-jwtproxy");
+    Pod jwtProxyPod = k8sEnv.getPodsCopy().get("che-jwtproxy");
     assertNotNull(jwtProxyPod);
 
     Service jwtProxyService = k8sEnv.getServices().get(jwtProxyProvisioner.getServiceName());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -111,7 +111,7 @@ public class KubernetesPluginsToolingApplierTest {
     lenient().when(podSpec.getContainers()).thenReturn(containers);
     lenient().when(pod.getMetadata()).thenReturn(meta);
     lenient().when(meta.getName()).thenReturn(POD_NAME);
-    internalEnvironment.addPod(POD_NAME, pod);
+    internalEnvironment.addPod(pod);
     internalEnvironment.getMachines().putAll(machines);
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -252,7 +252,7 @@ public class KubernetesPluginsToolingApplierTest {
           "Che plugins tooling configuration can be applied to a workspace with one pod only")
   public void throwsExceptionWhenTheNumberOfPodsIsNot1() throws Exception {
     PodData podData = new PodData(podSpec, meta);
-    when(internalEnvironment.getPodData()).thenReturn(of("pod1", podData, "pod2", podData));
+    when(internalEnvironment.getPodsData()).thenReturn(of("pod1", podData, "pod2", podData));
 
     applier.apply(internalEnvironment, singletonList(createChePlugin()));
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBrokerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBrokerTest.java
@@ -85,7 +85,7 @@ public class DeployBrokerTest {
     when(k8sNamespace.deployments()).thenReturn(k8sDeployments);
 
     pod = new PodBuilder().withNewMetadata().withName(PLUGIN_BROKER_POD_NAME).endMetadata().build();
-    when(k8sEnvironment.getPods()).thenReturn(ImmutableMap.of(PLUGIN_BROKER_POD_NAME, pod));
+    when(k8sEnvironment.getPodsCopy()).thenReturn(ImmutableMap.of(PLUGIN_BROKER_POD_NAME, pod));
     when(k8sEnvironment.getConfigMaps()).thenReturn(ImmutableMap.of("configMap", configMap));
 
     when(k8sDeployments.create(any())).thenReturn(pod);
@@ -146,7 +146,7 @@ public class DeployBrokerTest {
           "Plugin broker environment must have only one pod\\. Workspace `workspaceId` contains `0` pods\\.")
   public void shouldThrowExceptionIfThereIsNoAnyPodsInEnvironment() throws Exception {
     // given
-    when(k8sEnvironment.getPods()).thenReturn(emptyMap());
+    when(k8sEnvironment.getPodsCopy()).thenReturn(emptyMap());
 
     // when
     deployBrokerPhase.execute();
@@ -158,7 +158,7 @@ public class DeployBrokerTest {
           "Plugin broker environment must have only one pod\\. Workspace `workspaceId` contains `2` pods\\.")
   public void shouldThrowExceptionIfThereAreMoreThanOnePodsInEnvironment() throws Exception {
     // given
-    when(k8sEnvironment.getPods()).thenReturn(ImmutableMap.of("pod1", pod, "pod2", pod));
+    when(k8sEnvironment.getPodsCopy()).thenReturn(ImmutableMap.of("pod1", pod, "pod2", pod));
 
     // when
     deployBrokerPhase.execute();

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -13,14 +13,13 @@ package org.eclipse.che.workspace.infrastructure.openshift;
 
 import com.google.inject.assistedinject.Assisted;
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.openshift.api.model.Route;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -123,10 +122,12 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
 
     project.deployments().watchEvents(new MachineLogsPublisher());
     if (unrecoverablePodEventListenerFactory.isConfigured()) {
-      Map<String, Pod> pods = getContext().getEnvironment().getPods();
+      Set<String> toWatch = new HashSet<>();
+      OpenShiftEnvironment environment = getContext().getEnvironment();
+      toWatch.addAll(environment.getPodsCopy().keySet());
+      toWatch.addAll(environment.getDeploymentsCopy().keySet());
       UnrecoverablePodEventListener handler =
-          unrecoverablePodEventListenerFactory.create(
-              pods.keySet(), this::handleUnrecoverableEvent);
+          unrecoverablePodEventListenerFactory.create(toWatch, this::handleUnrecoverableEvent);
       project.deployments().watchEvents(handler);
     }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Warnings.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Warnings.java
@@ -33,10 +33,5 @@ public final class Warnings {
   public static final String SECRET_IGNORED_WARNING_MESSAGE =
       "Secrets specified in OpenShift recipe are ignored.";
 
-  public static final int CONFIG_MAP_IGNORED_WARNING_CODE =
-      org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.CONFIG_MAP_IGNORED_WARNING_CODE;
-  public static final String CONFIG_MAP_IGNORED_WARNING_MESSAGE =
-      "Config maps specified in OpenShift recipe are ignored.";
-
   private Warnings() {}
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironment.java
@@ -14,7 +14,6 @@ package org.eclipse.che.workspace.infrastructure.openshift.environment;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
@@ -29,7 +28,6 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfi
 import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.Builder;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Holds objects of OpenShift environment.
@@ -67,23 +65,13 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
       InternalEnvironment internalEnvironment,
       Map<String, Pod> pods,
       Map<String, Deployment> deployments,
-      Map<String, PodData> podData,
       Map<String, Service> services,
       Map<String, Ingress> ingresses,
       Map<String, PersistentVolumeClaim> pvcs,
       Map<String, Secret> secrets,
       Map<String, ConfigMap> configMaps,
       Map<String, Route> routes) {
-    super(
-        internalEnvironment,
-        pods,
-        deployments,
-        podData,
-        services,
-        ingresses,
-        pvcs,
-        secrets,
-        configMaps);
+    super(internalEnvironment, pods, deployments, services, ingresses, pvcs, secrets, configMaps);
     setType(TYPE);
     this.routes = routes;
   }
@@ -94,7 +82,6 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
       List<Warning> warnings,
       Map<String, Pod> pods,
       Map<String, Deployment> deployments,
-      Map<String, PodData> podData,
       Map<String, Service> services,
       Map<String, Ingress> ingresses,
       Map<String, PersistentVolumeClaim> pvcs,
@@ -107,7 +94,6 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
         warnings,
         pods,
         deployments,
-        podData,
         services,
         ingresses,
         pvcs,
@@ -157,26 +143,12 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
     @Override
     public Builder setPods(Map<String, Pod> pods) {
       this.pods.putAll(pods);
-      pods.entrySet()
-          .forEach(
-              e -> {
-                Pod pod = e.getValue();
-                podData.put(e.getKey(), new PodData(pod.getSpec(), pod.getMetadata()));
-              });
       return this;
     }
 
     @Override
     public Builder setDeployments(Map<String, Deployment> deployments) {
       this.deployments.putAll(deployments);
-      deployments
-          .entrySet()
-          .forEach(
-              e -> {
-                PodTemplateSpec podTemplate = e.getValue().getSpec().getTemplate();
-                podData.put(
-                    e.getKey(), new PodData(podTemplate.getSpec(), podTemplate.getMetadata()));
-              });
       return this;
     }
 
@@ -226,7 +198,6 @@ public class OpenShiftEnvironment extends KubernetesEnvironment {
           internalEnvironment,
           pods,
           deployments,
-          podData,
           services,
           ingresses,
           pvcs,

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.Route;
 import java.io.ByteArrayInputStream;
@@ -101,6 +102,7 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
         clientFactory.create().lists().load(new ByteArrayInputStream(content.getBytes())).get();
 
     Map<String, Pod> pods = new HashMap<>();
+    Map<String, Deployment> deployments = new HashMap<>();
     Map<String, Service> services = new HashMap<>();
     boolean isAnyRoutePresent = false;
     boolean isAnyPVCPresent = false;
@@ -112,6 +114,9 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
       } else if (object instanceof Pod) {
         Pod pod = (Pod) object;
         pods.put(pod.getMetadata().getName(), pod);
+      } else if (object instanceof Deployment) {
+        Deployment deployment = (Deployment) object;
+        deployments.put(deployment.getMetadata().getName(), deployment);
       } else if (object instanceof Service) {
         Service service = (Service) object;
         services.put(service.getMetadata().getName(), service);
@@ -161,6 +166,7 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
             .setMachines(machines)
             .setWarnings(warnings)
             .setPods(pods)
+            .setDeployments(deployments)
             .setServices(services)
             .setPersistentVolumeClaims(new HashMap<>())
             .setSecrets(new HashMap<>())

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -213,10 +213,10 @@ public class OpenShiftInternalRuntimeTest {
         ImmutableMap.of(POD_NAME, mockPod(ImmutableList.of(container)));
     when(services.create(any())).thenAnswer(a -> a.getArguments()[0]);
     when(routes.create(any())).thenAnswer(a -> a.getArguments()[0]);
-    when(deployments.deploy(any())).thenAnswer(a -> a.getArguments()[0]);
+    when(deployments.deploy(any(Pod.class))).thenAnswer(a -> a.getArguments()[0]);
     when(osEnv.getServices()).thenReturn(allServices);
     when(osEnv.getRoutes()).thenReturn(allRoutes);
-    when(osEnv.getPods()).thenReturn(allPods);
+    when(osEnv.getPodsCopy()).thenReturn(allPods);
     when(osEnv.getSecrets()).thenReturn(ImmutableMap.of("secret", new Secret()));
     when(osEnv.getConfigMaps()).thenReturn(ImmutableMap.of("configMap", new ConfigMap()));
   }
@@ -227,12 +227,12 @@ public class OpenShiftInternalRuntimeTest {
     final Container container2 = mockContainer(CONTAINER_NAME_2, EXPOSED_PORT_2, INTERNAL_PORT);
     final ImmutableMap<String, Pod> allPods =
         ImmutableMap.of(POD_NAME, mockPod(ImmutableList.of(container1, container2)));
-    when(osEnv.getPods()).thenReturn(allPods);
+    when(osEnv.getPodsCopy()).thenReturn(allPods);
     when(unrecoverablePodEventListenerFactory.isConfigured()).thenReturn(true);
 
     internalRuntime.startMachines();
 
-    verify(deployments).deploy(any());
+    verify(deployments).deploy(any(Pod.class));
     verify(routes).create(any());
     verify(services).create(any());
     verify(secrets).create(any());
@@ -250,11 +250,11 @@ public class OpenShiftInternalRuntimeTest {
     final Container container2 = mockContainer(CONTAINER_NAME_2, EXPOSED_PORT_2, INTERNAL_PORT);
     final ImmutableMap<String, Pod> allPods =
         ImmutableMap.of(POD_NAME, mockPod(ImmutableList.of(container1, container2)));
-    when(osEnv.getPods()).thenReturn(allPods);
+    when(osEnv.getPodsCopy()).thenReturn(allPods);
 
     internalRuntime.startMachines();
 
-    verify(deployments).deploy(any());
+    verify(deployments).deploy(any(Pod.class));
     verify(routes).create(any());
     verify(services).create(any());
 

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
@@ -17,8 +17,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACHINE_NAME_ANNOTATION_FMT;
-import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.CONFIG_MAP_IGNORED_WARNING_CODE;
-import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.CONFIG_MAP_IGNORED_WARNING_MESSAGE;
 import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.PVC_IGNORED_WARNING_CODE;
 import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.PVC_IGNORED_WARNING_MESSAGE;
 import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.ROUTES_IGNORED_WARNING_MESSAGE;
@@ -37,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.DoneableKubernetesList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -166,18 +165,19 @@ public class OpenShiftEnvironmentFactoryTest {
   }
 
   @Test
-  public void ignoreConfigMapsWhenRecipeContainsThem() throws Exception {
-    final List<HasMetadata> recipeObjects = singletonList(new ConfigMap());
+  public void addConfigMapsWhenRecipeContainsThem() throws Exception {
+    ConfigMap configMap =
+        new ConfigMapBuilder().withNewMetadata().withName("test-configmap").endMetadata().build();
+    final List<HasMetadata> recipeObjects = singletonList(configMap);
     when(validatedObjects.getItems()).thenReturn(recipeObjects);
 
     final KubernetesEnvironment parsed =
         osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
-    assertTrue(parsed.getConfigMaps().isEmpty());
-    assertEquals(parsed.getWarnings().size(), 1);
+    assertEquals(parsed.getConfigMaps().size(), 1);
     assertEquals(
-        parsed.getWarnings().get(0),
-        new WarningImpl(CONFIG_MAP_IGNORED_WARNING_CODE, CONFIG_MAP_IGNORED_WARNING_MESSAGE));
+        parsed.getConfigMaps().values().iterator().next().getMetadata().getName(),
+        configMap.getMetadata().getName());
   }
 
   @Test

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
@@ -201,9 +201,9 @@ public class OpenShiftEnvironmentFactoryTest {
     assertEquals(
         parsed.getPodsCopy().values().iterator().next().getMetadata().getName(),
         pod.getMetadata().getName());
-    assertEquals(parsed.getPodData().size(), 1);
+    assertEquals(parsed.getPodsData().size(), 1);
     assertEquals(
-        parsed.getPodData().values().iterator().next().getMetadata().getName(),
+        parsed.getPodsData().values().iterator().next().getMetadata().getName(),
         pod.getMetadata().getName());
   }
 
@@ -237,9 +237,9 @@ public class OpenShiftEnvironmentFactoryTest {
     assertEquals(
         parsed.getDeploymentsCopy().values().iterator().next().getMetadata().getName(),
         deployment.getMetadata().getName());
-    assertEquals(parsed.getPodData().size(), 1);
+    assertEquals(parsed.getPodsData().size(), 1);
     assertEquals(
-        parsed.getPodData().values().iterator().next().getMetadata().getName(),
+        parsed.getPodsData().values().iterator().next().getMetadata().getName(),
         podTemplate.getMetadata().getName());
   }
 
@@ -276,10 +276,10 @@ public class OpenShiftEnvironmentFactoryTest {
     final KubernetesEnvironment parsed =
         osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
-    assertEquals(parsed.getPodData().size(), 2);
+    assertEquals(parsed.getPodsData().size(), 2);
     assertTrue(
         parsed
-            .getPodData()
+            .getPodsData()
             .values()
             .stream()
             .allMatch(

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
@@ -44,10 +44,15 @@ import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
 import io.fabric8.kubernetes.client.dsl.RecreateFromServerGettable;
 import io.fabric8.openshift.api.model.Route;
@@ -173,6 +178,116 @@ public class OpenShiftEnvironmentFactoryTest {
     assertEquals(
         parsed.getWarnings().get(0),
         new WarningImpl(CONFIG_MAP_IGNORED_WARNING_CODE, CONFIG_MAP_IGNORED_WARNING_MESSAGE));
+  }
+
+  @Test
+  public void addPodsWhenRecipeContainsThem() throws Exception {
+    Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName("pod-test")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+
+    final List<HasMetadata> recipeObjects = singletonList(pod);
+    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+
+    final KubernetesEnvironment parsed =
+        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+
+    assertEquals(parsed.getPodsCopy().size(), 1);
+    assertEquals(
+        parsed.getPodsCopy().values().iterator().next().getMetadata().getName(),
+        pod.getMetadata().getName());
+    assertEquals(parsed.getPodData().size(), 1);
+    assertEquals(
+        parsed.getPodData().values().iterator().next().getMetadata().getName(),
+        pod.getMetadata().getName());
+  }
+
+  @Test
+  public void addDeploymentsWhenRecipeContainsThem() throws Exception {
+    PodTemplateSpec podTemplate =
+        new PodTemplateSpecBuilder()
+            .withNewMetadata()
+            .withName("deployment-pod")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("deployment-test")
+            .endMetadata()
+            .withNewSpec()
+            .withTemplate(podTemplate)
+            .endSpec()
+            .build();
+
+    final List<HasMetadata> recipeObjects = singletonList(deployment);
+    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+
+    final KubernetesEnvironment parsed =
+        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+
+    assertEquals(parsed.getDeploymentsCopy().size(), 1);
+    assertEquals(
+        parsed.getDeploymentsCopy().values().iterator().next().getMetadata().getName(),
+        deployment.getMetadata().getName());
+    assertEquals(parsed.getPodData().size(), 1);
+    assertEquals(
+        parsed.getPodData().values().iterator().next().getMetadata().getName(),
+        podTemplate.getMetadata().getName());
+  }
+
+  @Test
+  public void bothPodsAndDeploymentsIncludedInPodData() throws Exception {
+    PodTemplateSpec podTemplate =
+        new PodTemplateSpecBuilder()
+            .withNewMetadata()
+            .withName("deployment-pod")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    Deployment deployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("deployment-test")
+            .endMetadata()
+            .withNewSpec()
+            .withTemplate(podTemplate)
+            .endSpec()
+            .build();
+    Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName("bare-pod")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    final List<HasMetadata> recipeObjects = asList(deployment, pod);
+    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+
+    final KubernetesEnvironment parsed =
+        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+
+    assertEquals(parsed.getPodData().size(), 2);
+    assertTrue(
+        parsed
+            .getPodData()
+            .values()
+            .stream()
+            .allMatch(
+                podData -> {
+                  String name = podData.getMetadata().getName();
+                  return name.equals(podTemplate.getMetadata().getName())
+                      || name.equals(pod.getMetadata().getName());
+                }));
   }
 
   @Test

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/OpenShiftUniqueNamesProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/OpenShiftUniqueNamesProvisionerTest.java
@@ -61,7 +61,7 @@ public class OpenShiftUniqueNamesProvisionerTest {
     when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
     Pod pod = newPod();
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    doReturn(ImmutableMap.of(POD_NAME, podData)).when(osEnv).getPodData();
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(osEnv).getPodsData();
 
     uniqueNamesProvisioner.provision(osEnv, runtimeIdentity);
 

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/OpenShiftUniqueNamesProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/OpenShiftUniqueNamesProvisionerTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
+import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
@@ -25,6 +26,7 @@ import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
 import java.util.HashMap;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -57,10 +59,9 @@ public class OpenShiftUniqueNamesProvisionerTest {
   @Test
   public void provideUniquePodsNames() throws Exception {
     when(runtimeIdentity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
-    final HashMap<String, Pod> pods = new HashMap<>();
     Pod pod = newPod();
-    pods.put(POD_NAME, pod);
-    doReturn(pods).when(osEnv).getPods();
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    doReturn(ImmutableMap.of(POD_NAME, podData)).when(osEnv).getPodData();
 
     uniqueNamesProvisioner.provision(osEnv, runtimeIdentity);
 


### PR DESCRIPTION
### What does this PR do?
Adds support for Deployments and ConfigMaps in Kubernetes and OpenShift recipes.

This PR is split into ~~three~~six commits:
- The first commit adds support for Deployments and makes changes necessary to make main (not test) code compile. This commit only compiles if test compilation is skipped
- The second commit fixes tests to accommodate the changes. It's separated out for readability.
- The third commit adds support for configmaps. I'm lumping it with the rest of the PR because it's closely related and interconnected.
- The sixth commit adds user dashboard validation and processing for configmaps and deployments in recipes.

Some relatively major changes here:
- Since Deployments store the underlying pod as `PodTemplateSpec`, there is no way to provide provisioners with the environment's pods directly. As a result, I've added a class internal to `KubernetesEnvironment` that basically abstracts pod spec and template to allow us to return one map of objects to be provisioned. This means relatively minor changes to all the provisioners
   - The new class is `PodData`, and has the same methods as `Pod`s, so that it's mostly a drop-in replacement.
- Since environments now store both pods and/or deployments at the same time, the old methods `getPods()` and it's parallel `getDeployments()` need to be used more carefully. Ideally, they are only used when we need read-only access to these objects (e.g. when we're deploying them). Instead, `getPodData()` should be used, as this returns metadata and specs for all pods/deployments in the environment.
- A lot of tests had to be modified fairly significantly to not accidentally test the scenario where we are returning a modifiable map of pods due to mocking -- ideally there would be a way to assert that provisioners do not modify the pods map directly. In general, this PR makes provisioners more complicated in a way I'm not altogether happy with.
- I had to modify a lot of methods that took pods as parameters to instead take a pod spec and/or pod metadata separately, as there is no pod to pass around for the deployments case.

Feedback on implementation / improvements is more than welcome :)

### What issues does this PR fix or reference?
#11505 and #11507 

#### Release Notes
Add support for Kubernetes deployments and configmaps in Kubernetes and OpenShift recipes

#### Docs PR
https://github.com/eclipse/che-docs/pull/647
