### PR TITLE
Provision plugin attribute for machines that contains related plugin id

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptyList;
 import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DIRECTORY_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.CONTAINER_SOURCE_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.PLUGIN_MACHINE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.TOOL_CONTAINER_SOURCE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider.SECURE_EXPOSER_IMPL_PROPERTY;
 
@@ -215,6 +216,7 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
 
     InternalMachineConfig machineConfig = machineResolver.resolve();
     machineConfig.getAttributes().put(CONTAINER_SOURCE_ATTRIBUTE, TOOL_CONTAINER_SOURCE);
+    machineConfig.getAttributes().put(PLUGIN_MACHINE_ATTRIBUTE, chePlugin.getId());
     kubernetesEnvironment.getMachines().put(machineName, machineConfig);
 
     sidecarRelatedCommands.forEach(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -447,7 +447,7 @@ public class KubernetesPluginsToolingApplierTest {
   }
 
   @Test
-  public void setsSourceAndPluginAttributeForMachineAssociatedWithContainer() throws Exception {
+  public void setsSourceAndPluginAttributeForMachineAssociatedWithSidecar() throws Exception {
     ChePlugin chePlugin = createChePlugin();
 
     applier.apply(runtimeIdentity, internalEnvironment, singletonList(chePlugin));

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -20,6 +20,9 @@ import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DIRECTORY_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.CONTAINER_SOURCE_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.PLUGIN_MACHINE_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.TOOL_CONTAINER_SOURCE;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_ORIGINAL_NAME_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider.SECURE_EXPOSER_IMPL_PROPERTY;
@@ -441,6 +444,18 @@ public class KubernetesPluginsToolingApplierTest {
         machineConfig.getServers(),
         expectedSingleServer(
             443, "test-port", singletonMap("attr1", "value1"), true, "https", "/path/1"));
+  }
+
+  @Test
+  public void setsSourceAndPluginAttributeForMachineAssociatedWithContainer() throws Exception {
+    ChePlugin chePlugin = createChePlugin();
+
+    applier.apply(runtimeIdentity, internalEnvironment, singletonList(chePlugin));
+
+    InternalMachineConfig machineConfig = getOneAndOnlyNonUserMachine(internalEnvironment);
+    Map<String, String> attributes = machineConfig.getAttributes();
+    assertEquals(attributes.get(CONTAINER_SOURCE_ATTRIBUTE), TOOL_CONTAINER_SOURCE);
+    assertEquals(attributes.get(PLUGIN_MACHINE_ATTRIBUTE), chePlugin.getId());
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -34,15 +34,12 @@ public final class Constants {
   public static final String LINK_REL_CREATE_STACK = "create stack";
   public static final String LINK_REL_UPDATE_STACK = "update stack";
   public static final String LINK_REL_REMOVE_STACK = "remove stack";
-  public static final String LINK_REL_GET_STACK_BY_ID = "get stack by id";
-  public static final String LINK_REL_GET_STACKS_BY_CREATOR = "get stacks by creator";
+  public static final String LINK_REL_GET_STACK_BY_ID = "get stack by id";;
   public static final String LINK_REL_SEARCH_STACKS = "search stacks";
 
   public static final String LINK_REL_GET_ICON = "get icon link";
   public static final String LINK_REL_UPLOAD_ICON = "upload icon link";
   public static final String LINK_REL_DELETE_ICON = "delete icon link";
-
-  public static final String WS_AGENT_PROCESS_NAME = "CheWsAgent";
 
   public static final String CHE_WORKSPACE_AUTO_START = "che.workspace.auto_start";
 
@@ -162,8 +159,6 @@ public final class Constants {
   public static final String SERVER_EXEC_AGENT_WEBSOCKET_REFERENCE = "exec-agent/ws";
 
   public static final String WS_AGENT_PORT = "4401/tcp";
-
-  public static final String WS_MACHINE_NAME = "default";
 
   public static final String SUPPORTED_RECIPE_TYPES = "supportedRecipeTypes";
 

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.shared;
 
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
+import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 
 /**
@@ -168,8 +169,15 @@ public final class Constants {
 
   public static final String NO_ENVIRONMENT_RECIPE_TYPE = "no-environment";
 
-  /** Attribute to mark source of the container. */
+  /** Attribute of {@link Machine} to mark source of the container. */
   public static final String CONTAINER_SOURCE_ATTRIBUTE = "source";
+
+  /**
+   * Attribute of {@link Machine} that indicates by which plugin this machines is provisioned
+   *
+   * <p>It contains plugin id, like "plugin": "org.eclipse.che.editor.theia"
+   */
+  public static final String PLUGIN_MACHINE_ATTRIBUTE = "plugin";
 
   /** Mark containers applied to workspace with help recipe definition. */
   public static final String RECIPE_CONTAINER_SOURCE = "recipe";


### PR DESCRIPTION
### What does this PR do?
Added provisioning of plugin attribute for machines that contains related plugin id.
It's a small improvement that allows clients to match plugin with related Che Machines.

<details>

<summary>See how it affects workspace JSON</summary>

```json
{
    "links": {
        ...
    },
    "attributes": {
        
    },
    "namespace": "che",
    "temporary": false,
    "id": "workspacengy67s8og43vik8i",
    "status": "STARTING",
    "runtime": {
        "machines": {
            "ws/theia-ide": {
                "attributes": {
                    "memoryLimitBytes": "1536000000",
                    "memoryRequestBytes": "1536000000",
                    "source": "tool",
                    "plugin": "org.eclipse.che.editor.theia"
                },
                "servers": {
                    ...
                },
                "status": "STARTING"
            },
            "ws/che-machine-exec": {
                "attributes": {
                    "memoryLimitBytes": "134217728",
                    "memoryRequestBytes": "134217728",
                    "source": "tool",
                    "plugin": "che-machine-exec-plugin"
                },
                "servers": {
                    ...
                },
                "status": "STARTING"
            },
            "ws/dev": {
                "attributes": {
                    "memoryLimitBytes": "536870912",
                    "memoryRequestBytes": "536870912",
                    "source": "recipe"
                },
                "servers": {},
                "status": "STARTING"
            }
        },
        "warnings": [],
        "activeEnv": "default",
        "commands": [],
        "machineToken": "",
        "links": []
    },
    "config": {
        ...
}
```

</details>

It also contains removing of unused constants from Workspace API

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
N/A