### PR TITLE
Implement mountSources attribute for plugin containers

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -535,10 +535,10 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.7.0
-che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.7.0
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.7.1
-che.workspace.plugin_broker.vscode.image=eclipse/che-vscode-extension-broker:v0.7.0
+che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.8.0
+che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.8.0
+che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.8.0
+che.workspace.plugin_broker.vscode.image=eclipse/che-vscode-extension-broker:v0.8.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -34,11 +34,13 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.api.workspace.server.spi.provision.env.ProjectsRootEnvVariableProvider;
 import org.eclipse.che.api.workspace.server.wsplugins.ChePluginsApplier;
 import org.eclipse.che.api.workspace.server.wsplugins.model.CheContainer;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
@@ -66,20 +68,26 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
   private final String defaultSidecarMemoryLimitBytes;
   private final String sidecarImagePullPolicy;
   private final boolean isAuthEnabled;
+  private final ProjectsRootEnvVariableProvider projectsRootEnvVariableProvider;
 
   @Inject
   public KubernetesPluginsToolingApplier(
       @Named("che.workspace.sidecar.image_pull_policy") String sidecarImagePullPolicy,
       @Named("che.workspace.sidecar.default_memory_limit_mb") long defaultSidecarMemoryLimitMB,
-      @Named("che.agents.auth_enabled") boolean isAuthEnabled) {
+      @Named("che.agents.auth_enabled") boolean isAuthEnabled,
+      ProjectsRootEnvVariableProvider projectsRootEnvVariableProvider) {
     this.defaultSidecarMemoryLimitBytes = String.valueOf(defaultSidecarMemoryLimitMB * 1024 * 1024);
     this.isAuthEnabled = isAuthEnabled;
     this.sidecarImagePullPolicy =
         validImagePullPolicies.contains(sidecarImagePullPolicy) ? sidecarImagePullPolicy : null;
+    this.projectsRootEnvVariableProvider = projectsRootEnvVariableProvider;
   }
 
   @Override
