### PR TITLE
Set kubernetes namespace to null on workspace recipe parsing

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
@@ -124,6 +124,9 @@ public class KubernetesEnvironmentFactory
       checkNotNull(object.getMetadata(), "%s metadata must not be null", object.getKind());
       checkNotNull(object.getMetadata().getName(), "%s name must not be null", object.getKind());
 
+      // needed because Che master namespace is set by K8s API during list loading
+      object.getMetadata().setNamespace(null);
+
       if (object instanceof Pod) {
         Pod pod = (Pod) object;
         pods.put(pod.getMetadata().getName(), pod);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/environment/OpenShiftEnvironmentFactory.java
@@ -125,6 +125,9 @@ public class OpenShiftEnvironmentFactory extends InternalEnvironmentFactory<Open
       checkNotNull(object.getMetadata(), "%s metadata must not be null", object.getKind());
       checkNotNull(object.getMetadata().getName(), "%s name must not be null", object.getKind());
 
+      // needed because Che master namespace is set by K8s API during list loading
+      object.getMetadata().setNamespace(null);
+
       if (object instanceof DeploymentConfig) {
         throw new ValidationException("Supporting of deployment configs is not implemented yet.");
       } else if (object instanceof Pod) {


### PR DESCRIPTION
### What does this PR do?
Set kubernetes namespace to null on workspace recipe parsing.
Needed because current parsing sets Che master namespace and objects need to be created in another namespace in some cases.  
Thanks, @sleshchenko for the solution idea.  
Checked on minikube.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/12626

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
