### PR TITLE
Improved default referenced file resolution in devfile

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFileContentProvider.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFileContentProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server.urlfactory;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.net.URI;
+import org.eclipse.che.api.devfile.server.FileContentProvider;
+
+/**
+ * A simple implementation of the FileContentProvider that merely uses the function resolve relative
+ * paths and {@link URLFetcher} for retrieving the content, handling common error cases.
+ */
+public class URLFileContentProvider implements FileContentProvider {
+
+  private final URI devfileLocation;
+  private final URLFetcher urlFetcher;
+
+  public URLFileContentProvider(URI devfileLocation, URLFetcher urlFetcher) {
+    this.devfileLocation = devfileLocation;
+    this.urlFetcher = urlFetcher;
+  }
+
+  @Override
+  public String fetchContent(String fileName) throws IOException {
+    URI fileUrl = devfileLocation.resolve(fileName);
+    try {
+      return urlFetcher.fetch(fileUrl.toString());
+    } catch (IOException e) {
+      throw new IOException(
+          format(
+              "Failed to fetch a file %s as relative to devfile %s from URL %s. Make sure the URL"
+                  + " of the devfile points to the raw content of it (e.g. not to the webpage"
+                  + " showing it but really just its contents). Additionally, make sure the"
+                  + " referenced files are actually stored relative to the devfile on the same"
+                  + " host. If none of that is possible, try to host your devfile on some other"
+                  + " location together with the referenced files in such a way that resolving the"
+                  + " \"local\" name of a tool as a relative path against the devfile location"
+                  + " gives a true downloadable URL for that file. The current attempt to download"
+                  + " the file failed with the following error message: %s",
+              fileName, devfileLocation, fileUrl, e.getMessage()),
+          e);
+    }
+  }
+}

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server;
+
+import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.eclipse.che.api.devfile.model.Tool;
+import org.eclipse.che.api.devfile.server.DevfileManager;
+import org.eclipse.che.api.devfile.server.FileContentProvider;
+import org.eclipse.che.api.devfile.server.convert.CommandConverter;
+import org.eclipse.che.api.devfile.server.convert.DevfileConverter;
+import org.eclipse.che.api.devfile.server.convert.ProjectConverter;
+import org.eclipse.che.api.devfile.server.convert.tool.ToolProvisioner;
+import org.eclipse.che.api.devfile.server.convert.tool.ToolToWorkspaceApplier;
+import org.eclipse.che.api.devfile.server.schema.DevfileSchemaProvider;
+import org.eclipse.che.api.devfile.server.validator.DevfileIntegrityValidator;
+import org.eclipse.che.api.devfile.server.validator.DevfileSchemaValidator;
+import org.eclipse.che.api.factory.server.urlfactory.URLFactoryBuilder;
+import org.eclipse.che.api.factory.server.urlfactory.URLFetcher;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(value = {MockitoTestNGListener.class})
+public class DefaultFactoryParameterResolverTest {
+
+  private static final String DEVFILE =
+      "specVersion: 0.0.1\n"
+          + "name: test\n"
+          + "tools:\n"
+          + "- type: kubernetes\n"
+          + "  name: tool\n"
+          + "  local: ../localfile\n";
+
+  @Mock private URLFetcher urlFetcher;
+
+  @Test
+  public void shouldResolveRelativeFiles() throws Exception {
+    // given
+
+    // we need to set up an "almost real" devfile converter which is a little bit involved
+    DevfileSchemaValidator validator = new DevfileSchemaValidator(new DevfileSchemaProvider());
+    DevfileIntegrityValidator integrityValidator = new DevfileIntegrityValidator();
+    Set<ToolProvisioner> toolProvisioners = new HashSet<>();
+    Map<String, ToolToWorkspaceApplier> appliers = new HashMap<>();
+    ToolToWorkspaceApplier applier = mock(ToolToWorkspaceApplier.class);
+    appliers.put("kubernetes", applier);
+
+    doAnswer(
+            i -> {
+              // in here we mock that the tool applier requests the contents of the referenced
+              // local file. That's all we need to happen
+              FileContentProvider p = i.getArgument(2);
+              Tool tool = i.getArgument(1);
+              p.fetchContent(tool.getLocal());
+              return null;
+            })
+        .when(applier)
+        .apply(any(), any(), any());
+
+    DevfileConverter devfileConverter =
+        new DevfileConverter(
+            new ProjectConverter(), new CommandConverter(), toolProvisioners, appliers);
+
+    WorkspaceManager workspaceManager = mock(WorkspaceManager.class);
+
+    DevfileManager devfileManager =
+        new DevfileManager(validator, integrityValidator, devfileConverter, workspaceManager);
+
+    URLFactoryBuilder factoryBuilder =
+        new URLFactoryBuilder("editor", "plugin", urlFetcher, devfileManager);
+
+    DefaultFactoryParameterResolver res =
+        new DefaultFactoryParameterResolver(factoryBuilder, urlFetcher);
+
+    // set up our factory with the location of our devfile that is referencing our localfile
+    Map<String, String> factoryParameters = new HashMap<>();
+    factoryParameters.put(URL_PARAMETER_NAME, "scheme:/myloc/devfile");
+    doReturn(DEVFILE).when(urlFetcher).fetchSafely(eq("scheme:/myloc/devfile"));
+
+    // when
+    res.createFactory(factoryParameters);
+
+    // then
+    verify(urlFetcher).fetch(eq("scheme:/localfile"));
+  }
+}


### PR DESCRIPTION
### What does this PR do?
This PR teaches the default factory parameter resolver resolve the files referenced in the devfile by trying out basic URI resolution of the relative names.

This enables us to resolve referenced `local` files in kubernetes/openshift tools in any repository that is able to serve raw content of files and keeps the relative "position" of the files in the URIs.

E.g. This enables referencing the `local` files on gitlab, gitweb and possibly others by passing in the URL to the raw/plain content of the devfile to the factory.

### What issues does this PR fix or reference?
#12798 

#### Release Notes
* [x] https://github.com/eclipse/che-docs/pull/691
