### PR TITLE
Fix the output of the GET /activity to just contain the array of ws ids

### DIFF
--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityService.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityService.java
@@ -130,6 +130,6 @@ public class WorkspaceActivityService extends Service {
     Page<String> data =
         workspaceActivityManager.findWorkspacesInStatus(status, limit, maxItems, skipCount);
 
-    return Response.ok(data).header("Link", createLinkHeader(data)).build();
+    return Response.ok(data.getItems()).header("Link", createLinkHeader(data)).build();
   }
 }

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityServiceTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityServiceTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.activity;
 
 import static com.jayway.restassured.RestAssured.given;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -134,7 +135,7 @@ public class WorkspaceActivityServiceTest {
   public void shouldIgnoredMinDurationWhenThresholdSpecified() throws Exception {
     when(workspaceActivityManager.findWorkspacesInStatus(
             eq(WorkspaceStatus.STOPPED), anyLong(), anyInt(), anyLong()))
-        .thenReturn(new Page<>(emptyList(), 0, 1, 0));
+        .thenReturn(new Page<>(singletonList("ws-1"), 0, 1, 1));
 
     Response response =
         given()
@@ -142,6 +143,7 @@ public class WorkspaceActivityServiceTest {
             .get(URI.create(SERVICE_PATH + "?status=STOPPED&threshold=15&minDuration=55"));
 
     assertEquals(response.getStatusCode(), 200);
+    assertEquals(response.getBody().print(), "[\"ws-1\"]");
     verify(workspaceActivityManager, times(1))
         .findWorkspacesInStatus(
             eq(WorkspaceStatus.STOPPED), eq(15L), eq(Pages.DEFAULT_PAGE_SIZE), eq(0L));


### PR DESCRIPTION
### What does this PR do?
The new `GET /activity` REST endpoint introduced by #12177 returns the full serialized page object as its output instead of just the array of workspace ids as it was meant to return.

This PR fixes that and also adds a test for it.

#### What issues does this PR reference?

#12091 
