### PR TITLE
Make brokers pod use a unique name to avoid collisions

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
@@ -196,7 +196,7 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
   private Pod newPod() {
     return new PodBuilder()
         .withNewMetadata()
-        .withName(BROKERS_POD_NAME)
+        .withName(generateUniqueName(BROKERS_POD_NAME))
         .endMetadata()
         .withNewSpec()
         .withRestartPolicy("Never")


### PR DESCRIPTION
### What does this PR do?
Make brokers pod use a unique name to avoid collisions. This prevents failure of starting several workspaces concurrently. 

### What issues does this PR fix or reference?
Related to https://github.com/eclipse/che/issues/12238

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
