### PR TITLE
Different improvements of script that helps to build Devfile Docs

### DIFF
--- a/wsmaster/che-core-api-devfile/src/main/resources/Dockerfile
+++ b/wsmaster/che-core-api-devfile/src/main/resources/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && \
     apt-get install -y git \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
-RUN git clone -b '1.1.0' --single-branch git@github.com:adobe/jsonschema2md.git
+RUN git clone -b '1.1.0' --single-branch https://github.com/adobe/jsonschema2md.git
 RUN cd jsonschema2md && npm install && npm link
 
 COPY ./schema /schema

--- a/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
+++ b/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
@@ -44,7 +44,7 @@ build_native() {
    mkdir -p ${TMP_DIR}/schema
    cp -f schema/* ${TMP_DIR}/schema
    cd ${TMP_DIR}
-   git clone -b '1.1.0' --single-branch git@github.com:adobe/jsonschema2md.git
+   git clone -b '1.1.0' --single-branch https://github.com/adobe/jsonschema2md.git
    cd jsonschema2md
    npm install
    npm link

--- a/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
+++ b/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
@@ -92,7 +92,7 @@ print_help() {
    echo "Command line options:"
    echo "--docker      Build docs in docker container"
    echo "--no-deploy   Skip deploy result to remote"
-   echo "--message     Override default commit message"
+   echo "--message     Override default commit message. Example: --message=\"Update Devfile Docs\""
    echo "--folder|-f   If specified then script will save docs files in the specified folder. Examples: -f=.|-f=/home/user"
 }
 
@@ -108,7 +108,7 @@ parse_args() {
                IS_DEPLOY=false
                shift
            ;;
-           --message)
+           --message=*)
                MESSAGE="${i#*=}"
                shift
            ;;

--- a/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
+++ b/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
@@ -112,7 +112,6 @@ parse_args() {
            ;;
            -f=*| --folder=*)
                FOLDER="${i#*=}"
-               echo $FOLDER
                shift
            ;;
             -help|--help)
@@ -146,6 +145,9 @@ IS_DOCKER=${IS_DOCKER:-${DEFAULT_BUILD_DOCKER}}
 DEFAULT_DEPLOY=true
 IS_DEPLOY=${IS_DEPLOY:-${DEFAULT_DEPLOY}}
 
+DEFAULT_DO_CLEANUP=true
+DO_CLEANUP=${DO_CLEANUP:-${DEFAULT_DO_CLEANUP}}
+
 parse_args "$@"
 
 if [[ "$IS_DEPLOY" == "true" ]]; then
@@ -163,5 +165,7 @@ fi
 if [[ "$FOLDER" ]]; then
     copyDocs
 fi
+
+echo "Working Dir where script results can be found is ${TMP_DIR}"
 
 exit 0

--- a/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
+++ b/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
@@ -15,7 +15,9 @@ set -e
 
 check_github_token_is_set() {
   if [[ -z "${DEVFILE_DOCS_GITHUB_TOKEN}" ]]; then
-    echo "GitHub token not found, exiting now..."
+    echo "GitHub token not found."
+    echo "Specify env var DEVFILE_DOCS_GITHUB_TOKEN or use --no-deploy argument if you do not want to push Docs automatically"
+    echo "Exiting now..."
     exit 1
   else
     GH_TOKEN="${DEVFILE_DOCS_GITHUB_TOKEN}"

--- a/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
+++ b/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
@@ -13,14 +13,14 @@
 
 set -e
 
-TMP_DIR="/tmp/devfile"
-
-if [[ -z "${DEVFILE_DOCS_GITHUB_TOKEN}" ]]; then
-  echo "GitHub token not found, exiting now..."
-  exit 1
-else
-  GH_TOKEN="${DEVFILE_DOCS_GITHUB_TOKEN}"
-fi
+check_github_token_is_set() {
+  if [[ -z "${DEVFILE_DOCS_GITHUB_TOKEN}" ]]; then
+    echo "GitHub token not found, exiting now..."
+    exit 1
+  else
+    GH_TOKEN="${DEVFILE_DOCS_GITHUB_TOKEN}"
+  fi
+}
 
 
 DEFAULT_COMMIT_MESSAGE="Update devfile docs"
@@ -121,6 +121,10 @@ parse_args "$@"
 COMMIT_MESSAGE=${MESSAGE:-${DEFAULT_COMMIT_MESSAGE}}
 IS_DOCKER=${IS_DOCKER:-${DEFAULT_BUILD_DOCKER}}
 IS_DEPLOY=${IS_DEPLOY:-${DEFAULT_DEPLOY}}
+
+if [[ "$IS_DEPLOY" == "true" ]]; then
+  check_github_token_is_set
+fi
 
 if [[ "$IS_DOCKER" == "true" ]];
 then

--- a/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
+++ b/wsmaster/che-core-api-devfile/src/main/resources/build_docs.sh
@@ -88,10 +88,10 @@ cleanupTmpDir() {
 print_help() {
    echo "This script builds and deploys documentation in markdown format from devfile json schema."
    echo "Command line options:"
-   echo "--docker     Build docs in docker container"
-   echo "--no-deploy  Skip deploy result to remote"
-   echo "--message    Override default commit message"
-   echo "--folder     Optional. If specified then script will save docs file in the specified folder"
+   echo "--docker      Build docs in docker container"
+   echo "--no-deploy   Skip deploy result to remote"
+   echo "--message     Override default commit message"
+   echo "--folder|-f   If specified then script will save docs files in the specified folder. Examples: -f=.|-f=/home/user"
 }
 
 parse_args() {
@@ -110,6 +110,11 @@ parse_args() {
                MESSAGE="${i#*=}"
                shift
            ;;
+           -f=*| --folder=*)
+               FOLDER="${i#*=}"
+               echo $FOLDER
+               shift
+           ;;
             -help|--help)
                print_help
                exit 0
@@ -123,9 +128,13 @@ parse_args() {
      done
 }
 
-cleanup
-parse_args "$@"
+copyDocs() {
+  cd $RUN_DIR
+  cp -r ${TMP_DIR}/docs/. -t ${FOLDER}
+  echo "Docs is saved as ${FOLDER}/index.md"
+}
 
+RUN_DIR=$(pwd)
 TMP_DIR="/tmp/devfile"
 
 DEFAULT_COMMIT_MESSAGE="Update devfile docs"
@@ -154,6 +163,5 @@ fi
 if [[ "$FOLDER" ]]; then
     copyDocs
 fi
-
 
 exit 0


### PR DESCRIPTION
### What does this PR do?
This PR contains different improvements of the script that helps to build Devfile Docs:
- Fix build in dockerimage by using https instead of ssh to avoid generation of ssh keys
- Fix docs generation without deploying
- Add --folder argument to build_docs.sh script that allows to save built docs file
- Do not clean up working directory to make script results accessible
- Improve error message when Github token is missing
- Fix an ability to override commit message while publishing

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A


#### Docs PR
N/A