### PR TITLE
Add support of dockerimage tool in Devfile

### DIFF
--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
@@ -25,6 +25,8 @@ public class Constants {
 
   public static final String OPENSHIFT_TOOL_TYPE = "openshift";
 
+  public static final String DOCKERIMAGE_TOOL_TYPE = "dockerimage";
+
   /**
    * Workspace attribute which contains comma-separated list of mappings of tool id to its name
    * Example value:

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileConverter.java
@@ -20,6 +20,7 @@ import static org.eclipse.che.api.core.model.workspace.config.Command.PLUGIN_ATT
 import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DIRECTORY_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.Constants.ALIASES_WORKSPACE_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.devfile.server.Constants.CURRENT_SPEC_VERSION;
+import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
@@ -53,11 +54,14 @@ import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
  */
 public class DevfileConverter {
 
-  private KubernetesToolApplier kubernetesToolApplier;
+  private final KubernetesToolApplier kubernetesToolApplier;
+  private final DockerimageToolApplier dockerimageToolApplier;
 
   @Inject
-  public DevfileConverter(KubernetesToolApplier kubernetesToolApplier) {
+  public DevfileConverter(
+      KubernetesToolApplier kubernetesToolApplier, DockerimageToolApplier dockerimageToolApplier) {
     this.kubernetesToolApplier = kubernetesToolApplier;
+    this.dockerimageToolApplier = dockerimageToolApplier;
   }
 
   /**
@@ -168,6 +172,9 @@ public class DevfileConverter {
         case KUBERNETES_TOOL_TYPE:
         case OPENSHIFT_TOOL_TYPE:
           kubernetesToolApplier.apply(tool, devfile, config, contentProvider);
+          break;
+        case DOCKERIMAGE_TOOL_TYPE:
+          dockerimageToolApplier.apply(tool, devfile, config);
           break;
         default:
           throw new DevfileFormatException(

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DockerimageToolApplier.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DockerimageToolApplier.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.devfile.server;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
+import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
+import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.devfile.model.Devfile;
+import org.eclipse.che.api.devfile.model.Endpoint;
+import org.eclipse.che.api.devfile.model.Tool;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSize;
+
+/**
+ * Applies Kubernetes tool configuration on provided {@link Devfile} and {@link
+ * WorkspaceConfigImpl}.
+ *
+ * @author Sergii Leshchenko
+ */
+public class DockerimageToolApplier {
+
+  private static final String DOCKERIMAGE_RECIPE_TYPE = "dockerimage";
+
+  private final String projectFolderPath;
+
+  @Inject
+  public DockerimageToolApplier(@Named("che.workspace.projects.storage") String projectFolderPath) {
+    this.projectFolderPath = projectFolderPath;
+  }
+
+  /**
+   * Applies Kubernetes tool configuration on provided {@link Devfile} and {@link
+   * WorkspaceConfigImpl}.
+   *
+   * <p>It includes:
+   *
+   * <ul>
+   *   <li>provisioning environment based on specified configuration in tool: dockerimage, env,
+   *       volumes, etc.;
+   *   <li>provisioning machine name attribute to commands that are configured to be run in the
+   *       specified tool;
+   * </ul>
+   *
+   * @param tool dockerimage tool that should be applied to devfile and workspace config
+   * @param devfile devfile that should be changed according to the provided tool
+   * @param workspaceConfig workspace config that should be changed according to the provided tool
+   * @throws IllegalArgumentException when wrong type tool is passed
+   */
+  public void apply(Tool tool, Devfile devfile, WorkspaceConfigImpl workspaceConfig) {
+    checkArgument(tool != null, "Tool must not be null");
+    checkArgument(
+        tool.getType().equals(DOCKERIMAGE_TOOL_TYPE), "The tool must have `dockerimage` type");
+
+    String machineName = tool.getName();
+    MachineConfigImpl machineConfig = new MachineConfigImpl();
+
+    tool.getEnv().forEach(e -> machineConfig.getEnv().put(e.getName(), e.getValue()));
+
+    for (Endpoint endpoint : tool.getEndpoints()) {
+      HashMap<String, String> attributes = new HashMap<>(endpoint.getAttributes());
+
+      String protocol = attributes.remove("protocol");
+      if (isNullOrEmpty(protocol)) {
+        protocol = "http";
+      }
+
+      String path = attributes.remove("path");
+
+      machineConfig
+          .getServers()
+          .put(
+              endpoint.getName(),
+              new ServerConfigImpl(
+                  Integer.toString(endpoint.getPort()), protocol, path, attributes));
+    }
+
+    tool.getVolumes()
+        .forEach(
+            v ->
+                machineConfig
+                    .getVolumes()
+                    .put(v.getName(), new VolumeImpl().withPath(v.getContainerPath())));
+
+    if (tool.getMountSources()) {
+      machineConfig
+          .getVolumes()
+          .put(PROJECTS_VOLUME_NAME, new VolumeImpl().withPath(projectFolderPath));
+    }
+
+    machineConfig
+        .getAttributes()
+        .put(MEMORY_LIMIT_ATTRIBUTE, Long.toString(KubernetesSize.toBytes(tool.getMemoryLimit())));
+
+    RecipeImpl recipe = new RecipeImpl(DOCKERIMAGE_RECIPE_TYPE, null, tool.getImage(), null);
+    EnvironmentImpl environment =
+        new EnvironmentImpl(recipe, ImmutableMap.of(machineName, machineConfig));
+    workspaceConfig.getEnvironments().put(tool.getName(), environment);
+    workspaceConfig.setDefaultEnv(tool.getName());
+
+    devfile
+        .getCommands()
+        .stream()
+        .filter(command -> command.getActions().get(0).getTool().equals(tool.getName()))
+        .forEach(c -> c.getAttributes().put(MACHINE_NAME_ATTRIBUTE, machineName));
+  }
+}

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/KubernetesToolApplier.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/KubernetesToolApplier.java
@@ -144,7 +144,8 @@ public class KubernetesToolApplier {
   }
 
   /**
-   * Set {@link MACHINE_NAME_ATTRIBUTE} to commands which are configured in the specified tool.
+   * Set {@link org.eclipse.che.api.core.model.workspace.config.Command#MACHINE_NAME_ATTRIBUTE} to
+   * commands which are configured in the specified tool.
    *
    * <p>Machine name will be set only if the specified recipe objects has the only one container.
    */

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.devfile.server.validator;
 
 import static java.lang.String.format;
+import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
@@ -86,13 +87,15 @@ public class DevfileIntegrityValidator {
           break;
         case KUBERNETES_TOOL_TYPE:
         case OPENSHIFT_TOOL_TYPE:
+          checkFieldNotSet(tool, "id", tool.getId());
+          // fall through
+        case DOCKERIMAGE_TOOL_TYPE:
           if (recipeTool != null) {
             throw new DevfileFormatException(
                 format(
                     "Multiple non plugin or editor type tools found: '%s', '%s'",
                     recipeTool.getName(), tool.getName()));
           }
-          checkFieldNotSet(tool, "id", tool.getId());
           recipeTool = tool;
           break;
         default:

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -108,15 +108,34 @@
           "name",
           "type"
         ],
+        "additionalProperties": false,
         "oneOf" : [
           {
+            "properties": {
+              "type": {
+                "enum": [
+                  "cheEditor",
+                  "chePlugin"
+                ]
+              }
+            },
             "required": [
               "id"
-            ]},
+            ]
+          },
           {
+            "properties": {
+              "type": {
+                "enum": [
+                  "kubernetes",
+                  "openshift"
+                ]
+              }
+            },
             "required": [
               "local"
-            ]}
+            ]
+          }
         ],
         "properties": {
           "name": {
@@ -135,18 +154,18 @@
               "kubernetes"
             ]
           },
