### PR TITLE
Add an ability to provide local file content in devfile

### DIFF
--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplier.java
@@ -101,6 +101,10 @@ public class KubernetesToolToWorkspaceApplier implements ToolToWorkspaceApplier 
   private String retrieveContent(
       Tool recipeTool, @Nullable FileContentProvider fileContentProvider, String type)
       throws DevfileException {
+    if (!isNullOrEmpty(recipeTool.getLocalContent())) {
+      return recipeTool.getLocalContent();
+    }
+
     if (fileContentProvider == null) {
       throw new DevfileException(
           format(

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -108,6 +108,11 @@
           "name",
           "type"
         ],
+        "dependencies": {
+          "localContent": [
+            "local"
+          ]
+        },
         "additionalProperties": false,
         "oneOf" : [
           {
@@ -181,6 +186,13 @@
             "type": "string",
             "examples": [
               "petclinic-app.yaml"
+            ]
+          },
+          "localContent": {
+            "description": "Inlined content of a file specified in field 'local'",
+            "type": "string",
+            "examples": [
+              "{\"kind\":\"List\",\"items\":[{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"name\":\"ws\"},\"spec\":{\"containers\":[{\"image\":\"eclipse/che-dev:nightly\"}]}}]}"
             ]
           },
           "selector": {

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplierTest.java
@@ -138,6 +138,30 @@ public class KubernetesToolToWorkspaceApplierTest {
   }
 
   @Test
+  public void shouldUseLocalContentAsRecipeIfPresent() throws Exception {
+    String yamlRecipeContent = getResource("petclinic.yaml");
+    Tool tool =
+        new Tool()
+            .withType(KUBERNETES_TOOL_TYPE)
+            .withLocal(LOCAL_FILENAME)
+            .withLocalContent(yamlRecipeContent)
+            .withName(TOOL_NAME)
+            .withSelector(new HashMap<>());
+
+    applier.apply(workspaceConfig, tool, null);
+
+    String defaultEnv = workspaceConfig.getDefaultEnv();
+    assertNotNull(defaultEnv);
+    EnvironmentImpl environment = workspaceConfig.getEnvironments().get(defaultEnv);
+    assertNotNull(environment);
+    RecipeImpl recipe = environment.getRecipe();
+    assertNotNull(recipe);
+    assertEquals(recipe.getType(), KUBERNETES_TOOL_TYPE);
+    assertEquals(recipe.getContentType(), YAML_CONTENT_TYPE);
+    assertEquals(toK8SList(recipe.getContent()), toK8SList(yamlRecipeContent));
+  }
+
+  @Test
   public void shouldProvisionEnvironmentWithCorrectRecipeTypeAndContentFromOSList()
       throws Exception {
     // given

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.api.devfile.server.validator;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
@@ -27,12 +28,12 @@ public class DevfileSchemaValidatorTest {
   private DevfileSchemaValidator schemaValidator;
 
   @BeforeClass
-  public void setUp() throws Exception {
+  public void setUp() {
     schemaValidator = new DevfileSchemaValidator(new DevfileSchemaProvider());
   }
 
   @Test(dataProvider = "validDevfiles")
-  public void shouldDoNotThrowExceptionOnValidationValidDevfile(String resourceFilePath)
+  public void shouldNotThrowExceptionOnValidationValidDevfile(String resourceFilePath)
       throws Exception {
     schemaValidator.validateBySchema(getResource(resourceFilePath), false);
   }
@@ -41,7 +42,11 @@ public class DevfileSchemaValidatorTest {
   public Object[][] validDevfiles() {
     return new Object[][] {
       {"editor_plugin_tool/devfile_editor_plugins.yaml"},
+      {"kubernetes_openshift_tool/devfile_kubernetes_tool_local.yaml"},
+      {"kubernetes_openshift_tool/devfile_kubernetes_tool_local_and_content_as_block.yaml"},
       {"kubernetes_openshift_tool/devfile_openshift_tool.yaml"},
+      {"kubernetes_openshift_tool/devfile_openshift_tool_local_and_content.yaml"},
+      {"kubernetes_openshift_tool/devfile_openshift_tool_local_and_content_as_block.yaml"},
       {"dockerimage_tool/devfile_dockerimage_tool.yaml"}
     };
   }
@@ -53,7 +58,12 @@ public class DevfileSchemaValidatorTest {
       schemaValidator.validateBySchema(getResource(resourceFilePath), false);
     } catch (DevfileFormatException e) {
       if (!Pattern.matches(expectedMessageRegexp, e.getMessage())) {
-        fail("DevfileFormatException with unexpected message is thrown: " + e.getMessage());
+        // we don't need assertion here,
+        // but we use that to show the difference to simplify tests fixes
+        assertEquals(
+            e.getMessage(),
+            expectedMessageRegexp,
+            "DevfileFormatException thrown with message that doesn't match expected pattern:");
       }
       return;
     }
@@ -111,6 +121,14 @@ public class DevfileSchemaValidatorTest {
       {
         "kubernetes_openshift_tool/devfile_openshift_tool_with_missing_local.yaml",
         "Devfile schema validation failed\\. Errors: \\[instance failed to match exactly one schema \\(matched 0 out of 3\\)\\]"
+      },
+      {
+        "kubernetes_openshift_tool/devfile_openshift_tool_content_without_local.yaml",
+        "Devfile schema validation failed. Errors: \\[property \"localContent\" of object has missing property dependencies \\(schema requires \\[\"local\"\\]; missing: \\[\"local\"\\]\\), instance failed to match exactly one schema \\(matched 0 out of 3\\)\\]"
+      },
+      {
+        "kubernetes_openshift_tool/devfile_kubernetes_tool_content_without_local.yaml",
+        "Devfile schema validation failed. Errors: \\[property \"localContent\" of object has missing property dependencies \\(schema requires \\[\"local\"\\]; missing: \\[\"local\"\\]\\), instance failed to match exactly one schema \\(matched 0 out of 3\\)\\]"
       },
       // Dockerimage tool model testing
       {

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_kubernetes_tool_content_without_local.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_kubernetes_tool_content_without_local.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: kubernetes
+    localContent: petclinic.yaml
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+commands:
+  - name: build
+    actions:
+      - type: exec
+        tool: mysql
+        command: mvn clean
+        workdir: /projects/spring-petclinic

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_kubernetes_tool_local.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_kubernetes_tool_local.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: kubernetes
+    local: petclinic.yaml
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+commands:
+  - name: build
+    actions:
+      - type: exec
+        tool: mysql
+        command: mvn clean
+        workdir: /projects/spring-petclinic

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_kubernetes_tool_local_and_content_as_block.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_kubernetes_tool_local_and_content_as_block.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: kubernetes
+    local: petclinic.yaml
+    localContent: |
+      kind: List
+      items:
+       -
+        apiVersion: v1
+        kind: Pod
+        metadata:
+         name: ws
+        spec:
+         containers:
+          -
+           image: 'eclipse/che-dev:nightly'
+           name: dev
+           resources:
+            limits:
+             memory: 512Mi
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_content_without_local.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_content_without_local.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: openshift
+    localContent: this is content of file that is supposed to be in local field but it is missing
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic
+commands:
+  - name: build
+    actions:
+      - type: exec
+        tool: mysql
+        command: mvn clean
+        workdir: /projects/spring-petclinic

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_local_and_content.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_local_and_content.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: openshift
+    localContent: it is supposed to be a content of the file specified in the local field
+    local: petclinic.yaml
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_local_and_content_as_block.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/kubernetes_openshift_tool/devfile_openshift_tool_local_and_content_as_block.yaml
@@ -1,0 +1,39 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+tools:
+  - name: mysql
+    type: openshift
+    localContent: |
+      kind: List
+      items:
+       -
+        apiVersion: v1
+        kind: Pod
+        metadata:
+         name: ws
+        spec:
+         containers:
+          -
+           image: 'eclipse/che-dev:nightly'
+           name: dev
+           resources:
+            limits:
+             memory: 512Mi
+    local: petclinic.yaml
+    selector:
+      app.kubernetes.io/name: mysql
+      app.kubernetes.io/component: database
+      app.kubernetes.io/part-of: petclinic


### PR DESCRIPTION
### What does this PR do?
Add field 'localContent' to devfile tool.
It is allowed only when field 'local' is also used.
Added tests and improved tests error message.
Usage of block string makes yaml less somplicated:
```yaml
parent:
  child: |
    I can put anything here
    and it would be inlined
    but I still can still preserve
    structure so it looks good.
    Just remember to keep all the lines intended.
```
I used field `localContent` to keep content of file specified in field `local`. See an example:
```yaml
---
specVersion: 0.0.1
name: petclinic-dev-environment
tools:
  - name: mysql
    type: kubernetes
    content: |
      kind: List
      items:
       -
        apiVersion: v1
        kind: Pod
        metadata:
         name: ws
        spec:
         containers:
          -
           image: 'eclipse/che-dev:nightly'
           name: dev
           resources:
            limits:
             memory: 512Mi
    selector:
      app.kubernetes.io/name: mysql
      app.kubernetes.io/component: database
      app.kubernetes.io/part-of: petclinic
```
Here is a demo (but when I was recording it user had to specify either `local` or `content` and now it is both `local` and `localContent` or just `local`): https://youtu.be/gBIRNmQZNpY

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/12572
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
