### PR TITLE
Selenium: stabilize selenium tests, add tests to UNDER_REPAIR group

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaHostedPluginSelectPathForm.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaHostedPluginSelectPathForm.java
@@ -42,7 +42,7 @@ public class TheiaHostedPluginSelectPathForm {
 
   public interface Locators {
     String TITLE_XPATH =
-        "//div[@class='dialogBlock']//div[@class='dialogTitle']//div[text()='Hosted Plugin: Select Path']";
+        "//div[@class='dialogBlock']//div[@class='dialogTitle']//div[contains(text(),'Select Path')]";
     String CLOSE_ICON_XPATH =
         "//div[@class='dialogBlock']//div[@class='dialogTitle']//i[contains(@class, 'closeButton')]";
     String SUGGESTION_LIST_TITLE_XPATH =

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
@@ -124,7 +125,7 @@ public class CreateAndDeleteProjectsTest {
     notificationsPopupPanel.waitPopupPanelsAreClosed();
   }
 
-  @Test(priority = 1)
+  @Test(priority = 1, groups = UNDER_REPAIR)
   public void deleteProjectsFromDashboardTest() {
     switchToWindow(dashboardWindow);
     dashboard.selectWorkspacesItemOnDashboard();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
@@ -291,7 +291,13 @@ public class ContextMenuEditorTest {
     refactor.clickOkButtonRefactorForm();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
-    editor.waitTabIsPresent(editorTabName);
+
+    try {
+      editor.waitTabIsPresent(editorTabName);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known random failure https://github.com/eclipse/che/issues/11697");
+    }
 
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/Test1.java");
     editor.goToCursorPositionVisible(14, 15);
@@ -299,7 +305,14 @@ public class ContextMenuEditorTest {
     editor.clickOnItemInContextMenu(REFACTORING);
     editor.clickOnItemInContextMenu(REFACTORING_RENAME);
     editor.waitContextMenuIsNotPresent();
-    editor.typeTextIntoEditor(renamedEditorTabName);
+
+    try {
+      editor.waitTabIsPresent(renamedEditorTabName);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known random failure https://github.com/eclipse/che/issues/11697");
+    }
+
     editor.typeTextIntoEditor(Keys.ENTER.toString());
     loader.waitOnClosed();
     editor.waitTabIsPresent(renamedEditorTabName);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.editor.autocomplete;
 
 import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.CUSTOM;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
@@ -153,7 +154,7 @@ public class AutocompleteProposalJavaDocTest {
     checkProposalDocumentationHTML("<p>No documentation found.</p>\n");
   }
 
-  @Test
+  @Test(groups = UNDER_REPAIR)
   public void shouldDisplayAnotherModuleClassJavaDoc() throws IOException {
     // when
     editor.waitActive();
@@ -266,7 +267,7 @@ public class AutocompleteProposalJavaDocTest {
       editor.waitProposalDocumentationHTML(expectedText);
     } catch (TimeoutException ex) {
       // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/11743");
+      fail("Known permanent failure https://github.com/eclipse/che/issues/11743");
     }
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaDockerStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaDockerStackTest.java
@@ -12,8 +12,10 @@
 package org.eclipse.che.selenium.stack;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_DOCKER;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
@@ -25,12 +27,13 @@ import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.theia.TheiaIde;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Skoryk Serhii */
-@Test(groups = {TestGroup.DOCKER})
+@Test(groups = {TestGroup.DOCKER, UNDER_REPAIR})
 public class CreateWorkspaceFromJavaTheiaDockerStackTest {
   private static final String WORKSPACE_NAME = generate("workspace", 4);
 
@@ -66,7 +69,13 @@ public class CreateWorkspaceFromJavaTheiaDockerStackTest {
         By.id("ide-application-iframe"), PREPARING_WS_TIMEOUT_SEC);
 
     // wait Theia is ready to use
-    theiaIde.waitTheiaIde();
+    try {
+      theiaIde.waitTheiaIde();
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known permanent failure https://github.com/eclipse/che/issues/12218");
+    }
+
     theiaIde.waitTheiaIdeTopPanel();
     theiaIde.waitLoaderInvisibility();
     theiaIde.waitNotificationPanelClosed();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaOpenshiftStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaOpenshiftStackTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.che.selenium.stack;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_OPENSHIFT;
 
 import com.google.inject.Inject;
@@ -63,7 +63,7 @@ public class CreateWorkspaceFromJavaTheiaOpenshiftStackTest {
             JAVA_THEIA_OPENSHIFT, WORKSPACE_NAME);
 
     seleniumWebDriverHelper.waitAndSwitchToFrame(
-        By.id("ide-application-iframe"), PREPARING_WS_TIMEOUT_SEC);
+        By.id("ide-application-iframe"), APPLICATION_START_TIMEOUT_SEC);
 
     // wait Theia is ready to use
     theiaIde.waitTheiaIde();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaOpenshiftStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromJavaTheiaOpenshiftStackTest.java
@@ -12,8 +12,10 @@
 package org.eclipse.che.selenium.stack;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.APPLICATION_START_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA_THEIA_OPENSHIFT;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.TestGroup;
@@ -25,12 +27,13 @@ import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.theia.TheiaIde;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Skoryk Serhii */
-@Test(groups = {TestGroup.OPENSHIFT})
+@Test(groups = {TestGroup.OPENSHIFT, UNDER_REPAIR})
 public class CreateWorkspaceFromJavaTheiaOpenshiftStackTest {
   private static final String WORKSPACE_NAME = generate("workspace", 4);
 
@@ -66,7 +69,13 @@ public class CreateWorkspaceFromJavaTheiaOpenshiftStackTest {
         By.id("ide-application-iframe"), APPLICATION_START_TIMEOUT_SEC);
 
     // wait Theia is ready to use
-    theiaIde.waitTheiaIde();
+    try {
+      theiaIde.waitTheiaIde();
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known permanent failure https://github.com/eclipse/che/issues/12218");
+    }
+
     theiaIde.waitTheiaIdeTopPanel();
     theiaIde.waitLoaderInvisibility();
     theiaIde.waitNotificationPanelClosed();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4CheckRunSuitesAndScopesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4CheckRunSuitesAndScopesTest.java
@@ -11,25 +11,29 @@
  */
 package org.eclipse.che.selenium.testrunner;
 
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.FAILED;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.nio.file.Paths;
+import org.eclipse.che.api.workspace.server.DtoConverter;
+import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestBuildConstants;
 import org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
-import org.eclipse.che.selenium.pageobject.CheTerminal;
+import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
+import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole;
-import org.openqa.selenium.Keys;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,16 +48,23 @@ public class JavaTestPluginJunit4CheckRunSuitesAndScopesTest {
 
   @Inject private JavaTestRunnerPluginConsole pluginConsole;
   @Inject private ProjectExplorer projectExplorer;
+  @Inject private Loader loader;
   @Inject private NotificationsPopupPanel notifications;
   @Inject private Menu menu;
+
   @Inject private TestWorkspace ws;
+
   @Inject private Ide ide;
   @Inject private Consoles consoles;
-  @Inject private CheTerminal terminal;
+  @Inject private CodenvyEditor editor;
+  @Inject private TestCommandServiceClient testCommandServiceClient;
+  @Inject private CommandsPalette commandsPalette;
   @Inject private TestProjectServiceClient projectServiceClient;
 
   @BeforeClass
   public void prepareTestProject() throws Exception {
+    CompileCommand compileCommand = new CompileCommand();
+    testCommandServiceClient.createCommand(DtoConverter.asDto(compileCommand), ws.getId());
     projectServiceClient.importProject(
         ws.getId(),
         Paths.get(
@@ -63,10 +74,16 @@ public class JavaTestPluginJunit4CheckRunSuitesAndScopesTest {
         JUNIT4_PROJECT,
         ProjectTemplates.CONSOLE_JAVA_SIMPLE);
     ide.open(ws);
-    ide.waitOpenedWorkspaceIsReadyToUse();
-
+    loader.waitOnClosed();
     projectExplorer.waitItem(JUNIT4_PROJECT);
-    runCompileCommand();
+
+    try {
+      runCompileCommandByPallete(compileCommand);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known random failure https://github.com/eclipse/che/issues/12220");
+    }
+
     notifications.waitProgressPopupPanelClose();
     consoles.dragConsolesInDefinePosition(VALUE_OF_SHIFTING_CONSOLES_ALONG_X_AXIS);
   }
@@ -116,9 +133,9 @@ public class JavaTestPluginJunit4CheckRunSuitesAndScopesTest {
     assertTrue(pluginConsole.getTestErrorMessage().startsWith(expectedExceptionForFailedTest));
   }
 
-  private void runCompileCommand() {
-    consoles.selectProcessByTabName("Terminal");
-    terminal.typeIntoActiveTerminal("mvn test-compile -f " + JUNIT4_PROJECT + Keys.ENTER);
-    terminal.waitTextInTerminal(TestBuildConstants.BUILD_SUCCESS, EXPECTED_MESS_IN_CONSOLE_SEC);
+  private void runCompileCommandByPallete(CompileCommand compileCommand) {
+    commandsPalette.openCommandPalette();
+    commandsPalette.startCommandByDoubleClick(compileCommand.getName());
+    consoles.waitExpectedTextIntoConsole(TestBuildConstants.BUILD_SUCCESS);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4Test.java
@@ -14,6 +14,7 @@ package org.eclipse.che.selenium.testrunner;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.RUN_MENU;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.TEST;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.TEST_DROP_DAWN_ITEM;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.FAILED;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.IGNORED;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.PASSED;
@@ -21,21 +22,19 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import java.nio.file.Paths;
-import org.eclipse.che.api.workspace.server.DtoConverter;
-import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestBuildConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
+import org.eclipse.che.selenium.pageobject.CheTerminal;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole;
+import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -66,21 +65,17 @@ public class JavaTestPluginJunit4Test {
 
   @Inject private JavaTestRunnerPluginConsole pluginConsole;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private Loader loader;
   @Inject private NotificationsPopupPanel notifications;
   @Inject private Menu menu;
   @Inject private TestWorkspace ws;
   @Inject private Ide ide;
   @Inject private Consoles consoles;
   @Inject private CodenvyEditor editor;
-  @Inject private TestCommandServiceClient testCommandServiceClient;
-  @Inject private CommandsPalette commandsPalette;
+  @Inject private CheTerminal terminal;
   @Inject private TestProjectServiceClient projectServiceClient;
 
   @BeforeClass
   public void prepareTestProject() throws Exception {
-    CompileCommand compileCommand = new CompileCommand();
-    testCommandServiceClient.createCommand(DtoConverter.asDto(compileCommand), ws.getId());
     projectServiceClient.importProject(
         ws.getId(),
         Paths.get(
@@ -98,13 +93,13 @@ public class JavaTestPluginJunit4Test {
     notifications.waitProgressPopupPanelClose();
     projectExplorer.quickExpandWithJavaScript();
 
-    runCompileCommandByPallete(compileCommand);
+    runCompileCommand();
   }
 
-  private void runCompileCommandByPallete(CompileCommand compileCommand) {
-    commandsPalette.openCommandPalette();
-    commandsPalette.startCommandByDoubleClick(compileCommand.getName());
-    consoles.waitExpectedTextIntoConsole(TestBuildConstants.BUILD_SUCCESS);
+  private void runCompileCommand() {
+    consoles.selectProcessByTabName("Terminal");
+    terminal.typeIntoActiveTerminal("mvn test-compile -f " + JUNIT4_PROJECT + Keys.ENTER);
+    terminal.waitTextInTerminal(TestBuildConstants.BUILD_SUCCESS, EXPECTED_MESS_IN_CONSOLE_SEC);
   }
 
   @Test

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.selenium.testrunner;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.RUN_MENU;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.TEST;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.TEST_NG_TEST_DROP_DAWN_ITEM;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.FAILED;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.PASSED;
 import static org.testng.Assert.assertTrue;
@@ -22,24 +23,21 @@ import static org.testng.Assert.fail;
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
-import org.eclipse.che.api.workspace.server.DtoConverter;
-import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestBuildConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
-import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
+import org.eclipse.che.selenium.pageobject.CheTerminal;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole;
+import org.openqa.selenium.Keys;
 import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -78,33 +76,27 @@ public class JavaTestPluginTestNgTest {
   private TestWorkspace ws;
 
   @Inject private Ide ide;
-  @Inject private DefaultTestUser user;
-
   @Inject private JavaTestRunnerPluginConsole pluginConsole;
   @Inject private ProjectExplorer projectExplorer;
-  @Inject private Loader loader;
   @Inject private NotificationsPopupPanel notifications;
   @Inject private Menu menu;
-  @Inject private TestCommandServiceClient testCommandServiceClient;
   @Inject private TestProjectServiceClient testProjectServiceClient;
-  @Inject private CommandsPalette commandsPalette;
+  @Inject private CheTerminal terminal;
   @Inject private Consoles consoles;
   @Inject private CodenvyEditor editor;
 
   @BeforeClass
   public void prepareTestProject() throws Exception {
     URL resource = getClass().getResource("/projects/plugins/JavaTestRunnerPlugin/testng-tests");
-
-    CompileCommand compileCommand = new CompileCommand();
-    testCommandServiceClient.createCommand(DtoConverter.asDto(compileCommand), ws.getId());
     testProjectServiceClient.importProject(
         ws.getId(), Paths.get(resource.toURI()), PROJECT, ProjectTemplates.CONSOLE_JAVA_SIMPLE);
 
     ide.open(ws);
-    loader.waitOnClosed();
+    ide.waitOpenedWorkspaceIsReadyToUse();
+
     projectExplorer.waitItem(PROJECT);
     notifications.waitProgressPopupPanelClose();
-    runCompileCommandByPallete(compileCommand);
+    runCompileCommand();
   }
 
   @Test
@@ -200,9 +192,9 @@ public class JavaTestPluginTestNgTest {
         testErrorMessage.endsWith(END_OF_FAILED_TEST), "Actual message was: " + testErrorMessage);
   }
 
-  private void runCompileCommandByPallete(CompileCommand compileCommand) {
-    commandsPalette.openCommandPalette();
-    commandsPalette.startCommandByDoubleClick(compileCommand.getName());
-    consoles.waitExpectedTextIntoConsole(TestBuildConstants.BUILD_SUCCESS);
+  private void runCompileCommand() {
+    consoles.selectProcessByTabName("Terminal");
+    terminal.typeIntoActiveTerminal("mvn test-compile -f " + PROJECT + Keys.ENTER);
+    terminal.waitTextInTerminal(TestBuildConstants.BUILD_SUCCESS, EXPECTED_MESS_IN_CONSOLE_SEC);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -14,7 +14,6 @@ package org.eclipse.che.selenium.testrunner;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.RUN_MENU;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.TEST;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.TEST_NG_TEST_DROP_DAWN_ITEM;
-import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.EXPECTED_MESS_IN_CONSOLE_SEC;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.FAILED;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.PASSED;
 import static org.testng.Assert.assertTrue;
@@ -23,21 +22,24 @@ import static org.testng.Assert.fail;
 import com.google.inject.Inject;
 import java.net.URL;
 import java.nio.file.Paths;
+import org.eclipse.che.api.workspace.server.DtoConverter;
+import org.eclipse.che.selenium.core.client.TestCommandServiceClient;
 import org.eclipse.che.selenium.core.client.TestProjectServiceClient;
 import org.eclipse.che.selenium.core.constant.TestBuildConstants;
 import org.eclipse.che.selenium.core.project.ProjectTemplates;
+import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.workspace.InjectTestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.WorkspaceTemplate;
-import org.eclipse.che.selenium.pageobject.CheTerminal;
 import org.eclipse.che.selenium.pageobject.CodenvyEditor;
 import org.eclipse.che.selenium.pageobject.Consoles;
 import org.eclipse.che.selenium.pageobject.Ide;
+import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
+import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole;
-import org.openqa.selenium.Keys;
 import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -76,27 +78,39 @@ public class JavaTestPluginTestNgTest {
   private TestWorkspace ws;
 
   @Inject private Ide ide;
+  @Inject private DefaultTestUser user;
+
   @Inject private JavaTestRunnerPluginConsole pluginConsole;
   @Inject private ProjectExplorer projectExplorer;
+  @Inject private Loader loader;
   @Inject private NotificationsPopupPanel notifications;
   @Inject private Menu menu;
+  @Inject private TestCommandServiceClient testCommandServiceClient;
   @Inject private TestProjectServiceClient testProjectServiceClient;
-  @Inject private CheTerminal terminal;
+  @Inject private CommandsPalette commandsPalette;
   @Inject private Consoles consoles;
   @Inject private CodenvyEditor editor;
 
   @BeforeClass
   public void prepareTestProject() throws Exception {
     URL resource = getClass().getResource("/projects/plugins/JavaTestRunnerPlugin/testng-tests");
+
+    CompileCommand compileCommand = new CompileCommand();
+    testCommandServiceClient.createCommand(DtoConverter.asDto(compileCommand), ws.getId());
     testProjectServiceClient.importProject(
         ws.getId(), Paths.get(resource.toURI()), PROJECT, ProjectTemplates.CONSOLE_JAVA_SIMPLE);
 
     ide.open(ws);
-    ide.waitOpenedWorkspaceIsReadyToUse();
-
+    loader.waitOnClosed();
     projectExplorer.waitItem(PROJECT);
     notifications.waitProgressPopupPanelClose();
-    runCompileCommand();
+
+    try {
+      runCompileCommandByPallete(compileCommand);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known random failure https://github.com/eclipse/che/issues/12220");
+    }
   }
 
   @Test
@@ -192,9 +206,9 @@ public class JavaTestPluginTestNgTest {
         testErrorMessage.endsWith(END_OF_FAILED_TEST), "Actual message was: " + testErrorMessage);
   }
 
-  private void runCompileCommand() {
-    consoles.selectProcessByTabName("Terminal");
-    terminal.typeIntoActiveTerminal("mvn test-compile -f " + PROJECT + Keys.ENTER);
-    terminal.waitTextInTerminal(TestBuildConstants.BUILD_SUCCESS, EXPECTED_MESS_IN_CONSOLE_SEC);
+  private void runCompileCommandByPallete(CompileCommand compileCommand) {
+    commandsPalette.openCommandPalette();
+    commandsPalette.startCommandByDoubleClick(compileCommand.getName());
+    consoles.waitExpectedTextIntoConsole(TestBuildConstants.BUILD_SUCCESS);
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR:
- increase timeout for checking that workspace from **JavaTheiaOpenshift** stack started(```CreateWorkspaceFromJavaTheiaOpenshiftStackTest``` test);
- add info about known #11697 issue to ```ContexMenuEditorTest```;
- add ```CreateAndDeleteProjectsTest``` and ```AutocompleteProposalJavaDocTest``` selenium tests to UNDER_REPAIR group.
- add info about known #12220 issue to selenium tests from ```testrunner``` package;
- add info about known #12218 issue to **CreateWorkspaceFromJavaTheiaOpenshiftStackTest** and **CreateWorkspaceFromJavaTheiaDockerStackTest** tests.
