### PR TITLE
Check the latest version of @eclipse-che/api

### DIFF
--- a/typescript-dto/Dockerfile
+++ b/typescript-dto/Dockerfile
@@ -28,8 +28,10 @@ ADD package.json /che/package.json
 
 COPY ./index.d.ts /che/index.d.ts
 
+ADD publish.sh publish.sh
+
 ARG NPM_AUTH_TOKEN
 
 ARG CHE_VERSION
 
-RUN cd /che && yarn publish  --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version ${CHE_VERSION}
+RUN cd /che && ../publish.sh ${CHE_VERSION}

--- a/typescript-dto/README.md
+++ b/typescript-dto/README.md
@@ -1,0 +1,1 @@
+#This is Eclipse Che API generated from Java DTO interfaces

--- a/typescript-dto/publish.sh
+++ b/typescript-dto/publish.sh
@@ -1,10 +1,22 @@
 #!/usr/bin/env sh
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# See: https://sipb.mit.edu/doc/safe-shell/
+
+set -e
+set -u
 
 #get the latest version of @eclipse-che/api
 api_version=$(yarn -s info @eclipse-che/api version)
 
 #publish only if latest version doesn't match current version
-if [ $api_version != $1 ];
+if [ "$api_version" != "$1" ];
 then
-    yarn publish  --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version $1
+    yarn publish  --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version "$1"
 fi

--- a/typescript-dto/publish.sh
+++ b/typescript-dto/publish.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+#get the latest version of @eclipse-che/api
+api_version=$(yarn -s info @eclipse-che/api version)
+
+#publish only if latest version doesn't match current version
+if [ $api_version != $1 ];
+then
+    yarn publish  --registry=https://registry.npmjs.org/ --no-git-tag-version --new-version $1
+fi


### PR DESCRIPTION
 And publish only when it's don't match

### What does this PR do?
Fix publishing npm package with che dto d.ts file, during che release

### What issues does this PR fix or reference?
#12454 
