### PR TITLE
Use plugin ID instead of sidecar container name to override sidecar memory using workspace attributes

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/KubernetesSize.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/KubernetesSize.java
@@ -40,7 +40,30 @@ public class KubernetesSize {
   private static final Pattern HUMAN_SIZE_PATTERN =
       Pattern.compile("^([-+]?[0-9]*\\.?[0-9]+([eE][-+]?[0-9]+)?)\\s*(\\S+)?$");
 
-  /** Converts memory in Kubernetes format to bytes. */
+  /**
+   * Converts memory in Kubernetes format to bytes.
+   * <p>Format: "< number >< modifier >"
+   * <br>Where modifier is one of the following (case-insensitive):
+   * b, bi, k, ki, kib, m, mi, mib, g, gi, gib, t, ti, tib, p, pi, pib, e, ei, eib
+   *
+   * <ul>Conversion rules:
+   * <li>b, bi conversion not needed</li>
+   * <li>k multiplied by 1000</li>
+   * <li>ki, kib multiplied by 1024</li>
+   * <li>m multiplied by 1048576</li>
+   * <li>mi, mib multiplied by 1000000</li>
+   * <li>g multiplied by 1073741824</li>
+   * <li>gi, gib multiplied by 1000000000</li>
+   * <li>t multiplied by 1,09951162778e+12</li>
+   * <li>ti,tib multiplied by 1e+12</li>
+   * <li>p multiplied by 1,12589990684e+15</li>
+   * <li>pi, pib multiplied by 1e+15</li>
+   * <li>e multiplied by 1,1529215046e+18</li>
+   * <li>ei, eib multiplied by 1e+18</li>
+   * </ul>
+   *
+   * @throws IllegalArgumentException if specified string can not be parsed
+   */
   public static long toBytes(String sizeString) {
     final Matcher matcher;
     if ((matcher = HUMAN_SIZE_PATTERN.matcher(sizeString)).matches()) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/KubernetesSize.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/KubernetesSize.java
@@ -42,24 +42,26 @@ public class KubernetesSize {
 
   /**
    * Converts memory in Kubernetes format to bytes.
-   * <p>Format: "< number >< modifier >"
-   * <br>Where modifier is one of the following (case-insensitive):
-   * b, bi, k, ki, kib, m, mi, mib, g, gi, gib, t, ti, tib, p, pi, pib, e, ei, eib
    *
-   * <ul>Conversion rules:
-   * <li>b, bi conversion not needed</li>
-   * <li>k multiplied by 1000</li>
-   * <li>ki, kib multiplied by 1024</li>
-   * <li>m multiplied by 1048576</li>
-   * <li>mi, mib multiplied by 1000000</li>
-   * <li>g multiplied by 1073741824</li>
-   * <li>gi, gib multiplied by 1000000000</li>
-   * <li>t multiplied by 1,09951162778e+12</li>
-   * <li>ti,tib multiplied by 1e+12</li>
-   * <li>p multiplied by 1,12589990684e+15</li>
-   * <li>pi, pib multiplied by 1e+15</li>
-   * <li>e multiplied by 1,1529215046e+18</li>
-   * <li>ei, eib multiplied by 1e+18</li>
+   * <p>Format: "< number >< modifier >" <br>
+   * Where modifier is one of the following (case-insensitive): b, bi, k, ki, kib, m, mi, mib, g,
+   * gi, gib, t, ti, tib, p, pi, pib, e, ei, eib
+   *
+   * <ul>
+   *   Conversion rules:
+   *   <li>b, bi conversion not needed
+   *   <li>k multiplied by 1000
+   *   <li>ki, kib multiplied by 1024
+   *   <li>m multiplied by 1048576
+   *   <li>mi, mib multiplied by 1000000
+   *   <li>g multiplied by 1073741824
+   *   <li>gi, gib multiplied by 1000000000
+   *   <li>t multiplied by 1,09951162778e+12
+   *   <li>ti,tib multiplied by 1e+12
+   *   <li>p multiplied by 1,12589990684e+15
+   *   <li>pi, pib multiplied by 1e+15
+   *   <li>e multiplied by 1,1529215046e+18
+   *   <li>ei, eib multiplied by 1e+18
    * </ul>
    *
    * @throws IllegalArgumentException if specified string can not be parsed

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolver.java
@@ -79,7 +79,7 @@ public class MachineResolver {
       machineConfig.getAttributes().put(MEMORY_LIMIT_ATTRIBUTE, defaultSidecarMemoryLimitBytes);
     }
     String overriddenSidecarMemLimit =
-        wsAttributes.get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, cheContainer.getName()));
+        wsAttributes.get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, pluginId));
     if (!isNullOrEmpty(overriddenSidecarMemLimit)) {
       machineConfig
           .getAttributes()

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverTest.java
@@ -46,7 +46,7 @@ import org.testng.annotations.Test;
 public class MachineResolverTest {
 
   private static final String DEFAULT_MEM_LIMIT = "100001";
-  private static final String SIDECAR_NAME = "testSidecar";
+  private static final String PLUGIN_ID = "testplugin";
   private static final String PROJECTS_ENV_VAR = "env_with_with_location_of_projects";
   private static final String PROJECTS_MOUNT_PATH = "/wherever/i/may/roam";
 
@@ -64,15 +64,13 @@ public class MachineResolverTest {
     wsAttributes = new HashMap<>();
     resolver =
         new MachineResolver(
-            "plugin",
+            PLUGIN_ID,
             new Pair<>(PROJECTS_ENV_VAR, PROJECTS_MOUNT_PATH),
             container,
             cheContainer,
             DEFAULT_MEM_LIMIT,
             endpoints,
             wsAttributes);
-
-    cheContainer.setName(SIDECAR_NAME);
   }
 
   @Test
@@ -148,7 +146,7 @@ public class MachineResolverTest {
   public void shouldSetMemoryLimitOfASidecarIfCorrespondingWSConfigAttributeIsSet(
       String attributeValue, String expectedMemLimit) throws InfrastructureException {
     wsAttributes.put(
-        format(Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, SIDECAR_NAME), attributeValue);
+        format(Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, PLUGIN_ID), attributeValue);
 
     InternalMachineConfig machineConfig = resolver.resolve();
 
@@ -173,7 +171,7 @@ public class MachineResolverTest {
     String expectedMemLimit = toBytesString(attributeValue);
     Containers.addRamLimit(container, 123456789);
     wsAttributes.put(
-        format(Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, SIDECAR_NAME), attributeValue);
+        format(Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, PLUGIN_ID), attributeValue);
 
     InternalMachineConfig machineConfig = resolver.resolve();
 

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -119,6 +119,12 @@ public final class Constants {
    */
   public static final String WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE = "plugins";
 
+  /**
+   * Template for workspace attribute key that sets sidecar limit in a plugin.
+   * %s should be replaced with plugin ID. When plugin provides several sidecars this property sets
+   * the same limit for each sidecar, so is not that useful in such a case.
+   * Value format see {@link KubernetesSize}
+   */
   public static final String SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE = "sidecar.%s.memory_limit";
 
   /**

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -120,10 +120,9 @@ public final class Constants {
   public static final String WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE = "plugins";
 
   /**
-   * Template for workspace attribute key that sets sidecar limit in a plugin.
-   * %s should be replaced with plugin ID. When plugin provides several sidecars this property sets
-   * the same limit for each sidecar, so is not that useful in such a case.
-   * Value format see {@link KubernetesSize}
+   * Template for workspace attribute key that sets sidecar limit in a plugin. %s should be replaced
+   * with plugin ID. When plugin provides several sidecars this property sets the same limit for
+   * each sidecar, so is not that useful in such a case. Value format see {@link KubernetesSize}
    */
   public static final String SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE = "sidecar.%s.memory_limit";
 


### PR DESCRIPTION
### What does this PR do?
Use plugin ID instead of sidecar container name to override sidecar memory using workspace attributes.
When several sidecars are brought by a plugin all of them got the same RAM limit. 
Add docs.


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/11600

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
