### PR TITLE
Fix PerWorkspacePVC strategy

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -73,7 +73,6 @@ public class PVCSubPathHelper {
   static final String POD_PHASE_FAILED = "Failed";
   static final String JOB_MOUNT_PATH = "/tmp/job_mount";
 
-  private final String pvcName;
   private final String jobImage;
   private final String jobMemoryLimit;
   private final KubernetesNamespaceFactory factory;
@@ -83,12 +82,10 @@ public class PVCSubPathHelper {
 
   @Inject
   PVCSubPathHelper(
-      @Named("che.infra.kubernetes.pvc.name") String pvcName,
       @Named("che.infra.kubernetes.pvc.jobs.memorylimit") String jobMemoryLimit,
       @Named("che.infra.kubernetes.pvc.jobs.image") String jobImage,
       KubernetesNamespaceFactory factory,
       SecurityContextProvisioner securityContextProvisioner) {
-    this.pvcName = pvcName;
     this.jobMemoryLimit = jobMemoryLimit;
     this.jobImage = jobImage;
     this.factory = factory;
@@ -109,8 +106,13 @@ public class PVCSubPathHelper {
    * @param workspaceId workspace identifier
    * @param dirs workspace directories to create
    */
-  void createDirs(String workspaceId, String... dirs) {
-    execute(workspaceId, MKDIR_COMMAND_BASE, dirs);
+  void createDirs(String workspaceId, String pvcName, String... dirs) {
+    LOG.debug(
+        "Preparing PVC `{}` for workspace `{}`. Directories to create: {}",
+        pvcName,
+        workspaceId,
+        Arrays.toString(dirs));
+    execute(workspaceId, pvcName, MKDIR_COMMAND_BASE, dirs);
   }
 
   /**
@@ -119,9 +121,15 @@ public class PVCSubPathHelper {
    * @param workspaceId workspace identifier
    * @param dirs workspace directories to remove
    */
-  CompletableFuture<Void> removeDirsAsync(String workspaceId, String... dirs) {
+  CompletableFuture<Void> removeDirsAsync(String workspaceId, String pvcName, String... dirs) {
+    LOG.debug(
+        "Removing files in PVC `{}` of workspace `{}`. Directories to remove: {}",
+        pvcName,
+        workspaceId,
+        Arrays.toString(dirs));
     return CompletableFuture.runAsync(
-        ThreadLocalPropagateContext.wrap(() -> execute(workspaceId, RM_COMMAND_BASE, dirs)),
+        ThreadLocalPropagateContext.wrap(
+            () -> execute(workspaceId, pvcName, RM_COMMAND_BASE, dirs)),
         executor);
   }
 
@@ -132,11 +140,11 @@ public class PVCSubPathHelper {
    * @param arguments the list of arguments for the specified job
    */
   @VisibleForTesting
-  void execute(String workspaceId, String[] commandBase, String... arguments) {
+  void execute(String workspaceId, String pvcName, String[] commandBase, String... arguments) {
     final String jobName = commandBase[0];
     final String podName = jobName + '-' + workspaceId;
     final String[] command = buildCommand(commandBase, arguments);
-    final Pod pod = newPod(podName, command);
+    final Pod pod = newPod(podName, pvcName, command);
     securityContextProvisioner.provision(pod.getSpec());
 
     KubernetesDeployments deployments = null;
@@ -206,7 +214,7 @@ public class PVCSubPathHelper {
   }
 
   /** Returns new instance of {@link Pod} with given name and command. */
-  private Pod newPod(String podName, String[] command) {
+  private Pod newPod(String podName, String pvcName, String[] command) {
     final Container container =
         new ContainerBuilder()
             .withName(podName)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PerWorkspacePVCStrategy.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Workspace;
-import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 
@@ -72,8 +71,7 @@ public class PerWorkspacePVCStrategy extends CommonPVCStrategy {
   }
 
   @Override
-  protected PersistentVolumeClaim createCommonPVC(RuntimeIdentity runtimeId) {
-    String workspaceId = runtimeId.getWorkspaceId();
+  protected PersistentVolumeClaim createCommonPVC(String workspaceId) {
     String pvcName = pvcNamePrefix + '-' + workspaceId;
 
     PersistentVolumeClaim perWorkspacePVC = newPVC(pvcName, pvcAccessMode, pvcQuantity);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
@@ -79,7 +79,7 @@ public class PVCSubPathHelperTest {
   public void setup() throws Exception {
     pvcSubPathHelper =
         new PVCSubPathHelper(
-            PVC_NAME, jobMemoryLimit, jobImage, k8sNamespaceFactory, securityContextProvisioner);
+            jobMemoryLimit, jobImage, k8sNamespaceFactory, securityContextProvisioner);
     lenient().when(k8sNamespaceFactory.create(anyString())).thenReturn(k8sNamespace);
     lenient().when(k8sNamespace.deployments()).thenReturn(osDeployments);
     lenient().when(pod.getStatus()).thenReturn(podStatus);
@@ -105,7 +105,7 @@ public class PVCSubPathHelperTest {
   public void testSuccessfullyCreatesWorkspaceDirs() throws Exception {
     when(podStatus.getPhase()).thenReturn(POD_PHASE_SUCCEEDED);
 
-    pvcSubPathHelper.createDirs(WORKSPACE_ID, WORKSPACE_ID + PROJECTS_PATH);
+    pvcSubPathHelper.createDirs(WORKSPACE_ID, PVC_NAME, WORKSPACE_ID + PROJECTS_PATH);
 
     verify(osDeployments).create(podCaptor.capture());
     final List<String> actual = podCaptor.getValue().getSpec().getContainers().get(0).getCommand();
@@ -125,7 +125,7 @@ public class PVCSubPathHelperTest {
   public void testSetMemoryLimitAndRequest() throws Exception {
     when(podStatus.getPhase()).thenReturn(POD_PHASE_SUCCEEDED);
 
-    pvcSubPathHelper.createDirs(WORKSPACE_ID, WORKSPACE_ID + PROJECTS_PATH);
+    pvcSubPathHelper.createDirs(WORKSPACE_ID, PVC_NAME, WORKSPACE_ID + PROJECTS_PATH);
 
     verify(osDeployments).create(podCaptor.capture());
     ResourceRequirements actual =
@@ -146,7 +146,8 @@ public class PVCSubPathHelperTest {
   public void testLogErrorWhenJobExecutionFailed() throws Exception {
     when(podStatus.getPhase()).thenReturn(POD_PHASE_FAILED);
 
-    pvcSubPathHelper.execute(WORKSPACE_ID, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+    pvcSubPathHelper.execute(
+        WORKSPACE_ID, PVC_NAME, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
 
     verify(osDeployments).create(any());
     verify(osDeployments).wait(anyString(), anyInt(), any());
@@ -160,7 +161,8 @@ public class PVCSubPathHelperTest {
     when(k8sNamespaceFactory.create(WORKSPACE_ID))
         .thenThrow(new InfrastructureException("Kubernetes namespace creation failed"));
 
-    pvcSubPathHelper.execute(WORKSPACE_ID, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+    pvcSubPathHelper.execute(
+        WORKSPACE_ID, PVC_NAME, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
 
     verify(k8sNamespaceFactory).create(WORKSPACE_ID);
     verify(k8sNamespace, never()).deployments();
@@ -171,7 +173,8 @@ public class PVCSubPathHelperTest {
     when(osDeployments.create(any()))
         .thenThrow(new InfrastructureException("Kubernetes pod creation failed"));
 
-    pvcSubPathHelper.execute(WORKSPACE_ID, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+    pvcSubPathHelper.execute(
+        WORKSPACE_ID, PVC_NAME, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
 
     verify(k8sNamespaceFactory).create(WORKSPACE_ID);
     verify(k8sNamespace).deployments();
@@ -184,7 +187,8 @@ public class PVCSubPathHelperTest {
     when(podStatus.getPhase()).thenReturn(POD_PHASE_SUCCEEDED);
     doThrow(InfrastructureException.class).when(osDeployments).delete(anyString());
 
-    pvcSubPathHelper.execute(WORKSPACE_ID, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+    pvcSubPathHelper.execute(
+        WORKSPACE_ID, PVC_NAME, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
 
     verify(osDeployments).create(any());
     verify(osDeployments).wait(anyString(), anyInt(), any());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -15,7 +15,6 @@ import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_VOLUME_NAME_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategyTest.mockName;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newContainer;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.TestObjects.newPod;
 import static org.mockito.ArgumentMatchers.any;
@@ -476,7 +475,7 @@ public class UniqueWorkspacePVCStrategyTest {
   @Test
   public void testCreatesProvisionedPVCsOnPrepare() throws Exception {
     final String uniqueName = PVC_NAME_PREFIX + "-3121";
-    final PersistentVolumeClaim pvc = mockName(mock(PersistentVolumeClaim.class), uniqueName);
+    final PersistentVolumeClaim pvc = newPVC(uniqueName);
     k8sEnv.getPersistentVolumeClaims().clear();
     k8sEnv.getPersistentVolumeClaims().putAll(singletonMap(uniqueName, pvc));
     doReturn(pvc).when(pvcs).create(any());


### PR DESCRIPTION
### What does this PR do?
Previously PVC SubPath Helper used the configured value of PVC name for all strategies. And it doesn't work for `per-workspace` strategy since it uses the configured value as a prefix of PVC name and full name is `{CONFIGURED_PREFIX}` + `-` + `{WORKSPACE_ID}`.
This PR reworks `PVCSubPathHelper` to receive needed PVC name as argument.

Also, it contains the following small improvements:
1. `CommonsPVCStrategy#prepare` throw an exception if environment contains more than one PVC. For PVC it means that something works wrong in `provision` method.
2. `CommonsPVCStrategy#cleanup` method reuses PVC name provided by child class.
3. `PVCSubPathHelper` logs performed actions with Debug log level.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12520

#### Release Notes
N/A

#### Docs PR
N/A