### PR TITLE
che #12187: Cancelling TimeoutProbeTask to avoid potential memory leak in ProbeScheduler

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/HttpProbe.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/HttpProbe.java
@@ -62,6 +62,7 @@ public class HttpProbe extends Probe {
     } finally {
       if (httpURLConnection != null) {
         httpURLConnection.disconnect();
+        this.httpURLConnection = null;
       }
     }
   }
@@ -74,6 +75,7 @@ public class HttpProbe extends Probe {
   @Override
   public void cancel() {
     httpURLConnection.disconnect();
+    this.httpURLConnection = null;
   }
 
   private boolean isConnectionSuccessful(HttpURLConnection conn) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/ProbeScheduler.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/probe/ProbeScheduler.java
@@ -209,9 +209,11 @@ public class ProbeScheduler {
         return;
       }
       Probe probe = probeFactory.get();
+      TimeoutProbeTask timeoutProbeTask = new TimeoutProbeTask(probe);
       timeouts.schedule(
-          new TimeoutProbeTask(probe), TimeUnit.SECONDS.toMillis(probeConfig.getTimeoutSeconds()));
+          timeoutProbeTask, TimeUnit.SECONDS.toMillis(probeConfig.getTimeoutSeconds()));
       boolean success = probe.probe();
+      timeoutProbeTask.cancel();
       if (success) {
         // current success increases successes count and clears failures count
         successes++;


### PR DESCRIPTION
### What does this PR do?
Cancelling TimeoutProbeTask to avoid potential memory leak in ProbeScheduler

### What issues does this PR fix or reference?
#12187 

<!-- #### Changelog -->
Cancelling TimeoutProbeTask to avoid potential memory leak in ProbeScheduler

#### Release Notes
N/A

#### Docs PR
N/A
