### PR TITLE
Make Keycloak CLI client for E2E test as extendable

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/requestfactory/TestUserHttpJsonRequestFactory.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/requestfactory/TestUserHttpJsonRequestFactory.java
@@ -37,7 +37,7 @@ public class TestUserHttpJsonRequestFactory extends TestHttpJsonRequestFactory {
       return authServiceClient.login(testUser.getName(), testUser.getPassword());
     } catch (Exception ex) {
       throw new RuntimeException(
-          format("Failed to get access token for user '%s'", testUser.getName()));
+          format("Failed to get access token for user '%s'", testUser.getName()), ex);
     }
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/CheSeleniumSuiteModule.java
@@ -55,12 +55,6 @@ import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFacto
 import org.eclipse.che.selenium.core.requestfactory.TestUserHttpJsonRequestFactoryCreator;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.user.TestUserFactory;
-import org.eclipse.che.selenium.core.webdriver.DownloadedFileUtil;
-import org.eclipse.che.selenium.core.webdriver.DownloadedIntoGridFileUtil;
-import org.eclipse.che.selenium.core.webdriver.DownloadedLocallyFileUtil;
-import org.eclipse.che.selenium.core.webdriver.UploadIntoGridUtil;
-import org.eclipse.che.selenium.core.webdriver.UploadLocallyUtil;
-import org.eclipse.che.selenium.core.webdriver.UploadUtil;
 import org.eclipse.che.selenium.core.webdriver.log.WebDriverLogsReaderFactory;
 import org.eclipse.che.selenium.core.workspace.CheTestWorkspaceProvider;
 import org.eclipse.che.selenium.core.workspace.CheTestWorkspaceUrlResolver;
@@ -127,7 +121,7 @@ public class CheSeleniumSuiteModule extends AbstractModule {
       install(new CheSeleniumSingleUserModule());
     }
 
-    configureTestExecutionModeRelatedDependencies();
+    install(new TestExecutionModule());
   }
 
   private void configureInfrastructureRelatedDependencies(TestConfiguration config) {
@@ -162,17 +156,6 @@ public class CheSeleniumSuiteModule extends AbstractModule {
       default:
         throw new RuntimeException(
             format("Infrastructure '%s' hasn't been supported by tests.", cheInfrastructure));
-    }
-  }
-
-  private void configureTestExecutionModeRelatedDependencies() {
-    boolean gridMode = Boolean.valueOf(System.getProperty("grid.mode"));
-    if (gridMode) {
-      bind(DownloadedFileUtil.class).to(DownloadedIntoGridFileUtil.class);
-      bind(UploadUtil.class).to(UploadIntoGridUtil.class);
-    } else {
-      bind(DownloadedFileUtil.class).to(DownloadedLocallyFileUtil.class);
-      bind(UploadUtil.class).to(UploadLocallyUtil.class);
     }
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/TestExecutionModule.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/TestExecutionModule.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.selenium.core;
+
+import com.google.inject.AbstractModule;
+import org.eclipse.che.selenium.core.webdriver.DownloadedFileUtil;
+import org.eclipse.che.selenium.core.webdriver.DownloadedIntoGridFileUtil;
+import org.eclipse.che.selenium.core.webdriver.DownloadedLocallyFileUtil;
+import org.eclipse.che.selenium.core.webdriver.UploadIntoGridUtil;
+import org.eclipse.che.selenium.core.webdriver.UploadLocallyUtil;
+import org.eclipse.che.selenium.core.webdriver.UploadUtil;
+
+public class TestExecutionModule extends AbstractModule {
+
+  @Override
+  protected void configure() {
+    boolean gridMode = Boolean.valueOf(System.getProperty("grid.mode"));
+    if (gridMode) {
+      bind(DownloadedFileUtil.class).to(DownloadedIntoGridFileUtil.class);
+      bind(UploadUtil.class).to(UploadIntoGridUtil.class);
+    } else {
+      bind(DownloadedFileUtil.class).to(DownloadedLocallyFileUtil.class);
+      bind(UploadUtil.class).to(UploadLocallyUtil.class);
+    }
+  }
+}

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/keycloak/KeycloakTestAuthServiceClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/keycloak/KeycloakTestAuthServiceClient.java
@@ -70,11 +70,13 @@ public class KeycloakTestAuthServiceClient extends AbstractKeycloakTestAuthServi
     }
   }
 
+  @Override
   protected KeycloakToken loginRequest(String username, String password) {
     return requestToken(
         PASSWORD, ImmutableList.of(Pair.of("username", username), Pair.of("password", password)));
   }
 
