### PR TITLE
Make documentation links configurable

### DIFF
--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
@@ -13,6 +13,7 @@
 import {CheAPI} from '../../../../../components/api/che-api.factory';
 import {CheNotification} from '../../../../../components/notification/che-notification.factory';
 import {ConfirmDialogService} from '../../../../../components/service/confirm-dialog/confirm-dialog.service';
+import {CheBranding} from '../../../../../components/branding/che-branding.factory';
 
 /**
  * Controller for a factory information.
@@ -20,7 +21,7 @@ import {ConfirmDialogService} from '../../../../../components/service/confirm-di
  */
 export class FactoryInformationController {
 
-  static $inject = ['$scope', 'cheAPI', 'cheNotification', '$location', '$log', '$timeout', 'lodash', '$filter', '$q', 'confirmDialogService'];
+  static $inject = ['$scope', 'cheAPI', 'cheNotification', '$location', '$log', '$timeout', 'lodash', '$filter', '$q', 'cheBranding', 'confirmDialogService'];
 
   private confirmDialogService: ConfirmDialogService;
   private cheAPI: CheAPI;
@@ -47,6 +48,7 @@ export class FactoryInformationController {
   private workspaceConfig: any;
   private origName: string;
   private isEditorContentChanged: boolean = false;
+  private factoryDocs: string;
 
   /**
    * Default constructor that is using resource injection
@@ -60,6 +62,7 @@ export class FactoryInformationController {
               lodash: any,
               $filter: ng.IFilterService,
               $q: ng.IQService,
+              cheBranding: CheBranding,
               confirmDialogService: ConfirmDialogService) {
     this.cheAPI = cheAPI;
     this.cheNotification = cheNotification;
@@ -70,6 +73,7 @@ export class FactoryInformationController {
     this.lodash = lodash;
     this.$filter = $filter;
     this.confirmDialogService = confirmDialogService;
+    this.factoryDocs = cheBranding.getDocs().factory;
 
     this.timeoutPromise = null;
     $scope.$on('$destroy', () => {

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.html
@@ -178,7 +178,7 @@
       </md-content>
       <div layout="row" flex>
         <div>
-          <a href="/docs/factories-getting-started.html" target="_blank">Factory configuration docs</a>
+          <a ng-href="{{factoryInformationController.factoryDocs}}" target="_blank">Factory configuration docs</a>
         </div>
         <div layout="row" layout-align="end start" flex>
           <div>

--- a/dashboard/src/app/factories/list-factories/list-factories.html
+++ b/dashboard/src/app/factories/list-factories/list-factories.html
@@ -12,7 +12,7 @@
 
 -->
 <che-toolbar che-title="All factories" border-none></che-toolbar>
-<che-description che-link-title="Learn more." che-link="/docs/factories-getting-started.html">
+<che-description che-link-title="Learn more." che-link="{{branding.docs.factory}}">
   Factories enable workspace automation and are packaged as a consumer-friendly URL. Create new Factories to onboard your team, or integrate
   with your toolchain.
 </che-description>

--- a/dashboard/src/app/organizations/organizations.html
+++ b/dashboard/src/app/organizations/organizations.html
@@ -1,5 +1,5 @@
 <che-toolbar che-title="Organizations" border-none></che-toolbar>
-<che-description che-link-title="Learn more." che-link="/docs/organizations.html">Organizations allow
+<che-description che-link-title="Learn more." che-link="{{branding.docs.organization}}">Organizations allow
   groups of developers to collaborate with private and shared workspaces. Resources and permissions are controlled and
   allocated within the organization by administrator.
 </che-description>

--- a/dashboard/src/assets/branding/product.json
+++ b/dashboard/src/assets/branding/product.json
@@ -21,6 +21,9 @@
   },
   "docs" : {
     "stack" : "/docs/creating-starting-workspaces.html",
-    "workspace" : "/docs/what-are-workspaces.html"
+    "workspace" : "/docs/what-are-workspaces.html",
+    "factory" : "/docs/factories-getting-started.html",
+    "organization": "/docs/organizations.html",
+    "general": "/docs"
   }
 }

--- a/dashboard/src/components/branding/che-branding.factory.ts
+++ b/dashboard/src/components/branding/che-branding.factory.ts
@@ -32,6 +32,9 @@ interface IBranding {
   docs?: {
     stack?: string;
     workspace?: string;
+    factory?: string;
+    organization?: string;
+    general?: string;
   };
   workspace?: {
     priorityStacks?: Array<string>;
@@ -58,6 +61,9 @@ const DEFAULT_CLI_NAME = 'che.env';
 const DEFAULT_CLI_CONFIG_NAME = 'CHE';
 const DEFAULT_DOCS_STACK = '/docs/getting-started/runtime-stacks/index.html';
 const DEFAULT_DOCS_WORKSPACE = '/docs/getting-started/intro/index.html';
+const DEFAULT_DOCS_ORGANIZATION = '/docs/organizations.html';
+const DEFAULT_DOCS_FACTORY = '/docs/factories-getting-started.html';
+const DEFAULT_DOCS_GENERAL = '/docs';
 const DEFAULT_WORKSPACE_PRIORITY_STACKS = ['Java', 'Java-MySQL', 'Blank'];
 const DEFAULT_WORKSPACE_DEFAULT_STACK = 'java-mysql';
 const DEFAULT_WORKSPACE_CREATION_LINK = '#/create-workspace';
@@ -281,12 +287,15 @@ export class CheBranding {
 
   /**
    * Returns object with docs URLs.
-   * @returns {{stack: string, workspace: string}}
+   * @returns {{stack: string, workspace: string, factory: string, organization: string, general: string}}
    */
-  getDocs(): { stack: string; workspace: string } {
+  getDocs(): { stack: string; workspace: string; factory: string; organization: string; general: string } {
     return {
       stack: this.brandingData.docs && this.brandingData.docs.stack ? this.brandingData.docs.stack : DEFAULT_DOCS_STACK,
-      workspace: this.brandingData.docs && this.brandingData.docs.workspace ? this.brandingData.docs.workspace : DEFAULT_DOCS_WORKSPACE
+      workspace: this.brandingData.docs && this.brandingData.docs.workspace ? this.brandingData.docs.workspace : DEFAULT_DOCS_WORKSPACE,
+      factory: this.brandingData.docs && this.brandingData.docs.factory ? this.brandingData.docs.factory : DEFAULT_DOCS_FACTORY,
+      organization: this.brandingData.docs && this.brandingData.docs.organization ? this.brandingData.docs.organization : DEFAULT_DOCS_ORGANIZATION,
+      general: this.brandingData.docs && this.brandingData.docs.general ? this.brandingData.docs.general : DEFAULT_DOCS_GENERAL
     };
   }
 

--- a/dashboard/src/components/widget/footer/che-footer.directive.ts
+++ b/dashboard/src/components/widget/footer/che-footer.directive.ts
@@ -81,6 +81,7 @@ export class CheFooter {
       supportHelpTitle: '@cheSupportHelpTitle',
       supportEmail: '@cheSupportEmail',
       logo: '@cheLogo',
+      docs: '@cheDocs',
       version: '@cheVersion',
       productName: '@cheProductName',
       links: '=cheLinks',

--- a/dashboard/src/components/widget/footer/che-footer.html
+++ b/dashboard/src/components/widget/footer/che-footer.html
@@ -20,7 +20,7 @@
        ng-href="{{'mailto:' + cheFooterController.supportEmail + cheFooterController.getWishEmailSubject(cheFooterController.productName)}}">Make a wish</a>
     <a class="che-footer-button-blue che-footer-button" id="footer-email" ng-if="cheFooterController.email"
        ng-href="{{'mailto:' + cheFooterController.email.address + cheFooterController.getEmailSubject(cheFooterController.email.subject)}}">{{cheFooterController.email.title}}</a>
-    <a class="che-footer-button-blue che-footer-button" id="footer-docs" href="/docs" target="_blank">Docs</a>
+    <a class="che-footer-button-blue che-footer-button" id="footer-docs" ng-if="cheFooterController.docs" ng-href="{{cheFooterController.docs}}" target="_blank">Docs</a>
     <a class="che-footer-button-blue che-footer-button" id="footer-support" ng-if="cheFooterController.supportHelpPath && cheFooterController.supportHelpTitle"
        ng-href="{{cheFooterController.supportHelpPath}}" target="_blank">{{cheFooterController.supportHelpTitle}}</a>
 

--- a/dashboard/src/index.html
+++ b/dashboard/src/index.html
@@ -57,6 +57,7 @@
                 che-product-name="Eclipse Che"
                 che-links="branding.footer.links"
                 che-email="branding.footer.email"
+                che-docs="{{branding.docs.general}}"
                 ng-show="waitingLoaded && !showIDE">
       {{branding.footer.content}}
     </che-footer>


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
 Makes links to documentation - factories, organizations, stacks, general docs - configurable by product.json.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12052
