### PR TITLE
Refactor PVCs strategies by extracting common functionality

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java
@@ -12,42 +12,24 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
-import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newPVC;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolume;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolumeMount;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
 
 import com.google.inject.Inject;
-import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Workspace;
-import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
-import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
@@ -109,6 +91,9 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
   private final PVCSubPathHelper pvcSubPathHelper;
   private final KubernetesNamespaceFactory factory;
   private final EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
+  private final PVCProvisioner pvcProvisioner;
+  private final PodsVolumes podsVolumes;
+  private final SubPathPrefixes subpathPrefixes;
 
   @Inject
   public CommonPVCStrategy(
@@ -118,7 +103,10 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
       @Named("che.infra.kubernetes.pvc.precreate_subpaths") boolean preCreateDirs,
       PVCSubPathHelper pvcSubPathHelper,
       KubernetesNamespaceFactory factory,
-      EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter) {
+      EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter,
+      PVCProvisioner pvcProvisioner,
+      PodsVolumes podsVolumes,
+      SubPathPrefixes subpathPrefixes) {
     this.configuredPVCName = configuredPVCName;
     this.pvcQuantity = pvcQuantity;
     this.pvcAccessMode = pvcAccessMode;
@@ -126,6 +114,9 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
     this.pvcSubPathHelper = pvcSubPathHelper;
     this.factory = factory;
     this.ephemeralWorkspaceAdapter = ephemeralWorkspaceAdapter;
+    this.pvcProvisioner = pvcProvisioner;
+    this.podsVolumes = podsVolumes;
+    this.subpathPrefixes = subpathPrefixes;
   }
 
   /**
@@ -151,15 +142,16 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
     }
     log.debug("Provisioning PVC strategy for workspace '{}'", workspaceId);
 
+    pvcProvisioner.convertCheVolumes(k8sEnv, workspaceId);
+
     // Note that PVC name is used during prefixing
     // It MUST be done before changing all PVCs references to common PVC
-    prefixVolumeMountsSubpaths(k8sEnv, identity.getWorkspaceId());
+    subpathPrefixes.prefixVolumeMountsSubpaths(k8sEnv, identity.getWorkspaceId());
 
     PersistentVolumeClaim commonPVC = replacePVCsWithCommon(k8sEnv, identity);
 
-    replacePodsVolumesWithCommon(k8sEnv.getPodsData(), commonPVC.getMetadata().getName());
-
-    provisionCheVolumes(k8sEnv, workspaceId, commonPVC.getMetadata().getName());
+    podsVolumes.replacePVCVolumesWithCommon(
+        k8sEnv.getPodsData(), commonPVC.getMetadata().getName());
 
     if (preCreateDirs) {
       Set<String> subPaths = combineVolumeMountsSubpaths(k8sEnv);
@@ -226,43 +218,7 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
     String workspaceId = workspace.getId();
     PersistentVolumeClaim pvc = createCommonPVC(workspaceId);
     pvcSubPathHelper.removeDirsAsync(
-        workspaceId, pvc.getMetadata().getName(), getWorkspaceSubPath(workspaceId));
-  }
-
-  private void prefixVolumeMountsSubpaths(KubernetesEnvironment k8sEnv, String workspaceId) {
-    for (PodData pod : k8sEnv.getPodsData().values()) {
-      Map<String, String> volumeToClaimName = new HashMap<>();
-      for (io.fabric8.kubernetes.api.model.Volume volume : pod.getSpec().getVolumes()) {
-        if (volume.getPersistentVolumeClaim() == null) {
-          continue;
-        }
-        volumeToClaimName.put(volume.getName(), volume.getPersistentVolumeClaim().getClaimName());
-      }
-
-      if (volumeToClaimName.isEmpty()) {
-        // Pod does not have any volume that references PVC
-        continue;
-      }
-
-      Stream.concat(
-              pod.getSpec().getContainers().stream(), pod.getSpec().getInitContainers().stream())
-          .forEach(
-              c -> {
-                for (VolumeMount volumeMount : c.getVolumeMounts()) {
-                  String pvcName = volumeToClaimName.get(volumeMount.getName());
-                  if (pvcName == null) {
-                    // should not happens since Volume<>PVC links are checked during recipe
-                    // validation
-                    continue;
-                  }
-
-                  String volumeSubPath =
-                      getVolumeMountSubpath(
-                          volumeMount, pvcName, workspaceId, Names.machineName(pod, c));
-                  volumeMount.setSubPath(volumeSubPath);
-                }
-              });
-    }
+        workspaceId, pvc.getMetadata().getName(), subpathPrefixes.getWorkspaceSubPath(workspaceId));
   }
 
   private PersistentVolumeClaim replacePVCsWithCommon(
@@ -271,80 +227,6 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
     k8sEnv.getPersistentVolumeClaims().clear();
     k8sEnv.getPersistentVolumeClaims().put(commonPVC.getMetadata().getName(), commonPVC);
     return commonPVC;
-  }
-
-  private void replacePodsVolumesWithCommon(Map<String, PodData> pods, String commonPVCName) {
-    for (PodData pod : pods.values()) {
-      Set<String> pvcSourcedVolumes = reducePVCSourcedVolumes(pod.getSpec().getVolumes());
-
-      // add common PVC sourced volume instead of removed
-      pod.getSpec()
-          .getVolumes()
-          .add(
-              new VolumeBuilder()
-                  .withName(commonPVCName)
-                  .withNewPersistentVolumeClaim()
-                  .withClaimName(commonPVCName)
-                  .endPersistentVolumeClaim()
-                  .build());
-
-      Stream.concat(
-              pod.getSpec().getContainers().stream(), pod.getSpec().getInitContainers().stream())
-          .flatMap(c -> c.getVolumeMounts().stream())
-          .filter(vm -> pvcSourcedVolumes.contains(vm.getName()))
-          .forEach(vm -> vm.setName(commonPVCName));
-    }
-  }
-
-  private Set<String> reducePVCSourcedVolumes(
-      List<io.fabric8.kubernetes.api.model.Volume> volumes) {
-    Set<String> pvcSourcedVolumes = new HashSet<>();
-    Iterator<io.fabric8.kubernetes.api.model.Volume> volumeIterator = volumes.iterator();
-    while (volumeIterator.hasNext()) {
-      io.fabric8.kubernetes.api.model.Volume volume = volumeIterator.next();
-      if (volume.getPersistentVolumeClaim() != null) {
-        pvcSourcedVolumes.add(volume.getName());
-        volumeIterator.remove();
-      }
-    }
-    return pvcSourcedVolumes;
-  }
-
-  private void provisionCheVolumes(
-      KubernetesEnvironment k8sEnv, String workspaceId, String commonPVCName) {
-    for (PodData pod : k8sEnv.getPodsData().values()) {
-      PodSpec podSpec = pod.getSpec();
-      List<Container> containers = new ArrayList<>();
-      containers.addAll(podSpec.getContainers());
-      containers.addAll(podSpec.getInitContainers());
-      for (Container container : containers) {
-        String machineName = Names.machineName(pod, container);
-        InternalMachineConfig machineConfig = k8sEnv.getMachines().get(machineName);
-        if (machineConfig == null) {
-          continue;
-        }
-        addMachineVolumes(commonPVCName, workspaceId, pod, container, machineConfig.getVolumes());
-      }
-    }
-  }
-
-  private void addMachineVolumes(
-      String pvcName,
-      String workspaceId,
-      PodData pod,
-      Container container,
-      Map<String, Volume> volumes) {
-    if (volumes.isEmpty()) {
-      return;
-    }
-    for (Entry<String, Volume> volumeEntry : volumes.entrySet()) {
-      String volumePath = volumeEntry.getValue().getPath();
-      String subPath =
-          getVolumeSubPath(workspaceId, volumeEntry.getKey(), Names.machineName(pod, container));
-
-      container.getVolumeMounts().add(newVolumeMount(pvcName, volumePath, subPath));
-      addVolumeIfNeeded(pvcName, pod.getSpec());
-    }
   }
 
   private Set<String> combineVolumeMountsSubpaths(KubernetesEnvironment k8sEnv) {
@@ -357,39 +239,5 @@ public class CommonPVCStrategy implements WorkspaceVolumesStrategy {
         .map(VolumeMount::getSubPath)
         .filter(subpath -> !isNullOrEmpty(subpath))
         .collect(Collectors.toSet());
-  }
-
-  private void addVolumeIfNeeded(String pvcName, PodSpec podSpec) {
-    if (podSpec.getVolumes().stream().noneMatch(volume -> volume.getName().equals(pvcName))) {
-      podSpec.getVolumes().add(newVolume(pvcName, pvcName));
-    }
-  }
-
-  /** Get sub-path for particular Volume Mount in a particular workspace */
-  private String getVolumeMountSubpath(
-      VolumeMount volumeMount, String volumeName, String workspaceId, String machineName) {
-    String volumeMountSubPath = nullToEmpty(volumeMount.getSubPath());
-    if (!volumeMountSubPath.startsWith("/")) {
-      volumeMountSubPath = '/' + volumeMountSubPath;
-    }
-
-    return getVolumeSubPath(workspaceId, volumeName, machineName) + volumeMountSubPath;
-  }
-
-  /** Get sub-path for particular volume in a particular workspace */
-  private String getVolumeSubPath(String workspaceId, String volumeName, String machineName) {
-    // logs must be located inside the folder related to the machine because few machines can
-    // contain the identical agents and in this case, a conflict is possible.
-    if (LOGS_VOLUME_NAME.equals(volumeName)) {
-      return getWorkspaceSubPath(workspaceId) + '/' + volumeName + '/' + machineName;
-    }
-    // this path should correlate with path returned by method getWorkspaceSubPath
-    // because this logic is used to correctly cleanup sub-paths related to a workspace
-    return getWorkspaceSubPath(workspaceId) + '/' + volumeName;
-  }
-
-  /** Get sub-path that holds all the volumes of a particular workspace */
-  private String getWorkspaceSubPath(String workspaceId) {
-    return workspaceId;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCProvisioner.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_VOLUME_NAME_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newPVC;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolume;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolumeMount;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
+import org.eclipse.che.api.core.model.workspace.config.Volume;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+
+/**
+ * Helps to work with {@link PersistentVolumeClaim} and provision them to {@link
+ * KubernetesEnvironment}.
+ *
+ * @author Sergii Leshchenko
+ */
+public class PVCProvisioner {
+
+  private final String pvcNamePrefix;
+  private final String pvcAccessMode;
+  private final String pvcQuantity;
+  private final PodsVolumes podsVolumes;
+
+  @Inject
+  public PVCProvisioner(
+      @Named("che.infra.kubernetes.pvc.name") String pvcNamePrefix,
+      @Named("che.infra.kubernetes.pvc.quantity") String pvcQuantity,
+      @Named("che.infra.kubernetes.pvc.access_mode") String pvcAccessMode,
+      PodsVolumes podsVolumes) {
+    this.pvcAccessMode = pvcAccessMode;
+    this.pvcQuantity = pvcQuantity;
+    this.pvcNamePrefix = pvcNamePrefix;
+    this.podsVolumes = podsVolumes;
+  }
+
+  /**
+   * Converts {@link Volume} specified in {@link MachineConfig#getVolumes()} to {@link
+   * PersistentVolumeClaim}s and provision them to {@link KubernetesEnvironment}. The machines
+   * corresponding pods and containers are updated in accordance.
+   *
+   * @param k8sEnv environment to provision
+   * @param workspaceId identifier of workspace to which the specified environment belongs to
+   */
+  public void convertCheVolumes(KubernetesEnvironment k8sEnv, String workspaceId) {
+    Map<String, PersistentVolumeClaim> volumeName2PVC =
+        groupByVolumeName(k8sEnv.getPersistentVolumeClaims().values());
+
+    for (PodData pod : k8sEnv.getPodsData().values()) {
+      final PodSpec podSpec = pod.getSpec();
+      List<Container> containers = new ArrayList<>();
+      containers.addAll(podSpec.getContainers());
+      containers.addAll(podSpec.getInitContainers());
+      for (Container container : containers) {
+        final String machineName = Names.machineName(pod, container);
+        InternalMachineConfig machineConfig = k8sEnv.getMachines().get(machineName);
+        if (machineConfig == null) {
+          continue;
+        }
+        Map<String, Volume> volumes = machineConfig.getVolumes();
+        addMachineVolumes(workspaceId, k8sEnv, volumeName2PVC, pod, container, volumes);
+      }
+    }
+  }
+
+  /**
+   * Provision the specified PVCs to the environment.
+   *
+   * <p>Note that:<br>
+   * - PVC is not provisioned if environment already contains PVC for corresponding volume;<br>
+   * - PVC is provisioned with generated unique name;<br>
+   * - corresponding PVC references in Kubernetes Environment are updated during provisioning;<br>
+   *
+   * @param k8sEnv environment to provision
+   * @param toProvision PVCs that should be provisioned to the environment
+   */
+  public void provision(
+      KubernetesEnvironment k8sEnv, Map<String, PersistentVolumeClaim> toProvision) {
+    final Map<String, PersistentVolumeClaim> volumeName2PVC =
+        groupByVolumeName(k8sEnv.getPersistentVolumeClaims().values());
+
+    // process user-defined PVCs according to unique strategy
+    final Map<String, PersistentVolumeClaim> envClaims = k8sEnv.getPersistentVolumeClaims();
+    for (PersistentVolumeClaim pvc : toProvision.values()) {
+      String originalPVCName = pvc.getMetadata().getName();
+
+      PersistentVolumeClaim existingPVC = volumeName2PVC.get(originalPVCName);
+
+      if (existingPVC != null) {
+        // Replace pvc in environment with existing. Fix the references in Pods
+        podsVolumes.changePVCReferences(
+            k8sEnv.getPodsData().values(), originalPVCName, existingPVC.getMetadata().getName());
+      } else {
+        // there is no the corresponding existing pvc
+        // new one should be created with generated name
+        putLabel(pvc, CHE_VOLUME_NAME_LABEL, originalPVCName);
+
+        final String uniqueName = Names.generateName(pvcNamePrefix + '-');
+        pvc.getMetadata().setName(uniqueName);
+        envClaims.put(uniqueName, pvc);
+
+        volumeName2PVC.put(originalPVCName, pvc);
+        podsVolumes.changePVCReferences(k8sEnv.getPodsData().values(), originalPVCName, uniqueName);
+      }
+    }
+  }
+
+  /**
+   * Groups list of given PVCs by volume name. The result may be used for easy accessing to PVCs by
+   * Che Volume name.
+   */
+  private Map<String, PersistentVolumeClaim> groupByVolumeName(
+      Collection<PersistentVolumeClaim> pvcs) {
+    final Map<String, PersistentVolumeClaim> grouped = new HashMap<>();
+    for (PersistentVolumeClaim pvc : pvcs) {
+      final ObjectMeta metadata = pvc.getMetadata();
+      final String volumeName;
+      if (metadata.getLabels() != null
+          && (volumeName = metadata.getLabels().get(CHE_VOLUME_NAME_LABEL)) != null) {
+        grouped.put(volumeName, pvc);
+      } else {
+        grouped.put(metadata.getName(), pvc);
+        putLabel(metadata, CHE_VOLUME_NAME_LABEL, metadata.getName());
+      }
+    }
+    return grouped;
+  }
+
+  private void addMachineVolumes(
+      String workspaceId,
+      KubernetesEnvironment k8sEnv,
+      Map<String, PersistentVolumeClaim> volumeName2PVC,
+      PodData pod,
+      Container container,
+      Map<String, Volume> volumes) {
+    if (volumes.isEmpty()) {
+      return;
+    }
+
+    for (Entry<String, Volume> volumeEntry : volumes.entrySet()) {
+      final String volumePath = volumeEntry.getValue().getPath();
+      final String volumeName =
+          LOGS_VOLUME_NAME.equals(volumeEntry.getKey())
+              ? volumeEntry.getKey() + '-' + pod.getMetadata().getName()
+              : volumeEntry.getKey();
+      final PersistentVolumeClaim pvc;
+      // checks whether PVC for given workspace and volume present in environment
+      if (volumeName2PVC.containsKey(volumeName)) {
+        pvc = volumeName2PVC.get(volumeName);
+      }
+      // when PVC is not found in environment then create new one
+      else {
+        final String uniqueName = Names.generateName(pvcNamePrefix);
+        pvc = newPVC(uniqueName, pvcAccessMode, pvcQuantity);
+        putLabel(pvc, CHE_WORKSPACE_ID_LABEL, workspaceId);
+        putLabel(pvc, CHE_VOLUME_NAME_LABEL, volumeName);
+        k8sEnv.getPersistentVolumeClaims().put(uniqueName, pvc);
+        volumeName2PVC.put(volumeName, pvc);
+      }
+
+      // binds pvc to pod and container
+      String pvcName = pvc.getMetadata().getName();
+      PodSpec podSpec = pod.getSpec();
+      Optional<io.fabric8.kubernetes.api.model.Volume> volumeOpt =
+          podSpec
+              .getVolumes()
+              .stream()
+              .filter(
+                  volume ->
+                      volume.getPersistentVolumeClaim() != null
+                          && pvcName.equals(volume.getPersistentVolumeClaim().getClaimName()))
+              .findAny();
+      io.fabric8.kubernetes.api.model.Volume podVolume;
+      if (volumeOpt.isPresent()) {
+        podVolume = volumeOpt.get();
+      } else {
+        podVolume = newVolume(pvcName, pvcName);
+        podSpec.getVolumes().add(podVolume);
+      }
+
+      container.getVolumeMounts().add(newVolumeMount(podVolume.getName(), volumePath, ""));
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
@@ -55,7 +55,10 @@ public class PerWorkspacePVCStrategy extends CommonPVCStrategy {
       @Named("che.infra.kubernetes.pvc.precreate_subpaths") boolean preCreateDirs,
       PVCSubPathHelper pvcSubPathHelper,
       KubernetesNamespaceFactory factory,
-      EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter) {
+      EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter,
+      PVCProvisioner pvcProvisioner,
+      PodsVolumes podsVolumes,
+      SubPathPrefixes subpathPrefixes) {
     super(
         pvcName,
         pvcQuantity,
@@ -63,7 +66,10 @@ public class PerWorkspacePVCStrategy extends CommonPVCStrategy {
         preCreateDirs,
         pvcSubPathHelper,
         factory,
-        ephemeralWorkspaceAdapter);
+        ephemeralWorkspaceAdapter,
+        pvcProvisioner,
+        podsVolumes,
+        subpathPrefixes);
     this.pvcNamePrefix = pvcName;
     this.factory = factory;
     this.pvcAccessMode = pvcAccessMode;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PodsVolumes.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PodsVolumes.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+
+/**
+ * Helps to works with Pods Volumes, like reference them to another PVC.
+ *
+ * @author Sergii Leshchenko
+ */
+public class PodsVolumes {
+
+  /**
+   * Changes all pods volumes witch referenced the specified PVC to reference new PVC.
+   *
+   * @param pods pods to change
+   * @param currentPVCName current PVC name for filtering pods volumes
+   * @param newPVCName new PVC name that should be used
+   */
+  public void changePVCReferences(
+      Collection<PodData> pods, String currentPVCName, String newPVCName) {
+    pods.stream()
+        .flatMap(p -> p.getSpec().getVolumes().stream())
+        .filter(
+            v ->
+                v.getPersistentVolumeClaim() != null
+                    && v.getPersistentVolumeClaim().getClaimName().equals(currentPVCName))
+        .forEach(v -> v.getPersistentVolumeClaim().setClaimName(newPVCName));
+  }
+
+  /**
+   * Replaces all pods PVC sourced volumes with the specified one.
+   *
+   * @param pods pods to change
+   * @param commonPVCName PVC name that should be referenced in all existing PVC sources volumes
+   */
+  public void replacePVCVolumesWithCommon(Map<String, PodData> pods, String commonPVCName) {
+    for (PodData pod : pods.values()) {
+      Set<String> pvcSourcedVolumes = reducePVCSourcedVolumes(pod.getSpec().getVolumes());
+
+      if (pvcSourcedVolumes.isEmpty()) {
+        continue;
+      }
+
+      // add common PVC sourced volume instead of removed
+      pod.getSpec()
+          .getVolumes()
+          .add(
+              new VolumeBuilder()
+                  .withName(commonPVCName)
+                  .withNewPersistentVolumeClaim()
+                  .withClaimName(commonPVCName)
+                  .endPersistentVolumeClaim()
+                  .build());
+
+      Stream.concat(
+              pod.getSpec().getContainers().stream(), pod.getSpec().getInitContainers().stream())
+          .flatMap(c -> c.getVolumeMounts().stream())
+          .filter(vm -> pvcSourcedVolumes.contains(vm.getName()))
+          .forEach(vm -> vm.setName(commonPVCName));
+    }
+  }
+
+  private static Set<String> reducePVCSourcedVolumes(List<Volume> volumes) {
+    Set<String> pvcSourcedVolumes = new HashSet<>();
+    Iterator<Volume> volumeIterator = volumes.iterator();
+    while (volumeIterator.hasNext()) {
+      Volume volume = volumeIterator.next();
+      if (volume.getPersistentVolumeClaim() != null) {
+        pvcSourcedVolumes.add(volume.getName());
+        volumeIterator.remove();
+      }
+    }
+    return pvcSourcedVolumes;
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/SubPathPrefixes.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/SubPathPrefixes.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_VOLUME_NAME_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
+
+import com.google.common.base.Strings;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+
+/**
+ * Is responsible for prefixing sub-paths of volume mounts and should be used by all PVCs
+ * strategies.
+ *
+ * @author Sergii Leshchenko
+ */
+public class SubPathPrefixes {
+
+  /**
+   * Prefixes volumes mounts of containers inside of the specified kubernetes environment.
+   *
+   * <p>Subpaths have the following format: '{workspaceId}/{Che Volume name|PVC name}'.<br>
+   * Where Che Volume is used if it is present in PVC labels, otherwise PVC name will be used.<br>
+   * Note that logs volume has the special format: '{workspaceId}/{volumeName}/{machineName}'. It is
+   * done in this way to avoid conflicts e.g. two identical agents inside different machines produce
+   * the same log file.
+   *
+   * @param k8sEnv environment to process
+   * @param workspaceId workspace id that should be used as prefix
+   */
+  public void prefixVolumeMountsSubpaths(KubernetesEnvironment k8sEnv, String workspaceId) {
+    for (PodData pod : k8sEnv.getPodsData().values()) {
+      Map<String, String> volumeToCheVolumeName = new HashMap<>();
+      for (io.fabric8.kubernetes.api.model.Volume volume : pod.getSpec().getVolumes()) {
+        if (volume.getPersistentVolumeClaim() == null) {
+          continue;
+        }
+        PersistentVolumeClaim pvc =
+            k8sEnv
+                .getPersistentVolumeClaims()
+                .get(volume.getPersistentVolumeClaim().getClaimName());
+
+        String cheVolumeName = pvc.getMetadata().getLabels().get(CHE_VOLUME_NAME_LABEL);
+        if (cheVolumeName == null) {
+          cheVolumeName = pvc.getMetadata().getName();
+          pvc.getMetadata().getLabels().put(CHE_VOLUME_NAME_LABEL, cheVolumeName);
+        }
+        volumeToCheVolumeName.put(volume.getName(), cheVolumeName);
+      }
+
+      if (volumeToCheVolumeName.isEmpty()) {
+        // Pod does not have any volume that references PVC
+        continue;
+      }
+
+      Stream.concat(
+              pod.getSpec().getContainers().stream(), pod.getSpec().getInitContainers().stream())
+          .forEach(
+              c -> {
+                for (VolumeMount volumeMount : c.getVolumeMounts()) {
+                  String pvcName = volumeToCheVolumeName.get(volumeMount.getName());
+                  if (pvcName == null) {
+                    // should not happens since Volume<>PVC links are checked during recipe
+                    // validation
+                    continue;
+                  }
+
+                  String volumeSubPath =
+                      getVolumeMountSubpath(
+                          volumeMount, pvcName, workspaceId, Names.machineName(pod, c));
+                  volumeMount.setSubPath(volumeSubPath);
+                }
+              });
+    }
+  }
+
+  /** Get sub-path for particular Volume Mount in a particular workspace */
+  private String getVolumeMountSubpath(
+      VolumeMount volumeMount, String volumeName, String workspaceId, String machineName) {
+    String volumeMountSubPath = Strings.nullToEmpty(volumeMount.getSubPath());
+    if (!volumeMountSubPath.startsWith("/")) {
+      volumeMountSubPath = '/' + volumeMountSubPath;
+    }
+
+    return getVolumeSubpath(workspaceId, volumeName, machineName) + volumeMountSubPath;
+  }
+
+  private String getVolumeSubpath(String workspaceId, String volumeName, String machineName) {
+    // logs must be located inside the folder related to the machine because few machines can
+    // contain the identical agents and in this case, a conflict is possible.
+    if (LOGS_VOLUME_NAME.equals(volumeName)) {
+      return getWorkspaceSubPath(workspaceId) + '/' + volumeName + '/' + machineName;
+    }
+    return getWorkspaceSubPath(workspaceId) + '/' + volumeName;
+  }
+
+  /** Get sub-path that holds all the volumes of a particular workspace */
+  public String getWorkspaceSubPath(String workspaceId) {
+    return workspaceId;
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategy.java
@@ -12,43 +12,20 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
 import static java.util.stream.Collectors.toMap;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_VOLUME_NAME_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newPVC;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolume;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.newVolumeMount;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner.LOGS_VOLUME_NAME;
 
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.VolumeMount;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
-import java.util.stream.Stream;
 import javax.inject.Inject;
-import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Workspace;
-import org.eclipse.che.api.core.model.workspace.config.Volume;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
-import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
 import org.slf4j.Logger;
@@ -99,28 +76,21 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
 
   public static final String UNIQUE_STRATEGY = "unique";
 
-  // property of PersistentVolumeClaim#getAdditionalProperties that indicates that PVC is
-  // provisioned by Che Server but is not user-defined
-  private static final String CHE_PROVISIONED_PVC_PROPERTY = "CHE_PROVISIONED";
-
-  private final String pvcNamePrefix;
-  private final String pvcQuantity;
-  private final String pvcAccessMode;
   private final KubernetesNamespaceFactory factory;
   private final EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
+  private final PVCProvisioner pvcProvisioner;
+  private final SubPathPrefixes subpathPrefixes;
 
   @Inject
   public UniqueWorkspacePVCStrategy(
-      @Named("che.infra.kubernetes.pvc.name") String pvcNamePrefix,
-      @Named("che.infra.kubernetes.pvc.quantity") String pvcQuantity,
-      @Named("che.infra.kubernetes.pvc.access_mode") String pvcAccessMode,
       KubernetesNamespaceFactory factory,
-      EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter) {
-    this.pvcNamePrefix = pvcNamePrefix;
-    this.pvcQuantity = pvcQuantity;
-    this.pvcAccessMode = pvcAccessMode;
+      EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter,
+      PVCProvisioner pvcProvisioner,
+      SubPathPrefixes subpathPrefixes) {
     this.factory = factory;
     this.ephemeralWorkspaceAdapter = ephemeralWorkspaceAdapter;
+    this.pvcProvisioner = pvcProvisioner;
+    this.subpathPrefixes = subpathPrefixes;
   }
 
   @Override
@@ -134,15 +104,19 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
 
     LOG.debug("Provisioning PVC strategy for workspace '{}'", workspaceId);
 
+    Map<String, PersistentVolumeClaim> userDefinedPVCs =
+        new HashMap<>(k8sEnv.getPersistentVolumeClaims());
+
+    k8sEnv.getPersistentVolumeClaims().clear();
     fillInExistingPVCs(k8sEnv, workspaceId);
 
-    // fetches all existing PVCs related to given workspace and groups them by volume name
-    final Map<String, PersistentVolumeClaim> volumeName2PVC =
-        groupByVolumeName(k8sEnv.getPersistentVolumeClaims().values());
+    pvcProvisioner.provision(k8sEnv, userDefinedPVCs);
 
-    processUserDefinedPVCs(k8sEnv, identity, workspaceId, volumeName2PVC);
+    pvcProvisioner.convertCheVolumes(k8sEnv, workspaceId);
 
-    provisionCheVolumes(k8sEnv, workspaceId, volumeName2PVC);
+    subpathPrefixes.prefixVolumeMountsSubpaths(k8sEnv, identity.getWorkspaceId());
+
+    provisionWorkspaceIdLabel(k8sEnv.getPersistentVolumeClaims(), identity.getWorkspaceId());
 
     LOG.debug("PVC strategy provisioning done for workspace '{}'", workspaceId);
   }
@@ -194,242 +168,14 @@ public class UniqueWorkspacePVCStrategy implements WorkspaceVolumesStrategy {
             .persistentVolumeClaims()
             .getByLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
             .stream()
-            .peek(pvc -> pvc.getAdditionalProperties().put(CHE_PROVISIONED_PVC_PROPERTY, true))
             .collect(toMap(pvc -> pvc.getMetadata().getName(), Function.identity()));
 
     k8sEnv.getPersistentVolumeClaims().putAll(existingPVCs);
   }
 
-  /**
-   * Groups list of given PVCs by volume name. The result may be used for easy accessing to PVCs by
-   * Che Volume name.
-   */
-  private Map<String, PersistentVolumeClaim> groupByVolumeName(
-      Collection<PersistentVolumeClaim> pvcs) {
-    final Map<String, PersistentVolumeClaim> grouped = new HashMap<>();
-    for (PersistentVolumeClaim pvc : pvcs) {
-      final ObjectMeta metadata = pvc.getMetadata();
-      final String volumeName;
-      if (metadata != null
-          && metadata.getLabels() != null
-          && (volumeName = metadata.getLabels().get(CHE_VOLUME_NAME_LABEL)) != null) {
-        grouped.put(volumeName, pvc);
-      }
-    }
-    return grouped;
-  }
-
-  /**
-   * Operations that are done in this method are described in java doc of {@link
-   * UniqueWorkspacePVCStrategy}.
-   */
-  private void processUserDefinedPVCs(
-      KubernetesEnvironment k8sEnv,
-      RuntimeIdentity identity,
-      String workspaceId,
-      Map<String, PersistentVolumeClaim> volumeName2PVC) {
-    // process user-defined PVCs according to unique strategy
-    final Map<String, PersistentVolumeClaim> envClaims = k8sEnv.getPersistentVolumeClaims();
-    Map<String, PersistentVolumeClaim> userDefinedPVCs =
-        envClaims
-            .values()
-            .stream()
-            .filter(
-                p -> {
-                  Object isProvisioned =
-                      p.getAdditionalProperties().get(CHE_PROVISIONED_PVC_PROPERTY);
-                  return !(isProvisioned instanceof Boolean) || !(Boolean) isProvisioned;
-                })
-            .collect(toMap(pvc -> pvc.getMetadata().getName(), Function.identity()));
-
-    prefixSubpaths(userDefinedPVCs.keySet(), k8sEnv.getPodsData(), identity.getWorkspaceId());
-
-    for (PersistentVolumeClaim pvc : userDefinedPVCs.values()) {
-      String originalPVCName = pvc.getMetadata().getName();
-
-      PersistentVolumeClaim existingPVC = volumeName2PVC.get(originalPVCName);
-
-      if (existingPVC != null) {
-        // Replace pvc in environment with existing. Fix the references in Pods
-        envClaims.remove(originalPVCName);
-        changePVCReferences(
-            k8sEnv.getPodsData(), originalPVCName, existingPVC.getMetadata().getName());
-      } else {
-        // there is no the corresponding existing pvc
-        // new one should be created with generated name
-        putLabel(pvc, CHE_VOLUME_NAME_LABEL, originalPVCName);
-        putLabel(pvc, CHE_WORKSPACE_ID_LABEL, workspaceId);
-
-        final String uniqueName = Names.generateName(pvcNamePrefix + '-');
-        pvc.getMetadata().setName(uniqueName);
-        pvc.getAdditionalProperties().put(CHE_PROVISIONED_PVC_PROPERTY, true);
-        envClaims.remove(originalPVCName);
-        envClaims.put(uniqueName, pvc);
-
-        volumeName2PVC.put(originalPVCName, pvc);
-        changePVCReferences(k8sEnv.getPodsData(), originalPVCName, uniqueName);
-      }
-    }
-  }
-
-  /**
-   * Prefixes user-defined subpath with `{workspace id} + {PVC name}` where PVC name is supposed to
-   * be used as Che volume name.
-   *
-   * @param userDefinedPVCs set with user-defined PVCs names
-   * @param pods pods to change subpaths
-   * @param workspaceId workspace id to be used in subpath prefix
-   */
-  private void prefixSubpaths(
-      Set<String> userDefinedPVCs, Map<String, PodData> pods, String workspaceId) {
-    for (PodData pod : pods.values()) {
-      Map<String, String> volumeToClaimName = new HashMap<>();
-
-      for (io.fabric8.kubernetes.api.model.Volume volume : pod.getSpec().getVolumes()) {
-        if (volume.getPersistentVolumeClaim() == null) {
-          continue;
-        }
-
-        String claimName = volume.getPersistentVolumeClaim().getClaimName();
-        if (userDefinedPVCs.contains(claimName)) {
-          volumeToClaimName.put(volume.getName(), claimName);
-        }
-      }
-
-      if (volumeToClaimName.isEmpty()) {
-        continue;
-      }
-
-      Stream.concat(
-              pod.getSpec().getContainers().stream(), pod.getSpec().getInitContainers().stream())
-          .forEach(
-              c -> {
-                for (VolumeMount volumeMount : c.getVolumeMounts()) {
-                  String claimName = volumeToClaimName.get(volumeMount.getName());
-                  if (claimName == null) {
-                    // claim is not user-defined. No need to prefix it
-                    return;
-                  }
-                  String volumeSubPath =
-                      getVolumeMountSubpath(
-                          volumeMount, claimName, workspaceId, Names.machineName(pod, c));
-                  volumeMount.setSubPath(volumeSubPath);
-                }
-              });
-    }
-  }
-
-  private void changePVCReferences(Map<String, PodData> pods, String oldName, String newName) {
-    pods.values()
-        .stream()
-        .flatMap(p -> p.getSpec().getVolumes().stream())
-        .filter(
-            v ->
-                v.getPersistentVolumeClaim() != null
-                    && v.getPersistentVolumeClaim().getClaimName().equals(oldName))
-        .forEach(v -> v.getPersistentVolumeClaim().setClaimName(newName));
-  }
-
-  private void provisionCheVolumes(
-      KubernetesEnvironment k8sEnv,
-      String workspaceId,
-      Map<String, PersistentVolumeClaim> volumeName2PVC) {
-    for (PodData pod : k8sEnv.getPodsData().values()) {
-      final PodSpec podSpec = pod.getSpec();
-      List<Container> containers = new ArrayList<>();
-      containers.addAll(podSpec.getContainers());
-      containers.addAll(podSpec.getInitContainers());
-      for (Container container : containers) {
-        final String machineName = Names.machineName(pod, container);
-        InternalMachineConfig machineConfig = k8sEnv.getMachines().get(machineName);
-        if (machineConfig == null) {
-          continue;
-        }
-        Map<String, Volume> volumes = machineConfig.getVolumes();
-        addMachineVolumes(workspaceId, k8sEnv, volumeName2PVC, pod, container, volumes);
-      }
-    }
-  }
-
-  private void addMachineVolumes(
-      String workspaceId,
-      KubernetesEnvironment k8sEnv,
-      Map<String, PersistentVolumeClaim> volumeName2PVC,
-      PodData pod,
-      Container container,
-      Map<String, Volume> volumes) {
-    if (volumes.isEmpty()) {
-      return;
-    }
-
-    for (Entry<String, Volume> volumeEntry : volumes.entrySet()) {
-      final String volumePath = volumeEntry.getValue().getPath();
-      final String volumeName =
-          LOGS_VOLUME_NAME.equals(volumeEntry.getKey())
-              ? volumeEntry.getKey() + '-' + pod.getMetadata().getName()
-              : volumeEntry.getKey();
-      final PersistentVolumeClaim pvc;
-      // checks whether PVC for given workspace and volume present in environment
-      if (volumeName2PVC.containsKey(volumeName)) {
-        pvc = volumeName2PVC.get(volumeName);
-      }
-      // when PVC is not found in environment then create new one
-      else {
-        final String uniqueName = Names.generateName(pvcNamePrefix + '-');
-        pvc = newPVC(uniqueName, pvcAccessMode, pvcQuantity);
-        putLabel(pvc, CHE_WORKSPACE_ID_LABEL, workspaceId);
-        putLabel(pvc, CHE_VOLUME_NAME_LABEL, volumeName);
-        k8sEnv.getPersistentVolumeClaims().put(uniqueName, pvc);
-        volumeName2PVC.put(volumeName, pvc);
-      }
-
-      // binds pvc to pod and container
-      String pvcUniqueName = pvc.getMetadata().getName();
-      PodSpec podSpec = pod.getSpec();
-      Optional<io.fabric8.kubernetes.api.model.Volume> volumeOpt =
-          podSpec
-              .getVolumes()
-              .stream()
-              .filter(
-                  volume ->
-                      volume.getPersistentVolumeClaim() != null
-                          && pvcUniqueName.equals(volume.getPersistentVolumeClaim().getClaimName()))
-              .findAny();
-      io.fabric8.kubernetes.api.model.Volume podVolume;
-      if (volumeOpt.isPresent()) {
-        podVolume = volumeOpt.get();
-      } else {
-        podVolume = newVolume(pvcUniqueName, pvcUniqueName);
-        podSpec.getVolumes().add(podVolume);
-      }
-
-      container
-          .getVolumeMounts()
-          .add(
-              newVolumeMount(
-                  podVolume.getName(),
-                  volumePath,
-                  getVolumeSubpath(workspaceId, volumeName, Names.machineName(pod, container))));
-    }
-  }
-
-  /** Get sub-path for particular Volume Mount in a particular workspace */
-  private String getVolumeMountSubpath(
-      VolumeMount volumeMount, String volumeName, String workspaceId, String machineName) {
-    String volumeMountSubPath = Strings.nullToEmpty(volumeMount.getSubPath());
-    if (!volumeMountSubPath.startsWith("/")) {
-      volumeMountSubPath = '/' + volumeMountSubPath;
-    }
-
-    return getVolumeSubpath(workspaceId, volumeName, machineName) + volumeMountSubPath;
-  }
-
-  private String getVolumeSubpath(String workspaceId, String volumeName, String machineName) {
-    // logs must be located inside the folder related to the machine because few machines can
-    // contain the identical agents and in this case, a conflict is possible.
-    if (LOGS_VOLUME_NAME.equals(volumeName)) {
-      return workspaceId + '/' + volumeName + '/' + machineName;
-    }
-    return workspaceId + '/' + volumeName;
+  private void provisionWorkspaceIdLabel(
+      Map<String, PersistentVolumeClaim> pvcs, String workspaceId) {
+    pvcs.values()
+        .forEach(pvc -> pvc.getMetadata().getLabels().put(CHE_WORKSPACE_ID_LABEL, workspaceId));
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategyTest.java
@@ -15,12 +15,11 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.SUBPATHS_PROPERTY_FMT;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newContainer;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newPod;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -30,21 +29,12 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -52,12 +42,12 @@ import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -76,19 +66,6 @@ public class CommonPVCStrategyTest {
   private static final String WORKSPACE_ID = "workspace123";
   private static final String PVC_NAME = "che-claim";
 
-  private static final String POD_1_NAME = "main";
-  private static final String CONTAINER_1_NAME = "app";
-  private static final String CONTAINER_2_NAME = "db";
-  private static final String MACHINE_1_NAME = POD_1_NAME + '/' + CONTAINER_1_NAME;
-  private static final String MACHINE_2_NAME = POD_1_NAME + '/' + CONTAINER_2_NAME;
-
-  private static final String POD_2_NAME = "second";
-  private static final String CONTAINER_NAME_3 = "app2";
-  private static final String MACHINE_3_NAME = POD_2_NAME + '/' + CONTAINER_NAME_3;
-
-  private static final String VOLUME_1_NAME = "vol1";
-  private static final String VOLUME_2_NAME = "vol2";
-
   private static final String PVC_QUANTITY = "10Gi";
   private static final String PVC_ACCESS_MODE = "RWO";
 
@@ -99,9 +76,6 @@ public class CommonPVCStrategyTest {
 
   private KubernetesEnvironment k8sEnv;
 
-  private Pod pod;
-  private Pod pod2;
-
   @Mock private PVCSubPathHelper pvcSubPathHelper;
 
   @Mock private KubernetesNamespaceFactory factory;
@@ -109,6 +83,11 @@ public class CommonPVCStrategyTest {
   @Mock private KubernetesPersistentVolumeClaims pvcs;
 
   @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
+  @Mock private PVCProvisioner volumeConverter;
+  @Mock private PodsVolumes podsVolumes;
+  @Mock private SubPathPrefixes subpathPrefixes;
+
+  private InOrder provisionOrder;
 
   private CommonPVCStrategy commonPVCStrategy;
 
@@ -122,41 +101,14 @@ public class CommonPVCStrategyTest {
             true,
             pvcSubPathHelper,
             factory,
-            ephemeralWorkspaceAdapter);
+            ephemeralWorkspaceAdapter,
+            volumeConverter,
+            podsVolumes,
+            subpathPrefixes);
 
     k8sEnv = KubernetesEnvironment.builder().build();
 
-    k8sEnv
-        .getMachines()
-        .put(
-            MACHINE_1_NAME,
-            TestObjects.newMachineConfig()
-                .withVolume(VOLUME_1_NAME, "/path")
-                .withVolume(VOLUME_2_NAME, "/path2")
-                .build());
-
-    k8sEnv
-        .getMachines()
-        .put(
-            MACHINE_2_NAME,
-            TestObjects.newMachineConfig().withVolume(VOLUME_2_NAME, "/path2").build());
-
-    k8sEnv
-        .getMachines()
-        .put(
-            MACHINE_3_NAME,
-            TestObjects.newMachineConfig().withVolume(VOLUME_1_NAME, "/path").build());
-
-    pod =
-        newPod(POD_1_NAME)
-            .withContainers(
-                newContainer(CONTAINER_1_NAME).build(), newContainer(CONTAINER_2_NAME).build())
-            .build();
-
-    pod2 = newPod(POD_2_NAME).withContainers(newContainer(CONTAINER_NAME_3).build()).build();
-
-    k8sEnv.addPod(pod);
-    k8sEnv.addPod(pod2);
+    provisionOrder = inOrder(volumeConverter, subpathPrefixes, podsVolumes);
 
     lenient().doNothing().when(pvcSubPathHelper).execute(any(), any(), any());
     lenient()
@@ -166,25 +118,36 @@ public class CommonPVCStrategyTest {
 
     lenient().when(factory.create(WORKSPACE_ID)).thenReturn(k8sNamespace);
     lenient().when(k8sNamespace.persistentVolumeClaims()).thenReturn(pvcs);
+
+    lenient().when(subpathPrefixes.getWorkspaceSubPath(WORKSPACE_ID)).thenReturn(WORKSPACE_ID);
   }
 
   @Test
   public void testProvisionVolumesIntoKubernetesEnvironment() throws Exception {
+    // given
+    k8sEnv.getPersistentVolumeClaims().put("pvc1", newPVC("pvc1"));
+    k8sEnv.getPersistentVolumeClaims().put("pvc2", newPVC("pvc2"));
+
+    // when
     commonPVCStrategy.provision(k8sEnv, IDENTITY);
 
-    // 2 volumes in machine1
-    assertFalse(pod.getSpec().getVolumes().isEmpty());
-    assertFalse(pod.getSpec().getContainers().get(0).getVolumeMounts().isEmpty());
-    assertFalse(pod.getSpec().getContainers().get(1).getVolumeMounts().isEmpty());
-    assertFalse(pod2.getSpec().getVolumes().isEmpty());
-    assertFalse(pod2.getSpec().getContainers().get(0).getVolumeMounts().isEmpty());
-    assertFalse(k8sEnv.getPersistentVolumeClaims().isEmpty());
-    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(PVC_NAME));
+    // then
+    provisionOrder.verify(volumeConverter).convertCheVolumes(k8sEnv, WORKSPACE_ID);
+    provisionOrder.verify(subpathPrefixes).prefixVolumeMountsSubpaths(k8sEnv, WORKSPACE_ID);
+    provisionOrder.verify(podsVolumes).replacePVCVolumesWithCommon(k8sEnv.getPodsData(), PVC_NAME);
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    PersistentVolumeClaim commonPVC = k8sEnv.getPersistentVolumeClaims().get(PVC_NAME);
+    assertNotNull(commonPVC);
+    assertEquals(commonPVC.getMetadata().getName(), PVC_NAME);
+    assertEquals(commonPVC.getSpec().getAccessModes(), Collections.singletonList(PVC_ACCESS_MODE));
+    assertEquals(
+        commonPVC.getSpec().getResources().getRequests().get("storage"),
+        new Quantity(PVC_QUANTITY));
   }
 
   @Test
   public void testReplacePVCWhenItsAlreadyInKubernetesEnvironment() throws Exception {
-    final PersistentVolumeClaim provisioned = mock(PersistentVolumeClaim.class);
+    PersistentVolumeClaim provisioned = newPVC(PVC_NAME);
     k8sEnv.getPersistentVolumeClaims().put(PVC_NAME, provisioned);
 
     commonPVCStrategy.provision(k8sEnv, IDENTITY);
@@ -193,238 +156,7 @@ public class CommonPVCStrategyTest {
   }
 
   @Test
-  public void testProvisionVolumesWithSubpathsIntoKubernetesEnvironment() throws Exception {
-    commonPVCStrategy.provision(k8sEnv, IDENTITY);
-
-    final Map<String, PersistentVolumeClaim> actual = k8sEnv.getPersistentVolumeClaims();
-    assertFalse(actual.isEmpty());
-    assertTrue(actual.containsKey(PVC_NAME));
-    assertEquals(
-        (String[])
-            actual
-                .get(PVC_NAME)
-                .getAdditionalProperties()
-                .get(format(SUBPATHS_PROPERTY_FMT, WORKSPACE_ID)),
-        new String[] {expectedVolumeDir(VOLUME_1_NAME), expectedVolumeDir(VOLUME_2_NAME)});
-  }
-
-  @Test
-  public void testProcessingUserDefinedPVCsBoundToMultiplyContainers() throws Exception {
-    // given
-    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
-
-    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
-
-    pod.getSpec()
-        .getInitContainers()
-        .add(
-            new ContainerBuilder()
-                .withName("userInitContainer")
-                .withVolumeMounts(
-                    new VolumeMountBuilder()
-                        .withName("userData")
-                        .withSubPath("/tmp/init/userData")
-                        .build())
-                .build());
-
-    pod.getSpec()
-        .getContainers()
-        .get(0)
-        .getVolumeMounts()
-        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
-
-    pod.getSpec()
-        .getVolumes()
-        .add(
-            new VolumeBuilder()
-                .withName("userData")
-                .withPersistentVolumeClaim(
-                    new PersistentVolumeClaimVolumeSourceBuilder()
-                        .withClaimName("userDataPVC")
-                        .build())
-                .build());
-
-    // when
-    commonPVCStrategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
-    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(PVC_NAME));
-
-    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
-
-    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
-    assertEquals(userPodVolume.getPersistentVolumeClaim().getClaimName(), PVC_NAME);
-    assertEquals(podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(), PVC_NAME);
-
-    Container initContainer = podSpec.getInitContainers().get(0);
-    VolumeMount initVolumeMount = initContainer.getVolumeMounts().get(0);
-    assertEquals(initVolumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/tmp/init/userData");
-    assertEquals(initVolumeMount.getName(), userPodVolume.getName());
-
-    Container container = podSpec.getContainers().get(0);
-    VolumeMount volumeMount = container.getVolumeMounts().get(0);
-    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/home/user/data");
-    assertEquals(volumeMount.getName(), userPodVolume.getName());
-  }
-
-  @Test
-  public void testProcessingUserDefinedNonPVCPodsVolumes() throws Exception {
-    // given
-    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
-
-    pod.getSpec()
-        .getContainers()
-        .get(0)
-        .getVolumeMounts()
-        .add(
-            new VolumeMountBuilder()
-                .withName("configMapVolume")
-                .withSubPath("/home/user/config")
-                .build());
-
-    ConfigMapVolumeSource configMapVolumeSource =
-        new ConfigMapVolumeSourceBuilder().withName("configMap").build();
-    pod.getSpec()
-        .getVolumes()
-        .add(
-            new VolumeBuilder()
-                .withName("configMapVolume")
-                .withConfigMap(configMapVolumeSource)
-                .build());
-
-    // when
-    commonPVCStrategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
-
-    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
-    assertNull(userPodVolume.getPersistentVolumeClaim());
-    assertEquals(userPodVolume.getConfigMap(), configMapVolumeSource);
-
-    Container container = podSpec.getContainers().get(0);
-    VolumeMount volumeMount = container.getVolumeMounts().get(0);
-    assertEquals(volumeMount.getName(), "configMapVolume");
-    assertEquals(volumeMount.getSubPath(), "/home/user/config");
-  }
-
-  @Test
-  public void testMatchingUserDefinedPVCWithCheVolume() throws Exception {
-    // given
-    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
-
-    pod.getSpec()
-        .getVolumes()
-        .add(
-            new VolumeBuilder()
-                .withName("userData")
-                .withPersistentVolumeClaim(
-                    new PersistentVolumeClaimVolumeSourceBuilder()
-                        .withClaimName("userDataPVC")
-                        .build())
-                .build());
-
-    pod.getSpec()
-        .getContainers()
-        .get(0)
-        .getVolumeMounts()
-        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
-
-    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
-    k8sEnv
-        .getMachines()
-        .get(MACHINE_2_NAME)
-        .getVolumes()
-        .put("userDataPVC", new VolumeImpl().withPath("/"));
-
-    // when
-    commonPVCStrategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
-    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(PVC_NAME));
-
-    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
-
-    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
-    assertEquals(userPodVolume.getPersistentVolumeClaim().getClaimName(), PVC_NAME);
-    assertEquals(podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(), PVC_NAME);
-
-    // check container bound to user-defined PVC
-    Container container1 = podSpec.getContainers().get(0);
-    assertEquals(container1.getVolumeMounts().size(), 1);
-    VolumeMount volumeMount = container1.getVolumeMounts().get(0);
-    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/home/user/data");
-    assertEquals(volumeMount.getName(), userPodVolume.getName());
-
-    // check container that is bound to Che Volume via Machine configuration
-    Container container2 = podSpec.getContainers().get(1);
-    VolumeMount cheVolumeMount2 = container2.getVolumeMounts().get(0);
-    assertEquals(cheVolumeMount2.getSubPath(), WORKSPACE_ID + "/userDataPVC");
-    assertEquals(cheVolumeMount2.getName(), userPodVolume.getName());
-  }
-
-  @Test
-  public void testProcessingDifferentVolumeMountsBoundToTheSameVolume() throws Exception {
-    // given
-    k8sEnv = KubernetesEnvironment.builder().build();
-    k8sEnv.getPersistentVolumeClaims().put("appStorage", newPVC("appStorage"));
-
-    Pod pod =
-        newPod(POD_1_NAME)
-            .withContainers(
-                newContainer(CONTAINER_1_NAME)
-                    .withVolumeMount("appStorage", "/data", "data")
-                    .withVolumeMount("appStorage", "/config", "config")
-                    .build())
-            .withPVCVolume("appStorage", "appStorage")
-            .build();
-
-    k8sEnv.addPod(pod);
-
-    k8sEnv
-        .getMachines()
-        .put(
-            MACHINE_1_NAME,
-            TestObjects.newMachineConfig().withVolume("appStorage", "/app-storage").build());
-
-    // when
-    commonPVCStrategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
-    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(PVC_NAME));
-
-    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
-
-    assertEquals(podSpec.getVolumes().size(), 1);
-    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
-    assertEquals(userPodVolume.getPersistentVolumeClaim().getClaimName(), PVC_NAME);
-    assertEquals(podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(), PVC_NAME);
-
-    // check container bound to user-defined PVC
-    Container container1 = podSpec.getContainers().get(0);
-    assertEquals(container1.getVolumeMounts().size(), 3);
-
-    VolumeMount dataVolumeMount = container1.getVolumeMounts().get(0);
-    assertEquals(dataVolumeMount.getSubPath(), WORKSPACE_ID + "/appStorage/data");
-    assertEquals(dataVolumeMount.getMountPath(), "/data");
-    assertEquals(dataVolumeMount.getName(), userPodVolume.getName());
-
-    VolumeMount configVolumeMount = container1.getVolumeMounts().get(1);
-    assertEquals(configVolumeMount.getSubPath(), WORKSPACE_ID + "/appStorage/config");
-    assertEquals(configVolumeMount.getMountPath(), "/config");
-    assertEquals(configVolumeMount.getName(), userPodVolume.getName());
-
-    VolumeMount appStorage = container1.getVolumeMounts().get(2);
-    assertEquals(appStorage.getSubPath(), WORKSPACE_ID + "/appStorage");
-    assertEquals(appStorage.getMountPath(), "/app-storage");
-    assertEquals(appStorage.getName(), userPodVolume.getName());
-  }
-
-  @Test
-  public void testDoNotAddsSubpathsWhenPreCreationIsNotNeeded() throws Exception {
+  public void testDoNotAddsSubpathsPropertyWhenPreCreationIsNotNeeded() throws Exception {
     commonPVCStrategy =
         new CommonPVCStrategy(
             PVC_NAME,
@@ -433,7 +165,10 @@ public class CommonPVCStrategyTest {
             false,
             pvcSubPathHelper,
             factory,
-            ephemeralWorkspaceAdapter);
+            ephemeralWorkspaceAdapter,
+            volumeConverter,
+            podsVolumes,
+            subpathPrefixes);
 
     commonPVCStrategy.provision(k8sEnv, IDENTITY);
 
@@ -565,9 +300,5 @@ public class CommonPVCStrategyTest {
         .withNewSpec()
         .endSpec()
         .build();
-  }
-
-  private static String expectedVolumeDir(String volumeName) {
-    return WORKSPACE_ID + '/' + volumeName;
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCProvisionerTest.java
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_VOLUME_NAME_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newContainer;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newPod;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** @author Sergii Leshchenko */
+@Listeners(MockitoTestNGListener.class)
+public class PVCProvisionerTest {
+
+  private static final String WORKSPACE_ID = "workspace123";
+  private static final String PVC_NAME_PREFIX = "che-claim";
+
+  private static final String POD_1_NAME = "main";
+  private static final String CONTAINER_1_NAME = "app";
+  private static final String CONTAINER_2_NAME = "db";
+  private static final String MACHINE_1_NAME = POD_1_NAME + '/' + CONTAINER_1_NAME;
+  private static final String MACHINE_2_NAME = POD_1_NAME + '/' + CONTAINER_2_NAME;
+
+  private static final String POD_2_NAME = "second";
+  private static final String CONTAINER_3_NAME = "app2";
+  private static final String MACHINE_3_NAME = POD_2_NAME + '/' + CONTAINER_3_NAME;
+
+  private static final String VOLUME_1_NAME = "vol1";
+  private static final String VOLUME_2_NAME = "vol2";
+
+  private static final String PVC_QUANTITY = "10Gi";
+  private static final String PVC_ACCESS_MODE = "RWO";
+
+  private static final RuntimeIdentity IDENTITY =
+      new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");
+
+  private KubernetesEnvironment k8sEnv;
+
+  private Pod pod;
+  private Pod pod2;
+
+  @Mock private PodsVolumes podsVolumes;
+  private PVCProvisioner provisioner;
+
+  @BeforeMethod
+  public void setUp() {
+    provisioner = new PVCProvisioner(PVC_NAME_PREFIX, PVC_QUANTITY, PVC_ACCESS_MODE, podsVolumes);
+
+    k8sEnv = KubernetesEnvironment.builder().build();
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_1_NAME,
+            TestObjects.newMachineConfig()
+                .withVolume(VOLUME_1_NAME, "/path")
+                .withVolume(VOLUME_2_NAME, "/path2")
+                .build());
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_2_NAME,
+            TestObjects.newMachineConfig().withVolume(VOLUME_2_NAME, "/path2").build());
+
+    k8sEnv
+        .getMachines()
+        .put(
+            MACHINE_3_NAME,
+            TestObjects.newMachineConfig().withVolume(VOLUME_1_NAME, "/path").build());
+
+    pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME).build(), newContainer(CONTAINER_2_NAME).build())
+            .build();
+
+    pod2 = newPod(POD_2_NAME).withContainers(newContainer(CONTAINER_3_NAME).build()).build();
+
+    k8sEnv.addPod(pod);
+    k8sEnv.addPod(pod2);
+  }
+
+  @Test
+  public void testProvisionPVCsForEachVolumeWithUniqueName() throws Exception {
+    // given
+    k8sEnv.getPersistentVolumeClaims().clear();
+
+    // when
+    provisioner.convertCheVolumes(k8sEnv, WORKSPACE_ID);
+
+    // then
+    assertEquals(pod.getSpec().getVolumes().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(1).getVolumeMounts().size(), 1);
+
+    assertEquals(pod2.getSpec().getVolumes().size(), 1);
+    assertEquals(pod2.getSpec().getContainers().get(0).getVolumeMounts().size(), 1);
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 2);
+
+    PersistentVolumeClaim pvcForVolume1 =
+        findPvc(VOLUME_1_NAME, k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForVolume1);
+    assertTrue(pvcForVolume1.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
+
+    PersistentVolumeClaim pvcForVolume2 =
+        findPvc(VOLUME_2_NAME, k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForVolume2);
+    assertTrue(pvcForVolume2.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
+  }
+
+  @Test
+  public void testMatchingUserDefinedPVCWithCheVolume() throws Exception {
+    // given
+    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
+
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("userDataPVC")
+                        .build())
+                .build());
+
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
+
+    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
+    k8sEnv
+        .getMachines()
+        .get(MACHINE_2_NAME)
+        .getVolumes()
+        .put("userDataPVC", new VolumeImpl().withPath("/"));
+
+    // when
+    provisioner.convertCheVolumes(k8sEnv, WORKSPACE_ID);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    PersistentVolumeClaim pvcForUserData =
+        findPvc("userDataPVC", k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForUserData);
+    assertEquals("userDataPVC", pvcForUserData.getMetadata().getName());
+
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(
+        userPodVolume.getPersistentVolumeClaim().getClaimName(),
+        pvcForUserData.getMetadata().getName());
+    assertEquals(
+        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(),
+        pvcForUserData.getMetadata().getName());
+
+    // check container bound to user-defined PVC
+    Container container1 = podSpec.getContainers().get(0);
+    assertEquals(container1.getVolumeMounts().size(), 1);
+    VolumeMount volumeMount = container1.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getName(), userPodVolume.getName());
+
+    // check container that is bound to Che Volume via Machine configuration
+    Container container2 = podSpec.getContainers().get(1);
+    VolumeMount cheVolumeMount2 = container2.getVolumeMounts().get(0);
+    assertEquals(cheVolumeMount2.getName(), userPodVolume.getName());
+  }
+
+  @Test
+  public void testDoNotProvisionPVCsWhenItIsAlreadyProvisionedForGivenVolumeAndWorkspace()
+      throws Exception {
+    final String pvcUniqueName1 = PVC_NAME_PREFIX + "-3121";
+    PersistentVolumeClaim pvc1 =
+        newPVC(pvcUniqueName1, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_1_NAME));
+    pvc1.getAdditionalProperties().put("CHE_PROVISIONED", true);
+    final String pvcUniqueName2 = PVC_NAME_PREFIX + "-71333";
+    PersistentVolumeClaim pvc2 =
+        newPVC(pvcUniqueName2, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_2_NAME));
+    pvc2.getAdditionalProperties().put("CHE_PROVISIONED", true);
+
+    k8sEnv.getPersistentVolumeClaims().put(pvc1.getMetadata().getName(), pvc1);
+    k8sEnv.getPersistentVolumeClaims().put(pvc2.getMetadata().getName(), pvc2);
+
+    provisioner.convertCheVolumes(k8sEnv, WORKSPACE_ID);
+
+    assertEquals(pod.getSpec().getVolumes().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), 2);
+    assertEquals(pod.getSpec().getContainers().get(1).getVolumeMounts().size(), 1);
+    assertEquals(pod2.getSpec().getVolumes().size(), 1);
+    assertEquals(pod2.getSpec().getContainers().get(0).getVolumeMounts().size(), 1);
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 2);
+    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(pvcUniqueName1));
+    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(pvcUniqueName2));
+  }
+
+  @Test
+  public void testProvisioningPVCsToK8sEnvironment() throws Exception {
+    // given
+    k8sEnv = KubernetesEnvironment.builder().build();
+    Map<String, PersistentVolumeClaim> toProvision = new HashMap<>();
+    toProvision.put("appStorage", newPVC("appStorage"));
+
+    Pod pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME)
+                    .withVolumeMount("appStorage", "/data", "data")
+                    .withVolumeMount("appStorage", "/config", "config")
+                    .build())
+            .withPVCVolume("appStorage", "appStorage")
+            .build();
+
+    k8sEnv.addPod(pod);
+
+    // when
+    provisioner.provision(k8sEnv, toProvision);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    PersistentVolumeClaim pvcForUserData =
+        findPvc("appStorage", k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForUserData);
+    assertTrue(pvcForUserData.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
+
+    verify(podsVolumes)
+        .changePVCReferences(
+            k8sEnv.getPodsData().values(), "appStorage", pvcForUserData.getMetadata().getName());
+  }
+
+  @Test
+  public void testMatchEnvPVCsByVolumeNameWhenProvisioningPVCsToK8sEnvironment() throws Exception {
+    // given
+    k8sEnv = KubernetesEnvironment.builder().build();
+    k8sEnv
+        .getPersistentVolumeClaims()
+        .put(
+            "appStorage",
+            newPVC("pvc123123", ImmutableMap.of(CHE_VOLUME_NAME_LABEL, "appStorage")));
+
+    Map<String, PersistentVolumeClaim> toProvision = new HashMap<>();
+    toProvision.put("appStorage", newPVC("appStorage"));
+
+    Pod pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME)
+                    .withVolumeMount("appStorage", "/data", "data")
+                    .withVolumeMount("appStorage", "/config", "config")
+                    .build())
+            .withPVCVolume("appStorage", "appStorage")
+            .build();
+
+    k8sEnv.addPod(pod);
+
+    // when
+    provisioner.provision(k8sEnv, toProvision);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    PersistentVolumeClaim pvcForUserData =
+        findPvc("appStorage", k8sEnv.getPersistentVolumeClaims());
+    assertNotNull(pvcForUserData);
+    assertEquals("pvc123123", pvcForUserData.getMetadata().getName());
+
+    verify(podsVolumes)
+        .changePVCReferences(k8sEnv.getPodsData().values(), "appStorage", "pvc123123");
+  }
+
+  private static PersistentVolumeClaim newPVC(String name) {
+    return newPVC(name, new HashMap<>());
+  }
+
+  private static PersistentVolumeClaim newPVC(String name, Map<String, String> labels) {
+    return new PersistentVolumeClaimBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .withLabels(labels)
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
+  }
+
+  private PersistentVolumeClaim findPvc(
+      String volumeName, Map<String, PersistentVolumeClaim> claims) {
+    return claims
+        .values()
+        .stream()
+        .filter(c -> volumeName.equals(c.getMetadata().getLabels().get(CHE_VOLUME_NAME_LABEL)))
+        .findAny()
+        .orElse(null);
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategyTest.java
@@ -58,6 +58,10 @@ public class PerWorkspacePVCStrategyTest {
   @Mock private KubernetesPersistentVolumeClaims pvcs;
   @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
 
+  @Mock private PVCProvisioner volumeConverter;
+  @Mock private PodsVolumes podsVolumes;
+  @Mock private SubPathPrefixes subpathPrefixes;
+
   private PerWorkspacePVCStrategy strategy;
 
   @BeforeMethod
@@ -70,7 +74,10 @@ public class PerWorkspacePVCStrategyTest {
             true,
             pvcSubPathHelper,
             factory,
-            ephemeralWorkspaceAdapter);
+            ephemeralWorkspaceAdapter,
+            volumeConverter,
+            podsVolumes,
+            subpathPrefixes);
 
     lenient().when(factory.create(WORKSPACE_ID)).thenReturn(k8sNamespace);
     lenient().when(k8sNamespace.persistentVolumeClaims()).thenReturn(pvcs);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PodsVolumesTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PodsVolumesTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newContainer;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newPod;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.SecretVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/** @author Sergii Leshchenko */
+public class PodsVolumesTest {
+  private static final String POD_1_NAME = "main";
+  private static final String CONTAINER_1_NAME = "app";
+  private static final String CONTAINER_2_NAME = "db";
+
+  private PodData podData;
+
+  private PodsVolumes podsVolumes;
+
+  @BeforeMethod
+  public void setUp() {
+    Pod pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME).build(), newContainer(CONTAINER_2_NAME).build())
+            .build();
+    podData = new PodData(pod.getSpec(), pod.getMetadata());
+
+    podsVolumes = new PodsVolumes();
+  }
+
+  @Test
+  public void shouldChangePVCReference() {
+    // given
+    podData
+        .getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("userData")
+                        .build())
+                .build());
+
+    // when
+    podsVolumes.changePVCReferences(ImmutableList.of(podData), "userData", "newPVCName");
+
+    // then
+    assertEquals(podData.getSpec().getVolumes().size(), 1);
+    Volume volume = podData.getSpec().getVolumes().get(0);
+    assertEquals(volume.getPersistentVolumeClaim().getClaimName(), "newPVCName");
+  }
+
+  @Test
+  public void shouldNotChangeNonMatchingVolumesChangePVCReference() {
+    // given
+    podData
+        .getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("nonMatching")
+                        .build())
+                .build());
+
+    // when
+    podsVolumes.changePVCReferences(ImmutableList.of(podData), "userData", "newPVCName");
+
+    // then
+    assertEquals(podData.getSpec().getVolumes().size(), 1);
+    Volume volume = podData.getSpec().getVolumes().get(0);
+    assertEquals(volume.getPersistentVolumeClaim().getClaimName(), "nonMatching");
+  }
+
+  @Test
+  public void shouldReplaceVolumesWithCommon() {
+    // given
+    podData
+        .getSpec()
+        .getInitContainers()
+        .add(
+            new ContainerBuilder()
+                .withName("userInitContainer")
+                .withVolumeMounts(
+                    new VolumeMountBuilder()
+                        .withName("initData")
+                        .withSubPath("/tmp/init/userData")
+                        .build())
+                .build());
+
+    podData
+        .getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
+
+    podData
+        .getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("userDataPVC")
+                        .build())
+                .build());
+    podData
+        .getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("initData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName("initDataPVC")
+                        .build())
+                .build());
+
+    // when
+    podsVolumes.replacePVCVolumesWithCommon(ImmutableMap.of("pod", podData), "commonPVC");
+
+    // then
+    assertEquals(podData.getSpec().getVolumes().size(), 1);
+    assertEquals(
+        podData.getSpec().getVolumes().get(0).getPersistentVolumeClaim().getClaimName(),
+        "commonPVC");
+    assertEquals(
+        podData.getSpec().getInitContainers().get(0).getVolumeMounts().get(0).getName(),
+        "commonPVC");
+    assertEquals(
+        podData.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), "commonPVC");
+  }
+
+  @Test
+  public void shouldNotReplaceNonPVCVolumes() {
+    // given
+    podData
+        .getSpec()
+        .getInitContainers()
+        .add(
+            new ContainerBuilder()
+                .withName("userInitContainer")
+                .withVolumeMounts(new VolumeMountBuilder().withName("configMap").build())
+                .build());
+
+    podData
+        .getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("secret").withSubPath("/home/user/data").build());
+
+    podData
+        .getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("configMap")
+                .withConfigMap(new ConfigMapVolumeSourceBuilder().withName("configMap").build())
+                .build());
+    podData
+        .getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("secret")
+                .withSecret(new SecretVolumeSourceBuilder().withSecretName("secret").build())
+                .build());
+
+    // when
+    podsVolumes.replacePVCVolumesWithCommon(ImmutableMap.of("pod", podData), "commonPVC");
+
+    // then
+    assertEquals(podData.getSpec().getVolumes().size(), 2);
+    assertNotNull(podData.getSpec().getVolumes().get(0).getConfigMap());
+    assertNull(podData.getSpec().getVolumes().get(0).getPersistentVolumeClaim());
+
+    assertNotNull(podData.getSpec().getVolumes().get(1).getSecret());
+    assertNull(podData.getSpec().getVolumes().get(1).getPersistentVolumeClaim());
+
+    assertEquals(
+        podData.getSpec().getInitContainers().get(0).getVolumeMounts().get(0).getName(),
+        "configMap");
+    assertEquals(
+        podData.getSpec().getContainers().get(0).getVolumeMounts().get(0).getName(), "secret");
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/SubPathPrefixesTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/SubPathPrefixesTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_VOLUME_NAME_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newContainer;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newPod;
+import static org.testng.Assert.assertEquals;
+
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/** @author Sergii Leshchenko */
+public class SubPathPrefixesTest {
+
+  private static final String USER_DATA_PVC_NAME = "userDataPVC";
+  private static final String WORKSPACE_ID = "workspace123";
+
+  private static final String POD_1_NAME = "main";
+  private static final String CONTAINER_1_NAME = "app";
+  private static final String CONTAINER_2_NAME = "db";
+
+  private Pod pod;
+
+  private PersistentVolumeClaim pvc;
+
+  private KubernetesEnvironment k8sEnv;
+
+  private SubPathPrefixes subpathPrefixes;
+
+  @BeforeMethod
+  public void setup() throws Exception {
+    subpathPrefixes = new SubPathPrefixes();
+
+    k8sEnv = KubernetesEnvironment.builder().build();
+
+    pod =
+        newPod(POD_1_NAME)
+            .withContainers(
+                newContainer(CONTAINER_1_NAME).build(), newContainer(CONTAINER_2_NAME).build())
+            .build();
+
+    k8sEnv.addPod(pod);
+
+    pvc = newPVC(USER_DATA_PVC_NAME);
+    k8sEnv.getPersistentVolumeClaims().put(USER_DATA_PVC_NAME, pvc);
+
+    pod.getSpec()
+        .getInitContainers()
+        .add(
+            new ContainerBuilder()
+                .withName("userInitContainer")
+                .withVolumeMounts(
+                    new VolumeMountBuilder()
+                        .withName("userData")
+                        .withSubPath("/tmp/init/userData")
+                        .build())
+                .build());
+
+    pod.getSpec()
+        .getContainers()
+        .get(0)
+        .getVolumeMounts()
+        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
+
+    pod.getSpec()
+        .getVolumes()
+        .add(
+            new VolumeBuilder()
+                .withName("userData")
+                .withPersistentVolumeClaim(
+                    new PersistentVolumeClaimVolumeSourceBuilder()
+                        .withClaimName(USER_DATA_PVC_NAME)
+                        .build())
+                .build());
+  }
+
+  @Test
+  public void shouldPrefixVolumeMountsSubpathsAndUsePvcNameAsVolumeName() {
+    // when
+    subpathPrefixes.prefixVolumeMountsSubpaths(k8sEnv, WORKSPACE_ID);
+
+    // then
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(userPodVolume.getPersistentVolumeClaim().getClaimName(), USER_DATA_PVC_NAME);
+    assertEquals(
+        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(), USER_DATA_PVC_NAME);
+
+    Container initContainer = podSpec.getInitContainers().get(0);
+    VolumeMount initVolumeMount = initContainer.getVolumeMounts().get(0);
+    assertEquals(
+        initVolumeMount.getSubPath(),
+        WORKSPACE_ID + "/" + USER_DATA_PVC_NAME + "/tmp/init/userData");
+    assertEquals(initVolumeMount.getName(), userPodVolume.getName());
+
+    Container container = podSpec.getContainers().get(0);
+    VolumeMount volumeMount = container.getVolumeMounts().get(0);
+    assertEquals(
+        volumeMount.getSubPath(), WORKSPACE_ID + "/" + USER_DATA_PVC_NAME + "/home/user/data");
+    assertEquals(volumeMount.getName(), userPodVolume.getName());
+  }
+
+  @Test
+  public void shouldNotPrefixNotPVCSourcesVolumes() {
+    // given
+    Volume podVolume = pod.getSpec().getVolumes().get(0);
+    podVolume.setPersistentVolumeClaim(null);
+    podVolume.setConfigMap(new ConfigMapVolumeSourceBuilder().withName("configMap").build());
+
+    // when
+    subpathPrefixes.prefixVolumeMountsSubpaths(k8sEnv, WORKSPACE_ID);
+
+    // then
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume podDataVolume = podSpec.getVolumes().get(0);
+
+    Container initContainer = podSpec.getInitContainers().get(0);
+    VolumeMount initVolumeMount = initContainer.getVolumeMounts().get(0);
+    assertEquals(initVolumeMount.getSubPath(), "/tmp/init/userData");
+    assertEquals(initVolumeMount.getName(), podDataVolume.getName());
+
+    Container container = podSpec.getContainers().get(0);
+    VolumeMount volumeMount = container.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getSubPath(), "/home/user/data");
+    assertEquals(volumeMount.getName(), podDataVolume.getName());
+  }
+
+  @Test
+  public void shouldPrefixVolumeMountsSubpathsAndUseVolumeNameStoredInLabels() {
+    // given
+    String volumeName = "userDataVolume";
+    pvc.getMetadata().getLabels().put(CHE_VOLUME_NAME_LABEL, volumeName);
+
+    // when
+    subpathPrefixes.prefixVolumeMountsSubpaths(k8sEnv, WORKSPACE_ID);
+
+    // then
+    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
+
+    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
+    assertEquals(userPodVolume.getPersistentVolumeClaim().getClaimName(), USER_DATA_PVC_NAME);
+    assertEquals(
+        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(), USER_DATA_PVC_NAME);
+
+    Container initContainer = podSpec.getInitContainers().get(0);
+    VolumeMount initVolumeMount = initContainer.getVolumeMounts().get(0);
+    assertEquals(
+        initVolumeMount.getSubPath(), WORKSPACE_ID + "/" + volumeName + "/tmp/init/userData");
+    assertEquals(initVolumeMount.getName(), userPodVolume.getName());
+
+    Container container = podSpec.getContainers().get(0);
+    VolumeMount volumeMount = container.getVolumeMounts().get(0);
+    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/" + volumeName + "/home/user/data");
+    assertEquals(volumeMount.getName(), userPodVolume.getName());
+  }
+
+  @Test
+  public void shouldReturnWorkspaceIdAsSubpathForWorkspace() {
+    // when
+    String workspaceSubPath = subpathPrefixes.getWorkspaceSubPath(WORKSPACE_ID);
+
+    // then
+    assertEquals(workspaceSubPath, WORKSPACE_ID);
+  }
+
+  private static PersistentVolumeClaim newPVC(String name) {
+    return newPVC(name, new HashMap<>());
+  }
+
+  private static PersistentVolumeClaim newPVC(String name, Map<String, String> labels) {
+    return new PersistentVolumeClaimBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .withLabels(labels)
+        .endMetadata()
+        .withNewSpec()
+        .endSpec()
+        .build();
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -11,15 +11,15 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc;
 
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_VOLUME_NAME_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newContainer;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newPod;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -27,36 +27,25 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
-import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
-import io.fabric8.kubernetes.api.model.Container;
-import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimBuilder;
-import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
-import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.PodSpec;
-import io.fabric8.kubernetes.api.model.VolumeBuilder;
-import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -75,32 +64,21 @@ public class UniqueWorkspacePVCStrategyTest {
   private static final String WORKSPACE_ID = "workspace123";
   private static final String PVC_NAME_PREFIX = "che-claim";
 
-  private static final String POD_1_NAME = "main";
-  private static final String CONTAINER_1_NAME = "app";
-  private static final String CONTAINER_2_NAME = "db";
-  private static final String MACHINE_1_NAME = POD_1_NAME + '/' + CONTAINER_1_NAME;
-  private static final String MACHINE_2_NAME = POD_1_NAME + '/' + CONTAINER_2_NAME;
-
-  private static final String POD_2_NAME = "second";
-  private static final String CONTAINER_3_NAME = "app2";
-  private static final String MACHINE_3_NAME = POD_2_NAME + '/' + CONTAINER_3_NAME;
-
-  private static final String VOLUME_1_NAME = "vol1";
-  private static final String VOLUME_2_NAME = "vol2";
-
-  private static final String PVC_QUANTITY = "10Gi";
-  private static final String PVC_ACCESS_MODE = "RWO";
-
   private static final RuntimeIdentity IDENTITY =
       new RuntimeIdentityImpl(WORKSPACE_ID, "env1", "id1");
 
   private KubernetesEnvironment k8sEnv;
+
   @Mock private KubernetesNamespaceFactory factory;
   @Mock private KubernetesNamespace k8sNamespace;
   @Mock private KubernetesPersistentVolumeClaims pvcs;
-  private Pod pod;
-  private Pod pod2;
   @Mock private EphemeralWorkspaceAdapter ephemeralWorkspaceAdapter;
+  @Mock private PVCProvisioner pvcProvisioner;
+  @Mock private PodsVolumes podsVolumes;
+  @Mock private SubPathPrefixes subpathPrefixes;
+  @Captor private ArgumentCaptor<KubernetesEnvironment> k8sEnvCaptor;
+
+  private InOrder provisionOrder;
 
   private UniqueWorkspacePVCStrategy strategy;
 
@@ -108,368 +86,58 @@ public class UniqueWorkspacePVCStrategyTest {
   public void setup() throws Exception {
     strategy =
         new UniqueWorkspacePVCStrategy(
-            PVC_NAME_PREFIX, PVC_QUANTITY, PVC_ACCESS_MODE, factory, ephemeralWorkspaceAdapter);
+            factory, ephemeralWorkspaceAdapter, pvcProvisioner, subpathPrefixes);
 
     k8sEnv = KubernetesEnvironment.builder().build();
 
-    k8sEnv
-        .getMachines()
-        .put(
-            MACHINE_1_NAME,
-            TestObjects.newMachineConfig()
-                .withVolume(VOLUME_1_NAME, "/path")
-                .withVolume(VOLUME_2_NAME, "/path2")
-                .build());
-
-    k8sEnv
-        .getMachines()
-        .put(
-            MACHINE_2_NAME,
-            TestObjects.newMachineConfig().withVolume(VOLUME_2_NAME, "/path2").build());
-
-    k8sEnv
-        .getMachines()
-        .put(
-            MACHINE_3_NAME,
-            TestObjects.newMachineConfig().withVolume(VOLUME_1_NAME, "/path").build());
-
-    pod =
-        newPod(POD_1_NAME)
-            .withContainers(
-                newContainer(CONTAINER_1_NAME).build(), newContainer(CONTAINER_2_NAME).build())
-            .build();
-
-    pod2 = newPod(POD_2_NAME).withContainers(newContainer(CONTAINER_3_NAME).build()).build();
-
-    k8sEnv.addPod(pod);
-    k8sEnv.addPod(pod2);
+    provisionOrder = inOrder(pvcProvisioner, subpathPrefixes, podsVolumes);
 
     when(factory.create(WORKSPACE_ID)).thenReturn(k8sNamespace);
     when(k8sNamespace.persistentVolumeClaims()).thenReturn(pvcs);
   }
 
   @Test
-  public void testProvisionPVCsForEachVolumeWithUniqueName() throws Exception {
+  public void testProvisionVolumesIntoKubernetesEnvironment() throws Exception {
     // given
-    k8sEnv.getPersistentVolumeClaims().clear();
+    PersistentVolumeClaim pvc1 = newPVC("pvc1");
+    PersistentVolumeClaim pvc2 = newPVC("pvc2");
+    k8sEnv.getPersistentVolumeClaims().put("pvc1", pvc1);
+    k8sEnv.getPersistentVolumeClaims().put("pvc2", pvc2);
 
-    // when
-    strategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    assertEquals(pod.getSpec().getVolumes().size(), 2);
-    assertEquals(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), 2);
-    assertEquals(pod.getSpec().getContainers().get(1).getVolumeMounts().size(), 1);
-
-    assertEquals(pod2.getSpec().getVolumes().size(), 1);
-    assertEquals(pod2.getSpec().getContainers().get(0).getVolumeMounts().size(), 1);
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 2);
-
-    PersistentVolumeClaim pvcForVolume1 =
-        findPvc(VOLUME_1_NAME, k8sEnv.getPersistentVolumeClaims());
-    assertNotNull(pvcForVolume1);
-    assertTrue(pvcForVolume1.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
-
-    PersistentVolumeClaim pvcForVolume2 =
-        findPvc(VOLUME_2_NAME, k8sEnv.getPersistentVolumeClaims());
-    assertNotNull(pvcForVolume2);
-    assertTrue(pvcForVolume2.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
-  }
-
-  @Test
-  public void testProcessingUserDefinedPVCsBoundToMultiplyContainers() throws Exception {
-    // given
-    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
-
-    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
-
-    pod.getSpec()
-        .getInitContainers()
-        .add(
-            new ContainerBuilder()
-                .withName("userInitContainer")
-                .withVolumeMounts(
-                    new VolumeMountBuilder()
-                        .withName("userData")
-                        .withSubPath("/tmp/init/userData")
-                        .build())
-                .build());
-
-    pod.getSpec()
-        .getContainers()
-        .get(0)
-        .getVolumeMounts()
-        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
-
-    pod.getSpec()
-        .getVolumes()
-        .add(
-            new VolumeBuilder()
-                .withName("userData")
-                .withPersistentVolumeClaim(
-                    new PersistentVolumeClaimVolumeSourceBuilder()
-                        .withClaimName("userDataPVC")
-                        .build())
-                .build());
-
-    // when
-    strategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
-    PersistentVolumeClaim pvcForUserData =
-        findPvc("userDataPVC", k8sEnv.getPersistentVolumeClaims());
-    assertNotNull(pvcForUserData);
-    assertTrue(pvcForUserData.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
-    assertEquals(
-        pvcForUserData.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
-
-    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
-
-    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
-    assertEquals(
-        userPodVolume.getPersistentVolumeClaim().getClaimName(),
-        pvcForUserData.getMetadata().getName());
-    assertEquals(
-        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(),
-        pvcForUserData.getMetadata().getName());
-
-    Container initContainer = podSpec.getInitContainers().get(0);
-    VolumeMount initVolumeMount = initContainer.getVolumeMounts().get(0);
-    assertEquals(initVolumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/tmp/init/userData");
-    assertEquals(initVolumeMount.getName(), userPodVolume.getName());
-
-    Container container = podSpec.getContainers().get(0);
-    VolumeMount volumeMount = container.getVolumeMounts().get(0);
-    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/home/user/data");
-    assertEquals(volumeMount.getName(), userPodVolume.getName());
-  }
-
-  @Test
-  public void testProcessingUserDefinedNonPVCPodsVolumes() throws Exception {
-    // given
-    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
-
-    pod.getSpec()
-        .getContainers()
-        .get(0)
-        .getVolumeMounts()
-        .add(
-            new VolumeMountBuilder()
-                .withName("configMapVolume")
-                .withSubPath("/home/user/config")
-                .build());
-
-    ConfigMapVolumeSource configMapVolumeSource =
-        new ConfigMapVolumeSourceBuilder().withName("configMap").build();
-    pod.getSpec()
-        .getVolumes()
-        .add(
-            new VolumeBuilder()
-                .withName("configMapVolume")
-                .withConfigMap(configMapVolumeSource)
-                .build());
-
-    // when
-    strategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
-
-    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
-    assertNull(userPodVolume.getPersistentVolumeClaim());
-    assertEquals(userPodVolume.getConfigMap(), configMapVolumeSource);
-
-    Container container = podSpec.getContainers().get(0);
-    VolumeMount volumeMount = container.getVolumeMounts().get(0);
-    assertEquals(volumeMount.getName(), "configMapVolume");
-    assertEquals(volumeMount.getSubPath(), "/home/user/config");
-  }
-
-  @Test
-  public void testMatchingUserDefinedPVCWithCheVolume() throws Exception {
-    // given
-    k8sEnv.getPersistentVolumeClaims().put("userDataPVC", newPVC("userDataPVC"));
-
-    pod.getSpec()
-        .getVolumes()
-        .add(
-            new VolumeBuilder()
-                .withName("userData")
-                .withPersistentVolumeClaim(
-                    new PersistentVolumeClaimVolumeSourceBuilder()
-                        .withClaimName("userDataPVC")
-                        .build())
-                .build());
-
-    pod.getSpec()
-        .getContainers()
-        .get(0)
-        .getVolumeMounts()
-        .add(new VolumeMountBuilder().withName("userData").withSubPath("/home/user/data").build());
-
-    k8sEnv.getMachines().values().forEach(m -> m.getVolumes().clear());
-    k8sEnv
-        .getMachines()
-        .get(MACHINE_2_NAME)
-        .getVolumes()
-        .put("userDataPVC", new VolumeImpl().withPath("/"));
-
-    // when
-    strategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
-    PersistentVolumeClaim pvcForUserData =
-        findPvc("userDataPVC", k8sEnv.getPersistentVolumeClaims());
-    assertNotNull(pvcForUserData);
-    assertTrue(pvcForUserData.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
-    assertEquals(
-        pvcForUserData.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
-
-    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
-
-    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
-    assertEquals(
-        userPodVolume.getPersistentVolumeClaim().getClaimName(),
-        pvcForUserData.getMetadata().getName());
-    assertEquals(
-        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(),
-        pvcForUserData.getMetadata().getName());
-
-    // check container bound to user-defined PVC
-    Container container1 = podSpec.getContainers().get(0);
-    assertEquals(container1.getVolumeMounts().size(), 1);
-    VolumeMount volumeMount = container1.getVolumeMounts().get(0);
-    assertEquals(volumeMount.getSubPath(), WORKSPACE_ID + "/userDataPVC/home/user/data");
-    assertEquals(volumeMount.getName(), userPodVolume.getName());
-
-    // check container that is bound to Che Volume via Machine configuration
-    Container container2 = podSpec.getContainers().get(1);
-    VolumeMount cheVolumeMount2 = container2.getVolumeMounts().get(0);
-    assertEquals(cheVolumeMount2.getSubPath(), WORKSPACE_ID + "/userDataPVC");
-    assertEquals(cheVolumeMount2.getName(), userPodVolume.getName());
-  }
-
-  @Test
-  public void testProcessingDifferentVolumeMountsBoundToTheSameVolume() throws Exception {
-    // given
-    k8sEnv = KubernetesEnvironment.builder().build();
-    k8sEnv.getPersistentVolumeClaims().put("appStorage", newPVC("appStorage"));
-
-    Pod pod =
-        newPod(POD_1_NAME)
-            .withContainers(
-                newContainer(CONTAINER_1_NAME)
-                    .withVolumeMount("appStorage", "/data", "data")
-                    .withVolumeMount("appStorage", "/config", "config")
-                    .build())
-            .withPVCVolume("appStorage", "appStorage")
-            .build();
-
-    k8sEnv.addPod(pod);
-
-    k8sEnv
-        .getMachines()
-        .put(
-            MACHINE_1_NAME,
-            TestObjects.newMachineConfig().withVolume("appStorage", "/app-storage").build());
-
-    // when
-    strategy.provision(k8sEnv, IDENTITY);
-
-    // then
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
-    PersistentVolumeClaim pvcForUserData =
-        findPvc("appStorage", k8sEnv.getPersistentVolumeClaims());
-    assertNotNull(pvcForUserData);
-    assertTrue(pvcForUserData.getMetadata().getName().startsWith(PVC_NAME_PREFIX));
-    assertEquals(
-        pvcForUserData.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
-
-    PodSpec podSpec = k8sEnv.getPodsData().get(POD_1_NAME).getSpec();
-
-    assertEquals(podSpec.getVolumes().size(), 1);
-    io.fabric8.kubernetes.api.model.Volume userPodVolume = podSpec.getVolumes().get(0);
-    assertEquals(
-        userPodVolume.getPersistentVolumeClaim().getClaimName(),
-        pvcForUserData.getMetadata().getName());
-    assertEquals(
-        podSpec.getVolumes().get(0).getPersistentVolumeClaim().getClaimName(),
-        pvcForUserData.getMetadata().getName());
-
-    // check container bound to user-defined PVC
-    Container container1 = podSpec.getContainers().get(0);
-    assertEquals(container1.getVolumeMounts().size(), 3);
-
-    VolumeMount dataVolumeMount = container1.getVolumeMounts().get(0);
-    assertEquals(dataVolumeMount.getSubPath(), WORKSPACE_ID + "/appStorage/data");
-    assertEquals(dataVolumeMount.getMountPath(), "/data");
-    assertEquals(dataVolumeMount.getName(), userPodVolume.getName());
-
-    VolumeMount configVolumeMount = container1.getVolumeMounts().get(1);
-    assertEquals(configVolumeMount.getSubPath(), WORKSPACE_ID + "/appStorage/config");
-    assertEquals(configVolumeMount.getMountPath(), "/config");
-    assertEquals(configVolumeMount.getName(), userPodVolume.getName());
-
-    VolumeMount appStorage = container1.getVolumeMounts().get(2);
-    assertEquals(appStorage.getSubPath(), WORKSPACE_ID + "/appStorage");
-    assertEquals(appStorage.getMountPath(), "/app-storage");
-    assertEquals(appStorage.getName(), userPodVolume.getName());
-  }
-
-  @Test
-  public void testDoNotProvisionPVCsWhenItIsAlreadyProvisionedForGivenVolumeAndWorkspace()
-      throws Exception {
-    final String pvcUniqueName1 = PVC_NAME_PREFIX + "-3121";
-    PersistentVolumeClaim pvc1 =
-        newPVC(pvcUniqueName1, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_1_NAME));
-    pvc1.getAdditionalProperties().put("CHE_PROVISIONED", true);
-    final String pvcUniqueName2 = PVC_NAME_PREFIX + "-71333";
-    PersistentVolumeClaim pvc2 =
-        newPVC(pvcUniqueName2, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_2_NAME));
-    pvc2.getAdditionalProperties().put("CHE_PROVISIONED", true);
-    k8sEnv.getPersistentVolumeClaims().clear();
-    k8sEnv.getPersistentVolumeClaims().put(pvcUniqueName1, pvc1);
-    k8sEnv.getPersistentVolumeClaims().put(pvcUniqueName2, pvc2);
-
-    strategy.provision(k8sEnv, IDENTITY);
-
-    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(pvcUniqueName1));
-    assertNotNull(k8sEnv.getPersistentVolumeClaims().get(pvcUniqueName2));
-    assertEquals(pod.getSpec().getVolumes().size(), 2);
-    assertEquals(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), 2);
-    assertEquals(pod.getSpec().getContainers().get(1).getVolumeMounts().size(), 1);
-    assertEquals(pod2.getSpec().getVolumes().size(), 1);
-    assertEquals(pod2.getSpec().getContainers().get(0).getVolumeMounts().size(), 1);
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 2);
-  }
-
-  @Test
-  public void testDoNotProvisionPVCsWhenItAlreadyExistsForGivenVolumeAndWorkspace()
-      throws Exception {
-    final String pvcUniqueName1 = PVC_NAME_PREFIX + "-3121";
-    PersistentVolumeClaim pvc1 =
-        newPVC(pvcUniqueName1, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_1_NAME));
-    pvc1.getAdditionalProperties().put("CHE_PROVISIONED", true);
-    final String pvcUniqueName2 = PVC_NAME_PREFIX + "-71333";
-    PersistentVolumeClaim pvc2 =
-        newPVC(pvcUniqueName2, ImmutableMap.of(CHE_VOLUME_NAME_LABEL, VOLUME_2_NAME));
-    pvc2.getAdditionalProperties().put("CHE_PROVISIONED", true);
-
+    PersistentVolumeClaim existingPVC = newPVC("existingPVC");
     when(pvcs.getByLabel(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID))
-        .thenReturn(ImmutableList.of(pvc1, pvc2));
+        .thenReturn(singletonList(existingPVC));
 
+    // when
     strategy.provision(k8sEnv, IDENTITY);
 
-    assertEquals(pod.getSpec().getVolumes().size(), 2);
-    assertEquals(pod.getSpec().getContainers().get(0).getVolumeMounts().size(), 2);
-    assertEquals(pod.getSpec().getContainers().get(1).getVolumeMounts().size(), 1);
-    assertEquals(pod2.getSpec().getVolumes().size(), 1);
-    assertEquals(pod2.getSpec().getContainers().get(0).getVolumeMounts().size(), 1);
-    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 2);
-    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(pvcUniqueName1));
-    assertTrue(k8sEnv.getPersistentVolumeClaims().containsKey(pvcUniqueName2));
+    // then
+    provisionOrder
+        .verify(pvcProvisioner)
+        .provision(k8sEnvCaptor.capture(), eq(ImmutableMap.of("pvc1", pvc1, "pvc2", pvc2)));
+    provisionOrder.verify(pvcProvisioner).convertCheVolumes(k8sEnv, WORKSPACE_ID);
+    provisionOrder.verify(subpathPrefixes).prefixVolumeMountsSubpaths(k8sEnv, WORKSPACE_ID);
+
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    assertNotNull(k8sEnv.getPersistentVolumeClaims().get("existingPVC"));
+    ;
+  }
+
+  @Test
+  public void shouldProvisionWorkspaceIdLabelToPVCs() throws Exception {
+    // given
+    PersistentVolumeClaim existingPVC = newPVC("existingPVC");
+    when(pvcs.getByLabel(CHE_WORKSPACE_ID_LABEL, WORKSPACE_ID))
+        .thenReturn(singletonList(existingPVC));
+
+    // when
+    strategy.provision(k8sEnv, IDENTITY);
+
+    // then
+    assertEquals(k8sEnv.getPersistentVolumeClaims().size(), 1);
+    PersistentVolumeClaim pvc = k8sEnv.getPersistentVolumeClaims().get("existingPVC");
+    assertNotNull(pvc);
+    assertEquals(pvc.getMetadata().getLabels().get(CHE_WORKSPACE_ID_LABEL), WORKSPACE_ID);
   }
 
   @Test
@@ -572,15 +240,5 @@ public class UniqueWorkspacePVCStrategyTest {
         .withNewSpec()
         .endSpec()
         .build();
-  }
-
-  private PersistentVolumeClaim findPvc(
-      String volumeName, Map<String, PersistentVolumeClaim> claims) {
-    return claims
-        .values()
-        .stream()
-        .filter(c -> volumeName.equals(c.getMetadata().getLabels().get(CHE_VOLUME_NAME_LABEL)))
-        .findAny()
-        .orElse(null);
   }
 }


