### PR TITLE
Add support for command and args in dockerimage tool of devfile

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/convert/DockerImageEnvironmentConverter.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/convert/DockerImageEnvironmentConverter.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import java.util.HashMap;
 import java.util.Map;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
@@ -40,7 +41,12 @@ public class DockerImageEnvironmentConverter {
   static final String POD_NAME = "dockerimage";
   static final String CONTAINER_NAME = "container";
 
-  private EntryPointParser entryPointParser = new EntryPointParser();
+  private final EntryPointParser entryPointParser;
+
+  @Inject
+  public DockerImageEnvironmentConverter(EntryPointParser entryPointParser) {
+    this.entryPointParser = entryPointParser;
+  }
 
   public KubernetesEnvironment convert(DockerImageEnvironment environment)
       throws InfrastructureException {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/util/EntryPointParser.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/util/EntryPointParser.java
@@ -14,6 +14,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.environment.util;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import java.io.IOException;
@@ -23,7 +24,7 @@ import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 
 /** Can be used to parse container entry-point definition specified as a YAML list of strings. */
-public final class EntryPointParser {
+public class EntryPointParser {
   private final YAMLMapper mapper = new YAMLMapper();
 
   /**
@@ -50,6 +51,22 @@ public final class EntryPointParser {
         args == null ? emptyList() : parseAsList(args, MachineConfig.CONTAINER_ARGS_ATTRIBUTE);
 
     return new EntryPoint(commandList, argList);
+  }
+
+  /**
+   * Serializes an entry (that might have been produced from {@link #parse(Map)}) back to a string
+   * representation.
+   *
+   * @param entry the command or args entry
+   * @return a serialized representation of the entry
+   */
+  public String serializeEntry(List<String> entry) {
+    try {
+      return mapper.writer().writeValueAsString(entry);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(
+          format("Failed to serialize list of strings %s to YAML", entry), e);
+    }
   }
 
   private List<String> parseAsList(String data, String attributeName)

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/util/EntryPointParserTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/util/EntryPointParserTest.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptyList;
 import static org.testng.AssertJUnit.assertEquals;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
@@ -82,5 +83,22 @@ public class EntryPointParserTest {
       new String[] {"string value"},
       new String[] {"[a, b, [c]]"}
     };
+  }
+
+  @Test
+  public void shouldSerializeValidData() {
+    // given
+    List<String> data = asList("/bin/sh", "-c");
+
+    EntryPointParser parser = new EntryPointParser();
+
+    // when
+    String serialized = parser.serializeEntry(data);
+
+    // then
+
+    // this is dependent on the configuration of the YAML generator used by the YAMLMapper used in
+    // the EntryPointParser so this may start failing on jackson-dataformat-yaml library upgrade
+    assertEquals(serialized, "---\n- \"/bin/sh\"\n- \"-c\"\n");
   }
 }

--- a/wsmaster/che-core-api-devfile/README.md
+++ b/wsmaster/che-core-api-devfile/README.md
@@ -148,7 +148,7 @@ Devfile can only contain one tool with `dockerimage` type.
      type: dockerimage
      image: eclipe/maven-jdk8:latest
      volumes:
-       - name: maven-repo
+       - name: mavenrepo
          containerPath: /root/.m2
      env:
        - name: ENV_VAR
@@ -162,6 +162,8 @@ Devfile can only contain one tool with `dockerimage` type.
            public: 'true'
            discoverable: 'false'
      memoryLimit: 1536M
+     command: ['tail']
+     args: ['-f', '/dev/null']
 ```
 
 ### Commands expanded

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -162,7 +162,9 @@
               "mountSources": {},
               "volumes": {},
               "env": {},
-              "endpoints": {}
+              "endpoints": {},
+              "command": {},
+              "args": {}
             },
             "required": [
               "image",
@@ -236,6 +238,26 @@
             "type": "boolean",
             "description": "Describes whether projects sources should be mount to the tool. `CHE_PROJECTS_ROOT` environment variable should contains a path where projects sources are mount",
             "default": "false"
+          },
+          "command": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The command to run in the dockerimage tool instead of the default one provided in the image.",
+            "examples": [
+              "['/bin/sh', '-c']"
+            ]
+          },
+          "args": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The arguments to supply to the command running the dockerimage tool. The arguments are supplied either to the default command provided in the image or to the overridden command.",
+            "examples": [
+              "['-R', '-f']"
+            ]
           },
           "volumes": {
             "type": "array",

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -46,7 +46,8 @@ public class DevfileSchemaValidatorTest {
       {"kubernetes_openshift_tool/devfile_openshift_tool.yaml"},
       {"kubernetes_openshift_tool/devfile_openshift_tool_local_and_content.yaml"},
       {"kubernetes_openshift_tool/devfile_openshift_tool_local_and_content_as_block.yaml"},
-      {"dockerimage_tool/devfile_dockerimage_tool.yaml"}
+      {"dockerimage_tool/devfile_dockerimage_tool.yaml"},
+      {"dockerimage_tool/devfile_dockerimage_tool_without_entry_point.yaml"}
     };
   }
 

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool_without_entry_point.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/dockerimage_tool/devfile_dockerimage_tool_without_entry_point.yaml
@@ -32,5 +32,3 @@ tools:
           public: 'true'
           discoverable: 'false'
     memoryLimit: 1536M
-    command: ['/bin/sh']
-    args: ['-c', 'echo', 'hi']


### PR DESCRIPTION
### What does this PR do?
This adds support for `command` and `args` properties for dockerimage tools in the devfile. These two attributes are passed on to the workspace configuration as `containerCommand` and `containerArgs`.

Note that this PR builds on top of #12716 (which handles the assignment of the `containerCommand and `containerArgs` to the actual k8s container) and hence I marked this PR as draft so that we don't merge it prior to #12716.

An example devfile with the attributes applied so that we have an ever-running maven container in which we can run commands:

```yaml
specVersion: 0.0.1
name: entrypoint-test
projects:
- name: revapi
  source:
    type: git
    location: https://github.com/revapi/revapi.git
tools:
- name: theia
  type: cheEditor
  id: org.eclipse.che.editor.theia:1.0.0
- name: exec
  type: chePlugin
  id: che-machine-exec-plugin:0.0.1
- name: mvn
  type: dockerimage
  image: maven:3.6.0-jdk-11
  memoryLimit: 512M
  command: ['tail']
  args: ['-f', '/dev/null']
  mountSources: true
  volumes:
  - name: localrepo
    containerPath: /m2
  env:
  - name: MAVEN_OPTS
    value: '-Dmaven.repo.local=/m2/repository'
```
### What issues does this PR fix or reference?

#12668

#### Release Notes
* [ ] TODO


#### Docs PR
* [ ] Update the devfile documentation (added in PR https://github.com/eclipse/che/pull/12829)