### PR TITLE
Improve user dashboard validation of recipes

### DIFF
--- a/dashboard/src/components/api/environment/kubernetes-environment-manager.ts
+++ b/dashboard/src/components/api/environment/kubernetes-environment-manager.ts
@@ -52,8 +52,8 @@ const NAME_ANNOTATION_PREFIX: string = 'org.eclipse.che.container';
  */
 
 export class KubernetesEnvironmentManager extends EnvironmentManager {
-  parser: KubernetesEnvironmentRecipeParser;
-  private machineParser: KubernetesMachineRecipeParser;
+  parser: any;
+  protected machineParser: any;
 
   constructor($log: ng.ILogService) {
     super($log);
@@ -121,7 +121,7 @@ export class KubernetesEnvironmentManager extends EnvironmentManager {
       return machines;
     }
 
-    recipe.items.forEach((item: ISupportedListItem) => {
+    this.parser.getRecipeItems(recipe).forEach((item: ISupportedListItem) => {
       const podItem = getPodItemOrNull(item);
       if (!podItem) {
         return;

--- a/dashboard/src/components/api/environment/kubernetes-environment-recipe-parser.ts
+++ b/dashboard/src/components/api/environment/kubernetes-environment-recipe-parser.ts
@@ -62,6 +62,18 @@ export class KubernetesEnvironmentRecipeParser implements IParser {
   }
 
   /**
+   * Helper method for retreiving items with in a parsed recipe. Useful for overriding
+   * in subclasses mainly, as e.g. OpenShift recipes support templates as well as lists.
+   *
+   * Types are left as `any` to allow overriding
+   *
+   * @param recipe the parsed and validated recipe
+   */
+  getRecipeItems(recipe: any): Array<any> {
+    return recipe.items;
+  }
+
+  /**
    * Simple validation of recipe.
    * @param recipe {ISupportedItemList}
    */
@@ -88,10 +100,7 @@ export class KubernetesEnvironmentRecipeParser implements IParser {
           return;
         }
         if (!isSupportedItem(item)) {
-          // should throw a TypeError here but this code is currently used to validate OpenShift recipes
-          // (which support Routes) as well as Kubernetes recipes, so we need to ignore some elements
-          // rather than complain. Returning here prevents warning about typos in the `kind` section.
-          return;
+          throw new TypeError(`Item of kind '${item.kind}' is not supported in Kubernetes recipes`);
         }
         this.machineRecipeParser.validate(item);
       });

--- a/dashboard/src/components/api/environment/kubernetes-machine-recipe-parser.ts
+++ b/dashboard/src/components/api/environment/kubernetes-machine-recipe-parser.ts
@@ -13,6 +13,9 @@
 
 import {IParser} from './parser';
 
+/**
+ * Item types supported in Kubernetes recipes.
+ */
 export type ISupportedListItem = IPodItem | IDeploymentItem | IConfigMapItem | ISecretItem;
 
 export function isSupportedItem(item: any): item is ISupportedListItem {

--- a/dashboard/src/components/api/environment/openshift-environment-manager.ts
+++ b/dashboard/src/components/api/environment/openshift-environment-manager.ts
@@ -12,17 +12,48 @@
 'use strict';
 import {KubernetesEnvironmentManager} from './kubernetes-environment-manager';
 import {CheRecipeTypes} from '../recipe/che-recipe-types';
+import {OpenShiftEnvironmentRecipeParser} from './openshift-environment-recipe-parser';
+import {OpenShiftMachineRecipeParser} from './openshift-machine-recipe-parser';
 
 /**
  * This is the implementation of environment manager that handles the openshift format.
  *
+ * Format sample and specific description:
+ * <code>
+ * kind: List
+ * items:
+ * -
+ *   apiVersion: v1
+ *   kind: Pod
+ *   metadata:
+ *     name: podName
+ *   spec:
+ *     containers:
+ *     -
+ *       image: rhche/centos_jdk8:latest
+ *       name: containerName
+ * </code>
+ *
+ *
+ * The recipe type is <code>openshift</code>.
+ * Machines are described both in recipe and in machines attribute of the environment (machine configs).
+ * The machine configs contain memoryLimitBytes in attributes, servers and agent.
+ *
+ * The OpenShift format supports everything supported in the Kubernetes format plus
+ * OpenShift routes, and specifying the recipe as an OpenShift template instead of
+ * a list.
+ *
  *  @author Oleksii Orel
+ *  @author Angel Misevski
  */
 
 export class OpenshiftEnvironmentManager extends KubernetesEnvironmentManager {
 
   constructor($log: ng.ILogService) {
     super($log);
+
+    this.parser = new OpenShiftEnvironmentRecipeParser();
+    this.machineParser = new OpenShiftMachineRecipeParser();
   }
 
   get type(): string {

--- a/dashboard/src/components/api/environment/openshift-environment-recipe-parser.ts
+++ b/dashboard/src/components/api/environment/openshift-environment-recipe-parser.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+import {OpenShiftMachineRecipeParser, ISupportedOpenShiftItem, isSupportedOpenShiftItem} from './openshift-machine-recipe-parser';
+import {IParser} from './parser';
+import {KubernetesMachineRecipeParser, IObjectMetadata} from './kubernetes-machine-recipe-parser';
+
+export interface IOpenShiftList {
+  kind: string;
+  items: Array<ISupportedOpenShiftItem>;
+}
+
+export interface IOpenShiftTemplate {
+  kind: string;
+  metadata: IObjectMetadata;
+  objects: Array<ISupportedOpenShiftItem>;
+  parameters: Array<IOpenShiftTemplateParameter>;
+}
+
+export interface IOpenShiftTemplateParameter {
+  name: string;
+  value?: string;
+  generate?: string;
+  from?: string;
+  [propName: string]: string | Object;
+}
+
+export type IOpenShiftRecipe = IOpenShiftList | IOpenShiftTemplate;
+
+export function isOpenShiftList(item: IOpenShiftRecipe): item is IOpenShiftList {
+  return (item.kind && item.kind.toLowerCase() === 'list');
+}
+
+export function isOpenShiftTemplate(item: IOpenShiftRecipe): item is IOpenShiftTemplate {
+  return (item.kind && item.kind.toLowerCase() === 'template');
+}
+
+/**
+ * Wrapper for jsyaml and simple validator for openshift environment recipe.
+ * Can parse and validate either list or templated-based recipes
+ *
+ * @author Angel Misevski
+ */
+export class OpenShiftEnvironmentRecipeParser implements IParser {
+  private openShiftMachineRecipeParser = new OpenShiftMachineRecipeParser();
+  private recipeByContent: Map<string, IOpenShiftList | IOpenShiftTemplate> = new Map();
+  private recipeKeys: Array<string> = [];
+
+  /**
+   * Parses recipe content
+   * @param content {string} recipe content
+   * @returns {IOpenShiftRecipe} recipe object
+   */
+  parse(content: string): IOpenShiftRecipe {
+    let recipe: IOpenShiftRecipe;
+    if (this.recipeByContent.has(content)) {
+      recipe = angular.copy(this.recipeByContent.get(content));
+      this.validate(recipe);
+      return recipe;
+    }
+    recipe = jsyaml.safeLoad(content);
+
+    // add to buffer
+    this.recipeByContent.set(content, angular.copy(recipe));
+    this.recipeKeys.push(content);
+    if (this.recipeKeys.length > 3) {
+      this.recipeByContent.delete(this.recipeKeys.shift());
+    }
+    this.validate(recipe);
+
+    return recipe;
+  }
+
+  /**
+   * Dumps recipe object.
+   * @param recipe {IOpenShiftRecipe} recipe object
+   * @returns {string} recipe content
+   */
+  dump(recipe: IOpenShiftRecipe): string {
+    return jsyaml.safeDump(recipe, {'indent': 1});
+  }
+
+  /**
+   * If recipe is a list, return list.items. If recipe is a template, return
+   * recipe.objects instead.
+   *
+   * If recipe is neither, return an empty array.
+   *
+   * @param recipe the parsed and validated recipe
+   */
+  getRecipeItems(recipe: any): Array<any> {
+    if (isOpenShiftList(recipe)) {
+      return recipe.items;
+    } else if (isOpenShiftTemplate) {
+      return recipe.objects;
+    } else {
+      return new Array<ISupportedOpenShiftItem>();
+    }
+  }
+
+  private validate(recipe: IOpenShiftRecipe): void {
+    if (!recipe || !recipe.kind) {
+      throw new TypeError(`Recipe should contain a 'kind' section.`);
+    }
+    if (isOpenShiftList(recipe)) {
+      this.validateList(recipe);
+    } else if (isOpenShiftTemplate(recipe)) {
+      this.validateTemplate(recipe);
+    } else {
+      throw new TypeError(`OpenShift recipe must be either 'List' or 'Template'`);
+    }
+  }
+
+  private validateList(recipe: IOpenShiftList): void {
+    if (!recipe.items) {
+      throw new TypeError(`Recipe 'list' must contain an 'items' section`);
+    }
+    if (!angular.isArray(recipe.items) || recipe.items.length === 0) {
+      throw new TypeError(`Recipe should contain at least one OpenShift object`);
+    }
+    this.validateItems(recipe.items);
+  }
+
+  private validateTemplate(recipe: IOpenShiftTemplate): void {
+    if (!recipe.objects) {
+      throw new TypeError(`Recipe 'Template' must contain an 'objects' section`);
+    }
+    if (!angular.isArray(recipe.objects) || recipe.objects.length === 0) {
+      throw new TypeError(`Recipe should contain at least one OpenShift object`);
+    }
+    this.validateItems(recipe.objects);
+
+    if (recipe.parameters
+        && angular.isArray(recipe.parameters)
+        && recipe.parameters.length > 0) {
+      this.validateTemplateParameters(recipe.parameters);
+    }
+  }
+
+  private validateItems(items: Array<any>): void {
+    items.forEach((item: any) => {
+      if (!item) {
+        return;
+      }
+      // skip services
+      if (item.kind && item.kind.toLowerCase() === 'service') {
+        return;
+      }
+      if (!isSupportedOpenShiftItem(item)) {
+        throw new TypeError(`Item of kind '${item.kind}' is not supported in OpenShift recipes`);
+      }
+      this.openShiftMachineRecipeParser.validate(item);
+    });
+  }
+
+  private validateTemplateParameters(params: Array<IOpenShiftTemplateParameter>): void {
+    params.forEach((param: IOpenShiftTemplateParameter) => {
+      if (!param) {
+        return;
+      }
+      if (!param.name) {
+        throw new TypeError(`Template parameters require a 'name' field`);
+      }
+      // make sure parameter has a default value since it cannot be specified later
+      // note: generated parameters are not supported due to https://github.com/fabric8io/kubernetes-client/issues/1340
+      if (param.value) {
+        return;
+      } else {
+        throw new TypeError(`Template parameters must have default value.`);
+      }
+    });
+  }
+}

--- a/dashboard/src/components/api/environment/openshift-machine-recipe-parser.ts
+++ b/dashboard/src/components/api/environment/openshift-machine-recipe-parser.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import {KubernetesMachineRecipeParser, ISupportedListItem, IObjectMetadata, isSupportedItem} from './kubernetes-machine-recipe-parser';
+import {IParser} from './parser';
+
+/**
+ * Item types supported in OpenShift recipes.
+ */
+export type ISupportedOpenShiftItem = ISupportedListItem | IRouteItem;
+
+export function isSupportedOpenShiftItem(item: any): item is ISupportedOpenShiftItem {
+  return isRouteItem(item) || isSupportedItem(item);
+}
+
+export function isRouteItem(item: ISupportedOpenShiftItem): item is IRouteItem {
+  return (item.kind && item.kind.toLowerCase() === 'route');
+}
+
+export interface IRouteItem {
+  apiVersion: string;
+  kind: string;
+  metadata: IObjectMetadata;
+  spec: {
+    host: string;
+    port: {
+      targetPort: string;
+    }
+    to: {
+      kind: string;
+      name: string;
+    }
+  }
+}
+
+/**
+ * Wrapper for jsyaml and simple validator for OpenShift machine recipe.
+ *
+ * Uses KubernetesMachineRecipeParser to parse objects supported by Kubernetes,
+ * and handles Routes in addition.
+ *
+ * @author Angel Misevski
+ */
+export class OpenShiftMachineRecipeParser implements IParser {
+  private recipeByContent: Map<string, ISupportedListItem> = new Map();
+  private recipeKeys: Array<string> = [];
+  private kubernetesMachineRecipeParser: KubernetesMachineRecipeParser = new KubernetesMachineRecipeParser();
+
+
+  parse(content: string): ISupportedOpenShiftItem {
+    let recipe: ISupportedOpenShiftItem;
+    if (this.recipeByContent.has(content)) {
+      recipe = angular.copy(this.recipeByContent.get(content));
+      this.validate(recipe);
+      return recipe;
+    }
+    recipe = jsyaml.safeLoad(content);
+    // add to buffer
+    this.recipeByContent.set(content, angular.copy(recipe));
+    this.recipeKeys.push(content);
+    if (this.recipeKeys.length > 10) {
+      this.recipeByContent.delete(this.recipeKeys.shift());
+    }
+    this.validate(recipe);
+
+    return recipe;
+  }
+
+  dump(recipe: ISupportedListItem): string {
+    return jsyaml.safeDump(recipe, {'indent': 1});
+  }
+
+  validate(recipe: ISupportedOpenShiftItem): void {
+    if (!recipe || !recipe.kind) {
+      throw new TypeError(`Recipe item should contain a 'kind' section.`);
+    }
+    if (!recipe.apiVersion) {
+      throw new TypeError(`Recipe item should contain 'apiVersion' section`);
+    }
+    if (isSupportedItem(recipe)) {
+      this.kubernetesMachineRecipeParser.validate(recipe);
+    } else if (isRouteItem(recipe)) {
+      this.validateRoute(<IRouteItem>recipe);
+    }
+  }
+
+  validateRoute(route: IRouteItem): void {
+    this.kubernetesMachineRecipeParser.validateMetadata(route.metadata);
+    if (!route.spec) {
+      throw new TypeError(`Recipe route item should contain a 'spec' section`);
+    }
+    if (!route.spec.to
+        || !route.spec.to.kind
+        || route.spec.to.kind.toLowerCase() !== 'service') {
+      throw new TypeError(`Recipe route item should have .spec.to.kind='Service'`);
+    }
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Various improvements to dashboard validation of user recipes:
- Add OpenShift-specific parsing and validation
  - This allows us to support OpenShift templates as recipes, as well as route objects in recipes (https://github.com/eclipse/che/issues/11530)
  - Ensure parameters have a default value when templates are used
- Throw a TypeError when an unsupported object is encountered (e.g. misspelled 'kind' field, route in Kubernetes recipe, etc).

Recipes for testing (in create new stack dialog):
<details>
<summary>A recipe containing an OpenShift route; if entered as Kubernetes recipe, should notify user that 'kind: Route' is unrecognized.</summary>

```yaml
kind: List
apiVersion: v1
items:
  - 
    apiVersion: v1
    kind: Pod
    metadata:
      name: ws
    spec:
      containers:
        - 
          image: 'eclipse/che-dev:nightly'
          name: dev
          resources:
            limits:
              memory: 512Mi
  -
    apiVersion: v1
    kind: Route
    metadata:
      name: test-route
    spec:
      host: test.192.168.42.162.nip.io
      port:
        targetPort: test
      to:
        kind: Service
        name: stack-service
  -
    apiVersion: v1
    kind: Service
    metadata:
      name: stack-service
    spec:
      ports:
      - name: test
        port: 1234
        protocol: TCP
        targetPort: 3100
```
</details>

<details>
<summary>A recipe consisting of a template; on Kubernetes side, should notify that 'kind: template' is not supported. On OpenShift side, should validate that all parameters have default values (try removing).</summary>

```yaml
kind: Template
apiVersion: v1
metadata:
  name: template-test
objects:
- 
  apiVersion: v1
  kind: Pod
  metadata:
    name: ws
    labels:
      parameter: ${TEST}
  spec:
    containers:
    - 
      image: 'eclipse/che-dev:nightly'
      name: dev
      resources:
        limits:
        memory: 512Mi
parameters:
- name: TEST
  value: test
```
</details>

### What issues does this PR fix or reference?
#12535 

#### Release Notes
Improve validation when creating a stack from an OpenShift or Kubernetes recipe, catching issues earlier.

#### Docs PR
N/A, documentation needs no changes.