### PR TITLE
Upgrade to the latest version of the `che-theia-generator`

### DIFF
--- a/dockerfiles/theia-dev/Dockerfile
+++ b/dockerfiles/theia-dev/Dockerfile
@@ -36,7 +36,7 @@ ENV HOME=/home/theia-dev \
     GIT_EXEC_PATH=/usr/libexec/git-core
 
 # Define package of the theia generator to use
-ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1548256751
+ARG THEIA_GENERATOR_PACKAGE=@eclipse-che/theia-generator@0.0.1-1548277816
 
 WORKDIR ${HOME}
 


### PR DESCRIPTION
### What does this PR do?

This PR upgrade the `theia-dev` docker file to use the latest version of the `che-theia-generator`

This includes the following changes:
- Use a tagged version of che-theia instead of master -> version
0.0.1-1548256751
- Fix of a bug that prevented Che extensions to be put in the
`che.xxxx.js` chunk -> version 0.0.1-1548277816

### What issues does this PR fix or reference?

This PR references no issue