### PR TITLE
Exclude flaky selenium tests from execution by default

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -79,6 +79,7 @@ initVariables() {
     PRODUCT_HOST=$(detectDockerInterfaceIp)
     PRODUCT_PORT=8080
     INCLUDE_TESTS_UNDER_REPAIR=false
+    INCLUDE_FLAKY_TESTS=false
 
     unset DEBUG_OPTIONS
     unset MAVEN_OPTIONS
@@ -151,6 +152,7 @@ checkParameters() {
         elif [[ "$var" == --multiuser ]]; then :
         elif [[ "$var" =~ --exclude=.* ]]; then :
         elif [[ "$var" =~ --include-tests-under-repair ]]; then :
+        elif [[ "$var" =~ --include-flaky-tests ]]; then :
 
         else
             printHelp
@@ -213,6 +215,9 @@ applyCustomOptions() {
 
         elif [[ "$var" == --include-tests-under-repair ]]; then
             INCLUDE_TESTS_UNDER_REPAIR=true
+
+        elif [[ "$var" == --include-flaky-tests ]]; then
+            INCLUDE_FLAKY_TESTS=true
 
         fi
     done
@@ -424,6 +429,7 @@ Other options:
     --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
                                         Default value is 0, that means that test workspaces are created on demand.
     --include-tests-under-repair        Include tests which belong to group 'UNDER REPAIR'
+    --include-flaky-tests               Include tests which randomly failed and so belong to group 'FLAKY'
 
 HOW TO of usage:
     Test Eclipse Che single user assembly:
@@ -441,8 +447,8 @@ HOW TO of usage:
     Run suite:
         ${CALLER} <...> --suite=<PATH_TO_SUITE>
 
-    Include tests which belong to group 'UNDER REPAIR'
-        ./selenium-tests.sh --include-tests-under-repair
+    Include tests which belong to groups 'UNDER REPAIR' and 'FLAKY'
+        ./selenium-tests.sh --include-tests-under-repair --include-flaky-tests
 
     Rerun failed tests:
         ${CALLER} <...> --failed-tests
@@ -737,6 +743,10 @@ getExcludedGroups() {
 
     if [[ ${INCLUDE_TESTS_UNDER_REPAIR} == false ]]; then
       excludeParamArray+=( 'under_repair' )
+    fi
+
+    if [[ ${INCLUDE_FLAKY_TESTS} == false ]]; then
+      excludeParamArray+=( 'flaky' )
     fi
 
     echo $(IFS=$','; echo "${excludeParamArray[*]}")

--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -428,8 +428,8 @@ Other options:
     --skip-sources-validation           Fast build. Skips source validation and enforce plugins
     --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
                                         Default value is 0, that means that test workspaces are created on demand.
-    --include-tests-under-repair        Include tests which belong to group 'UNDER REPAIR'
-    --include-flaky-tests               Include tests which randomly failed and so belong to group 'FLAKY'
+    --include-tests-under-repair        Include tests which permanently fail and so belong to group 'UNDER REPAIR'
+    --include-flaky-tests               Include tests which randomly fail and so belong to group 'FLAKY'
 
 HOW TO of usage:
     Test Eclipse Che single user assembly:

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/TestGroup.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/TestGroup.java
@@ -21,4 +21,5 @@ public interface TestGroup {
   String OSIO = "osio";
   String K8S = "k8s";
   String UNDER_REPAIR = "under_repair";
+  String FLAKY = "flaky";
 }

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/TestFilter.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/inject/TestFilter.java
@@ -85,6 +85,7 @@ public class TestFilter {
     groups.remove(TestGroup.MULTIUSER);
     groups.remove(TestGroup.GITHUB);
     groups.remove(TestGroup.UNDER_REPAIR);
+    groups.remove(TestGroup.FLAKY);
     if (!groups.isEmpty() && !groups.contains(infrastructure.toString().toLowerCase())) {
       annotation.setEnabled(false);
     }

--- a/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/TestFilterTest.java
+++ b/selenium/che-selenium-core/src/test/java/org/eclipse/che/selenium/core/inject/TestFilterTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.core.inject;
 
 import static org.eclipse.che.selenium.core.TestGroup.DOCKER;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.TestGroup.GITHUB;
 import static org.eclipse.che.selenium.core.TestGroup.K8S;
 import static org.eclipse.che.selenium.core.TestGroup.MULTIUSER;
@@ -73,7 +74,7 @@ public class TestFilterTest {
         CHE_SINGLEUSER,
         Infrastructure.OPENSHIFT
       },
-      {new String[] {OPENSHIFT, UNDER_REPAIR}, GITHUB, CHE_MULTIUSER, Infrastructure.DOCKER},
+      {new String[] {OPENSHIFT, FLAKY}, GITHUB, CHE_MULTIUSER, Infrastructure.DOCKER},
       {new String[] {MULTIUSER}, SOME_GROUP, CHE_SINGLEUSER, Infrastructure.DOCKER},
       {
         new String[] {OPENSHIFT, OSIO}, EMPTY_EXCLUDED_GROUPS, CHE_SINGLEUSER, Infrastructure.DOCKER

--- a/selenium/che-selenium-test/README.md
+++ b/selenium/che-selenium-test/README.md
@@ -124,7 +124,8 @@ Other options:
     --skip-sources-validation           Fast build. Skips source validation and enforce plugins
     --workspace-pool-size=[<SIZE>|auto] Size of test workspace pool.
                                         Default value is 0, that means that test workspaces are created on demand.
-    --include-tests-under-repair        Include tests which belong to group 'UNDER REPAIR'        
+    --include-tests-under-repair        Include tests which permanently fail and so belong to group 'UNDER REPAIR'
+    --include-flaky-tests               Include tests which randomly fail and so belong to group 'FLAKY'        
 
 HOW TO of usage:
     Test Eclipse Che single user assembly:
@@ -142,8 +143,8 @@ HOW TO of usage:
     Run suite:
         ./selenium-tests.sh <...> --suite=<PATH_TO_SUITE>
 
-    Include tests which belong to group 'UNDER REPAIR'
-        ./selenium-tests.sh --include-tests-under-repair
+    Include tests which belong to groups 'UNDER REPAIR' and 'FLAKY'
+        ./selenium-tests.sh --include-tests-under-repair --include-flaky-tests
          
     Rerun failed tests:
         ./selenium-tests.sh <...> --failed-tests

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -12,7 +12,7 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.JAVA;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
@@ -125,7 +125,7 @@ public class CreateAndDeleteProjectsTest {
     notificationsPopupPanel.waitPopupPanelsAreClosed();
   }
 
-  @Test(priority = 1, groups = UNDER_REPAIR)
+  @Test(priority = 1, groups = FLAKY)
   public void deleteProjectsFromDashboardTest() {
     switchToWindow(dashboardWindow);
     dashboard.selectWorkspacesItemOnDashboard();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/ShareWorkspaceOwnerTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/organization/ShareWorkspaceOwnerTest.java
@@ -37,7 +37,14 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-@Test(groups = {TestGroup.MULTIUSER, TestGroup.DOCKER, TestGroup.OPENSHIFT, TestGroup.K8S})
+@Test(
+    groups = {
+      TestGroup.MULTIUSER,
+      TestGroup.DOCKER,
+      TestGroup.OPENSHIFT,
+      TestGroup.K8S,
+      TestGroup.FLAKY
+    })
 public class ShareWorkspaceOwnerTest {
 
   private static final String WORKSPACE_NAME = generate("workspace", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/ChangeVariableWithEvaluatingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/ChangeVariableWithEvaluatingTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.debugger;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -45,8 +46,10 @@ import org.eclipse.che.selenium.pageobject.intelligent.CommandsPalette;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = FLAKY)
 public class ChangeVariableWithEvaluatingTest {
   private static final String PROJECT_NAME_CHANGE_VARIABLE =
       NameGenerator.generate(ChangeVariableWithEvaluatingTest.class.getSimpleName(), 2);
@@ -111,6 +114,7 @@ public class ChangeVariableWithEvaluatingTest {
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME_CHANGE_VARIABLE);
   }
 
+  @Test
   public void changeVariableTest() throws Exception {
     buildProjectAndOpenMainClass();
     commandsPalette.openCommandPalette();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/InnerClassAndLambdaDebuggingTest.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.che.selenium.debugger;
 
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.pageobject.debug.DebugPanel.DebuggerActionButtons.BTN_DISCONNECT;
 import static org.eclipse.che.selenium.pageobject.debug.DebugPanel.DebuggerActionButtons.RESUME_BTN_ID;
 import static org.testng.Assert.fail;
@@ -42,7 +42,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /** @author Dmytro Nochevnov */
-@Test(groups = UNDER_REPAIR)
+@Test(groups = FLAKY)
 public class InnerClassAndLambdaDebuggingTest {
   private static final String PROJECT = "java-inner-lambda";
   private static final String PATH_TO_CLASS = PROJECT + "/src/main/java/test/App.java";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/NodeJsDebugTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/NodeJsDebugTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.debugger;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.REDRAW_UI_ELEMENTS_TIMEOUT_SEC;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -43,6 +44,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** Created by mmusienko on 12.02.17. */
+@Test(groups = FLAKY)
 public class NodeJsDebugTest {
 
   private static final String PROJECT_NAME =

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/debugger/StepIntoStepOverStepReturnWithChangeVariableTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.debugger;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestProjectExplorerContextMenuConstants.ContextMenuCommandGoals.COMMON_GOAL;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOADER_TIMEOUT_SEC;
 import static org.testng.Assert.assertTrue;
@@ -49,6 +50,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = FLAKY)
 public class StepIntoStepOverStepReturnWithChangeVariableTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(StepIntoStepOverStepReturnWithChangeVariableTest.class);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/CheckRestoringSplitEditorTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.editor;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_JAVA_MULTIMODULE;
@@ -43,6 +44,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = FLAKY)
 public class CheckRestoringSplitEditorTest {
   private String javaClassName = "AppController.java";
   private String readmeFileName = "README.md";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/editor/ContextMenuEditorTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.editor;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.ContextMenuLocator.CLOSE;
 import static org.eclipse.che.selenium.pageobject.CodenvyEditor.ContextMenuLocator.FIND;
@@ -270,7 +271,7 @@ public class ContextMenuEditorTest {
     editor.closeFileByNameWithSaving("ModelAndView.class");
   }
 
-  @Test(priority = 6, alwaysRun = true)
+  @Test(priority = 6, alwaysRun = true, groups = FLAKY)
   public void checkRefactoring() {
     final String editorTabName = "Test1";
     final String renamedEditorTabName = "Zclass";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithMultiModuleTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithMultiModuleTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.factory;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.testng.Assert.fail;
 
@@ -38,6 +39,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = FLAKY)
 public class CheckFactoryWithMultiModuleTest {
   private static final String PROJECT_NAME = NameGenerator.generate("project", 6);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerClickCreatePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerClickCreatePolicyTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -31,6 +32,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Mihail Kuznyetsov */
+@Test(groups = FLAKY)
 public class CheckFactoryWithPerClickCreatePolicyTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Dashboard dashboard;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckFactoryWithPerUserCreatePolicyTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
@@ -34,7 +35,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Mihail Kuznyetsov */
-@Test(groups = UNDER_REPAIR)
+@Test(groups = {FLAKY, UNDER_REPAIR})
 public class CheckFactoryWithPerUserCreatePolicyTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private Dashboard dashboard;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.factory;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.CREATE_PROJECT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.WIDGET_TIMEOUT_SEC;
@@ -41,6 +42,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
+@Test(groups = FLAKY)
 public class CheckOpenFileFeatureTest {
   private static final String PROJECT_NAME = CheckOpenFileFeatureTest.class.getSimpleName();
   private static final String OPEN_FILE_URL = "/CheckOpenFileFeatureTest/pom.xml";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromUiWithKeepDirTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestGitConstants.CONFIGURING_PROJECT_AND_CLONING_SOURCE_CODE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.CREATE_FACTORY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.IMPORT_PROJECT;
@@ -54,6 +55,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = FLAKY)
 public class CreateFactoryFromUiWithKeepDirTest {
   private static final String PROJECT_NAME = generate("project", 5);
   private static final String PROJECT_URL = "https://github.com/spring-guides/gs-rest-service";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolderTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolderTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.factory;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.TestGroup.GITHUB;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -36,7 +37,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
-@Test(groups = {GITHUB})
+@Test(groups = {GITHUB, FLAKY})
 public class DirectUrlFactoryWithRootFolderTest {
   @Inject private ProjectExplorer projectExplorer;
   @Inject private DefaultTestUser testUser;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/RemoveFilesWithActiveTabs.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/filewatcher/RemoveFilesWithActiveTabs.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.filewatcher;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Edit.DELETE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Edit.EDIT;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
@@ -39,6 +40,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = FLAKY)
 public class RemoveFilesWithActiveTabs {
   private static final String PROJECT_NAME = NameGenerator.generate("project", 6);
   @Inject private TestWorkspace ws;

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportWizardFormTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/ImportWizardFormTest.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.che.selenium.git;
 
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Git.BRANCHES;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Git.GIT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.IMPORT_PROJECT;
@@ -408,7 +408,7 @@ public class ImportWizardFormTest {
     editor.waitActive();
   }
 
-  @Test(priority = 1, groups = UNDER_REPAIR)
+  @Test(priority = 1, groups = FLAKY)
   public void checkImportProjectSubmoduleByHttpsUrl() {
     projectExplorer.waitProjectExplorer();
     currentProjectName = multimoduleRepo.getName() + "Https";
@@ -418,7 +418,7 @@ public class ImportWizardFormTest {
     openAndCheckRegularSubmodule(currentProjectName);
   }
 
-  @Test(priority = 1, groups = UNDER_REPAIR)
+  @Test(priority = 1, groups = FLAKY)
   public void checkImportProjectSubmoduleBySshUrl() {
     projectExplorer.waitProjectExplorer();
     currentProjectName = multimoduleRepo.getName() + "Ssh";
@@ -428,7 +428,7 @@ public class ImportWizardFormTest {
     openAndCheckRegularSubmodule(currentProjectName);
   }
 
-  @Test(priority = 1, groups = UNDER_REPAIR)
+  @Test(priority = 1, groups = FLAKY)
   public void checkImportProjectSubmoduleFromGithub() throws Exception {
     projectExplorer.waitProjectExplorer();
     currentProjectName = multimoduleRepo.getName();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/YamlFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/YamlFileEditingTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.languageserver;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.GO_TO_SYMBOL;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Profile.PREFERENCES;
@@ -172,7 +173,7 @@ public class YamlFileEditingTest {
     editor.waitTextIntoEditor("spec:");
   }
 
-  @Test(priority = 1)
+  @Test(priority = 1, groups = FLAKY)
   public void checkHoverFeature() {
     editor.selectTabByName("deployment.yaml");
 
@@ -192,7 +193,7 @@ public class YamlFileEditingTest {
             + "http://releases\\.k8s\\.io/HEAD/docs/devel/api\\-conventions\\.md\\#resources");
   }
 
-  @Test(priority = 1)
+  @Test(priority = 1, groups = FLAKY)
   public void checkCodeValidation() {
     editor.selectTabByName("deployment.yaml");
     editor.waitAllMarkersInvisibility(ERROR);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/csharp/CSharpFileEditingTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/csharp/CSharpFileEditingTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.languageserver.csharp;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.CREATE_PROJECT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
@@ -42,7 +43,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
-@Test(groups = UNDER_REPAIR)
 public class CSharpFileEditingTest {
 
   private final String PROJECT_NAME = NameGenerator.generate("AspProject", 4);
@@ -81,12 +81,12 @@ public class CSharpFileEditingTest {
     initLanguageServer();
   }
 
-  @Test
+  @Test(groups = FLAKY)
   public void checkCodeEditing() {
     checkCodeValidation();
   }
 
-  @Test(priority = 1)
+  @Test(priority = 1, groups = UNDER_REPAIR)
   public void checkInitializingAfterFirstStarting() {
     projectExplorer.openItemByPath(PROJECT_NAME + "/Program.cs");
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/php/PhpAssistantFeaturesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/languageserver/php/PhpAssistantFeaturesTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.languageserver.php;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_PROJECT_SYMBOL;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FIND_REFERENCES;
@@ -109,7 +110,7 @@ public class PhpAssistantFeaturesTest {
     editor.waitTextIntoEditor(EXPECTED_ORIGINAL_TEXT);
   }
 
-  @Test
+  @Test(groups = FLAKY)
   public void hoverShouldBeDisplayedWithExpectedText() {
     projectExplorer.openItemByPath(PATH_TO_INDEX_PHP);
     editor.waitActive();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureNodesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/FileStructureNodesTest.java
@@ -16,7 +16,6 @@ import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.A
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.FILE_STRUCTURE;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SIMPLE;
 import static org.openqa.selenium.Keys.ESCAPE;
-import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.net.URL;
@@ -29,7 +28,6 @@ import org.eclipse.che.selenium.pageobject.Ide;
 import org.eclipse.che.selenium.pageobject.Menu;
 import org.eclipse.che.selenium.pageobject.ProjectExplorer;
 import org.openqa.selenium.Keys;
-import org.openqa.selenium.WebDriverException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -164,13 +162,7 @@ public class FileStructureNodesTest {
     menu.runCommand(ASSISTANT, FILE_STRUCTURE);
     fileStructure.waitFileStructureFormIsOpen(JAVA_FILE_NAME);
 
-    try {
-      fileStructure.waitExpectedTextInFileStructure(ITEMS_CLASS);
-    } catch (WebDriverException ex) {
-      // remove try-catch block after issue has been resolved
-      fail("Known random failure https://github.com/eclipse/che/issues/8300");
-    }
-
+    fileStructure.waitExpectedTextInFileStructure(ITEMS_CLASS);
     fileStructure.type("get");
     fileStructure.waitExpectedTextInFileStructure(ITEMS_FILTERED_GET);
     fileStructure.type(ESCAPE.toString());

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/NavigateToFileTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.miscellaneous;
 
 import static java.lang.String.format;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestCommandsConstants.CUSTOM;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.ASSISTANT;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Assistant.NAVIGATE_TO_FILE;
@@ -86,20 +87,20 @@ public class NavigateToFileTest {
     projectExplorer.waitItem(PROJECT_NAME_2);
   }
 
-  @Test(dataProvider = "dataForCheckingTheSameFileInDifferentProjects")
+  @Test(dataProvider = "dataForCheckingTheSameFileInDifferentProjects", groups = FLAKY)
   public void shouldNavigateToFileForFirstProject(
       String inputValueForChecking, Map<Integer, String> expectedValues) {
     // Open the project one and check function 'Navigate To File'
     launchNavigateToFileAndCheckResults(inputValueForChecking, expectedValues, 1);
   }
 
-  @Test(dataProvider = "dataForCheckingTheSameFileInDifferentProjects")
+  @Test(dataProvider = "dataForCheckingTheSameFileInDifferentProjects", groups = FLAKY)
   public void shouldDoNavigateToFileForSecondProject(
       String inputValueForChecking, Map<Integer, String> expectedValues) {
     launchNavigateToFileAndCheckResults(inputValueForChecking, expectedValues, 2);
   }
 
-  @Test(dataProvider = "dataToNavigateToFileCreatedOutsideIDE")
+  @Test(dataProvider = "dataToNavigateToFileCreatedOutsideIDE", groups = FLAKY)
   public void shouldNavigateToFileWithJustCreatedFiles(
       String inputValueForChecking, Map<Integer, String> expectedValues) throws Exception {
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/miscellaneous/WorkingWithTerminalTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.miscellaneous;
 
 import static java.lang.String.valueOf;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.PanelSelector.PanelTypes.LEFT_BOTTOM_ID;
 import static org.testng.Assert.fail;
@@ -165,7 +166,7 @@ public class WorkingWithTerminalTest {
     terminal.typeIntoActiveTerminal("" + Keys.ESCAPE + Keys.ESCAPE);
   }
 
-  @Test
+  @Test(groups = FLAKY)
   public void shouldResizeTerminal() {
     openMC("/");
 
@@ -208,7 +209,7 @@ public class WorkingWithTerminalTest {
     }
   }
 
-  @Test
+  @Test(groups = FLAKY)
   public void shouldNavigateToMC() {
     openMC("/");
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.stack;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsConstants.CommandItem.INSTALL_DEPENDENCIES_COMMAND_ITEM;
 import static org.eclipse.che.selenium.core.constant.TestIntelligentCommandsConstants.CommandItem.RUN_COMMAND_ITEM;
@@ -125,7 +126,7 @@ public class CreateWorkspaceFromNodeStackTest {
     consoles.closeProcessTabWithAskDialog(RUN_COMMAND_ITEM.getItem(NODE_JS_PROJECT));
   }
 
-  @Test(priority = 1)
+  @Test(priority = 1, groups = FLAKY)
   public void checkWebNodejsSimpleProjectCommands() {
     By textOnPreviewPage = By.xpath("//p[text()=' from the Yeoman team']");
 
@@ -148,7 +149,11 @@ public class CreateWorkspaceFromNodeStackTest {
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     ide.waitOpenedWorkspaceIsReadyToUse();
 
-    consoles.waitPreviewUrlIsPresent();
+    try {
+      consoles.waitPreviewUrlIsPresent();
+    } catch (TimeoutException ex) {
+      fail("Known random failure https://github.com/eclipse/che/issues/11419", ex);
+    }
 
     consoles.checkWebElementVisibilityAtPreviewPage(textOnPreviewPage);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/stack/CreateWorkspaceFromNodeStackTest.java
@@ -148,11 +148,7 @@ public class CreateWorkspaceFromNodeStackTest {
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
     ide.waitOpenedWorkspaceIsReadyToUse();
 
-    try {
-      consoles.waitPreviewUrlIsPresent();
-    } catch (TimeoutException ex) {
-      fail("Known random failure https://github.com/eclipse/che/issues/11419", ex);
-    }
+    consoles.waitPreviewUrlIsPresent();
 
     consoles.checkWebElementVisibilityAtPreviewPage(textOnPreviewPage);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4CheckRunSuitesAndScopesTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4CheckRunSuitesAndScopesTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.testrunner;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.pageobject.plugins.JavaTestRunnerPluginConsole.JunitMethodsState.FAILED;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
@@ -38,6 +39,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
+@Test(groups = FLAKY)
 public class JavaTestPluginJunit4CheckRunSuitesAndScopesTest {
   private static final String JUNIT4_PROJECT = "junit4-tests-with-separeted-suites";
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4Test.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginJunit4Test.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.testrunner;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.RUN_MENU;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.TEST;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.TEST_DROP_DAWN_ITEM;
@@ -42,6 +43,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Dmytro Nochevnov */
+@Test(groups = FLAKY)
 public class JavaTestPluginJunit4Test {
 
   private static final String JUNIT4_PROJECT = "junit4-tests";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/testrunner/JavaTestPluginTestNgTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.testrunner;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.RUN_MENU;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Run.TEST;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.TEST_NG_TEST_DROP_DAWN_ITEM;
@@ -45,6 +46,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Dmytro Nochevnov */
+@Test(groups = FLAKY)
 public class JavaTestPluginTestNgTest {
 
   private static final String PROJECT = "testng-tests";

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterWorkspaceRestartTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterWorkspaceRestartTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.workspaces;
 
+import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.STOP_WORKSPACE;
 import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
 import static org.eclipse.che.selenium.core.project.ProjectTemplates.MAVEN_SPRING;
@@ -33,6 +34,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev on 10.03.16 */
+@Test(groups = FLAKY)
 public class ProjectStateAfterWorkspaceRestartTest {
   private static final String PROJECT_NAME = NameGenerator.generate("project", 4);
   private static final String EXP_TEXT_NOT_PRESENT =


### PR DESCRIPTION
### What does this PR do?
It excludes "flaky" tests (those which randomly fail) from E2E test execution by default.
Such tests assigned to TestNG group "flaky", and there is mandatory try/catch block around the failing test command with reference to the issue which described failure.
For example:
```
import static org.eclipse.che.selenium.core.TestGroup.FLAKY;
...

@Test(groups = FLAKY)
public class CheckOpenFileFeatureTest {
...
  @Test
  public void checkOpenFileFeatureTest() throws Exception {
    ...
    try {
      editor.waitTabIsPresent("web-java-spring", WIDGET_TIMEOUT_SEC);
    } catch (TimeoutException ex) {
      // remove try-catch block after issue has been resolved
      fail("Known random failure https://github.com/eclipse/che/issues/11001");
    }
  }
...
```

There is dedicated parameter of _E2E test launcher webdriver.sh_ to include "flaky" tests into execution: `--include-flaky-tests`.

### What issues does this PR fix or reference?
#12129 