### PR TITLE
Add ProcessMemoryMetrics ProcessThreadMetrics

### DIFF
--- a/core/che-core-metrics-core/pom.xml
+++ b/core/che-core-metrics-core/pom.xml
@@ -21,15 +21,6 @@
     </parent>
     <artifactId>che-core-metrics-core</artifactId>
     <name>Che Core :: Metrics :: Core</name>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.github.mweirauch</groupId>
-                <artifactId>micrometer-jvm-extras</artifactId>
-                <version>0.1.3</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/core/che-core-metrics-core/pom.xml
+++ b/core/che-core-metrics-core/pom.xml
@@ -21,6 +21,15 @@
     </parent>
     <artifactId>che-core-metrics-core</artifactId>
     <name>Che Core :: Metrics :: Core</name>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.github.mweirauch</groupId>
+                <artifactId>micrometer-jvm-extras</artifactId>
+                <version>0.1.3</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -33,6 +42,10 @@
         <dependency>
             <groupId>com.google.inject.extensions</groupId>
             <artifactId>guice-servlet</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.mweirauch</groupId>
+            <artifactId>micrometer-jvm-extras</artifactId>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/MetricsModule.java
+++ b/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/MetricsModule.java
@@ -14,6 +14,8 @@ package org.eclipse.che.core.metrics;
 import com.google.common.annotations.Beta;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
+import io.github.mweirauch.micrometer.jvm.extras.ProcessMemoryMetrics;
+import io.github.mweirauch.micrometer.jvm.extras.ProcessThreadMetrics;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
@@ -49,5 +51,7 @@ public class MetricsModule extends AbstractModule {
     meterMultibinder.addBinding().to(UptimeMetrics.class);
     meterMultibinder.addBinding().to(FileStoresMeterBinder.class);
     meterMultibinder.addBinding().to(ApiResponseCounter.class);
+    meterMultibinder.addBinding().to(ProcessMemoryMetrics.class);
+    meterMultibinder.addBinding().to(ProcessThreadMetrics.class);
   }
 }

--- a/deploy/openshift/templates/che-monitoring.yaml
+++ b/deploy/openshift/templates/che-monitoring.yaml
@@ -196,7 +196,7 @@ objects:
         "editable": true,
         "gnetId": 4701,
         "graphTooltip": 1,
-        "iteration": 1550504993993,
+        "iteration": 1550958562834,
         "links": [],
         "panels": [
           {
@@ -979,6 +979,112 @@ objects:
                 "logBase": 1,
                 "max": null,
                 "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "Che",
+            "editable": true,
+            "error": false,
+            "fill": 1,
+            "grid": {
+              "leftLogBase": 1,
+              "leftMax": null,
+              "leftMin": null,
+              "rightLogBase": 1,
+              "rightMax": null,
+              "rightMin": null
+            },
+            "gridPos": {
+              "h": 7,
+              "w": 6,
+              "x": 18,
+              "y": 5
+            },
+            "id": 86,
+            "legend": {
+              "avg": false,
+              "current": true,
+              "max": true,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": true
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 3,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "(process_memory_pss_bytes{application=\"$application\", instance=\"$instance\"} + process_memory_swap_bytes{application=\"$application\", instance=\"$instance\"}  - on(application,instance) sum(jvm_memory_committed_bytes{application=\"$application\", instance=\"$instance\"})  by(application,instance)) >= 0",
+                "format": "time_series",
+                "hide": false,
+                "intervalFactor": 2,
+                "legendFormat": "native",
+                "metric": "",
+                "refId": "A",
+                "step": 2400
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "JVM Native Memory",
+            "tooltip": {
+              "msResolution": false,
+              "shared": true,
+              "sort": 0,
+              "value_type": "cumulative"
+            },
+            "type": "graph",
+            "x-axis": true,
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "y-axis": true,
+            "y_formats": [
+              "mbytes",
+              "short"
+            ],
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": "",
+                "logBase": 1,
+                "max": null,
+                "min": "0",
                 "show": true
               },
               {
@@ -1929,7 +2035,7 @@ objects:
             "points": false,
             "renderer": "flot",
             "repeat": null,
-            "repeatIteration": 1550504993993,
+            "repeatIteration": 1550958562834,
             "repeatPanelId": 3,
             "scopedVars": {
               "jvm_memory_pool_heap": {
@@ -2070,7 +2176,7 @@ objects:
             "points": false,
             "renderer": "flot",
             "repeat": null,
-            "repeatIteration": 1550504993993,
+            "repeatIteration": 1550958562834,
             "repeatPanelId": 3,
             "scopedVars": {
               "jvm_memory_pool_heap": {
@@ -2364,7 +2470,7 @@ objects:
             "points": false,
             "renderer": "flot",
             "repeat": null,
-            "repeatIteration": 1550504993993,
+            "repeatIteration": 1550958562834,
             "repeatPanelId": 78,
             "scopedVars": {
               "jvm_memory_pool_nonheap": {
@@ -2505,7 +2611,7 @@ objects:
             "points": false,
             "renderer": "flot",
             "repeat": null,
-            "repeatIteration": 1550504993993,
+            "repeatIteration": 1550958562834,
             "repeatPanelId": 78,
             "scopedVars": {
               "jvm_memory_pool_nonheap": {
@@ -3683,7 +3789,7 @@ objects:
           ]
         },
         "time": {
-          "from": "now-5m",
+          "from": "now-30m",
           "to": "now"
         },
         "timepicker": {


### PR DESCRIPTION
### What does this PR do?
|  Name | Decription   | Graph  |  Line   | 
|---|---|---|---|
|process.memory.vss   | Virtual set size. The amount of virtual memory the process can access. Mostly useles, but included for completeness sake.  | N/a  | N/a  |
| process.memory.rss  | Resident set size. The amount of process memory currently in RAM.   | 1  |  rss  |
|process.memory.pss   | Proportional set size. The amount of process memory currently in RAM, accounting for shared pages among processes. This metric is the most accurate in terms of "real" memory usage.  | 1  | pss  |
|process.memory.swap   |The amount of process memory paged out to swap.   | 1   | swap  |
|process.memory.swappss   | The amount of process memory paged out to swap accounting for shared memory among processes. Since Linux 4.3. Will return -1 if your kernel is older. As with pss, the most accurate metric to watch.  | 1  |  swappss |
| process.threads  | The number of process threads as seen by the operating system.  | 3  |  process |
| process.memory.pss +process.memory.swap | Total memory used by JVM | 1  |  phys |
| process.memory.pss +process.memory.swap - jvm_memory_committed_bytes | Off-heap memory used by JVM | 2  |  native |




NEW
![2](https://user-images.githubusercontent.com/1614429/53322196-57022200-38e3-11e9-8087-adfa33f5ecf6.jpg)
NOW
![00 29 58](https://user-images.githubusercontent.com/1614429/53292452-5aa28580-37cb-11e9-9b2a-c4fe3acde736.png)

 CQ micrometer-jvm-extras:0.1.3  https://dev.eclipse.org/ipzilla/show_bug.cgi?id=19016 




### What issues does this PR fix or reference?
n/a

#### Release Notes
n/a

#### Docs PR
n/a
