### PR TITLE
Added support of PVC in Kuberentes/OpenShift recipe

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
@@ -23,10 +23,6 @@ public final class Warnings {
       "Ingresses specified in Kubernetes recipe are ignored. "
           + "To expose ports please define servers in machine configuration.";
 
-  public static final int PVC_IGNORED_WARNING_CODE = 4101;
-  public static final String PVC_IGNORED_WARNING_MESSAGE =
-      "Persistent volume claims specified in Kubernetes recipe are ignored.";
-
   public static final int SECRET_IGNORED_WARNING_CODE = 4102;
   public static final String SECRET_IGNORED_WARNING_MESSAGE =
       "Secrets specified in Kubernetes recipe are ignored.";

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
@@ -108,10 +108,12 @@ public class KubernetesEnvironmentFactory
     boolean isAnyIngressPresent = false;
     boolean isAnySecretPresent = false;
     for (HasMetadata object : list.getItems()) {
+      checkNotNull(object.getKind(), "Environment contains object without specified kind field");
+      checkNotNull(object.getMetadata(), "%s metadata must not be null", object.getKind());
+      checkNotNull(object.getMetadata().getName(), "%s name must not be null", object.getKind());
+
       if (object instanceof Pod) {
         Pod pod = (Pod) object;
-        checkNotNull(pod.getMetadata(), "Pod metadata must not be null");
-        checkNotNull(pod.getMetadata().getName(), "Pod metadata name must not be null");
         pods.put(pod.getMetadata().getName(), pod);
       } else if (object instanceof Deployment) {
         Deployment deployment = (Deployment) object;
@@ -188,6 +190,13 @@ public class KubernetesEnvironmentFactory
   private void checkNotNull(Object object, String errorMessage) throws ValidationException {
     if (object == null) {
       throw new ValidationException(errorMessage);
+    }
+  }
+
+  private void checkNotNull(Object object, String messageFmt, Object... messageArguments)
+      throws ValidationException {
+    if (object == null) {
+      throw new ValidationException(format(messageFmt, messageArguments));
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
@@ -104,8 +104,8 @@ public class KubernetesEnvironmentFactory
     Map<String, Deployment> deployments = new HashMap<>();
     Map<String, Service> services = new HashMap<>();
     Map<String, ConfigMap> configMaps = new HashMap<>();
+    Map<String, PersistentVolumeClaim> pvcs = new HashMap<>();
     boolean isAnyIngressPresent = false;
-    boolean isAnyPVCPresent = false;
     boolean isAnySecretPresent = false;
     for (HasMetadata object : list.getItems()) {
       if (object instanceof Pod) {
@@ -122,7 +122,8 @@ public class KubernetesEnvironmentFactory
       } else if (object instanceof Ingress) {
         isAnyIngressPresent = true;
       } else if (object instanceof PersistentVolumeClaim) {
-        isAnyPVCPresent = true;
+        PersistentVolumeClaim pvc = (PersistentVolumeClaim) object;
+        pvcs.put(pvc.getMetadata().getName(), pvc);
       } else if (object instanceof Secret) {
         isAnySecretPresent = true;
       } else if (object instanceof ConfigMap) {
@@ -138,11 +139,6 @@ public class KubernetesEnvironmentFactory
       warnings.add(
           new WarningImpl(
               Warnings.INGRESSES_IGNORED_WARNING_CODE, Warnings.INGRESSES_IGNORED_WARNING_MESSAGE));
-    }
-
-    if (isAnyPVCPresent) {
-      warnings.add(
-          new WarningImpl(Warnings.PVC_IGNORED_WARNING_CODE, Warnings.PVC_IGNORED_WARNING_MESSAGE));
     }
 
     if (isAnySecretPresent) {
@@ -161,6 +157,7 @@ public class KubernetesEnvironmentFactory
             .setPods(pods)
             .setDeployments(deployments)
             .setServices(services)
+            .setPersistentVolumeClaims(pvcs)
             .setIngresses(new HashMap<>())
             .setPersistentVolumeClaims(new HashMap<>())
             .setSecrets(new HashMap<>())

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidator.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironmentValidator.checkArgument;
+
+import com.google.common.base.Joiner;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+
+/**
+ * Validates {@link KubernetesEnvironment#getPodsData()}.
+ *
+ * @author Sergii Leshchenko
+ */
+public class KubernetesEnvironmentPodsValidator {
+
+  public void validate(KubernetesEnvironment env) throws ValidationException {
+    checkArgument(
+        !env.getPodsData().isEmpty(), "Environment should contain at least 1 pod or deployment");
+
+    ensureHasMetaAndSpec(env.getPodsData());
+
+    ensureConfiguredMachinesHaveContainers(env);
+
+    validatePodVolumes(env);
+  }
+
+  private void ensureHasMetaAndSpec(Map<String, PodData> podsData) throws ValidationException {
+    for (PodData podData : podsData.values()) {
+      if (podData.getMetadata() == null) {
+        throw new ValidationException("Environment contains pod with missing metadata");
+      }
+
+      if (podData.getSpec() == null) {
+        throw new ValidationException(
+            String.format("Pod '%s' with missing metadata", podData.getMetadata().getName()));
+      }
+    }
+  }
+
+  private void validatePodVolumes(KubernetesEnvironment env) throws ValidationException {
+    Set<String> pvcsNames = env.getPersistentVolumeClaims().keySet();
+    for (PodData pod : env.getPodsData().values()) {
+      Set<String> volumesNames = new HashSet<>();
+      for (Volume volume : pod.getSpec().getVolumes()) {
+        volumesNames.add(volume.getName());
+
+        PersistentVolumeClaimVolumeSource pvcSource = volume.getPersistentVolumeClaim();
+        if (pvcSource != null && !pvcsNames.contains(pvcSource.getClaimName())) {
+          throw new ValidationException(
+              String.format(
+                  "Pod '%s' contains volume '%s' with PVC sources that references missing PVC '%s'",
+                  pod.getMetadata().getName(), volume.getName(), pvcSource.getClaimName()));
+        }
+      }
+
+      for (Container container : pod.getSpec().getContainers()) {
+        for (VolumeMount volumeMount : container.getVolumeMounts()) {
+          if (!volumesNames.contains(volumeMount.getName())) {
+            throw new ValidationException(
+                String.format(
+                    "Container '%s' in pod '%s' contains volume mount that references missing volume '%s'",
+                    container.getName(), pod.getMetadata().getName(), volumeMount.getName()));
+          }
+        }
+      }
+    }
+  }
+
+  private void ensureConfiguredMachinesHaveContainers(KubernetesEnvironment env)
+      throws ValidationException {
+    Set<String> missingMachines = new HashSet<>(env.getMachines().keySet());
+    for (PodData pod : env.getPodsData().values()) {
+      if (pod.getSpec() != null && pod.getSpec().getContainers() != null) {
+        for (Container container : pod.getSpec().getContainers()) {
+          missingMachines.remove(Names.machineName(pod, container));
+        }
+      }
+    }
+    checkArgument(
+        missingMachines.isEmpty(),
+        "Environment contains machines that are missing in recipe: %s",
+        Joiner.on(", ").join(missingMachines));
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidator.java
@@ -13,13 +13,8 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
 
 import static java.lang.String.format;
 
-import com.google.common.base.Joiner;
-import io.fabric8.kubernetes.api.model.Container;
-import java.util.HashSet;
-import java.util.Set;
+import javax.inject.Inject;
 import org.eclipse.che.api.core.ValidationException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
  * Validates {@link KubernetesEnvironment}.
@@ -27,6 +22,12 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
  * @author Sergii Leshchenko
  */
 public class KubernetesEnvironmentValidator {
+  private final KubernetesEnvironmentPodsValidator podsValidator;
+
+  @Inject
+  public KubernetesEnvironmentValidator(KubernetesEnvironmentPodsValidator podsValidator) {
+    this.podsValidator = podsValidator;
+  }
 
   /**
    * Validates {@link KubernetesEnvironment}.
@@ -35,31 +36,19 @@ public class KubernetesEnvironmentValidator {
    * @throws ValidationException if the specified {@link KubernetesEnvironment} is invalid
    */
   public void validate(KubernetesEnvironment env) throws ValidationException {
-    checkArgument(
-        !env.getPodsData().isEmpty(), "Environment should contain at least 1 pod or deployment");
+    podsValidator.validate(env);
 
-    Set<String> missingMachines = new HashSet<>(env.getMachines().keySet());
-    for (PodData pod : env.getPodsData().values()) {
-      if (pod.getSpec() != null && pod.getSpec().getContainers() != null) {
-        for (Container container : pod.getSpec().getContainers()) {
-          missingMachines.remove(Names.machineName(pod, container));
-        }
-      }
-    }
-    checkArgument(
-        missingMachines.isEmpty(),
-        "Environment contains machines that are missing in recipe: %s",
-        Joiner.on(", ").join(missingMachines));
-    // TODO Implement validation Kubernetes objects https://github.com/eclipse/che/issues/7381
+    // TODO Implement validation for other Kubernetes objects
+    // https://github.com/eclipse/che/issues/7381
   }
 
-  private static void checkArgument(boolean expression, String error) throws ValidationException {
+  static void checkArgument(boolean expression, String error) throws ValidationException {
     if (!expression) {
       throw new ValidationException(error);
     }
   }
 
-  private static void checkArgument(
+  static void checkArgument(
       boolean expression, String errorMessageTemplate, Object... errorMessageParams)
       throws ValidationException {
     if (!expression) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
@@ -129,14 +129,16 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
   }
 
   /**
-   * May be overridden by child class for changing common scope. Like common per user or common per
-   * workspace.
+   * Creates PVC objects that should be used for the specified runtime identity.
    *
-   * @param identity runtime identity that needs PVC
-   * @return pvc name that should be used for the specified runtime identity
+   * <p>May be overridden by child class for changing common scope. Like common per user or common
+   * per workspace.
+   *
+   * @param runtimeId runtime identity that needs PVC
+   * @return pvc that should be used for the specified runtime identity
    */
-  protected String getCommonPVCName(RuntimeIdentity identity) {
-    return configuredPVCName;
+  protected PersistentVolumeClaim createCommonPVC(RuntimeIdentity runtimeId) {
+    return newPVC(configuredPVCName, pvcAccessMode, pvcQuantity);
   }
 
   @Override
@@ -254,10 +256,9 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
 
   private PersistentVolumeClaim replacePVCsWithCommon(
       KubernetesEnvironment k8sEnv, RuntimeIdentity identity) {
-    String commonPVCName = getCommonPVCName(identity);
-    final PersistentVolumeClaim commonPVC = newPVC(commonPVCName, pvcAccessMode, pvcQuantity);
+    final PersistentVolumeClaim commonPVC = createCommonPVC(identity);
     k8sEnv.getPersistentVolumeClaims().clear();
-    k8sEnv.getPersistentVolumeClaims().put(commonPVCName, commonPVC);
+    k8sEnv.getPersistentVolumeClaims().put(commonPVC.getMetadata().getName(), commonPVC);
     return commonPVC;
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
@@ -12,8 +12,10 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newPVC;
 
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Workspace;
@@ -43,6 +45,8 @@ public class PerWorkspacePVCStrategy extends CommonPVCStrategy {
 
   private final KubernetesNamespaceFactory factory;
   private final String pvcNamePrefix;
+  private final String pvcAccessMode;
+  private final String pvcQuantity;
 
   @Inject
   public PerWorkspacePVCStrategy(
@@ -63,11 +67,18 @@ public class PerWorkspacePVCStrategy extends CommonPVCStrategy {
         ephemeralWorkspaceAdapter);
     this.pvcNamePrefix = pvcName;
     this.factory = factory;
+    this.pvcAccessMode = pvcAccessMode;
+    this.pvcQuantity = pvcQuantity;
   }
 
   @Override
-  protected String getCommonPVCName(RuntimeIdentity identity) {
-    return pvcNamePrefix + '-' + identity.getWorkspaceId();
+  protected PersistentVolumeClaim createCommonPVC(RuntimeIdentity runtimeId) {
+    String workspaceId = runtimeId.getWorkspaceId();
+    String pvcName = pvcNamePrefix + '-' + workspaceId;
+
+    PersistentVolumeClaim perWorkspacePVC = newPVC(pvcName, pvcAccessMode, pvcQuantity);
+    perWorkspacePVC.getMetadata().getLabels().put(CHE_WORKSPACE_ID_LABEL, workspaceId);
+    return perWorkspacePVC;
   }
 
   @Override

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleaner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/WorkspacePVCCleaner.java
@@ -23,7 +23,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Cleans the workspace related Kubernetes resources after {@code WorkspaceRemovedEvent}.
+ * Cleans the workspace related Kubernetes resources after {@link WorkspaceRemovedEvent}.
  *
  * <p>Note that depending on a configuration different types of cleaners may be chosen. In case of
  * configuration when new Kubernetes namespace created for each workspace, the whole namespace will

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidatorTest.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
+
+import static java.util.Collections.emptyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link KubernetesEnvironmentPodsValidator}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class KubernetesEnvironmentPodsValidatorTest {
+
+  @Mock private KubernetesEnvironment kubernetesEnvironment;
+
+  private KubernetesEnvironmentPodsValidator podsValidator;
+
+  @BeforeMethod
+  public void setUp() {
+    podsValidator = new KubernetesEnvironmentPodsValidator();
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp = "Environment should contain at least 1 pod or deployment")
+  public void shouldThrowExceptionWhenEnvDoesNotHaveAnyPods() throws Exception {
+    // given
+    when(kubernetesEnvironment.getPodsData()).thenReturn(emptyMap());
+
+    // when
+    podsValidator.validate(kubernetesEnvironment);
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Environment contains machines that are missing in recipe: pod1/db")
+  public void shouldThrowExceptionWhenMachineIsDeclaredButThereIsNotContainerInKubernetesRecipe()
+      throws Exception {
+    // given
+    String podName = "pod1";
+    Pod pod = createPod("pod1", "main");
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of(podName, podData));
+    when(kubernetesEnvironment.getMachines())
+        .thenReturn(ImmutableMap.of(podName + "/db", mock(InternalMachineConfig.class)));
+
+    // when
+    podsValidator.validate(kubernetesEnvironment);
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp = "Environment contains pod with missing metadata")
+  public void shouldThrowExceptionWhenPodHasNoMetadata() throws Exception {
+    // given
+    PodData podData = new PodData(new PodSpec(), null);
+    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of("", podData));
+
+    // when
+    podsValidator.validate(kubernetesEnvironment);
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp = "Pod 'pod1' with missing metadata")
+  public void shouldThrowExceptionWhenPodHasNoSpec() throws Exception {
+    // given
+    PodData podData = new PodData(null, new ObjectMetaBuilder().withName("pod1").build());
+    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of("pod1", podData));
+
+    // when
+    podsValidator.validate(kubernetesEnvironment);
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Pod 'pod1' contains volume 'user-data' with PVC sources that references missing PVC 'non-existing'")
+  public void shouldThrowExceptionWhenPodHasVolumeThatReferencesMissingPVC() throws Exception {
+    // given
+    String podName = "pod1";
+    Pod pod = createPod("pod1", "main");
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("user-data")
+                .withNewPersistentVolumeClaim()
+                .withClaimName("non-existing")
+                .endPersistentVolumeClaim()
+                .build());
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of(podName, podData));
+    when(kubernetesEnvironment.getMachines())
+        .thenReturn(ImmutableMap.of(podName + "/main", mock(InternalMachineConfig.class)));
+
+    // when
+    podsValidator.validate(kubernetesEnvironment);
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Container 'main' in pod 'pod1' contains volume mount that references missing volume 'non-existing'")
+  public void shouldThrowExceptionWhenContainerHasVolumeMountThatReferencesMissingPodVolume()
+      throws Exception {
+    // given
+    String podName = "pod1";
+    Pod pod = createPod("pod1", "main");
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("non-existing").withMountPath("/tmp/data").build());
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of(podName, podData));
+    when(kubernetesEnvironment.getMachines())
+        .thenReturn(ImmutableMap.of(podName + "/main", mock(InternalMachineConfig.class)));
+
+    // when
+    podsValidator.validate(kubernetesEnvironment);
+  }
+
+  private Pod createPod(String name, String... containers) {
+    return new PodBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .withNewSpec()
+        .withContainers(
+            Arrays.stream(containers).map(this::createContainer).collect(Collectors.toList()))
+        .endSpec()
+        .build();
+  }
+
+  private Container createContainer(String name) {
+    return new ContainerBuilder().withName(name).build();
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentValidatorTest.java
@@ -11,23 +11,9 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
 
-import static java.util.Collections.emptyMap;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodBuilder;
-import java.util.Arrays;
-import java.util.stream.Collectors;
-import org.eclipse.che.api.core.ValidationException;
-import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -38,57 +24,18 @@ import org.testng.annotations.Test;
  */
 @Listeners(MockitoTestNGListener.class)
 public class KubernetesEnvironmentValidatorTest {
+  @Mock private KubernetesEnvironmentPodsValidator podsValidator;
+
   @Mock private KubernetesEnvironment kubernetesEnvironment;
 
-  private KubernetesEnvironmentValidator environmentValidator;
+  @InjectMocks private KubernetesEnvironmentValidator environmentValidator;
 
-  @BeforeMethod
-  public void setUp() throws Exception {
-    environmentValidator = new KubernetesEnvironmentValidator();
-  }
-
-  @Test(
-      expectedExceptions = ValidationException.class,
-      expectedExceptionsMessageRegExp = "Environment should contain at least 1 pod or deployment")
-  public void shouldThrowExceptionWhenEnvDoesNotHaveAnyPods() throws Exception {
-    // given
-    when(kubernetesEnvironment.getPodsData()).thenReturn(emptyMap());
-
+  @Test
+  public void shouldPerformChecksOnEnvironmentValidation() throws Exception {
     // when
     environmentValidator.validate(kubernetesEnvironment);
-  }
 
-  @Test(
-      expectedExceptions = ValidationException.class,
-      expectedExceptionsMessageRegExp =
-          "Environment contains machines that are missing in recipe: pod1/db")
-  public void shouldThrowExceptionWhenMachineIsDeclaredButThereIsNotContainerInKubernetesRecipe()
-      throws Exception {
-    // given
-    String podName = "pod1";
-    Pod pod = createPod("pod1", "main");
-    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of(podName, podData));
-    when(kubernetesEnvironment.getMachines())
-        .thenReturn(ImmutableMap.of(podName + "/db", mock(InternalMachineConfig.class)));
-
-    // when
-    environmentValidator.validate(kubernetesEnvironment);
-  }
-
-  private Pod createPod(String name, String... containers) {
-    return new PodBuilder()
-        .withNewMetadata()
-        .withName(name)
-        .endMetadata()
-        .withNewSpec()
-        .withContainers(
-            Arrays.stream(containers).map(this::createContainer).collect(Collectors.toList()))
-        .endSpec()
-        .build();
-  }
-
-  private Container createContainer(String name) {
-    return new ContainerBuilder().withName(name).build();
+    // then
+    podsValidator.validate(kubernetesEnvironment);
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -12,46 +12,51 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.SUBPATHS_PROPERTY_FMT;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newContainer;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newPod;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
-import java.util.ArrayList;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
-import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
@@ -65,43 +70,46 @@ import org.testng.annotations.Test;
  * Tests {@link CommonPVCStrategy}.
  *
  * @author Anton Korneta
+ * @author Sergii Leshchenko
  */
 @Listeners(MockitoTestNGListener.class)
 public class CommonPVCStrategyTest {
 
   private static final String WORKSPACE_ID = "workspace123";
   private static final String PVC_NAME = "che-claim";
-  private static final String POD_NAME = "main";
-  private static final String POD_NAME_2 = "second";
-  private static final String CONTAINER_NAME = "app";
-  private static final String CONTAINER_NAME_2 = "db";
+
+  private static final String POD_1_NAME = "main";
+  private static final String CONTAINER_1_NAME = "app";
+  private static final String CONTAINER_2_NAME = "db";
+  private static final String MACHINE_1_NAME = POD_1_NAME + '/' + CONTAINER_1_NAME;
+  private static final String MACHINE_2_NAME = POD_1_NAME + '/' + CONTAINER_2_NAME;
+
+  private static final String POD_2_NAME = "second";
   private static final String CONTAINER_NAME_3 = "app2";
-  private static final String MACHINE_1_NAME = POD_NAME + '/' + CONTAINER_NAME;
-  private static final String MACHINE_2_NAME = POD_NAME + '/' + CONTAINER_NAME_2;
-  private static final String MACHINE_3_NAME = POD_NAME_2 + '/' + CONTAINER_NAME_3;
-  private static final String PVC_QUANTITY = "10Gi";
-  private static final String PVC_ACCESS_MODE = "RWO";
+  private static final String MACHINE_3_NAME = POD_2_NAME + '/' + CONTAINER_NAME_3;
+
   private static final String VOLUME_1_NAME = "vol1";
   private static final String VOLUME_2_NAME = "vol2";
+
+  private static final String PVC_QUANTITY = "10Gi";
+  private static final String PVC_ACCESS_MODE = "RWO";
 
   private static final String[] WORKSPACE_SUBPATHS = {"/projects", "/logs"};
 
   private static final RuntimeIdentity IDENTITY =
       new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");
 
-  @Mock private Pod pod;
-  @Mock private Pod pod2;
-  @Mock private PodSpec podSpec;
-  @Mock private PodSpec podSpec2;
-  @Mock private Container container;
-  @Mock private Container container2;
-  @Mock private Container container3;
-  @Mock private KubernetesEnvironment k8sEnv;
+  private KubernetesEnvironment k8sEnv;
+
+  private Pod pod;
+  private Pod pod2;
+
   @Mock private PVCSubPathHelper pvcSubPathHelper;
+
   @Mock private KubernetesNamespaceFactory factory;
   @Mock private KubernetesNamespace k8sNamespace;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
-  @Mock private Workspace workspace;
+
   @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
 
   private CommonPVCStrategy commonPVCStrategy;
@@ -118,91 +126,68 @@ public class CommonPVCStrategyTest {
             factory,
             ephemeralWorkspaceAdapter);
 
-    Map<String, InternalMachineConfig> machines = new HashMap<>();
-    InternalMachineConfig machine1 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes1 = new HashMap<>();
-    volumes1.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
-    volumes1.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
-    lenient().when(machine1.getVolumes()).thenReturn(volumes1);
-    machines.put(MACHINE_1_NAME, machine1);
-    InternalMachineConfig machine2 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes2 = new HashMap<>();
-    volumes2.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
-    lenient().when(machine2.getVolumes()).thenReturn(volumes2);
-    machines.put(MACHINE_2_NAME, machine2);
-    InternalMachineConfig machine3 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes3 = new HashMap<>();
-    volumes3.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
-    lenient().when(machine3.getVolumes()).thenReturn(volumes3);
-    machines.put(MACHINE_3_NAME, machine3);
-    lenient().when(k8sEnv.getMachines()).thenReturn(machines);
+    k8sEnv = KubernetesEnvironment.builder().build();
 
-    lenient().when(pod.getSpec()).thenReturn(podSpec);
-    lenient().when(pod2.getSpec()).thenReturn(podSpec2);
-    lenient().when(podSpec.getContainers()).thenReturn(asList(container, container2));
-    lenient().when(podSpec2.getContainers()).thenReturn(singletonList(container3));
-    lenient().when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
-    lenient().when(podSpec2.getVolumes()).thenReturn(new ArrayList<>());
-    lenient().when(container.getName()).thenReturn(CONTAINER_NAME);
-    lenient().when(container2.getName()).thenReturn(CONTAINER_NAME_2);
-    lenient().when(container3.getName()).thenReturn(CONTAINER_NAME_3);
-    lenient().when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
-    lenient().when(container2.getVolumeMounts()).thenReturn(new ArrayList<>());
-    lenient().when(container3.getVolumeMounts()).thenReturn(new ArrayList<>());
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_1_NAME,
+            TestObjects.newMachineConfig()
+                .withVolume(VOLUME_1_NAME, "/path")
+                .withVolume(VOLUME_2_NAME, "/path2")
+                .build());
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_2_NAME,
+            TestObjects.newMachineConfig().withVolume(VOLUME_2_NAME, "/path2").build());
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_3_NAME,
+            TestObjects.newMachineConfig().withVolume(VOLUME_1_NAME, "/path").build());
+
+    pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME).build(), newContainer(CONTAINER_2_NAME).build())
+            .build();
+
+    pod2 = newPod(POD_2_NAME).withContainers(newContainer(CONTAINER_NAME_3).build()).build();
+
+    k8sEnv.addPod(pod);
+    k8sEnv.addPod(pod2);
 
     lenient().doNothing().when(pvcSubPathHelper).execute(any(), any(), any());
-    lenient().when(k8sEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
     lenient()
-        .when(pvcSubPathHelper.removeDirsAsync(anyString(), any(String.class)))
-        .thenReturn(CompletableFuture.completedFuture(null));
+        .doReturn(CompletableFuture.completedFuture(null))
+        .when(pvcSubPathHelper)
+        .removeDirsAsync(anyString(), any(String.class));
+
     lenient().when(factory.create(WORKSPACE_ID)).thenReturn(k8sNamespace);
     lenient().when(k8sNamespace.persistentVolumeClaims()).thenReturn(pvcs);
-
-    mockName(pod, POD_NAME);
-    mockName(pod2, POD_NAME_2);
-
-    Map<String, PodData> podData =
-        ImmutableMap.of(
-            POD_NAME, new PodData(pod.getSpec(), pod.getMetadata()),
-            POD_NAME_2, new PodData(pod2.getSpec(), pod2.getMetadata()));
-    lenient().when(k8sEnv.getPodsData()).thenReturn(podData);
-
-    when(workspace.getId()).thenReturn(WORKSPACE_ID);
-    Map<String, String> workspaceAttributes = new HashMap<>();
-    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
-    when(workspace.getConfig()).thenReturn(workspaceConfig);
-    when(workspaceConfig.getAttributes()).thenReturn(workspaceAttributes);
   }
 
   @Test
   public void testProvisionVolumesIntoKubernetesEnvironment() throws Exception {
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
-
     commonPVCStrategy.provision(k8sEnv, IDENTITY);
 
     // 2 volumes in machine1
-    verify(container, times(2)).getVolumeMounts();
-    verify(container2).getVolumeMounts();
-    verify(container3).getVolumeMounts();
-    // 1 addition + 3 checks because there are 3 volumes in pod
-    verify(podSpec, times(4)).getVolumes();
-    // 1 addition + 1 check
-    verify(podSpec2, times(2)).getVolumes();
-    assertFalse(podSpec.getVolumes().isEmpty());
-    assertFalse(podSpec2.getVolumes().isEmpty());
-    assertFalse(container.getVolumeMounts().isEmpty());
-    assertFalse(container2.getVolumeMounts().isEmpty());
-    assertFalse(container3.getVolumeMounts().isEmpty());
+    assertFalse(pod.getSpec().getVolumes().isEmpty());
+    assertFalse(pod.getSpec().getContainers().get(0).getVolumeMounts().isEmpty());
+    assertFalse(pod.getSpec().getContainers().get(1).getVolumeMounts().isEmpty());
+    assertFalse(pod2.getSpec().getVolumes().isEmpty());
+    assertFalse(pod2.getSpec().getContainers().get(0).getVolumeMounts().isEmpty());
     assertFalse(k8sEnv.getPersistentVolumeClaims().isEmpty());
     assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(PVC_NAME));
   }
 
   @Test
   public void testReplacePVCWhenItsAlreadyInKubernetesEnvironment() throws Exception {
-    final Map<String, PersistentVolumeClaim> claims = new HashMap<>();
     final PersistentVolumeClaim provisioned = mock(PersistentVolumeClaim.class);
-    claims.put(PVC_NAME, provisioned);
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(claims);
+    k8sEnv.getPersistentVolumeClaims().put(PVC_NAME, provisioned);
 
     commonPVCStrategy.provision(k8sEnv, IDENTITY);
 
@@ -210,7 +195,7 @@ public class CommonPVCStrategyTest {
   }
 
   @Test
-  public void testProvisionVolumesWithSubpathsIntoKubernetesEnviromnent() throws Exception {
+  public void testProvisionVolumesWithSubpathsIntoKubernetesEnvironment() throws Exception {
     commonPVCStrategy.provision(k8sEnv, IDENTITY);
 
     final Map<String, PersistentVolumeClaim> actual = k8sEnv.getPersistentVolumeClaims();
@@ -223,6 +208,221 @@ public class CommonPVCStrategyTest {
                 .getAdditionalProperties()
                 .get(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID)),
         new String[] {expectedVolumeDir(VOLUME_1_NAME), expectedVolumeDir(VOLUME_2_NAME)});
+  }
+
+  @Test
+  public void testProcessingUserDefinedPVCsBoundToMultiplyContainers() throws Exception {
+    // given
+    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
+
+    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
+
+    pod.getSpec()
+        .getInitContainers()
+        .add(
+            new ContainerBuilder()
+                .withName("userInitContainer")
+                .withVolumeMounts(
+                    new VolumeMountBuilder()
+                        .withName("userData")
+                        .withSubPath("/tmp/init/userData")
+                        .build())
+                .build());
+
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
+
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("userDataPVC")
+                        .build())
+                .build());
+
+    // when
+    commonPVCStrategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(PVC_NAME));
+
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(userPodVolume.getPersistentVolumeClaim().getClaimName(), PVC_NAME);
+    assertEquals(podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(), PVC_NAME);
+
+    Container initContainer = podSpec.getInitContainers().get(0);
+    VolumeMount initVolumeMount = initContainer.getVolumeMounts().get(0);
+    assertEquals(initVolumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/tmp/init/userData");
+    assertEquals(initVolumeMount.getName(), userPodVolume.getName());
+
+    Container container = podSpec.getContainers().get(0);
+    VolumeMount volumeMount = container.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/home/user/data");
+    assertEquals(volumeMount.getName(), userPodVolume.getName());
+  }
+
+  @Test
+  public void testProcessingUserDefinedNonPVCPodsVolumes() throws Exception {
+    // given
+    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
+
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(
+            new VolumeMountBuilder()
+                .withName("configMapVolume")
+                .withSubPath("/home/user/config")
+                .build());
+
+    ConfigMapVolumeSource configMapVolumeSource =
+        new ConfigMapVolumeSourceBuilder().withName("configMap").build();
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("configMapVolume")
+                .withConfigMap(configMapVolumeSource)
+                .build());
+
+    // when
+    commonPVCStrategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertNull(userPodVolume.getPersistentVolumeClaim());
+    assertEquals(userPodVolume.getConfigMap(), configMapVolumeSource);
+
+    Container container = podSpec.getContainers().get(0);
+    VolumeMount volumeMount = container.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getName(), "configMapVolume");
+    assertEquals(volumeMount.getSubPath(), "/home/user/config");
+  }
+
+  @Test
+  public void testMatchingUserDefinedPVCWithCheVolume() throws Exception {
+    // given
+    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
+
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("userDataPVC")
+                        .build())
+                .build());
+
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
+
+    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
+    k8sEnv
+        .getMachines()
+        .get(MACHINE_2_NAME)
+        .getVolumes()
+        .put("userDataPVC", new VolumeImpl().withPath("/"));
+
+    // when
+    commonPVCStrategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(PVC_NAME));
+
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(userPodVolume.getPersistentVolumeClaim().getClaimName(), PVC_NAME);
+    assertEquals(podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(), PVC_NAME);
+
+    // check container bound to user-defined PVC
+    Container container1 = podSpec.getContainers().get(0);
+    assertEquals(container1.getVolumeMounts().size(), 1);
+    VolumeMount volumeMount = container1.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/home/user/data");
+    assertEquals(volumeMount.getName(), userPodVolume.getName());
+
+    // check container that is bound to Che Volume via Machine configuration
+    Container container2 = podSpec.getContainers().get(1);
+    VolumeMount cheVolumeMount2 = container2.getVolumeMounts().get(0);
+    assertEquals(cheVolumeMount2.getSubPath(), WORKSPACE_ID + "/userDataPVC");
+    assertEquals(cheVolumeMount2.getName(), userPodVolume.getName());
+  }
+
+  @Test
+  public void testProcessingDifferentVolumeMountsBoundToTheSameVolume() throws Exception {
+    // given
+    k8sEnv = KubernetesEnvironment.builder().build();
+    k8sEnv.getPersistentVolumeClaims().put("appStorage", newPVC("appStorage"));
+
+    Pod pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME)
+                    .withVolumeMount("appStorage", "/data", "data")
+                    .withVolumeMount("appStorage", "/config", "config")
+                    .build())
+            .withPVCVolume("appStorage", "appStorage")
+            .build();
+
+    k8sEnv.addPod(pod);
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_1_NAME,
+            TestObjects.newMachineConfig().withVolume("appStorage", "/app-storage").build());
+
+    // when
+    commonPVCStrategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(PVC_NAME));
+
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    assertEquals(podSpec.getVolumes().size(), 1);
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(userPodVolume.getPersistentVolumeClaim().getClaimName(), PVC_NAME);
+    assertEquals(podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(), PVC_NAME);
+
+    // check container bound to user-defined PVC
+    Container container1 = podSpec.getContainers().get(0);
+    assertEquals(container1.getVolumeMounts().size(), 3);
+
+    VolumeMount dataVolumeMount = container1.getVolumeMounts().get(0);
+    assertEquals(dataVolumeMount.getSubPath(), WORKSPACE_ID + "/appStorage/data");
+    assertEquals(dataVolumeMount.getMountPath(), "/data");
+    assertEquals(dataVolumeMount.getName(), userPodVolume.getName());
+
+    VolumeMount configVolumeMount = container1.getVolumeMounts().get(1);
+    assertEquals(configVolumeMount.getSubPath(), WORKSPACE_ID + "/appStorage/config");
+    assertEquals(configVolumeMount.getMountPath(), "/config");
+    assertEquals(configVolumeMount.getName(), userPodVolume.getName());
+
+    VolumeMount appStorage = container1.getVolumeMounts().get(2);
+    assertEquals(appStorage.getSubPath(), WORKSPACE_ID + "/appStorage");
+    assertEquals(appStorage.getMountPath(), "/app-storage");
+    assertEquals(appStorage.getName(), userPodVolume.getName());
   }
 
   @Test
