### PR TITLE
Remove redundant elements (<groupId> and <version>)

### DIFF
--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -20,7 +20,6 @@
         <version>6.17.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
-    <groupId>org.eclipse.che</groupId>
     <artifactId>che-assembly-parent</artifactId>
     <packaging>pom</packaging>
     <name>Che IDE :: Parent</name>

--- a/core/che-core-dynamodule-maven-plugin/pom.xml
+++ b/core/che-core-dynamodule-maven-plugin/pom.xml
@@ -19,7 +19,6 @@
         <groupId>org.eclipse.che.core</groupId>
         <version>6.17.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-dynamodule-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>Che Core :: API :: DynaModule maven plugin</name>

--- a/core/che-core-typescript-dto-maven-plugin/pom.xml
+++ b/core/che-core-typescript-dto-maven-plugin/pom.xml
@@ -19,7 +19,6 @@
         <groupId>org.eclipse.che.core</groupId>
         <version>6.17.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-typescript-dto-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
     <name>Che Core :: API :: TypeScript DTO maven plugin</name>

--- a/ide/che-core-ide-api/pom.xml
+++ b/ide/che-core-ide-api/pom.xml
@@ -19,7 +19,6 @@
         <groupId>org.eclipse.che.core</groupId>
         <version>6.17.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-api</artifactId>
     <packaging>gwt-lib</packaging>
     <name>Che Core :: IDE :: API</name>

--- a/ide/che-core-ide-generators/pom.xml
+++ b/ide/che-core-ide-generators/pom.xml
@@ -19,7 +19,6 @@
         <groupId>org.eclipse.che.core</groupId>
         <version>6.17.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-generators</artifactId>
     <packaging>jar</packaging>
     <name>Che Core :: IDE :: Generators</name>

--- a/ide/che-core-ide-stacks/pom.xml
+++ b/ide/che-core-ide-stacks/pom.xml
@@ -19,7 +19,6 @@
         <groupId>org.eclipse.che.core</groupId>
         <version>6.17.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-stacks</artifactId>
     <packaging>jar</packaging>
     <name>Che Core :: IDE :: STACKS</name>

--- a/ide/che-core-ide-templates/pom.xml
+++ b/ide/che-core-ide-templates/pom.xml
@@ -19,7 +19,6 @@
         <groupId>org.eclipse.che.core</groupId>
         <version>6.17.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-templates</artifactId>
     <packaging>jar</packaging>
     <name>Che Core :: IDE :: TEMPLATES</name>

--- a/ide/che-core-ide-ui/pom.xml
+++ b/ide/che-core-ide-ui/pom.xml
@@ -19,7 +19,6 @@
         <groupId>org.eclipse.che.core</groupId>
         <version>6.17.0-SNAPSHOT</version>
     </parent>
-    <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-core-ide-ui</artifactId>
     <packaging>gwt-lib</packaging>
     <name>Che Core :: IDE :: UI</name>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
     </parent>
     <groupId>org.eclipse.che</groupId>
     <artifactId>che-parent</artifactId>
-    <version>6.17.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Che Parent</name>
     <modules>

--- a/wsagent/pom.xml
+++ b/wsagent/pom.xml
@@ -20,7 +20,6 @@
         <version>6.17.0-SNAPSHOT</version>
         <relativePath>../core/pom.xml</relativePath>
     </parent>
-    <groupId>org.eclipse.che.core</groupId>
     <artifactId>che-agent-parent</artifactId>
     <packaging>pom</packaging>
     <name>Che Agent Parent</name>


### PR DESCRIPTION
### What does this PR do?

Removing redundant elements in child POMs. Elements should be inherited from their parent POM.
