### PR TITLE
[Selenium] Change selenium tests from 'projectexplorer' package to wait that jdtls is fully initialized before working with project 

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckAutoSaveForFileWhichAlreadyExistTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckAutoSaveForFileWhichAlreadyExistTest.java
@@ -18,6 +18,7 @@ import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -51,6 +52,7 @@ public class CheckAutoSaveForFileWhichAlreadyExistTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
@@ -62,6 +64,8 @@ public class CheckAutoSaveForFileWhichAlreadyExistTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckCollapseAllNodesProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckCollapseAllNodesProjectTest.java
@@ -52,6 +52,8 @@ public class CheckCollapseAllNodesProjectTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckCopyCutFeaturesForFilesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckCopyCutFeaturesForFilesTest.java
@@ -64,12 +64,13 @@ public class CheckCopyCutFeaturesForFilesTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test
   public void checkCopyPutFeaturesForFilesTest() {
     projectExplorer.waitProjectExplorer();
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
     loader.waitOnClosed();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckDisplayingArtifactIdTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckDisplayingArtifactIdTest.java
@@ -22,6 +22,7 @@ import org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuCons
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.Preferences;
@@ -40,6 +41,7 @@ public class CheckDisplayingArtifactIdTest {
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private TestProjectServiceClient projectServiceClient;
   @Inject private Menu menu;
+  @Inject private Consoles consoles;
   @Inject private Preferences preferences;
 
   @BeforeClass
@@ -50,6 +52,8 @@ public class CheckDisplayingArtifactIdTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckErrorMessageWhenCreationDuplicateFolderOrFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckErrorMessageWhenCreationDuplicateFolderOrFileTest.java
@@ -19,6 +19,7 @@ import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Events;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
@@ -44,6 +45,7 @@ public class CheckErrorMessageWhenCreationDuplicateFolderOrFileTest {
   @Inject private Loader loader;
   @Inject private Menu menu;
   @Inject private Events events;
+  @Inject private Consoles consoles;
   @Inject private WarningDialog warningDialog;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private AskForValueDialog askForValueDialog;
@@ -58,6 +60,8 @@ public class CheckErrorMessageWhenCreationDuplicateFolderOrFileTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckHiddenFolderAndFileCreatedFromCommandTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckHiddenFolderAndFileCreatedFromCommandTest.java
@@ -23,6 +23,7 @@ import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -50,6 +51,7 @@ public class CheckHiddenFolderAndFileCreatedFromCommandTest {
   @Inject private Loader loader;
   @Inject private Menu menu;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private TestCommandServiceClient testCommandServiceClient;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
@@ -74,6 +76,8 @@ public class CheckHiddenFolderAndFileCreatedFromCommandTest {
         TestCommandsConstants.CUSTOM,
         testWorkspace.getId());
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   /**

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckOnValidAndInvalidClassNameTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckOnValidAndInvalidClassNameTest.java
@@ -58,9 +58,11 @@ public class CheckOnValidAndInvalidClassNameTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
+
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test(dataProvider = "validClassNames")

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckOnValidAndInvalidPackageNameTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckOnValidAndInvalidPackageNameTest.java
@@ -59,6 +59,9 @@ public class CheckOnValidAndInvalidPackageNameTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    console.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
+
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
     loader.waitOnClosed();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckRecentFilesAndRevealResourceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckRecentFilesAndRevealResourceTest.java
@@ -19,6 +19,7 @@ import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -46,6 +47,7 @@ public class CheckRecentFilesAndRevealResourceTest {
   @Inject private Loader loader;
   @Inject private RecentFiles recentFiles;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
@@ -64,6 +66,8 @@ public class CheckRecentFilesAndRevealResourceTest {
         SECOND_PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(FIRST_PROJECT_NAME, SECOND_PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckRefreshProjectTreeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckRefreshProjectTreeTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -44,6 +45,7 @@ public class CheckRefreshProjectTreeTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
@@ -55,6 +57,8 @@ public class CheckRefreshProjectTreeTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckTreeStructureAfterCloseTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CheckTreeStructureAfterCloseTest.java
@@ -18,6 +18,7 @@ import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
@@ -43,6 +44,7 @@ public class CheckTreeStructureAfterCloseTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
@@ -55,6 +57,8 @@ public class CheckTreeStructureAfterCloseTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/ClosingSeveralOpenFilesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/ClosingSeveralOpenFilesTest.java
@@ -54,6 +54,8 @@ public class ClosingSeveralOpenFilesTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewFoldersTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewFoldersTest.java
@@ -19,6 +19,7 @@ import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -43,6 +44,7 @@ public class CreateNewFoldersTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private Menu menu;
+  @Inject private Consoles consoles;
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
@@ -55,6 +57,8 @@ public class CreateNewFoldersTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewJavaFilesFromContextMenuTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewJavaFilesFromContextMenuTest.java
@@ -68,12 +68,13 @@ public class CreateNewJavaFilesFromContextMenuTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test
   public void createNewFileFromContextMenuTest() throws Exception {
     projectExplorer.waitItem(PROJECT_NAME);
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
     notificationsPopupPanel.waitProgressPopupPanelClose();
 
     // go to folder for creation files

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewJavaFilesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewJavaFilesTest.java
@@ -70,10 +70,12 @@ public class CreateNewJavaFilesTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
+
     projectExplorer.waitItem(PROJECT_NAME);
     notificationsPopupPanel.waitProgressPopupPanelClose();
     projectExplorer.quickExpandWithJavaScript();
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewNotJavaFilesFromContextMenuTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewNotJavaFilesFromContextMenuTest.java
@@ -28,6 +28,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
@@ -71,6 +72,7 @@ public class CreateNewNotJavaFilesFromContextMenuTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private TestProjectServiceClient testProjectServiceClient;
@@ -84,6 +86,8 @@ public class CreateNewNotJavaFilesFromContextMenuTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewNotJavaFilesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewNotJavaFilesTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -66,6 +67,7 @@ public class CreateNewNotJavaFilesTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private Menu menu;
   @Inject private AskForValueDialog askForValueDialog;
@@ -80,6 +82,8 @@ public class CreateNewNotJavaFilesTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewPackagesWithHelpCreationJavaClassTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateNewPackagesWithHelpCreationJavaClassTest.java
@@ -22,6 +22,7 @@ import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -44,6 +45,7 @@ public class CreateNewPackagesWithHelpCreationJavaClassTest {
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private Menu menu;
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private TestProjectServiceClient testProjectServiceClient;
@@ -59,6 +61,8 @@ public class CreateNewPackagesWithHelpCreationJavaClassTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateProjectInSelectedFolderTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateProjectInSelectedFolderTest.java
@@ -24,6 +24,7 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.ConfigureClasspath;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -48,6 +49,7 @@ public class CreateProjectInSelectedFolderTest {
   @Inject private ProjectExplorer explorer;
   @Inject private Loader loader;
   @Inject private CodenvyEditor editor;
+  @Inject private Consoles consoles;
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private Wizard projectWizard;
   @Inject private ConfigureClasspath selectPath;
@@ -64,6 +66,8 @@ public class CreateProjectInSelectedFolderTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateProjectTest.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -41,11 +42,13 @@ public class CreateProjectTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Loader loader;
   @Inject private Wizard projectWizard;
+  @Inject private Consoles consoles;
   @Inject private Menu menu;
 
   @BeforeClass
   public void setUp() throws Exception {
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
   }
 
   @Test
@@ -54,14 +57,17 @@ public class CreateProjectTest {
     loader.waitOnClosed();
     // create project with help context menu in the list of projects
     createProject(PROJECT_NAMES.get(0), Wizard.PackagingMavenType.NOT_SPECIFIED);
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAMES.get(0));
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAMES.get(0));
     loader.waitOnClosed();
     createProject(PROJECT_NAMES.get(1), Wizard.PackagingMavenType.JAR);
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAMES.get(1));
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAMES.get(1));
     loader.waitOnClosed();
     createProject(PROJECT_NAMES.get(2), Wizard.PackagingMavenType.WAR);
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAMES.get(2));
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAMES.get(2));
     loader.waitOnClosed();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateProjectsForArtikPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/CreateProjectsForArtikPluginTest.java
@@ -77,6 +77,7 @@ public class CreateProjectsForArtikPluginTest {
   @BeforeClass
   public void setUp() throws Exception {
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeleteFilesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeleteFilesTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -69,6 +70,7 @@ public class DeleteFilesTest {
   @Inject private CodenvyEditor editor;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private AskDialog askDialog;
+  @Inject private Consoles consoles;
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
@@ -81,6 +83,8 @@ public class DeleteFilesTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeletePackageFromContextMenuTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeletePackageFromContextMenuTest.java
@@ -21,6 +21,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
@@ -54,6 +55,7 @@ public class DeletePackageFromContextMenuTest {
   @Inject private CodenvyEditor editor;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private AskDialog askDialog;
+  @Inject private Consoles consoles;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
@@ -65,6 +67,8 @@ public class DeletePackageFromContextMenuTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeletePackageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeletePackageTest.java
@@ -70,10 +70,12 @@ public class DeletePackageTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
+
     projectExplorer.waitItem(PROJECT_NAME);
     notificationsPopupPanel.waitProgressPopupPanelClose();
     projectExplorer.quickExpandWithJavaScript();
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeletePackageWithOpenedFilesTabTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/DeletePackageWithOpenedFilesTabTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -45,6 +46,7 @@ public class DeletePackageWithOpenedFilesTabTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private CodenvyEditor editor;
   @Inject private AskDialog askDialog;
+  @Inject private Consoles consoles;
   @Inject private Menu menu;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
@@ -57,6 +59,8 @@ public class DeletePackageWithOpenedFilesTabTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/FileNotExistIntoEditorAfterDeleteTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/FileNotExistIntoEditorAfterDeleteTest.java
@@ -94,6 +94,8 @@ public class FileNotExistIntoEditorAfterDeleteTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/FileOpenedAfterCreationTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/FileOpenedAfterCreationTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -46,6 +47,7 @@ public class FileOpenedAfterCreationTest {
   @Inject private Menu menu;
   @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private Loader loader;
+  @Inject private Consoles consoles;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
@@ -57,6 +59,8 @@ public class FileOpenedAfterCreationTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/JustCreatedFileNotExistIntoEditorAfterDeleteTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/JustCreatedFileNotExistIntoEditorAfterDeleteTest.java
@@ -21,6 +21,7 @@ import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskDialog;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
@@ -46,6 +47,7 @@ public class JustCreatedFileNotExistIntoEditorAfterDeleteTest {
   @Inject private AskDialog askDialog;
   @Inject private Menu menu;
   @Inject private Loader loader;
+  @Inject private Consoles consoles;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
@@ -57,6 +59,8 @@ public class JustCreatedFileNotExistIntoEditorAfterDeleteTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/NavigationByKeyboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/NavigationByKeyboardTest.java
@@ -87,10 +87,12 @@ public class NavigationByKeyboardTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
+
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
     notificationsPopupPanel.waitProgressPopupPanelClose();
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
     consoles.closeProcessesArea();
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/OpenFileWithHelpContextMenuTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/OpenFileWithHelpContextMenuTest.java
@@ -175,6 +175,8 @@ public class OpenFileWithHelpContextMenuTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/PreviewHtmlFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/PreviewHtmlFileTest.java
@@ -24,6 +24,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -46,6 +47,7 @@ public class PreviewHtmlFileTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private CodenvyEditor editor;
   @Inject private Loader loader;
+  @Inject private Consoles consoles;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
   @Inject private TestProjectServiceClient testProjectServiceClient;
@@ -59,6 +61,8 @@ public class PreviewHtmlFileTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameJustCreatedNotJavaFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameJustCreatedNotJavaFileTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.pageobject.AskForValueDialog;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
@@ -42,6 +43,7 @@ public class RenameJustCreatedNotJavaFileTest {
   @Inject private CodenvyEditor editor;
   @Inject private AskForValueDialog askForValueDialog;
   @Inject private Menu menu;
+  @Inject private Consoles consoles;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
@@ -53,6 +55,8 @@ public class RenameJustCreatedNotJavaFileTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenameProjectTest.java
@@ -59,9 +59,11 @@ public class RenameProjectTest {
 
     // open workspace and wait LS initialization
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
+
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenamedAlreadyCreatedNotJavaFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/RenamedAlreadyCreatedNotJavaFileTest.java
@@ -59,6 +59,8 @@ public class RenamedAlreadyCreatedNotJavaFileTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
   }
 
   @Test
@@ -66,7 +68,6 @@ public class RenamedAlreadyCreatedNotJavaFileTest {
     // preparation
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.quickExpandWithJavaScript();
-    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
 
     // open file and check editor tab appears
     projectExplorer.openItemByPath(PATH_TO_FILE);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/ShowFileReferenceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/ShowFileReferenceTest.java
@@ -21,6 +21,7 @@ import java.util.Random;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
+import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.ShowReference;
@@ -41,6 +42,7 @@ public class ShowFileReferenceTest {
   @Inject private Ide ide;
   @Inject private ProjectExplorer projectExplorer;
   @Inject private ShowReference showReference;
+  @Inject private Consoles consoles;
   @Inject private TestProjectServiceClient testProjectServiceClient;
 
   @BeforeClass
@@ -52,6 +54,8 @@ public class ShowFileReferenceTest {
         PROJECT_NAME,
         ProjectTemplates.MAVEN_SPRING);
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
+    consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
 
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.expandPathInProjectExplorerAndOpenFile(PATH_FOR_EXPAND, "AppController.java");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/UploadIntoProjectTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/projectexplorer/UploadIntoProjectTest.java
@@ -71,6 +71,7 @@ public class UploadIntoProjectTest {
         ProjectTemplates.PLAIN_JAVA);
 
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
     projectExplorer.waitVisibleItem(PROJECT_NAME);
   }


### PR DESCRIPTION
### What does this PR do?
Change selenium tests from ```projectexplorer``` package to wait that **jdtls** is fully initialized before working with project.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12205
