### PR TITLE
Selenium: Delete the 'try-catch' expression from 'refactor.parameters' tests

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/parameters/FailParametersTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/parameters/FailParametersTest.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.selenium.refactor.parameters;
 
-import static org.testng.Assert.fail;
-
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -30,7 +28,6 @@ import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -97,14 +94,7 @@ public class FailParametersTest {
     refactor.typeAndWaitNewName(testParamObj.getRefactorValue());
     if (testParamObj.isHandleRefactorWithConfirming()) {
       refactor.clickOkButtonRefactorForm();
-
-      try {
-        askDialog.acceptDialogWithText(testParamObj.getExpectedDialogTextInRefactorWidget());
-      } catch (TimeoutException ex) {
-        // remove try-catch block after issue has been resolved
-        fail("Known random failure https://github.com/eclipse/che/issues/11185");
-      }
-
+      askDialog.acceptDialogWithText(testParamObj.getExpectedDialogTextInRefactorWidget());
     } else {
       refactor.waitTextInErrorMessage(testParamObj.getExpectedDialogTextInRefactorWidget());
       refactor.clickCancelButtonRefactorForm();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/parameters/RenameParametersTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/parameters/RenameParametersTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.selenium.refactor.parameters;
 
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.DEFAULT_TIMEOUT;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -32,7 +31,6 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -187,12 +185,7 @@ public class RenameParametersTest {
     renameLocalVariableByRefactorForm("j");
 
     // accept the ask dialog about duplicate parameters
-    try {
-      askDialog.acceptDialogWithText("Duplicate parameter j");
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11185");
-    }
+    askDialog.acceptDialogWithText("Duplicate parameter j");
 
     loader.waitOnClosed();
     refactor.waitRenameParametersFormIsClosed();


### PR DESCRIPTION
### What does this PR do?
* Delete the _try-catch_ expression for the selenium tests in the package _refactor.parameters_ related to close issue
* Related selenium tests: _RenameParametersTest_, _FailParametersTest_

### What issues does this PR fix or reference?
#11185
#12209