### PR TITLE
Use meaningful value for plugin broker container name instead of generated one

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
@@ -170,7 +170,7 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
       @Nullable String brokerVolumeName) {
     final ContainerBuilder cb =
         new ContainerBuilder()
-            .withName(generateUniqueName(CONTAINER_NAME_SUFFIX))
+            .withName(image.toLowerCase().replaceAll("[^\\d\\w-]", "-"))
             .withImage(image)
             .withArgs(
                 "-push-endpoint",


### PR DESCRIPTION
### What does this PR do?
During manual testing of PVCs supporting in K8s/OS recipes, I discovered that Che 7 workspace acquires new folder for each workspace start. So, each Che 7 workspace start increases folders number in common PV:
```
pv0069
`-- workspacewsgi9hoklsfdwp7x
    |-- che-logs
    |   |-- che-plugin-broker
    |   |   |-- broker3zeff1
    |   |   |-- broker8iylgg
    |   |   |-- brokergeky82
    |   |   |-- brokerr7l031
    |   |   |-- brokerrmt1lb
    |   |   `-- brokery19p82
    |   |   ...
    |   `-- ws
    |       |-- che-hello
    |       |-- che-machine-exec
    |       |-- dev
    |       |-- theia-dev
    |       `-- theia-ide
    |-- plugins
    |   `-- che_ui_service_plugin.theia
    `-- projects
```
Note that it unique PVC strategy does not have the described issue (but I did investigated why):
```
----
pv0041
`-- workspacewsgi9hoklsfdwp7x
    `-- che-logs-che-plugin-broker
----
pv0061
`-- workspacewsgi9hoklsfdwp7x
    `-- plugins
        `-- che_ui_service_plugin.theia
----
pv0079
`-- workspacewsgi9hoklsfdwp7x
    `-- projects
----
pv0065
`-- workspacewsgi9hoklsfdwp7x
    `-- che-logs-ws
```
Since Plugin Brokers do not write any logs in Logs volume it makes sense to deprecate usage of logs volume at all. The corresponding issue https://github.com/eclipse/che/issues/11806.
But while there is no final decision whether it should be removed or not, it makes sense to use meaningful names for plugins brokers machines.
It also could help during issues investigation, like an example if for some reason plugin broker container is invalid - we will see error `Container plugin-broker/broker1n71g0` is not valid`, after aplying these changes we will see `Container plugin-broker/eclipse-plugin-broker-che is not valid `


After these changes PV of common PVC has the following folders structure:
```
pv0027
|-- workspacefgr3e973rcupbt2x
|   |-- che-logs
|   |   |-- che-plugin-broker
|   |   |   |-- eclipse-che-init-plugin-broker-v0-7-0
|   |   |   `-- eclipse-che-plugin-broker-v0-7-0
|   |   `-- ws
|   |       |-- che-machine-exec
|   |       |-- dev
|   |       `-- theia-ide
|   |-- plugins
|   `-- projects
```

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
N/A