### PR TITLE
Detect tools containers on dashboard and disable action items for them

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.controller.ts
@@ -13,6 +13,7 @@
 import {ConfirmDialogService} from '../../../../components/service/confirm-dialog/confirm-dialog.service';
 import {IEnvironmentManagerMachine} from '../../../../components/api/environment/environment-manager-machine';
 import {EnvironmentManager} from '../../../../components/api/environment/environment-manager';
+import {CheMachineSourceTypes} from '../../../../components/api/workspace/che-machine-source-types';
 
 interface IEnvironmentVariable {
   name: string;
@@ -42,6 +43,7 @@ export class EnvVariablesController {
   private envVariablesList: Array<IEnvironmentVariable> = [];
   private envVariablesSelectedNumber: number = 0;
   private onChange: Function;
+  private isToolContainer: boolean;
 
   /**
    * Default constructor that is using resource
@@ -70,6 +72,8 @@ export class EnvVariablesController {
     if (!selectedMachine || !this.environmentManager) {
       return;
     }
+    this.isToolContainer = this.selectedMachine.attributes && this.selectedMachine.attributes.source ? this.selectedMachine.attributes.source === CheMachineSourceTypes.TOOL : false;
+
     this.isEnvVarEditable = this.environmentManager.canEditEnvVariables(selectedMachine);
     this.envVariables = this.environmentManager.getEnvVariables(selectedMachine);
     this.envVariablesList = [];

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.html
@@ -7,6 +7,7 @@
     <div flex layout="column" md-theme="maincontent-theme">
       <che-list-header che-add-button-title="Add Env Variable"
                        che-on-add="envVariablesController.showEditDialog()"
+                       che-hide-add="envVariablesController.isToolContainer"
                        che-delete-button-title="Delete"
                        che-on-delete="envVariablesController.deleteSelectedEnvVariables()"
                        che-hide-delete="envVariablesController.envVariablesSelectedNumber === 0"
@@ -39,6 +40,9 @@
           </div>
         </div>
       </che-list-header>
+      <div ng-if="!envVariablesController.envVariablesList.length" class="che-list-empty">
+        <span>There are no environment variables defined for this container.</span>
+      </div>
       <!-- Env variables list -->
       <che-list class="environment-variables-list" flex
                 ng-if="envVariablesController.envVariablesList && envVariablesController.envVariablesList.length > 0">

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.controller.ts
@@ -16,6 +16,7 @@ import {
   IEnvironmentManagerMachine,
   IEnvironmentManagerMachineServer
 } from '../../../../components/api/environment/environment-manager-machine';
+import {CheMachineSourceTypes} from '../../../../components/api/workspace/che-machine-source-types';
 
 interface IServerListItem extends IEnvironmentManagerMachineServer {
   reference: string;
@@ -44,6 +45,7 @@ export class MachineServersController {
   private serversSelectedNumber: number = 0;
   private onChange: Function;
   private hasUserScope: boolean;
+  private isToolContainer: boolean;
 
   /**
    * Default constructor that is using resource.
@@ -72,6 +74,8 @@ export class MachineServersController {
     if (!selectedMachine || !this.environmentManager) {
       return;
     }
+    this.isToolContainer = this.selectedMachine.attributes && this.selectedMachine.attributes.source ? this.selectedMachine.attributes.source === CheMachineSourceTypes.TOOL : false;
+
     this.servers = this.environmentManager.getServers(selectedMachine);
     if (!angular.isObject(this.servers)) {
       return;

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.html
@@ -4,6 +4,7 @@
     <div flex layout="column" md-theme="maincontent-theme">
       <che-list-header che-add-button-title="Add Server"
                        che-on-add="machineServersController.showEditDialog()"
+                       che-hide-add="machineServersController.isToolContainer"
                        che-delete-button-title="Delete"
                        che-on-delete="machineServersController.deleteSelectedServers()"
                        che-hide-delete="machineServersController.serversSelectedNumber === 0"
@@ -39,6 +40,9 @@
           </div>
         </div>
       </che-list-header>
+      <div ng-if="!machineServersController.serversList.length" class="che-list-empty">
+        <span>There are no servers defined for this container.</span>
+      </div>
       <!-- Servers list-->
       <che-list class="machine-servers-list" flex
                 ng-if="machineServersController.serversList && machineServersController.serversList.length > 0">

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/machine-volumes.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/machine-volumes.controller.ts
@@ -14,6 +14,7 @@ import {ConfirmDialogService} from '../../../../components/service/confirm-dialo
 import {IEnvironmentManagerMachine} from '../../../../components/api/environment/environment-manager-machine';
 import {EnvironmentManager} from '../../../../components/api/environment/environment-manager';
 import {CheListHelperFactory} from '../../../../components/widget/list/che-list-helper.factory';
+import {CheMachineSourceTypes} from '../../../../components/api/workspace/che-machine-source-types';
 
 /**
  * @ngdoc controller
@@ -35,6 +36,7 @@ export class MachineVolumesController {
   private machineVolumes: { [volumeName: string]: { path: string } } = {};
   private machineVolumesSelectedNumber: number = 0;
   private onChange: Function;
+  private isToolContainer: boolean;
 
   /**
    * Default constructor that is using resource
@@ -67,6 +69,8 @@ export class MachineVolumesController {
     if (!selectedMachine || !this.environmentManager) {
       return;
     }
+
+    this.isToolContainer = this.selectedMachine.attributes && this.selectedMachine.attributes.source ? this.selectedMachine.attributes.source === CheMachineSourceTypes.TOOL : false;
     this.machineVolumes = this.environmentManager.getMachineVolumes(selectedMachine);
     if (angular.isObject(this.machineVolumes)) {
       this.cheListHelper.setList(Object.keys(this.machineVolumes).map((key: string) => {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/machine-volumes.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/machine-volumes.html
@@ -4,6 +4,7 @@
     <div flex layout="column" md-theme="maincontent-theme">
       <che-list-header che-add-button-title="Add Volume"
                        che-on-add="machineVolumesController.showEditDialog()"
+                       che-hide-add="machineVolumesController.isToolContainer"
                        che-delete-button-title="Delete"
                        che-on-delete="machineVolumesController.deleteSelectedMachineVolumes()"
                        che-hide-delete="machineVolumesController.cheListHelper.isNoItemSelected"
@@ -36,6 +37,9 @@
           </div>
         </div>
       </che-list-header>
+      <div ng-if="machineVolumesController.cheListHelper.visibleItemsNumber === 0" class="che-list-empty">
+        <span>There are no volumes defined for this container.</span>
+      </div>
       <!-- Machine volume list -->
       <che-list class="machine-volume-list" flex
                 ng-show="machineVolumesController.cheListHelper.visibleItemsNumber > 0">

--- a/dashboard/src/components/api/environment/che-environment-manager.factory.ts
+++ b/dashboard/src/components/api/environment/che-environment-manager.factory.ts
@@ -19,7 +19,7 @@ import {ComposeEnvironmentManager} from './compose-environment-manager';
 import {OpenshiftEnvironmentManager} from './openshift-environment-manager';
 import {DefaultEnvironmentManager} from './default-environment-manager';
 import {KubernetesEnvironmentManager} from './kubernetes-environment-manager';
-import { NoEnvironmentManager } from './no-environment-manager';
+import {NoEnvironmentManager} from './no-environment-manager';
 
 export class CheEnvironmentManager {
 

--- a/dashboard/src/components/api/environment/environment-manager.ts
+++ b/dashboard/src/components/api/environment/environment-manager.ts
@@ -177,7 +177,7 @@ export abstract class EnvironmentManager {
 
     Object.keys(runtime.machines).forEach((machineName: string) => {
       let runtimeMachine = runtime.machines[machineName];
-      let machine: any = {name: machineName, servers: {}};
+      let machine: any = {name: machineName, servers: {}, attributes: runtimeMachine.attributes};
       if (runtimeMachine && runtimeMachine.servers) {
         machine.runtime = {
           servers: runtimeMachine.servers

--- a/dashboard/src/components/api/environment/kubernetes-environment-manager.ts
+++ b/dashboard/src/components/api/environment/kubernetes-environment-manager.ts
@@ -177,12 +177,7 @@ export class KubernetesEnvironmentManager extends EnvironmentManager {
     let newEnvironment: che.IWorkspaceEnvironment = angular.copy(environment);
 
     machines.forEach((machine: IEnvironmentManagerMachine) => {
-      const podItem = machine.recipe;
-      const podItemContainer = machine.recipe.spec.containers[0];
-      const annotations = podItem.metadata.annotations;
-      const podName = podItem.metadata.name ? podItem.metadata.name : podItem.metadata.generateName;
-      const nameAnnotation = `${NAME_ANNOTATION_PREFIX}.${podItemContainer.name}.${MACHINE_NAME}`;
-      const machineName = annotations && annotations[nameAnnotation] ? annotations[nameAnnotation] : `${podName}/${podItemContainer.name}`;
+      const machineName = machine.name;
 
       if (angular.isUndefined(newEnvironment.machines)) {
         newEnvironment.machines = {};

--- a/dashboard/src/components/api/workspace/che-machine-source-types.ts
+++ b/dashboard/src/components/api/workspace/che-machine-source-types.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+/**
+ * This is constants of machine source types.
+ *
+ *  @author Ann Shumilova
+ */
+class CheMachineSourceTypesStatic {
+
+  static get TOOL(): string {
+    return 'tool';
+  }
+
+  static get RECIPE(): string {
+    return 'recipe';
+  }
+
+  static getValues(): Array<string> {
+    return [
+      CheMachineSourceTypesStatic.TOOL,
+      CheMachineSourceTypesStatic.RECIPE
+    ];
+  }
+
+}
+
+export const CheMachineSourceTypes: che.resource.ICheMachineSourceTypes = CheMachineSourceTypesStatic;

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -171,6 +171,11 @@ declare namespace che {
       NOENVIRONMENT: string;
       getValues(): Array<string>;
     }
+
+    export interface ICheMachineSourceTypes {
+      TOOL,
+      RECIPE
+    }
   }
 
   export namespace service {
@@ -332,6 +337,7 @@ declare namespace che {
     installers?: string[];
     attributes?: {
       memoryLimitBytes?: string|number;
+      source?: string;
       [attrName: string]: string|number;
     };
     servers?: {


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
As far as user cannot modify environment variables, servers and volumes for tools containers, the PR contain changes, that differ the containers: tools and user defined ones, and disables "Add", "Edit" and "Delete" actions for runtime containers.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12337


