### PR TITLE
Add workspace confing autosave

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.controller.ts
@@ -289,13 +289,19 @@ export class WorkspaceMachinesController {
     if (!this.machines || !memoryLimitGBytes) {
       return;
     }
-    const memoryLimitBytesWithUnit = this.$filter('changeMemoryUnit')(memoryLimitGBytes, [MemoryUnit[MemoryUnit.GB], MemoryUnit[MemoryUnit.B]]);
-    const memoryLimitBytes = this.getNumber(memoryLimitBytesWithUnit);
     const machine: IEnvironmentManagerMachine = this.machines.find((machine: IEnvironmentManagerMachine) => {
       return machine && machine.name === name;
     });
 
-    if (machine && this.environmentManager.getMemoryLimit(machine).toString() !== memoryLimitBytes.toString()) {
+    if (!machine) {
+      return;
+    } 
+
+    const currentMemoryLimitBytes = this.environmentManager.getMemoryLimit(machine);
+    const currentMemoryLimitGBytes = currentMemoryLimitBytes === -1 ? 0 : this.getNumber(this.$filter('changeMemoryUnit')(currentMemoryLimitBytes, [MemoryUnit[MemoryUnit.B], MemoryUnit[MemoryUnit.GB]]));
+    if (memoryLimitGBytes !== currentMemoryLimitGBytes) {
+      const memoryLimitBytesWithUnit = this.$filter('changeMemoryUnit')(memoryLimitGBytes, [MemoryUnit[MemoryUnit.GB], MemoryUnit[MemoryUnit.B]]);
+      const memoryLimitBytes = this.getNumber(memoryLimitBytesWithUnit);
       this.environmentManager.setMemoryLimit(machine, memoryLimitBytes);
       const environment = this.environmentManager.getEnvironment(this.environment, this.machines);
       this.updateEnvironment(environment);

--- a/dashboard/src/components/api/environment/environment-manager.ts
+++ b/dashboard/src/components/api/environment/environment-manager.ts
@@ -354,7 +354,7 @@ export abstract class EnvironmentManager {
   setMemoryLimit(machine: IEnvironmentManagerMachine, limit: number): void {
     machine.attributes = machine.attributes ? machine.attributes : {};
     if (limit) {
-      machine.attributes.memoryLimitBytes = limit;
+      machine.attributes.memoryLimitBytes = limit.toString();
     }
   }
 }

--- a/dashboard/src/components/widget/editor/che-editor.controller.ts
+++ b/dashboard/src/components/widget/editor/che-editor.controller.ts
@@ -90,6 +90,8 @@ export class CheEditorController {
       lineNumbers: true,
       onLoad: (editor: IEditor) => {
         $timeout(() => {
+          //to avoid Ctrl+Z clear the content
+          editor.getDoc().clearHistory();
           editor.refresh();
         }, 2500);
         const doc = editor.getDoc();
@@ -144,7 +146,7 @@ export class CheEditorController {
             }
 
             this.editorForm.$setValidity('custom-validator', this.editorState.isValid, null);
-          }, 2500);
+          }, 500);
         });
       }
     };

--- a/dashboard/src/components/widget/editor/che-editor.directive.ts
+++ b/dashboard/src/components/widget/editor/che-editor.directive.ts
@@ -79,7 +79,7 @@ export class CheEditor implements ng.IDirective {
               <ng-form name="cheEditorController.editorForm">
                 <textarea ui-codemirror="cheEditorController.editorOptions"
                           aria-label="editor"
-                          ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 500, 'blur': 0 }, allowInvalid: true }"
+                          ng-model-options="{ updateOn: 'default blur', debounce: { 'default': 100, 'blur': 0 }, allowInvalid: true }"
                           ng-model="cheEditorController.editorContent"></textarea>
                 <div class="validator-checks">
                   <div ng-messages="cheEditorController.editorForm.$invalid">


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Allows the workspace configuration to be saved automatically.
Along with that - fixes few bugs with editing workspace config:
- pressing ctrl+z without changes in the editor - caused editor content to be empty
- when RAM was set in amount of bytes, that could not be converted to gigabytes without rounding - caused the workspace config to always have unsaved changes.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12136

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

