### PR TITLE
Use Java Base64 method instead of javax.xml.bind.DatatypeConverter

### DIFF
--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestGitHubServiceClient.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/client/TestGitHubServiceClient.java
@@ -22,9 +22,9 @@ import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import javax.xml.bind.DatatypeConverter;
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.rest.HttpJsonRequestFactory;
 import org.eclipse.che.api.core.rest.HttpJsonResponse;
@@ -223,7 +223,7 @@ public class TestGitHubServiceClient {
   private String createBasicAuthHeader(String username, String password)
       throws UnsupportedEncodingException {
     byte[] nameAndPass = (username + ":" + password).getBytes("UTF-8");
-    String base64 = DatatypeConverter.printBase64Binary(nameAndPass);
+    String base64 = Base64.getEncoder().encodeToString(nameAndPass);
     return "Basic " + base64;
   }
 }


### PR DESCRIPTION
### What does this PR do?

Fix import when using Java11

Change-Id: I8434bc583734fb5fa2ceb007ab02628afed735d8
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A


#### Docs PR
N/A
