### PR TITLE
Fix editing running workspace config with tools containers and multiuser

### DIFF
--- a/dashboard/src/components/api/environment/kubernetes-environment-manager.ts
+++ b/dashboard/src/components/api/environment/kubernetes-environment-manager.ts
@@ -16,6 +16,7 @@ import {IEnvironmentManagerMachine} from './environment-manager-machine';
 import {CheRecipeTypes} from '../recipe/che-recipe-types';
 import {ISupportedItemList, KubernetesEnvironmentRecipeParser} from './kubernetes-environment-recipe-parser';
 import {ISupportedListItem, IPodItem, IPodItemContainer, KubernetesMachineRecipeParser, getPodItemOrNull} from './kubernetes-machine-recipe-parser';
+import {CheMachineSourceTypes} from '../workspace/che-machine-source-types';
 
 enum MemoryUnit { 'B', 'Ki', 'Mi', 'Gi' }
 
@@ -175,9 +176,13 @@ export class KubernetesEnvironmentManager extends EnvironmentManager {
    */
   getEnvironment(environment: che.IWorkspaceEnvironment, machines: IEnvironmentManagerMachine[]): che.IWorkspaceEnvironment {
     let newEnvironment: che.IWorkspaceEnvironment = angular.copy(environment);
-
     machines.forEach((machine: IEnvironmentManagerMachine) => {
       const machineName = machine.name;
+
+      let isToolContainer = machine.attributes && machine.attributes.source ? machine.attributes.source === CheMachineSourceTypes.TOOL : false;
+      if (isToolContainer) {
+        return;
+      }
 
       if (angular.isUndefined(newEnvironment.machines)) {
         newEnvironment.machines = {};

--- a/dashboard/src/components/api/environment/kubernetes-machine-recipe-parser.ts
+++ b/dashboard/src/components/api/environment/kubernetes-machine-recipe-parser.ts
@@ -39,7 +39,9 @@ export function isSecretItem(item: ISupportedListItem): item is ISecretItem {
 }
 
 export function getPodItemOrNull(item: ISupportedListItem): IPodItem {
-  if (isDeploymentItem(item)) {
+  if (!item) {
+    return null;
+  } else if (isDeploymentItem(item)) {
     return item.spec.template;
   } else if (isPodItem(item)) {
     return item;


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
The issue is reproduced on multi-user Che, but existed in single user too. The idea is that when user edits containers in running workspace and there are tooling containers in runtime - those tooling containers are added to environment (but should not) and thus the problem occurs. In single user such environment can be saved, in multi user we have error, that environment contains machines that are not defined in recipe.

### What issues does this PR fix or reference?
Issue was discovered, when during work on this one - https://github.com/eclipse/che/issues/12337

