### PR TITLE
Add periodical job that stops Runtimes without existing pods

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -498,6 +498,21 @@ che.infra.kubernetes.tls_enabled=false
 # Ignored by OpenShift infrastructure
 che.infra.kubernetes.tls_secret=
 
+# Defines the period with which runtimes consistency checks will be performed.
+# If runtime has inconsistent state then runtime will be stopped automatically.
+# Value must be more than 0 or `-1`, where `-1` means that checks won't be performed at all.
+#
+# It is disabled by default because there is possible Che Server configuration when Che Server
+# doesn't have an ability to interact with Kubernetes API when operation is not invoked by user.
+#
+# It DOES work on the following configurations:
+# - workspaces objects are created in the same namespace where Che Server is located;
+# - cluster-admin service account token is mount to Che Server pod;
+#
+# It DOES NOT work on the following configurations:
+# - Che Server communicates with Kubernetes API using token from OAuth provider;
+che.infra.kubernetes.runtimes_consistency_check_period_min=-1
+
 ### OpenShift Infra parameters
 #
 # Since OpenShift infrastructure reuse Kubernetes infrastructure components

--- a/infrastructures/kubernetes/pom.xml
+++ b/infrastructures/kubernetes/pom.xml
@@ -133,6 +133,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-schedule</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-tracing</artifactId>
         </dependency>
         <dependency>

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/InconsistentRuntimesDetector.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/InconsistentRuntimesDetector.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.TimeUnit;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalRuntime;
+import org.eclipse.che.commons.schedule.ScheduleDelay;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.RuntimeEventsPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Periodically checks runtimes consistency and forcibly stop ones which has inconsistent state.
+ *
+ * @author Sergii Leshchenko
+ */
+@Singleton
+public class InconsistentRuntimesDetector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InconsistentRuntimesDetector.class);
+
+  private final RuntimeEventsPublisher eventPublisher;
+  private final WorkspaceRuntimes workspaceRuntimes;
+
+  @Inject
+  public InconsistentRuntimesDetector(
+      RuntimeEventsPublisher eventPublisher, WorkspaceRuntimes workspaceRuntimes) {
+    this.eventPublisher = eventPublisher;
+    this.workspaceRuntimes = workspaceRuntimes;
+  }
+
+  @ScheduleDelay(
+      delayParameterName = "che.infra.kubernetes.runtimes_consistency_check_period_min",
+      initialDelayParameterName = "che.infra.kubernetes.runtimes_consistency_check_period_min",
+      unit = TimeUnit.MINUTES)
+  public void check() {
+    LOG.debug("Runtimes consistency check is running");
+    for (String runningWorkspaceId : workspaceRuntimes.getRunning()) {
+      try {
+        checkOne(runningWorkspaceId);
+      } catch (InfrastructureException e) {
+        LOG.error(
+            "Checking consistency of runtime for workspace `{}` is failed. Cause: ",
+            e.getMessage(),
+            e);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  void checkOne(String workspaceId) throws InfrastructureException {
+    LOG.debug("Checking consistency of runtime for workspace `{}`", workspaceId);
+    KubernetesInternalRuntime k8sRuntime = getKubernetesInternalRuntime(workspaceId);
+    RuntimeIdentity runtimeId = k8sRuntime.getContext().getIdentity();
+
+    try {
+      if (k8sRuntime.isConsistent()) {
+        return;
+      }
+    } catch (InfrastructureException e) {
+      throw new InfrastructureException(
+          format(
+              "Error occurred during runtime '%s:%s' consistency checking. Cause: %s",
+              runtimeId.getWorkspaceId(), runtimeId.getOwnerId(), e.getMessage()),
+          e);
+    }
+
+    // check if status is still RUNNING
+    // not to initialize abnormal stop for a runtime that is not RUNNING anymore
+    if (!isRunning(k8sRuntime)) {
+      return;
+    }
+
+    LOG.warn(
+        "Found runtime `{}:{}` with inconsistent state. It's going to be stopped automatically",
+        runtimeId.getWorkspaceId(),
+        runtimeId.getOwnerId());
+
+    stopAbnormally(k8sRuntime);
+    LOG.debug("Checking consistency of runtime for workspace `{}` is finished", workspaceId);
+  }
+
+  private boolean isRunning(KubernetesInternalRuntime k8sRuntime) throws InfrastructureException {
+    try {
+      return k8sRuntime.getStatus() == WorkspaceStatus.RUNNING;
+    } catch (InfrastructureException e) {
+      throw new InfrastructureException(
+          "Error occurred during runtime status fetching during consistency checking. Cause: "
+              + e.getMessage(),
+          e);
+    }
+  }
+
+  private void stopAbnormally(KubernetesInternalRuntime k8sRuntime) throws InfrastructureException {
+    RuntimeIdentity runtimeId = k8sRuntime.getContext().getIdentity();
+    eventPublisher.sendAbnormalStoppingEvent(runtimeId, "The runtime has inconsistent state.");
+    try {
+      k8sRuntime.stop(emptyMap());
+    } catch (InfrastructureException e) {
+      throw new InfrastructureException(
+          format(
+              "Failed to stop the runtime '%s:%s' which has inconsistent state. Error: %s",
+              runtimeId.getWorkspaceId(), runtimeId.getOwnerId(), e.getMessage()),
+          e);
+    } finally {
+      eventPublisher.sendAbnormalStoppedEvent(runtimeId, "The runtime has inconsistent state.");
+    }
+  }
+
+  private KubernetesInternalRuntime getKubernetesInternalRuntime(String workspaceId)
+      throws InfrastructureException {
+    InternalRuntime<?> internalRuntime;
+    try {
+      internalRuntime = workspaceRuntimes.getInternalRuntime(workspaceId);
+    } catch (InfrastructureException | ServerException e) {
+      throw new InfrastructureException(
+          format(
+              "Failed to get internal runtime for workspace `%s` to check consistency. Cause: %s",
+              workspaceId, e.getMessage()),
+          e);
+    }
+
+    RuntimeIdentity runtimeId = internalRuntime.getContext().getIdentity();
+    if (!(internalRuntime instanceof KubernetesInternalRuntime)) {
+      // must not happen
+      throw new InfrastructureException(
+          format(
+              "Fetched internal runtime '%s:%s' is not Kubernetes, it is not possible to check consistency.",
+              runtimeId.getWorkspaceId(), runtimeId.getOwnerId()));
+    }
+
+    return (KubernetesInternalRuntime) internalRuntime;
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -80,6 +80,7 @@ public class KubernetesInfraModule extends AbstractModule {
     factories.addBinding(Constants.NO_ENVIRONMENT_RECIPE_TYPE).to(NoEnvironmentFactory.class);
 
     bind(RuntimeInfrastructure.class).to(KubernetesInfrastructure.class);
+    bind(InconsistentRuntimesDetector.class).asEagerSingleton();
 
     bind(new TypeLiteral<KubernetesEnvironmentProvisioner<KubernetesEnvironment>>() {})
         .to(KubernetesEnvironmentProvisioner.KubernetesEnvironmentProvisionerImpl.class);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -46,6 +46,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
@@ -900,6 +901,34 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
             format(
                 "Unrecoverable event occurred: '%s', '%s', '%s'",
                 reason, message, podEvent.getPodName())));
+  }
+
+  /**
+   * Returns true if the runtime is working normally, or returns false if the runtime has
+   * inconsistent state and should be stopped immediately
+   *
+   * <p>Runtime is considered as inconsistent if all its pods don't exist anymore. In this case, all
+   * workspace servers are not available and it doesn't make sense to keep it RUNNING.
+   *
+   * <p>Runtime is considered as consistent if there is at least one existing pod because existing
+   * pod may provide user needed services and there is no need to stop such workspaces.
+   *
+   * @throws InfrastructureException if any exception occurs during check performing
+   */
+  public boolean isConsistent() throws InfrastructureException {
+    Set<String> podNames =
+        getInternalMachines()
+            .values()
+            .stream()
+            .map(KubernetesMachineImpl::getPodName)
+            .collect(Collectors.toSet());
+    for (String podName : podNames) {
+      if (namespace.deployments().get(podName).isPresent()) {
+        return true;
+      }
+    }
+    // runtime has only non-existing pods
+    return false;
   }
 
   private class ServerReadinessHandler implements Consumer<String> {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -327,7 +327,7 @@ public class KubernetesDeployments {
     try {
       final String podName = getPodName(name);
       final PodResource<Pod, DoneablePod> podResource =
-          clientFactory.create().pods().inNamespace(namespace).withName(podName);
+          clientFactory.create(workspaceId).pods().inNamespace(namespace).withName(podName);
       final Watch watch =
           podResource.watch(
               new Watcher<Pod>() {
@@ -383,7 +383,7 @@ public class KubernetesDeployments {
         try {
           String podLog =
               clientFactory
-                  .create()
+                  .create(workspaceId)
                   .pods()
                   .inNamespace(namespace)
                   .withName(pod.getMetadata().getName())

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -390,8 +390,9 @@ public class KubernetesDeployments {
                   .getLog();
           exceptionMessage = exceptionMessage.concat(" Pod logs: ").concat(podLog);
 
-        } catch (InfrastructureException e) {
-          exceptionMessage = exceptionMessage.concat(" Error occurred while fetching pod logs.");
+        } catch (InfrastructureException | KubernetesClientException e) {
+          exceptionMessage =
+              exceptionMessage.concat(" Error occurred while fetching pod logs: " + e.getMessage());
         }
       } else {
         exceptionMessage = exceptionMessage.concat(" Reason: ").concat(reason);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/InconsistentRuntimesDetectorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/InconsistentRuntimesDetectorTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import static java.util.Collections.emptyMap;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.google.common.collect.ImmutableSet;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.InternalRuntime;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.RuntimeEventsPublisher;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link InconsistentRuntimesDetectorTest}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class InconsistentRuntimesDetectorTest {
+
+  private RuntimeIdentity runtimeId = new RuntimeIdentityImpl("workspace1", "envName", "owner1");
+
+  @Mock private RuntimeEventsPublisher eventPublisher;
+  @Mock private WorkspaceRuntimes workspaceRuntimes;
+
+  @Mock private KubernetesInternalRuntime k8sRuntime;
+  @Mock private KubernetesRuntimeContext k8sContext;
+
+  @InjectMocks private InconsistentRuntimesDetector inconsistentRuntimesDetector;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    inconsistentRuntimesDetector =
+        spy(new InconsistentRuntimesDetector(eventPublisher, workspaceRuntimes));
+    lenient().when(k8sRuntime.getContext()).thenReturn(k8sContext);
+    lenient().when(k8sContext.getIdentity()).thenReturn(runtimeId);
+
+    lenient().when(k8sRuntime.getStatus()).thenReturn(WorkspaceStatus.RUNNING);
+  }
+
+  @Test
+  public void shouldCheckRuntimesConsistencyOneByOne() throws Exception {
+    // given
+    when(workspaceRuntimes.getRunning())
+        .thenReturn(ImmutableSet.of("workspace1", "workspace2", "workspace3"));
+    doNothing().when(inconsistentRuntimesDetector).checkOne(any());
+
+    // when
+    inconsistentRuntimesDetector.check();
+
+    // then
+    verify(inconsistentRuntimesDetector).checkOne("workspace1");
+    verify(inconsistentRuntimesDetector).checkOne("workspace2");
+    verify(inconsistentRuntimesDetector).checkOne("workspace3");
+  }
+
+  @Test
+  public void shouldCheckRuntimesConsistencyOneByOneWhenExceptionOccursOnChecking()
+      throws Exception {
+    // given
+    when(workspaceRuntimes.getRunning())
+        .thenReturn(ImmutableSet.of("workspace1", "workspace2", "workspace3"));
+    doThrow(new InfrastructureException("error"))
+        .when(inconsistentRuntimesDetector)
+        .checkOne(any());
+
+    // when
+    inconsistentRuntimesDetector.check();
+
+    // then
+    verify(inconsistentRuntimesDetector).checkOne("workspace1");
+    verify(inconsistentRuntimesDetector).checkOne("workspace2");
+    verify(inconsistentRuntimesDetector).checkOne("workspace3");
+  }
+
+  @Test
+  public void shouldDoNothingIfRuntimeHasConsistentStateOnChecking() throws Exception {
+    // given
+    doReturn(k8sRuntime).when(workspaceRuntimes).getInternalRuntime("workspace1");
+    doReturn(true).when(k8sRuntime).isConsistent();
+
+    // when
+    inconsistentRuntimesDetector.checkOne("workspace1");
+
+    // then
+    verifyNoMoreInteractions(eventPublisher);
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Fetched internal runtime 'workspace1:owner1' is not Kubernetes, it is not possible to check consistency.")
+  public void shouldThrowExceptionIfNonK8sRuntimeIsReturnOnCheckingConsistency() throws Exception {
+    // given
+    InternalRuntime runtime = mock(InternalRuntime.class);
+    when(runtime.getContext()).thenReturn(k8sContext);
+    doReturn(runtime).when(workspaceRuntimes).getInternalRuntime("workspace1");
+
+    // when
+    inconsistentRuntimesDetector.checkOne("workspace1");
+
+    // then
+    verifyNoMoreInteractions(eventPublisher);
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Failed to get internal runtime for workspace `workspace1` to check consistency. Cause: error")
+  public void shouldThrowExceptionIfExceptionOccursDuringRuntimeFetchingOnCheckingConsistency()
+      throws Exception {
+    // given
+    doThrow(new InfrastructureException("error"))
+        .when(workspaceRuntimes)
+        .getInternalRuntime("workspace1");
+
+    // when
+    inconsistentRuntimesDetector.checkOne("workspace1");
+
+    // then
+    verifyNoMoreInteractions(eventPublisher);
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error occurred during runtime 'workspace1:owner1' consistency checking. Cause: error")
+  public void shouldThrowExceptionIfExceptionOccursOnCheckingConsistency() throws Exception {
+    // given
+    doReturn(k8sRuntime).when(workspaceRuntimes).getInternalRuntime("workspace1");
+    doThrow(new InfrastructureException("error")).when(k8sRuntime).isConsistent();
+
+    // when
+    inconsistentRuntimesDetector.checkOne("workspace1");
+
+    // then
+    verifyNoMoreInteractions(eventPublisher);
+  }
+
+  @Test
+  public void
+      shouldMarkRuntimeAsStoppedEvenWhenExceptionOccursDuringRuntimeStoppingOnCheckingConsistency()
+          throws Exception {
+    // given
+    doReturn(k8sRuntime).when(workspaceRuntimes).getInternalRuntime("workspace1");
+    doReturn(false).when(k8sRuntime).isConsistent();
+    doThrow(new InfrastructureException("error")).when(k8sRuntime).stop(any());
+
+    // when
+    InfrastructureException caughtException = null;
+    try {
+      inconsistentRuntimesDetector.checkOne("workspace1");
+    } catch (InfrastructureException e) {
+      caughtException = e;
+    }
+
+    // then
+    assertNotNull(caughtException);
+    assertEquals(
+        caughtException.getMessage(),
+        "Failed to stop the runtime 'workspace1:owner1' which has inconsistent state. Error: error");
+    verify(k8sRuntime).stop(emptyMap());
+    verify(eventPublisher)
+        .sendAbnormalStoppingEvent(runtimeId, "The runtime has inconsistent state.");
+    verify(eventPublisher)
+        .sendAbnormalStoppedEvent(runtimeId, "The runtime has inconsistent state.");
+  }
+
+  @Test
+  public void shouldStopRuntimeAbnormallyIfRuntimeHasInConsistentStateOnChecking()
+      throws Exception {
+    // given
+    doReturn(k8sRuntime).when(workspaceRuntimes).getInternalRuntime("workspace1");
+    doReturn(false).when(k8sRuntime).isConsistent();
+
+    // when
+    inconsistentRuntimesDetector.checkOne("workspace1");
+
+    // then
+    verify(k8sRuntime).stop(emptyMap());
+    verify(eventPublisher)
+        .sendAbnormalStoppingEvent(runtimeId, "The runtime has inconsistent state.");
+    verify(eventPublisher)
+        .sendAbnormalStoppedEvent(runtimeId, "The runtime has inconsistent state.");
+  }
+
+  @Test
+  public void shouldNotStopRuntimeAbnormallyIfRuntimeHasInconsistentStateButIsNotRunningAnyMore()
+      throws Exception {
+    // given
+    doReturn(k8sRuntime).when(workspaceRuntimes).getInternalRuntime("workspace1");
+    doReturn(false).when(k8sRuntime).isConsistent();
+    when(k8sRuntime.getStatus()).thenReturn(WorkspaceStatus.STOPPING);
+
+    // when
+    inconsistentRuntimesDetector.checkOne("workspace1");
+
+    // then
+    verify(k8sRuntime, never()).stop(emptyMap());
+    verify(eventPublisher, never())
+        .sendAbnormalStoppingEvent(runtimeId, "The runtime has inconsistent state.");
+    verify(eventPublisher, never())
+        .sendAbnormalStoppedEvent(runtimeId, "The runtime has inconsistent state.");
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -291,6 +291,82 @@ public class KubernetesInternalRuntimeTest {
   }
 
   @Test
+  public void shouldReturnTrueIfAllPodsExistOnRuntimeConsistencyChecking() throws Exception {
+    // given
+    KubernetesMachineImpl machine1 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine1", "pod1", "container 1", null, emptyMap(), emptyMap());
+    KubernetesMachineImpl machine2 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine2", "pod1", "container 2", null, emptyMap(), emptyMap());
+    KubernetesMachineImpl machine3 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine3", "pod2", "container 1", null, emptyMap(), emptyMap());
+    machinesCache.put(IDENTITY, machine1);
+    machinesCache.put(IDENTITY, machine2);
+    machinesCache.put(IDENTITY, machine3);
+
+    doReturn(Optional.of(mock(Pod.class))).when(deployments).get(anyString());
+
+    // when
+    boolean isConsistent = internalRuntime.isConsistent();
+
+    // then
+    assertTrue(isConsistent);
+  }
+
+  @Test
+  public void shouldReturnTrueIfOnlyOnePodExistsOnRuntimeConsistencyChecking() throws Exception {
+    // given
+    KubernetesMachineImpl machine1 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine1", "pod1", "container 1", null, emptyMap(), emptyMap());
+    KubernetesMachineImpl machine2 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine2", "pod1", "container 2", null, emptyMap(), emptyMap());
+    KubernetesMachineImpl machine3 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine3", "pod2", "container 1", null, emptyMap(), emptyMap());
+    machinesCache.put(IDENTITY, machine1);
+    machinesCache.put(IDENTITY, machine2);
+    machinesCache.put(IDENTITY, machine3);
+
+    doReturn(Optional.of(mock(Pod.class))).when(deployments).get("pod1");
+    doReturn(Optional.empty()).when(deployments).get("pod2");
+
+    // when
+    boolean isConsistent = internalRuntime.isConsistent();
+
+    // then
+    assertTrue(isConsistent);
+  }
+
+  @Test
+  public void shouldReturnFalseIfAllPodsExistOnRuntimeConsistencyChecking() throws Exception {
+    // given
+    KubernetesMachineImpl machine1 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine1", "pod1", "container 1", null, emptyMap(), emptyMap());
+    KubernetesMachineImpl machine2 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine2", "pod1", "container 2", null, emptyMap(), emptyMap());
+    KubernetesMachineImpl machine3 =
+        new KubernetesMachineImpl(
+            WORKSPACE_ID, "machine3", "pod2", "container 1", null, emptyMap(), emptyMap());
+    machinesCache.put(IDENTITY, machine1);
+    machinesCache.put(IDENTITY, machine2);
+    machinesCache.put(IDENTITY, machine3);
+
+    doReturn(Optional.empty()).when(deployments).get(anyString());
+
+    // when
+    boolean isConsistent = internalRuntime.isConsistent();
+
+    // then
+    assertFalse(isConsistent);
+  }
+
+  @Test
   public void startsKubernetesEnvironment() throws Exception {
     when(k8sEnv.getSecrets()).thenReturn(ImmutableMap.of("secret", new Secret()));
     when(k8sEnv.getConfigMaps()).thenReturn(ImmutableMap.of("configMap", new ConfigMap()));

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeploymentsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeploymentsTest.java
@@ -73,7 +73,6 @@ public class KubernetesDeploymentsTest {
     when(earlyPod.getStatus()).thenReturn(earlyPodStatus);
     when(podResource.get()).thenReturn(earlyPod);
 
-    lenient().when(clientFactory.create()).thenReturn(kubernetesClient);
     lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
 
     final MixedOperation mixedOperation = mock(MixedOperation.class);
@@ -185,7 +184,7 @@ public class KubernetesDeploymentsTest {
 
     doThrow(new InfrastructureException("Failure while retrieving pod logs"))
         .when(clientFactory)
-        .create();
+        .create(anyString());
 
     // when
     verify(podResource).watch(watcherCaptor.capture());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeploymentsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeploymentsTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.POD_STATUS_PHASE_FAILED;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.POD_STATUS_PHASE_RUNNING;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.POD_STATUS_PHASE_SUCCEEDED;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -23,21 +24,30 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import io.fabric8.kubernetes.api.model.DoneablePod;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.AppsAPIGroupDSL;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.ScalableResource;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -49,44 +59,56 @@ public class KubernetesDeploymentsTest {
   private static final String POD_NAME = "podName";
 
   @Mock private KubernetesClientFactory clientFactory;
-
-  @Mock private PodResource<Pod, DoneablePod> podResource;
-
   @Mock private KubernetesClient kubernetesClient;
 
+  // Deployments Mocks
+  @Mock private AppsAPIGroupDSL apps;
+  @Mock private MixedOperation deploymentsMixedOperation;
+  @Mock private NonNamespaceOperation deploymentsNamespaceOperation;
+  @Mock private ScalableResource deploymentResource;
+  @Mock private Deployment deployment;
+  @Mock private ObjectMeta deploymentMetadata;
+
+  // Pod Mocks
   @Mock private Pod pod;
-
   @Mock private PodStatus status;
-
+  @Mock private PodResource<Pod, DoneablePod> podResource;
   @Mock private ObjectMeta metadata;
+  @Mock private MixedOperation podsMixedOperation;
+  @Mock private NonNamespaceOperation podsNamespaceOperation;
 
-  private ArgumentCaptor<Watcher> watcherCaptor;
-
-  private Watcher watcher;
+  @Captor private ArgumentCaptor<Watcher<Pod>> watcherCaptor;
 
   private KubernetesDeployments kubernetesDeployments;
 
   @BeforeMethod
   public void setUp() throws Exception {
-    final Pod earlyPod = mock(Pod.class);
-    final PodStatus earlyPodStatus = mock(PodStatus.class);
-    when(earlyPod.getStatus()).thenReturn(earlyPodStatus);
-    when(podResource.get()).thenReturn(earlyPod);
-
     lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
-
-    final MixedOperation mixedOperation = mock(MixedOperation.class);
-    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-    doReturn(mixedOperation).when(kubernetesClient).pods();
-    lenient().when(mixedOperation.withName(anyString())).thenReturn(podResource);
-    when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-    when(namespaceOperation.withName(anyString())).thenReturn(podResource);
 
     when(pod.getStatus()).thenReturn(status);
     when(pod.getMetadata()).thenReturn(metadata);
     when(metadata.getName()).thenReturn(POD_NAME);
-    lenient().when(podResource.getLog()).thenReturn("Pod fail log");
-    watcherCaptor = ArgumentCaptor.forClass(Watcher.class);
+
+    // Model DSL: client.pods().inNamespace(...).withName(...).get().getMetadata().getName();
+    lenient().doReturn(podsMixedOperation).when(kubernetesClient).pods();
+    lenient().doReturn(podsNamespaceOperation).when(podsMixedOperation).inNamespace(anyString());
+    lenient().doReturn(podResource).when(podsNamespaceOperation).withName(anyString());
+    lenient().doReturn(pod).when(podResource).get();
+
+    // Model DSL:
+    // client.apps().deployments(...).inNamespace(...).withName(...).get().getMetadata().getName();
+    lenient().doReturn(apps).when(kubernetesClient).apps();
+    lenient().doReturn(deploymentsMixedOperation).when(apps).deployments();
+    lenient()
+        .doReturn(deploymentsNamespaceOperation)
+        .when(deploymentsMixedOperation)
+        .inNamespace(anyString());
+    lenient()
+        .doReturn(deploymentResource)
+        .when(deploymentsNamespaceOperation)
+        .withName(anyString());
+    lenient().doReturn(deployment).when(deploymentResource).get();
+    lenient().doReturn(deploymentMetadata).when(deployment).getMetadata();
 
     kubernetesDeployments = new KubernetesDeployments("namespace", "workspace123", clientFactory);
   }
@@ -99,7 +121,7 @@ public class KubernetesDeploymentsTest {
 
     // when
     verify(podResource).watch(watcherCaptor.capture());
-    watcher = watcherCaptor.getValue();
+    Watcher<Pod> watcher = watcherCaptor.getValue();
     watcher.eventReceived(Watcher.Action.MODIFIED, pod);
 
     // then
@@ -114,7 +136,7 @@ public class KubernetesDeploymentsTest {
 
     // when
     verify(podResource).watch(watcherCaptor.capture());
-    watcher = watcherCaptor.getValue();
+    Watcher<Pod> watcher = watcherCaptor.getValue();
     watcher.eventReceived(Watcher.Action.MODIFIED, pod);
 
     // then
@@ -138,7 +160,7 @@ public class KubernetesDeploymentsTest {
 
     // when
     verify(podResource).watch(watcherCaptor.capture());
-    watcher = watcherCaptor.getValue();
+    Watcher<Pod> watcher = watcherCaptor.getValue();
     watcher.eventReceived(Watcher.Action.MODIFIED, pod);
 
     // then
@@ -157,11 +179,12 @@ public class KubernetesDeploymentsTest {
           throws Exception {
     // given
     when(status.getPhase()).thenReturn(POD_STATUS_PHASE_FAILED);
+    when(podResource.getLog()).thenReturn("Pod fail log");
     CompletableFuture future = kubernetesDeployments.waitRunningAsync(POD_NAME);
 
     // when
     verify(podResource).watch(watcherCaptor.capture());
-    watcher = watcherCaptor.getValue();
+    Watcher<Pod> watcher = watcherCaptor.getValue();
     watcher.eventReceived(Watcher.Action.MODIFIED, pod);
 
     // then
@@ -179,16 +202,16 @@ public class KubernetesDeploymentsTest {
       shouldCompleteExceptionallyFutureForWaitingPodIfStatusIsFailedAndReasonNorLogsAreNotAvailable()
           throws Exception {
     // given
-    when(status.getPhase()).thenReturn(POD_STATUS_PHASE_FAILED);
     CompletableFuture future = kubernetesDeployments.waitRunningAsync(POD_NAME);
 
-    doThrow(new InfrastructureException("Failure while retrieving pod logs"))
+    when(status.getPhase()).thenReturn(POD_STATUS_PHASE_FAILED);
+    doThrow(new InfrastructureException("Unable to create client"))
         .when(clientFactory)
         .create(anyString());
 
     // when
     verify(podResource).watch(watcherCaptor.capture());
-    watcher = watcherCaptor.getValue();
+    Watcher<Pod> watcher = watcherCaptor.getValue();
     watcher.eventReceived(Watcher.Action.MODIFIED, pod);
 
     // then
@@ -198,7 +221,119 @@ public class KubernetesDeploymentsTest {
     } catch (ExecutionException e) {
       assertEquals(
           e.getCause().getMessage(),
-          "Pod 'podName' failed to start. Error occurred while fetching pod logs.");
+          "Pod 'podName' failed to start. Error occurred while fetching pod logs: Unable to create client");
     }
+  }
+
+  @Test
+  public void testDeleteNonExistingPodBeforeWatch() throws Exception {
+    final String POD_NAME = "nonExistingPod";
+    doReturn(POD_NAME).when(metadata).getName();
+
+    doReturn(Boolean.FALSE).when(podResource).delete();
+    Watch watch = mock(Watch.class);
+    doReturn(watch).when(podResource).watch(any());
+
+    new KubernetesDeployments("", "", clientFactory).doDeletePod(POD_NAME).get(5, TimeUnit.SECONDS);
+
+    verify(watch).close();
+  }
+
+  @Test
+  public void testDeletePodThrowingKubernetesClientExceptionShouldCloseWatch() throws Exception {
+    final String POD_NAME = "nonExistingPod";
+    doReturn(POD_NAME).when(metadata).getName();
+
+    doThrow(KubernetesClientException.class).when(podResource).delete();
+    Watch watch = mock(Watch.class);
+    doReturn(watch).when(podResource).watch(any());
+
+    try {
+      new KubernetesDeployments("", "", clientFactory)
+          .doDeletePod(POD_NAME)
+          .get(5, TimeUnit.SECONDS);
+    } catch (KubernetesInfrastructureException e) {
+      assertTrue(e.getCause() instanceof KubernetesClientException);
+      verify(watch).close();
+      return;
+    }
+    fail("The exception should have been rethrown");
+  }
+
+  @Test
+  public void testDeleteNonExistingDeploymentBeforeWatch() throws Exception {
+    final String DEPLOYMENT_NAME = "nonExistingPod";
+    doReturn(DEPLOYMENT_NAME).when(deploymentMetadata).getName();
+
+    doReturn(Boolean.FALSE).when(deploymentResource).delete();
+    Watch watch = mock(Watch.class);
+    doReturn(watch).when(podResource).watch(any());
+
+    new KubernetesDeployments("", "", clientFactory)
+        .doDeleteDeployment(DEPLOYMENT_NAME)
+        .get(5, TimeUnit.SECONDS);
+
+    verify(watch).close();
+  }
+
+  @Test
+  public void testDeleteDeploymentThrowingKubernetesClientExceptionShouldCloseWatch()
+      throws Exception {
+    final String DEPLOYMENT_NAME = "nonExistingPod";
+    doReturn(DEPLOYMENT_NAME).when(deploymentMetadata).getName();
+
+    doThrow(KubernetesClientException.class).when(deploymentResource).delete();
+    Watch watch = mock(Watch.class);
+    doReturn(watch).when(podResource).watch(any());
+
+    try {
+      new KubernetesDeployments("", "", clientFactory)
+          .doDeleteDeployment(DEPLOYMENT_NAME)
+          .get(5, TimeUnit.SECONDS);
+    } catch (KubernetesInfrastructureException e) {
+      assertTrue(e.getCause() instanceof KubernetesClientException);
+      verify(watch).close();
+      return;
+    }
+    fail("The exception should have been rethrown");
+  }
+
+  @Test
+  public void testDeletePodThrowingAnyExceptionShouldCloseWatch() throws Exception {
+    final String POD_NAME = "nonExistingPod";
+    doReturn(POD_NAME).when(metadata).getName();
+
+    doThrow(RuntimeException.class).when(podResource).delete();
+    Watch watch = mock(Watch.class);
+    doReturn(watch).when(podResource).watch(any());
+
+    try {
+      new KubernetesDeployments("", "", clientFactory)
+          .doDeletePod(POD_NAME)
+          .get(5, TimeUnit.SECONDS);
+    } catch (RuntimeException e) {
+      verify(watch).close();
+      return;
+    }
+    fail("The exception should have been rethrown");
+  }
+
+  @Test
+  public void testDeleteDeploymentThrowingAnyExceptionShouldCloseWatch() throws Exception {
+    final String DEPLOYMENT_NAME = "nonExistingPod";
+
+    doThrow(RuntimeException.class).when(deploymentResource).delete();
+    Watch watch = mock(Watch.class);
+    doReturn(watch).when(podResource).watch(any());
+
+    try {
+      new KubernetesDeployments("", "", clientFactory)
+          .doDeleteDeployment(DEPLOYMENT_NAME)
+          .get(5, TimeUnit.SECONDS);
+    } catch (RuntimeException e) {
+      verify(watch).close();
+      return;
+    }
+    fail("The exception should have been rethrown");
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -96,7 +96,6 @@ public class KubernetesNamespaceTest {
 
   @BeforeMethod
   public void setUp() throws Exception {
-    lenient().when(clientFactory.create()).thenReturn(kubernetesClient);
     lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
 
     lenient().doReturn(namespaceOperation).when(kubernetesClient).namespaces();

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -33,6 +33,7 @@ import org.eclipse.che.api.workspace.server.wsplugins.ChePluginsApplier;
 import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.InconsistentRuntimesDetector;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientTermination;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironmentProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
@@ -79,6 +80,7 @@ public class OpenShiftInfraModule extends AbstractModule {
     factories.addBinding(DockerImageEnvironment.TYPE).to(DockerImageEnvironmentFactory.class);
     factories.addBinding(Constants.NO_ENVIRONMENT_RECIPE_TYPE).to(NoEnvironmentFactory.class);
 
+    bind(InconsistentRuntimesDetector.class).asEagerSingleton();
     bind(RuntimeInfrastructure.class).to(OpenShiftInfrastructure.class);
 
     bind(KubernetesNamespaceFactory.class).to(OpenShiftProjectFactory.class);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/OpenShiftUniqueNamesProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/OpenShiftUniqueNamesProvisioner.java
@@ -35,10 +35,10 @@ public class OpenShiftUniqueNamesProvisioner extends UniqueNamesProvisioner<Open
     final Set<Route> routes = new HashSet<>(osEnv.getRoutes().values());
     osEnv.getRoutes().clear();
     for (Route route : routes) {
-      final ObjectMeta ingressMeta = route.getMetadata();
-      putLabel(route, Constants.CHE_ORIGINAL_NAME_LABEL, ingressMeta.getName());
+      final ObjectMeta routeMeta = route.getMetadata();
+      putLabel(route, Constants.CHE_ORIGINAL_NAME_LABEL, routeMeta.getName());
       final String routeName = Names.generateName("route");
-      ingressMeta.setName(routeName);
+      routeMeta.setName(routeName);
       osEnv.getRoutes().put(routeName, route);
     }
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -73,7 +73,6 @@ public class OpenShiftProjectTest {
 
   @BeforeMethod
   public void setUp() throws Exception {
-    lenient().when(clientFactory.create()).thenReturn(kubernetesClient);
     lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
     lenient().when(clientFactory.createOC()).thenReturn(openShiftClient);
     lenient().when(clientFactory.createOC(anyString())).thenReturn(openShiftClient);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -471,7 +471,7 @@ public class WorkspaceRuntimes {
         firstNonNull(
             sessionUserNameOr(workspace.getAttributes().get(WORKSPACE_STOPPED_BY)), "undefined");
     LOG.info(
-        "Workspace '{}/{}' with id '{}' is being stopped by user '{}'",
+        "Workspace '{}/{}' with id '{}' is stopping by user '{}'",
         workspace.getNamespace(),
         workspace.getConfig().getName(),
         workspace.getId(),
@@ -511,7 +511,7 @@ public class WorkspaceRuntimes {
           statuses.remove(workspaceId);
         }
         LOG.info(
-            "Workspace '{}/{}' with id '{}' stopped by user '{}'",
+            "Workspace '{}/{}' with id '{}' is stopped by user '{}'",
             workspace.getNamespace(),
             workspace.getConfig().getName(),
             workspaceId,
@@ -889,6 +889,13 @@ public class WorkspaceRuntimes {
             identity.getOwnerId());
       }
 
+      LOG.info(
+          "Runtime '{}:{}:{}' is stopping abnormally. Reason: {}",
+          workspaceId,
+          identity.getEnvName(),
+          identity.getOwnerId(),
+          event.getReason());
+
       publishWorkspaceStatusEvent(
           workspaceId,
           STOPPING,
@@ -919,6 +926,13 @@ public class WorkspaceRuntimes {
             identity.getEnvName(),
             identity.getOwnerId());
       }
+
+      LOG.info(
+          "Runtime '{}:{}:{}' is stopped abnormally. Reason: {}",
+          workspaceId,
+          identity.getEnvName(),
+          identity.getOwnerId(),
+          event.getReason());
 
       publishWorkspaceStatusEvent(
           workspaceId,

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -722,18 +722,18 @@ public class WorkspaceRuntimes {
    * Gets the workspaces identifiers managed by this component. If an identifier is present in set
    * then that workspace wasn't stopped at the moment of method execution.
    *
-   * @return workspaces identifiers for those workspaces that are running(not stopped), or an empty
-   *     set if there is no a single running workspace
+   * @return workspaces identifiers for those workspaces that are active(not stopped), or an empty
+   *     set if there is no a single active workspace
    */
-  public Set<String> getRunning() {
+  public Set<String> getActive() {
     return ImmutableSet.copyOf(statuses.asMap().keySet());
   }
 
   /**
-   * Returns true if there is at least one workspace running(it's status is different from {@link
+   * Returns true if there is at least one workspace active(it's status is different from {@link
    * WorkspaceStatus#STOPPED}), otherwise returns false.
    */
-  public boolean isAnyRunning() {
+  public boolean isAnyActive() {
     return !statuses.asMap().isEmpty();
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTermination.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTermination.java
@@ -145,7 +145,7 @@ public class WorkspaceServiceTermination implements ServiceTermination {
   }
 
   private void stopRunningAndStartingWorkspacesAsync() {
-    for (String workspaceId : runtimes.getRunning()) {
+    for (String workspaceId : runtimes.getActive()) {
       WorkspaceStatus status = runtimes.getStatus(workspaceId);
       if (status == WorkspaceStatus.RUNNING || status == WorkspaceStatus.STARTING) {
         try {
@@ -169,7 +169,7 @@ public class WorkspaceServiceTermination implements ServiceTermination {
     private final AtomicInteger currentlyStopped;
 
     private WorkspaceStoppedEventsPropagator() {
-      this.totalRunning = runtimes.getRunning().size();
+      this.totalRunning = runtimes.getActive().size();
       this.currentlyStopped = new AtomicInteger(0);
     }
 
@@ -221,7 +221,7 @@ public class WorkspaceServiceTermination implements ServiceTermination {
         new TimerTask() {
           @Override
           public void run() {
-            if (!runtimes.isAnyRunning()) {
+            if (!runtimes.isAnyActive()) {
               timer.cancel();
               latch.countDown();
             }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/InternalRuntime.java
@@ -169,7 +169,7 @@ public abstract class InternalRuntime<T extends RuntimeContext> {
    *     inconsistent status (e.g. stop(interrupt) might not be allowed during start)
    * @throws InfrastructureException when any other error occurs
    */
-  public final void stop(Map<String, String> stopOptions) throws InfrastructureException {
+  public void stop(Map<String, String> stopOptions) throws InfrastructureException {
     TracingTags.WORKSPACE_ID.set(getContext().getIdentity()::getWorkspaceId);
 
     markStopping();
@@ -202,7 +202,7 @@ public abstract class InternalRuntime<T extends RuntimeContext> {
   public abstract Map<String, String> getProperties();
 
   /** @return the Context */
-  public final T getContext() {
+  public T getContext() {
     return context;
   }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -559,7 +559,7 @@ public class WorkspaceManagerTest {
             })
         .when(runtimes)
         .injectRuntime(workspace);
-    lenient().when(runtimes.isAnyRunning()).thenReturn(true);
+    lenient().when(runtimes.isAnyActive()).thenReturn(true);
 
     return runtime;
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -550,6 +550,26 @@ public class WorkspaceRuntimesTest {
     assertTrue(active.containsAll(asList("ws1", "ws2", "ws3")));
   }
 
+  @Test
+  public void shouldReturnWorkspaceIdsOfRunningRuntimes() {
+    // given
+    when(statuses.asMap())
+        .thenReturn(
+            ImmutableMap.of(
+                "ws1", WorkspaceStatus.STARTING,
+                "ws2", WorkspaceStatus.RUNNING,
+                "ws3", WorkspaceStatus.RUNNING,
+                "ws4", WorkspaceStatus.RUNNING,
+                "ws5", WorkspaceStatus.STOPPING));
+
+    // when
+    Set<String> running = runtimes.getRunning();
+
+    // then
+    assertEquals(running.size(), 3);
+    assertTrue(running.containsAll(asList("ws2", "ws3", "ws4")));
+  }
+
   private RuntimeContext mockContext(RuntimeIdentity identity)
       throws ValidationException, InfrastructureException {
     RuntimeContext context = mock(RuntimeContext.class);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -543,7 +543,7 @@ public class WorkspaceRuntimesTest {
                 "ws3", WorkspaceStatus.STOPPING));
 
     // when
-    Set<String> active = runtimes.getRunning();
+    Set<String> active = runtimes.getActive();
 
     // then
     assertEquals(active.size(), 3);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTerminationTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTerminationTest.java
@@ -69,10 +69,10 @@ public class WorkspaceServiceTerminationTest {
     String workspaceId = "workspace123";
 
     AtomicBoolean isAnyRunning = new AtomicBoolean(true);
-    when(workspaceRuntimes.isAnyRunning()).thenAnswer(inv -> isAnyRunning.get());
+    when(workspaceRuntimes.isAnyActive()).thenAnswer(inv -> isAnyRunning.get());
 
     // one workspace is running
-    when(workspaceRuntimes.getRunning()).thenReturn(Collections.singleton(workspaceId));
+    when(workspaceRuntimes.getActive()).thenReturn(Collections.singleton(workspaceId));
     when(workspaceRuntimes.getStatus(workspaceId)).thenReturn(status);
 
     when(runtimeInfrastructure.getIdentities()).thenReturn(Collections.emptySet());
@@ -96,7 +96,7 @@ public class WorkspaceServiceTerminationTest {
     String workspaceId = "workspace123";
 
     // one workspace is running
-    when(workspaceRuntimes.getRunning()).thenReturn(Collections.singleton(workspaceId));
+    when(workspaceRuntimes.getActive()).thenReturn(Collections.singleton(workspaceId));
     when(workspaceRuntimes.getStatus(workspaceId)).thenReturn(WorkspaceStatus.RUNNING);
 
     when(workspaceRuntimes.isAnyInProgress())
@@ -115,7 +115,7 @@ public class WorkspaceServiceTerminationTest {
 
   @Test
   public void publishesStoppedWorkspaceStoppedEventsAsServiceItemStoppedEvents() throws Exception {
-    when(workspaceRuntimes.getRunning()).thenReturn(ImmutableSet.of("id1", "id2", "id3"));
+    when(workspaceRuntimes.getActive()).thenReturn(ImmutableSet.of("id1", "id2", "id3"));
     doAnswer(
             inv -> {
               @SuppressWarnings("unchecked")


### PR DESCRIPTION
### What does this PR do?
#### The main change
Sometimes it may happen that workspace Pods goes down when Che Server considers that workspace is `RUNNING`.
For example, the user stopped it from OpenShift/K8s console, admin can terminate (miner detection) pod or infrastructure node goes down.
The main purpose of this PR is adding a periodical job that will stop such Runtimes without existing pods.
It is disabled by default because there is possible Che Server configuration when Che Server doesn't have an ability to interact with Kubernetes API when operation is not invoked by user. And it may be enabled by configuring `che.infra.kubernetes.runtimes_consistency_check_period_min` property with value more than `0` (the corresponding environment variable `CHE_INFRA_KUBERNETES_RUNTIMES__CONSISTENCY__CHECK__PERIOD__MIN`).

It DOES work on the following configurations:
- workspaces objects are created in the same namespace where Che Server is located;
- cluster-admin service account token is mount to Che Server pod;

It DOES NOT work on the following configurations(InconsistentRuntimesDetector will fail to check runtime consistency):
- Che Server communicates with Kubernetes API using token from OAuth provider;

#### Related changes
It also contains the following changes which are needed to make it possible to implement such job:
- Add an ability to get running internal runtimes via WorkspaceRuntimes;
- Change 'running' word to 'active' not to avoid confusing with RUNNING status;
- Fix get pod by name method to return empty optional if pod doesn't exist;
- Add an ability to get running internal runtimes via WorkspaceRuntimes;

#### Major fixes
- I've discovered that `RuntimeHangingDetector` does not publish an abnormal stopped event when an exception occurred on stopping hanging k8s runtimes. It may lead to hanging workspace in `stopping` state. So, fixed it by publishing the abnormal stopped event in `finally` statement.

#### Minor fixes
It also contains other minor fixes:
- Fix creation k8s clients without workspace id specified;
- Fix tests for KubernetesDeployments;
Reviewers sorry for changes non-related to implemented to feature but I place them here because I discovered them during implementing PR goal feature and didn't create a separate PR not to spend additional time for `ci-build`/`ci-test` jobs.
- Fix typo: 'ingressMeta' -> 'routeMeta'

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12207

### How have you tested this PR?
This PR is tested on the following configurations:
- SingleUser Che Deployed on Minishift
- SingleUser Che Deployed on Minikube

#### Release Notes
Added a periodical job that will stop Runtimes which have no existing pods anymore. 
An example of a situation when such workspaces may appear may be a user stopped it from OpenShift/K8s console, admin terminates pod or infrastructure node goes down.
It is disabled by default. It may be enabled by configuring `CHE_INFRA_KUBERNETES_RUNTIMES__CONSISTENCY__CHECK__PERIOD__MIN` env var for Che Server with value more than `0`. 
Note that to make it working correctly it is needed to configure Che Server to have access token to Kubernetes/OpenShift cluster without user interaction:
- create workspace objects in the same namespace where Che Server is created.
- mount service account with cluster admin permissions to Che Server Pod.
So, and it won't work if OAuth provider is configured.


#### Docs PR
https://github.com/eclipse/che-docs/pull/652