### PR TITLE
Selenium: add selenium tests to UNDER_REPAIR group

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
@@ -101,7 +101,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.selectTabByName(APP_CLASS_NAME);
   }
 
-  @Test(groups = UNDER_REPAIR)
+  @Test
   public void shouldDisplayJavaDocOfClassMethod() throws Exception {
     // given
     final String expectedJavadocHtmlText =
@@ -155,7 +155,7 @@ public class AutocompleteProposalJavaDocTest {
     checkProposalDocumentationHTML("<p>No documentation found.</p>\n");
   }
 
-  @Test(groups = UNDER_REPAIR)
+  @Test
   public void shouldDisplayAnotherModuleClassJavaDoc() throws IOException {
     // when
     editor.waitActive();
@@ -211,7 +211,7 @@ public class AutocompleteProposalJavaDocTest {
     editor.waitProposalDocumentationHTML("UPDATE. Implementation of Book interface.");
   }
 
-  @Test(groups = UNDER_REPAIR)
+  @Test
   public void shouldDisplayJavaDocOfJreClass() throws IOException {
     // when
     editor.waitActive();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/autocomplete/AutocompleteProposalJavaDocTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /** @author Dmytro Nochevnov */
+@Test(groups = UNDER_REPAIR)
 public class AutocompleteProposalJavaDocTest {
   private static final String PROJECT = "multi-module-java-with-ext-libs";
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCentosNodeStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCentosNodeStackTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsCons
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.BUILD_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.RUN_GOAL;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.CENTOS_NODEJS;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
@@ -31,6 +32,7 @@ import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -86,11 +88,16 @@ public class CreateWorkspaceFromCentosNodeStackTest {
   public void checkAngularPatternfyStarterProjectCommands() {
     By textOnPreviewPage = By.xpath("//span[text()='UNIFIED MANAGEMENT EXPERIENCE']");
 
-    consoles.executeCommandFromProjectExplorer(
-        ANGULAR_PROJECT,
-        BUILD_GOAL,
-        INSTALL_DEPENDENCIES_COMMAND_ITEM.getItem(ANGULAR_PROJECT),
-        "bower_components/font-awesome");
+    try {
+      consoles.executeCommandFromProjectExplorer(
+          ANGULAR_PROJECT,
+          BUILD_GOAL,
+          INSTALL_DEPENDENCIES_COMMAND_ITEM.getItem(ANGULAR_PROJECT),
+          "bower_components/font-awesome");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known permanent failure https://github.com/eclipse/che/issues/12259");
+    }
 
     consoles.executeCommandFromProjectExplorer(
         ANGULAR_PROJECT, RUN_GOAL, RUN_COMMAND_ITEM.getItem(ANGULAR_PROJECT), "Waiting...");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCentosNodeStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromCentosNodeStackTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.stack;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsConstants.CommandItem.INSTALL_DEPENDENCIES_COMMAND_ITEM;
 import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsConstants.CommandItem.RUN_COMMAND_ITEM;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.BUILD_GOAL;
@@ -81,7 +82,7 @@ public class CreateWorkspaceFromCentosNodeStackTest {
     projectExplorer.waitProjectInitialization(WEB_NODE_JS_PROJECT);
   }
 
-  @Test(priority = 1)
+  @Test(priority = 1, groups = UNDER_REPAIR)
   public void checkAngularPatternfyStarterProjectCommands() {
     By textOnPreviewPage = By.xpath("//span[text()='UNIFIED MANAGEMENT EXPERIENCE']");
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
@@ -91,11 +91,16 @@ public class CreateWorkspaceFromNodeStackTest {
   public void checkAngularPatternfyStarterProjectCommands() {
     By textOnPreviewPage = By.xpath("//span[text()='UNIFIED MANAGEMENT EXPERIENCE']");
 
-    consoles.executeCommandFromProjectExplorer(
-        ANGULAR_PROJECT,
-        BUILD_GOAL,
-        INSTALL_DEPENDENCIES_COMMAND_ITEM.getItem(ANGULAR_PROJECT),
-        "bower_components/font-awesome");
+    try {
+      consoles.executeCommandFromProjectExplorer(
+          ANGULAR_PROJECT,
+          BUILD_GOAL,
+          INSTALL_DEPENDENCIES_COMMAND_ITEM.getItem(ANGULAR_PROJECT),
+          "bower_components/font-awesome");
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known permanent failure https://github.com/eclipse/che/issues/12259");
+    }
 
     consoles.executeCommandFromProjectExplorer(
         ANGULAR_PROJECT, RUN_GOAL, RUN_COMMAND_ITEM.getItem(ANGULAR_PROJECT), "Waiting...");

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.stack;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsConstants.CommandItem.INSTALL_DEPENDENCIES_COMMAND_ITEM;
 import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsConstants.CommandItem.RUN_COMMAND_ITEM;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.BUILD_GOAL;
@@ -86,7 +87,7 @@ public class CreateWorkspaceFromNodeStackTest {
     projectExplorer.waitProjectInitialization(WEB_NODE_JS_PROJECT);
   }
 
-  @Test(priority = 1)
+  @Test(priority = 1, groups = UNDER_REPAIR)
   public void checkAngularPatternfyStarterProjectCommands() {
     By textOnPreviewPage = By.xpath("//span[text()='UNIFIED MANAGEMENT EXPERIENCE']");
 


### PR DESCRIPTION
### What does this PR do?
This PR:
- adds **AutocompleteProposalJavaDocTest** selenium test to UNDER_REPAIR group;
- add checking ```angular-patternfly-starter``` sample project  in **CreateWorkspaceFromNodeStackTest** selenium test to UNDER_REPAIR group(https://github.com/eclipse/che/issues/12259).
