### PR TITLE
Added -f -S flags for curl commands in installers

### DIFF
--- a/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.script.sh
+++ b/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.script.sh
@@ -198,7 +198,7 @@ else
     elif curl ${CA_ARG} -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
       curl ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
     fi
-    curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
+    curl -sSf $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
   else
     CA_ARG=""
     if [ -f /tmp/che/secret/ca.crt ]; then

--- a/agents/terminal/src/main/resources/installers/1.0.1/org.eclipse.che.terminal.script.sh
+++ b/agents/terminal/src/main/resources/installers/1.0.1/org.eclipse.che.terminal.script.sh
@@ -193,7 +193,7 @@ else
     elif curl ${CA_ARG} -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
       curl ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
     fi
-    curl -s $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
+    curl -sSf $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
   else
     CA_ARG=""
     if [ -f /tmp/che/secret/ca.crt ]; then

--- a/wsagent/agent/src/main/resources/installers/1.0.3/org.eclipse.che.ws-agent.script.sh
+++ b/wsagent/agent/src/main/resources/installers/1.0.3/org.eclipse.che.ws-agent.script.sh
@@ -272,7 +272,7 @@ else
         CA_ARG="--cacert /tmp/che/secret/ca.crt"
       fi
 
-      curl -s ${CA_ARG} ${AGENT_BINARIES_URI} | tar  xzf - -C ${CHE_DIR}/ws-agent
+      curl -sSf ${CA_ARG} ${AGENT_BINARIES_URI} | tar  xzf - -C ${CHE_DIR}/ws-agent
     else
       # replace https by http as wget may not be able to handle ssl
       AGENT_BINARIES_URI=$(echo ${AGENT_BINARIES_URI} | sed 's/https/http/g')


### PR DESCRIPTION
### What does this PR do?
Added -f -S flags for curl commands in installers.
From `curl --help`:
1. ` -f, --fail          Fail silently (no output at all) on HTTP errors` <- fails if http code is not 2XX
2. `-S, --show-error    Show error even when -s is used`

How it looks like if workspace agent binaries are missing in Che Server packaging
![screenshot_20190218_174737](https://user-images.githubusercontent.com/5887312/52962389-ce94f600-33a5-11e9-9319-4e1f88c5f1b7.png)
We can see a message that could help to understand the cause of failing
```
curl: (22) The requested URL returned error: 404
```
Previously it was not clear why archive is not valid
![screenshot_20190218_175956](https://user-images.githubusercontent.com/5887312/52962858-081a3100-33a7-11e9-8af8-a55ef72a91d7.png)

### What issues does this PR fix or reference?
It's related to https://github.com/eclipse/che/issues/12677

#### Release Notes
N/A

#### Docs PR
N/A