### PR TITLE
API info service to use meta-info from war-s manifest instead of jar

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoProvider.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoProvider.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.rest;
+
+import java.io.InputStream;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import org.eclipse.che.api.core.rest.shared.dto.ApiInfo;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class ApiInfoProvider implements Provider<ApiInfo> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ApiInfoProvider.class);
+
+  private ApiInfo apiInfo;
+
+  @Inject
+  public ApiInfoProvider(@Context ServletContext context) {
+    this.apiInfo = readApiInfo(context);
+  }
+
+  @Override
+  public ApiInfo get() {
+    return apiInfo;
+  }
+
+  private ApiInfo readApiInfo(ServletContext context) {
+    try {
+      try (InputStream inputStream = context.getResourceAsStream("/META-INF/MANIFEST.MF")) {
+        final Manifest manifest = new Manifest(inputStream);
+        final Attributes mainAttributes = manifest.getMainAttributes();
+        final DtoFactory dtoFactory = DtoFactory.getInstance();
+        return dtoFactory
+            .createDto(ApiInfo.class)
+            .withSpecificationVendor(mainAttributes.getValue("Specification-Vendor"))
+            .withImplementationVendor(mainAttributes.getValue("Implementation-Vendor"))
+            .withSpecificationTitle("Codenvy REST API")
+            .withSpecificationVersion(mainAttributes.getValue("Specification-Version"))
+            .withImplementationVersion(mainAttributes.getValue("Implementation-Version"))
+            .withScmRevision(mainAttributes.getValue("SCM-Revision"));
+      }
+    } catch (Exception e) {
+      LOG.error("Unable to read API info. Error: " + e.getMessage(), e);
+      throw new RuntimeException("Unable to read API information", e);
+    }
+  }
+}

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoProvider.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoProvider.java
@@ -56,7 +56,7 @@ public class ApiInfoProvider implements Provider<ApiInfo> {
             .createDto(ApiInfo.class)
             .withSpecificationVendor(mainAttributes.getValue("Specification-Vendor"))
             .withImplementationVendor(mainAttributes.getValue("Implementation-Vendor"))
-            .withSpecificationTitle("Codenvy REST API")
+            .withSpecificationTitle("Che REST API")
             .withSpecificationVersion(mainAttributes.getValue("Specification-Version"))
             .withImplementationVersion(mainAttributes.getValue("Implementation-Version"))
             .withScmRevision(mainAttributes.getValue("SCM-Revision"));

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoProvider.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoProvider.java
@@ -24,6 +24,11 @@ import org.eclipse.che.dto.server.DtoFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Provides api info by reading it from war manifest.
+ *
+ * @author Max Shaposhnyk
+ */
 @Singleton
 public class ApiInfoProvider implements Provider<ApiInfo> {
 

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
@@ -14,6 +14,7 @@ package org.eclipse.che.api.core.rest;
 import static java.util.stream.Collectors.toList;
 
 import java.io.InputStream;
+import java.lang.ref.SoftReference;
 import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -43,13 +44,14 @@ import org.slf4j.LoggerFactory;
 public class ApiInfoService {
   private static final Logger LOG = LoggerFactory.getLogger(ApiInfoService.class);
 
-  private volatile ApiInfo apiInfo;
+  private SoftReference<ApiInfo> apiInfo = new SoftReference<>(null);
 
   @OPTIONS
   public ApiInfo info(@Context ServletContext context) throws ServerException {
-    ApiInfo myApiInfo = apiInfo;
+    ApiInfo myApiInfo = apiInfo.get();
     if (myApiInfo == null) {
-      apiInfo = myApiInfo = readApiInfo(context);
+      myApiInfo = readApiInfo(context);
+      apiInfo = new SoftReference<>(myApiInfo);
     }
     return myApiInfo;
   }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
@@ -13,66 +13,32 @@ package org.eclipse.che.api.core.rest;
 
 import static java.util.stream.Collectors.toList;
 
-import java.io.InputStream;
 import java.util.function.Function;
-import java.util.jar.Attributes;
-import java.util.jar.Manifest;
-import javax.inject.Singleton;
+import javax.inject.Inject;
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
-import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.rest.annotations.OPTIONS;
 import org.eclipse.che.api.core.rest.shared.dto.ApiInfo;
 import org.eclipse.che.commons.annotation.Nullable;
-import org.eclipse.che.dto.server.DtoFactory;
 import org.everrest.core.ObjectFactory;
 import org.everrest.core.ResourceBinder;
 import org.everrest.core.resource.ResourceDescriptor;
 import org.everrest.services.RestServicesList.RootResource;
 import org.everrest.services.RestServicesList.RootResourcesList;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** @author andrew00x */
 @Path("/")
-@Singleton
 public class ApiInfoService {
-  private static final Logger LOG = LoggerFactory.getLogger(ApiInfoService.class);
 
-  private ApiInfo apiInfo;
+  @Inject private ApiInfoProvider apiInfoProvider;
 
   @OPTIONS
-  public ApiInfo info(@Context ServletContext context) throws ServerException {
-    ApiInfo myApiInfo = apiInfo;
-    if (myApiInfo == null) {
-      apiInfo = myApiInfo = readApiInfo(context);
-    }
-    return myApiInfo;
-  }
-
-  private ApiInfo readApiInfo(ServletContext context) throws ServerException {
-    try {
-      try (InputStream inputStream = context.getResourceAsStream("/META-INF/MANIFEST.MF")) {
-        final Manifest manifest = new Manifest(inputStream);
-        final Attributes mainAttributes = manifest.getMainAttributes();
-        final DtoFactory dtoFactory = DtoFactory.getInstance();
-        return dtoFactory
-            .createDto(ApiInfo.class)
-            .withSpecificationVendor(mainAttributes.getValue("Specification-Vendor"))
-            .withImplementationVendor(mainAttributes.getValue("Implementation-Vendor"))
-            .withSpecificationTitle("Codenvy REST API")
-            .withSpecificationVersion(mainAttributes.getValue("Specification-Version"))
-            .withImplementationVersion(mainAttributes.getValue("Implementation-Version"))
-            .withScmRevision(mainAttributes.getValue("SCM-Revision"));
-      }
-    } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
-      throw new ServerException("Unable read info about API. Contact support for assistance.");
-    }
+  public ApiInfo info() {
+    return apiInfoProvider.get();
   }
 
   @GET

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
@@ -14,7 +14,6 @@ package org.eclipse.che.api.core.rest;
 import static java.util.stream.Collectors.toList;
 
 import java.io.InputStream;
-import java.lang.ref.SoftReference;
 import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
@@ -44,14 +43,13 @@ import org.slf4j.LoggerFactory;
 public class ApiInfoService {
   private static final Logger LOG = LoggerFactory.getLogger(ApiInfoService.class);
 
-  private SoftReference<ApiInfo> apiInfo = new SoftReference<>(null);
+  private ApiInfo apiInfo;
 
   @OPTIONS
   public ApiInfo info(@Context ServletContext context) throws ServerException {
-    ApiInfo myApiInfo = apiInfo.get();
+    ApiInfo myApiInfo = apiInfo;
     if (myApiInfo == null) {
-      myApiInfo = readApiInfo(context);
-      apiInfo = new SoftReference<>(myApiInfo);
+      apiInfo = myApiInfo = readApiInfo(context);
     }
     return myApiInfo;
   }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
@@ -34,11 +34,11 @@ import org.everrest.services.RestServicesList.RootResourcesList;
 @Path("/")
 public class ApiInfoService {
 
-  @Inject private ApiInfoProvider apiInfoProvider;
+  @Inject private ApiInfo apiInfo;
 
   @OPTIONS
   public ApiInfo info() {
-    return apiInfoProvider.get();
+    return apiInfo;
   }
 
   @GET

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoService.java
@@ -11,11 +11,12 @@
  */
 package org.eclipse.che.api.core.rest;
 
-import com.google.common.base.Function;
+import static java.util.stream.Collectors.toList;
+
 import java.io.InputStream;
+import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import java.util.stream.Collectors;
 import javax.inject.Singleton;
 import javax.servlet.ServletContext;
 import javax.ws.rs.GET;
@@ -94,6 +95,6 @@ public class ApiInfoService {
                         descriptor.getUriPattern().getRegex());
                   }
                 })
-            .collect(Collectors.toList()));
+            .collect(toList()));
   }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CoreRestModule.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CoreRestModule.java