@@ -252,7 +452,7 @@ public class CommonPVCStrategyTest {
   @Test
   public void testCreatesPVCsWithSubpathsOnPrepare() throws Exception {
     final PersistentVolumeClaim pvc = mockName(mock(PersistentVolumeClaim.class), PVC_NAME);
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(PVC_NAME, pvc));
+    k8sEnv.getPersistentVolumeClaims().put(PVC_NAME, pvc);
     final Map<String, Object> subPaths = new HashMap<>();
     subPaths.put(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID), WORKSPACE_SUBPATHS);
     when(pvc.getAdditionalProperties()).thenReturn(subPaths);
@@ -268,8 +468,7 @@ public class CommonPVCStrategyTest {
 
   @Test(expectedExceptions = InfrastructureException.class)
   public void throwsInfrastructureExceptionWhenFailedToGetExistingPVCs() throws Exception {
-    when(k8sEnv.getPersistentVolumeClaims())
-        .thenReturn(singletonMap(PVC_NAME, mock(PersistentVolumeClaim.class)));
+    k8sEnv.getPersistentVolumeClaims().put(PVC_NAME, mock(PersistentVolumeClaim.class));
     doThrow(InfrastructureException.class).when(pvcs).get();
 
     commonPVCStrategy.prepare(k8sEnv, WORKSPACE_ID, 100);
@@ -278,7 +477,7 @@ public class CommonPVCStrategyTest {
   @Test(expectedExceptions = InfrastructureException.class)
   public void throwsInfrastructureExceptionWhenPVCCreationFailed() throws Exception {
     final PersistentVolumeClaim claim = mockName(mock(PersistentVolumeClaim.class), PVC_NAME);
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(PVC_NAME, claim));
+    k8sEnv.getPersistentVolumeClaims().put(PVC_NAME, claim);
     when(pvcs.get()).thenReturn(emptyList());
     doThrow(InfrastructureException.class).when(pvcs).create(any());
 
@@ -286,10 +485,76 @@ public class CommonPVCStrategyTest {
   }
 
   @Test
-  public void testCleanup() throws Exception {
+  public void shouldDeletePVCsIfThereIsNoPersistAttributeInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
+
+    // when
     commonPVCStrategy.cleanup(workspace);
 
+    // then
     verify(pvcSubPathHelper).removeDirsAsync(WORKSPACE_ID, WORKSPACE_ID);
+  }
+
+  @Test
+  public void shouldDeletePVCsIfPersistAttributeIsSetToTrueInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
+
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
+    workspaceConfigAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "true");
+
+    // when
+    commonPVCStrategy.cleanup(workspace);
+
+    // then
+    verify(pvcSubPathHelper).removeDirsAsync(WORKSPACE_ID, WORKSPACE_ID);
+  }
+
+  @Test
+  public void shouldDoNothingIfPersistAttributeIsSetToFalseInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
+    workspaceConfigAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");
+
+    // when
+    commonPVCStrategy.cleanup(workspace);
+
+    // then
+    verify(pvcSubPathHelper, never()).removeDirsAsync(WORKSPACE_ID, WORKSPACE_ID);
+  }
+
+  private static PersistentVolumeClaim newPVC(String name) {
+    return new PersistentVolumeClaimBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
   }
 
   static <T extends HasMetadata> T mockName(T obj, String name) {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
@@ -11,51 +11,21 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
-import static java.lang.String.format;
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
-import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.SUBPATHS_PROPERTY_FMT;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
-import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
@@ -75,45 +45,24 @@ public class PerWorkspacePVCStrategyTest {
 
   private static final String WORKSPACE_ID = "workspace123";
   private static final String PVC_NAME_PREFIX = "che-claim";
-  private static final String PVC_NAME = PVC_NAME_PREFIX + '-' + WORKSPACE_ID;
-  private static final String POD_NAME = "main";
-  private static final String POD_NAME_2 = "second";
-  private static final String CONTAINER_NAME = "app";
-  private static final String CONTAINER_NAME_2 = "db";
-  private static final String CONTAINER_NAME_3 = "app2";
-  private static final String MACHINE_1_NAME = POD_NAME + '/' + CONTAINER_NAME;
-  private static final String MACHINE_2_NAME = POD_NAME + '/' + CONTAINER_NAME_2;
-  private static final String MACHINE_3_NAME = POD_NAME_2 + '/' + CONTAINER_NAME_3;
+
   private static final String PVC_QUANTITY = "10Gi";
   private static final String PVC_ACCESS_MODE = "RWO";
-  private static final String VOLUME_1_NAME = "vol1";
-  private static final String VOLUME_2_NAME = "vol2";
-
-  private static final String[] WORKSPACE_SUBPATHS = {"/projects", "/logs"};
 
   private static final RuntimeIdentity IDENTITY =
       new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");
 
-  @Mock private Pod pod;
-  @Mock private Pod pod2;
-  @Mock private PodSpec podSpec;
-  @Mock private PodSpec podSpec2;
-  @Mock private Container container;
-  @Mock private Container container2;
-  @Mock private Container container3;
-  @Mock private KubernetesEnvironment k8sEnv;
   @Mock private PVCSubPathHelper pvcSubPathHelper;
   @Mock private KubernetesNamespaceFactory factory;
   @Mock private KubernetesNamespace k8sNamespace;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
-  @Mock private Workspace workspace;
   @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
 
-  private PerWorkspacePVCStrategy perWorkspaceStrategy;
+  private PerWorkspacePVCStrategy strategy;
 
   @BeforeMethod
   public void setup() throws Exception {
-    perWorkspaceStrategy =
+    strategy =
         new PerWorkspacePVCStrategy(
             PVC_NAME_PREFIX,
             PVC_QUANTITY,
@@ -123,194 +72,78 @@ public class PerWorkspacePVCStrategyTest {
             factory,
             ephemeralWorkspaceAdapter);
 
-    Map<String, InternalMachineConfig> machines = new HashMap<>();
-    InternalMachineConfig machine1 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes1 = new HashMap<>();
-    volumes1.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
-    volumes1.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
-    lenient().when(machine1.getVolumes()).thenReturn(volumes1);
-    machines.put(MACHINE_1_NAME, machine1);
-
-    InternalMachineConfig machine2 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes2 = new HashMap<>();
-    volumes2.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
-    lenient().when(machine2.getVolumes()).thenReturn(volumes2);
-    machines.put(MACHINE_2_NAME, machine2);
-
-    InternalMachineConfig machine3 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes3 = new HashMap<>();
-    volumes3.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
-    lenient().when(machine3.getVolumes()).thenReturn(volumes3);
-    machines.put(MACHINE_3_NAME, machine3);
-    lenient().when(k8sEnv.getMachines()).thenReturn(machines);
-
-    lenient().when(pod.getSpec()).thenReturn(podSpec);
-    lenient().when(pod2.getSpec()).thenReturn(podSpec2);
-    lenient().when(podSpec.getContainers()).thenReturn(asList(container, container2));
-    lenient().when(podSpec2.getContainers()).thenReturn(singletonList(container3));
-    lenient().when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
-    lenient().when(podSpec2.getVolumes()).thenReturn(new ArrayList<>());
-    lenient().when(container.getName()).thenReturn(CONTAINER_NAME);
-    lenient().when(container2.getName()).thenReturn(CONTAINER_NAME_2);
-    lenient().when(container3.getName()).thenReturn(CONTAINER_NAME_3);
-    lenient().when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
-    lenient().when(container2.getVolumeMounts()).thenReturn(new ArrayList<>());
-    lenient().when(container3.getVolumeMounts()).thenReturn(new ArrayList<>());
-
-    lenient().doNothing().when(pvcSubPathHelper).execute(any(), any(), any());
-    lenient().when(k8sEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
-    lenient()
-        .when(pvcSubPathHelper.removeDirsAsync(anyString(), any(String.class)))
-        .thenReturn(CompletableFuture.completedFuture(null));
     lenient().when(factory.create(WORKSPACE_ID)).thenReturn(k8sNamespace);
     lenient().when(k8sNamespace.persistentVolumeClaims()).thenReturn(pvcs);
+  }
 
-    mockName(pod, POD_NAME);
-    mockName(pod2, POD_NAME_2);
+  @Test
+  public void shouldReturnCommonPVCNameSuffixedWithWorkspaceId() throws Exception {
+    // when
+    String commonPVCName = strategy.getCommonPVCName(IDENTITY);
 
-    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    PodData pod2Data = new PodData(pod2.getSpec(), pod2.getMetadata());
-    lenient()
-        .when(k8sEnv.getPodsData())
-        .thenReturn(ImmutableMap.of(POD_NAME, podData, POD_NAME_2, pod2Data));
+    // then
+    assertEquals(commonPVCName, PVC_NAME_PREFIX + "-" + WORKSPACE_ID);
+  }
 
+  @Test
+  public void shouldDeletePVCsIfThereIsNoPersistAttributeInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
     lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
-    Map<String, String> workspaceAttributes = new HashMap<>();
+
     WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
     lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
-    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceAttributes);
-  }
 
-  @Test
-  public void testProvisionVolumesIntoKubernetesEnvironment() throws Exception {
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
 
-    perWorkspaceStrategy.provision(k8sEnv, IDENTITY);
+    // when
+    strategy.cleanup(workspace);
 
-    // 2 volumes in machine1
-    verify(container, times(2)).getVolumeMounts();
-    verify(container2).getVolumeMounts();
-    verify(container3).getVolumeMounts();
-    // 1 addition + 3 checks because there are 3 volumes in pod
-    verify(podSpec, times(4)).getVolumes();
-    // 1 addition + 1 check
-    verify(podSpec2, times(2)).getVolumes();
-    assertFalse(podSpec.getVolumes().isEmpty());
-    assertFalse(podSpec2.getVolumes().isEmpty());
-    assertFalse(container.getVolumeMounts().isEmpty());
-    assertFalse(container2.getVolumeMounts().isEmpty());
-    assertFalse(container3.getVolumeMounts().isEmpty());
-    assertFalse(k8sEnv.getPersistentVolumeClaims().isEmpty());
-    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(PVC_NAME));
-  }
-
-  @Test
-  public void testReplacePVCWhenItsAlreadyInKubernetesEnvironment() throws Exception {
-    final Map<String, PersistentVolumeClaim> claims = new HashMap<>();
-    final PersistentVolumeClaim provisioned = mock(PersistentVolumeClaim.class);
-    claims.put(PVC_NAME, provisioned);
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(claims);
-
-    perWorkspaceStrategy.provision(k8sEnv, IDENTITY);
-
-    assertNotEquals(k8sEnv.getPersistentVolumeClaims().get(PVC_NAME), provisioned);
-  }
-
-  @Test
-  public void testProvisionVolumesWithSubpathsIntoKubernetesEnvironment() throws Exception {
-    perWorkspaceStrategy.provision(k8sEnv, IDENTITY);
-
-    final Map<String, PersistentVolumeClaim> actual = k8sEnv.getPersistentVolumeClaims();
-    assertFalse(actual.isEmpty());
-    assertTrue(actual.containsKey(PVC_NAME));
-    Set<String> subpaths =
-        Arrays.stream(
-                (String[])
-                    actual
-                        .get(PVC_NAME)
-                        .getAdditionalProperties()
-                        .get(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID)))
-            .collect(Collectors.toSet());
-    assertEquals(subpaths.size(), 2);
-    assertTrue(subpaths.contains(expectedVolumeDir(VOLUME_1_NAME)));
-    assertTrue(subpaths.contains(expectedVolumeDir(VOLUME_2_NAME)));
-  }
-
-  @Test
-  public void testDoNotAddsSubpathsWhenPreCreationIsNotNeeded() throws Exception {
-    perWorkspaceStrategy =
-        new PerWorkspacePVCStrategy(
-            PVC_NAME_PREFIX,
-            PVC_QUANTITY,
-            PVC_ACCESS_MODE,
-            false,
-            pvcSubPathHelper,
-            factory,
-            ephemeralWorkspaceAdapter);
-
-    perWorkspaceStrategy.provision(k8sEnv, IDENTITY);
-
-    final Map<String, PersistentVolumeClaim> actual = k8sEnv.getPersistentVolumeClaims();
-    assertFalse(actual.isEmpty());
-    assertTrue(actual.containsKey(PVC_NAME));
-    assertFalse(
-        actual
-            .get(PVC_NAME)
-            .getAdditionalProperties()
-            .containsKey(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID)));
-  }
-
-  @Test
-  public void testCreatesPVCWithSubpathsOnPrepare() throws Exception {
-    final PersistentVolumeClaim pvc = mockName(mock(PersistentVolumeClaim.class), PVC_NAME);
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(PVC_NAME, pvc));
-    final Map<String, Object> subPaths = new HashMap<>();
-    subPaths.put(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID), WORKSPACE_SUBPATHS);
-    when(pvc.getAdditionalProperties()).thenReturn(subPaths);
-    doNothing().when(pvcSubPathHelper).createDirs(WORKSPACE_ID, WORKSPACE_SUBPATHS);
-
-    perWorkspaceStrategy.prepare(k8sEnv, WORKSPACE_ID, 100);
-
-    verify(pvcs).get();
-    verify(pvcs).create(pvc);
-    verify(pvcs).waitBound(PVC_NAME, 100);
-    verify(pvcSubPathHelper).createDirs(any(), any());
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwsInfrastructureExceptionWhenFailedToGetExistingPVCs() throws Exception {
-    when(k8sEnv.getPersistentVolumeClaims())
-        .thenReturn(singletonMap(PVC_NAME, mock(PersistentVolumeClaim.class)));
-    doThrow(InfrastructureException.class).when(pvcs).get();
-
-    perWorkspaceStrategy.prepare(k8sEnv, WORKSPACE_ID, 100);
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwsInfrastructureExceptionWhenPVCCreationFailed() throws Exception {
-    final PersistentVolumeClaim claim = mockName(mock(PersistentVolumeClaim.class), PVC_NAME);
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(PVC_NAME, claim));
-    when(pvcs.get()).thenReturn(emptyList());
-    doThrow(InfrastructureException.class).when(pvcs).create(any());
-
-    perWorkspaceStrategy.prepare(k8sEnv, WORKSPACE_ID, 100);
-  }
-
-  @Test
-  public void testCleanup() throws Exception {
-    perWorkspaceStrategy.cleanup(workspace);
-
+    // then
     verify(pvcs).delete(ImmutableMap.of(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID));
   }
 
