### PR TITLE
 Fix LoginNewUserWithOpenShiftOAuthTest selenium test

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -565,7 +565,10 @@ public class NewWorkspace {
   }
 
   public void clickOnCreateButtonAndOpenInIDE() {
-    seleniumWebDriverHelper.waitAndClick(bottomCreateWorkspaceButton);
+    // need to move cursor to button to avoid failure https://github.com/eclipse/che/issues/12309
+    seleniumWebDriverHelper.waitVisibility(bottomCreateWorkspaceButton);
+    seleniumWebDriverHelper.moveCursorTo(bottomCreateWorkspaceButton);
+    bottomCreateWorkspaceButton.click();
   }
 
   public void clickOnCreateButtonAndEditWorkspace() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/site/ocpoauth/LoginExistedUserWithOpenShiftOAuthTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/site/ocpoauth/LoginExistedUserWithOpenShiftOAuthTest.java
@@ -144,9 +144,6 @@ public class LoginExistedUserWithOpenShiftOAuthTest {
     newWorkspace.selectStack(JAVA);
     newWorkspace.typeWorkspaceName(WORKSPACE_NAME);
     newWorkspace.clickOnCreateButtonAndOpenInIDE();
-    // store info about created workspace to make SeleniumTestHandler.captureTestWorkspaceLogs()
-    // possible to read logs in case of test failure
-    testWorkspace = testWorkspaceProvider.getWorkspace(WORKSPACE_NAME, defaultTestUser);
 
     // switch to the Eclipse Che IDE and wait until workspace is ready to use
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/site/ocpoauth/LoginNewUserWithOpenShiftOAuthTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/site/ocpoauth/LoginNewUserWithOpenShiftOAuthTest.java
@@ -131,9 +131,6 @@ public class LoginNewUserWithOpenShiftOAuthTest {
     newWorkspace.selectStack(JAVA);
     newWorkspace.typeWorkspaceName(WORKSPACE_NAME);
     newWorkspace.clickOnCreateButtonAndOpenInIDE();
-    // store info about created workspace to make SeleniumTestHandler.captureTestWorkspaceLogs()
-    // possible to read logs in case of test failure
-    testWorkspace = testWorkspaceProvider.getWorkspace(WORKSPACE_NAME, NEW_TEST_USER);
 
     // switch to the Eclipse Che IDE and wait until workspace is ready to use
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
@@ -87,7 +87,7 @@ public class CreateWorkspaceOnDashboardTest {
 
     // store info about created workspace to make SeleniumTestHandler.captureTestWorkspaceLogs()
     // possible to read logs in case of test failure
-    testWorkspace = testWorkspaceProvider.getWorkspace(WORKSPACE, defaultTestUser);
+    testWorkspace = testWorkspaceProvider.getWorkspace(WS_NAME, defaultTestUser);
 
     seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
 


### PR DESCRIPTION
### What does this PR do?
It fixes **LoginNewUserWithOpenShiftOAuthTest#checkNewCheUserOcpProjectCreationAndRemoval()** test which started failing [after updating version of selenium chrome-node in E2E selenium tests to 3.141.59-dubnium](https://github.com/eclipse/che/issues/11455):
- adds movement of cursor to "**bottomCreateWorkspaceButton**" in method _NewWorkspace#clickOnCreateButtonAndOpenInIDE()_ to avoid failure;
- fixes _seleniumWebDriverHelper#switchToIdeFrameAndWaitAvailability()_ method to prevent too earlier timeout exception. 

It also:
- removes error-prone command from **LoginExistedUserWithOpenShiftOAuthTest**;
- fixes workspace name in **CreateWorkspaceOnDashboardTest**;
- fixes getting existed test workspace id in class **CheTestWorkspace**.

### What issues does this PR fix or reference?
#12309