### PR TITLE
Added machine name estimation for commands in K8s/OS tool

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DIRECTORY_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.CONTAINER_SOURCE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.TOOL_CONTAINER_SOURCE;
@@ -241,7 +242,7 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
             command.getCommand().stream().collect(Collectors.joining(" ")),
             "custom");
     cmd.getAttributes().put(WORKING_DIRECTORY_ATTRIBUTE, command.getWorkingDir());
-    cmd.getAttributes().put("machineName", machineName);
+    cmd.getAttributes().put(MACHINE_NAME_ATTRIBUTE, machineName);
     return cmd;
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -17,6 +17,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DIRECTORY_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
@@ -152,7 +153,8 @@ public class KubernetesPluginsToolingApplierTest {
     assertEquals(envCommand.getType(), "custom");
     assertEquals(
         envCommand.getAttributes().get(WORKING_DIRECTORY_ATTRIBUTE), pluginCommand.getWorkingDir());
-    assertEquals(envCommand.getAttributes().get("machineName"), POD_NAME + "/plugin-container");
+    assertEquals(
+        envCommand.getAttributes().get(MACHINE_NAME_ATTRIBUTE), POD_NAME + "/plugin-container");
   }
 
   @Test
@@ -176,7 +178,8 @@ public class KubernetesPluginsToolingApplierTest {
     assertEquals(envCommand.getType(), pluginCommand.getType());
     assertEquals(envCommand.getCommandLine(), pluginCommand.getCommandLine());
     assertEquals(envCommand.getAttributes().get("plugin"), pluginRef);
-    assertEquals(envCommand.getAttributes().get("machineName"), POD_NAME + "/plugin-container");
+    assertEquals(
+        envCommand.getAttributes().get(MACHINE_NAME_ATTRIBUTE), POD_NAME + "/plugin-container");
   }
 
   @Test

--- a/wsmaster/che-core-api-devfile/pom.xml
+++ b/wsmaster/che-core-api-devfile/pom.xml
@@ -92,6 +92,10 @@
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.infrastructure</groupId>
+            <artifactId>infrastructure-kubernetes</artifactId>
+        </dependency>
+        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is adding machine name estimation for commands in K8s/OS tool.
Note that machine name will be estimated only if k8s/OS tool contains one container otherwise Theia will ask a user to choose a target container from all workspace containers (not only from tool containers). UX should be improved in such a case.

Also, this PR contains:
- Refactoring Devfile API to be able to provision machine attribute into command;
- Small fix: Use machine name command attribute name from Constants;

### How it can be manually tested

The following URL can be used for testing implemented functionality 
`{CHE_HOST}/f?url=https://github.com/eclipse/che/tree/devfileche`
Where CHE_HOST is a host of Che Server which has the made changes.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12479

#### Release Notes
N/A

#### Docs PR
N/A