### PR TITLE
Add kubernetes type tool into devfile API

### DIFF
--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
@@ -23,6 +23,8 @@ public class Constants {
 
   public static final String KUBERNETES_TOOL_TYPE = "kubernetes";
 
+  public static final String OPENSHIFT_TOOL_TYPE = "openshift";
+
   /**
    * Workspace attribute which contains comma-separated list of mappings of tool id to its name
    * Example value:

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
@@ -21,6 +21,8 @@ public class Constants {
 
   public static final String PLUGIN_TOOL_TYPE = "chePlugin";
 
+  public static final String KUBERNETES_TOOL_TYPE = "kubernetes";
+
   /**
    * Workspace attribute which contains comma-separated list of mappings of tool id to its name
    * Example value:

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
@@ -125,7 +125,9 @@ public class DevfileConverter {
           break;
         case KUBERNETES_TOOL_TYPE:
         case OPENSHIFT_TOOL_TYPE:
-          continue; // this kind of tools shouldn't be present in mapping
+          // this kind of tool ignored here since it contain only reference to tool configuration
+          // which should be resolved and provisioned into workspace config recipe separately.
+          continue;
         default:
           throw new DevfileFormatException(
               format("Unsupported tool %s type provided: %s", tool.getName(), tool.getType()));

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
@@ -19,6 +19,7 @@ import static org.eclipse.che.api.devfile.server.Constants.ALIASES_WORKSPACE_ATT
 import static org.eclipse.che.api.devfile.server.Constants.CURRENT_SPEC_VERSION;
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_EDITOR_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE;
@@ -123,6 +124,7 @@ public class DevfileConverter {
           pluginsStringJoiner.add(tool.getId());
           break;
         case KUBERNETES_TOOL_TYPE:
+        case OPENSHIFT_TOOL_TYPE:
           continue; // this kind of tools shouldn't be present in mapping
         default:
           throw new DevfileFormatException(

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
@@ -18,6 +18,7 @@ import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DI
 import static org.eclipse.che.api.devfile.server.Constants.ALIASES_WORKSPACE_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.devfile.server.Constants.CURRENT_SPEC_VERSION;
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_EDITOR_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE;
@@ -121,6 +122,8 @@ public class DevfileConverter {
         case PLUGIN_TOOL_TYPE:
           pluginsStringJoiner.add(tool.getId());
           break;
+        case KUBERNETES_TOOL_TYPE:
+          continue; // this kind of tools shouldn't be present in mapping
         default:
           throw new DevfileFormatException(
               format("Unsupported tool %s type provided: %s", tool.getName(), tool.getType()));

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
@@ -20,7 +20,6 @@ import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Supplier;
 import java.util.regex.Pattern;
 import javax.inject.Singleton;
 import org.eclipse.che.api.devfile.model.Action;
@@ -76,14 +75,14 @@ public class DevfileIntegrityValidator {
                     "Multiple editor tools found: '%s', '%s'",
                     editorTool.getName(), tool.getName()));
           }
-          checkFieldNotSet(tool, "local", tool::getLocal);
+          checkFieldNotSet(tool, "local", tool.getLocal());
           editorTool = tool;
           break;
         case PLUGIN_TOOL_TYPE:
-          checkFieldNotSet(tool, "local", tool::getLocal);
+          checkFieldNotSet(tool, "local", tool.getLocal());
           break;
         case KUBERNETES_TOOL_TYPE:
-          checkFieldNotSet(tool, "id", tool::getId);
+          checkFieldNotSet(tool, "id", tool.getId());
           break;
         default:
           throw new DevfileFormatException(
@@ -93,9 +92,9 @@ public class DevfileIntegrityValidator {
     return existingNames;
   }
 
-  private void checkFieldNotSet(Tool tool, String fieldName, Supplier<String> fieldSupplier)
+  private void checkFieldNotSet(Tool tool, String fieldName, String fieldValue)
       throws DevfileFormatException {
-    if (!isNullOrEmpty(fieldSupplier.get())) {
+    if (!isNullOrEmpty(fieldValue)) {
       throw new DevfileFormatException(
           format(
               "Tool of type '%s' cannot contain '%s' field, please check '%s' tool",

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
@@ -64,6 +64,7 @@ public class DevfileIntegrityValidator {
   private Set<String> validateTools(Devfile devfile) throws DevfileFormatException {
     Set<String> existingNames = new HashSet<>();
     Tool editorTool = null;
+    Tool recipeTool = null;
     for (Tool tool : devfile.getTools()) {
       if (!existingNames.add(tool.getName())) {
         throw new DevfileFormatException(format("Duplicate tool name found:'%s'", tool.getName()));
@@ -84,7 +85,14 @@ public class DevfileIntegrityValidator {
           break;
         case KUBERNETES_TOOL_TYPE:
         case OPENSHIFT_TOOL_TYPE:
+          if (recipeTool != null) {
+            throw new DevfileFormatException(
+                format(
+                    "Multiple non plugin or editor type tools found: '%s', '%s'",
+                    recipeTool.getName(), tool.getName()));
+          }
           checkFieldNotSet(tool, "id", tool.getId());
+          recipeTool = tool;
           break;
         default:
           throw new DevfileFormatException(

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
@@ -16,6 +16,7 @@ import static java.lang.String.format;
 import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 
 import java.util.HashSet;
@@ -82,6 +83,7 @@ public class DevfileIntegrityValidator {
           checkFieldNotSet(tool, "local", tool.getLocal());
           break;
         case KUBERNETES_TOOL_TYPE:
+        case OPENSHIFT_TOOL_TYPE:
           checkFieldNotSet(tool, "id", tool.getId());
           break;
         default:

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -112,7 +112,7 @@
             ]
           },
           "local": {
-            "description": "Describes location of Kubernetes list yaml file. Applicable only for 'kubernetes' type tools.",
+            "description": "Describes location of Kubernetes list yaml file. Applicable only for 'kubernetes' and 'openshift' type tools.",
             "type": "string",
             "examples": [
               "petclinic-app.yaml"

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -83,22 +83,39 @@
         "type": "object",
         "required": [
           "name",
-          "type",
-          "id"
+          "type"
+        ],
+        "oneOf" : [
+          {
+            "required": [
+              "id"
+            ]},
+          {
+            "required": [
+              "local"
+            ]}
         ],
         "properties": {
           "name": {
+            "description": "Describes the name of the tool. Should be unique per tool set.",
             "type": "string",
             "examples": [
               "mvn-stack"
             ]
           },
           "type": {
-            "description": "Describes type or tool, e.g. whether it is and plugin or editor or other type",
+            "description": "Describes type of the tool, e.g. whether it is an plugin or editor or other type",
             "type": "string",
             "examples": [
               "chePlugin",
               "cheEditor"
+            ]
+          },
+          "local": {
+            "description": "Describes location of Kubernetes list yaml file. Applicable only for 'kubernetes' type tools.",
+            "type": "string",
+            "examples": [
+              "petclinic-app.yaml"
             ]
           },
           "id": {
@@ -122,6 +139,7 @@
         ],
         "properties": {
           "name": {
+            "description": "Describes the name of the command. Should be unique per commands set.",
             "type": "string",
             "examples": [
               "build"

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileConverterTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileConverterTest.java
@@ -108,7 +108,7 @@ public class DevfileConverterTest {
       }
     }
 
-    assertEquals(devFile.getTools().size(), expectedDevFile.getTools().size());
+    // assertEquals(devFile.getTools().size(), expectedDevFile.getTools().size());
     for (Tool tool : devFile.getTools()) {
       Tool expectedTool =
           expectedDevFile

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileConverterTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileConverterTest.java
@@ -108,7 +108,6 @@ public class DevfileConverterTest {
       }
     }
 
-    // assertEquals(devFile.getTools().size(), expectedDevFile.getTools().size());
     for (Tool tool : devFile.getTools()) {
       Tool expectedTool =
           expectedDevFile

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
@@ -71,6 +71,7 @@ public class DevfileIntegrityValidatorTest {
               + "' cannot contain 'id' field, please check 'k8s' tool")
   public void shouldThrowExceptionOnUnsupportedKubernetesToolField() throws Exception {
     Devfile broken = copyOf(initialDevfile);
+    broken.getTools().clear();
     broken
         .getTools()
         .add(new Tool().withName("k8s").withType(KUBERNETES_TOOL_TYPE).withId("anyId"));
@@ -81,12 +82,30 @@ public class DevfileIntegrityValidatorTest {
   @Test(
       expectedExceptions = DevfileFormatException.class,
       expectedExceptionsMessageRegExp =
+          "Multiple non plugin or editor type tools found: 'k8s', 'os'")
+  public void shouldThrowExceptionOnMultipleNonPluginTools() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getTools().clear();
+    broken
+        .getTools()
+        .add(new Tool().withName("k8s").withType(KUBERNETES_TOOL_TYPE).withLocal("foo.yaml"));
+    broken
+        .getTools()
+        .add(new Tool().withName("os").withType(OPENSHIFT_TOOL_TYPE).withLocal("bar.yaml"));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
           "Tool of type '"
               + OPENSHIFT_TOOL_TYPE
-              + "' cannot contain 'id' field, please check 'k8s' tool")
+              + "' cannot contain 'id' field, please check 'os' tool")
   public void shouldThrowExceptionOnUnsupportedOpenshiftToolField() throws Exception {
     Devfile broken = copyOf(initialDevfile);
-    broken.getTools().add(new Tool().withName("k8s").withType(OPENSHIFT_TOOL_TYPE).withId("anyId"));
+    broken.getTools().clear();
+    broken.getTools().add(new Tool().withName("os").withType(OPENSHIFT_TOOL_TYPE).withId("anyId"));
     // when
     integrityValidator.validateDevfile(broken);
   }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.devfile.server.validator;
 
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -73,6 +74,19 @@ public class DevfileIntegrityValidatorTest {
     broken
         .getTools()
         .add(new Tool().withName("k8s").withType(KUBERNETES_TOOL_TYPE).withId("anyId"));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Tool of type '"
+              + OPENSHIFT_TOOL_TYPE
+              + "' cannot contain 'id' field, please check 'k8s' tool")
+  public void shouldThrowExceptionOnUnsupportedOpenshiftToolField() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getTools().add(new Tool().withName("k8s").withType(OPENSHIFT_TOOL_TYPE).withId("anyId"));
     // when
     integrityValidator.validateDevfile(broken);
   }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
@@ -11,6 +11,10 @@
  */
 package org.eclipse.che.api.devfile.server.validator;
 
+import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.util.ArrayList;
@@ -60,10 +64,56 @@ public class DevfileIntegrityValidatorTest {
 
   @Test(
       expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Tool of type '"
+              + KUBERNETES_TOOL_TYPE
+              + "' cannot contain 'id' field, please check 'k8s' tool")
+  public void shouldThrowExceptionOnUnsupportedKubernetesToolField() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken
+        .getTools()
+        .add(new Tool().withName("k8s").withType(KUBERNETES_TOOL_TYPE).withId("anyId"));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Tool of type '"
+              + EDITOR_TOOL_TYPE
+              + "' cannot contain 'local' field, please check 'foo' tool")
+  public void shouldThrowExceptionOnUnsupportedEditorToolField() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getTools().clear();
+    broken
+        .getTools()
+        .add(new Tool().withName("foo").withType(EDITOR_TOOL_TYPE).withLocal("k8x.yaml"));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Tool of type '"
+              + PLUGIN_TOOL_TYPE
+              + "' cannot contain 'local' field, please check 'foo' tool")
+  public void shouldThrowExceptionOnUnsupportedPluginToolField() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken
+        .getTools()
+        .add(new Tool().withName("foo").withType(PLUGIN_TOOL_TYPE).withLocal("k8x.yaml"));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
       expectedExceptionsMessageRegExp = "Multiple editor tools found: 'theia-ide', 'editor-2'")
   public void shouldThrowExceptionOnMultipleEditors() throws Exception {
     Devfile broken = copyOf(initialDevfile);
-    broken.getTools().add(new Tool().withName("editor-2").withType("cheEditor"));
+    broken.getTools().add(new Tool().withName("editor-2").withType(EDITOR_TOOL_TYPE));
     // when
     integrityValidator.validateDevfile(broken);
   }

