### PR TITLE
Add targetPort attribute to runtime server

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerResolver.java
@@ -111,7 +111,8 @@ public class KubernetesServerResolver {
               String path =
                   buildPath(ingressRule.getHttp().getPaths().get(0).getPath(), config.getPath());
               servers.put(
-                  name, new RuntimeServerBuilder()
+                  name,
+                  new RuntimeServerBuilder()
                       .protocol(config.getProtocol())
                       .host(host)
                       .path(path)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerResolver.java
@@ -21,8 +21,6 @@ import io.fabric8.kubernetes.api.model.extensions.IngressRule;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
-import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
@@ -87,12 +85,14 @@ public class KubernetesServerResolver {
             (name, config) ->
                 servers.put(
                     name,
-                    newServer(
-                        config.getProtocol(),
-                        service.getMetadata().getName(),
-                        config.getPort(),
-                        config.getPath(),
-                        config.getAttributes())));
+                    new RuntimeServerBuilder()
+                        .protocol(config.getProtocol())
+                        .host(service.getMetadata().getName())
+                        .port(config.getPort())
+                        .path(config.getPath())
+                        .attributes(config.getAttributes())
+                        .targetPort(config.getPort())
+                        .build()));
   }
 
   private void fillIngressServers(Ingress ingress, Map<String, ServerImpl> servers) {
@@ -111,7 +111,13 @@ public class KubernetesServerResolver {
               String path =
                   buildPath(ingressRule.getHttp().getPaths().get(0).getPath(), config.getPath());
               servers.put(
-                  name, newServer(config.getProtocol(), host, null, path, config.getAttributes()));
+                  name, new RuntimeServerBuilder()
+                      .protocol(config.getProtocol())
+                      .host(host)
+                      .path(path)
+                      .attributes(config.getAttributes())
+                      .targetPort(config.getPort())
+                      .build());
             });
   }
 
@@ -131,35 +137,5 @@ public class KubernetesServerResolver {
     }
 
     return sb.toString();