-          "local": {
-            "description": "Describes location of Kubernetes list yaml file. Applicable only for 'kubernetes' and 'openshift' type tools",
-            "type": "string",
-            "examples": [
-              "petclinic-app.yaml"
-            ]
-          },
           "id": {
             "type": "string",
             "description": "Describes the tool FQN",
             "examples": [
               "eclipse/maven-jdk8:1.0.0"
+            ]
+          },
+          "local": {
+            "description": "Describes location of Kubernetes list yaml file. Applicable only for 'kubernetes' and 'openshift' type tools",
+            "type": "string",
+            "examples": [
+              "petclinic-app.yaml"
             ]
           },
           "selector": {
@@ -185,6 +204,8 @@
             "type": "array",
             "description" : "List of the actions of given command. Now the only one command must be specified in list but there are plans to implement supporting multiple actions commands.",
             "title": "The Command Actions List",
+            "minItems": 1,
+            "maxItems": 1,
             "items": {
               "type": "object",
               "required": [

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -135,6 +135,19 @@
             "required": [
               "local"
             ]
+          },
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "dockerimage"
+                ]
+              }
+            },
+            "required": [
+              "image",
+              "memoryLimit"
+            ]
           }
         ],
         "properties": {
@@ -151,7 +164,9 @@
             "examples": [
               "chePlugin",
               "cheEditor",
-              "kubernetes"
+              "kubernetes",
+              "openshift",
+              "dockerimage"
             ]
           },
           "id": {
@@ -174,6 +189,128 @@
             "examples": [
               "{\n   \"app.kubernetes.io/name\" : \"mysql\", \n   \"app.kubernetes.io/component\" : \"database\", \n   \"app.kubernetes.io/part-of\" : \"petclinic\" \n}"
             ]
+          },
+          "image": {
+            "type": "string",
+            "description": "Specifies the docker image that should be used for tool",
+            "examples": [
+              "eclipse/maven-jdk8:1.0.0"
+            ]
+          },
+          "memoryLimit": {
+            "type": "string",
+            "description": "Describes memory limit for the tool. You can express memory as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki",
+            "examples": [
+              "128974848", "129e6", "129M", "123Mi"
+            ]
+          },
+          "mountSources": {
+            "type": "boolean",
+            "description": "Describes whether projects sources should be mount to the tool. `CHE_PROJECTS_ROOT` environment variable should contains a path where projects sources are mount",
+            "default": "false"
+          },
+          "volumes": {
+            "type": "array",
+            "description": "Describes volumes which should be mount to tool",
+            "items": {
+              "type": "object",
+              "description": "Describe volume that should be mount to tool",
+              "required": [
+                "name",
+                "containerPath"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "The Volume Name",
+                  "description": "The volume name. If several tools mount the same volume then they will reuse the volume and will be able to access to the same files",
+                  "examples": [
+                    "my-data"
+                  ]
+                },
+                "containerPath": {
+                  "type": "string",
+                  "title": "The path where volume should be mount to container",
+                  "examples": [
+                    "/home/user/data"
+                  ]
+                }
+              }
+            }
+          },
+          "env": {
+            "type": "array",
+            "description": "The environment variables list that should be set to docker container",
+            "items": {
+              "type": "object",
+              "description": "Describes environment variable",
+              "required": [
+                "name",
+                "value"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "The Environment Variable Name",
+                  "description": "The environment variable name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "The Environment Variable Value",
+                  "description": "The environment variable value"
+                }
+              }
+            }
+          },
+          "endpoints": {
+            "type": "array",
+            "description": "Describes dockerimage tool endpoints",
+            "items": {
+              "name": "object",
+              "description": "Describes dockerimage tool endpoint",
+              "required": [
+                "name",
+                "port"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "The Environment Variable Name",
+                  "description": "The environment variable name"
+                },
+                "port": {
+                  "type": "integer",
+                  "title": "The Environment Variable Name",
+                  "description": "The environment variable name"
+                },
+                "attributes" : {
+                  "type": "object",
+                  "public": {
+                    "type": "boolean",
+                    "description": "Identifies endpoint as workspace internally or externally accessible.",
+                    "default": "true"
+                  },
+                  "secure": {
+                    "type": "boolean",
+                    "description": "Identifies server as secure or non-secure. Requests to secure servers will be authenticated and must contain machine token",
+                    "default": "false"
+                  },
+                  "discoverable": {
+                    "type": "boolean",
+                    "description": "Identifies endpoint as accessible by its name.",
+                    "default": "false"
+                  },
+                  "protocol": {
+                    "type": "boolean",
+                    "description": "Defines protocol that should be used for communication with endpoint. Is used for endpoint URL evaluation"
+                  },
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "javaType": "java.util.Map<String, String>"
+                }
+              }
+            }
           }
         }
       }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileConverterTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileConverterTest.java
