### PR TITLE
Improved JSON Schema not to allow fields that are not typical for concrete tool type

### DIFF
--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
@@ -19,7 +19,6 @@ import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.inject.Singleton;
@@ -77,17 +76,13 @@ public class DevfileIntegrityValidator {
                     "Multiple editor tools found: '%s', '%s'",
                     editorTool.getName(), tool.getName()));
           }
-          checkFieldNotSet(tool, "local", tool.getLocal());
-          checkFieldNotSet(tool, "selector", tool.getSelector());
           editorTool = tool;
           break;
         case PLUGIN_TOOL_TYPE:
-          checkFieldNotSet(tool, "local", tool.getLocal());
-          checkFieldNotSet(tool, "selector", tool.getSelector());
+          // do nothing
           break;
         case KUBERNETES_TOOL_TYPE:
         case OPENSHIFT_TOOL_TYPE:
-          checkFieldNotSet(tool, "id", tool.getId());
           // fall through
         case DOCKERIMAGE_TOOL_TYPE:
           if (recipeTool != null) {
@@ -152,31 +147,6 @@ public class DevfileIntegrityValidator {
                     + "digits or these following special characters ._-",
                 project.getName()));
       }
-    }
-  }
-
-  private void checkFieldNotSet(Tool tool, String fieldName, Object fieldValue)
-      throws DevfileFormatException {
-    checkFieldNotSet(tool, fieldName, fieldValue == null);
-  }
-
-  private void checkFieldNotSet(Tool tool, String fieldName, Map fieldValue)
-      throws DevfileFormatException {
-    checkFieldNotSet(tool, fieldName, fieldValue == null || fieldValue.isEmpty());
-  }
-
-  private void checkFieldNotSet(Tool tool, String fieldName, boolean check)
-      throws DevfileFormatException {
-    checkField(
-        check,
-        format(
-            "Tool of type '%s' cannot contain '%s' field, please check '%s' tool",
-            tool.getType(), fieldName, tool.getName()));
-  }
-
-  private void checkField(Boolean check, String message) throws DevfileFormatException {
-    if (!check) {
-      throw new DevfileFormatException(message);
     }
   }
 }

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -122,11 +122,14 @@
                   "cheEditor",
                   "chePlugin"
                 ]
