### PR TITLE
Save selection when process tree updates

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/processes/panel/ProcessesPanelPresenter.java
@@ -166,6 +166,7 @@ public class ProcessesPanelPresenter extends BasePresenter
   ProcessTreeNode rootNode;
   private ProcessTreeNode contextTreeNode;
   private Map<String, MachineImpl> machines;
+  private ProcessTreeNode lastSelectedNode;
 
   @Inject
   public ProcessesPanelPresenter(
@@ -648,6 +649,7 @@ public class ProcessesPanelPresenter extends BasePresenter
   @Override
   public void onTreeNodeSelected(final ProcessTreeNode node) {
     setSelection(new Selection.NoSelectionProvided());
+    lastSelectedNode = node;
 
     if (node != null) {
       String nodeId = node.getId();
@@ -909,6 +911,7 @@ public class ProcessesPanelPresenter extends BasePresenter
     machineTreeNode.getChildren().remove(childNode);
     view.setProcessesData(rootNode);
     rootNode.getChildren().forEach(node -> refreshStopButtonState(node.getId()));
+    view.selectNode(lastSelectedNode);
   }
 
   @Nullable


### PR DESCRIPTION
### What does this PR do?
This changes proposal add small fix that saves selection when process tree updates.

![process_tree_selection](https://user-images.githubusercontent.com/1968177/50217146-93b81700-0390-11e9-8325-302968acd3a8.gif)


Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#11744 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A
