### PR TITLE
Use justify validator for devfile schema validation

### DIFF
--- a/wsmaster/che-core-api-devfile/pom.xml
+++ b/wsmaster/che-core-api-devfile/pom.xml
@@ -44,12 +44,14 @@
             <artifactId>jackson-coreutils</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.github.java-json-tools</groupId>
-            <artifactId>json-schema-core</artifactId>
+            <groupId>org.leadpony.justify</groupId>
+            <artifactId>justify</artifactId>
+            <version>0.12.0</version>
         </dependency>
         <dependency>
-            <groupId>com.github.java-json-tools</groupId>
-            <artifactId>json-schema-validator</artifactId>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.json</artifactId>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileManager.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileManager.java
@@ -66,14 +66,13 @@ public class DevfileManager {
    * input data.
    *
    * @param devfileContent raw content of devfile
-   * @param verbose when true, method returns more explained validation error messages if any
    * @return Devfile object created from the source content
    * @throws DevfileFormatException when any of schema or integrity validations fail
    * @throws JsonProcessingException when parsing error occurs
    */
-  public Devfile parse(String devfileContent, boolean verbose)
+  public Devfile parse(String devfileContent)
       throws DevfileFormatException, JsonProcessingException {
-    JsonNode parsed = schemaValidator.validateBySchema(devfileContent, verbose);
+    JsonNode parsed = schemaValidator.validateBySchema(devfileContent);
     Devfile devfile = objectMapper.treeToValue(parsed, Devfile.class);
     initializeMaps(devfile);
     integrityValidator.validateDevfile(devfile);

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileService.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileService.java
@@ -92,7 +92,7 @@ public class DevfileService extends Service {
    * Creates workspace from provided devfile
    *
    * @param data devfile content
-   * @param verbose return more explained validation error messages if any
+   * @param verbose rYeturn more explained validation error messages if any
    * @return created workspace configuration
    */
   @POST
@@ -113,18 +113,13 @@ public class DevfileService extends Service {
     @ApiResponse(code = 403, message = "The user does not have access to create a new workspace"),
     @ApiResponse(code = 500, message = "Internal server error occurred")
   })
-  public Response createFromYaml(
-      String data,
-      @ApiParam(value = "Provide extended validation messages")
-          @DefaultValue("false")
-          @QueryParam("verbose")
-          boolean verbose)
+  public Response createFromYaml(String data)
       throws ServerException, ConflictException, NotFoundException, ValidationException,
           BadRequestException {
 
     WorkspaceImpl workspace;
     try {
-      Devfile devfile = devfileManager.parse(data, verbose);
+      Devfile devfile = devfileManager.parse(data);
       workspace = devfileManager.createWorkspace(devfile, null);
     } catch (DevfileException e) {
       throw new BadRequestException(e.getMessage());

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/schema/DevfileSchemaProvider.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/schema/DevfileSchemaProvider.java
@@ -15,9 +15,8 @@ import static org.eclipse.che.api.devfile.server.Constants.SCHEMA_LOCATION;
 import static org.eclipse.che.commons.lang.IoUtil.getResource;
 import static org.eclipse.che.commons.lang.IoUtil.readAndCloseQuietly;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jackson.JsonLoader;
 import java.io.IOException;
+import java.io.StringReader;
 import java.lang.ref.SoftReference;
 import javax.inject.Singleton;
 
@@ -36,8 +35,8 @@ public class DevfileSchemaProvider {
     return schema;
   }
 
-  public JsonNode getJsoneNode() throws IOException {
-    return JsonLoader.fromString(getSchemaContent());
+  public StringReader getAsReader() throws IOException {
+    return new StringReader(getSchemaContent());
   }
 
   private String loadFile() throws IOException {

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileManagerTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileManagerTest.java
@@ -73,9 +73,9 @@ public class DevfileManagerTest {
   public void testValidateAndConvert() throws Exception {
     String yamlContent = getTestResource("devfile.yaml");
 
-    devfileManager.parse(yamlContent, true);
+    devfileManager.parse(yamlContent);
 
-    verify(schemaValidator).validateBySchema(eq(yamlContent), eq(true));
+    verify(schemaValidator).validateBySchema(eq(yamlContent));
     verify(integrityValidator).validateDevfile(any(Devfile.class));
   }
 
@@ -85,9 +85,9 @@ public class DevfileManagerTest {
   public void shouldThrowExceptionWhenUnconvertableContentProvided() throws Exception {
     String yamlContent = getTestResource("devfile.yaml").concat("foos:");
 
-    devfileManager.parse(yamlContent, true);
+    devfileManager.parse(yamlContent);
 
-    verify(schemaValidator).validateBySchema(eq(yamlContent), eq(true));
+    verify(schemaValidator).validateBySchema(eq(yamlContent));
     verifyNoMoreInteractions(integrityValidator);
   }
 
@@ -112,7 +112,7 @@ public class DevfileManagerTest {
             });
     String yamlContent =
         Files.readFile(getClass().getClassLoader().getResourceAsStream("devfile.yaml"));
-    Devfile devfile = devfileManager.parse(yamlContent, true);
+    Devfile devfile = devfileManager.parse(yamlContent);
     // when
     devfileManager.createWorkspace(devfile, null);
     // then

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileServiceTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileServiceTest.java
@@ -16,7 +16,6 @@ import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -88,7 +87,7 @@ public class DevfileServiceTest {
         Files.readFile(getClass().getClassLoader().getResourceAsStream("devfile.yaml"));
     Devfile devfile = createDevfile(yamlContent);
     WorkspaceImpl ws = createWorkspace(WorkspaceStatus.STOPPED);
-    when(devfileManager.parse(anyString(), anyBoolean())).thenReturn(devfile);
+    when(devfileManager.parse(anyString())).thenReturn(devfile);
     when(devfileManager.createWorkspace(any(Devfile.class), any())).thenReturn(ws);
     final Response response =
         given()

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -34,7 +34,7 @@ public class DevfileSchemaValidatorTest {
   @Test(dataProvider = "validDevfiles")
   public void shouldDoNotThrowExceptionOnValidationValidDevfile(String resourceFilePath)
       throws Exception {
-    schemaValidator.validateBySchema(getResource(resourceFilePath), false);
+    schemaValidator.validateBySchema(getResource(resourceFilePath));
   }
 
   @DataProvider
@@ -50,7 +50,7 @@ public class DevfileSchemaValidatorTest {
   public void shouldThrowExceptionOnValidationNonValidDevfile(
       String resourceFilePath, String expectedMessageRegexp) throws Exception {
     try {
-      schemaValidator.validateBySchema(getResource(resourceFilePath), false);
+      schemaValidator.validateBySchema(getResource(resourceFilePath));
     } catch (DevfileFormatException e) {
       if (!Pattern.matches(expectedMessageRegexp, e.getMessage())) {
         fail("DevfileFormatException with unexpected message is thrown: " + e.getMessage());


### PR DESCRIPTION
### What does this PR do?
Use justify validator for devfile schema validation

Error output examples:
```[[line:1,column:80] The object must have a property whose name is "type".,``` 
```[line:1,column:82] The object must have a property whose name is "name".]```
```[[line:1,column:115] The object must have a property whose name is "type".]```

```[Exactly one of the following sets of problems must be resolved.]``` -> 
```[line:1,column:106] The object must have a property whose name is "id".``` or 
```[line:1,column:105] The value must be one of ["kubernetes", "openshift"].``` or
```[line:1,column:105] The value must be one of ["dockerimage"].```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12714