### PR TITLE
[WIP DO NOT MERGE] Update license headers

### DIFF
--- a/assembly/assembly-workspace-loader-war/pom.xml
+++ b/assembly/assembly-workspace-loader-war/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2018 Red Hat, Inc.
+    Copyright (c) 2018 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/assembly/assembly-workspace-loader-war/src/main/java/org/eclipse/che/WSLoaderController.java
+++ b/assembly/assembly-workspace-loader-war/src/main/java/org/eclipse/che/WSLoaderController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/assembly/assembly-workspace-loader-war/src/main/webapp/WEB-INF/web.xml
+++ b/assembly/assembly-workspace-loader-war/src/main/webapp/WEB-INF/web.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2018 Red Hat, Inc.
+    Copyright (c) 2018 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/pom.xml
+++ b/dockerfiles/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2018 Red Hat, Inc.
+    Copyright (c) 2018 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/theia-dev/pom.xml
+++ b/dockerfiles/theia-dev/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2018 Red Hat, Inc.
+    Copyright (c) 2018 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/theia-dev/src/entrypoint.sh
+++ b/dockerfiles/theia-dev/src/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018-2018 Red Hat, Inc.
+# Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/theia/pom.xml
+++ b/dockerfiles/theia/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2018 Red Hat, Inc.
+    Copyright (c) 2018 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dockerfiles/theia/src/entrypoint.sh
+++ b/dockerfiles/theia/src/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2018-2018 Red Hat, Inc.
+# Copyright (c) 2018 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/EvaluateExpressionTest.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/EvaluateExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/GetValueTest.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/GetValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/StackFrameDumpTest.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/StackFrameDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/util/JavaDebuggerTestUtils.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/java/org/eclipse/che/plugin/jdb/server/util/JavaDebuggerTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/testclasses/BreakpointsTest.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/testclasses/BreakpointsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/testclasses/GetValueTest.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/testclasses/GetValueTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/testclasses/HelloWorld.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/testclasses/HelloWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/testclasses/StackFrameDumpTest.java
+++ b/plugins/plugin-java-debugger/che-plugin-java-debugger-server/src/test/resources/testclasses/StackFrameDumpTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/GetEffectivePomAction.java
+++ b/plugins/plugin-java/che-plugin-java-ext-lang-client/src/main/java/org/eclipse/che/ide/ext/java/client/action/GetEffectivePomAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/plugins/plugin-testing-java/plugin-testing-base/src/main/java/org/eclipse/che/plugin/java/testing/ClasspathUtil.java
+++ b/plugins/plugin-testing-java/plugin-testing-base/src/main/java/org/eclipse/che/plugin/java/testing/ClasspathUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012-2018 Red Hat, Inc.
+ * Copyright (c) 2012-2017 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/pom.xml
+++ b/workspace-loader/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018-2018 Red Hat, Inc.
+    Copyright (c) 2018 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/custom.d.ts
+++ b/workspace-loader/src/custom.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/index.html
+++ b/workspace-loader/src/index.html
@@ -1,6 +1,6 @@
 <!--
 
-    Copyright (c) 2018-2018 Red Hat, Inc.
+    Copyright (c) 2018 Red Hat, Inc.
     This program and the accompanying materials are made
     available under the terms of the Eclipse Public License 2.0
     which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/index.ts
+++ b/workspace-loader/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/json-rpc/che-json-rpc-api-service.ts
+++ b/workspace-loader/src/json-rpc/che-json-rpc-api-service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/json-rpc/che-json-rpc-master-api.ts
+++ b/workspace-loader/src/json-rpc/che-json-rpc-master-api.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/json-rpc/json-rpc-client.ts
+++ b/workspace-loader/src/json-rpc/json-rpc-client.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/json-rpc/util.ts
+++ b/workspace-loader/src/json-rpc/util.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/json-rpc/websocket-client.ts
+++ b/workspace-loader/src/json-rpc/websocket-client.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/loader/loader.ts
+++ b/workspace-loader/src/loader/loader.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/workspace-loader/src/style.css
+++ b/workspace-loader/src/style.css
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018-2018 Red Hat, Inc.
+ * Copyright (c) 2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adapting to `license-maven-plugin-git` extension, that would be used for checking license years: https://github.com/mycila/license-maven-plugin/tree/master/license-maven-plugin-git

here are the changes to existing files
- license headers with starting and ending years being the same year, would be collapsed into one - e.g. "2018-2018"  would be transformed into "2018"
- there are some files, that have last year in license header as 2018, however git indicates those files being last changed in 2017 (date of commit).
 This causes an odd behaviour of license plugin - mvn license:check cannot pass, because it wants year 2017, but setting it to 2017 and running maven license:check again would fail, because it picks up the last change from git, that was made now (in 2018), so it wants 2018 again, creating a loop situation.

The solution to this is described on `license-maven-plugin-git` page, is to make two commits, one which will make changes to files ending on -2017, and the next commit that will change it back to 2018. This is why it is important to merge this PR without squash, with two commits as is.

This PR should be merged only after respective changes in che-parent and che-dev
https://github.com/eclipse/che-dev/pull/16