### PR TITLE
[dockerfile] Use a tagged version of che-theia instead of master

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -36,7 +36,7 @@ ENV HOME=/home/theia-dev \
     GIT_EXEC_PATH=/usr/libexec/git-core
 
 # Define package of the theia generator to use
-ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1548066371
+ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1548256751
 
 WORKDIR ${HOME}
 


### PR DESCRIPTION
### What does this PR do?
Use a tagged version for che-theia repository instead of master

### What issues does this PR fix or reference?
N/A

Change-Id: I623b096628e0015f59e7ea1c9c4f6c5288d4a5ff
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

