### PR TITLE
Update to lsp4j 0.6.0

### DIFF
--- a/plugins/plugin-java/che-plugin-java-server/pom.xml
+++ b/plugins/plugin-java/che-plugin-java-server/pom.xml
@@ -154,6 +154,7 @@
                         <classe>org.eclipse.lsp4j.Position</classe>
                         <classe>org.eclipse.lsp4j.WorkspaceEdit</classe>
                         <classe>org.eclipse.lsp4j.ResourceChange</classe>
+                        <classe>org.eclipse.lsp4j.ResourceOperation</classe>
                         <classe>org.eclipse.lsp4j.RenameParams</classe>
                         <classe>org.eclipse.lsp4j.TextDocumentIdentifier</classe>
                         <classe>org.eclipse.lsp4j.TextEdit</classe>

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/pom.xml
@@ -237,7 +237,9 @@
                         <exclude>org.eclipse.lsp4j.WatchKind</exclude>
                         <exclude>org.eclipse.lsp4j.MarkupKind</exclude>
                         <exclude>org.eclipse.lsp4j.CodeActionKind</exclude>
+                        <exclude>org.eclipse.lsp4j.FailureHandlingKind</exclude>
                         <exclude>org.eclipse.lsp4j.FoldingRangeKind</exclude>
+                        <exclude>org.eclipse.lsp4j.ResourceOperationKind</exclude>
                     </excludes>
                     <dtoPackages>
                         <package>org.eclipse.lsp4j</package>

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/rename/LSRenameAction.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/rename/LSRenameAction.java
@@ -27,7 +27,9 @@ import org.eclipse.che.ide.api.editor.texteditor.TextEditor;
 import org.eclipse.che.ide.api.parts.WorkspaceAgent;
 import org.eclipse.che.plugin.languageserver.ide.LanguageServerLocalization;
 import org.eclipse.che.plugin.languageserver.ide.editor.LanguageServerEditorConfiguration;
+import org.eclipse.lsp4j.RenameOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 /** Action for rename feature */
 @Singleton
@@ -65,12 +67,20 @@ public class LSRenameAction extends AbstractPerspectiveAction {
       if (configuration instanceof LanguageServerEditorConfiguration) {
         ServerCapabilities capabilities =
             ((LanguageServerEditorConfiguration) configuration).getServerCapabilities();
-        presentation.setEnabledAndVisible(
-            capabilities.getRenameProvider() != null && capabilities.getRenameProvider());
+        presentation.setEnabledAndVisible(isRenameEnabled(capabilities));
         return;
       }
     }
     presentation.setEnabledAndVisible(false);
+  }
+
+  private boolean isRenameEnabled(ServerCapabilities capabilities) {
+    Either<Boolean, RenameOptions> capability = capabilities.getRenameProvider();
+    if (capability.isLeft()) {
+      return Boolean.TRUE.equals(capability.getLeft());
+    } else {
+      return capability.getRight() != null;
+    }
   }
 
   @Override

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/rename/RenamePresenter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/rename/RenamePresenter.java
@@ -336,7 +336,6 @@ public class RenamePresenter extends BasePresenter implements ActionDelegate {
     List<Either<TextDocumentEdit, ResourceOperation>> edits = new ArrayList<>();
     for (RenameProject project : projects) {
       project.getTextDocumentEdits().forEach(edit -> edits.add(Either.forLeft(edit)));
-      ;
     }
     workspaceEditAction.applyWorkspaceEdit(new WorkspaceEdit(edits));
   }

--- a/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/rename/RenamePresenter.java
+++ b/plugins/plugin-languageserver/che-plugin-languageserver-ide/src/main/java/org/eclipse/che/plugin/languageserver/ide/rename/RenamePresenter.java
@@ -53,10 +53,12 @@ import org.eclipse.che.plugin.languageserver.ide.util.DtoBuildHelper;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.ResourceOperation;
 import org.eclipse.lsp4j.TextDocumentEdit;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.slf4j.Logger;
 
 /** Main controller for rename feature, calls rename and shows rename edits */
