### PR TITLE
Continue recovering workspaces when unchecked exception is thrown

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -743,7 +743,7 @@ public class WorkspaceRuntimes {
       for (RuntimeIdentity identity : identities) {
         try {
           recoverOne(infrastructure, identity);
-        } catch (ServerException | ConflictException e) {
+        } catch (Exception e) {
           LOG.error(
               "An error occurred while attempting to recover runtime '{}' using infrastructure '{}'. Reason: '{}'",
               identity.getWorkspaceId(),

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -307,6 +307,64 @@ public class WorkspaceRuntimesTest {
   }
 
   @Test
+  public void runtimeRecoveryContinuesThroughRuntimeException() throws Exception {
+    // Given
+    RuntimeIdentityImpl identity1 = new RuntimeIdentityImpl("workspace1", "env1", "owner1");
+    RuntimeIdentityImpl identity2 = new RuntimeIdentityImpl("workspace2", "env2", "owner2");
+    RuntimeIdentityImpl identity3 = new RuntimeIdentityImpl("workspace3", "env3", "owner3");
+    Set<RuntimeIdentity> identities =
+        ImmutableSet.<RuntimeIdentity>builder()
+            .add(identity1)
+            .add(identity2)
+            .add(identity3)
+            .build();
+    doReturn(identities).when(infrastructure).getIdentities();
+
+    mockWorkspace(identity1);
+    mockWorkspace(identity2);
+    mockWorkspace(identity3);
+    when(statuses.get(anyString())).thenReturn(WorkspaceStatus.STARTING);
+
+    RuntimeContext context1 = mockContext(identity1);
+    when(context1.getRuntime())
+        .thenReturn(new TestInternalRuntime(context1, emptyMap(), WorkspaceStatus.STARTING));
+    doReturn(context1).when(infrastructure).prepare(eq(identity1), any());
+    RuntimeContext context2 = mockContext(identity1);
+    when(context2.getRuntime())
+        .thenReturn(new TestInternalRuntime(context2, emptyMap(), WorkspaceStatus.STARTING));
+    doReturn(context2).when(infrastructure).prepare(eq(identity2), any());
+    RuntimeContext context3 = mockContext(identity1);
+    when(context3.getRuntime())
+        .thenReturn(new TestInternalRuntime(context3, emptyMap(), WorkspaceStatus.STARTING));
+    doReturn(context3).when(infrastructure).prepare(eq(identity3), any());
+
+    InternalEnvironment internalEnvironment = mock(InternalEnvironment.class);
+    doReturn(internalEnvironment).when(testEnvFactory).create(any(Environment.class));
+
+    // Want to fail recovery of identity2
+    doThrow(new RuntimeException("oops!"))
+        .when(infrastructure)
+        .prepare(eq(identity2), any(InternalEnvironment.class));
+
+    // When
+    runtimes.new RecoverRuntimesTask(identities).run();
+
+    // Then
+    verify(infrastructure).prepare(identity1, internalEnvironment);
+    verify(infrastructure).prepare(identity2, internalEnvironment);
+    verify(infrastructure).prepare(identity3, internalEnvironment);
+
+    WorkspaceImpl workspace1 = new WorkspaceImpl(identity1.getWorkspaceId(), null, null);
+    runtimes.injectRuntime(workspace1);
+    assertNotNull(workspace1.getRuntime());
+    assertEquals(workspace1.getStatus(), WorkspaceStatus.STARTING);
+    WorkspaceImpl workspace3 = new WorkspaceImpl(identity3.getWorkspaceId(), null, null);
+    runtimes.injectRuntime(workspace3);
+    assertNotNull(workspace3.getRuntime());
+    assertEquals(workspace3.getStatus(), WorkspaceStatus.STARTING);
+  }
+
+  @Test
   public void attributesIsSetWhenRuntimeAbnormallyStopped() throws Exception {
     String error = "Some kind of error happened";
     EventService localEventService = new EventService();


### PR DESCRIPTION
### What does this PR do?
This PR is broken into two commits:

- The first commit refactors `WorkspaceRuntimes` slightly (sorting methods, etc) to put them into the normal order (static, then public, then private, then private classes).
- The second commit ensures that runtimes recovery completes in case of an unchecked exception being thrown, instead of ending recovery early.

### What issues does this PR fix or reference?
When an unchecked exception is thrown, recovery stop and the internal runtime cache does not get fully populated. This interferes with things like the consistency check.

For example, in rhche we encounter the error 
```
java.lang.IllegalArgumentException: Environment contains '2' machines with wsagent server. Machines names: '[web/main, web/mysql]'
at org.eclipse.che.api.workspace.server.WsAgentMachineFinderUtil.getWsAgentServerMachine(WsAgentMachineFinderUtil.java:63)
at org.eclipse.che.api.workspace.server.spi.provision.ProjectsVolumeForWsAgentProvisioner.provision(ProjectsVolumeForWsAgentProvisioner.java:51)
at org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure.prepare(RuntimeInfrastructure.java:102)
at org.eclipse.che.api.workspace.server.WorkspaceRuntimes.recoverOne(WorkspaceRuntimes.java:675)
at org.eclipse.che.api.workspace.server.WorkspaceRuntimes$RecoverRuntimesTask.run(WorkspaceRuntimes.java:621)
at org.eclipse.che.commons.lang.concurrent.CopyThreadLocalRunnable.run(CopyThreadLocalRunnable.java:38)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
at java.lang.Thread.run(Thread.java:748)
```
