### PR TITLE
Add log message when starting InconsistentRuntimesDetector

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/InconsistentRuntimesDetector.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/InconsistentRuntimesDetector.java
@@ -15,6 +15,7 @@ import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -54,8 +55,10 @@ public class InconsistentRuntimesDetector {
       initialDelayParameterName = "che.infra.kubernetes.runtimes_consistency_check_period_min",
       unit = TimeUnit.MINUTES)
   public void check() {
-    LOG.debug("Runtimes consistency check is running");
-    for (String runningWorkspaceId : workspaceRuntimes.getRunning()) {
+    Set<String> runningWorkspaces = workspaceRuntimes.getRunning();
+    LOG.info(
+        "Runtimes consistency check is running. Checking {} workspaces", runningWorkspaces.size());
+    for (String runningWorkspaceId : runningWorkspaces) {
       try {
         checkOne(runningWorkspaceId);
       } catch (InfrastructureException e) {


### PR DESCRIPTION
### What does this PR do?
Logs message when `InconsistentRuntimesDetector` begins its process including how many workspaces are to be recovered.

### What issues does this PR fix or reference?
It's hard to track if there are issues with the consistency check since it is completely silent most of the time.