-              }
+              },
+              "name": {},
+              "id": {}
             },
             "required": [
               "id"
-            ]
+            ],
+            "additionalProperties": false
           },
           {
             "properties": {
@@ -135,11 +138,16 @@
                   "kubernetes",
                   "openshift"
                 ]
-              }
+              },
+              "name": {},
+              "local": {},
+              "localContent": {},
+              "selector": {}
             },
             "required": [
               "local"
-            ]
+            ],
+            "additionalProperties": false
           },
           {
             "properties": {
@@ -147,12 +155,20 @@
                 "enum": [
                   "dockerimage"
                 ]
-              }
+              },
+              "name": {},
+              "image": {},
+              "memoryLimit": {},
+              "mountSources": {},
+              "volumes": {},
+              "env": {},
+              "endpoints": {}
             },
             "required": [
               "image",
               "memoryLimit"
-            ]
+            ],
+            "additionalProperties": false
           }
         ],
         "properties": {

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
@@ -15,12 +15,10 @@ import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
-import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_TOOL_TYPE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.eclipse.che.api.devfile.model.Action;
 import org.eclipse.che.api.devfile.model.Command;
@@ -68,64 +66,6 @@ public class DevfileIntegrityValidatorTest {
   @Test(
       expectedExceptions = DevfileFormatException.class,
       expectedExceptionsMessageRegExp =
-          "Tool of type '"
-              + KUBERNETES_TOOL_TYPE
-              + "' cannot contain 'id' field, please check 'k8s' tool")
-  public void shouldThrowExceptionOnUnsupportedKubernetesToolIdField() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken.getTools().clear();
-    broken
-        .getTools()
-        .add(new Tool().withName("k8s").withType(KUBERNETES_TOOL_TYPE).withId("anyId"));
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Tool of type '"
-              + EDITOR_TOOL_TYPE
-              + "' cannot contain 'selector' field, please check 'editor1' tool")
-  public void shouldThrowExceptionOnUnsupportedEditorToolSelectorField() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken.getTools().clear();
-    broken
-        .getTools()
-        .add(
-            new Tool()
-                .withName("editor1")
-                .withType(EDITOR_TOOL_TYPE)
-                .withId("anyId")
-                .withSelector(Collections.singletonMap("key", "value")));
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Tool of type '"
-              + PLUGIN_TOOL_TYPE
-              + "' cannot contain 'selector' field, please check 'plugin1' tool")
-  public void shouldThrowExceptionOnUnsupportedPluginToolSelectorField() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken.getTools().clear();
-    broken
-        .getTools()
-        .add(
-            new Tool()
-                .withName("plugin1")
-                .withType(PLUGIN_TOOL_TYPE)
-                .withId("anyId")
-                .withSelector(Collections.singletonMap("key", "value")));
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
           "Multiple non plugin or editor type tools found: 'k8s', 'os'")
   public void shouldThrowExceptionOnMultipleNonPluginTools() throws Exception {
     Devfile broken = copyOf(initialDevfile);
@@ -152,51 +92,6 @@ public class DevfileIntegrityValidatorTest {
         .getTools()
         .add(new Tool().withName("k8s").withType(KUBERNETES_TOOL_TYPE).withLocal("foo.yaml"));
     broken.getTools().add(new Tool().withName("dockerimage").withType(DOCKERIMAGE_TOOL_TYPE));
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Tool of type '"
-              + OPENSHIFT_TOOL_TYPE
-              + "' cannot contain 'id' field, please check 'os' tool")
-  public void shouldThrowExceptionOnUnsupportedOpenshiftToolIdField() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken.getTools().clear();
-    broken.getTools().add(new Tool().withName("os").withType(OPENSHIFT_TOOL_TYPE).withId("anyId"));
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Tool of type '"
-              + EDITOR_TOOL_TYPE
-              + "' cannot contain 'local' field, please check 'foo' tool")
-  public void shouldThrowExceptionOnUnsupportedEditorToolLocalField() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken.getTools().clear();
-    broken
-        .getTools()
-        .add(new Tool().withName("foo").withType(EDITOR_TOOL_TYPE).withLocal("k8x.yaml"));
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Tool of type '"
-              + PLUGIN_TOOL_TYPE
-              + "' cannot contain 'local' field, please check 'foo' tool")
-  public void shouldThrowExceptionOnUnsupportedPluginToolField() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken
-        .getTools()
-        .add(new Tool().withName("foo").withType(PLUGIN_TOOL_TYPE).withLocal("k8x.yaml"));
     // when
     integrityValidator.validateDevfile(broken);
   }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -92,7 +92,13 @@ public class DevfileSchemaValidatorTest {
       },
       {
         "tool/devfile_tool_with_undeclared_field.yaml",
-        "Devfile schema validation failed. Error: /devfile/tools/0 object instance has properties which are not allowed by the schema: [\"unknown\"]"
+        "Devfile schema validation failed. Errors: [/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"unknown\"],"
+            + "instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"unknown\"],"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"id\",\"unknown\"],"
+            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"id\",\"unknown\"],"
+            + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       // Command model testing
       {
@@ -115,6 +121,14 @@ public class DevfileSchemaValidatorTest {
             + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
             + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
+      {
+        "editor_plugin_tool/devfile_editor_tool_with_indistinctive_field_local.yaml",
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"local\"],"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"id\"],"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"id\",\"local\"],"
+            + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
+      },
       // kubernetes/openshift tool model testing
       {
         "kubernetes_openshift_tool/devfile_openshift_tool_with_missing_local.yaml",
@@ -127,32 +141,56 @@ public class DevfileSchemaValidatorTest {
         "kubernetes_openshift_tool/devfile_openshift_tool_content_without_local.yaml",
         "Devfile schema validation failed. Errors: [/devfile/tools/0 property \"localContent\" of object has missing property dependencies (schema requires [\"local\"]; missing: [\"local\"]),"
             + "instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"localContent\",\"selector\"],"
             + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
             + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"localContent\",\"selector\"],"
             + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       {
         "kubernetes_openshift_tool/devfile_kubernetes_tool_content_without_local.yaml",
         "Devfile schema validation failed. Errors: [/devfile/tools/0 property \"localContent\" of object has missing property dependencies (schema requires [\"local\"]; missing: [\"local\"]),"
             + "instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"localContent\",\"selector\"],"
             + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
             + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"localContent\",\"selector\"],"
+            + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
+      },
+      {
+        "kubernetes_openshift_tool/devfile_openshift_tool_with_indistinctive_field_id.yaml",
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3)"
+            + ",/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"local\",\"selector\"],"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"id\"],"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"id\",\"local\",\"selector\"],"
             + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       // Dockerimage tool model testing
       {
         "dockerimage_tool/devfile_dockerimage_tool_with_missing_image.yaml",
         "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"memoryLimit\"],"
             + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"memoryLimit\"],"
             + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
             + "/devfile/tools/0 object has missing required properties ([\"image\"])]"
       },
       {
         "dockerimage_tool/devfile_dockerimage_tool_with_missing_memory_limit.yaml",
         "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"image\"],"
             + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
-            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"image\"],/devfile/tools/0 object has missing required properties ([\"local\"]),"
             + "/devfile/tools/0 object has missing required properties ([\"memoryLimit\"])]"
+      },
+      {
+        "dockerimage_tool/devfile_dockerimage_tool_with_indistinctive_field_selector.yaml",
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"endpoints\",\"env\",\"image\",\"memoryLimit\",\"selector\",\"volumes\"],"
+            + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"endpoints\",\"env\",\"image\",\"memoryLimit\",\"volumes\"],"
+            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object instance has properties which are not allowed by the schema: [\"selector\"]]"
       },
     };
   }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -110,29 +110,49 @@ public class DevfileSchemaValidatorTest {
       // cheEditor/chePlugin tool model testing
       {
         "editor_plugin_tool/devfile_editor_tool_with_missing_id.yaml",
-        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       // kubernetes/openshift tool model testing
       {
         "kubernetes_openshift_tool/devfile_openshift_tool_with_missing_local.yaml",
-        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       {
         "kubernetes_openshift_tool/devfile_openshift_tool_content_without_local.yaml",
-        "Devfile schema validation failed. Errors: [/devfile/tools/0 property \"localContent\" of object has missing property dependencies (schema requires [\"local\"]; missing: [\"local\"]),instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
+        "Devfile schema validation failed. Errors: [/devfile/tools/0 property \"localContent\" of object has missing property dependencies (schema requires [\"local\"]; missing: [\"local\"]),"
+            + "instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       {
         "kubernetes_openshift_tool/devfile_kubernetes_tool_content_without_local.yaml",
-        "Devfile schema validation failed. Errors: [/devfile/tools/0 property \"localContent\" of object has missing property dependencies (schema requires [\"local\"]; missing: [\"local\"]),instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
+        "Devfile schema validation failed. Errors: [/devfile/tools/0 property \"localContent\" of object has missing property dependencies (schema requires [\"local\"]; missing: [\"local\"]),"
+            + "instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       // Dockerimage tool model testing
       {
         "dockerimage_tool/devfile_dockerimage_tool_with_missing_image.yaml",
-        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\"])]"
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"image\"])]"
       },
       {
         "dockerimage_tool/devfile_dockerimage_tool_with_missing_memory_limit.yaml",
-        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"memoryLimit\"])]"
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),"
+            + "/devfile/tools/0 object has missing required properties ([\"id\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"local\"]),"
+            + "/devfile/tools/0 object has missing required properties ([\"memoryLimit\"])]"
       },
     };
   }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -15,7 +15,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
-import java.util.regex.Pattern;
 import org.eclipse.che.api.devfile.server.DevfileFormatException;
 import org.eclipse.che.api.devfile.server.schema.DevfileSchemaProvider;
 import org.testng.annotations.BeforeClass;
@@ -57,14 +56,10 @@ public class DevfileSchemaValidatorTest {
     try {
       schemaValidator.validateBySchema(getResource(resourceFilePath));
     } catch (DevfileFormatException e) {
-      if (!Pattern.matches(expectedMessageRegexp, e.getMessage())) {
-        // we don't need assertion here,
-        // but we use that to show the difference to simplify tests fixes
-        assertEquals(
-            e.getMessage(),
-            expectedMessageRegexp,
-            "DevfileFormatException thrown with message that doesn't match expected pattern:");
-      }
+      assertEquals(
+          e.getMessage(),
+          expectedMessageRegexp,
+          "DevfileFormatException thrown with message that doesn't match expected pattern:");
       return;
     }
     fail("DevfileFormatException expected to be thrown but is was not");
@@ -76,68 +71,68 @@ public class DevfileSchemaValidatorTest {
       // Devfile model testing
       {
         "devfile/devfile_missing_name.yaml",
-        "Devfile schema validation failed. Error: /devfile object has missing required properties \\(\\[\"name\"\\]\\)$"
+        "Devfile schema validation failed. Error: /devfile object has missing required properties ([\"name\"])"
       },
       {
         "devfile/devfile_missing_spec_version.yaml",
-        "Devfile schema validation failed. Error: /devfile object has missing required properties \\(\\[\"specVersion\"\\]\\)$"
+        "Devfile schema validation failed. Error: /devfile object has missing required properties ([\"specVersion\"])"
       },
       {
         "devfile/devfile_with_undeclared_field.yaml",
-        "Devfile schema validation failed. Error: /devfile object instance has properties which are not allowed by the schema: \\[\"unknown\"\\]$"
+        "Devfile schema validation failed. Error: /devfile object instance has properties which are not allowed by the schema: [\"unknown\"]"
       },
       // Tool model testing
       {
         "tool/devfile_missing_tool_name.yaml",
-        "Devfile schema validation failed. Error: /devfile/tools/0 object has missing required properties \\(\\[\"name\"\\]\\)$"
+        "Devfile schema validation failed. Error: /devfile/tools/0 object has missing required properties ([\"name\"])"
       },
       {
         "tool/devfile_missing_tool_type.yaml",
-        "Devfile schema validation failed. Error: /devfile/tools/0 object has missing required properties \\(\\[\"type\"\\]\\)$"
+        "Devfile schema validation failed. Error: /devfile/tools/0 object has missing required properties ([\"type\"])"
       },
       {
         "tool/devfile_tool_with_undeclared_field.yaml",
-        "Devfile schema validation failed. Error: /devfile/tools/0 object instance has properties which are not allowed by the schema: \\[\"unknown\"\\]$"
+        "Devfile schema validation failed. Error: /devfile/tools/0 object instance has properties which are not allowed by the schema: [\"unknown\"]"
       },
       // Command model testing
       {
         "command/devfile_missing_command_name.yaml",
-        "Devfile schema validation failed. Error: /devfile/commands/0 object has missing required properties \\(\\[\"name\"\\]\\)$"
+        "Devfile schema validation failed. Error: /devfile/commands/0 object has missing required properties ([\"name\"])"
       },
       {
         "command/devfile_missing_command_actions.yaml",
-        "Devfile schema validation failed. Error: /devfile/commands/0 object has missing required properties \\(\\[\"actions\"\\]\\)$"
+        "Devfile schema validation failed. Error: /devfile/commands/0 object has missing required properties ([\"actions\"])"
       },
       {
         "command/devfile_multiple_commands_actions.yaml",
-        "Devfile schema validation failed. Error: /devfile/commands/0/actions array is too long: must have at most 1 elements but instance has 2 elements$"
+        "Devfile schema validation failed. Error: /devfile/commands/0/actions array is too long: must have at most 1 elements but instance has 2 elements"
       },
       // cheEditor/chePlugin tool model testing
       {
         "editor_plugin_tool/devfile_editor_tool_with_missing_id.yaml",
-        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\),/devfile/tools/0 object has missing required properties \\(\\[\"id\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"local\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"image\",\"memoryLimit\"\\]\\)\\]"
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       // kubernetes/openshift tool model testing
       {
         "kubernetes_openshift_tool/devfile_openshift_tool_with_missing_local.yaml",
-        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\),/devfile/tools/0 object has missing required properties \\(\\[\"id\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"local\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"image\",\"memoryLimit\"\\]\\)\\]"
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       {
         "kubernetes_openshift_tool/devfile_openshift_tool_content_without_local.yaml",
-        "Devfile schema validation failed. Errors: \\[/devfile/tools/0 property \"localContent\" of object has missing property dependencies \\(schema requires \\[\"local\"\\]; missing: \\[\"local\"\\]\\),instance failed to match exactly one schema \\(matched 0 out of 3\\),/devfile/tools/0 object has missing required properties \\(\\[\"id\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"local\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"image\",\"memoryLimit\"\\]\\)\\]"
+        "Devfile schema validation failed. Errors: [/devfile/tools/0 property \"localContent\" of object has missing property dependencies (schema requires [\"local\"]; missing: [\"local\"]),instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       {
         "kubernetes_openshift_tool/devfile_kubernetes_tool_content_without_local.yaml",
-        "Devfile schema validation failed. Errors: \\[/devfile/tools/0 property \"localContent\" of object has missing property dependencies \\(schema requires \\[\"local\"\\]; missing: \\[\"local\"\\]\\),instance failed to match exactly one schema \\(matched 0 out of 3\\),/devfile/tools/0 object has missing required properties \\(\\[\"id\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"local\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"image\",\"memoryLimit\"\\]\\)\\]"
+        "Devfile schema validation failed. Errors: [/devfile/tools/0 property \"localContent\" of object has missing property dependencies (schema requires [\"local\"]; missing: [\"local\"]),instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
       // Dockerimage tool model testing
       {
         "dockerimage_tool/devfile_dockerimage_tool_with_missing_image.yaml",
-        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\),/devfile/tools/0 object has missing required properties \\(\\[\"id\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"local\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"image\"\\]\\)\\]"
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"image\"])]"
       },
       {
         "dockerimage_tool/devfile_dockerimage_tool_with_missing_memory_limit.yaml",
-        "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\),/devfile/tools/0 object has missing required properties \\(\\[\"id\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"local\"\\]\\),/devfile/tools/0 object has missing required properties \\(\\[\"memoryLimit\"\\]\\)\\]"
+        "Devfile schema validation failed. Errors: [instance failed to match exactly one schema (matched 0 out of 3),/devfile/tools/0 object has missing required properties ([\"id\"]),/devfile/tools/0 object has missing required properties ([\"local\"]),/devfile/tools/0 object has missing required properties ([\"memoryLimit\"])]"
       },
     };
   }

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool_with_indistinctive_field_selector.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool_with_indistinctive_field_selector.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: maven
+    type: dockerimage
+    image: eclipe/maven-jdk8:latest
+    volumes:
+      - name: maven-repo
+        containerPath: /root/.m2
+    env:
+      - name: ENV_VAR
+        value: value
+    endpoints:
+      - name: maven-server
+        port: 3101
+        attributes:
+          protocol: http
+          secure: 'true'
+          public: 'true'
+          discoverable: 'false'
+    memoryLimit: 1536M
+    selector:
+      app.kubernetes.io/name: mysql

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_tool/devfile_editor_tool_with_indistinctive_field_local.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_tool/devfile_editor_tool_with_indistinctive_field_local.yaml
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: theia-ide
+    type: cheEditor
+    id: eclipse/theia:0.0.3
+    local: petclinic.yaml

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_with_indistinctive_field_id.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_with_indistinctive_field_id.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: openshift
+    local: petclinic.yaml
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+    id: eclipse/theia:0.0.3
+commands:
+  - name: build
+    actions:
+      - type: exec
+        tool: mysql
+        command: mvn clean
+        workdir: /projects/spring-petclinic


### PR DESCRIPTION
### What does this PR do?
This PR improves JSON Schema not to allow fields that are not typical for concrete tool type.
Previously it was done by `DevfileIntegrityValidator` but actually, it is not a thing that should be checked by integrity validator and schema is able to handle it.

Also, it contains the following small but important changes:
- Check if messages are equal instead of matching pattern in DevfileSchemaValidatorTest.
It allows avoiding characters escaping for improving test cases readability.

- Format expected messages in DevfileSchemaValidatorTest for improving test cases readability.

### What issues does this PR fix or reference?
This PR DOES NOT RESOLVE but is related to https://github.com/eclipse/che/issues/12587

#### Release Notes
N/A

#### Docs PR
N/A