@@ -33,11 +33,12 @@ public class DevfileConverterTest {
 
   private ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
   private KubernetesToolApplier kubernetesToolApplier = new KubernetesToolApplier();
+  private DockerimageToolApplier dockerimageToolApplier = new DockerimageToolApplier("/projects");
   private DevfileConverter devfileConverter;
 
   @BeforeClass
   public void setUp() {
-    devfileConverter = new DevfileConverter(kubernetesToolApplier);
+    devfileConverter = new DevfileConverter(kubernetesToolApplier, dockerimageToolApplier);
   }
 
   @Test

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileConverterTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileConverterTest.java
@@ -11,6 +11,10 @@
  */
 package org.eclipse.che.api.devfile.server;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -22,10 +26,12 @@ import org.eclipse.che.api.devfile.model.Command;
 import org.eclipse.che.api.devfile.model.Devfile;
 import org.eclipse.che.api.devfile.model.Project;
 import org.eclipse.che.api.devfile.model.Tool;
+import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.commons.json.JsonHelper;
-import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.testng.reporters.Files;
 
@@ -33,11 +39,12 @@ public class DevfileConverterTest {
 
   private ObjectMapper objectMapper = new ObjectMapper(new YAMLFactory());
   private KubernetesToolApplier kubernetesToolApplier = new KubernetesToolApplier();
-  private DockerimageToolApplier dockerimageToolApplier = new DockerimageToolApplier("/projects");
+  private DockerimageToolApplier dockerimageToolApplier;
   private DevfileConverter devfileConverter;
 
-  @BeforeClass
+  @BeforeMethod
   public void setUp() {
+    dockerimageToolApplier = mock(DockerimageToolApplier.class);
     devfileConverter = new DevfileConverter(kubernetesToolApplier, dockerimageToolApplier);
   }
 
@@ -134,14 +141,79 @@ public class DevfileConverterTest {
   @Test(
       expectedExceptions = WorkspaceExportException.class,
       expectedExceptionsMessageRegExp =
-          "Workspace .* cannot be converted to devfile since it contains environments which have no equivalent in devfile model")
-  public void shouldThrowExceptionWhenWorkspaceHasEnvironments() throws Exception {
+          "Workspace `ws123` cannot be converted to devfile since it has several environments which have no equivalent in devfile model")
+  public void shouldThrowExceptionWhenWorkspaceHasMultipleEnvironments() throws Exception {
     // given
     WorkspaceConfigImpl workspaceConfig = new WorkspaceConfigImpl();
+    workspaceConfig.setName("ws123");
     workspaceConfig.getEnvironments().put("env1", new EnvironmentImpl());
+    workspaceConfig.getEnvironments().put("env2", new EnvironmentImpl());
 
     // when
     devfileConverter.workspaceToDevFile(workspaceConfig);
+  }
+
+  @Test(
+      expectedExceptions = WorkspaceExportException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace `ws123` cannot be converted to devfile since it has environment with 'any' recipe type. Currently only workspaces with `dockerimage` recipe can be exported.")
+  public void shouldThrowExceptionWhenWorkspaceHasEnvironmentWithNonDockerimageRecipe()
+      throws Exception {
+    // given
+    WorkspaceConfigImpl workspaceConfig = new WorkspaceConfigImpl();
+    workspaceConfig.setName("ws123");
+    EnvironmentImpl environment = new EnvironmentImpl();
+    environment.setRecipe(new RecipeImpl("any", null, null, null));
+    workspaceConfig.getEnvironments().put("env1", environment);
+
+    // when
+    devfileConverter.workspaceToDevFile(workspaceConfig);
+  }
+
+  @Test
+  public void shouldAddDockerimageToolIfEnvironmentHasDockerimageRecipe() throws Exception {
+    // given
+    WorkspaceConfigImpl workspaceConfig = new WorkspaceConfigImpl();
+    workspaceConfig.setName("ws123");
+    EnvironmentImpl environment = new EnvironmentImpl();
+    environment.setRecipe(new RecipeImpl("dockerimage", null, null, null));
+    workspaceConfig.getEnvironments().put("env1", environment);
+
+    Tool dockerimageTool = new Tool();
+    when(dockerimageToolApplier.from(any(), any())).thenReturn(dockerimageTool);
+
+    // when
+    Devfile devfile = devfileConverter.workspaceToDevFile(workspaceConfig);
+
+    // then
+    verify(dockerimageToolApplier).from("env1", environment);
+    assertEquals(devfile.getTools().size(), 1);
+    assertEquals(devfile.getTools().get(0), dockerimageTool);
+  }
+
+  @Test
+  public void shouldSetDockerimageToolForCommandsWhichAreNotConfiguredToBeRunInPlugins()
+      throws Exception {
+    // given
+    WorkspaceConfigImpl workspaceConfig = new WorkspaceConfigImpl();
+    workspaceConfig.setName("ws123");
+    EnvironmentImpl environment = new EnvironmentImpl();
+    environment.setRecipe(new RecipeImpl("dockerimage", null, null, null));
+    workspaceConfig.getEnvironments().put("env1", environment);
+
+    workspaceConfig.getCommands().add(new CommandImpl("cmd1", "echo Hello", "custom"));
+
+    Tool dockerimageTool = new Tool().withName("dockerimageTool");
+    when(dockerimageToolApplier.from(any(), any())).thenReturn(dockerimageTool);
+
+    // when
+    Devfile devfile = devfileConverter.workspaceToDevFile(workspaceConfig);
+
+    // then
+    assertEquals(devfile.getCommands().size(), 1);
+    Command command = devfile.getCommands().get(0);
+    assertEquals(command.getActions().size(), 1);
+    assertEquals(command.getActions().get(0).getTool(), "dockerimageTool");
   }
 
   private String getTestResource(String resource) throws IOException {

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileManagerTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileManagerTest.java
@@ -56,6 +56,7 @@ public class DevfileManagerTest {
   private DevfileConverter devfileConverter;
   @Mock private WorkspaceManager workspaceManager;
   @Mock private KubernetesToolApplier kubernetesToolApplier;
+  @Mock private DockerimageToolApplier dockerimageToolApplier;
 
   private DevfileManager devfileManager;
 
@@ -63,7 +64,7 @@ public class DevfileManagerTest {
   public void setUp() throws Exception {
     schemaValidator = spy(new DevfileSchemaValidator(new DevfileSchemaProvider()));
     integrityValidator = spy(new DevfileIntegrityValidator());
-    devfileConverter = spy(new DevfileConverter(kubernetesToolApplier));
+    devfileConverter = spy(new DevfileConverter(kubernetesToolApplier, dockerimageToolApplier));
     devfileManager =
         new DevfileManager(schemaValidator, integrityValidator, devfileConverter, workspaceManager);
   }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DockerimageToolApplierTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DockerimageToolApplierTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.devfile.server;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
+import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Map;
+import org.eclipse.che.api.devfile.model.Devfile;
+import org.eclipse.che.api.devfile.model.Endpoint;
+import org.eclipse.che.api.devfile.model.Env;
+import org.eclipse.che.api.devfile.model.Tool;
+import org.eclipse.che.api.devfile.model.Volume;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link DockerimageToolApplier}.
+ *
+ * @author Sergii Leshchenko
+ */
+public class DockerimageToolApplierTest {
+
+  private static final String PROJECTS_MOUNT_PATH = "/projects";
+
+  private Devfile devfile;
+  private WorkspaceConfigImpl workspaceConfig;
+
+  private DockerimageToolApplier applier;
+
+  @BeforeMethod
+  public void setUp() {
+    applier = new DockerimageToolApplier(PROJECTS_MOUNT_PATH);
+    workspaceConfig = new WorkspaceConfigImpl();
+    devfile = new Devfile().withTools(new ArrayList<>());
+  }
+
+  @Test(
+      expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = "The tool must have `dockerimage` type")
+  public void shouldThrowExceptionIfNonDockerimageToolIsSpecified() throws Exception {
+    applier.apply(new Tool().withType("cheEditor"), devfile, workspaceConfig);
+  }
+
+  @Test
+  public void shouldProvisionEnvironmentWithDockerimageRecipe() throws Exception {
+    // given
+    Tool dockerimageTool =
+        new Tool()
+            .withName("jdk")
+            .withType(DOCKERIMAGE_TOOL_TYPE)
+            .withImage("eclipse/ubuntu_jdk8:latest")
+            .withMemoryLimit("1G");
+
+    devfile.getTools().add(dockerimageTool);
+
+    // when
+    applier.apply(dockerimageTool, devfile, workspaceConfig);
+
+    // then
+    String defaultEnvName = workspaceConfig.getDefaultEnv();
+    assertNotNull(defaultEnvName);
+    EnvironmentImpl defaultEnv = workspaceConfig.getEnvironments().get(defaultEnvName);
+    RecipeImpl recipe = defaultEnv.getRecipe();
+    assertEquals(recipe.getType(), "dockerimage");
+    assertEquals(recipe.getContent(), "eclipse/ubuntu_jdk8:latest");
+
+    assertEquals(defaultEnv.getMachines().size(), 1);
+
+    MachineConfigImpl machineConfig = defaultEnv.getMachines().get("jdk");
+    assertNotNull(machineConfig);
+  }
+
+  @Test
+  public void shouldProvisionMachineConfigWithEnvVarSpecified() throws Exception {
+    // given
+    Tool dockerimageTool =
+        new Tool()
+            .withName("jdk")
+            .withType(DOCKERIMAGE_TOOL_TYPE)
+            .withImage("eclipse/ubuntu_jdk8:latest")
+            .withMemoryLimit("1G")
+            .withEnv(singletonList(new Env().withName("envName").withValue("envValue")));
+
+    devfile.getTools().add(dockerimageTool);
+
+    // when
+    applier.apply(dockerimageTool, devfile, workspaceConfig);
+
+    // then
+    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    Map<String, String> envVars = machineConfig.getEnv();
+    assertEquals(envVars.size(), 1);
+    assertEquals(envVars.get("envName"), "envValue");
+  }
+
+  @Test
+  public void shouldProvisionMachineConfigWithMemoryLimitAttributeServersSpecified()
+      throws Exception {
+    // given
+    Tool dockerimageTool =
+        new Tool()
+            .withName("jdk")
+            .withType(DOCKERIMAGE_TOOL_TYPE)
+            .withImage("eclipse/ubuntu_jdk8:latest")
+            .withMemoryLimit("1G");
+
+    devfile.getTools().add(dockerimageTool);
+
+    // when
+    applier.apply(dockerimageTool, devfile, workspaceConfig);
+
+    // then
+    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    assertEquals(machineConfig.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE), "1000000000");
+  }
+
+  @Test
+  public void shouldProvisionMachineConfigWithConfiguredServers() throws Exception {
+    // given
+    Endpoint endpoint =
+        new Endpoint()
+            .withName("jdk-ls")
+            .withPort(4923)
+            .withAttributes(
+                ImmutableMap.of(
+                    "protocol",
+                    "http",
+                    "path",
+                    "/ls",
+                    "public",
+                    "false",
+                    "secure",
+                    "false",
+                    "discoverable",
+                    "true"));
+    Tool dockerimageTool =
+        new Tool()
+            .withName("jdk")
+            .withType(DOCKERIMAGE_TOOL_TYPE)
+            .withImage("eclipse/ubuntu_jdk8:latest")
+            .withMemoryLimit("1G")
+            .withEndpoints(singletonList(endpoint));
+
+    devfile.getTools().add(dockerimageTool);
+
+    // when
+    applier.apply(dockerimageTool, devfile, workspaceConfig);
+
+    // then
+    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    assertEquals(machineConfig.getServers().size(), 1);
+    ServerConfigImpl serverConfig = machineConfig.getServers().get("jdk-ls");
+    assertEquals(serverConfig.getProtocol(), "http");
+    assertEquals(serverConfig.getPath(), "/ls");
+    assertEquals(serverConfig.getPort(), "4923");
+    Map<String, String> attributes = serverConfig.getAttributes();
+    assertEquals(attributes.size(), 3);
+    assertEquals(attributes.get("public"), "false");
+    assertEquals(attributes.get("secure"), "false");
+    assertEquals(attributes.get("discoverable"), "true");
+  }
+
+  @Test
+  public void shouldProvisionServersWithHttpPortIsTheCorrespondingAttrIsMissing() throws Exception {
+    // given
+    Endpoint endpoint = new Endpoint().withName("jdk-ls").withPort(4923).withAttributes(emptyMap());
+    Tool dockerimageTool =
+        new Tool()
+            .withName("jdk")
+            .withType(DOCKERIMAGE_TOOL_TYPE)
+            .withImage("eclipse/ubuntu_jdk8:latest")
+            .withMemoryLimit("1G")
+            .withEndpoints(singletonList(endpoint));
+
+    devfile.getTools().add(dockerimageTool);
+
+    // when
+    applier.apply(dockerimageTool, devfile, workspaceConfig);
+
+    // then
+    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    assertEquals(machineConfig.getServers().size(), 1);
+    ServerConfigImpl serverConfig = machineConfig.getServers().get("jdk-ls");
+    assertEquals(serverConfig.getProtocol(), "http");
+  }
+
+  @Test
+  public void shouldProvisionMachineConfigWithConfiguredVolumes() throws Exception {
+    // given
+    Tool dockerimageTool =
+        new Tool()
+            .withName("jdk")
+            .withType(DOCKERIMAGE_TOOL_TYPE)
+            .withImage("eclipse/ubuntu_jdk8:latest")
+            .withMemoryLimit("1G")
+            .withVolumes(
+                singletonList(new Volume().withName("data").withContainerPath("/tmp/data/")));
+
+    devfile.getTools().add(dockerimageTool);
+
+    // when
+    applier.apply(dockerimageTool, devfile, workspaceConfig);
+
+    // then
+    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    VolumeImpl volume = machineConfig.getVolumes().get("data");
+    assertNotNull(volume);
+    assertEquals(volume.getPath(), "/tmp/data/");
+  }
+
+  @Test
+  public void shouldProvisionMachineConfigWithMountSources() throws Exception {
+    // given
+    Tool dockerimageTool =
+        new Tool()
+            .withName("jdk")
+            .withType(DOCKERIMAGE_TOOL_TYPE)
+            .withImage("eclipse/ubuntu_jdk8:latest")
+            .withMemoryLimit("1G")
+            .withMountSources(true);
+
+    // when
+    applier.apply(dockerimageTool, devfile, workspaceConfig);
+
+    // then
+    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    VolumeImpl projectsVolume = machineConfig.getVolumes().get(PROJECTS_VOLUME_NAME);
+    assertNotNull(projectsVolume);
+    assertEquals(projectsVolume.getPath(), PROJECTS_MOUNT_PATH);
+  }
+
+  @Test
+  public void shouldProvisionMachineConfigWithoutSourcesByDefault() throws Exception {
+    // given
+    Tool dockerimageTool =
+        new Tool()
+            .withName("jdk")
+            .withType(DOCKERIMAGE_TOOL_TYPE)
+            .withImage("eclipse/ubuntu_jdk8:latest")
+            .withMemoryLimit("1G");
+
+    // when
+    applier.apply(dockerimageTool, devfile, workspaceConfig);
+
+    // then
+    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    assertFalse(machineConfig.getVolumes().containsKey(PROJECTS_VOLUME_NAME));
+  }
+
+  private MachineConfigImpl getMachineConfig(
+      WorkspaceConfigImpl workspaceConfig, String machineName) {
+    String defaultEnvName = workspaceConfig.getDefaultEnv();
+    EnvironmentImpl defaultEnv = workspaceConfig.getEnvironments().get(defaultEnvName);
+
+    MachineConfigImpl machineConfig = defaultEnv.getMachines().get(machineName);
+    assertNotNull(machineConfig);
+
+    return machineConfig;
+  }
+}

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.api.devfile.server.validator;
 
+import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
@@ -135,6 +136,22 @@ public class DevfileIntegrityValidatorTest {
     broken
         .getTools()
         .add(new Tool().withName("os").withType(OPENSHIFT_TOOL_TYPE).withLocal("bar.yaml"));
+    // when
+    integrityValidator.validateDevfile(broken);
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Multiple non plugin or editor type tools found: 'k8s', 'dockerimage'")
+  public void shouldThrowExceptionOnKubernetesAndDockerimagesTools() throws Exception {
+    Devfile broken = copyOf(initialDevfile);
+    broken.getCommands().clear();
+    broken.getTools().clear();
+    broken
+        .getTools()
+        .add(new Tool().withName("k8s").withType(KUBERNETES_TOOL_TYPE).withLocal("foo.yaml"));
+    broken.getTools().add(new Tool().withName("dockerimage").withType(DOCKERIMAGE_TOOL_TYPE));
     // when
     integrityValidator.validateDevfile(broken);
   }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -41,7 +41,8 @@ public class DevfileSchemaValidatorTest {
   public Object[][] validDevfiles() {
     return new Object[][] {
       {"editor_plugin_tool/devfile_editor_plugins.yaml"},
-      {"kubernetes_openshift_tool/devfile_openshift_tool.yaml"}
+      {"kubernetes_openshift_tool/devfile_openshift_tool.yaml"},
+      {"dockerimage_tool/devfile_dockerimage_tool.yaml"}
     };
   }
 
@@ -104,12 +105,21 @@ public class DevfileSchemaValidatorTest {
       // cheEditor/chePlugin tool model testing
       {
         "editor_plugin_tool/devfile_editor_tool_with_missing_id.yaml",
-        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 2\\)\\]"
+        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\)\\]"
       },
       // kubernetes/openshift tool model testing
       {
         "kubernetes_openshift_tool/devfile_openshift_tool_with_missing_local.yaml",
-        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 2\\)\\]"
+        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\)\\]"
+      },
+      // Dockerimage tool model testing
+      {
+        "dockerimage_tool/devfile_dockerimage_tool_with_missing_image.yaml",
+        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\)\\]"
+      },
+      {
+        "dockerimage_tool/devfile_dockerimage_tool_with_missing_memory_limit.yaml",
+        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\)\\]"
       },
     };
   }

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/command/devfile_missing_command_actions.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/command/devfile_missing_command_actions.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+ - name: theia
+   type: cheEditor
+   id: eclipse/theia:0.0.3
+commands:
+  - name: build

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/command/devfile_missing_command_name.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/command/devfile_missing_command_name.yaml
@@ -13,17 +13,12 @@
 ---
 specVersion: 0.0.1
 name: petclinic-dev-environment
