### PR TITLE
Added propagating curl errors in exec/terminal installers

### DIFF
--- a/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.script.sh
+++ b/agents/exec/installer/src/main/resources/installers/1.0.1/org.eclipse.che.exec.script.sh
@@ -194,9 +194,16 @@ else
     fi
 
     if curl ${CA_ARG} -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g'); then
-      curl ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+      curl -sSf ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
     elif curl ${CA_ARG} -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
-      curl ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+      curl -sSf ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    else
+      # both of test curl commands failed.
+      # perform them without --silent option to propagate errors
+      echo "Trying: curl -sSf ${CA_ARG} -o /dev/null --head $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')"
+      curl -sSf ${CA_ARG} -o /dev/null --head $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+      echo "Trying: curl -sSf ${CA_ARG} -o /dev/null --head $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')"
+      curl -sSf ${CA_ARG} -o /dev/null --head $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
     fi
     curl -sSf $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
   else

--- a/agents/terminal/src/main/resources/installers/1.0.1/org.eclipse.che.terminal.script.sh
+++ b/agents/terminal/src/main/resources/installers/1.0.1/org.eclipse.che.terminal.script.sh
@@ -189,9 +189,16 @@ else
     fi
 
     if curl ${CA_ARG} -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g'); then
-      curl ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+      curl -sSf ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
     elif curl ${CA_ARG} -o /dev/null --silent --head --fail $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g'); then
-      curl ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') -s $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+      curl -sSf ${CA_ARG} -o $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g' | sed 's/file:\/\///g') $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
+    else
+      # both of test curl commands failed.
+      # perform them without --silent option to propagate errors
+      echo "Trying: curl -sSf ${CA_ARG} -o /dev/null --head $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')"
+      curl -sSf ${CA_ARG} -o /dev/null --head $(echo ${AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g')
+      echo "Trying: curl -sSf ${CA_ARG} -o /dev/null --head $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')"
+      curl -sSf ${CA_ARG} -o /dev/null --head $(echo ${AGENT_BINARIES_URI} | sed 's/-\${PREFIX}//g')
     fi
     curl -sSf $(echo ${TARGET_AGENT_BINARIES_URI} | sed 's/\${PREFIX}/'${PREFIX}'/g') | tar  xzf - -C ${CHE_DIR}
   else


### PR DESCRIPTION
### What does this PR do?
Added propagating curl errors in exec/terminal installers.
How it looks like if exec binaries are not available:
![screenshot_20190220_095143](https://user-images.githubusercontent.com/5887312/53075658-64d83180-34f6-11e9-9d0f-08a2065d02ef.png)

Previously it was not clear why archive is not valid
![screenshot_20190220_091105](https://user-images.githubusercontent.com/5887312/53075392-b3390080-34f5-11e9-8fb0-2763a913bd87.png)

### What issues does this PR fix or reference?
Is related to https://github.com/eclipse/che/issues/12677
