### PR TITLE
Make CheTestWorkspaceProvider class visible outside the package

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/CheTestWorkspaceProvider.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/workspace/CheTestWorkspaceProvider.java
@@ -52,7 +52,7 @@ public class CheTestWorkspaceProvider implements TestWorkspaceProvider {
   private ArrayBlockingQueue<TestWorkspace> testWorkspaceQueue;
 
   @Inject
-  CheTestWorkspaceProvider(
+  public CheTestWorkspaceProvider(
       @Named("che.workspace_pool_size") String poolSize,
       @Named("che.threads") int threads,
       @Named("workspace.default_memory_gb") int defaultMemoryGb,


### PR DESCRIPTION
### What does this PR do?
It make it possible to extend `CheTestWorkspaceProvider` in downstream project.