-  static <T extends HasMetadata> T mockName(T obj, String name) {
-    final ObjectMeta objectMeta = mock(ObjectMeta.class);
-    lenient().when(obj.getMetadata()).thenReturn(objectMeta);
-    lenient().when(objectMeta.getName()).thenReturn(name);
-    return obj;
+  @Test
+  public void shouldDeletePVCsIfPersistAttributeIsSetToTrueInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
+    workspaceConfigAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "true");
+
+    // when
+    strategy.cleanup(workspace);
+
+    // then
+    verify(pvcs).delete(ImmutableMap.of(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID));
   }
 
-  private static String expectedVolumeDir(String volumeName) {
-    return WORKSPACE_ID + '/' + volumeName;
+  @Test
+  public void shouldDoNothingIfPersistAttributeIsSetToFalseInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
+    workspaceConfigAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");
+
+    // when
+    strategy.cleanup(workspace);
+
+    // then
+    verify(pvcs, never()).delete(ImmutableMap.of(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID));
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.Workspace;
@@ -77,12 +78,13 @@ public class PerWorkspacePVCStrategyTest {
   }
 
   @Test
-  public void shouldReturnCommonPVCNameSuffixedWithWorkspaceId() throws Exception {
+  public void shouldReturnPVCPerWorkspace() throws Exception {
     // when
-    String commonPVCName = strategy.getCommonPVCName(IDENTITY);
+    PersistentVolumeClaim commonPVC = strategy.createCommonPVC(IDENTITY);
 
     // then
-    assertEquals(commonPVCName, PVC_NAME_PREFIX + "-" + WORKSPACE_ID);
+    assertEquals(commonPVC.getMetadata().getName(), PVC_NAME_PREFIX + "-" + WORKSPACE_ID);
+    assertEquals(commonPVC.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/TestObjects.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/TestObjects.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+
+/**
+ * Helps prepare objects for PVC strategy tests.
+ *
+ * @author Sergii Leshchenko
+ */
+public class TestObjects {
+
+  public static InternalMachineConfigBuilder newMachineConfig() {
+    return new InternalMachineConfigBuilder();
+  }
+
+  public static TestPodBuilder newPod(String podName) {
+    return new TestPodBuilder(podName);
+  }
+
+  public static TestContainerBuilder newContainer(String containerName) {
+    return new TestContainerBuilder(containerName);
+  }
+
+  public static class TestPodBuilder {
+
+    private String name;
+    private List<Container> initContainers = new ArrayList<>();
+    private List<Container> containers = new ArrayList<>();
+    private List<Volume> volumes = new ArrayList<>();
+
+    public TestPodBuilder(String podName) {
+      this.name = podName;
+    }
+
+    public TestPodBuilder withInitContainers(Container... containers) {
+      this.initContainers.addAll(Arrays.asList(containers));
+      return this;
+    }
+
+    public TestPodBuilder withContainers(Container... containers) {
+      this.containers.addAll(Arrays.asList(containers));
+      return this;
+    }
+
+    public TestPodBuilder withPVCVolume(String volumeName, String pvcName) {
+      this.volumes.add(
+          new VolumeBuilder()
+              .withName(volumeName)
+              .withNewPersistentVolumeClaim()
+              .withClaimName(pvcName)
+              .endPersistentVolumeClaim()
+              .build());
+      return this;
+    }
+
+    public Pod build() {
+      return new PodBuilder()
+          .withNewMetadata()
+          .withName(name)
+          .endMetadata()
+          .withNewSpec()
+          .withInitContainers(initContainers)
+          .withContainers(containers)
+          .withVolumes(volumes)
+          .endSpec()
+          .build();
+    }
+  }
+
+  public static class TestContainerBuilder {
+
+    private String name;
+    private List<VolumeMount> volumeMounts = new ArrayList<>();
+
+    public TestContainerBuilder(String containerName) {
+      this.name = containerName;
+    }
+
+    public TestContainerBuilder withVolumeMount(
+        String volumeName, String mountPath, String subpath) {
+      this.volumeMounts.add(
+          new VolumeMountBuilder()
+              .withName(volumeName)
+              .withMountPath(mountPath)
+              .withSubPath(subpath)
+              .build());
+      return this;
+    }
+
+    public Container build() {
+      return new ContainerBuilder().withName(name).withVolumeMounts(volumeMounts).build();
+    }
+  }
+
+  public static class InternalMachineConfigBuilder {
+
+    private Map<String, VolumeImpl> volumes = new HashMap<>();
+
+    public InternalMachineConfigBuilder withVolume(String volumeName, String path) {
+      volumes.put(volumeName, new VolumeImpl().withPath(path));
+      return this;
+    }
+
+    public InternalMachineConfig build() {
+      return new InternalMachineConfig(
+          new ArrayList<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), volumes);
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -11,43 +11,50 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_VOLUME_NAME_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategyTest.mockName;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newContainer;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newPod;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
-import java.util.ArrayList;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
-import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
@@ -61,40 +68,39 @@ import org.testng.annotations.Test;
  * Tests {@link UniqueWorkspacePVCStrategy}.
  *
  * @author Anton Korneta
+ * @author Sergii Leshchenko
  */
 @Listeners(MockitoTestNGListener.class)
 public class UniqueWorkspacePVCStrategyTest {
 
   private static final String WORKSPACE_ID = "workspace123";
   private static final String PVC_NAME_PREFIX = "che-claim";
-  private static final String POD_NAME = "main";
-  private static final String POD_NAME_2 = "second";
-  private static final String CONTAINER_NAME = "app";
-  private static final String CONTAINER_NAME_2 = "db";
-  private static final String CONTAINER_NAME_3 = "app2";
-  private static final String MACHINE_NAME = POD_NAME + '/' + CONTAINER_NAME;
-  private static final String MACHINE_NAME_2 = POD_NAME + '/' + CONTAINER_NAME_2;
-  private static final String MACHINE_NAME_3 = POD_NAME_2 + '/' + CONTAINER_NAME_3;
-  private static final String PVC_QUANTITY = "10Gi";
-  private static final String PVC_ACCESS_MODE = "RWO";
+
+  private static final String POD_1_NAME = "main";
+  private static final String CONTAINER_1_NAME = "app";
+  private static final String CONTAINER_2_NAME = "db";
+  private static final String MACHINE_1_NAME = POD_1_NAME + '/' + CONTAINER_1_NAME;
+  private static final String MACHINE_2_NAME = POD_1_NAME + '/' + CONTAINER_2_NAME;
+
+  private static final String POD_2_NAME = "second";
+  private static final String CONTAINER_3_NAME = "app2";
+  private static final String MACHINE_3_NAME = POD_2_NAME + '/' + CONTAINER_3_NAME;
+
   private static final String VOLUME_1_NAME = "vol1";
   private static final String VOLUME_2_NAME = "vol2";
+
+  private static final String PVC_QUANTITY = "10Gi";
+  private static final String PVC_ACCESS_MODE = "RWO";
 
   private static final RuntimeIdentity IDENTITY =
       new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");
 
-  @Mock private KubernetesEnvironment k8sEnv;
+  private KubernetesEnvironment k8sEnv;
   @Mock private KubernetesNamespaceFactory factory;
   @Mock private KubernetesNamespace k8sNamespace;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
-  @Mock private Pod pod;
-  @Mock private Pod pod2;
-  @Mock private PodSpec podSpec;
-  @Mock private PodSpec podSpec2;
-  @Mock private Container container;
-  @Mock private Container container2;
-  @Mock private Container container3;
-  @Mock private Workspace workspace;
+  private Pod pod;
+  private Pod pod2;
   @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
 
   private UniqueWorkspacePVCStrategy strategy;
@@ -105,74 +111,312 @@ public class UniqueWorkspacePVCStrategyTest {
         new UniqueWorkspacePVCStrategy(
             PVC_NAME_PREFIX, PVC_QUANTITY, PVC_ACCESS_MODE, factory, ephemeralWorkspaceAdapter);
 
-    Map<String, InternalMachineConfig> machines = new HashMap<>();
-    InternalMachineConfig machine1 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes1 = new HashMap<>();
-    volumes1.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
-    volumes1.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
-    lenient().when(machine1.getVolumes()).thenReturn(volumes1);
-    machines.put(MACHINE_NAME, machine1);
-    InternalMachineConfig machine2 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes2 = new HashMap<>();
-    volumes2.put(VOLUME_2_NAME, new VolumeImpl().withPath("/path2"));
-    lenient().when(machine2.getVolumes()).thenReturn(volumes2);
-    machines.put(MACHINE_NAME_2, machine2);
-    InternalMachineConfig machine3 = mock(InternalMachineConfig.class);
-    Map<String, Volume> volumes3 = new HashMap<>();
-    volumes3.put(VOLUME_1_NAME, new VolumeImpl().withPath("/path"));
-    lenient().when(machine3.getVolumes()).thenReturn(volumes3);
-    machines.put(MACHINE_NAME_3, machine3);
-    lenient().when(k8sEnv.getMachines()).thenReturn(machines);
+    k8sEnv = KubernetesEnvironment.builder().build();
 
-    lenient().when(pod.getSpec()).thenReturn(podSpec);
-    lenient().when(pod2.getSpec()).thenReturn(podSpec2);
-    lenient().when(podSpec.getContainers()).thenReturn(asList(container, container2));
-    lenient().when(podSpec2.getContainers()).thenReturn(singletonList(container3));
-    lenient().when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
-    lenient().when(podSpec2.getVolumes()).thenReturn(new ArrayList<>());
-    lenient().when(container.getName()).thenReturn(CONTAINER_NAME);
-    lenient().when(container2.getName()).thenReturn(CONTAINER_NAME_2);
-    lenient().when(container3.getName()).thenReturn(CONTAINER_NAME_3);
-    lenient().when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
-    lenient().when(container2.getVolumeMounts()).thenReturn(new ArrayList<>());
-    lenient().when(container3.getVolumeMounts()).thenReturn(new ArrayList<>());
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_1_NAME,
+            TestObjects.newMachineConfig()
+                .withVolume(VOLUME_1_NAME, "/path")
+                .withVolume(VOLUME_2_NAME, "/path2")
+                .build());
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_2_NAME,
+            TestObjects.newMachineConfig().withVolume(VOLUME_2_NAME, "/path2").build());
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_3_NAME,
+            TestObjects.newMachineConfig().withVolume(VOLUME_1_NAME, "/path").build());
+
+    pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME).build(), newContainer(CONTAINER_2_NAME).build())
+            .build();
+
+    pod2 = newPod(POD_2_NAME).withContainers(newContainer(CONTAINER_3_NAME).build()).build();
+
+    k8sEnv.addPod(pod);
+    k8sEnv.addPod(pod2);
 
     when(factory.create(WORKSPACE_ID)).thenReturn(k8sNamespace);
     when(k8sNamespace.persistentVolumeClaims()).thenReturn(pvcs);
-
-    mockName(pod, POD_NAME);
-    mockName(pod2, POD_NAME_2);
-
-    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
-    PodData pod2Data = new PodData(pod2.getSpec(), pod2.getMetadata());
-    lenient()
-        .when(k8sEnv.getPodsData())
-        .thenReturn(ImmutableMap.of(POD_NAME, podData, POD_NAME_2, pod2Data));
-
-    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
-    Map<String, String> workspaceAttributes = new HashMap<>();
-    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
-    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
-    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceAttributes);
   }
 
   @Test
   public void testProvisionPVCsForEachVolumeWithUniqueName() throws Exception {
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(new HashMap<>());
+    // given
+    k8sEnv.getPersistentVolumeClaims().clear();
 
+    // when
     strategy.provision(k8sEnv, IDENTITY);
 
-    assertEquals(podSpec.getVolumes().size(), 2);
-    assertEquals(podSpec2.getVolumes().size(), 1);
-    assertEquals(container.getVolumeMounts().size(), 2);
-    assertEquals(container2.getVolumeMounts().size(), 1);
-    assertEquals(container3.getVolumeMounts().size(), 1);
+    // then
+    assertEquals(pod.getSpec().getVolumes().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(1).getVolumeMounts().size(), 1);
+
+    assertEquals(pod2.getSpec().getVolumes().size(), 1);
+    assertEquals(pod2.getSpec().getContainers().get(0).getVolumeMounts().size(), 1);
     assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 2);
-    for (PersistentVolumeClaim pvc : k8sEnv.getPersistentVolumeClaims().values()) {
-      String volumeName = pvc.getMetadata().getLabels().get(CHE_VOLUME_NAME_LABEL);
-      assertNotNull(volumeName);
-      assertTrue(volumeName.equals(VOLUME_1_NAME) || volumeName.equals(VOLUME_2_NAME));
-    }
+
+    PersistentVolumeClaim pvcForVolume1 =
+        findPvc(VOLUME_1_NAME, k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForVolume1);
+    assertTrue(pvcForVolume1.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
+
+    PersistentVolumeClaim pvcForVolume2 =
+        findPvc(VOLUME_2_NAME, k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForVolume2);
+    assertTrue(pvcForVolume2.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
+  }
+
+  @Test
+  public void testProcessingUserDefinedPVCsBoundToMultiplyContainers() throws Exception {
+    // given
+    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
+
+    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
+
+    pod.getSpec()
+        .getInitContainers()
+        .add(
+            new ContainerBuilder()
+                .withName("userInitContainer")
+                .withVolumeMounts(
+                    new VolumeMountBuilder()
+                        .withName("userData")
+                        .withSubPath("/tmp/init/userData")
+                        .build())
+                .build());
+
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
+
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("userDataPVC")
+                        .build())
+                .build());
+
+    // when
+    strategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    PersistentVolumeClaim pvcForUserData =
+        findPvc("userDataPVC", k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForUserData);
+    assertTrue(pvcForUserData.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
+    assertEquals(
+        pvcForUserData.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
+
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(
+        userPodVolume.getPersistentVolumeClaim().getClaimName(),
+        pvcForUserData.getMetadata().getName());
+    assertEquals(
+        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(),
+        pvcForUserData.getMetadata().getName());
+
+    Container initContainer = podSpec.getInitContainers().get(0);
+    VolumeMount initVolumeMount = initContainer.getVolumeMounts().get(0);
+    assertEquals(initVolumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/tmp/init/userData");
+    assertEquals(initVolumeMount.getName(), userPodVolume.getName());
+
+    Container container = podSpec.getContainers().get(0);
+    VolumeMount volumeMount = container.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/home/user/data");
+    assertEquals(volumeMount.getName(), userPodVolume.getName());
+  }
+
+  @Test
+  public void testProcessingUserDefinedNonPVCPodsVolumes() throws Exception {
+    // given
+    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
+
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(
+            new VolumeMountBuilder()
+                .withName("configMapVolume")
+                .withSubPath("/home/user/config")
+                .build());
+
+    ConfigMapVolumeSource configMapVolumeSource =
+        new ConfigMapVolumeSourceBuilder().withName("configMap").build();
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("configMapVolume")
+                .withConfigMap(configMapVolumeSource)
+                .build());
+
+    // when
+    strategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertNull(userPodVolume.getPersistentVolumeClaim());
+    assertEquals(userPodVolume.getConfigMap(), configMapVolumeSource);
+
+    Container container = podSpec.getContainers().get(0);
+    VolumeMount volumeMount = container.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getName(), "configMapVolume");
+    assertEquals(volumeMount.getSubPath(), "/home/user/config");
+  }
+
+  @Test
+  public void testMatchingUserDefinedPVCWithCheVolume() throws Exception {
+    // given
+    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
+
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("userDataPVC")
+                        .build())
+                .build());
+
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
+
+    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
+    k8sEnv
+        .getMachines()
+        .get(MACHINE_2_NAME)
+        .getVolumes()
+        .put("userDataPVC", new VolumeImpl().withPath("/"));
+
+    // when
+    strategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    PersistentVolumeClaim pvcForUserData =
+        findPvc("userDataPVC", k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForUserData);
+    assertTrue(pvcForUserData.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
+    assertEquals(
+        pvcForUserData.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
+
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(
+        userPodVolume.getPersistentVolumeClaim().getClaimName(),
+        pvcForUserData.getMetadata().getName());
+    assertEquals(
+        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(),
+        pvcForUserData.getMetadata().getName());
+
+    // check container bound to user-defined PVC
+    Container container1 = podSpec.getContainers().get(0);
+    assertEquals(container1.getVolumeMounts().size(), 1);
+    VolumeMount volumeMount = container1.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/home/user/data");
+    assertEquals(volumeMount.getName(), userPodVolume.getName());
+
+    // check container that is bound to Che Volume via Machine configuration
+    Container container2 = podSpec.getContainers().get(1);
+    VolumeMount cheVolumeMount2 = container2.getVolumeMounts().get(0);
+    assertEquals(cheVolumeMount2.getSubPath(), WORKSPACE_ID + "/userDataPVC");
+    assertEquals(cheVolumeMount2.getName(), userPodVolume.getName());
+  }
+
+  @Test
+  public void testProcessingDifferentVolumeMountsBoundToTheSameVolume() throws Exception {
+    // given
+    k8sEnv = KubernetesEnvironment.builder().build();
+    k8sEnv.getPersistentVolumeClaims().put("appStorage", newPVC("appStorage"));
+
+    Pod pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME)
+                    .withVolumeMount("appStorage", "/data", "data")
+                    .withVolumeMount("appStorage", "/config", "config")
+                    .build())
+            .withPVCVolume("appStorage", "appStorage")
+            .build();
+
+    k8sEnv.addPod(pod);
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_1_NAME,
+            TestObjects.newMachineConfig().withVolume("appStorage", "/app-storage").build());
+
+    // when
+    strategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    PersistentVolumeClaim pvcForUserData =
+        findPvc("appStorage", k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForUserData);
+    assertTrue(pvcForUserData.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
+    assertEquals(
+        pvcForUserData.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
+
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    assertEquals(podSpec.getVolumes().size(), 1);
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(
+        userPodVolume.getPersistentVolumeClaim().getClaimName(),
+        pvcForUserData.getMetadata().getName());
+    assertEquals(
+        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(),
+        pvcForUserData.getMetadata().getName());
+
+    // check container bound to user-defined PVC
+    Container container1 = podSpec.getContainers().get(0);
+    assertEquals(container1.getVolumeMounts().size(), 3);
+
+    VolumeMount dataVolumeMount = container1.getVolumeMounts().get(0);
+    assertEquals(dataVolumeMount.getSubPath(), WORKSPACE_ID + "/appStorage/data");
+    assertEquals(dataVolumeMount.getMountPath(), "/data");
+    assertEquals(dataVolumeMount.getName(), userPodVolume.getName());
+
+    VolumeMount configVolumeMount = container1.getVolumeMounts().get(1);
+    assertEquals(configVolumeMount.getSubPath(), WORKSPACE_ID + "/appStorage/config");
+    assertEquals(configVolumeMount.getMountPath(), "/config");
+    assertEquals(configVolumeMount.getName(), userPodVolume.getName());
+
+    VolumeMount appStorage = container1.getVolumeMounts().get(2);
+    assertEquals(appStorage.getSubPath(), WORKSPACE_ID + "/appStorage");
+    assertEquals(appStorage.getMountPath(), "/app-storage");
+    assertEquals(appStorage.getName(), userPodVolume.getName());
   }
 
   @Test
@@ -180,80 +424,164 @@ public class UniqueWorkspacePVCStrategyTest {
       throws Exception {
     final String pvcUniqueName1 = PVC_NAME_PREFIX + "-3121";
     PersistentVolumeClaim pvc1 =
-        mockPVC(ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_1_NAME), pvcUniqueName1);
+        newPVC(pvcUniqueName1, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_1_NAME));
+    pvc1.getAdditionalProperties().put("CHE_PROVISIONED", true);
     final String pvcUniqueName2 = PVC_NAME_PREFIX + "-71333";
     PersistentVolumeClaim pvc2 =
-        mockPVC(ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_2_NAME), pvcUniqueName2);
-    when(k8sEnv.getPersistentVolumeClaims())
-        .thenReturn(ImmutableMap.of(pvcUniqueName1, pvc1, pvcUniqueName2, pvc2));
+        newPVC(pvcUniqueName2, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_2_NAME));
+    pvc2.getAdditionalProperties().put("CHE_PROVISIONED", true);
+    k8sEnv.getPersistentVolumeClaims().clear();
+    k8sEnv.getPersistentVolumeClaims().put(pvcUniqueName1, pvc1);
+    k8sEnv.getPersistentVolumeClaims().put(pvcUniqueName2, pvc2);
 
     strategy.provision(k8sEnv, IDENTITY);
 
