### PR TITLE
fix(npm): ensure npm is properly setup in home

### DIFF
--- a/agents/ls-typescript/src/main/resources/installers/1.0.1/org.eclipse.che.ls.typescript.script.sh
+++ b/agents/ls-typescript/src/main/resources/installers/1.0.1/org.eclipse.che.ls.typescript.script.sh
@@ -167,6 +167,7 @@ unset TS_NPMS
 command -v tsserver >/dev/null 2>&1 || { TS_NPMS=${TS_NPMS}" typescript"; }
 command -v typescript-language-server >/dev/null 2>&1 || { TS_NPMS=${TS_NPMS}" typescript-language-server"; }
 
+npm ping
 test "${TS_NPMS}" = "" || {
        ${SUDO} npm install -g ${TS_NPMS};
    }


### PR DESCRIPTION
## What does this PR do?

In cases where npm has never been run in the current container, it will create `$HOME/.config/configstore/update-notifier-npm.json` as root with no other rw permissions.  This will cause various errors for anything that will write to `$HOME/.config` during the runtime.  This "ping" will ensure that before it is run as `sudo` it will be configured with the proper permissions.  


### What issues does this PR fix or reference?
This will address #12769.

