### PR TITLE
Upgrade Che brokers versions

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -535,10 +535,10 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.10.0
-che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.10.0
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.10.0
-che.workspace.plugin_broker.vscode.image=eclipse/che-vscode-extension-broker:v0.10.0
+che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.11.0
+che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.11.0
+che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.11.0
+che.workspace.plugin_broker.vscode.image=eclipse/che-vscode-extension-broker:v0.11.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
Signed-off-by: Anatoliy Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Upgrade Che brokers versions v0.10.0 -> v0.11.0
The new version allows to download VS Code extensions by URL

### Related issues
https://github.com/eclipse/che/issues/12549
https://github.com/eclipse/che-plugin-broker/pull/30

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
