### PR TITLE
Devfile fixes

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/Command.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/Command.java
@@ -28,6 +28,19 @@ public interface Command {
   String WORKING_DIRECTORY_ATTRIBUTE = "workingDir";
 
   /**
+   * {@link Command} attribute which indicates in which machine command must be run. It is optional,
+   * IDE should asks user to choose machine if null.
+   */
+  String MACHINE_NAME_ATTRIBUTE = "machineName";
+
+  /**
+   * {@link Command} attribute which indicates in which plugin command must be run. If specified
+   * plugin has multiple containers then first containers should be used. Attribute value has the
+   * following format: `{PLUGIN_ID}:{PLUGIN_VERSION}`. For example: org.eclipse.sample-plugin:0.0.1
+   */
+  String PLUGIN_ATTRIBUTE = "plugin";
+
+  /**
    * Returns command name (i.e. 'start tomcat') The name should be unique per user in one workspace,
    * which means that user may create only one command with the same name in the same workspace
    */

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/factory/model/ActionImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/factory/model/ActionImpl.java
@@ -41,7 +41,7 @@ public class ActionImpl implements Action {
   @Override
   public Map<String, String> getProperties() {
     if (properties == null) {
-      return new HashMap<>();
+      properties = new HashMap<>();
     }
     return properties;
   }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/factory/model/OnAppClosedImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/factory/model/OnAppClosedImpl.java
@@ -36,7 +36,7 @@ public class OnAppClosedImpl implements OnAppClosed {
   @Override
   public List<ActionImpl> getActions() {
     if (actions == null) {
-      return new ArrayList<>();
+      actions = new ArrayList<>();
     }
     return actions;
   }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/factory/model/OnAppLoadedImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/factory/model/OnAppLoadedImpl.java
@@ -36,7 +36,7 @@ public class OnAppLoadedImpl implements OnAppLoaded {
   @Override
   public List<ActionImpl> getActions() {
     if (actions == null) {
-      return new ArrayList<>();
+      actions = new ArrayList<>();
     }
     return actions;
   }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/factory/model/OnProjectsLoadedImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/factory/model/OnProjectsLoadedImpl.java
@@ -36,7 +36,7 @@ public class OnProjectsLoadedImpl implements OnProjectsLoaded {
   @Override
   public List<ActionImpl> getActions() {
     if (actions == null) {
-      return new ArrayList<>();
+      actions = new ArrayList<>();
     }
     return actions;
   }

--- a/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/WorkspaceConfigImpl.java
+++ b/ide/che-core-ide-api/src/main/java/org/eclipse/che/ide/api/workspace/model/WorkspaceConfigImpl.java
@@ -112,7 +112,7 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
   @Override
   public Map<String, EnvironmentImpl> getEnvironments() {
     if (environments == null) {
-      return new HashMap<>();
+      environments = new HashMap<>();
     }
     return environments;
   }
@@ -120,7 +120,7 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
   @Override
   public Map<String, String> getAttributes() {
     if (attributes == null) {
-      return new HashMap<>();
+      attributes = new HashMap<>();
     }
     return attributes;
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -216,7 +216,12 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
     machineConfig.getAttributes().put(CONTAINER_SOURCE_ATTRIBUTE, TOOL_CONTAINER_SOURCE);
     kubernetesEnvironment.getMachines().put(machineName, machineConfig);
 
-    sidecarRelatedCommands.forEach(c -> c.getAttributes().put("machineName", machineName));
+    sidecarRelatedCommands.forEach(
+        c ->
+            c.getAttributes()
+                .put(
+                    org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE,
+                    machineName));
 
     container
         .getCommands()
@@ -241,6 +246,7 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
   }
 
   private static class CommandsResolver {
+
     private final KubernetesEnvironment k8sEnvironment;
     private final ArrayListMultimap<String, CommandImpl> pluginRefToCommand;
 
@@ -252,7 +258,11 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
           .getCommands()
           .forEach(
               (c) -> {
-                String pluginRef = c.getAttributes().get("plugin");
+                String pluginRef =
+                    c.getAttributes()
+                        .get(
+                            org.eclipse.che.api.core.model.workspace.config.Command
+                                .PLUGIN_ATTRIBUTE);
                 if (pluginRef != null) {
                   pluginRefToCommand.put(pluginRef, c);
                 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
@@ -15,6 +15,7 @@ import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.core.model.workspace.config.Command.PLUGIN_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DIRECTORY_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.Constants.ALIASES_WORKSPACE_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.devfile.server.Constants.CURRENT_SPEC_VERSION;
@@ -204,7 +205,7 @@ public class DevfileConverter {
               .filter(tool -> tool.getName().equals(devAction.getTool()))
               .findFirst();
       if (toolOfCommand.isPresent() && !isNullOrEmpty(toolOfCommand.get().getId())) {
-        command.getAttributes().put("pluginId", toolOfCommand.get().getId());
+        command.getAttributes().put(PLUGIN_ATTRIBUTE, toolOfCommand.get().getId());
       }
       if (devCommand.getAttributes() != null) {
         command.getAttributes().putAll(devCommand.getAttributes());
@@ -221,12 +222,12 @@ public class DevfileConverter {
     if (!isNullOrEmpty(workingDir)) {
       action.setWorkdir(workingDir);
     }
-    action.setTool(toolsIdToName.getOrDefault(command.getAttributes().get("pluginId"), ""));
+    action.setTool(toolsIdToName.getOrDefault(command.getAttributes().get(PLUGIN_ATTRIBUTE), ""));
     devCommand.getActions().add(action);
     devCommand.setAttributes(command.getAttributes());
     // Remove internal attributes
     devCommand.getAttributes().remove(WORKING_DIRECTORY_ATTRIBUTE);
-    devCommand.getAttributes().remove("pluginId");
+    devCommand.getAttributes().remove(PLUGIN_ATTRIBUTE);
     return devCommand;
   }
 

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
@@ -192,7 +192,7 @@ public class DevfileConverter {
     List<CommandImpl> commands = new ArrayList<>();
     for (Action devAction : devCommand.getActions()) {
       CommandImpl command = new CommandImpl();
-      command.setName(devCommand.getName() + ":" + devAction.getTool());
+      command.setName(devCommand.getName());
       command.setType(devAction.getType());
       command.setCommandLine(devAction.getCommand());
       if (devAction.getWorkdir() != null) {

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileManager.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileManager.java
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.annotations.Beta;
+import java.util.HashMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.ConflictException;
@@ -74,8 +75,22 @@ public class DevfileManager {
       throws DevfileFormatException, JsonProcessingException {
     JsonNode parsed = schemaValidator.validateBySchema(devfileContent, verbose);
     Devfile devfile = objectMapper.treeToValue(parsed, Devfile.class);
+    initializeMaps(devfile);
     integrityValidator.validateDevfile(devfile);
     return devfile;
+  }
+
+  private void initializeMaps(Devfile devfile) {
+    devfile
+        .getCommands()
+        .stream()
+        .filter(command -> command.getAttributes() == null)
+        .forEach(command -> command.setAttributes(new HashMap<>()));
+    devfile
+        .getTools()
+        .stream()
+        .filter(tool -> tool.getSelector() == null)
+        .forEach(command -> command.setSelector(new HashMap<>()));
   }
 
   /**

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
@@ -12,13 +12,13 @@
 package org.eclipse.che.api.devfile.server.validator;
 
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toSet;
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.inject.Singleton;
@@ -103,17 +103,6 @@ public class DevfileIntegrityValidator {
     return existingNames;
   }
 
-  private void checkFieldNotSet(Tool tool, String fieldName, Object fieldValue)
-      throws DevfileFormatException {
-    if (fieldValue == null) {
-      return;
-    }
-    throw new DevfileFormatException(
-        format(
-            "Tool of type '%s' cannot contain '%s' field, please check '%s' tool",
-            tool.getType(), fieldName, tool.getName()));
-  }
-
   private void validateCommands(Devfile devfile, Set<String> toolNames)
       throws DevfileFormatException {
     Set<String> existingNames = new HashSet<>();
@@ -143,7 +132,6 @@ public class DevfileIntegrityValidator {
                 "Command '%s' has action that refers to non-existing tools '%s'",
                 command.getName(), action.getTool()));
       }
-
     }
   }
 
@@ -161,6 +149,31 @@ public class DevfileIntegrityValidator {
                     + "digits or these following special characters ._-",
                 project.getName()));
       }
+    }
+  }
+
+  private void checkFieldNotSet(Tool tool, String fieldName, Object fieldValue)
+      throws DevfileFormatException {
+    checkFieldNotSet(tool, fieldName, fieldValue == null);
+  }
+
+  private void checkFieldNotSet(Tool tool, String fieldName, Map fieldValue)
+      throws DevfileFormatException {
+    checkFieldNotSet(tool, fieldName, fieldValue == null || fieldValue.isEmpty());
+  }
+
+  private void checkFieldNotSet(Tool tool, String fieldName, boolean check)
+      throws DevfileFormatException {
+    checkField(
+        check,
+        format(
+            "Tool of type '%s' cannot contain '%s' field, please check '%s' tool",
+            tool.getType(), fieldName, tool.getName()));
+  }
+
+  private void checkField(Boolean check, String message) throws DevfileFormatException {
+    if (!check) {
+      throw new DevfileFormatException(message);
     }
   }
 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
@@ -122,19 +122,28 @@ public class DevfileIntegrityValidator {
         throw new DevfileFormatException(
             format("Duplicate command name found:'%s'", command.getName()));
       }
-      Set<String> nonExistingToolActions =
-          command
-              .getActions()
-              .stream()
-              .map(Action::getTool)
-              .filter(t -> !toolNames.contains(t))
-              .collect(toSet());
-      if (!nonExistingToolActions.isEmpty()) {
+
+      if (command.getActions().isEmpty()) {
+        throw new DevfileFormatException(
+            format("Command '%s' does not have actions.", command.getName()));
+      }
+
+      // It is temporary restriction while exec plugin is not able to handle multiple commands
+      // in different containers as one Task. Later supporting of multiple actions in one command
+      // may be implemented.
+      if (command.getActions().size() > 1) {
+        throw new DevfileFormatException(
+            format("Multiple actions in command '%s' are not supported yet.", command.getName()));
+      }
+      Action action = command.getActions().get(0);
+
+      if (!toolNames.contains(action.getTool())) {
         throw new DevfileFormatException(
             format(
-                "Found actions which refer to non-existing tools in command '%s':'%s'",
-                command.getName(), String.join(",", nonExistingToolActions)));
+                "Command '%s' has action that refers to non-existing tools '%s'",
+                command.getName(), action.getTool()));
       }
+
     }
   }
 

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -183,7 +183,7 @@
           },
           "actions": {
             "type": "array",
-            "description" : "List of the actions of given command",
+            "description" : "List of the actions of given command. Now the only one command must be specified in list but there are plans to implement supporting multiple actions commands.",
             "title": "The Command Actions List",
             "items": {
               "type": "object",

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
@@ -206,11 +206,37 @@ public class DevfileIntegrityValidatorTest {
 
   @Test(
       expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp = "Command 'build' does not have actions.")
+  public void shouldThrowExceptionWhenCommandDoesNotHaveActions() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getCommands().get(0).getActions().clear();
+
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
       expectedExceptionsMessageRegExp =
-          "Found actions which refer to non-existing tools in command 'build':'no_such_tool'")
+          "Multiple actions in command 'build' are not supported yet.")
+  public void shouldThrowExceptionWhenCommandHasMultipleActions() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getCommands().get(0).getActions().add(new Action());
+    ;
+
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Command 'build' has action that refers to non-existing tools 'no_such_tool'")
   public void shouldThrowExceptionOnUnexistingCommandActionTool() throws Exception {
     Devfile broken = copyOf(initialDevfile);
+    broken.getCommands().get(0).getActions().clear();
     broken.getCommands().get(0).getActions().add(new Action().withTool("no_such_tool"));
+
     // when
     integrityValidator.validateDevfile(broken);
   }

--- a/wsmaster/che-core-api-devfile/src/test/resources/workspace_config.json
+++ b/wsmaster/che-core-api-devfile/src/test/resources/workspace_config.json
@@ -15,7 +15,7 @@
   "commands": [
     {
       "commandLine": "mvn package",
-      "name": "build:mvn-stack",
+      "name": "build",
       "type": "exec",
       "attributes": {
         "plugin": "eclipse/maven-jdk8:1.0.0",
@@ -24,7 +24,7 @@
     },
     {
       "commandLine": "mvn spring-boot:run",
-      "name": "run:mvn-stack",
+      "name": "run",
       "type": "exec",
       "attributes": {
         "plugin": "eclipse/maven-jdk8:1.0.0",
@@ -34,7 +34,7 @@
     },
     {
       "commandLine": "run.sh",
-      "name": "other:jdt.ls",
+      "name": "other",
       "type": "exec",
       "attributes": {
         "plugin": "eclipse/theia-jdtls:0.0.3"

--- a/wsmaster/che-core-api-devfile/src/test/resources/workspace_config.json
+++ b/wsmaster/che-core-api-devfile/src/test/resources/workspace_config.json
@@ -18,7 +18,7 @@
       "name": "build:mvn-stack",
       "type": "exec",
       "attributes": {
-        "pluginId": "eclipse/maven-jdk8:1.0.0",
+        "plugin": "eclipse/maven-jdk8:1.0.0",
         "workingDir": "/projects/spring-petclinic"
       }
     },
@@ -27,7 +27,7 @@
       "name": "run:mvn-stack",
       "type": "exec",
       "attributes": {
-        "pluginId": "eclipse/maven-jdk8:1.0.0",
+        "plugin": "eclipse/maven-jdk8:1.0.0",
         "runType": "sequential",
         "workingDir": "/projects/spring-petclinic"
       }
@@ -37,7 +37,7 @@
       "name": "other:jdt.ls",
       "type": "exec",
       "attributes": {
-        "pluginId": "eclipse/theia-jdtls:0.0.3"
+        "plugin": "eclipse/theia-jdtls:0.0.3"
       }
     }
   ],

--- a/wsmaster/che-core-api-devfile/src/test/resources/workspace_config_no_environment.json
+++ b/wsmaster/che-core-api-devfile/src/test/resources/workspace_config_no_environment.json
@@ -15,7 +15,7 @@
   "commands": [
     {
       "commandLine": "mvn package",
-      "name": "build:mvn-stack",
+      "name": "build",
       "type": "exec",
       "attributes": {
         "plugin": "eclipse/maven-jdk8:1.0.0",
@@ -24,7 +24,7 @@
     },
     {
       "commandLine": "mvn spring-boot:run",
-      "name": "run:mvn-stack",
+      "name": "run",
       "type": "exec",
       "attributes": {
         "plugin": "eclipse/maven-jdk8:1.0.0",
@@ -34,7 +34,7 @@
     },
     {
       "commandLine": "run.sh",
-      "name": "other:jdt.ls",
+      "name": "other",
       "type": "exec",
       "attributes": {
         "plugin": "eclipse/theia-jdtls:0.0.3"

--- a/wsmaster/che-core-api-devfile/src/test/resources/workspace_config_no_environment.json
+++ b/wsmaster/che-core-api-devfile/src/test/resources/workspace_config_no_environment.json
@@ -18,7 +18,7 @@
       "name": "build:mvn-stack",
       "type": "exec",
       "attributes": {
-        "pluginId": "eclipse/maven-jdk8:1.0.0",
+        "plugin": "eclipse/maven-jdk8:1.0.0",
         "workingDir": "/projects/spring-petclinic"
       }
     },
@@ -27,7 +27,7 @@
       "name": "run:mvn-stack",
       "type": "exec",
       "attributes": {
-        "pluginId": "eclipse/maven-jdk8:1.0.0",
+        "plugin": "eclipse/maven-jdk8:1.0.0",
         "runType": "sequential",
         "workingDir": "/projects/spring-petclinic"
       }
@@ -37,7 +37,7 @@
       "name": "other:jdt.ls",
       "type": "exec",
       "attributes": {
-        "pluginId": "eclipse/theia-jdtls:0.0.3"
+        "plugin": "eclipse/theia-jdtls:0.0.3"
       }
     }
   ],

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/ActionImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/ActionImpl.java
@@ -75,7 +75,7 @@ public class ActionImpl implements Action {
   @Override
   public Map<String, String> getProperties() {
     if (properties == null) {
-      return new HashMap<>();
+      properties = new HashMap<>();
     }
     return properties;
   }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnAppClosedImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnAppClosedImpl.java
@@ -64,7 +64,7 @@ public class OnAppClosedImpl implements OnAppClosed {
   @Override
   public List<ActionImpl> getActions() {
     if (actions == null) {
-      return new ArrayList<>();
+      actions = new ArrayList<>();
     }
     return actions;
   }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnAppLoadedImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnAppLoadedImpl.java
@@ -64,7 +64,7 @@ public class OnAppLoadedImpl implements OnAppLoaded {
   @Override
   public List<ActionImpl> getActions() {
     if (actions == null) {
-      return new ArrayList<>();
+      actions = new ArrayList<>();
     }
     return actions;
   }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnProjectsLoadedImpl.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/model/impl/OnProjectsLoadedImpl.java
@@ -64,7 +64,7 @@ public class OnProjectsLoadedImpl implements OnProjectsLoaded {
   @Override
   public List<ActionImpl> getActions() {
     if (actions == null) {
-      return new ArrayList<>();
+      actions = new ArrayList<>();
     }
     return actions;
   }

--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/PreferenceEntity.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/jpa/PreferenceEntity.java
@@ -62,7 +62,7 @@ public class PreferenceEntity {
 
   public Map<String, String> getPreferences() {
     if (preferences == null) {
-      return new HashMap<>();
+      preferences = new HashMap<>();
     }
     return preferences;
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceConfigImpl.java
@@ -184,7 +184,7 @@ public class WorkspaceConfigImpl implements WorkspaceConfig {
   @Override
   public Map<String, EnvironmentImpl> getEnvironments() {
     if (environments == null) {
-      return new HashMap<>();
+      environments = new HashMap<>();
     }
     return environments;
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/stack/StackImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/stack/StackImpl.java
@@ -197,7 +197,7 @@ public class StackImpl implements Stack {
   @Override
   public List<String> getTags() {
     if (tags == null) {
-      return new ArrayList<>();
+      tags = new ArrayList<>();
     }
     return tags;
   }
@@ -218,7 +218,7 @@ public class StackImpl implements Stack {
   @Override
   public List<StackComponentImpl> getComponents() {
     if (components == null) {
-      return new ArrayList<>();
+      components = new ArrayList<>();
     }
     return components;
   }


### PR DESCRIPTION
### What does this PR do?
This PR contains several fixes and improvements that are in separate commits:
1. Fix lazy initialization of collections in some POJOs. Previously they returned new collections implementation without saving it to field. As result invocation of `workspaceConfig.getAttibutes().put("something", "something")' does not modify `WorkspaceConfig`.

2. Move 'machineName' and 'plugin' attributes definition to Command class. It would prevent typos errors in other parts of code where this attribute is also set.

3. Fix configuring plugin reference for Devfile commands. 
Previously `pluginId` was used but actually Che Server respects only `plugin` attribute.

3. Fix Devfile commands converting
For some reasons, command name was used as `{DevfileCommand#getName}:{DevfileAction#getTool}`.
Not workspace config commands are named in the same was as Devfile declares.

4. Improve validation of `Devfile#Commands#Actions` list.
We don't support multiple actions in `Devfile#commands` because of current commands model on Workspace API level. `Exec/terminal` plugin is not able to handle multiple exec commands in different containers as one Task.
Later it can be implemented along with Commands model changing on Workspace API level.

5. Set empty HashMap for null Map fields in Devfile.
We used to expect from POJO to return empty collections(including Maps) instead of null. `jsonschema2pojo-maven-plugin` returns empty collections only for List, Set types but not for Map. This commit manually initialize Devfile Maps fields after Devfile parsing. 
Maybe later it can be handled on `jsonschema2pojo-maven-plugin`, the corresponding issues is created https://github.com/joelittlejohn/jsonschema2pojo/issues/955.

### What issues does this PR fix or reference?
It is needed for https://github.com/eclipse/che/issues/12479.

#### Release Notes
N/A

#### Docs PR
N/A