-  public void apply(InternalEnvironment internalEnvironment, Collection<ChePlugin> chePlugins)
+  public void apply(
+      RuntimeIdentity runtimeIdentity,
+      InternalEnvironment internalEnvironment,
+      Collection<ChePlugin> chePlugins)
       throws InfrastructureException {
     if (chePlugins.isEmpty()) {
       return;
@@ -106,7 +114,13 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
       Collection<CommandImpl> pluginRelatedCommands = commandsResolver.resolve(chePlugin);
 
       for (CheContainer container : chePlugin.getContainers()) {
-        addSidecar(pod, container, chePlugin, kubernetesEnvironment, pluginRelatedCommands);
+        addSidecar(
+            pod,
+            container,
+            chePlugin,
+            kubernetesEnvironment,
+            pluginRelatedCommands,
+            runtimeIdentity);
       }
     }
 
@@ -169,7 +183,8 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
       CheContainer container,
       ChePlugin chePlugin,
       KubernetesEnvironment kubernetesEnvironment,
-      Collection<CommandImpl> sidecarRelatedCommands)
+      Collection<CommandImpl> sidecarRelatedCommands,
+      RuntimeIdentity runtimeIdentity)
       throws InfrastructureException {
 
     K8sContainerResolver k8sContainerResolver =
@@ -193,6 +208,8 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
             .setContainerEndpoints(containerEndpoints)
             .setDefaultSidecarMemorySizeAttribute(defaultSidecarMemoryLimitBytes)
             .setAttributes(kubernetesEnvironment.getAttributes())
+            .setProjectsRootPathEnvVar(projectsRootEnvVariableProvider.get(runtimeIdentity))
+            .setPluginId(chePlugin.getId())
             .build();
 
     InternalMachineConfig machineConfig = machineResolver.resolve();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolver.java
@@ -15,6 +15,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE;
 
 import io.fabric8.kubernetes.api.model.Container;
@@ -26,43 +27,47 @@ import java.util.Map.Entry;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.wsplugins.model.CheContainer;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePluginEndpoint;
 import org.eclipse.che.api.workspace.server.wsplugins.model.Volume;
+import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSize;
 
 /** @author Oleksandr Garagatyi */
 public class MachineResolver {
 
+  private final String pluginId;
   private final Container container;
   private final CheContainer cheContainer;
   private final String defaultSidecarMemoryLimitBytes;
   private final List<ChePluginEndpoint> containerEndpoints;
   private Map<String, String> wsAttributes;
+  private final Pair<String, String> projectsRootPathEnvVar;
 
   public MachineResolver(
+      String pluginId,
+      Pair<String, String> projectsRootPathEnvVar,
       Container container,
       CheContainer cheContainer,
       String defaultSidecarMemoryLimitBytes,
       List<ChePluginEndpoint> containerEndpoints,
       Map<String, String> wsAttributes) {
+    this.pluginId = pluginId;
     this.container = container;
     this.cheContainer = cheContainer;
     this.defaultSidecarMemoryLimitBytes = defaultSidecarMemoryLimitBytes;
     this.containerEndpoints = containerEndpoints;
     this.wsAttributes = wsAttributes != null ? wsAttributes : Collections.emptyMap();
+    this.projectsRootPathEnvVar = projectsRootPathEnvVar;
   }
 
-  public InternalMachineConfig resolve() {
+  public InternalMachineConfig resolve() throws InfrastructureException {
     InternalMachineConfig machineConfig =
         new InternalMachineConfig(
-            null,
-            toServers(containerEndpoints),
-            null,
-            null,
-            toWorkspaceVolumes(cheContainer.getVolumes()));
+            null, toServers(containerEndpoints), null, null, toWorkspaceVolumes(cheContainer));
 
     normalizeMemory(container, machineConfig);
     return machineConfig;
@@ -85,11 +90,31 @@ public class MachineResolver {
   }
 
   private Map<String, ? extends org.eclipse.che.api.core.model.workspace.config.Volume>
-      toWorkspaceVolumes(List<Volume> volumes) {
+      toWorkspaceVolumes(CheContainer container) throws InfrastructureException {
 
     Map<String, VolumeImpl> result = new HashMap<>();
 
-    for (Volume volume : volumes) {
+    if (container.isMountSources()) {
+      result.put(PROJECTS_VOLUME_NAME, new VolumeImpl().withPath(projectsRootPathEnvVar.second));
+    }
+
+    for (Volume volume : container.getVolumes()) {
+      if (volume.getName().equals(PROJECTS_VOLUME_NAME)
+          && !projectsRootPathEnvVar.second.equals(volume.getMountPath())) {
+        throw new InfrastructureException(
+            format(
+                "Plugin '%s' tried to manually mount the '%s' volume into its container '%s' on"
+                    + " path '%s'. This is illegal because sources need to be mounted to '%s'. Set"
+                    + " the mountSources attribute to true instead and remove the manual volume"
+                    + " mount in the plugin. After that the mount path of the sources will be"
+                    + " available automatically in the '%s' environment variable.",
+                pluginId,
+                PROJECTS_VOLUME_NAME,
+                container.getName(),
+                volume.getMountPath(),
+                projectsRootPathEnvVar.second,
+                projectsRootPathEnvVar.first));
+      }
       result.put(volume.getName(), new VolumeImpl().withPath(volume.getMountPath()));
     }
     return result;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverBuilder.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.workspace.server.wsplugins.model.CheContainer;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePluginEndpoint;
+import org.eclipse.che.commons.lang.Pair;
 
 /** @author Alexander Garagatyi */
 public class MachineResolverBuilder {
@@ -25,17 +26,23 @@ public class MachineResolverBuilder {
   private String defaultSidecarMemorySizeAttribute;
   private List<ChePluginEndpoint> containerEndpoints;
   private Map<String, String> wsAttributes;
+  private Pair<String, String> projectsRootPathEnvVar;
+  private String pluginId;
 
   public MachineResolver build() {
     if (container == null
         || cheContainer == null
         || defaultSidecarMemorySizeAttribute == null
         || wsAttributes == null
-        || containerEndpoints == null) {
+        || containerEndpoints == null
+        || projectsRootPathEnvVar == null
+        || pluginId == null) {
       throw new IllegalStateException();
     }
 
     return new MachineResolver(
+        pluginId,
+        projectsRootPathEnvVar,
         container,
         cheContainer,
         defaultSidecarMemorySizeAttribute,
@@ -66,6 +73,17 @@ public class MachineResolverBuilder {
 
   public MachineResolverBuilder setAttributes(Map<String, String> wsConfigAttributes) {
     this.wsAttributes = wsConfigAttributes;
+    return this;
+  }
+
+  public MachineResolverBuilder setProjectsRootPathEnvVar(
+      Pair<String, String> projectsRootPathEnvVar) {
+    this.projectsRootPathEnvVar = projectsRootPathEnvVar;
+    return this;
+  }
+
+  public MachineResolverBuilder setPluginId(String pluginId) {
+    this.pluginId = pluginId;
     return this;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
@@ -76,7 +76,7 @@ public class SidecarToolingProvisioner<E extends KubernetesEnvironment> {
     List<ChePlugin> chePlugins =
         pluginBrokerManager.getTooling(id, startSynchronizer, pluginsMeta, isEphemeral);
 
-    pluginsApplier.apply(environment, chePlugins);
+    pluginsApplier.apply(id, environment, chePlugins);
     if (isEphemeral) {
       brokerApplier.apply(environment, id, pluginsMeta);
     }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
@@ -94,7 +94,7 @@ public class SidecarToolingProvisionerTest {
   public void shouldNotAddInitContainerWhenWorkspaceIsNotEphemeral() throws Exception {
     provisioner.provision(runtimeId, startSynchronizer, nonEphemeralEnvironment);
 
-    verify(chePluginsApplier, times(1)).apply(any(), any());
+    verify(chePluginsApplier, times(1)).apply(any(), any(), any());
     verify(brokerApplier, times(0)).apply(any(), any(), any());
   }
 
@@ -102,7 +102,7 @@ public class SidecarToolingProvisionerTest {
   public void shouldIncludeInitContainerWhenWorkspaceIsEphemeral() throws Exception {
     provisioner.provision(runtimeId, startSynchronizer, ephemeralEnvironment);
 
-    verify(chePluginsApplier, times(1)).apply(any(), any());
+    verify(chePluginsApplier, times(1)).apply(any(), any(), any());
     verify(brokerApplier, times(1)).apply(any(), any(), any());
   }
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -171,5 +171,8 @@ public final class Constants {
   /** Mark containers created workspace api like tooling for user development. */
   public static final String TOOL_CONTAINER_SOURCE = "tool";
 
+  /** The projects volume has a standard name used in a couple of locations. */
+  public static final String PROJECTS_VOLUME_NAME = "projects";
+
   private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/ChePluginsApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/ChePluginsApplier.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.server.wsplugins;
 
 import com.google.common.annotations.Beta;
 import java.util.Collection;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
@@ -29,11 +30,16 @@ public interface ChePluginsApplier {
   /**
    * Applies Che plugins tooling configuration to internal environment.
    *
+   * @param runtimeIdentity the runtime identity of the workspace that the plugins are being applied
+   *     to
    * @param internalEnvironment infrastructure specific representation of workspace runtime
    *     environment
    * @param chePlugins Che plugins tooling configuration to apply to {@code internalEnvironment}
    * @throws InfrastructureException when applying Che plugins tooling fails
    */
-  void apply(InternalEnvironment internalEnvironment, Collection<ChePlugin> chePlugins)
+  void apply(
+      RuntimeIdentity runtimeIdentity,
+      InternalEnvironment internalEnvironment,
+      Collection<ChePlugin> chePlugins)
       throws InfrastructureException;
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/CheContainer.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/CheContainer.java
@@ -32,6 +32,9 @@ public class CheContainer {
   @JsonProperty("memory-limit")
   private String memoryLimit = null;
 
+  @JsonProperty("mountSources")
+  private boolean mountSources = false;
+
   public CheContainer image(String image) {
     this.image = image;
     return this;
@@ -138,6 +141,19 @@ public class CheContainer {
     this.memoryLimit = memoryLimit;
   }
 
+  public CheContainer mountSources(boolean mountSources) {
+    this.mountSources = mountSources;
+    return this;
+  }
+
+  public boolean isMountSources() {
+    return mountSources;
+  }
+
+  public void setMountSources(boolean mountSources) {
+    this.mountSources = mountSources;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -153,13 +169,21 @@ public class CheContainer {
         && Objects.equals(getVolumes(), that.getVolumes())
         && Objects.equals(getPorts(), that.getPorts())
         && Objects.equals(getMemoryLimit(), that.getMemoryLimit())
-        && Objects.equals(getName(), that.getName());
+        && Objects.equals(getName(), that.getName())
+        && isMountSources() == that.isMountSources();
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(
-        getImage(), getEnv(), getCommands(), getVolumes(), getPorts(), getMemoryLimit(), getName());
+        getImage(),
+        getEnv(),
+        getCommands(),
+        getVolumes(),
+        getPorts(),
+        getMemoryLimit(),
+        getName(),
+        isMountSources());
   }
 
   @Override
@@ -180,6 +204,8 @@ public class CheContainer {
         + memoryLimit
         + ", name="
         + name
+        + ", mountSources="
+        + mountSources
         + '}';
   }
 }


### PR DESCRIPTION
### What does this PR do?
Implement automatic mounting of project sources volume into /projects
by specifying the mountSources attribute in che-plugin.yaml.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12510

#### Release Notes
* [x] https://github.com/eclipse/che-docs/pull/675


#### Docs PR
N/A