-    assertEquals(podSpec.getVolumes().size(), 2);
-    assertEquals(podSpec2.getVolumes().size(), 1);
-    assertEquals(container.getVolumeMounts().size(), 2);
-    assertEquals(container2.getVolumeMounts().size(), 1);
-    assertEquals(container3.getVolumeMounts().size(), 1);
+    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(pvcUniqueName1));
+    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(pvcUniqueName2));
+    assertEquals(pod.getSpec().getVolumes().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(1).getVolumeMounts().size(), 1);
+    assertEquals(pod2.getSpec().getVolumes().size(), 1);
+    assertEquals(pod2.getSpec().getContainers().get(0).getVolumeMounts().size(), 1);
     assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 2);
   }
 
   @Test
-  public void testDoNotProvisionPVCsWhenItIsAlreadyExistsForGivenVolumeAndWorkspace()
+  public void testDoNotProvisionPVCsWhenItAlreadyExistsForGivenVolumeAndWorkspace()
       throws Exception {
     final String pvcUniqueName1 = PVC_NAME_PREFIX + "-3121";
     PersistentVolumeClaim pvc1 =
-        mockPVC(ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_1_NAME), pvcUniqueName1);
+        newPVC(pvcUniqueName1, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_1_NAME));
+    pvc1.getAdditionalProperties().put("CHE_PROVISIONED", true);
     final String pvcUniqueName2 = PVC_NAME_PREFIX + "-71333";
     PersistentVolumeClaim pvc2 =