-projects:
-  - name: petclinic
-    source:
-      type: git
-      location: 'git@github.com:spring-projects/spring-petclinic.git'
 tools:
-  - type: chePlugin
-    id: eclipse/maven-jdk8:1.0.0
+ - name: theia
+   type: cheEditor
+   id: eclipse/theia:0.0.3
 commands:
-  - name: build
-    actions:
+  - actions:
       - type: exec
         tool: mvn-stack
         command: mvn package

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/command/devfile_multiple_commands_actions.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/command/devfile_multiple_commands_actions.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: openshift
+    local: petclinic.yaml
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+commands:
+  - name: build
+    actions:
+      - type: exec
+        tool: mysql
+        command: mvn clean
+        workdir: /projects/spring-petclinic
+      - type: exec
+        tool: mysql
+        command: mvn package
+        workdir: /projects/spring-petclinic

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/devfile/devfile_missing_name.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/devfile/devfile_missing_name.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+tools:
+  - name: maven
+    id: eclipse/maven-jdk8:1.0.0

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/devfile/devfile_missing_spec_version.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/devfile/devfile_missing_spec_version.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+name: petclinic-dev-environment
+tools:
+  - name: maven
+    id: eclipse/maven-jdk8:1.0.0

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/devfile/devfile_with_undeclared_field.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/devfile/devfile_with_undeclared_field.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+unknown: blah-blah
+tools:
+  - name: maven
+    type: chePlugin
+    id: eclipse/maven-jdk8:1.0.0

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: maven
+    type: dockerimage
+    image: eclipe/maven-jdk8:latest
+    volumes:
+      - name: maven-repo
+        containerPath: /root/.m2
+    env:
+      - name: ENV_VAR
+        value: value
+    endpoints:
+      - name: maven-server
+        port: 3101
+        attributes:
+          protocol: http
+          secure: 'true'
+          public: 'true'
+          discoverable: 'false'
+    memoryLimit: 1536M

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool_with_missing_image.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool_with_missing_image.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: maven
+    type: dockerimage
+    memoryLimit: 1G

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool_with_missing_memory_limit.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool_with_missing_memory_limit.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: maven
+    type: dockerimage
+    image: eclipse/ubuntu-jdk:latest

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_tool/devfile_editor_plugins.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_tool/devfile_editor_plugins.yaml
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+projects:
+  - name: petclinic
+    source:
+      type: git
+      location: 'git@github.com:spring-projects/spring-petclinic.git'
+tools:
+  - name: theia-ide
+    type: cheEditor
+    id: eclipse/theia:0.0.3
+  - name: mvn-stack
+    type: chePlugin
+    id: eclipse/maven-jdk8:1.0.0
+  - name: jdt.ls
+    type: chePlugin
+    id: eclipse/theia-jdtls:0.0.3
+commands:
+  - name: build
+    actions:
+      - type: exec
+        tool: mvn-stack
+        command: mvn package
+        workdir: /projects/spring-petclinic

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_tool/devfile_editor_tool_with_missing_id.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_tool/devfile_editor_tool_with_missing_id.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: theia-ide
+    type: cheEditor

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: openshift
+    local: petclinic.yaml
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+commands:
+  - name: build
+    actions:
+      - type: exec
+        tool: mysql
+        command: mvn clean
+        workdir: /projects/spring-petclinic

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_with_missing_local.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_with_missing_local.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: openshift

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/tool/devfile_missing_tool_name.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/tool/devfile_missing_tool_name.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - type: chePlugin
+    id: eclipse/maven-jdk8:1.0.0

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/tool/devfile_missing_tool_type.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/tool/devfile_missing_tool_type.yaml
@@ -13,18 +13,6 @@
 ---
 specVersion: 0.0.1
 name: petclinic-dev-environment
