### PR TITLE
[WIP] Make variable expansion work for environment variables in k8s

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverter.java
@@ -11,8 +11,13 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision.env;
 
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
+import java.util.List;
+import java.util.Map;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -43,13 +48,30 @@ public class EnvVarsConverter implements ConfigurationProvisioner {
       for (Container container : pod.getSpec().getContainers()) {
         String machineName = Names.machineName(pod, container);
         InternalMachineConfig machineConf = k8sEnv.getMachines().get(machineName);
-        machineConf
-            .getEnv()
-            .forEach(
-                (key, value) -> {
-                  container.getEnv().removeIf(env -> key.equals(env.getName()));
-                  container.getEnv().add(new EnvVar(key, value, null));
-                });
+
+        // we need to combine the env vars from the machine config with the variables already
+        // present in the container. Let's key the variables by name and use the map for merging
+        Map<String, EnvVar> envVars =
+            machineConf
+                .getEnv()
+                .entrySet()
+                .stream()
+                .map(e -> new EnvVar(e.getKey(), e.getValue(), null))
+                .collect(toMap(EnvVar::getName, identity()));
+
+        // the env vars defined in our machine config take precedence over the ones already defined
+        // in the container, if any
+        container.getEnv().forEach(v -> envVars.putIfAbsent(v.getName(), v));
+
+        // The environment variable interpolation only works if a variable that is referenced
+        // is already defined earlier in the list of environment variables.
+        // We need to produce a list where variables that reference others always appear later
+        // in the list.
+        // Yes, we're doing a graph traversal and cycle detection here, because k8s is kinda stupid
+        // in this regard.
+        List<EnvVar> sorted = EnvironmentVariablesSorter.sort(envVars);
+
+        container.setEnv(sorted);
       }
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvironmentVariablesSorter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvironmentVariablesSorter.java
@@ -157,6 +157,8 @@ final class EnvironmentVariablesSorter implements Comparator<EnvVar> {
 
     while (matcher.find()) {
       int start = matcher.start();
+
+      // the variable reference can be escaped using a double $, e.g. $$(VAR) is not a reference
       if (start > 0 && val.charAt(start - 1) == '$') {
         continue;
       }
@@ -164,10 +166,7 @@ final class EnvironmentVariablesSorter implements Comparator<EnvVar> {
       // extract the variable name out of the reference $(NAME) -> NAME
       String refName = matcher.group().substring(2, matcher.group().length() - 1);
       if (refName.equals(var.getName())) {
-        throw new CycleException(
-            format(
-                "Environment variable %s defined using itself. That's not supposed to work.",
-                refName));
+        throw new CycleException(refName);
       }
       ret.add(refName);
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvironmentVariablesSorter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvironmentVariablesSorter.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision.env;
+
+import static java.lang.String.format;
+import static java.util.Comparator.naturalOrder;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+
+/**
+ * If there are any references to other environment variables in the value of some environment
+ * variable, the "dependent" environment variable needs to be defined "later" than the env var it
+ * depends on for Kubernetes variable expansion to work.
+ *
+ * <p>This class makes sure that the environment variables are sorted.
+ */
+final class EnvironmentVariablesSorter implements Comparator<EnvVar> {
+
+  private static final Pattern REFERENCE_PATTERN = Pattern.compile("\\$\\(\\w+\\)");
+
+  private final Map<String, SortedSet<String>> referenceMap;
+  private final Map<String, SortedSet<String>> recursiveReferenceMap;
+
+  private EnvironmentVariablesSorter(Map<String, EnvVar> envVars) {
+    this.referenceMap = new HashMap<>(envVars.size());
+    for (Map.Entry<String, EnvVar> e : envVars.entrySet()) {
+      referenceMap.put(e.getKey(), findReferences(e.getValue()));
+    }
+
+    recursiveReferenceMap = new HashMap<>(envVars.size());
+  }
+
+  /**
+   * Sorts the provided env variables so that a variable depending on some other variable is always
+   * later in the returned list than the env var it depends on.
+   *
+   * @param envVars the collection of environment variables to sort
+   * @return a sorted list of the environment variables
+   * @throws InfrastructureException if there is a cycle in the value dependencies and thus the
+   *     expansion is impossible
+   */
+  static List<EnvVar> sort(Map<String, EnvVar> envVars) throws InfrastructureException {
+    try {
+      EnvironmentVariablesSorter sorter = new EnvironmentVariablesSorter(envVars);
+      List<EnvVar> ret = new ArrayList<>(envVars.values());
+      ret.sort(sorter);
+      return ret;
+    } catch (CycleException e) {
+      throw new InfrastructureException(e.getMessage());
+    }
+  }
+
+  @Override
+  public int compare(EnvVar a, EnvVar b) throws CycleException {
+    if (a == b) {
+      return 0;
+    }
+
+    SortedSet<String> aRefs = referenceMap.get(a.getName());
+    SortedSet<String> bRefs = referenceMap.get(b.getName());
+
+    // quickly deal with the common case of no references in the value
+    if (aRefs.isEmpty()) {
+      // we need to have a total ordering, so if there is no difference in references, we need
+      // to pick a different sorting criteria
+      return bRefs.isEmpty() ? a.getName().compareTo(b.getName()) : -1;
+    } else if (bRefs.isEmpty()) {
+      // b has no references, a has, therefore a > b.
+      return 1;
+    }
+
+    // ok, we have variable references in both a and b
+    // we need to establish the transitive closure over the references to figure out whether there
+    // is a cycle in the dependencies, or not
+    SortedSet<String> aTransRefs = transitiveClosure(a.getName());
+    SortedSet<String> bTransRefs = transitiveClosure(b.getName());
+
+    // we don't need to check for cycle here, because that has been detected when establishing
+    // the closure.
+    if (aTransRefs.contains(b.getName())) {
+      // a depends on b, hence a > b.
+      return 1;
+    } else if (bTransRefs.contains(a.getName())) {
+      // b depends on a -> a < b.
+      return -1;
+    }
+
+    // ok, the two env vars don't depend on each other, so we actually don't care too much about
+    // the order. We need to be consistent and total, though...
+
+    int sizeDiff = aTransRefs.size() - bTransRefs.size();
+    if (sizeDiff != 0) {
+      return sizeDiff;
+    }
+
+    // ah, the two env vars have the same number of references, so we need to take a "slow path"
+    // in determining the total order.
+    Iterator<String> aIt = aRefs.iterator();
+    Iterator<String> bIt = bRefs.iterator();
+    while (aIt.hasNext()) {
+      if (!bIt.hasNext()) {
+        // a has more references than b
+        return 1;
+      }
+
+      String aRef = aIt.next();
+      String bRef = bIt.next();
+
+      int res = aRef.compareTo(bRef);
+      if (res != 0) {
+        return res;
+      }
+    }
+
+    return 0;
+  }
+
+  private SortedSet<String> transitiveClosure(String variableName) {
+    SortedSet<String> recRefs = recursiveReferenceMap.get(variableName);
+    if (recRefs == null) {
+      recRefs = new TreeSet<>(naturalOrder());
+      fillRecursiveReferences(variableName, referenceMap, recRefs);
+      recursiveReferenceMap.put(variableName, recRefs);
+    }
+    return recRefs;
+  }
+
+  @VisibleForTesting
+  static SortedSet<String> findReferences(EnvVar var) throws CycleException {
+    String val = var.getValue();
+
+    Matcher matcher = REFERENCE_PATTERN.matcher(val);
+
+    SortedSet<String> ret = new TreeSet<>(naturalOrder());
+
+    while (matcher.find()) {
+      int start = matcher.start();
+      if (start > 0 && val.charAt(start - 1) == '$') {
+        continue;
+      }
+
+      // extract the variable name out of the reference $(NAME) -> NAME
+      String refName = matcher.group().substring(2, matcher.group().length() - 1);
+      if (refName.equals(var.getName())) {
+        throw new CycleException(
+            format(
+                "Environment variable %s defined using itself. That's not supposed to work.",
+                refName));
+      }
+      ret.add(refName);
+    }
+
+    return ret;
+  }
+
+  private static void fillRecursiveReferences(
+      String name, Map<String, SortedSet<String>> directReferences, SortedSet<String> result)
+      throws CycleException {
+
+    Set<String> nameRefs = directReferences.get(name);
+    if (nameRefs == null || nameRefs.isEmpty()) {
+      return;
+    }
+
+    if (result.contains(name)) {
+      throw new CycleException(name);
+    }
+
+    for (String refName : nameRefs) {
+      result.add(refName);
+      fillRecursiveReferences(refName, directReferences, result);
+    }
+  }
+
+  static final class CycleException extends RuntimeException {
+
+    CycleException(String variableName) {
+      super(format("Recursive definition of environment variable %s", variableName));
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverterTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision.env;
+
+import static java.util.Collections.singletonList;
+import static org.testng.Assert.assertEquals;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class EnvVarsConverterTest {
+
+  private static final String PRE_EXISTING_VAR = "VAR_THAT_EXISTS";
+  private static final String PRE_EXISTING_VAR_VALUE = "me llamo VAR";
+  private static final String PRE_EXISTING_VAR_NEW_VALUE = "my name is VAR";
+  private static final String A_VAR = "A";
+  private static final String A_VAL = "$(C)";
+  private static final String B_VAR = "B";
+  private static final String B_VAL = "b";
+  private static final String C_VAR = "C";
+  private static final String C_VAL = "c";
+
+  private KubernetesEnvironment environment;
+  private RuntimeIdentity identity;
+  private Container testContainer;
+  private InternalMachineConfig machine;
+
+  @BeforeMethod
+  public void setup() {
+    List<EnvVar> preExistingEnvironment = new ArrayList<>();
+    preExistingEnvironment.add(new EnvVar(PRE_EXISTING_VAR, PRE_EXISTING_VAR_VALUE, null));
+
+    testContainer = new Container();
+    testContainer.setEnv(preExistingEnvironment);
+
+    PodSpec podSpec = new PodSpec();
+    podSpec.setContainers(singletonList(testContainer));
+
+    ObjectMeta podMeta = new ObjectMeta();
+    podMeta.setName("pod");
+
+    Pod pod = new Pod();
+    pod.setSpec(podSpec);
+    pod.setMetadata(podMeta);
+
+    environment =
+        KubernetesEnvironment.builder()
+            .setPods(
+                new HashMap<String, Pod>() {
+                  {
+                    put("pod", pod);
+                  }
+                })
+            .build();
+
+    machine = new InternalMachineConfig();
+    machine.getEnv().put(PRE_EXISTING_VAR, PRE_EXISTING_VAR_NEW_VALUE);
+    machine.getEnv().put(A_VAR, A_VAL);
+    machine.getEnv().put(B_VAR, B_VAL);
+    machine.getEnv().put(C_VAR, C_VAL);
+
+    environment.setMachines(
+        Collections.singletonMap(Names.machineName(podMeta, testContainer), machine));
+
+    identity = new RuntimeIdentityImpl("wsId", "blah", "bleh");
+  }
+
+  @Test
+  public void shouldProvisionEnvironmentVariablesSorted() throws InfrastructureException {
+    // given
+    List<EnvVar> preExistingEnvironment = new ArrayList<>();
+    preExistingEnvironment.add(new EnvVar(PRE_EXISTING_VAR, PRE_EXISTING_VAR_VALUE, null));
+    testContainer.setEnv(preExistingEnvironment);
+
+    machine.getEnv().put(PRE_EXISTING_VAR, PRE_EXISTING_VAR_NEW_VALUE);
+    machine.getEnv().put(A_VAR, A_VAL);
+    machine.getEnv().put(B_VAR, B_VAL);
+    machine.getEnv().put(C_VAR, C_VAL);
+
+    // when
+    EnvVarsConverter converter = new EnvVarsConverter();
+    converter.provision(environment, identity);
+
+    // then
+    EnvVar expectedA = new EnvVar(A_VAR, A_VAL, null);
+    EnvVar expectedB = new EnvVar(B_VAR, B_VAL, null);
+    EnvVar expectedC = new EnvVar(C_VAR, C_VAL, null);
+    EnvVar expectedPreExisting = new EnvVar(PRE_EXISTING_VAR, PRE_EXISTING_VAR_NEW_VALUE, null);
+
+    assertEquals(4, testContainer.getEnv().size());
+    assertEquals(expectedB, testContainer.getEnv().get(0));
+    assertEquals(expectedC, testContainer.getEnv().get(1));
+    assertEquals(expectedPreExisting, testContainer.getEnv().get(2));
+    assertEquals(expectedA, testContainer.getEnv().get(3));
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvVarsConverterTest.java
@@ -51,11 +51,7 @@ public class EnvVarsConverterTest {
 
   @BeforeMethod
   public void setup() {
-    List<EnvVar> preExistingEnvironment = new ArrayList<>();
-    preExistingEnvironment.add(new EnvVar(PRE_EXISTING_VAR, PRE_EXISTING_VAR_VALUE, null));
-
     testContainer = new Container();
-    testContainer.setEnv(preExistingEnvironment);
 
     PodSpec podSpec = new PodSpec();
     podSpec.setContainers(singletonList(testContainer));
@@ -78,10 +74,6 @@ public class EnvVarsConverterTest {
             .build();
 
     machine = new InternalMachineConfig();
-    machine.getEnv().put(PRE_EXISTING_VAR, PRE_EXISTING_VAR_NEW_VALUE);
-    machine.getEnv().put(A_VAR, A_VAL);
-    machine.getEnv().put(B_VAR, B_VAL);
-    machine.getEnv().put(C_VAR, C_VAL);
 
     environment.setMachines(
         Collections.singletonMap(Names.machineName(podMeta, testContainer), machine));

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvironmentVariableSorterTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/env/EnvironmentVariableSorterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision.env;
+
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.function.Function.identity;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvironmentVariablesSorter.findReferences;
+import static org.testng.Assert.assertEquals;
+
+import io.fabric8.kubernetes.api.model.EnvVar;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.testng.annotations.Test;
+
+public class EnvironmentVariableSorterTest {
+
+  @Test
+  public void shouldDetectReferences() {
+    // creating a separate test case for each of these is just too much for me :)
+    // breaking given-when-then flow of our tests on purpose here, because the below would result
+    // in 15 test cases I refuse to write out manually
+
+    testSingleValue("value", emptySet(), "no refs");
+    testSingleValue("$(NO_REF", emptySet(), "unclosed ref");
+    testSingleValue("$$(NO_REF)", emptySet(), "escaped ref");
+    testSingleValue("$NO_REF)", emptySet(), "invalid start ref");
+    testSingleValue("$(REF)", singleton("REF"), "valid ref");
+  }
+
+  @Test
+  public void shouldSortByNameIfNoDependencies() throws Exception {
+    // given
+    Map<String, EnvVar> vars = vars(var("b", "b"), var("a", "a"), var("c", "c"));
+
+    // when
+    List<EnvVar> sorted = EnvironmentVariablesSorter.sort(vars);
+
+    // then
+    assertEquals(sorted, Arrays.asList(var("a", "a"), var("b", "b"), var("c", "c")));
+  }
+
+  @Test
+  public void shouldSortDependenciesBeforeDependents() throws Exception {
+    // given
+    Map<String, EnvVar> vars = vars(var("a", "$(b)"), var("b", "b"), var("c", "c"));
+
+    // when
+    List<EnvVar> sorted = EnvironmentVariablesSorter.sort(vars);
+
+    // then
+    assertEquals(sorted, Arrays.asList(var("b", "b"), var("c", "c"), var("a", "$(b)")));
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void shouldDetectSelfReference() throws Exception {
+    // given
+    Map<String, EnvVar> vars = vars(var("a", "$(a)"));
+
+    // when
+    EnvironmentVariablesSorter.sort(vars);
+
+    // then the exception is expected
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void shouldDetectDirectCycles() throws Exception {
+    // given
+    Map<String, EnvVar> vars = vars(var("a", "$(b)"), var("b", "$(a)"));
+
+    // when
+    EnvironmentVariablesSorter.sort(vars);
+
+    // then the exception is expected
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void shouldDetectIndirectCycles() throws Exception {
+    // given
+    Map<String, EnvVar> vars = vars(var("a", "$(b)"), var("b", "$(c)"), var("c", "$(a)"));
+
+    // when
+    EnvironmentVariablesSorter.sort(vars);
+
+    // then the exception is expected
+  }
+
+  private static EnvVar var(String name, String value) {
+    return new EnvVar(name, value, null);
+  }
+
+  private static Map<String, EnvVar> vars(EnvVar... vars) {
+    return Stream.of(vars).collect(Collectors.toMap(EnvVar::getName, identity()));
+  }
+
+  private static void testSingleValue(String value, Set<String> expected, String caseName) {
+    assertEquals(findReferences(var("name", value)), expected, caseName + ": sole");
+    assertEquals(findReferences(var("name", value + "v")), expected, caseName + ": start");
+    assertEquals(findReferences(var("name", "v" + value + "v")), expected, caseName + ": middle");
+    assertEquals(findReferences(var("name", value + "v")), expected, caseName + ": end");
+  }
+}


### PR DESCRIPTION
### What does this PR do?
K8s does the expansion only if it already knows about the variable being
expanded.

This means we have to sort the environment variable list prior to sending
it to k8s in such a way that vars that reference others always follow the
referenced ones.

### What issues does this PR fix or reference?
#12577

#### Release Notes
* [ ] TODO