-        mockPVC(ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_2_NAME), pvcUniqueName2);
+        newPVC(pvcUniqueName2, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_2_NAME));
+    pvc2.getAdditionalProperties().put("CHE_PROVISIONED", true);
+
     when(pvcs.getByLabel(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID))
         .thenReturn(ImmutableList.of(pvc1, pvc2));
 
     strategy.provision(k8sEnv, IDENTITY);
 
-    assertEquals(podSpec.getVolumes().size(), 2);
-    assertEquals(podSpec2.getVolumes().size(), 1);
-    assertEquals(container.getVolumeMounts().size(), 2);
-    assertEquals(container2.getVolumeMounts().size(), 1);
-    assertEquals(container3.getVolumeMounts().size(), 1);
-    assertTrue(k8sEnv.getPersistentVolumeClaims().isEmpty());
+    assertEquals(pod.getSpec().getVolumes().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(1).getVolumeMounts().size(), 1);
+    assertEquals(pod2.getSpec().getVolumes().size(), 1);
+    assertEquals(pod2.getSpec().getContainers().get(0).getVolumeMounts().size(), 1);
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 2);
+    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(pvcUniqueName1));
+    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(pvcUniqueName2));
   }
 
   @Test
   public void testCreatesProvisionedPVCsOnPrepare() throws Exception {
     final String uniqueName = PVC_NAME_PREFIX + "-3121";
     final PersistentVolumeClaim pvc = mockName(mock(PersistentVolumeClaim.class), uniqueName);
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(uniqueName, pvc));
+    k8sEnv.getPersistentVolumeClaims().clear();
+    k8sEnv.getPersistentVolumeClaims().putAll(singletonMap(uniqueName, pvc));
     doReturn(pvc).when(pvcs).create(any());
 
     strategy.prepare(k8sEnv, WORKSPACE_ID, 100);
 