-projects:
-  - name: petclinic
-    source:
-      type: git
-      location: 'git@github.com:spring-projects/spring-petclinic.git'
 tools:
-  - name: mvn-stack
-    type: chePlugin
+  - name: maven
     id: eclipse/maven-jdk8:1.0.0
-  - name: theia-ide
-    type: cheEditor
-    id: eclipse/theia:0.0.3
-  - name: jdt.ls
-    type: chePlugin
-    id: eclipse/theia-jdtls:0.0.3

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/tool/devfile_tool_with_undeclared_field.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/tool/devfile_tool_with_undeclared_field.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - type: chePlugin
+    name: maven
+    id: eclipse/maven-jdk8:1.0.0
+    unknown: blah-blah


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is adding support of dockerimage tool in Devfile.

But it also contains the following Devfile API improvements:
1. Improve devfile.json:
  * Deny additional properties for Tool;
  * Make tool implementation specific fields required accordingly to type value;
  * Limit actions number in command to 1 item since we don't support more yet;
2. Add testing of Devfile JSON Schema. It allows us to guarantee that no any restrictions are broken because of a typo in `devfile.json` or validator implementation we use (I faced an issue that we declare our devfile.json as JSON Spec 07 Draft but validator that we use don't support `if/then/else` statements and just skip them.
It also allows seeing an error message that is thrown by a validator in the source code, like `instance failed to match exactly one schema (matched 0 out of 3)` when `chePlugin` tool does not have id required field. It is a definitely confusing message and we should consider rewriting `devfile.json`/use another validator/customize current one to make a message more clear.

As an example of `che-in-che` Devfile with dockerimage
<details>
<summary>Che-in-Che Devfile with dockerimage tool used</summary>

```yaml
specVersion: 0.0.1
name: che-in-che
projects:
  - name: che
    source:
      type: git
      location: 'https://github.com/eclipse/che.git'
tools:
  - name: theia-editor
    type: cheEditor
    id: org.eclipse.che.editor.theia:1.0.0
  - name: exec-plugin
    type: chePlugin
    id: che-machine-exec-plugin:0.0.1
  - name: che-dev
    type: dockerimage
    image: eclipse/che-dev:nightly
    env:
      - name: TEST_ENV_VAR
        value: -\_-_-_/-
    endpoints:
      - name: tomcat
        port: 8080
        attributes:
          public: 'true'
    volumes:
      - name: maven
        containerPath: /home/user/.m2
    memoryLimit: 1536M
    mountSources: true
commands:
  - name: build
    actions:
      - type: exec
        tool: che-dev
        command: cd /projects/che && mvn -Pnative clean install
        workdir: /projects/che
```
</details>

To test changes the following link might be used `{CHE_HOST}/f?url=https://github.com/sleshchenko/che/tree/dockerimage-che-in-che`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12389

#### Release Notes
Added support of `dockerimage` tool in Devfile. It allows defining one container tool much easier than using other tools types. The detailed description of Devfile format see https://redhat-developer.github.io/devfile.

#### Docs PR
I think `devfile.json` contains all the needed changes.