### PR TITLE
Handle more fields in plugin meta YAML

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
@@ -12,7 +12,9 @@
 package org.eclipse.che.api.workspace.server.wsplugins.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /** @author Oleksandr Garagatyi */
@@ -24,9 +26,18 @@ public class PluginMeta {
   private String version = null;
   private String title = null;
   private String description = null;
+  private String category = null;
+  private String publisher = null;
+  private String repository = null;
+  private List<String> tags = null;
+  private String mediaImage = null;
+  private String mediaVideo = null;
+  private String firstPublicationDate = null;
+  private String latestUpdateDate = null;
+  private String preview = null;
   private String icon = null;
   private String url = null;
-  private Map<String, String> attributes = new HashMap<>();
+  private Map<String, String> attributes = null;
 
   public PluginMeta name(String name) {
     this.name = name;
@@ -110,5 +121,89 @@ public class PluginMeta {
   public PluginMeta attributes(Map<String, String> attributes) {
     this.attributes = attributes;
     return this;
+  }
+
+  public PluginMeta category(String category) {
+    this.category = category;
+    return this;
+  }
+
+  public String getCategory() {
+    return category;
+  }
+
+  public PluginMeta publisher(String publisher) {
+    this.publisher = publisher;
+    return this;
+  }
+
+  public String getPublisher() {
+    return publisher;
+  }
+
+  public PluginMeta repository(String repository) {
+    this.repository = repository;
+    return this;
+  }
+
+  public String getRepository() {
+    return repository;
+  }
+
+  public PluginMeta tags(List<String> tags) {
+    this.tags = tags;
+    return this;
+  }
+
+  public List<String> getTags() {
+    if (tags == null) {
+      tags = new ArrayList<>();
+    }
+    return tags;
+  }
+
+  public PluginMeta mediaImage(String mediaImage) {
+    this.mediaImage = mediaImage;
+    return this;
+  }
+
+  public String getMediaImage() {
+    return mediaImage;
+  }
+
+  public PluginMeta mediaVideo(String mediaVideo) {
+    this.mediaVideo = mediaVideo;
+    return this;
+  }
+
+  public String getMediaVideo() {
+    return mediaVideo;
+  }
+
+  public PluginMeta preview(String preview) {
+    this.preview = preview;
+    return this;
+  }
+
+  public String getPreview() {
+    return preview;
+  }
+
+  public PluginMeta firstPublicationDate(String firstPublicationDate) {
+    this.firstPublicationDate = firstPublicationDate;
+    return this;
+  }
+
+  public String getFirstPublicationDate() {
+    return firstPublicationDate;
+  }
+
+  public PluginMeta latestUpdateDate(String latestUpdateDate) {
+    this.latestUpdateDate = latestUpdateDate;
+    return this;
+  }
+
+  public String getLatestUpdateDate() {
+    return latestUpdateDate;
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add more possible fields for plugin yaml (not validated anyhow atm), for use in plugin viewer:
category
publisher
repository
tags
mediaImage
mediaVideo
firstPublicationDate
latestUpdateDate
preview

### What issues does this PR fix or reference?
https://github.com/eclipse/che-plugin-registry/issues/71

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