+  @Override
   protected KeycloakToken refreshRequest(KeycloakToken prevToken) {
     return requestToken(
         REFRESH_TOKEN, ImmutableList.of(Pair.of("refresh_token", prevToken.getRefreshToken())));

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/keycloak/cli/KeycloakCliClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/keycloak/cli/KeycloakCliClient.java
@@ -14,11 +14,12 @@ package org.eclipse.che.selenium.core.client.keycloak.cli;
 import static java.lang.String.format;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.inject.Singleton;
+import org.eclipse.che.selenium.core.client.keycloak.KeycloakSettings;
+import org.eclipse.che.selenium.core.client.keycloak.TestKeycloakSettingsServiceClient;
 import org.eclipse.che.selenium.core.provider.AdminTestUserProvider;
 import org.eclipse.che.selenium.core.provider.RemovableUserProvider;
 import org.eclipse.che.selenium.core.user.AdminTestUser;
@@ -40,26 +41,23 @@ public class KeycloakCliClient {
   private static final Pattern EXTRACT_USER_ID_PATTERN =
       Pattern.compile("^.*Created new user with id '(.*)'.*$", Pattern.DOTALL);
 
-  private static final String DEFAULT_CHE_KEYCLOAK_REALM = "che";
-
   // we need to inject AdminTestUser separately to avoid circular dependency error
   @Inject private AdminTestUserProvider adminTestUserProvider;
 
   private final TestUserFactory<DefaultTestUser> defaultTestUserFactory;
   private final TestUserFactory<TestUserImpl> testUserFactory;
+  private final KeycloakSettings keycloakSettings;
 
   @Inject private KeycloakCliCommandExecutor executor;
-
-  @Inject(optional = true)
-  @Named("che.keycloak.realm")
-  private String cheKeycloakRealm;
 
   @Inject
   public KeycloakCliClient(
       TestUserFactory<TestUserImpl> testUserFactory,
-      TestUserFactory<DefaultTestUser> defaultTestUserFactory) {
+      TestUserFactory<DefaultTestUser> defaultTestUserFactory,
+      TestKeycloakSettingsServiceClient testKeycloakSettingsServiceClient) {
     this.testUserFactory = testUserFactory;
     this.defaultTestUserFactory = defaultTestUserFactory;
+    this.keycloakSettings = testKeycloakSettingsServiceClient.read();
   }
 
   public TestUserImpl createUser(RemovableUserProvider testUserProvider) throws IOException {
@@ -177,6 +175,6 @@ public class KeycloakCliClient {
   }
 
   private String getCheKeycloakRealm() {
-    return cheKeycloakRealm != null ? cheKeycloakRealm : DEFAULT_CHE_KEYCLOAK_REALM;
+    return keycloakSettings.getKeycloakRealm();
   }
 }

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/executor/hotupdate/HotUpdateUtil.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/executor/hotupdate/HotUpdateUtil.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import org.eclipse.che.selenium.core.client.TestUserPreferencesServiceClient;
 import org.eclipse.che.selenium.core.executor.OpenShiftCliCommandExecutor;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is a set of methods which make easier to do updating of the che pod and wait of the updating
@@ -137,6 +138,9 @@ public class HotUpdateUtil {
    */
   public int getMasterPodRevision() {
     try {
+      String getRevisionOfCheDeploymentCommand = getRevisionOfCheDeploymentCommand();
+      LoggerFactory.getLogger(this.getClass())
+          .info("getRevisionOfCheDeploymentCommand: " + getRevisionOfCheDeploymentCommand);
       return Integer.parseInt(
           openShiftCliCommandExecutor.execute(getRevisionOfCheDeploymentCommand()));
     } catch (IOException ex) {
@@ -151,6 +155,10 @@ public class HotUpdateUtil {
    */
   public String getMasterPodName() {
     try {
+      String getNameOfCheDeploymentCommand = getNameOfCheDeploymentCommand();
+      LoggerFactory.getLogger(this.getClass())
+          .info("getNameOfCheDeploymentCommand: " + getNameOfCheDeploymentCommand);
+
       return openShiftCliCommandExecutor.execute(getNameOfCheDeploymentCommand());
     } catch (IOException ex) {
       throw new RuntimeException(ex.getLocalizedMessage(), ex);


### PR DESCRIPTION
### What does this PR do?
It allows to run E2E selenium tests on OpenShift assembly with different
- _Che_ _OpenShift_ pod name;
- _Keycloak_ _OpenShift_ app name;
- _Che_ _Keycloak_ realm name.