### PR TITLE
Use close form handler in git compare window to check file dirty state

### DIFF
--- a/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/CompareViewImpl.java
+++ b/plugins/plugin-git/che-plugin-git-ext-git/src/main/java/org/eclipse/che/ide/ext/git/client/compare/CompareViewImpl.java
@@ -82,7 +82,7 @@ final class CompareViewImpl extends Window implements CompareView {
 
     setWidget(UI_BINDER.createAndBindUi(this));
 
-    addFooterButton(locale.buttonClose(), "git-compare-close-btn", event -> hide());
+    addFooterButton(locale.buttonClose(), "git-compare-close-btn", event -> delegate.onClose());
     addFooterButton(
         locale.buttonRefresh(), "git-compare-refresh-btn", event -> compareWidget.refresh());
 


### PR DESCRIPTION
### What does this PR do?
This changes proposal fix the problem when file edits in git compare window and after clicking close button the ask dialog is not appeared to save changes to the current file.

Signed-off-by: Vladyslav Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#11769 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A