@@ -331,9 +333,10 @@ public class RenamePresenter extends BasePresenter implements ActionDelegate {
   }
 
   private void applyRename(List<RenameProject> projects) {
-    List<TextDocumentEdit> edits = new ArrayList<>();
+    List<Either<TextDocumentEdit, ResourceOperation>> edits = new ArrayList<>();
     for (RenameProject project : projects) {
-      edits.addAll(project.getTextDocumentEdits());
+      project.getTextDocumentEdits().forEach(edit -> edits.add(Either.forLeft(edit)));
+      ;
     }
     workspaceEditAction.applyWorkspaceEdit(new WorkspaceEdit(edits));
   }

--- a/wsagent/che-core-api-languageserver/pom.xml
+++ b/wsagent/che-core-api-languageserver/pom.xml
@@ -153,7 +153,9 @@
                         <exclude>org.eclipse.lsp4j.WatchKind</exclude>
                         <exclude>org.eclipse.lsp4j.MarkupKind</exclude>
                         <exclude>org.eclipse.lsp4j.CodeActionKind</exclude>
+                        <exclude>org.eclipse.lsp4j.FailureHandlingKind</exclude>
                         <exclude>org.eclipse.lsp4j.FoldingRangeKind</exclude>
+                        <exclude>org.eclipse.lsp4j.ResourceOperationKind</exclude>
                     </excludes>
                     <dtoPackages>
                         <package>org.eclipse.lsp4j</package>

--- a/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/ServerCapabilitiesAccumulator.java
+++ b/wsagent/che-core-api-languageserver/src/main/java/org/eclipse/che/api/languageserver/ServerCapabilitiesAccumulator.java
@@ -17,9 +17,11 @@ import java.util.List;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import javax.inject.Singleton;
+import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
+import org.eclipse.lsp4j.RenameOptions;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.SignatureHelpOptions;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
@@ -197,7 +199,7 @@ public class ServerCapabilitiesAccumulator implements BinaryOperator<ServerCapab
     private ServerCapabilities compute() {
 
       ServerCapabilities result = new ServerCapabilities();
-      result.setCodeActionProvider(or(ServerCapabilities::getCodeActionProvider));
+      result.setCodeActionProvider(or(ServerCapabilitiesOverlay::getCodeActionProvider));
       result.setCodeLensProvider(getCodeLensProvider());
       result.setCompletionProvider(getCompletionProvider());
       result.setDefinitionProvider(or(ServerCapabilities::getDefinitionProvider));
@@ -209,12 +211,36 @@ public class ServerCapabilitiesAccumulator implements BinaryOperator<ServerCapab
       result.setDocumentSymbolProvider(or(ServerCapabilities::getDocumentSymbolProvider));
       result.setHoverProvider(or(ServerCapabilities::getHoverProvider));
       result.setReferencesProvider(or(ServerCapabilities::getReferencesProvider));
-      result.setRenameProvider(or(ServerCapabilities::getRenameProvider));
+      result.setRenameProvider(or(ServerCapabilitiesOverlay::getRenameProvider));
       result.setSignatureHelpProvider(getSignatureHelpProvider());
       result.setTextDocumentSync(getTextDocumentSync());
       result.setWorkspaceSymbolProvider(or(ServerCapabilities::getWorkspaceSymbolProvider));
 
       return result;
+    }
+
+    private static Boolean getCodeActionProvider(ServerCapabilities cap) {
+      Either<Boolean, CodeActionOptions> codeActionProvider = cap.getCodeActionProvider();
+      if (codeActionProvider == null) {
+        return false;
+      }
+      if (codeActionProvider.isRight()) {
+        return codeActionProvider.getRight() != null;
+      } else {
+        return codeActionProvider.getLeft();
+      }
+    }
+
+    private static Boolean getRenameProvider(ServerCapabilities cap) {
+      Either<Boolean, RenameOptions> provider = cap.getRenameProvider();
+      if (provider == null) {
+        return false;
+      }
+      if (provider.isRight()) {
+        return provider.getRight() != null;
+      } else {
+        return provider.getLeft();
+      }
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Thomas Mäder <tmader@redhat.com>

### What does this PR do?
Updates Che to work with LSP4J 0.6.0. None of the new features in 0.6.0 are actually used, this PR is just to make the current features work with the new version.

### What issues does this PR fix or reference?
Update lsp4j to 0.6.0 version #12262

This PR depends on this compantion PR: https://github.com/eclipse/che-parent/pull/102
Do not merge separately
