### PR TITLE
Copy resources in KubernetesEnvironment constructor instead of reusing

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
@@ -94,8 +94,8 @@ public class KubernetesEnvironment extends InternalEnvironment {
       Map<String, ConfigMap> configMaps) {
     super(internalEnvironment);
     setType(TYPE);
-    this.pods = pods;
-    this.deployments = deployments;
+    this.pods = new HashMap<>(pods);
+    this.deployments = new HashMap<>(deployments);
     this.services = services;
     this.ingresses = ingresses;
     this.persistentVolumeClaims = persistentVolumeClaims;


### PR DESCRIPTION
### What does this PR do?
Copy pods and deployments maps when creating a KubernetesEnvironment, to avoid e.g. using an immutable map when the `KubernetesEnvironment(KubernetesEnvironment k8sEnv)` constructor is used.

This should've been caught by e2e tests, I don't know how this didn't show up for a week after merging.

### What issues does this PR fix or reference?
#12418 
