### PR TITLE
Enable getting workspace events from ReplicaSets and Deployments

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -383,7 +383,7 @@ che.infra.kubernetes.ingress_start_timeout_min=5
 
 # If during workspace startup an unrecoverable event defined in the property occurs,
 # terminate workspace immediately instead of waiting until timeout
-che.infra.kubernetes.workspace_unrecoverable_events=FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image
+che.infra.kubernetes.workspace_unrecoverable_events=FailedMount,FailedScheduling,MountVolume.SetUp failed,Failed to pull image,FailedCreate
 
 che.infra.kubernetes.bootstrapper.binary_url=http://${CHE_HOST}:${CHE_PORT}/agent-binaries/linux_amd64/bootstrapper/bootstrapper
 che.infra.kubernetes.bootstrapper.installer_timeout_sec=180

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -32,7 +32,6 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -646,10 +645,14 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
     // namespace.pods().watch(new AbnormalStopHandler());
     namespace.deployments().watchEvents(new MachineLogsPublisher());
     if (unrecoverableEventListenerFactory.isConfigured()) {
-      Set<String> toWatch = new HashSet<>();
       KubernetesEnvironment environment = getContext().getEnvironment();
-      toWatch.addAll(environment.getPodsCopy().keySet());
-      toWatch.addAll(environment.getDeploymentsCopy().keySet());
+      Set<String> toWatch =
+          environment
+              .getPodsData()
+              .values()
+              .stream()
+              .map(podData -> podData.getMetadata().getName())
+              .collect(Collectors.toSet());
       namespace
           .deployments()
           .watchEvents(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -93,6 +93,8 @@ public class KubernetesDeployments {
   public static final int POD_CREATION_TIMEOUT_MIN = 1;
 
   private static final String POD_OBJECT_KIND = "Pod";
+  private static final String REPLICASET_OBJECT_KIND = "ReplicaSet";
+  private static final String DEPLOYMENT_OBJECT_KIND = "Deployment";
   // error stream data initial capacity
   public static final int ERROR_BUFF_INITIAL_CAP = 2048;
   public static final String STDOUT = "stdout";
@@ -472,7 +474,9 @@ public class KubernetesDeployments {
             public void eventReceived(Action action, Event event) {
               ObjectReference involvedObject = event.getInvolvedObject();
 
-              if (POD_OBJECT_KIND.equals(involvedObject.getKind())) {
+              if (POD_OBJECT_KIND.equals(involvedObject.getKind())
+                  || REPLICASET_OBJECT_KIND.equals(involvedObject.getKind())
+                  || DEPLOYMENT_OBJECT_KIND.equals(involvedObject.getKind())) {
 
                 String podName = involvedObject.getName();
 


### PR DESCRIPTION
### What does this PR do?
- Changes `KubernetesDeployments#watchEvents` handle events from replica sets and deployments in addition to pods. This is necessary because when a deployment cannot scale a replica set up due to quota limits, the event occurs on the replica set (since no pod exists)
- Fix regression (?) where **no** unrecoverable events were handled in some cases, due to changes in how `KubernetesEnvironment` works.
  - Basic gist: `KubernetesEnvironment.pods.keys()` did not get provisioned names (i.e. it would be `dockerimage` instead of `<workspace-id>.dockerimage`) which broke matching events to workspaces.
- Add `FailedCreate` to unrecoverable events to catch quota issues.

### What issues does this PR fix or reference?
#12593

### Testing
Create a workspace with memory higher than quota. It should fail with a sensible message. A sample quota that works with the default che deployment and a workspace requesting 1.1GB memory is:
```yaml
apiVersion: v1
kind: ResourceQuota
metadata:
  name: compute-resources
spec:
  hard:
    limits.memory: 2Gi
  scopes:
  - NotTerminating
status: {}

```

### Potential improvements
- There's no rate limiting, and all unrecoverable events are logged. In the case of quota issues, this results in >10 identical messages.
- In the case of a pod requesting more memory than is allowed, we still have to wait 1 minute for `POD_CREATION_TIMEOUT` to elapse. This is because we wait [here](https://github.com/eclipse/che/blob/e596a28030f34b94a49926fc5582c6ca0f4ecf99/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java#L187) and this future does not get completed since no pods are changed. Instead startup should fail as soon as the event is received, but I don't see a clean way to improve this.