### PR DESCRIPTION
### What does this PR do?
Refactor PVCs strategies by extracting common functionality.

### What issues does this PR fix or reference?
It is related to the following discussions:
https://github.com/eclipse/che/pull/12335#discussion_r247099347
https://github.com/eclipse/che/pull/12335#discussion_r248075444

### How to tests changes?

<details>
<summary>Workspace Config for testing</summary>

```json
{
  "commands": [],
  "environments": {
    "default": {
      "recipe": {
        "type": "kubernetes",
        "content": "kind: List\nitems:\n -\n  apiVersion: v1\n  kind: Pod\n  metadata:\n    name: ws\n  spec:\n    initContainers:\n     -\n       name: init\n       image: alpine:3.5\n       command: [\"sh\", \"-c\", \"echo Hello > /init-data/hello.txt\"]\n       volumeMounts:\n       -\n         mountPath: /init-data\n         name: data-volume\n         subPath: user/data\n    containers:\n     -\n      image: 'eclipse/che-dev:nightly'\n      name: dev\n      resources:\n        limits:\n          memory: 512Mi\n      volumeMounts:\n       -\n         mountPath: /data\n         name: data-volume\n         subPath: user/data\n     -\n      image: 'eclipse/che-dev:nightly'\n      name: dev2\n      resources:\n        limits:\n          memory: 256Mi\n    volumes:\n     -\n      name: data-volume\n      persistentVolumeClaim:\n        claimName: userdata\n -\n  apiVersion: v1\n  kind: PersistentVolumeClaim\n  metadata:\n    name: userdata\n  spec:\n    accessModes:\n     - ReadWriteOnce\n    resources:\n      requests:\n        storage: 1Gi\n",
        "contentType": "application/x-yaml"
      },
      "machines": {
        "ws/dev2": {
          "env": {},
          "servers": {},
          "installers": [],
          "volumes": {
            "userdata": {
              "path": "/data"
            }
          },
          "attributes": {
            "memoryLimitBytes": "322122547"
          }
        },
        "ws/dev": {
          "env": {},
          "servers": {},
          "installers": [],
          "volumes": {
            "projects": {
              "path": "/projects"
            }
          },
          "attributes": {
            "memoryLimitBytes": "536870912"
          }
        }
      }
    }
  },
  "defaultEnv": "default",
  "projects": [],
  "name": "che7",
  "attributes": {
    "editor": "org.eclipse.che.editor.theia:1.0.0",
    "plugins": "che-machine-exec-plugin:0.0.1"
  },
  "links": []
}
```
</details>

