### PR TITLE
Fix typo in metrics ingress

### DIFF
--- a/deploy/kubernetes/helm/che/templates/metrics-ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/metrics-ingress.yaml
@@ -38,7 +38,7 @@ spec:
   tls:
   - hosts:
     - {{ template "prometheusHost" . }}
-    - {{ template "granfanaHost" . }}
+    - {{ template "grafanaHost" . }}
     secretName: {{ .Values.global.tls.secretName }}
 {{- end }}
   rules:


### PR DESCRIPTION
### What does this PR do?

Fix a typo in the metrics-ingress definition. Change `granfanaHost` to `grafanaHost`.


### What issues does this PR fix or reference?

N/A

#### Release Notes

N/A

#### Docs PR

N/A