--- a/wsmaster/che-core-api-devfile/src/test/resources/devfile.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/devfile.yaml
@@ -28,8 +28,11 @@ tools:
   - name: jdt.ls
     type: chePlugin
     id: eclipse/theia-jdtls:0.0.3
-  - name: recipe
+  - name: k8s-recipe
     type: kubernetes
+    local: petclinic-app.yaml
+  - name: os-recipe
+    type: openshift
     local: petclinic-app.yaml
 commands:
   - name: build

--- a/wsmaster/che-core-api-devfile/src/test/resources/devfile.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/devfile.yaml
@@ -28,6 +28,9 @@ tools:
   - name: jdt.ls
     type: chePlugin
     id: eclipse/theia-jdtls:0.0.3
+  - name: recipe
+    type: kubernetes
+    local: petclinic-app.yaml
 commands:
   - name: build
     actions:

--- a/wsmaster/che-core-api-devfile/src/test/resources/devfile.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/devfile.yaml
@@ -28,9 +28,6 @@ tools:
   - name: jdt.ls
     type: chePlugin
     id: eclipse/theia-jdtls:0.0.3
-  - name: k8s-recipe
-    type: kubernetes
-    local: petclinic-app.yaml
   - name: os-recipe
     type: openshift
     local: petclinic-app.yaml


### PR DESCRIPTION
### What does this PR do?
Add for new `kubernetes` and `openshift` tool types for K8S list  into devfile API to be able to specify workspace environment configuration in Devfile.
<details>
<summary>
# Example of Devfile with Kubernetes/OpenShift tool specified
</summary>

```yaml
---
specVersion: 0.0.1
name: petclinic-dev-environment
projects:
  - name: petclinic
    source:
      type: git
      location: 'git@github.com:spring-projects/spring-petclinic.git'
tools:
  - name: petclinic-app
    type: kubernetes
    local: petclinic-app.yml
  - name: theia-ide
    type: cheEditor
    id: eclipse/theia:0.0.3
  - name: jdt.ls
    type: chePlugin
    id: eclipse/theia-jdtls:0.0.3
commands:
  - name: run
    actions:
      - type: exec
        tool: petclinic-app
        command: `./catalina.sh start`
        workdir: /home/user/app/tomcat
```
</details>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11906


#### Release Notes
N/A


#### Docs PR
N/A