### PR TITLE
CORS: use internal or external api url depending on needs

### DIFF
--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentCorsAllowedOriginsProvider.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentCorsAllowedOriginsProvider.java
@@ -46,11 +46,13 @@ public class CheWsAgentCorsAllowedOriginsProvider implements Provider<String> {
 
   @Inject
   public CheWsAgentCorsAllowedOriginsProvider(
-      @Named("che.api") String apiEndpoint,
+      @Named("che.api.external") String apiExternal,
+      @Named("che.api.internal") String apiInternal,
       @Nullable @Named("che.wsagent.cors.allowed_origins") String allowedOrigins,
       HttpJsonRequestFactory httpJsonRequestFactory)
       throws ApiException, IOException {
-    this.allowedOrigins = evaluateOrigins(apiEndpoint, allowedOrigins, httpJsonRequestFactory);
+    this.allowedOrigins =
+        evaluateOrigins(apiExternal, apiInternal, allowedOrigins, httpJsonRequestFactory);
   }
 
   @Override
@@ -60,14 +62,17 @@ public class CheWsAgentCorsAllowedOriginsProvider implements Provider<String> {
   }
 
   private String evaluateOrigins(
-      String apiEndpoint, String allowedOrigins, HttpJsonRequestFactory httpJsonRequestFactory)
+      String apiExternal,
+      String apiInternal,
+      String allowedOrigins,
+      HttpJsonRequestFactory httpJsonRequestFactory)
       throws ApiException, IOException {
     if (allowedOrigins != null) {
       return allowedOrigins;
     }
 
     final UriBuilder builder =
-        UriBuilder.fromUri(apiEndpoint)
+        UriBuilder.fromUri(apiInternal)
             .path(WorkspaceService.class)
             .path(WorkspaceService.class, "getByKey")
             .queryParam("includeInternalServers", "true");
@@ -80,7 +85,7 @@ public class CheWsAgentCorsAllowedOriginsProvider implements Provider<String> {
     if (ideUrl != null) {
       return UriBuilder.fromUri(ideUrl).replacePath(null).build().toString();
     }
-    return UriBuilder.fromUri(workspaceDto.getLinks().getOrDefault("ide", apiEndpoint))
+    return UriBuilder.fromUri(workspaceDto.getLinks().getOrDefault("ide", apiExternal))
         .replacePath(null)
         .build()
         .toString();

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentCorsAllowedOriginsProvider.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentCorsAllowedOriginsProvider.java
@@ -33,8 +33,7 @@ import org.slf4j.LoggerFactory;
  * <ul>
  *   <li>If set che.wsagent.cors.allowed_origins
  *   <li>Server with "ide" attribute in workspace config
- *   <li>Server from url of "ide" link in workspace config
- *   <li>che.api
+ *   <li>che.api.external
  * </ul>
  */
 public class CheWsAgentCorsAllowedOriginsProvider implements Provider<String> {
@@ -85,7 +84,7 @@ public class CheWsAgentCorsAllowedOriginsProvider implements Provider<String> {
     if (ideUrl != null) {
       return UriBuilder.fromUri(ideUrl).replacePath(null).build().toString();
     }
-    return UriBuilder.fromUri(workspaceDto.getLinks().getOrDefault("ide", apiExternal))
+    return UriBuilder.fromUri(apiExternal)
         .replacePath(null)
         .build()
         .toString();

--- a/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentCorsAllowedOriginsProvider.java
+++ b/wsagent/che-wsagent-core/src/main/java/org/eclipse/che/wsagent/server/CheWsAgentCorsAllowedOriginsProvider.java
@@ -84,10 +84,7 @@ public class CheWsAgentCorsAllowedOriginsProvider implements Provider<String> {
     if (ideUrl != null) {
       return UriBuilder.fromUri(ideUrl).replacePath(null).build().toString();
     }
-    return UriBuilder.fromUri(apiExternal)
-        .replacePath(null)
-        .build()
-        .toString();
+    return UriBuilder.fromUri(apiExternal).replacePath(null).build().toString();
   }
 
   private String getIdeUrl(WorkspaceDto workspaceDto) {


### PR DESCRIPTION
### What does this PR do?
CORS: use internal or external api url depending on needs
On workspace agent  on Linux we have such variables
```
CHE_API_EXTERNAL=http://172.19.20.121:8080/api
CHE_API=http://che-host:8080/api
CHE_API_INTERNAL=http://che-host:8080/api
```
The issue was in fact that we use ```che-host:8080``` as an allowed host for CORS. But this URL 
is needed only to query che master from workspace agent.

After this PR we will use CHE_API_INTERNAL to query workspace master to get workspace config.
CHE_API_EXTERNAL as fallback url to determine cors allowed host if there is no other way.

Can't use "ide" link in workspace config since it depends on the way how workspace config was retrieved with help of internal API or external.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12463 Import/Create project does not work on docker platform

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
