### PR TITLE
Get logs from pvc helper pods when job fails

### DIFF
--- a/infrastructures/kubernetes/pom.xml
+++ b/infrastructures/kubernetes/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>jackson-dataformat-yaml</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
         </dependency>

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -718,7 +718,7 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
     final KubernetesEnvironment environment = getContext().getEnvironment();
     final Map<String, InternalMachineConfig> machineConfigs = environment.getMachines();
     final String workspaceId = getContext().getIdentity().getWorkspaceId();
-    LOG.info("Begin pods creation for workspace '{}'", workspaceId);
+    LOG.debug("Begin pods creation for workspace '{}'", workspaceId);
     for (Pod toCreate : environment.getPodsCopy().values()) {
       startTracingContainersStartup(toCreate.getMetadata(), toCreate.getSpec());
       ObjectMeta toCreateMeta = toCreate.getMetadata();
@@ -737,7 +737,7 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
       final ObjectMeta templateMeta = toCreate.getSpec().getTemplate().getMetadata();
       storeStartingMachine(createdPod, templateMeta, machineConfigs, serverResolver);
     }
-    LOG.info("Pods creation finished in workspace '{}'", workspaceId);
+    LOG.debug("Pods creation finished in workspace '{}'", workspaceId);
   }
 
   /** Puts createdPod in the {@code machines} map and sends the starting event for this machine */

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -58,6 +58,7 @@ import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import okhttp3.Response;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
@@ -650,6 +651,30 @@ public class KubernetesDeployments {
       }
     } catch (KubernetesClientException e) {
       throw new KubernetesInfrastructureException(e);
+    }
+  }
+
+  /**
+   * Get logs from pod with specified name. The name can refer to either a deployment or pod
+   * directly. In case of a deployment being provided, logs are returned from pods in that
+   * deployment.
+   *
+   * @return the logs from the pod or null if pod cannot be found.
+   */
+  @Nullable
+  public String getPodLogs(String name) {
+    String podName;
+    try {
+      podName = getPodName(name);
+      return clientFactory
+          .create(workspaceId)
+          .pods()
+          .inNamespace(namespace)
+          .withName(podName)
+          .getLog();
+    } catch (InfrastructureException e) {
+      LOG.error("Could not get logs from pod {}. Pod not found", name);
+      return null;
     }
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.Kube
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
@@ -145,10 +146,11 @@ public class PVCSubPathHelper {
       final Pod finished = deployments.wait(podName, WAIT_POD_TIMEOUT_MIN, POD_PREDICATE::apply);
       PodStatus finishedStatus = finished.getStatus();
       if (POD_PHASE_FAILED.equals(finishedStatus.getPhase())) {
+        String logs = deployments.getPodLogs(podName);
         LOG.error(
-            "Job command '{}' execution is failed. Status '{}'.",
+            "Job command '{}' execution is failed. Logs: {}",
             Arrays.toString(command),
-            finishedStatus);
+            Strings.nullToEmpty(logs).replace("\n", " \\n")); // Force logs onto one line
       }
     } catch (InfrastructureException ex) {
       LOG.error(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
@@ -151,6 +151,7 @@ public class PVCSubPathHelperTest {
     verify(osDeployments).create(any());
     verify(osDeployments).wait(anyString(), anyInt(), any());
     verify(podStatus).getPhase();
+    verify(osDeployments).getPodLogs(any());
     verify(osDeployments).delete(anyString());
   }
 


### PR DESCRIPTION
### What does this PR do?
Add `#getPodLogs()` method to KubernetesDeployments. This method is used to get logs of failed PVC subpath helper jobs and log them to aid in debugging PVC issues.

For example, when #12445 occurs, the message 
`2019-01-28 18:53:23,610[er-ThreadPool-0]  [ERROR] [e.c.w.i.k.n.p.PVCSubPathHelper 150]  - Job command '[rm, -rf, /tmp/job_mount/workspacegij0p3l3wwio2g3j]' execution is failed. Logs: rm: cannot remove '/tmp/job_mount/workspacegij0p3l3wwio2g3j/projects': Permission denied \nrm: cannot remove '/tmp/job_mount/workspacegij0p3l3wwio2g3j/m2': Permission denied \nrm: cannot remove '/tmp/job_mount/workspacegij0p3l3wwio2g3j/javadata': Permission denied \nrm: cannot remove '/tmp/job_mount/workspacegij0p3l3wwio2g3j/che-logs/dev-machine': Permission denied \n`
is logged.

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/12445