<details>
<summary>PV folders structures for Unique PVC Strategy</summary>

```
pv0094
`-- workspacek0lczo7h3wc79fzq
    `-- user-data
        `-- user
            `-- data
                `-- hello.txt

pv0076
`-- workspacek0lczo7h3wc79fzq
    `-- projects

pv0087
`-- workspacek0lczo7h3wc79fzq
    `-- che-logs-ws

pv0010
`-- workspacek0lczo7h3wc79fzq
    `-- plugins

pv0029
`-- workspacek0lczo7h3wc79fzq
    `-- che-logs-che-plugin-broker
```
</details>

<details>
<summary>PV folders structures for Common PVC Strategy</summary>

```
pv0069
`-- workspacehidcgmz3nt7jrhwk
    |-- che-logs
    |   |-- che-plugin-broker
    |   |   |-- broker1n71g0          !!!!!!!!!! TODO Each workspace start produces new folder. Take a look
    |   |   |-- brokera1v6s5
    |   |   |-- brokerec98fk
    |   |   |-- brokernse7nx
    |   |   |-- brokerotuw9x
    |   |   |-- brokerpfilyo
    |   |   |-- brokerqj3fng
    |   |   `-- brokerye8acc
    |   `-- ws
    |       |-- che-machine-exec
    |       |-- dev
    |       `-- theia-ide
    |-- plugins
    |-- projects
    `-- user-data
        `-- user
            `-- data
                `-- hello.txt

```
</details>

#### Release Notes
N/A

#### Docs PR
N/A