### PR TITLE
Selenium: add info about known issues, stabilize tests

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
@@ -488,7 +488,7 @@ public class CodenvyEditor {
    * @param expectedText text which should be present in the editor
    */
   public void waitTextIntoEditor(final String expectedText) {
-    waitTextIntoEditor(expectedText, ELEMENT_TIMEOUT_SEC);
+    waitTextIntoEditor(expectedText, WIDGET_TIMEOUT_SEC);
   }
 
   /**

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/CodenvyEditor.java
@@ -488,7 +488,7 @@ public class CodenvyEditor {
    * @param expectedText text which should be present in the editor
    */
   public void waitTextIntoEditor(final String expectedText) {
-    waitTextIntoEditor(expectedText, WIDGET_TIMEOUT_SEC);
+    waitTextIntoEditor(expectedText, ELEMENT_TIMEOUT_SEC);
   }
 
   /**
@@ -976,7 +976,7 @@ public class CodenvyEditor {
    * @param markerLocator marker's type, defined in {@link MarkerLocator}
    */
   public void waitAllMarkersInvisibility(MarkerLocator markerLocator) {
-    seleniumWebDriverHelper.waitInvisibility(By.xpath(markerLocator.get()));
+    seleniumWebDriverHelper.waitInvisibility(By.xpath(markerLocator.get()), WIDGET_TIMEOUT_SEC);
   }
 
   /**

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
@@ -13,6 +13,7 @@ package org.eclipse.che.selenium.pageobject.theia;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.ELEMENT_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.LOAD_PAGE_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.PREPARING_WS_TIMEOUT_SEC;
 import static org.eclipse.che.selenium.pageobject.theia.TheiaIde.Locators.NOTIFICATION_CLOSE_BUTTON;
@@ -98,7 +99,7 @@ public class TheiaIde {
   public void waitNotificationEqualsTo(String expectedText) {
     final String notificationXpath = getNotificationEqualsToXpath(expectedText);
 
-    seleniumWebDriverHelper.waitVisibility(By.xpath(notificationXpath));
+    seleniumWebDriverHelper.waitVisibility(By.xpath(notificationXpath), ELEMENT_TIMEOUT_SEC);
   }
 
   public boolean isNotificationEqualsTo(String notificationText) {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -264,8 +264,8 @@ public class NewWorkspacePageTest {
 
   private static final List<NewWorkspace.Stack> EXPECTED_DOCKER_QUICK_START_STACKS_REVERSE_ORDER =
       asList(
-          JAVA,
           JAVA_MYSQL,
+          JAVA,
           BLANK,
           JAVA_THEIA_DOCKER,
           RAILS,

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CheckOpenFileFeatureTest.java
@@ -67,6 +67,7 @@ public class CheckOpenFileFeatureTest {
   @BeforeClass
   public void setUp() throws Exception {
     ide.open(testWorkspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
   }
 
   @AfterClass

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithKeepDirectoryTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithKeepDirectoryTest.java
@@ -13,7 +13,9 @@ package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.selenium.core.TestGroup.GITHUB;
 import static org.eclipse.che.selenium.core.TestGroup.OPENSHIFT;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.nio.file.Path;
@@ -28,7 +30,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Test(groups = {GITHUB, OPENSHIFT})
+@Test(groups = {GITHUB, OPENSHIFT, UNDER_REPAIR})
 public class DirectUrlFactoryWithKeepDirectoryTest {
 
   @Inject private TestFactoryInitializer testFactoryInitializer;
@@ -74,6 +76,12 @@ public class DirectUrlFactoryWithKeepDirectoryTest {
     theiaProjectTree.waitItem(repositoryName + "/my-lib/src");
 
     Assert.assertTrue(theiaProjectTree.isItemVisible(repositoryName + "/my-lib/pom.xml"));
-    Assert.assertFalse(theiaProjectTree.isItemVisible(repositoryName + "/my-webapp"));
+
+    try {
+      Assert.assertFalse(theiaProjectTree.isItemVisible(repositoryName + "/my-webapp"));
+    } catch (AssertionError ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known permanent failure https://github.com/eclipse/che/issues/12311");
+    }
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckGeneratingMavenArchetypeTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckGeneratingMavenArchetypeTest.java
@@ -57,6 +57,7 @@ public class CheckGeneratingMavenArchetypeTest {
             PROJECT_NAME + "/src/test/java/" + GROUP_ID + "/AppTest.java",
             PROJECT_NAME + "/pom.xml");
     ide.open(workspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
     menu.runCommand(
         TestMenuCommandsConstants.Workspace.WORKSPACE,
         TestMenuCommandsConstants.Workspace.CREATE_PROJECT);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckMavenPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/mavenplugin/CheckMavenPluginTest.java
@@ -57,6 +57,7 @@ public class CheckMavenPluginTest {
     testProjectServiceClient.importProject(
         workspace.getId(), get(resource.toURI()), PROJECT_NAME, MAVEN_SPRING);
     ide.open(workspace);
+    ide.waitOpenedWorkspaceIsReadyToUse();
     consoles.waitJDTLSProjectResolveFinishedMessage(PROJECT_NAME);
     projectExplorer.waitProjectExplorer();
     projectExplorer.waitItem(PROJECT_NAME);


### PR DESCRIPTION
### What does this PR do?
This PR:
- add info about known #8909 issue to ```WorkspaceDetailsComposeTest``` test;
- add info about known #12311 issue to ```DirectUrlFactoryWithKeepDirectoryTest``` test;
- fix expected stacks list in ```NewWorkspacePageTest```;
- add waiting that **IDE** is ready to use before working with projects in ```CheckGeneratingMavenArchetypeTest```, ```CheckOpenFileFeatureTest``` and ```CheckMavenPluginTest``` tests;
- increase timeout for checking **Editor** markers invisibility in ```CodenvyEditor``` page object.
