### PR TITLE
fix cacerts path

### DIFF
--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -292,7 +292,7 @@ init() {
 
 add_cert_to_truststore() {
   if [ "${CHE_SELF__SIGNED__CERT}" != "" ]; then
-    DEFAULT_JAVA_TRUST_STORE=$JAVA_HOME/lib/security/cacerts
+    DEFAULT_JAVA_TRUST_STORE=$JAVA_HOME/jre/lib/security/cacerts
     DEFAULT_JAVA_TRUST_STOREPASS="changeit"
 
     JAVA_TRUST_STORE=/home/user/cacerts


### PR DESCRIPTION
after [switching to JDK](https://github.com/eclipse/che/commit/42d01eda8ab11a123d473a40ee2fb962577ac0ff) actual path to cacerts should be updated