### PR TITLE
CHE-12329 Rework the way of retrieving editor provider by file-type

### DIFF
--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -12,18 +12,24 @@
 package org.eclipse.che.ide.editor;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.gwt.regexp.shared.RegExp.compile;
 import static java.lang.Boolean.parseBoolean;
+import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.FAIL;
 import static org.eclipse.che.ide.api.notification.StatusNotification.Status.WARNING;
 import static org.eclipse.che.ide.api.parts.PartStackType.EDITING;
+import static org.eclipse.che.ide.util.NameUtils.getFileExtension;
 
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.user.client.rpc.AsyncCallback;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import com.google.inject.name.Named;
 import com.google.web.bindery.event.shared.EventBus;
 import elemental.json.Json;
 import elemental.json.JsonArray;
@@ -34,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.api.promises.client.Operation;
@@ -119,6 +126,7 @@ public class EditorAgentImpl
   private final PromiseProvider promiseProvider;
   private final ResourceProvider resourceProvider;
   private final NotificationManager notificationManager;
+  private final FileType unknownFileType;
   private List<EditorPartPresenter> dirtyEditors;
   private EditorPartPresenter activeEditor;
   private PartPresenter activePart;
@@ -135,7 +143,8 @@ public class EditorAgentImpl
       EditorContentSynchronizer editorContentSynchronizer,
       PromiseProvider promiseProvider,
       ResourceProvider resourceProvider,
-      NotificationManager notificationManager) {
+      NotificationManager notificationManager,
+      @Named("defaultFileType") FileType unknownFileType) {
     this.eventBus = eventBus;
     this.fileTypeRegistry = fileTypeRegistry;
     this.preferencesManager = preferencesManager;
@@ -147,6 +156,7 @@ public class EditorAgentImpl
     this.promiseProvider = promiseProvider;
     this.resourceProvider = resourceProvider;
     this.notificationManager = notificationManager;
+    this.unknownFileType = unknownFileType;
     this.openedEditors = newArrayList();
     this.openingEditorsPathsToStacks = new HashMap<>();
     this.openedEditorsToProviders = new HashMap<>();
@@ -298,23 +308,57 @@ public class EditorAgentImpl
       VirtualFile file, EditorPartStack editorPartStackConsumer, OpenEditorCallback callback) {
 
     addToOpeningFilesList(file.getLocation(), editorPartStackConsumer);
+    Set<FileType> fileTypesByFileName = getFileTypesByFileName(file.getName());
+    Optional<FileType> registeredFileType =
+        fileTypesByFileName
+            .stream()
+            .filter(fileType -> editorRegistry.getEditor(fileType) instanceof AsyncEditorProvider)
+            .findAny();
+    if (registeredFileType.isPresent()) {
+      FileType fileType = registeredFileType.get();
+      final EditorProvider editorProvider = editorRegistry.getEditor(fileType);
+      ((AsyncEditorProvider) editorProvider)
+          .createEditor(file)
+          .then(
+              editor -> {
+                initEditor(
+                    file, callback, fileType, editor, editorPartStackConsumer, editorProvider);
+              });
+    } else {
+      FileType fileType = fileTypesByFileName.stream().findAny().orElse(unknownFileType);
+      final EditorProvider editorProvider = editorRegistry.getEditor(fileType);
+      final EditorPartPresenter editor = editorProvider.getEditor();
+      initEditor(file, callback, fileType, editor, editorPartStackConsumer, editorProvider);
+    }
+  }
 
-    final FileType fileType = fileTypeRegistry.getFileTypeByFile(file);
-    final EditorProvider editorProvider = editorRegistry.getEditor(fileType);
-    if (editorProvider instanceof AsyncEditorProvider) {
-      AsyncEditorProvider provider = (AsyncEditorProvider) editorProvider;
-      Promise<EditorPartPresenter> promise = provider.createEditor(file);
-      if (promise != null) {
-        promise.then(
-            editor -> {
-              initEditor(file, callback, fileType, editor, editorPartStackConsumer, editorProvider);
-            });
-        return;
-      }
+  private Set<FileType> getFileTypesByFileName(String name) {
+    if (isNullOrEmpty(name)) {
+      return emptySet();
     }
 
-    final EditorPartPresenter editor = editorProvider.getEditor();
-    initEditor(file, callback, fileType, editor, editorPartStackConsumer, editorProvider);
+    Set<FileType> typesByNamePattern =
+        fileTypeRegistry
+            .getFileTypes()
+            .stream()
+            .filter(
+                type ->
+                    type.getNamePatterns()
+                        .stream()
+                        .anyMatch(namePattern -> compile(namePattern).test(name)))
+            .collect(toSet());
+
+    String fileExtension = getFileExtension(name);
+    if (isNullOrEmpty(fileExtension)) {
+      return typesByNamePattern;
+    }
+
+    Set<FileType> fileTypes =
+        typesByNamePattern
+            .stream()
+            .filter(type -> fileExtension.equals(type.getExtension()))
+            .collect(toSet());
+    return fileTypes.isEmpty() ? typesByNamePattern : fileTypes;
   }
 
   private void initEditor(

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -17,6 +17,7 @@ import static com.google.common.collect.Lists.newArrayList;
 import static com.google.gwt.regexp.shared.RegExp.compile;
 import static java.lang.Boolean.parseBoolean;
 import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.ide.api.notification.StatusNotification.DisplayMode.EMERGE_MODE;
@@ -35,7 +36,13 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.util.ArrayOf;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
@@ -356,7 +363,7 @@ public class EditorAgentImpl
             .collect(toSet());
     fileTypes = fileTypes.isEmpty() ? typesByNamePattern : fileTypes;
     return fileTypes.isEmpty()
-        ? Collections.singleton(fileTypeRegistry.getFileTypeByExtension(fileExtension))
+        ? singleton(fileTypeRegistry.getFileTypeByExtension(fileExtension))
         : fileTypes;
   }
 

--- a/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
+++ b/ide/che-core-ide-app/src/main/java/org/eclipse/che/ide/editor/EditorAgentImpl.java
@@ -35,13 +35,7 @@ import elemental.json.Json;
 import elemental.json.JsonArray;
 import elemental.json.JsonObject;
 import elemental.util.ArrayOf;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.api.promises.client.Operation;
 import org.eclipse.che.api.promises.client.OperationException;
@@ -360,7 +354,10 @@ public class EditorAgentImpl
             .stream()
             .filter(type -> fileExtension.equals(type.getExtension()))
             .collect(toSet());
-    return fileTypes.isEmpty() ? typesByNamePattern : fileTypes;
+    fileTypes = fileTypes.isEmpty() ? typesByNamePattern : fileTypes;
+    return fileTypes.isEmpty()
+        ? Collections.singleton(fileTypeRegistry.getFileTypeByExtension(fileExtension))
+        : fileTypes;
   }
 
   private void initEditor(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes bug when a maven file-type (without linked editor provider) is registered and another file type for `pom.xml` files (with linked editor provider) is registered as well, but when the `pom.xml` file is opened default editor provider is returned. The fix iterates registered editor providers if the the default provider is registered for the found file type.

### What issues does this PR fix or reference?
fixes #12329 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A