### PR TITLE
Add @JsonIgnoreProperties into PluginMeta to allow more fields in meta.yaml

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
@@ -11,10 +11,12 @@
  */
 package org.eclipse.che.api.workspace.server.wsplugins.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.HashMap;
 import java.util.Map;
 
 /** @author Oleksandr Garagatyi */
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class PluginMeta {
   private String name = null;
   private String id = null;

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginMeta.java
@@ -16,7 +16,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /** @author Oleksandr Garagatyi */
-@JsonIgnoreProperties(ignoreUnknown=true)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class PluginMeta {
   private String name = null;
   private String id = null;


### PR DESCRIPTION
### What does this PR do?
There is an PR which adds more fields into plugins `meta.yaml` in plugin-registry (https://github.com/eclipse/che-plugin-registry/pull/79).  
Update of che server is in separate PR https://github.com/eclipse/che/pull/12489
Since those updates may be desynchronized, so there is possibility that old che-server code will reject to work with updated plugins. Ths PR prevents that situation and allows to work with any additional fields in `meta.yaml`

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A


#### Docs PR
N/A