### PR TITLE
Do autosave after user stops typing for a while and avoid formatting during typing

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.directive.ts
+++ b/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.directive.ts
@@ -35,6 +35,7 @@ export class WorkspaceConfigImport {
   constructor() {
     // scope values
     this.scope = {
+      isActive: '=',
       workspaceConfig: '=',
       workspaceConfigOnChange: '&'
     };

--- a/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.html
+++ b/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.html
@@ -1,4 +1,7 @@
 <div layout="column" class="config-import">
+  <div class="saving-message">
+    <span ng-if="workspaceConfigImportController.isSaving">Saving workspace config...</span>
+  </div>
   <div class="config-editor">
     <che-editor editor-content="workspaceConfigImportController.importWorkspaceJson"
                 editor-state="editorState"

--- a/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.styl
+++ b/dashboard/src/app/workspaces/workspace-details/config-import/workspace-config-import.styl
@@ -18,3 +18,9 @@
 
   .error-message
     color $error-color
+
+  .saving-message
+    color $label-info-color
+    height 18px
+    top 12px
+    position absolute

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -156,7 +156,7 @@ export class WorkspaceDetailsController {
       },
       saveButton: {
         action: () => {
-          this.saveConfigChanges();
+          this.saveConfigChanges(true);
         },
         title: 'Save',
         disabled: false
@@ -303,7 +303,7 @@ export class WorkspaceDetailsController {
     
     if (!failedTabs || failedTabs.length === 0) {
       let runningWorkspace = this.getWorkspaceStatus() === WorkspaceStatus[WorkspaceStatus.STARTING] || this.getWorkspaceStatus() === WorkspaceStatus[WorkspaceStatus.RUNNING];
-      this.saveConfigChanges(runningWorkspace);
+      this.saveConfigChanges(false, runningWorkspace);
     }
   }
 
@@ -454,8 +454,9 @@ export class WorkspaceDetailsController {
 
   /**
    * Updates workspace with new config.
+   * 
    */
-  saveConfigChanges(notifyRestart?: boolean): void {
+  saveConfigChanges(refreshPage: boolean, notifyRestart?: boolean): void {
     this.editOverlayConfig.disabled = true;
 
     this.loading = true;
@@ -476,9 +477,11 @@ export class WorkspaceDetailsController {
 
         this.$scope.$broadcast('edit-workspace-details', {status: 'saved'});
 
-        return this.cheWorkspace.fetchWorkspaceDetails(this.originWorkspaceDetails.id).then(() => {
-          this.$location.path('/workspace/' + this.namespaceId + '/' + this.workspaceDetails.config.name).search({tab: this.tab[this.selectedTabIndex]});
-        });
+        if (refreshPage) {
+          return this.cheWorkspace.fetchWorkspaceDetails(this.originWorkspaceDetails.id).then(() => {
+            this.$location.path('/workspace/' + this.namespaceId + '/' + this.workspaceDetails.config.name).search({tab: this.tab[this.selectedTabIndex]});
+          });
+        }
       })
       .catch((error: any) => {
         this.$scope.$broadcast('edit-workspace-details', {status: 'failed'});

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -135,7 +135,8 @@
     </md-tab>
 
     <!-- Config tab -->
-    <md-tab md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Config);">
+    <md-tab md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Config); isConfigActive = true"
+      md-on-deselect="isConfigActive = false">
       <md-tab-label>
         <i ng-show="workspaceDetailsController.checkFormsNotValid(workspaceDetailsController.tab.Config)"
            class="error-state fa fa-exclamation-circle" aria-hidden="true"></i>
@@ -146,6 +147,7 @@
           <ng-form name="workspaceConfigForm">
             <che-workspace-config-import
               ng-init="workspaceDetailsController.setForm(workspaceDetailsController.tab.Config, workspaceConfigForm)"
+              is-active="isConfigActive"
               workspace-config="workspaceDetailsController.workspaceDetails.config"
               workspace-config-on-change="workspaceDetailsController.updateWorkspaceConfigImport(config)"></che-workspace-config-import>
           </ng-form>

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.styl
@@ -25,7 +25,7 @@
     padding 0
 
   .config-import .config-editor
-    margin-top 7px
+    margin-top 10px
 
     .CodeMirror
       height: 500px

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.styl
@@ -29,7 +29,7 @@ md-tab-content .plugin-page-separator
         height inherit
 
   div.che-list-header-column
-    line-height inheri
+    line-height inherit
     .header-sort-direction
       position absolute
 


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Provides number of fixes around auto-save of workspace config:
- the changes are saved, when user stops typing for few seconds
- avoid formatting the config, while typing


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12570
https://github.com/eclipse/che/issues/12456
https://github.com/eclipse/che/issues/12550