-    verify(pvcs).create(any());
+    verify(pvcs).createIfNotExist(any());
     verify(pvcs).waitBound(uniqueName, 100);
   }
 
   @Test(expectedExceptions = InfrastructureException.class)
   public void throwsInfrastructureExceptionWhenFailedToCreatePVCs() throws Exception {
     final PersistentVolumeClaim pvc = mock(PersistentVolumeClaim.class);
-    when(k8sEnv.getPersistentVolumeClaims()).thenReturn(singletonMap(PVC_NAME_PREFIX, pvc));
-    doThrow(InfrastructureException.class).when(pvcs).create(any(PersistentVolumeClaim.class));
+    when(pvc.getMetadata()).thenReturn(new ObjectMetaBuilder().withName(PVC_NAME_PREFIX).build());
+    k8sEnv.getPersistentVolumeClaims().clear();
+    k8sEnv.getPersistentVolumeClaims().put(PVC_NAME_PREFIX, pvc);
+    doThrow(InfrastructureException.class).when(pvcs).createIfNotExist(any());
 
     strategy.prepare(k8sEnv, WORKSPACE_ID, 100);
   }
 
   @Test
-  public void testRemovesPVCWhenCleanupCalled() throws Exception {
+  public void shouldDeletePVCsIfThereIsNoPersistAttributeInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
+
+    // when
     strategy.cleanup(workspace);
 
+    // then
     verify(pvcs).delete(ImmutableMap.of(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID));
   }
 
