### PR TITLE
[WIP]Introduced two web-socket endpoints for workspace master to split JSON-RPC messages

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/CheMajorWebSocketEndpoint.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/CheMajorWebSocketEndpoint.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.deploy;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.websocket.server.ServerEndpoint;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessorConfigurator;
+import org.eclipse.che.api.core.jsonrpc.impl.ServerSideRequestProcessor;
+import org.eclipse.che.api.core.websocket.commons.WebSocketMessageReceiver;
+import org.eclipse.che.api.core.websocket.impl.BasicWebSocketEndpoint;
+import org.eclipse.che.api.core.websocket.impl.GuiceInjectorEndpointConfigurator;
+import org.eclipse.che.api.core.websocket.impl.MessagesReSender;
+import org.eclipse.che.api.core.websocket.impl.WebSocketSessionRegistry;
+import org.eclipse.che.api.core.websocket.impl.WebsocketIdService;
+import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
+import org.slf4j.Logger;
+
+/**
+ * Implementation of {@link BasicWebSocketEndpoint} for Che packaging. Add only mapping
+ * "/websocket".
+ */
+@ServerEndpoint(value = "/websocket", configurator = GuiceInjectorEndpointConfigurator.class)
+public class CheMajorWebSocketEndpoint extends BasicWebSocketEndpoint {
+  private static final Logger LOG = getLogger(CheMajorWebSocketEndpoint.class);
+
+  private final int maxPoolSize;
+  private final RequestProcessorConfigurator requestProcessorConfigurator;
+
+  private ThreadPoolExecutor executor;
+
+  @Inject
+  public CheMajorWebSocketEndpoint(
+      WebSocketSessionRegistry registry,
+      MessagesReSender reSender,
+      WebSocketMessageReceiver receiver,
+      WebsocketIdService websocketIdService,
+      RequestProcessorConfigurator requestProcessorConfigurator,
+      @Named("che.core.jsonrpc.processor_max_pool_size") int maxPoolSize) {
+    super(registry, reSender, receiver, websocketIdService);
+    this.maxPoolSize = maxPoolSize;
+    this.requestProcessorConfigurator = requestProcessorConfigurator;
+  }
+
+  @Override
+  protected String getEndpointId() {
+    return "master-websocket-major-endpoint";
+  }
+
+  @PostConstruct
+  private void postConstruct() {
+    ThreadFactory factory =
+        new ThreadFactoryBuilder()
+            .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
+            .setNameFormat(ServerSideRequestProcessor.class.getSimpleName() + "-%d")
+            .setDaemon(true)
+            .build();
+
+    executor =
+        new ThreadPoolExecutor(0, maxPoolSize, 60L, SECONDS, new SynchronousQueue<>(), factory);
+    executor.setRejectedExecutionHandler(
+        (r, __) -> LOG.warn("Message {} rejected for execution", r));
+    requestProcessorConfigurator.put(getEndpointId(), () -> executor);
+  }
+
+  @PreDestroy
+  private void preDestroy() {
+    executor.shutdown();
+    try {
+      if (executor.awaitTermination(3, SECONDS)) {
+        executor.shutdownNow();
+        executor.awaitTermination(3, SECONDS);
+      }
+    } catch (InterruptedException ie) {
+      executor.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/CheMinorWebSocketEndpoint.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/CheMinorWebSocketEndpoint.java
@@ -22,12 +22,12 @@ import org.eclipse.che.api.core.websocket.impl.WebsocketIdService;
 
 /**
  * Implementation of {@link BasicWebSocketEndpoint} for Che packaging. Add only mapping
- * "/websocket".
+ * "/websocket-minor".
  */
-@ServerEndpoint(value = "/websocket", configurator = GuiceInjectorEndpointConfigurator.class)
-public class CheWebSocketEndpoint extends BasicWebSocketEndpoint {
+@ServerEndpoint(value = "/websocket-minor", configurator = GuiceInjectorEndpointConfigurator.class)
+public class CheMinorWebSocketEndpoint extends BasicWebSocketEndpoint {
   @Inject
-  public CheWebSocketEndpoint(
+  public CheMinorWebSocketEndpoint(
       WebSocketSessionRegistry registry,
       MessagesReSender reSender,
       WebSocketMessageReceiver receiver,
@@ -37,6 +37,6 @@ public class CheWebSocketEndpoint extends BasicWebSocketEndpoint {
 
   @Override
   protected String getEndpointId() {
-    return "master-websocket-endpoint";
+    return "master-websocket-minor-endpoint";
   }
 }

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -21,6 +21,10 @@ che.api=http://${CHE_HOST}:${CHE_PORT}/api
 # for websocket interaction/messaging.
 che.websocket.endpoint=ws://${CHE_HOST}:${CHE_PORT}/api/websocket
 
+# Che websocket minor endpoint. Provides basic communication endpoint
+# for websocket interaction/messaging.
+che.websocket.minor.endpoint=ws://${CHE_HOST}:${CHE_PORT}/api/websocket-minor
+
 # Your projects are synchronized from the Che server into the machine running each
 # workspace. This is the directory in the ws runtime where your projects are mounted.
 che.workspace.storage=${che.home}/workspaces
@@ -276,6 +280,9 @@ che.infra.docker.master_api_endpoint=http://che-host:${CHE_PORT}/api
 
 # This is the webscoket base endpoint of the workspace master running within the core Che server.
 che.infra.docker.master_websocket_endpoint=ws://che-host:${CHE_PORT}/api/websocket
+
+# This is the minor webscoket base endpoint of the workspace master running within the core Che server.
+che.infra.docker.master_websocket_minor_endpoint=ws://che-host:${CHE_PORT}/api/websocket-minor
 
 # Time (in minutes) given for bootstrapping.
 # If boostrapping is not finished in time it will be failed and workspace start will fail.

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -17,13 +17,13 @@ che.database=${che.home}/storage
 # API service. Browsers initiate REST communications to Che server with this URL
 che.api=http://${CHE_HOST}:${CHE_PORT}/api
 
-# Che websocket endpoint. Provides basic communication endpoint
-# for websocket interaction/messaging.
+# Che websocket major endpoint. Provides basic communication endpoint
+# for major websocket interaction/messaging.
 che.websocket.endpoint=ws://${CHE_HOST}:${CHE_PORT}/api/websocket
 
 # Che websocket minor endpoint. Provides basic communication endpoint
-# for websocket interaction/messaging.
-che.websocket.minor.endpoint=ws://${CHE_HOST}:${CHE_PORT}/api/websocket-minor
+# for minor websocket interaction/messaging.
+che.websocket.endpoint_minor=ws://${CHE_HOST}:${CHE_PORT}/api/websocket-minor
 
 # Your projects are synchronized from the Che server into the machine running each
 # workspace. This is the directory in the ws runtime where your projects are mounted.

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiver.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiver.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.core.jsonrpc.commons;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.eclipse.che.api.core.websocket.impl.WebsocketIdService.SEPARATOR;
 import static org.slf4j.LoggerFactory.getLogger;
 
 import java.util.List;
@@ -70,7 +71,7 @@ public class JsonRpcMessageReceiver implements WebSocketMessageReceiver {
     List<String> messages = jsonRpcUnmarshaller.unmarshalArray(message);
     for (String innerMessage : messages) {
       if (jsonRpcQualifier.isJsonRpcRequest(innerMessage)) {
-        String endpointId = combinedEndpointId.split("<-:->")[1];
+        String endpointId = combinedEndpointId.split(SEPARATOR)[1];
         ProcessRequestTask task = new ProcessRequestTask(combinedEndpointId, innerMessage);
         requestProcessor.process(endpointId, task);
       } else if (jsonRpcQualifier.isJsonRpcResponse(innerMessage)) {

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestProcessor.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestProcessor.java
@@ -18,5 +18,5 @@ public interface RequestProcessor {
    *
    * @param runnable runnable to be called for processing of a request
    */
-  void process(Runnable runnable);
+  void process(String endpointId, Runnable runnable);
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestProcessor.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestProcessor.java
@@ -16,6 +16,7 @@ public interface RequestProcessor {
   /**
    * Process a runnable interface
    *
+   * @param endpointId an endpoint that requested the processing
    * @param runnable runnable to be called for processing of a request
    */
   void process(String endpointId, Runnable runnable);

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestProcessorConfigurator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestProcessorConfigurator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.jsonrpc.commons;
+
+import java.util.concurrent.ExecutorService;
+
+/** Request processor configurator */
+public interface RequestProcessorConfigurator {
+  /**
+   * Configure processing for specified endpoint
+   *
+   * @param endpointId endpointId
+   * @param configuration configuration
+   */
+  void put(String endpointId, Configuration configuration);
+
+  /**
+   * Get request processor configuration for specified endpoint, returns null if no corresponding
+   * configuration is found.
+   *
+   * @param endpointId endpoint id
+   * @return
+   */
+  Configuration getOrNull(String endpointId);
+
+  /**
+   * Get request processor configuration for specified endpoint, returns default value if no
+   * corresponding configuration is found.
+   *
+   * @param endpointId endpoint id
+   * @return
+   */
+  Configuration getOrDefault(String endpointId);
+
+  /** Request processor configuration */
+  interface Configuration {
+    ExecutorService getExecutionService();
+  }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcModule.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/JsonRpcModule.java
@@ -23,6 +23,7 @@ import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcQualifier;
 import org.eclipse.che.api.core.jsonrpc.commons.JsonRpcUnmarshaller;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessor;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessorConfigurator;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestTransmitter;
 import org.eclipse.che.api.core.jsonrpc.commons.TimeoutActionRunner;
 import org.eclipse.che.dto.server.DtoFactory;
@@ -39,6 +40,7 @@ public class JsonRpcModule extends AbstractModule {
     bind(JsonRpcComposer.class).to(GsonJsonRpcComposer.class);
 
     bind(RequestProcessor.class).to(ServerSideRequestProcessor.class);
+    bind(RequestProcessorConfigurator.class).to(ServerSideRequestProcessorConfigurator.class);
     bind(TimeoutActionRunner.class).to(ServerSideTimeoutActionRunner.class);
   }
 

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideRequestProcessor.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideRequestProcessor.java
@@ -11,73 +11,27 @@
  */
 package org.eclipse.che.api.core.jsonrpc.impl;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
-import javax.inject.Named;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessor;
-import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessorConfigurator;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessorConfigurator.Configuration;
 import org.eclipse.che.commons.lang.concurrent.ThreadLocalPropagateContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 public class ServerSideRequestProcessor implements RequestProcessor {
-
-  private static final Logger LOG = LoggerFactory.getLogger(ServerSideRequestProcessor.class);
-
-  private ExecutorService executorService;
-  private final int maxPoolSize;
+  private final RequestProcessorConfigurator requestProcessorConfigurator;
 
   @Inject
-  public ServerSideRequestProcessor(
-      @Named("che.core.jsonrpc.processor_max_pool_size") int maxPoolSize) {
-    this.maxPoolSize = maxPoolSize;
-    LOG.debug("che.core.jsonrpc.processor_max_pool_size {}  ", maxPoolSize);
-  }
-
-  @PostConstruct
-  private void postConstruct() {
-    ThreadFactory factory =
-        new ThreadFactoryBuilder()
-            .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
-            .setNameFormat(ServerSideRequestProcessor.class.getSimpleName() + "-%d")
-            .setDaemon(true)
-            .build();
-
-    executorService =
-        new ThreadPoolExecutor(
-            0, maxPoolSize, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), factory);
-    ((ThreadPoolExecutor) executorService)
-        .setRejectedExecutionHandler(
-            (r, executor) -> LOG.warn("Message {} rejected for execution", r));
-  }
-
-  @PreDestroy
-  private void preDestroy() {
-    executorService.shutdown();
-    try {
-      if (executorService.awaitTermination(5, SECONDS)) {
-        executorService.shutdownNow();
-        executorService.awaitTermination(5, SECONDS);
-      }
-    } catch (InterruptedException ie) {
-      executorService.shutdownNow();
-      Thread.currentThread().interrupt();
-    }
+  public ServerSideRequestProcessor(RequestProcessorConfigurator requestProcessorConfigurator) {
+    this.requestProcessorConfigurator = requestProcessorConfigurator;
   }
 
   @Override
-  public void process(Runnable runnable) {
-    executorService.execute(ThreadLocalPropagateContext.wrap(runnable));
+  public void process(String endpointId, Runnable runnable) {
+    Configuration configuration = requestProcessorConfigurator.getOrDefault(endpointId);
+    ExecutorService executionService = configuration.getExecutionService();
+    executionService.execute(ThreadLocalPropagateContext.wrap(runnable));
   }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideRequestProcessorConfigurator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideRequestProcessorConfigurator.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.api.core.jsonrpc.impl;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
-
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -24,7 +22,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import javax.inject.Named;
 import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessorConfigurator;
 import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
@@ -63,20 +60,6 @@ public class ServerSideRequestProcessorConfigurator implements RequestProcessorC
     ((ThreadPoolExecutor) defaultExecutorService)
         .setRejectedExecutionHandler(
             (r, executor) -> LOG.warn("Message {} rejected for execution", r));
-  }
-
-  @PreDestroy
-  private void preDestroy() {
-    defaultExecutorService.shutdown();
-    try {
-      if (defaultExecutorService.awaitTermination(3, SECONDS)) {
-        defaultExecutorService.shutdownNow();
-        defaultExecutorService.awaitTermination(5, SECONDS);
-      }
-    } catch (InterruptedException ie) {
-      defaultExecutorService.shutdownNow();
-      Thread.currentThread().interrupt();
-    }
   }
 
   @Override

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideRequestProcessorConfigurator.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/ServerSideRequestProcessorConfigurator.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.jsonrpc.impl;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Named;
+import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessorConfigurator;
+import org.eclipse.che.commons.lang.concurrent.LoggingUncaughtExceptionHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class ServerSideRequestProcessorConfigurator implements RequestProcessorConfigurator {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ServerSideRequestProcessorConfigurator.class);
+
+  private ExecutorService defaultExecutorService;
+  private final int maxPoolSize;
+  private final Map<String, Configuration> configurations = new ConcurrentHashMap<>();
+
+  @Inject
+  public ServerSideRequestProcessorConfigurator(
+      @Named("che.core.jsonrpc.processor_max_pool_size") int maxPoolSize) {
+    this.maxPoolSize = maxPoolSize;
+    LOG.debug("che.core.jsonrpc.processor_max_pool_size {}  ", maxPoolSize);
+  }
+
+  @PostConstruct
+  private void postConstruct() {
+    ThreadFactory factory =
+        new ThreadFactoryBuilder()
+            .setUncaughtExceptionHandler(LoggingUncaughtExceptionHandler.getInstance())
+            .setNameFormat(ServerSideRequestProcessorConfigurator.class.getSimpleName() + "-%d")
+            .setDaemon(true)
+            .build();
+
+    defaultExecutorService =
+        new ThreadPoolExecutor(
+            0, maxPoolSize, 60L, TimeUnit.SECONDS, new SynchronousQueue<>(), factory);
+    ((ThreadPoolExecutor) defaultExecutorService)
+        .setRejectedExecutionHandler(
+            (r, executor) -> LOG.warn("Message {} rejected for execution", r));
+  }
+
+  @PreDestroy
+  private void preDestroy() {
+    defaultExecutorService.shutdown();
+    try {
+      if (defaultExecutorService.awaitTermination(3, SECONDS)) {
+        defaultExecutorService.shutdownNow();
+        defaultExecutorService.awaitTermination(5, SECONDS);
+      }
+    } catch (InterruptedException ie) {
+      defaultExecutorService.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @Override
+  public void put(String endpointId, Configuration configuration) {
+    configurations.put(endpointId, configuration);
+  }
+
+  @Override
+  public Configuration getOrNull(String endpointId) {
+    return configurations.get(endpointId);
+  }
+
+  @Override
+  public Configuration getOrDefault(String endpointId) {
+    return configurations.getOrDefault(endpointId, () -> defaultExecutorService);
+  }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebsocketIdService.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/WebsocketIdService.java
@@ -26,7 +26,7 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestHandlerConfigurator;
  */
 @Singleton
 public class WebsocketIdService {
-  private static final String SEPARATOR = "<-:->";
+  public static final String SEPARATOR = "<-:->";
   private static final Random GENERATOR = new Random();
 
   public static String randomClientId() {

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiverTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiverTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 public class JsonRpcMessageReceiverTest {
 
   static final String MESSAGE = "message";
-  static final String ENDPOINT_ID = "endpoint-id";
+  static final String ENDPOINT_ID = "client-id<-:->endpoint-id";
 
   @Mock RequestDispatcher requestDispatcher;
   @Mock ResponseDispatcher responseDispatcher;
@@ -92,6 +92,6 @@ public class JsonRpcMessageReceiverTest {
 
     jsonRpcMessageReceiver.receive(ENDPOINT_ID, MESSAGE);
 
-    verify(requestProcessor).process(any());
+    verify(requestProcessor).process(any(), any());
   }
 }

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiverTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiverTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.eclipse.che.api.core.websocket.impl.WebsocketIdService;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -30,7 +31,7 @@ import org.testng.annotations.Test;
 public class JsonRpcMessageReceiverTest {
 
   static final String MESSAGE = "message";
-  static final String ENDPOINT_ID = "client-id<-:->endpoint-id";
+  static final String ENDPOINT_ID = "client-id" + WebsocketIdService.SEPARATOR + "endpoint-id";
 
   @Mock RequestDispatcher requestDispatcher;
   @Mock ResponseDispatcher responseDispatcher;

--- a/deploy/openshift/templates/che-server-template.yaml
+++ b/deploy/openshift/templates/che-server-template.yaml
@@ -96,6 +96,8 @@ objects:
             value: "${PROTOCOL}://che-${NAMESPACE}.${ROUTING_SUFFIX}/api"
           - name: CHE_WEBSOCKET_ENDPOINT
             value: "${WS_PROTOCOL}://che-${NAMESPACE}.${ROUTING_SUFFIX}/api/websocket"
+          - name: CHE_WEBSOCKET_ENDPOINT__MINOR
+            value: "${WS_PROTOCOL}://che-${NAMESPACE}.${ROUTING_SUFFIX}/api/websocket-minor"
           - name: CHE_DEBUG_SERVER
             value: "false"
           - name: CHE_INFRASTRUCTURE_ACTIVE

--- a/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/ClientSideRequestProcessor.java
+++ b/ide/commons-gwt/src/main/java/org/eclipse/che/ide/jsonrpc/ClientSideRequestProcessor.java
@@ -18,7 +18,7 @@ import org.eclipse.che.api.core.jsonrpc.commons.RequestProcessor;
 public class ClientSideRequestProcessor implements RequestProcessor {
 
   @Override
-  public void process(Runnable runnable) {
+  public void process(String endpointId, Runnable runnable) {
     runnable.run();
   }
 }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/bootstrap/DockerBootstrapper.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/bootstrap/DockerBootstrapper.java
@@ -61,11 +61,17 @@ public class DockerBootstrapper extends AbstractBootstrapper {
       @Assisted List<? extends Installer> installers,
       EventService eventService,
       @Named("che.infra.docker.master_websocket_endpoint") String cheWebsocketEndpoint,
+      @Named("che.infra.docker.master_websocket_minor_endpoint") String cheWebsocketMinorEndpoint,
       @Named("che.infra.docker.bootstrapper.timeout_min") int bootstrappingTimeoutMinutes,
       @Named("che.infra.docker.bootstrapper.installer_timeout_sec") int installerTimeoutSeconds,
       @Named("che.infra.docker.bootstrapper.server_check_period_sec")
           int serverCheckPeriodSeconds) {
-    super(machineName, runtimeIdentity, cheWebsocketEndpoint, cheWebsocketEndpoint, eventService);
+    super(
+        machineName,
+        runtimeIdentity,
+        cheWebsocketEndpoint,
+        cheWebsocketMinorEndpoint,
+        eventService);
     this.machineName = machineName;
     this.runtimeIdentity = runtimeIdentity;
     this.dockerMachine = dockerMachine;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
@@ -77,7 +77,7 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
       @Assisted KubernetesNamespace namespace,
       @Assisted StartSynchronizer startSynchronizer,
       @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
-      @Named("che.websocket.minor.endpoint") String cheWebsocketMinorEndpoint,
+      @Named("che.websocket.endpoint_minor") String cheWebsocketMinorEndpoint,
       @Named("che.infra.kubernetes.bootstrapper.binary_url") String bootstrapperBinaryUrl,
       @Named("che.infra.kubernetes.bootstrapper.installer_timeout_sec") int installerTimeoutSeconds,
       @Named("che.infra.kubernetes.bootstrapper.server_check_period_sec")

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
@@ -77,6 +77,7 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
       @Assisted KubernetesNamespace namespace,
       @Assisted StartSynchronizer startSynchronizer,
       @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
+      @Named("che.websocket.minor.endpoint") String cheWebsocketMinorEndpoint,
       @Named("che.infra.kubernetes.bootstrapper.binary_url") String bootstrapperBinaryUrl,
       @Named("che.infra.kubernetes.bootstrapper.installer_timeout_sec") int installerTimeoutSeconds,
       @Named("che.infra.kubernetes.bootstrapper.server_check_period_sec")
@@ -88,7 +89,7 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
         kubernetesMachine.getName(),
         runtimeIdentity,
         cheWebsocketEndpoint,
-        cheWebsocketEndpoint,
+        cheWebsocketMinorEndpoint,
         eventService);
     this.bootstrapperBinaryUrl = bootstrapperBinaryUrl;
     this.runtimeIdentity = runtimeIdentity;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/bootstrapper/KubernetesBootstrapper.java
@@ -76,8 +76,8 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
       @Assisted KubernetesMachineImpl kubernetesMachine,
       @Assisted KubernetesNamespace namespace,
       @Assisted StartSynchronizer startSynchronizer,
-      @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
       @Named("che.websocket.endpoint_minor") String cheWebsocketMinorEndpoint,
+      @Named("che.websocket.endpoint") String cheWebsocketEndpoint,
       @Named("che.infra.kubernetes.bootstrapper.binary_url") String bootstrapperBinaryUrl,
       @Named("che.infra.kubernetes.bootstrapper.installer_timeout_sec") int installerTimeoutSeconds,
       @Named("che.infra.kubernetes.bootstrapper.server_check_period_sec")
@@ -88,8 +88,8 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
     super(
         kubernetesMachine.getName(),
         runtimeIdentity,
-        cheWebsocketEndpoint,
         cheWebsocketMinorEndpoint,
+        cheWebsocketEndpoint,
         eventService);
     this.bootstrapperBinaryUrl = bootstrapperBinaryUrl;
     this.runtimeIdentity = runtimeIdentity;
@@ -222,6 +222,11 @@ public class KubernetesBootstrapper extends AbstractBootstrapper {
   }
 
   private void exec(String... command) throws InfrastructureException {
+    LOG.debug(
+        "Executing Pod={} ContainerName={} command={}",
+        kubernetesMachine.getPodName(),
+        kubernetesMachine.getContainerName(),
+        command);
     namespace
         .deployments()
         .exec(


### PR DESCRIPTION
Related issue: https://github.com/eclipse/che/issues/11961

Introduced two web-socket endpoints for workspace master to split JSON-RPC messages into minor and major. Minor is expected to be used for not important messages like logger messages etc., while major endpoint is for important ones like statuses.