@@ -14,15 +14,16 @@ package org.eclipse.che.api.core.rest;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
+import org.eclipse.che.api.core.rest.shared.dto.ApiInfo;
 
 /** @author andrew00x */
 public class CoreRestModule extends AbstractModule {
   @Override
   protected void configure() {
-    bind(ApiInfoProvider.class);
     bind(CheJsonProvider.class);
     bind(ApiExceptionMapper.class);
     bind(RuntimeExceptionMapper.class);
+    bind(ApiInfo.class).toProvider(ApiInfoProvider.class);
     Multibinder.newSetBinder(binder(), Class.class, Names.named("che.json.ignored_classes"));
   }
 }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CoreRestModule.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CoreRestModule.java
@@ -19,6 +19,7 @@ import com.google.inject.name.Names;
 public class CoreRestModule extends AbstractModule {
   @Override
   protected void configure() {
+    bind(ApiInfoProvider.class);
     bind(CheJsonProvider.class);
     bind(ApiExceptionMapper.class);
     bind(RuntimeExceptionMapper.class);


### PR DESCRIPTION
### What does this PR do?
Since Codeready Workspaces™ uses same jars but have different versioning, API info service returns incorrect (mainstream) version instead of current CRW version. This PR makes API version read from  war's manifest, so it will be correct in each product.

Also PR contains some minor code improvements.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12686

#### Release Notes
N/A


#### Docs PR
N/A