### PR TITLE
Trust self-signed TLS certificate in selenium tests

### DIFF
--- a/selenium/che-selenium-core/bin/webdriver.sh
+++ b/selenium/che-selenium-core/bin/webdriver.sh
@@ -359,7 +359,7 @@ checkDockerComposeRequirements() {
 checkIfProductIsRun() {
     local url=${PRODUCT_PROTOCOL}"://"${PRODUCT_HOST}:${PRODUCT_PORT}${API_SUFFIX};
 
-    curl -s -X OPTIONS ${url} > /dev/null
+    curl -s -k -X OPTIONS ${url} > /dev/null
     if [[ $? != 0 ]]; then
         echo "[TEST] "${url}" is down"
         exit 1

--- a/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
+++ b/selenium/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/SeleniumWebDriver.java
@@ -249,6 +249,7 @@ public class SeleniumWebDriver
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--no-sandbox");
         options.addArguments("--dns-prefetch-disable");
+        options.addArguments("--ignore-certificate-errors");
 
         // set parameters required for automatic download capability
         Map<String, Object> chromePrefs = new HashMap<>();

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/keycloak/TestKeycloakSettingsServiceClient.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/core/client/keycloak/TestKeycloakSettingsServiceClient.java
@@ -17,6 +17,15 @@ import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.google.inject.Inject;
 import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 import org.eclipse.che.api.core.ApiException;
 import org.eclipse.che.api.core.rest.DefaultHttpJsonRequestFactory;
 import org.eclipse.che.selenium.core.provider.TestApiEndpointUrlProvider;
@@ -40,11 +49,45 @@ public class TestKeycloakSettingsServiceClient {
 
   public KeycloakSettings read() {
     try {
+      trustAllTlsCertificates();
+
       return gson.fromJson(
           requestFactory.fromUrl(keycloakSettingsServiceUrl).useGetMethod().request().asString(),
           KeycloakSettings.class);
-    } catch (ApiException | IOException | JsonSyntaxException ex) {
+    } catch (ApiException
+        | IOException
+        | JsonSyntaxException
+        | NoSuchAlgorithmException
+        | KeyManagementException ex) {
       throw new RuntimeException("Error during retrieving Che Keycloak configuration: ", ex);
     }
+  }
+
+  /**
+   * Trust all TLS certificates to be able to test Eclipse Che with self-signed TLS certificate
+   * support
+   *
+   * @throws NoSuchAlgorithmException
+   * @throws KeyManagementException
+   */
+  private void trustAllTlsCertificates() throws NoSuchAlgorithmException, KeyManagementException {
+    TrustManager[] trustAllCerts =
+        new TrustManager[] {
+          new X509TrustManager() {
+            public X509Certificate[] getAcceptedIssuers() {
+              return null;
+            }
+
+            public void checkClientTrusted(X509Certificate[] certs, String authType) {}
+
+            public void checkServerTrusted(X509Certificate[] certs, String authType) {}
+          }
+        };
+
+    SSLContext sc = SSLContext.getInstance("SSL");
+    sc.init(null, trustAllCerts, new SecureRandom());
+    HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+    HostnameVerifier allHostsVerifier = (arg0, arg1) -> true;
+    HttpsURLConnection.setDefaultHostnameVerifier(allHostsVerifier);
   }
 }


### PR DESCRIPTION
### What does this PR do?
This PR allows to run selenium e2e tests against Eclipse Che with self-signed TLS certificate.
It adds code to accept server's self-signed TLS certificate in curl, webdriver and Java HttpsURLConnection library by default.