### PR TITLE
Selenium: Delete the 'try-catch' expression from the 'CodeAssistAfterMoveItemTest'

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/CodeAssistAfterMoveItemTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/refactor/move/CodeAssistAfterMoveItemTest.java
@@ -11,11 +11,9 @@
  */
 package org.eclipse.che.selenium.refactor.move;
 
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.DEFAULT_TIMEOUT;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.WARNING;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -32,12 +30,10 @@ import org.eclipse.che.selenium.pageobject.Loader;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.Refactor;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev */
-@Test(groups = UNDER_REPAIR)
 public class CodeAssistAfterMoveItemTest {
 
   private static final String APPLY_WORKSPACE_CHANGES = "Apply Workspace Changes\nDone";
@@ -114,14 +110,7 @@ public class CodeAssistAfterMoveItemTest {
     editor.goToCursorPositionVisible(33, 5);
     editor.launchPropositionAssistPanel();
     loader.waitOnClosed();
-
-    try {
-      editor.waitTextIntoFixErrorProposition("Import 'A5' (p1)");
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/11701");
-    }
-
+    editor.waitTextIntoFixErrorProposition("Import 'A5' (p1)");
     editor.enterTextIntoFixErrorPropByEnter("Import 'A5' (p1)");
     editor.waitTextIntoEditor("import p1.A5;");
   }


### PR DESCRIPTION
### What does this PR do?
* Delete the _try-catch_ expression from the selenium test _CodeAssistAfterMoveItemTest_ related to close issue
* Delete the group _UNDER_REPAIR_

### What issues does this PR fix or reference?
#11701
#12211