### PR TITLE
Selenium: stabilize selenium tests

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
@@ -277,6 +277,7 @@ public class ContextMenuEditorTest {
 
     projectExplorer.waitItem(PROJECT_NAME);
     projectExplorer.openItemByPath(PROJECT_NAME + "/src/main/java/com/example/Test1.java");
+
     editor.goToCursorPositionVisible(14, 15);
     editor.openContextMenuOnElementInEditor(editorTabName);
     editor.clickOnItemInContextMenu(REFACTORING);
@@ -291,6 +292,7 @@ public class ContextMenuEditorTest {
     refactor.clickOkButtonRefactorForm();
     refactor.waitMoveItemFormIsClosed();
     loader.waitOnClosed();
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
 
     try {
       editor.waitTabIsPresent(editorTabName);
@@ -305,6 +307,10 @@ public class ContextMenuEditorTest {
     editor.clickOnItemInContextMenu(REFACTORING);
     editor.clickOnItemInContextMenu(REFACTORING_RENAME);
     editor.waitContextMenuIsNotPresent();
+    editor.typeTextIntoEditor(renamedEditorTabName);
+    editor.typeTextIntoEditor(Keys.ENTER.toString());
+    loader.waitOnClosed();
+    notificationsPopupPanel.waitPopupPanelsAreClosed();
 
     try {
       editor.waitTabIsPresent(renamedEditorTabName);
@@ -313,9 +319,6 @@ public class ContextMenuEditorTest {
       fail("Known random failure https://github.com/eclipse/che/issues/11697");
     }
 
-    editor.typeTextIntoEditor(Keys.ENTER.toString());
-    loader.waitOnClosed();
-    editor.waitTabIsPresent(renamedEditorTabName);
     editor.waitTextIntoEditor("public class Zclass");
     projectExplorer.waitItem(PROJECT_NAME + "/src/main/java/org/eclipse/qa/examples/Zclass.java");
   }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
@@ -100,7 +100,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectTabByName(APP_CLASS_NAME);
   }
 
-  @Test
+  @Test(groups = UNDER_REPAIR)
   public void shouldDisplayJavaDocOfClassMethod() throws Exception {
     // given
     final String expectedJavadocHtmlText =
@@ -210,7 +210,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.waitProposalDocumentationHTML("UPDATE. Implementation of Book interface.");
   }
 
-  @Test
+  @Test(groups = UNDER_REPAIR)
   public void shouldDisplayJavaDocOfJreClass() throws IOException {
     // when
     editor.waitActive();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/intelligencecommand/CheckIntelligenceCommandFromToolbarTest.java
@@ -70,6 +70,7 @@ public class CheckIntelligenceCommandFromToolbarTest {
     waitOnAvailablePreviewPage(currentWindow, "Enter your name");
     consoles.waitExpectedTextIntoConsole(" Server startup in");
     seleniumWebDriver.navigate().refresh();
+    ide.waitOpenedWorkspaceIsReadyToUse();
     projectExplorer.waitProjectExplorer();
     consoles.selectProcessByTabName(PROJECT_NAME + ": build and run");
     consoles.waitExpectedTextIntoConsole(" Server startup in");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/ClangFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/ClangFileEditingTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.A
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_DEFINITION;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.LS_RENAME;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.Refactoring.REFACTORING;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.CPP;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.ContextMenuLocator.FORMAT;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
@@ -67,6 +68,7 @@ public class ClangFileEditingTest {
     projectExplorer.waitAndSelectItem(PROJECT_NAME);
     projectExplorer.openItemByPath(PROJECT_NAME);
     projectExplorer.openItemByPath(PATH_TO_CPP_FILE);
+    editor.waitActive(WIDGET_TIMEOUT_SEC);
     editor.waitTabIsPresent(CPP_FILE_NAME);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/GolangFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/GolangFileEditingTest.java
@@ -197,23 +197,6 @@ public class GolangFileEditingTest {
     editor.clickOnCloseFileIcon("print.go");
   }
 
-  @Test(priority = 1, groups = UNDER_REPAIR)
-  public void checkRenameFeature() {
-    projectExplorer.openItemByPath(PROJECT_NAME + "/towers.go");
-    editor.waitTabIsPresent("towers.go");
-    editor.goToCursorPositionVisible(22, 5);
-    editor.waitTextElementsActiveLine("if n == 1");
-    editor.launchLocalRefactor();
-    editor.doRenamingByLanguageServerField("k");
-
-    try {
-      editor.waitTextElementsActiveLine("if k == 1");
-    } catch (TimeoutException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known permanent failure https://github.com/eclipse/che/issues/11907");
-    }
-  }
-
   @Test(priority = 1)
   public void checkFindReferencesFeature() {
     projectExplorer.openItemByPath(PROJECT_NAME + "/towers.go");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/JsonFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/JsonFileEditingTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.A
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.GO_TO_SYMBOL;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.CREATE_PROJECT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.workspace.WorkspaceTemplate.NODEJS_WITH_JSON_LS;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.MarkerLocator.ERROR;
 import static org.eclipse.che.selenium.pageobject.Wizard.SamplesName.NODEJS_HELLO_WORLD;
@@ -91,6 +92,7 @@ public class JsonFileEditingTest {
     pullRequestPanel.waitOpenPanel();
     projectExplorer.openItemByPath(PROJECT_NAME);
     projectExplorer.openItemByPath(PATH_TO_JSON_FILE);
+    editor.waitActive(WIDGET_TIMEOUT_SEC);
     editor.waitTabIsPresent(JSON_FILE_NAME);
 
     // check JSON language server initialized


### PR DESCRIPTION
### What does this PR do?
This PR:
- stabilize selenium tests;
- not check rename feature in **GolangFileEditingTest** test because of https://github.com/eclipse/che/issues/11907;
- add **AutocompleteProposalJavaDocTest** test methods to UNDER_REPAIR group.
