### PR TITLE
Add '.d.ts' DTO generator

### DIFF
--- a/core/che-core-typescript-dto-maven-plugin/pom.xml
+++ b/core/che-core-typescript-dto-maven-plugin/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>che-core-api-dto</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
         </dependency>

--- a/core/che-core-typescript-dto-maven-plugin/src/it/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojoITest.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/it/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojoITest.java
@@ -48,10 +48,14 @@ public class TypeScriptDTOGeneratorMojoITest {
      */
     private static final String GENERATED_DTO_NAME = "my-typescript-test-module.ts";
 
+    private static final String GENERATED_DTO_DTS_NAME = "my-typescript-test-module.d.ts";
+
     /**
      * DTO new name
      */
     private static final String DTO_FILENAME = "dto.ts";
+
+    private static final String DTO_DTS_FILENAME = "dtoD.d.ts";
 
     /**
      * DTO test name
@@ -251,7 +255,7 @@ public class TypeScriptDTOGeneratorMojoITest {
         // search DTO
         Path p = this.buildDirectory;
         final int maxDepth = 10;
-        Stream<Path> matches = java.nio.file.Files.find(p, maxDepth, (path, basicFileAttributes) -> path.getFileName().toString().equals(GENERATED_DTO_NAME));
+        Stream<Path> matches = java.nio.file.Files.find( p, maxDepth, (path, basicFileAttributes) -> path.getFileName().toString().equals(GENERATED_DTO_NAME));
 
         // take first
         Optional<Path> optionalPath = matches.findFirst();
@@ -263,6 +267,19 @@ public class TypeScriptDTOGeneratorMojoITest {
 
         //copy it in test resources folder where package.json is
         java.nio.file.Files.copy(generatedDtoPath, this.rootPath.resolve(DTO_FILENAME), StandardCopyOption.REPLACE_EXISTING);
+
+        matches = java.nio.file.Files.find( p, maxDepth, (path, basicFileAttributes) -> path.getFileName().toString().equals(GENERATED_DTO_DTS_NAME));
+
+        // take first
+        optionalPath = matches.findFirst();
+        if (!optionalPath.isPresent()) {
+            throw new IllegalStateException("Unable to find generated DTO file named '" + GENERATED_DTO_DTS_NAME + "'. Check it has been generated first");
+        }
+
+        generatedDtoPath = optionalPath.get();
+
+        //copy it in test resources folder where package.json is
+        java.nio.file.Files.copy(generatedDtoPath, this.rootPath.resolve(DTO_DTS_FILENAME), StandardCopyOption.REPLACE_EXISTING);
 
         // setup command line
         List<String> command = getDockerExec();

--- a/core/che-core-typescript-dto-maven-plugin/src/it/resources/dto.spec.ts
+++ b/core/che-core-typescript-dto-maven-plugin/src/it/resources/dto.spec.ts
@@ -106,11 +106,19 @@ describe("DTO serialization tests", () => {
     });
 
     it("check d.ts types", () => {
-        const customDto: che.plugin.typescript.MySimple = {
-            id: 1
-        }
+        const customDto: che.plugin.typescript.MyCustom = {
+            internal: {
+                internalValue: "foo"
+            },
+            status: "SHUTDOWN",
+            customMap: {"bar": { name: "foo"}},
+            arguments: [{}, {},]
+        };
 
-        expect(customDto).to.eql({id: 1} as che.plugin.typescript.MySimple)
+
+        expect(customDto.internal).to.eql({ internalValue: "foo" } as che.plugin.typescript.internal.Internal);
+        expect(customDto.customMap).to.have.property("bar");
+        expect(customDto.customMap["bar"].name).to.eql("foo");
     });
 
 

--- a/core/che-core-typescript-dto-maven-plugin/src/it/resources/dto.spec.ts
+++ b/core/che-core-typescript-dto-maven-plugin/src/it/resources/dto.spec.ts
@@ -11,6 +11,8 @@
  */
 import {org} from './dto';
 
+import {che} from './dtoD'
+
 let expect = require('chai').expect;
 
 class DTOBuilder {
@@ -103,6 +105,13 @@ describe("DTO serialization tests", () => {
         expect(myCustomDTO.toJson()).to.eql(myCustomDTOFromSource.toJson());
     });
 
+    it("check d.ts types", () => {
+        const customDto: che.plugin.typescript.MySimple = {
+            id: 1
+        }
+
+        expect(customDto).to.eql({id: 1} as che.plugin.typescript.MySimple)
+    });
 
 
 

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
@@ -201,7 +201,7 @@ public class DTOHelper {
     return typePackage + "." + convertToDTSName((Class) type);
   }
 
-  /** Remove 'Dto' suffix from class nam */
+  /** Remove 'Dto' suffix from class name */
   public static String convertToDTSName(Class type) {
     String name = type.getSimpleName();
     if (name.toLowerCase().endsWith("dto")) {

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojo.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojo.java
@@ -18,7 +18,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -47,6 +46,10 @@ public class TypeScriptDTOGeneratorMojo extends AbstractMojo {
   @Parameter(defaultValue = "${project.build.directory}")
   private File targetDirectory;
 
+  /** should build new '.d.ts' DTO on old 'ts' DTO interfaces */
+  @Parameter(defaultValue = "false", property = "dts")
+  private boolean dts;
+
   @Component private MavenProjectHelper projectHelper;
 
   /** Path to the generated typescript file */
@@ -56,10 +59,43 @@ public class TypeScriptDTOGeneratorMojo extends AbstractMojo {
   private boolean useClassPath;
 
   @Override
-  public void execute() throws MojoExecutionException, MojoFailureException {
+  public void execute() throws MojoExecutionException {
+    if (dts) {
+      getLog().info("Generating TypeScript DTO d.ts");
+      generateDTs();
+    } else {
+      getLog().info("Generating TypeScript DTO");
+      generateTs();
+    }
+  }
 
-    getLog().info("Generating TypeScript DTO");
+  private void generateDTs() throws MojoExecutionException {
+    TypeScriptDtoDTSGenerator typeScriptDtoGenerator = new TypeScriptDtoDTSGenerator();
 
+    typeScriptDtoGenerator.setUseClassPath(useClassPath);
+
+    // define output path for the file to write with typescript definition
+    String output = typeScriptDtoGenerator.execute();
+
+    this.typescriptFile = new File(targetDirectory, project.getArtifactId() + ".d.ts");
+    File parentDir = this.typescriptFile.getParentFile();
+    if (!parentDir.exists() && !parentDir.mkdirs()) {
+      throw new MojoExecutionException(
+          "Unable to create a directory for writing DTO typescript file '" + parentDir + "'.");
+    }
+
+    try (Writer fileWriter =
+        Files.newBufferedWriter(this.typescriptFile.toPath(), StandardCharsets.UTF_8)) {
+      fileWriter.write(output);
+    } catch (IOException e) {
+      throw new MojoExecutionException("Cannot write DTO typescript file");
+    }
+
+    // attach this typescript file as maven artifact
+    projectHelper.attachArtifact(project, "ts", typescriptFile);
+  }
+
+  private void generateTs() throws MojoExecutionException {
     TypeScriptDtoGenerator typeScriptDtoGenerator = new TypeScriptDtoGenerator();
 
     typeScriptDtoGenerator.setUseClassPath(useClassPath);

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDtoDTSGenerator.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDtoDTSGenerator.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.typescript.dto;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.plugin.typescript.dto.model.DtoModel;
+import org.eclipse.che.plugin.typescript.dto.model.DtoNamespace;
+import org.stringtemplate.v4.ST;
+
+/** Write all DTOs found in classpath into a specific '.d.ts' file */
+public class TypeScriptDtoDTSGenerator extends TypeScriptDtoGenerator {
+
+  /** Name of the template */
+  public static final String TEMPLATE_NAME =
+      "/"
+          .concat(TypeScriptDtoDTSGenerator.class.getPackage().getName().replace(".", "/"))
+          .concat("/typescript.d.ts.template");
+
+  /** String template instance used */
+  private ST st;
+
+  private Map<String, DtoNamespace> dtoNamespaces = new HashMap<>();
+
+  public static void main(String[] args) {
+    TypeScriptDtoGenerator.main(args);
+  }
+
+  @Override
+  protected void analyze(Class<?> dto) {
+    // for each dto class, store some data about it
+    DtoModel model = new DtoModel(dto);
+    String namespace = model.getDTSPackageName();
+    if (!dtoNamespaces.containsKey(namespace)) {
+      dtoNamespaces.put(namespace, new DtoNamespace(namespace));
+    }
+
+    dtoNamespaces.get(namespace).addModel(model);
+  }
+
+  @Override
+  public String execute() {
+    init();
+    ST template = getTemplate();
+    template.add("dtoNamespaces", this.dtoNamespaces.values());
+    String output = template.render();
+    return output;
+  }
+
+  /**
+   * Get the template for typescript
+   *
+   * @return the String Template
+   */
+  protected ST getTemplate() {
+    if (st == null) {
+      URL url = Resources.getResource(TypeScriptDtoGenerator.class, TEMPLATE_NAME);
+      try {
+        st = new ST(Resources.toString(url, UTF_8));
+      } catch (IOException e) {
+        throw new IllegalArgumentException("Unable to read template", e);
+      }
+    }
+    return st;
+  }
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/DtoModel.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/DtoModel.java
@@ -20,6 +20,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.dto.shared.DTO;
 
 /**
  * * Model of the DTO It includes attributes/fields and methods.
@@ -39,6 +42,10 @@ public class DtoModel {
 
   /** Model for the attributes of this interface (for generating implementation) */
   private List<FieldAttributeModel> fieldAttributeModels;
+
+  private String interfaces;
+
+  private boolean extendsDto;
 
   /**
    * Build a new model for the given DTO class by scanning it.
@@ -85,6 +92,16 @@ public class DtoModel {
             field ->
                 fieldAttributeModels.add(
                     new FieldAttributeModel(field.getKey(), field.getValue(), dto)));
+
+    String interfaces =
+        Arrays.stream(this.dto.getInterfaces())
+            .filter(i -> i.getAnnotation(DTO.class) != null)
+            .map(i -> convertTypeForDTS(this.dto, i))
+            .collect(Collectors.joining(", "));
+    if (!interfaces.isEmpty()) {
+      this.interfaces = interfaces;
+      this.extendsDto = true;
+    }
   }
 
   /**
@@ -96,9 +113,10 @@ public class DtoModel {
   protected void analyzeDtoGetterMethod(Method method, MethodModel methodModel) {
     methodModel.setGetter(true);
     Type fieldType = method.getGenericReturnType();
-    String fieldName = getGetterFieldName(method);
-    fieldAttributes.put(fieldName, fieldType);
-    methodModel.setFieldName(fieldName);
+    Pair<String, String> names = getGetterFieldName(method);
+    fieldAttributes.put(names.first, fieldType);
+    methodModel.setFieldName(names.first);
+    methodModel.setArgumentName(names.second);
     methodModel.setFieldType(convertType(fieldType));
   }
 
@@ -112,9 +130,10 @@ public class DtoModel {
     methodModel.setSetter(true);
     // add the parameter
     Type fieldType = method.getGenericParameterTypes()[0];
-    String fieldName = getSetterFieldName(method);
-    fieldAttributes.put(fieldName, fieldType);
-    methodModel.setFieldName(fieldName);
+    Pair<String, String> names = getSetterFieldName(method);
+    fieldAttributes.put(names.first, fieldType);
+    methodModel.setFieldName(names.first);
+    methodModel.setArgumentName(names.second);
     methodModel.setFieldType(convertType(fieldType));
   }
 
@@ -128,9 +147,10 @@ public class DtoModel {
     methodModel.setWith(true);
     // add the parameter
     Type fieldType = method.getGenericParameterTypes()[0];
-    String fieldName = getWithFieldName(method);
-    fieldAttributes.put(fieldName, fieldType);
-    methodModel.setFieldName(fieldName);
+    Pair<String, String> names = getWithFieldName(method);
+    fieldAttributes.put(names.first, fieldType);
+    methodModel.setFieldName(names.first);
+    methodModel.setArgumentName(names.second);
     methodModel.setFieldType(convertType(fieldType));
   }
 
@@ -193,5 +213,13 @@ public class DtoModel {
    */
   public String getDtsName() {
     return convertToDTSName(this.dto);
+  }
+
+  public String getInterfaces() {
+    return interfaces;
+  }
+
+  public boolean isExtendsDto() {
+    return extendsDto;
   }
 }

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/DtoModel.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/DtoModel.java
@@ -11,13 +11,7 @@
  */
 package org.eclipse.che.plugin.typescript.dto.model;
 
-import static org.eclipse.che.plugin.typescript.dto.DTOHelper.convertType;
-import static org.eclipse.che.plugin.typescript.dto.DTOHelper.getGetterFieldName;
-import static org.eclipse.che.plugin.typescript.dto.DTOHelper.getSetterFieldName;
-import static org.eclipse.che.plugin.typescript.dto.DTOHelper.getWithFieldName;
-import static org.eclipse.che.plugin.typescript.dto.DTOHelper.isDtoGetter;
-import static org.eclipse.che.plugin.typescript.dto.DTOHelper.isDtoSetter;
-import static org.eclipse.che.plugin.typescript.dto.DTOHelper.isDtoWith;
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.*;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
@@ -90,7 +84,7 @@ public class DtoModel {
         .forEach(
             field ->
                 fieldAttributeModels.add(
-                    new FieldAttributeModel(field.getKey(), field.getValue())));
+                    new FieldAttributeModel(field.getKey(), field.getValue(), dto)));
   }
 
   /**
@@ -155,6 +149,16 @@ public class DtoModel {
   }
 
   /**
+   * Gets the package name of this interface, without 'dto', 'shared', 'api' sections and
+   * 'org.eclipse.' prefix
+   *
+   * @return the package name of this interface
+   */
+  public String getDTSPackageName() {
+    return convertToDTSPackageName(this.dto);
+  }
+
+  /**
    * Gets the short (simple) name of the interface. Like HelloWorld if FQN class is
    * foo.bar.HelloWorld
    *
@@ -180,5 +184,14 @@ public class DtoModel {
    */
   public List<MethodModel> getMethods() {
     return this.methods;
+  }
+
+  /**
+   * Gets the FQN of this interface like foo.bar.HelloWorld, but without 'Dto' suffix
+   *
+   * @return the name of the interface
+   */
+  public String getDtsName() {
+    return convertToDTSName(this.dto);
   }
 }

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/DtoNamespace.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/DtoNamespace.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.typescript.dto.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** Class for storing all Dto TS namespace interfaces */
+public class DtoNamespace {
+
+  private final String namespace;
+  private List<DtoModel> childs = new ArrayList<>();
+
+  public DtoNamespace(String namespace) {
+    this.namespace = namespace;
+  }
+
+  /** @return the namespace name */
+  public String getNamespace() {
+    return namespace;
+  }
+
+  /** @return all interfaces that placed in this namespace */
+  public List<DtoModel> getDtoInterfaces() {
+    return childs;
+  }
+
+  /**
+   * Add Dto in this namespace
+   *
+   * @param model the dto
+   */
+  public void addModel(DtoModel model) {
+    childs.add(model);
+  }
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/FieldAttributeModel.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/FieldAttributeModel.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.plugin.typescript.dto.model;
 
 import static org.eclipse.che.plugin.typescript.dto.DTOHelper.convertType;
+import static org.eclipse.che.plugin.typescript.dto.DTOHelper.convertTypeForDTS;
 
 import com.google.gson.internal.Primitives;
 import java.lang.reflect.ParameterizedType;
@@ -65,16 +66,31 @@ public class FieldAttributeModel {
   /** type is a Enum object. */
   private boolean isEnum;
 
+  /** Map key type */
+  private String mapKeyType;
+
+  /** Map value type */
+  private String mapValueType;
+
+  /** Dto type for d.ts */
+  private String dtsType;
+
+  /** Dto class where this field declared */
+  private Class declarationClass;
+
   /**
    * Build a new field model based on the name and Java type
    *
    * @param fieldName the name of the field
    * @param type the Java raw type that will allow further analyzes
+   * @param declarationClass
    */
-  public FieldAttributeModel(String fieldName, Type type) {
+  public FieldAttributeModel(String fieldName, Type type, Class declarationClass) {
     this.fieldName = fieldName;
     this.type = type;
     this.typeName = convertType(type);
+    this.dtsType = convertTypeForDTS(declarationClass, type);
+    this.declarationClass = declarationClass;
 
     if (typeName.startsWith("Array<") || typeName.startsWith("Map<")) {
       this.needInitialize = true;
@@ -113,12 +129,18 @@ public class FieldAttributeModel {
       }
     } else if (Map.class.equals(rawType)) {
       isMap = true;
+      mapKeyType =
+          convertTypeForDTS(declarationClass, parameterizedType.getActualTypeArguments()[0]);
       if (parameterizedType.getActualTypeArguments()[1] instanceof Class
           && ((Class) parameterizedType.getActualTypeArguments()[1])
               .isAnnotationPresent(DTO.class)) {
+
         isMapOfDto = true;
         dtoImpl = convertType(parameterizedType.getActualTypeArguments()[1]) + "Impl";
       }
+
+      mapValueType =
+          convertTypeForDTS(declarationClass, parameterizedType.getActualTypeArguments()[1]);
     }
   }
 
@@ -176,5 +198,17 @@ public class FieldAttributeModel {
 
   public String getSimpleType() {
     return this.typeName;
+  }
+
+  public String getMapKeyType() {
+    return mapKeyType;
+  }
+
+  public String getMapValueType() {
+    return mapValueType;
+  }
+
+  public String getDtsType() {
+    return dtsType;
   }
 }

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/MethodModel.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/model/MethodModel.java
@@ -54,6 +54,9 @@ public class MethodModel {
   /** Type of the field associated to this method. */
   private String fieldType;
 
+  /** Name of setter or with* method argument */
+  private String argumentName;
+
   /**
    * Build a new model around the DTO method.
    *
@@ -145,5 +148,13 @@ public class MethodModel {
     return this.getName().equals(methodModelOther.getName())
         && this.returnType.equals(methodModelOther.returnType)
         && Arrays.equals(this.parameters.toArray(), methodModelOther.parameters.toArray());
+  }
+
+  public String getArgumentName() {
+    return argumentName;
+  }
+
+  public void setArgumentName(String argumentName) {
+    this.argumentName = argumentName;
   }
 }

--- a/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.d.ts.template
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.d.ts.template
@@ -1,0 +1,20 @@
+// File has been generated automatically by Eclipse Che TypeScript DTO generator
+
+<dtoNamespaces: { namespaces |
+
+<! Write TypeScript DTO interface first !>
+
+<! BEGIN declare dto module !>
+export namespace <namespaces.namespace> {
+
+  <! BEGIN declare interfaces !>
+<namespaces.dtoInterfaces: { dto |
+  //<dto.name>
+  export interface <dto.dtsName> {
+     <! BEGIN declare fields !>
+  <dto.fieldAttributeModels:{ field |
+  <field.name>?: <if(field.map)> { [key: <field.mapKeyType>]: <field.mapValueType>; \}<else><field.dtsType><endif>;
+}>  \} <! END declare interface !>
+
+}>\} <! END declare dto module !>
+}>

--- a/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.d.ts.template
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.d.ts.template
@@ -9,7 +9,7 @@ export namespace <namespaces.namespace> {
 
   <! BEGIN declare interfaces !>
 <namespaces.dtoInterfaces: { dto |
-  //<dto.name>
+  // <dto.name>
   export interface <dto.dtsName> {
      <! BEGIN declare fields !>
   <dto.fieldAttributeModels:{ field |

--- a/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.d.ts.template
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.d.ts.template
@@ -10,7 +10,7 @@ export namespace <namespaces.namespace> {
   <! BEGIN declare interfaces !>
 <namespaces.dtoInterfaces: { dto |
   // <dto.name>
-  export interface <dto.dtsName> {
+  export interface <dto.dtsName> <if(dto.extendsDto)>extends <dto.interfaces><endif> {
      <! BEGIN declare fields !>
   <dto.fieldAttributeModels:{ field |
   <field.name>?: <if(field.map)> { [key: <field.mapKeyType>]: <field.mapValueType>; \}<else><field.dtsType><endif>;

--- a/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.template
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/resources/org/eclipse/che/plugin/typescript/dto/typescript.template
@@ -85,14 +85,14 @@ export module <dto.packageName> {
     <endif>
     <! Generate setter code !>
     <if(method.setter)>
-    <method.name>(<method.fieldName> : <method.fieldType>) : void {
-      this.<method.fieldName> = <method.fieldName>;
+    <method.name>(<method.argumentName> : <method.fieldType>) : void {
+      this.<method.fieldName> = <method.argumentName>;
     \}
     <endif>
     <! Generate with code !>
     <if(method.with)>
-    <method.name>(<method.fieldName> : <method.fieldType>) : <method.returnType> {
-      this.<method.fieldName> = <method.fieldName>;
+    <method.name>(<method.argumentName> : <method.fieldType>) : <method.returnType> {
+      this.<method.fieldName> = <method.argumentName>;
       return this;
     \}
     <endif>

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MyCustomDTO.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MyCustomDTO.java
@@ -14,6 +14,7 @@ package org.eclipse.che.plugin.typescript.dto;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.che.dto.shared.DTO;
+import org.eclipse.che.plugin.typescript.dto.internal.InternalDto;
 
 /** @author Florent Benoit */
 @DTO
@@ -49,4 +50,8 @@ public interface MyCustomDTO {
   void setArguments(List<MyOtherDTO> arguments);
 
   MyCustomDTO withArguments(List<MyOtherDTO> arguments);
+
+  InternalDto getInternal();
+
+  void setInternal(InternalDto internal);
 }

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojoTest.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojoTest.java
@@ -84,7 +84,7 @@ public class TypeScriptDTOGeneratorMojoTest {
   }
 
   @Test
-  public void checkD_TS_fileCreated() throws Exception {
+  public void checkDTSFileCreated() throws Exception {
     File projectCopy = this.resources.getBasedir("project-d-ts");
     File pom = new File(projectCopy, "pom.xml");
     assertNotNull(pom);

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojoTest.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/TypeScriptDTOGeneratorMojoTest.java
@@ -82,4 +82,23 @@ public class TypeScriptDTOGeneratorMojoTest {
         "The MyCustomDTO has not been generated in the typescript definition file.",
         foundMyCustomDTO);
   }
+
+  @Test
+  public void checkD_TS_fileCreated() throws Exception {
+    File projectCopy = this.resources.getBasedir("project-d-ts");
+    File pom = new File(projectCopy, "pom.xml");
+    assertNotNull(pom);
+    assertTrue(pom.exists());
+
+    TypeScriptDTOGeneratorMojo mojo =
+        (TypeScriptDTOGeneratorMojo) this.rule.lookupMojo("build", pom);
+    configure(mojo, projectCopy);
+    mojo.execute();
+
+    File typeScriptFile = mojo.getTypescriptFile();
+    Assert.assertNotNull(typeScriptFile);
+
+    // Check file has been generated
+    Assert.assertTrue(typeScriptFile.exists());
+  }
 }

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/internal/InternalDto.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/internal/InternalDto.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.typescript.dto.internal;
+
+import org.eclipse.che.dto.shared.DTO;
+
+@DTO
+public interface InternalDto {
+  String getInternalValue();
+
+  void setInternalValue(String value);
+}

--- a/core/che-core-typescript-dto-maven-plugin/src/test/projects/project-d-ts/pom.xml
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/projects/project-d-ts/pom.xml
@@ -1,0 +1,39 @@
+<!--
+
+    Copyright (c) 2012-2018 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.eclipse.che.test</groupId>
+    <artifactId>my-typescript-test-module</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Test of Eclipse Che TypeScript plugin</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-typescript-dto-maven-plugin</artifactId>
+                <configuration>
+                    <dts>true</dts>
+                    <project implementation="org.eclipse.che.plugin.typescript.dto.stub.TypeScriptDTOGeneratorMojoProjectStub"/>
+                </configuration>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
### What does this PR do?
Provide new DTO generator for TypeScript which can generate `.d.ts` file
To enable new generator add:
```xml
<dts>true</dts>
```
in `<configuration>` section of `che-core-typescript-dto-maven-plugin`

### What issues does this PR fix or reference?
#12132

Also this pull use string union literals for Java Enum types:
```typescript
export interface MyCustom  {
   status?: 'SHUTDOWN' | 'ALIVE';
}
```

and adds super interfaces to DTO type declaration:
```typescript

  // org.eclipse.che.plugin.typescript.dto.MySuperClassDTO
  export interface MySuperClass  {
    name?: string;
  } 
  // org.eclipse.che.plugin.typescript.dto.MyOtherDTO
  export interface MyOther extends MySuperClass {
    name?: string;
  } 
```