-  }
-
-  /** Constructs {@link ServerImpl} instance from provided parameters. */
-  protected ServerImpl newServer(
-      String protocol, String host, String port, String path, Map<String, String> attributes) {
-    StringBuilder ub = new StringBuilder();
-    if (protocol != null) {
-      ub.append(protocol).append("://");
-    } else {
-      ub.append("tcp://");
-    }
-    ub.append(host);
-    if (port != null) {
-      ub.append(':').append(removeSuffix(port));
-    }
-    if (path != null) {
-      if (!path.isEmpty() && !path.startsWith("/")) {
-        ub.append("/");
-      }
-      ub.append(path);
-    }
-    return new ServerImpl()
-        .withUrl(ub.toString())
-        .withStatus(ServerStatus.UNKNOWN)
-        .withAttributes(attributes);
-  }
-
-  /** Removes suffix of {@link ServerConfig} such as "/tcp" when port value "8080/tcp". */
-  private String removeSuffix(String port) {
-    return port.split("/")[0];
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.server;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
+import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+
+/**
+ * Helper class to build {@link ServerImpl} from parts like port, host, path, etc.
+ * It also adds port that let to server creation as attribute {@link org.eclipse.che.api.workspace.shared.Constants#SERVER_TARGET_PORT_ATTRIBUTE}
+ *
+ * @author Oleksandr Garagatyi
+ */
+public class RuntimeServerBuilder {
+
+  private String protocol;
+  private String host;
+  private String port;
+  private String path;
+  private Map<String, String> attributes;
+  private String targetPort;
+
+  public RuntimeServerBuilder protocol(String protocol) {
+    this.protocol = protocol;
+    return this;
+  }
+
+  public RuntimeServerBuilder host(String host) {
+    this.host = host;
+    return this;
+  }
+
+  public RuntimeServerBuilder port(String port) {
+    this.port = port;
+    return this;
+  }
+
+  public RuntimeServerBuilder path(String path) {
+    this.path = path;
+    return this;
+  }
+
+  public RuntimeServerBuilder attributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+    return this;
+  }
+
+  public RuntimeServerBuilder targetPort(String targetPort) {
+    this.targetPort = removeSuffix(targetPort);
+    return this;
+  }
+
+  public ServerImpl build() {
+    StringBuilder ub = new StringBuilder();
+    if (protocol != null) {
+      ub.append(protocol).append("://");
+    } else {
+      ub.append("tcp://");
+    }
+    ub.append(host);
+    if (port != null) {
+      ub.append(':').append(removeSuffix(port));
+    }
+    if (path != null) {
+      if (!path.isEmpty() && !path.startsWith("/")) {
+        ub.append("/");
+      }
+      ub.append(path);
+    }
+    Map<String, String> completeAttributes = new HashMap<>(attributes);
+    completeAttributes.put("targetPort", targetPort);
+    return new ServerImpl()
+        .withUrl(ub.toString())
+        .withStatus(ServerStatus.UNKNOWN)
+        .withAttributes(completeAttributes);
+  }
+
+  /**
+   * Removes suffix of {@link ServerConfig} such as "/tcp" when port value "8080/tcp".
+   */
+  private String removeSuffix(String port) {
+    return port.split("/")[0];
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+import org.eclipse.che.api.workspace.shared.Constants;
 
 /**
  * Helper class to build {@link ServerImpl} from parts like port, host, path, etc. It also adds port
@@ -81,7 +82,7 @@ public class RuntimeServerBuilder {
       ub.append(path);
     }
     Map<String, String> completeAttributes = new HashMap<>(attributes);
-    completeAttributes.put("targetPort", targetPort);
+    completeAttributes.put(Constants.SERVER_TARGET_PORT_ATTRIBUTE, targetPort);
     return new ServerImpl()
         .withUrl(ub.toString())
         .withStatus(ServerStatus.UNKNOWN)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
@@ -18,8 +18,9 @@ import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 
 /**
- * Helper class to build {@link ServerImpl} from parts like port, host, path, etc.
- * It also adds port that let to server creation as attribute {@link org.eclipse.che.api.workspace.shared.Constants#SERVER_TARGET_PORT_ATTRIBUTE}
+ * Helper class to build {@link ServerImpl} from parts like port, host, path, etc. It also adds port
+ * that let to server creation as attribute {@link
+ * org.eclipse.che.api.workspace.shared.Constants#SERVER_TARGET_PORT_ATTRIBUTE}
  *
  * @author Oleksandr Garagatyi
  */
@@ -87,9 +88,7 @@ public class RuntimeServerBuilder {
         .withAttributes(completeAttributes);
   }
 
-  /**
-   * Removes suffix of {@link ServerConfig} such as "/tcp" when port value "8080/tcp".
-   */
+  /** Removes suffix of {@link ServerConfig} such as "/tcp" when port value "8080/tcp". */
   private String removeSuffix(String port) {
     return port.split("/")[0];
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
@@ -21,7 +21,7 @@ import org.eclipse.che.api.workspace.shared.Constants;
 /**
  * Helper class to build {@link ServerImpl} from parts like port, host, path, etc. It also adds port
  * that let to server creation as attribute {@link
- * org.eclipse.che.api.workspace.shared.Constants#SERVER_TARGET_PORT_ATTRIBUTE}
+ * org.eclipse.che.api.workspace.shared.Constants#SERVER_PORT_ATTRIBUTE}
  *
  * @author Oleksandr Garagatyi
  */
@@ -82,7 +82,7 @@ public class RuntimeServerBuilder {
       ub.append(path);
     }
     Map<String, String> completeAttributes = new HashMap<>(attributes);
-    completeAttributes.put(Constants.SERVER_TARGET_PORT_ATTRIBUTE, targetPort);
+    completeAttributes.put(Constants.SERVER_PORT_ATTRIBUTE, targetPort);
     return new ServerImpl()
         .withUrl(ub.toString())
         .withStatus(ServerStatus.UNKNOWN)

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerResolverTest.java
@@ -93,7 +93,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX + "/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -115,7 +115,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX)
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -137,7 +137,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX)
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -159,7 +159,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX + "/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -183,7 +183,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://service11:3054/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -207,7 +207,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("xxx://service11:3054/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   private Service createService(
@@ -267,8 +267,8 @@ public class KubernetesServerResolverTest {
   }
 
   private Map<String, String> defaultAttributeAnd(String key, String value) {
-    HashMap<String, String> map = new HashMap<>(ATTRIBUTES_MAP);
-    map.put(key, value);
-    return map;
+    HashMap<String, String> attributes = new HashMap<>(ATTRIBUTES_MAP);
+    attributes.put(key, value);
+    return attributes;
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerResolverTest.java
@@ -27,11 +27,13 @@ import io.fabric8.kubernetes.api.model.extensions.Ingress;
 import io.fabric8.kubernetes.api.model.extensions.IngressBackend;
 import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
 import io.fabric8.kubernetes.api.model.extensions.IngressRule;
+import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations.Serializer;
@@ -91,7 +93,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX + "/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -113,7 +115,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX)
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -135,7 +137,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX)
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -157,7 +159,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX + "/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -181,7 +183,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("http://service11:3054/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -205,7 +207,7 @@ public class KubernetesServerResolverTest {
         new ServerImpl()
             .withUrl("xxx://service11:3054/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   private Service createService(
@@ -262,5 +264,11 @@ public class KubernetesServerResolverTest {
         .endLoadBalancer()
         .endStatus()
         .build();
+  }
+
+  private Map<String, String> defaultAttributeAnd(String key, String value) {
+    HashMap<String, String> map = new HashMap<>(ATTRIBUTES_MAP);
+    map.put(key, value);
+    return map;
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerResolver.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerResolver.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.KubernetesServerResolver;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.RuntimeServerBuilder;
 
 /**
  * Helps to resolve {@link ServerImpl servers} by machine name according to specified {@link Route
@@ -61,11 +62,12 @@ public class OpenShiftServerResolver extends KubernetesServerResolver {
             (name, config) ->
                 servers.put(
                     name,
-                    newServer(
-                        config.getProtocol(),
-                        route.getSpec().getHost(),
-                        null,
-                        config.getPath(),
-                        config.getAttributes())));
+                    new RuntimeServerBuilder()
+                        .protocol(config.getProtocol())
+                        .host(route.getSpec().getHost())
+                        .path(config.getPath())
+                        .attributes(config.getAttributes())
+                        .targetPort(config.getPort())
+                        .build()));
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftServerResolverTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftServerResolverTest.java
@@ -24,9 +24,11 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
+import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations.Serializer;
 import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftServerResolver;
@@ -86,7 +88,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://localhost/api")
             .withStatus(UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -109,7 +111,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://localhost")
             .withStatus(UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -131,7 +133,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://localhost")
             .withStatus(UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -154,7 +156,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://localhost/api")
             .withStatus(UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -179,7 +181,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://service11:3054/api")
             .withStatus(UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -204,7 +206,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("xxx://service11:3054/api")
             .withStatus(UNKNOWN)
-            .withAttributes(ATTRIBUTES_MAP));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
   }
 
   private Service createService(
@@ -251,5 +253,11 @@ public class OpenShiftServerResolverTest {
         .endTo()
         .endSpec()
         .build();
+  }
+
+  private Map<String, String> defaultAttributeAnd(String key, String value) {
+    HashMap<String, String> map = new HashMap<>(ATTRIBUTES_MAP);
+    map.put(key, value);
+    return map;
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftServerResolverTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftServerResolverTest.java
@@ -88,7 +88,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://localhost/api")
             .withStatus(UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -111,7 +111,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://localhost")
             .withStatus(UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -133,7 +133,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://localhost")
             .withStatus(UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -156,7 +156,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://localhost/api")
             .withStatus(UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -181,7 +181,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("http://service11:3054/api")
             .withStatus(UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   @Test
@@ -206,7 +206,7 @@ public class OpenShiftServerResolverTest {
         new ServerImpl()
             .withUrl("xxx://service11:3054/api")
             .withStatus(UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_TARGET_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
   }
 
   private Service createService(

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -176,7 +176,7 @@ public final class Constants {
   public static final String PROJECTS_VOLUME_NAME = "projects";
 
   /** Attribute of {@link Server} that specifies exposure of which port created the server */
-  public static final String SERVER_TARGET_PORT_ATTRIBUTE = "targetPort";
+  public static final String SERVER_TARGET_PORT_ATTRIBUTE = "port";
 
   private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -176,7 +176,7 @@ public final class Constants {
   public static final String PROJECTS_VOLUME_NAME = "projects";
 
   /** Attribute of {@link Server} that specifies exposure of which port created the server */
-  public static final String SERVER_TARGET_PORT_ATTRIBUTE = "port";
+  public static final String SERVER_PORT_ATTRIBUTE = "port";
 
   private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.shared;
 
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.Server;
 
 /**
  * Constants for Workspace API
@@ -173,6 +174,9 @@ public final class Constants {
 
   /** The projects volume has a standard name used in a couple of locations. */
   public static final String PROJECTS_VOLUME_NAME = "projects";
+
+  /** Attribute of {@link Server} that specifies exposure of which port created the server */
+  public static final String SERVER_TARGET_PORT_ATTRIBUTE = "targetPort";
 
   private Constants() {}
 }


### PR DESCRIPTION
### What does this PR do?
Add port attribute to runtime server.
This is needed to help clients in figuring out which port led
to creating a server in a workspace.
Also refactor some code.

![image](https://user-images.githubusercontent.com/1851863/52484653-8d3f6200-2bbf-11e9-81b6-efec76d18684.png)


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/12611
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
