### PR TITLE
Initial devfile to work che in che

### DIFF
--- a/.che-dev.yaml
+++ b/.che-dev.yaml
@@ -1,0 +1,46 @@
+---
+kind: List
+items:
+ - apiVersion: v1
+   kind: Pod
+   metadata:
+     name: ws
+   spec:
+     containers:
+     - name: dev
+       image: 'eclipse/che-dev:nightly'
+       resources:
+         limits:
+           memory: 5Gi
+       volumeMounts:
+       - mountPath: /projects
+         name: projects
+       - mountPath: /home/user/.m2
+         name: maven
+     volumes:
+     - name: projects
+       persistentVolumeClaim:
+         claimName: projects
+     - name: maven
+       persistentVolumeClaim:
+          claimName: maven
+ - apiVersion: v1
+   kind: PersistentVolumeClaim
+   metadata:
+     name: projects
+   spec:
+     accessModes:
+      - ReadWriteOnce
+     resources:
+       requests:
+         storage: 2Gi
+ - apiVersion: v1
+   kind: PersistentVolumeClaim
+   metadata:
+     name: maven
+   spec:
+     accessModes:
+      - ReadWriteOnce
+     resources:
+       requests:
+         storage: 3Gi

--- a/.devfile
+++ b/.devfile
@@ -1,0 +1,24 @@
+specVersion: 0.0.1
+name: che-in-che
+projects:
+  - name: che
+    source:
+      type: git
+      location: 'https://github.com/eclipse/che.git'
+tools:
+  - name: theia-editor
+    type: cheEditor
+    id: org.eclipse.che.editor.theia:1.0.0
+  - name: exec-plugin
+    type: chePlugin
+    id: che-machine-exec-plugin:0.0.1
+  - name: che-dev
+    type: kubernetes
+    local: .che-dev.yaml
+commands:
+  - name: fastbuild
+    actions:
+      - type: exec
+        tool: che-dev
+        command: cd /projects/che && mvn clean install -Pnative -DskipTests=true
+        workdir: /projects/che


### PR DESCRIPTION
### What does this PR do?

Introduce ***.devfile** skeleton to work che in che.
![input](https://user-images.githubusercontent.com/1614429/50527178-5a4d7d00-0aef-11e9-8d38-998ec65da479.gif)

<img width="775" alt="17 26 07" src="https://user-images.githubusercontent.com/1614429/52535604-20f86600-2d59-11e9-967e-6749494ceddb.png">


### How to test ###
- ```http://{CHE_HOST}/f?url=https://github.com/eclipse/che/tree/devfileche```
- after pr will be merged  ```http://{che-host}/f?url=https://github.com/eclipse/che.git```



### What issues does this PR fix or reference?
n/a

#### Release Notes
n/a

#### Docs PR
n/a