-  private static PersistentVolumeClaim mockPVC(Map<String, String> labels, String name) {
-    final PersistentVolumeClaim pvc = mock(PersistentVolumeClaim.class);
-    final ObjectMeta metadata = mock(ObjectMeta.class);
-    when(pvc.getMetadata()).thenReturn(metadata);
-    when(metadata.getLabels()).thenReturn(labels);
-    when(metadata.getName()).thenReturn(name);
-    return pvc;
+  @Test
+  public void shouldDeletePVCsIfPersistAttributeIsSetToTrueInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
+    workspaceConfigAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "true");
+
+    // when
+    strategy.cleanup(workspace);
+
+    // then
+    verify(pvcs).delete(any());
+  }
+
+  @Test
+  public void shouldDoNothingIfPersistAttributeIsSetToFalseInWorkspaceConfigWhenCleanupCalled()
+      throws Exception {
+    // given
+    Workspace workspace = mock(Workspace.class);
+    lenient().when(workspace.getId()).thenReturn(WORKSPACE_ID);
+
+    WorkspaceConfig workspaceConfig = mock(WorkspaceConfig.class);
+    lenient().when(workspace.getConfig()).thenReturn(workspaceConfig);
+
+    Map<String, String> workspaceConfigAttributes = new HashMap<>();
+    lenient().when(workspaceConfig.getAttributes()).thenReturn(workspaceConfigAttributes);
+    workspaceConfigAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");
+
+    // when
+    strategy.cleanup(workspace);
+
+    // then
+    verify(pvcs, never()).delete(any());
+  }
+
+  private static PersistentVolumeClaim newPVC(String name) {
+    return newPVC(name, new HashMap<>());
+  }
+
+  private static PersistentVolumeClaim newPVC(String name, Map<String, String> labels) {
+    return new PersistentVolumeClaimBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .withLabels(labels)
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
+  }
+
+  private PersistentVolumeClaim findPvc(
+      String volumeName, Map<String, PersistentVolumeClaim> claims) {
+    return claims
+        .values()
+        .stream()
+        .filter(c -> volumeName.equals(c.getMetadata().getLabels().get(CHE_VOLUME_NAME_LABEL)))
+        .findAny()
+        .orElse(null);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Warnings.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Warnings.java
@@ -23,11 +23,6 @@ public final class Warnings {
       "Routes specified in OpenShift recipe are ignored. "
           + "To expose ports please define servers in machine configuration.";
 
-  public static final int PVC_IGNORED_WARNING_CODE =
-      org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.PVC_IGNORED_WARNING_CODE;
-  public static final String PVC_IGNORED_WARNING_MESSAGE =
-      "Persistent volume claims specified in OpenShift recipe are ignored.";
-
   public static final int SECRET_IGNORED_WARNING_CODE =
       org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.SECRET_IGNORED_WARNING_CODE;
   public static final String SECRET_IGNORED_WARNING_MESSAGE =

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
@@ -105,8 +105,8 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
     Map<String, Deployment> deployments = new HashMap<>();
     Map<String, Service> services = new HashMap<>();
     Map<String, ConfigMap> configMaps = new HashMap<>();
+    Map<String, PersistentVolumeClaim> pvcs = new HashMap<>();
     boolean isAnyRoutePresent = false;
-    boolean isAnyPVCPresent = false;
     boolean isAnySecretPresent = false;
     for (HasMetadata object : list.getItems()) {
       if (object instanceof DeploymentConfig) {
@@ -125,7 +125,8 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
       } else if (object instanceof Route) {
         isAnyRoutePresent = true;
       } else if (object instanceof PersistentVolumeClaim) {
-        isAnyPVCPresent = true;
+        PersistentVolumeClaim pvc = (PersistentVolumeClaim) object;
+        pvcs.put(pvc.getMetadata().getName(), pvc);
       } else if (object instanceof Secret) {
         isAnySecretPresent = true;
       } else if (object instanceof ConfigMap) {
@@ -141,11 +142,6 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
       warnings.add(
           new WarningImpl(
               Warnings.ROUTE_IGNORED_WARNING_CODE, Warnings.ROUTES_IGNORED_WARNING_MESSAGE));
-    }
-
-    if (isAnyPVCPresent) {
-      warnings.add(
-          new WarningImpl(Warnings.PVC_IGNORED_WARNING_CODE, Warnings.PVC_IGNORED_WARNING_MESSAGE));
     }
 
     if (isAnySecretPresent) {
@@ -164,7 +160,7 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
             .setPods(pods)
             .setDeployments(deployments)
             .setServices(services)
-            .setPersistentVolumeClaims(new HashMap<>())
+            .setPersistentVolumeClaims(pvcs)
             .setSecrets(new HashMap<>())
             .setConfigMaps(configMaps)
             .setRoutes(new HashMap<>())

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
@@ -109,6 +109,10 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
     boolean isAnyRoutePresent = false;
     boolean isAnySecretPresent = false;
     for (HasMetadata object : list.getItems()) {
+      checkNotNull(object.getKind(), "Environment contains object without specified kind field");
+      checkNotNull(object.getMetadata(), "%s metadata must not be null", object.getKind());
+      checkNotNull(object.getMetadata().getName(), "%s name must not be null", object.getKind());
+
       if (object instanceof DeploymentConfig) {
         throw new ValidationException("Supporting of deployment configs is not implemented yet.");
       } else if (object instanceof Pod) {
@@ -190,6 +194,13 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
   private void checkNotNull(Object object, String errorMessage) throws ValidationException {
     if (object == null) {
       throw new ValidationException(errorMessage);
+    }
+  }
+
+  private void checkNotNull(Object object, String messageFmt, Object... messageArguments)
+      throws ValidationException {
+    if (object == null) {
+      throw new ValidationException(format(messageFmt, messageArguments));
     }
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactoryTest.java
@@ -17,8 +17,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACHINE_NAME_ANNOTATION_FMT;
-import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.PVC_IGNORED_WARNING_CODE;
-import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.PVC_IGNORED_WARNING_MESSAGE;
 import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.ROUTES_IGNORED_WARNING_MESSAGE;
 import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.ROUTE_IGNORED_WARNING_CODE;
 import static org.eclipse.che.workspace.infrastructure.openshift.Warnings.SECRET_IGNORED_WARNING_CODE;
@@ -43,6 +41,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
@@ -51,6 +50,8 @@ import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Secret;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.client.dsl.KubernetesListMixedOperation;
@@ -89,14 +90,14 @@ public class OpenShiftEnvironmentFactoryTest {
   private static final String MACHINE_NAME_1 = "machine1";
   private static final String MACHINE_NAME_2 = "machine2";
 
-  private OpenShiftEnvironmentFactory osEnvironmentFactory;
+  private OpenShiftEnvironmentFactory osEnvFactory;
 
   @Mock private OpenShiftClientFactory clientFactory;
   @Mock private KubernetesEnvironmentValidator k8sEnvValidator;
   @Mock private OpenShiftClient client;
   @Mock private InternalRecipe internalRecipe;
   @Mock private KubernetesListMixedOperation listMixedOperation;
-  @Mock private KubernetesList validatedObjects;
+  @Mock private KubernetesList parsedList;
   @Mock private InternalMachineConfig machineConfig1;
   @Mock private InternalMachineConfig machineConfig2;
   @Mock private MemoryAttributeProvisioner memoryProvisioner;
@@ -109,25 +110,61 @@ public class OpenShiftEnvironmentFactoryTest {
 
   @BeforeMethod
   public void setup() throws Exception {
-    osEnvironmentFactory =
+    osEnvFactory =
         new OpenShiftEnvironmentFactory(
             null, null, null, clientFactory, k8sEnvValidator, memoryProvisioner);
     when(clientFactory.create()).thenReturn(client);
     when(client.lists()).thenReturn(listMixedOperation);
     when(listMixedOperation.load(any(InputStream.class))).thenReturn(serverGettable);
-    when(serverGettable.get()).thenReturn(validatedObjects);
+    when(serverGettable.get()).thenReturn(parsedList);
     when(internalRecipe.getContentType()).thenReturn(YAML_RECIPE);
     when(internalRecipe.getContent()).thenReturn("recipe content");
     machines = ImmutableMap.of(MACHINE_NAME_1, machineConfig1, MACHINE_NAME_2, machineConfig2);
   }
 
   @Test
+  public void shouldCreateOpenShiftEnvironmentWithServicesFromRecipe() throws Exception {
+    // given
+    Service service1 =
+        new ServiceBuilder().withNewMetadata().withName("service1").endMetadata().build();
+    Service service2 =
+        new ServiceBuilder().withNewMetadata().withName("service2").endMetadata().build();
+    when(parsedList.getItems()).thenReturn(asList(service1, service2));
+
+    // when
+    KubernetesEnvironment osEnv = osEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+
+    // then
+    assertEquals(osEnv.getServices().size(), 2);
+    assertEquals(osEnv.getServices().get("service1"), service1);
+    assertEquals(osEnv.getServices().get("service2"), service2);
+  }
+
+  @Test
+  public void shouldCreateOpenShiftEnvironmentWithPVCsFromRecipe() throws Exception {
+    // given
+    PersistentVolumeClaim pvc1 =
+        new PersistentVolumeClaimBuilder().withNewMetadata().withName("pvc1").endMetadata().build();
+    PersistentVolumeClaim pvc2 =
+        new PersistentVolumeClaimBuilder().withNewMetadata().withName("pvc2").endMetadata().build();
+    when(parsedList.getItems()).thenReturn(asList(pvc1, pvc2));
+
+    // when
+    OpenShiftEnvironment osEnv = osEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+
+    // then
+    assertEquals(osEnv.getPersistentVolumeClaims().size(), 2);
+    assertEquals(osEnv.getPersistentVolumeClaims().get("pvc1"), pvc1);
+    assertEquals(osEnv.getPersistentVolumeClaims().get("pvc2"), pvc2);
+  }
+
+  @Test
   public void ignoreRoutesWhenRecipeContainsThem() throws Exception {
     final List<HasMetadata> objects = asList(new Route(), new Route());
-    when(validatedObjects.getItems()).thenReturn(objects);
+    when(parsedList.getItems()).thenReturn(objects);
 
     final OpenShiftEnvironment parsed =
-        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+        osEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
     assertTrue(parsed.getRoutes().isEmpty());
     assertEquals(parsed.getWarnings().size(), 1);
@@ -137,27 +174,12 @@ public class OpenShiftEnvironmentFactoryTest {
   }
 
   @Test
-  public void ignorePVCsWhenRecipeContainsThem() throws Exception {
-    final List<HasMetadata> pvc = singletonList(new PersistentVolumeClaim());
-    when(validatedObjects.getItems()).thenReturn(pvc);
-
-    final OpenShiftEnvironment parsed =
-        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
-
-    assertTrue(parsed.getPersistentVolumeClaims().isEmpty());
-    assertEquals(parsed.getWarnings().size(), 1);
-    assertEquals(
-        parsed.getWarnings().get(0),
-        new WarningImpl(PVC_IGNORED_WARNING_CODE, PVC_IGNORED_WARNING_MESSAGE));
-  }
-
-  @Test
   public void ignoreSecretsWhenRecipeContainsThem() throws Exception {
     final List<HasMetadata> recipeObjects = singletonList(new Secret());
-    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+    when(parsedList.getItems()).thenReturn(recipeObjects);
 
     final OpenShiftEnvironment parsed =
-        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+        osEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
     assertTrue(parsed.getSecrets().isEmpty());
     assertEquals(parsed.getWarnings().size(), 1);
@@ -171,10 +193,10 @@ public class OpenShiftEnvironmentFactoryTest {
     ConfigMap configMap =
         new ConfigMapBuilder().withNewMetadata().withName("test-configmap").endMetadata().build();
     final List<HasMetadata> recipeObjects = singletonList(configMap);
-    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+    when(parsedList.getItems()).thenReturn(recipeObjects);
 
     final KubernetesEnvironment parsed =
-        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+        osEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
     assertEquals(parsed.getConfigMaps().size(), 1);
     assertEquals(
@@ -184,33 +206,31 @@ public class OpenShiftEnvironmentFactoryTest {
 
   @Test
   public void addPodsWhenRecipeContainsThem() throws Exception {
+    // given
     Pod pod =
         new PodBuilder()
             .withNewMetadata()
-            .withName("pod-test")
+            .withName("pod")
             .endMetadata()
-            .withNewSpec()
-            .endSpec()
+            .withSpec(new PodSpec())
             .build();
+    when(parsedList.getItems()).thenReturn(singletonList(pod));
 
-    final List<HasMetadata> recipeObjects = singletonList(pod);
-    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+    // when
+    KubernetesEnvironment osEnv = osEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
-    final KubernetesEnvironment parsed =
-        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+    // then
+    assertEquals(osEnv.getPodsCopy().size(), 1);
+    assertEquals(osEnv.getPodsCopy().get("pod"), pod);
 
-    assertEquals(parsed.getPodsCopy().size(), 1);
-    assertEquals(
-        parsed.getPodsCopy().values().iterator().next().getMetadata().getName(),
-        pod.getMetadata().getName());
-    assertEquals(parsed.getPodsData().size(), 1);
-    assertEquals(
-        parsed.getPodsData().values().iterator().next().getMetadata().getName(),
-        pod.getMetadata().getName());
+    assertEquals(osEnv.getPodsData().size(), 1);
+    assertEquals(osEnv.getPodsData().get("pod").getMetadata(), pod.getMetadata());
+    assertEquals(osEnv.getPodsData().get("pod").getSpec(), pod.getSpec());
   }
 
   @Test
   public void addDeploymentsWhenRecipeContainsThem() throws Exception {
+    // given
     PodTemplateSpec podTemplate =
         new PodTemplateSpecBuilder()
             .withNewMetadata()
@@ -230,23 +250,25 @@ public class OpenShiftEnvironmentFactoryTest {
             .build();
 
     final List<HasMetadata> recipeObjects = singletonList(deployment);
-    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+    when(parsedList.getItems()).thenReturn(recipeObjects);
 
-    final KubernetesEnvironment parsed =
-        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+    // when
+    final KubernetesEnvironment osEnv =
+        osEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
-    assertEquals(parsed.getDeploymentsCopy().size(), 1);
+    // then
+    assertEquals(osEnv.getDeploymentsCopy().size(), 1);
+    assertEquals(osEnv.getDeploymentsCopy().get("deployment-test"), deployment);
+
+    assertEquals(osEnv.getPodsData().size(), 1);
     assertEquals(
-        parsed.getDeploymentsCopy().values().iterator().next().getMetadata().getName(),
-        deployment.getMetadata().getName());
-    assertEquals(parsed.getPodsData().size(), 1);
-    assertEquals(
-        parsed.getPodsData().values().iterator().next().getMetadata().getName(),
-        podTemplate.getMetadata().getName());
+        osEnv.getPodsData().get("deployment-test").getMetadata(), podTemplate.getMetadata());
+    assertEquals(osEnv.getPodsData().get("deployment-test").getSpec(), podTemplate.getSpec());
   }
 
   @Test
   public void bothPodsAndDeploymentsIncludedInPodData() throws Exception {
+    // given
     PodTemplateSpec podTemplate =
         new PodTemplateSpecBuilder()
             .withNewMetadata()
@@ -272,24 +294,21 @@ public class OpenShiftEnvironmentFactoryTest {
             .withNewSpec()
             .endSpec()
             .build();
-    final List<HasMetadata> recipeObjects = asList(deployment, pod);
-    when(validatedObjects.getItems()).thenReturn(recipeObjects);
+    when(parsedList.getItems()).thenReturn(asList(deployment, pod));
 
-    final KubernetesEnvironment parsed =
-        osEnvironmentFactory.doCreate(internalRecipe, emptyMap(), emptyList());
+    // when
+    final KubernetesEnvironment osEnv =
+        osEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
 
-    assertEquals(parsed.getPodsData().size(), 2);
-    assertTrue(
-        parsed
-            .getPodsData()
-            .values()
-            .stream()
-            .allMatch(
-                podData -> {
-                  String name = podData.getMetadata().getName();
-                  return name.equals(podTemplate.getMetadata().getName())
-                      || name.equals(pod.getMetadata().getName());
-                }));
+    // then
+    assertEquals(osEnv.getPodsData().size(), 2);
+
+    assertEquals(
+        osEnv.getPodsData().get("deployment-test").getMetadata(), podTemplate.getMetadata());
+    assertEquals(osEnv.getPodsData().get("deployment-test").getSpec(), podTemplate.getSpec());
+
+    assertEquals(osEnv.getPodsData().get("bare-pod").getMetadata(), pod.getMetadata());
+    assertEquals(osEnv.getPodsData().get("bare-pod").getSpec(), pod.getSpec());
   }
 
   @Test(
@@ -334,7 +353,7 @@ public class OpenShiftEnvironmentFactoryTest {
             mockPod(MACHINE_NAME_1, firstMachineRamLimit, firstMachineRamRequest),
             mockPod(MACHINE_NAME_2, secondMachineRamLimit, secondMachineRamRequest));
 
-    osEnvironmentFactory.addRamAttributes(machines, pods);
+    osEnvFactory.addRamAttributes(machines, pods);
 
     verify(memoryProvisioner)
         .provision(eq(machineConfig1), eq(firstMachineRamLimit), eq(firstMachineRamRequest));


### PR DESCRIPTION
### What does this PR do?
#### Additional changes
Fix creating of per-workspace PVC 

#### Main change
This PR adds support of PVC in Kuberentes/OpenShift recipe. The corresponding changes are in a separate commit `Make K8s/OS infras respect PVCs from recipe`

PVCs strategies are updated with the following changes:

#### Unique PVC Strategy
User-defined PVCs are provisioned with generated unique names.
Pods volumes that reference PVCs are updated accordingly.
Subpaths of the corresponding containers volume mounts are prefixed with `'{workspaceId}/{originalPVCName}'`.

User-defined PVC name is used as Che Volume name. It means that if Machine is configured to use Che Volume with the same name as user-defined PVC has then Che Volume with reuse user-defined PVC.

Note that quantity and access mode of user-defined PVCs are not overridden
with Che Server configured.

#### Common PVC Strategy
User-defined PVCs are removed from environment.
Pods volumes that reference PVCs are replaced with volume that references common PVC.
The corresponding containers volume mounts are relinked to common volume and subpaths are prefixed with `'{workspaceId}/{originalPVCName}'`.

User-defined PVC name is used as Che Volume name. It means that if Machine is configured to use Che Volume with the same name as user-defined PVC has then they will use the same shared folder in common PVC.

Note that quantity and access mode of user-defined PVCs are ignored since common PVC is used and it has preconfigured configuration.

#### PerWorkspace PVC Strategy
No changes since it business logic from Common PVC Strategy.

#### Ephemeral Volume Strategy
User-defined PVCs are removed from environment and the corresponding PVC volumes in Pods are replaced with `emptyDir` volumes.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12269

### How have you tested this PR?
I've tested it on Single-user Che Deployed on `minishift`.

<details>
<summary>Workspace Config for testing</summary>

```json
{
  "commands": [],
  "environments": {
    "default": {
      "recipe": {
        "type": "kubernetes",
        "content": "kind: List\nitems:\n -\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n  spec:\n    initContainers:\n     -\n       name: init\n       image: alpine:3.5\n       command: [\"sh\", \"-c\", \"echo Hello > /init-data/hello.txt\"]\n       volumeMounts:\n       -\n         mountPath: /init-data\n         name: data-volume\n         subPath: user/data\n    containers:\n     -\n      image: 'eclipse/che-dev:nightly'\n      name: dev\n      resources:\n        limits:\n          memory: 512Mi\n      volumeMounts:\n       -\n         mountPath: /data\n         name: data-volume\n         subPath: user/data\n     -\n      image: 'eclipse/che-dev:nightly'\n      name: dev2\n      resources:\n        limits:\n          memory: 256Mi\n    volumes:\n     -\n      name: data-volume\n      persistentVolumeClaim:\n        claimName: userdata\n -\n  apiVersion: v1\n  kind: PersistentVolumeClaim\n  metadata:\n    name: userdata\n  spec:\n    accessModes:\n     - ReadWriteOnce\n    resources:\n      requests:\n        storage: 1Gi\n",
        "contentType": "application/x-yaml"
      },
      "machines": {
        "ws/dev2": {
          "env": {},
          "servers": {},
          "installers": [],
          "volumes": {
            "userdata": {
              "path": "/data"
            }
          },
          "attributes": {
            "memoryLimitBytes": "322122547"
          }
        },
        "ws/dev": {
          "env": {},
          "servers": {},
          "installers": [],
          "volumes": {
            "projects": {
              "path": "/projects"
            }
          },
          "attributes": {
            "memoryLimitBytes": "536870912"
          }
        }
      }
    }
  },
  "defaultEnv": "default",
  "projects": [],
  "name": "che7",
  "attributes": {
    "editor": "org.eclipse.che.editor.theia:1.0.0",
    "plugins": "che-machine-exec-plugin:0.0.1"
  },
  "links": []
}
```
</details>

<details>
<summary>PV folders structures for Unique PVC Strategy</summary>

```
pv0094
`-- workspacek0lczo7h3wc79fzq
    `-- user-data
        `-- user
            `-- data
                `-- hello.txt

pv0076
`-- workspacek0lczo7h3wc79fzq
    `-- projects

pv0087
`-- workspacek0lczo7h3wc79fzq
    `-- che-logs-ws

pv0010
`-- workspacek0lczo7h3wc79fzq
    `-- plugins

pv0029
`-- workspacek0lczo7h3wc79fzq
    `-- che-logs-che-plugin-broker
```
</details>

<details>
<summary>PV folders structures for Common PVC Strategy</summary>

```
pv0069
`-- workspacehidcgmz3nt7jrhwk
    |-- che-logs
    |   |-- che-plugin-broker
    |   |   |-- broker1n71g0          !!!!!!!!!! TODO Each workspace start produces new folder. Take a look
    |   |   |-- brokera1v6s5
    |   |   |-- brokerec98fk
    |   |   |-- brokernse7nx
    |   |   |-- brokerotuw9x
    |   |   |-- brokerpfilyo
    |   |   |-- brokerqj3fng
    |   |   `-- brokerye8acc
    |   `-- ws
    |       |-- che-machine-exec
    |       |-- dev
    |       `-- theia-ide
    |-- plugins
    |-- projects
    `-- user-data
        `-- user
            `-- data
                `-- hello.txt

```
</details>

#### Release Notes
Added support of PVCs in Kubernetes/OpenShift recipes. Different PVC Strategies processes user-defined PVCs in a different way. Details see https://www.eclipse.org/che/docs/che-6/kubernetes-admin-guide.html#how-the-che-server-uses-PVCs-and-PVs-for-storage

#### Docs PR
https://github.com/eclipse/che-docs/pull/657
