### PR TITLE
Make Devfile parse k8s/os recipe content in the same way as infrastructures do

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesRecipeParser.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesRecipeParser.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static java.lang.String.format;
+
+import com.google.common.collect.ImmutableSet;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Set;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+
+/**
+ * Parses Kubernetes objects from recipe.
+ *
+ * <p>Note that this class can also parse OpenShift specific objects.
+ *
+ * @author Sergii Leshchenko
+ */
+public class KubernetesRecipeParser {
+
+  private static final Set<String> SUPPORTED_CONTENT_TYPES =
+      ImmutableSet.of("application/x-yaml", "text/yaml", "text/x-yaml");
+
+  private final KubernetesClientFactory clientFactory;
+
+  @Inject
+  public KubernetesRecipeParser(KubernetesClientFactory clientFactory) {
+    this.clientFactory = clientFactory;
+  }
+
+  /**
+   * Parses Kubernetes objects from recipe.
+   *
+   * @param recipe that contains objects to parse
+   * @return parsed objects
+   * @throws IllegalArgumentException if recipe content is null
+   * @throws IllegalArgumentException if recipe content type is null
+   * @throws ValidationException if recipe content has broken format
+   * @throws ValidationException if recipe content has unrecognized objects
+   * @throws InfrastructureException when exception occurred during kubernetes client creation
+   */
+  public List<HasMetadata> parse(InternalRecipe recipe)
+      throws ValidationException, InfrastructureException {
+    String content = recipe.getContent();
+    String contentType = recipe.getContentType();
+    checkNotNull(contentType, "Recipe content type must not be null");
+
+    if (!SUPPORTED_CONTENT_TYPES.contains(contentType)) {
+      throw new ValidationException(
+          format(
+              "Provided environment recipe content type '%s' is unsupported. Supported values are: %s",
+              contentType, String.join(", ", SUPPORTED_CONTENT_TYPES)));
+    }
+
+    return parse(content);
+  }
+
+  /**
+   * Parses Kubernetes objects from recipe content.
+   *
+   * @param recipeContent recipe content that should be parsed
+   * @return parsed objects
+   * @throws IllegalArgumentException if recipe content is null
+   * @throws ValidationException if recipe content has broken format
+   * @throws ValidationException if recipe content has unrecognized objects
+   * @throws InfrastructureException when exception occurred during kubernetes client creation
+   */
+  public List<HasMetadata> parse(String recipeContent)
+      throws ValidationException, InfrastructureException {
+    checkNotNull(recipeContent, "Recipe content type must not be null");
+
+    try {
+      // Behavior:
+      // - If `content` is a single object like Deployment, load().get() will get the object in that
+      // list
+      // - If `content` is a Kubernetes List, load().get() will get the objects in that list
+      // - If `content` is an OpenShift template, load().get() will get the objects in the template
+      //   with parameters substituted (e.g. with default values).
+      List<HasMetadata> parsed =
+          clientFactory.create().load(new ByteArrayInputStream(recipeContent.getBytes())).get();
+
+      // needed because Che master namespace is set by K8s API during list loading
+      parsed
+          .stream()
+          .filter(o -> o.getMetadata() != null)
+          .forEach(o -> o.getMetadata().setNamespace(null));
+
+      return parsed;
+    } catch (KubernetesClientException e) {
+      // KubernetesClient wraps the error when a JsonMappingException occurs so we need the cause
+      String message = e.getCause() == null ? e.getMessage() : e.getCause().getMessage();
+      if (message.contains("\n")) {
+        // Clean up message if it comes from JsonMappingException. Format is e.g.
+        // `No resource type found for:v1#Route1\n at [...]`
+        message = message.split("\\n", 2)[0];
+      }
+      throw new ValidationException(format("Could not parse Kubernetes recipe: %s", message));
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactoryTest.java
@@ -53,10 +53,6 @@ import io.fabric8.kubernetes.api.model.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import io.fabric8.kubernetes.api.model.extensions.IngressBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -66,7 +62,7 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalRecipe;
 import org.eclipse.che.api.workspace.server.spi.environment.MemoryAttributeProvisioner;
-import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -81,37 +77,27 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class KubernetesEnvironmentFactoryTest {
 
-  private static final String YAML_RECIPE = "application/x-yaml";
   public static final String MACHINE_NAME_1 = "machine1";
   public static final String MACHINE_NAME_2 = "machine2";
 
   private KubernetesEnvironmentFactory k8sEnvFactory;
 
-  @Mock private KubernetesClientFactory clientFactory;
   @Mock private KubernetesEnvironmentValidator k8sEnvValidator;
-  @Mock private KubernetesClient client;
   @Mock private InternalEnvironment internalEnvironment;
   @Mock private InternalRecipe internalRecipe;
   @Mock private InternalMachineConfig machineConfig1;
   @Mock private InternalMachineConfig machineConfig2;
   @Mock private MemoryAttributeProvisioner memoryProvisioner;
+  @Mock private KubernetesRecipeParser k8sRecipeParser;
 
   private Map<String, InternalMachineConfig> machines;
-
-  @Mock
-  private ParameterNamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean>
-      loadedRecipe;
 
   @BeforeMethod
   public void setup() throws Exception {
     k8sEnvFactory =
         new KubernetesEnvironmentFactory(
-            null, null, null, clientFactory, k8sEnvValidator, memoryProvisioner);
-    when(clientFactory.create()).thenReturn(client);
-    when(client.load(any(InputStream.class))).thenReturn(loadedRecipe);
+            null, null, null, k8sRecipeParser, k8sEnvValidator, memoryProvisioner);
     lenient().when(internalEnvironment.getRecipe()).thenReturn(internalRecipe);
-    when(internalRecipe.getContentType()).thenReturn(YAML_RECIPE);
-    when(internalRecipe.getContent()).thenReturn("recipe content");
     machines = ImmutableMap.of(MACHINE_NAME_1, machineConfig1, MACHINE_NAME_2, machineConfig2);
   }
 
@@ -122,7 +108,7 @@ public class KubernetesEnvironmentFactoryTest {
         new ServiceBuilder().withNewMetadata().withName("service1").endMetadata().build();
     Service service2 =
         new ServiceBuilder().withNewMetadata().withName("service2").endMetadata().build();
-    when(loadedRecipe.get()).thenReturn(asList(service1, service2));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(asList(service1, service2));
 
     // when
     KubernetesEnvironment k8sEnv = k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -140,7 +126,7 @@ public class KubernetesEnvironmentFactoryTest {
         new PersistentVolumeClaimBuilder().withNewMetadata().withName("pvc1").endMetadata().build();
     PersistentVolumeClaim pvc2 =
         new PersistentVolumeClaimBuilder().withNewMetadata().withName("pvc2").endMetadata().build();
-    when(loadedRecipe.get()).thenReturn(asList(pvc1, pvc2));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(asList(pvc1, pvc2));
 
     // when
     KubernetesEnvironment k8sEnv = k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -153,7 +139,7 @@ public class KubernetesEnvironmentFactoryTest {
 
   @Test
   public void ignoreIgressesWhenRecipeContainsThem() throws Exception {
-    when(loadedRecipe.get())
+    when(k8sRecipeParser.parse(any(InternalRecipe.class)))
         .thenReturn(
             asList(
                 new IngressBuilder().withNewMetadata().withName("ingress1").endMetadata().build(),
@@ -173,7 +159,7 @@ public class KubernetesEnvironmentFactoryTest {
   public void addSecretsWhenRecipeContainsThem() throws Exception {
     Secret secret =
         new SecretBuilder().withNewMetadata().withName("test-secret").endMetadata().build();
-    when(loadedRecipe.get()).thenReturn(singletonList(secret));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(singletonList(secret));
 
     final KubernetesEnvironment parsed =
         k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -188,7 +174,7 @@ public class KubernetesEnvironmentFactoryTest {
   public void addConfigMapsWhenRecipeContainsThem() throws Exception {
     ConfigMap configMap =
         new ConfigMapBuilder().withNewMetadata().withName("test-configmap").endMetadata().build();
-    when(loadedRecipe.get()).thenReturn(singletonList(configMap));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(singletonList(configMap));
 
     final KubernetesEnvironment parsed =
         k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -207,7 +193,7 @@ public class KubernetesEnvironmentFactoryTest {
             .endMetadata()
             .withSpec(new PodSpec())
             .build();
-    when(loadedRecipe.get()).thenReturn(singletonList(pod));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(singletonList(pod));
 
     // when
     KubernetesEnvironment k8sEnv = k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
@@ -242,7 +228,7 @@ public class KubernetesEnvironmentFactoryTest {
             .endSpec()
             .build();
 
-    when(loadedRecipe.get()).thenReturn(singletonList(deployment));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(singletonList(deployment));
 
     // when
     final KubernetesEnvironment k8sEnv =
@@ -286,7 +272,7 @@ public class KubernetesEnvironmentFactoryTest {
             .withNewSpec()
             .endSpec()
             .build();
-    when(loadedRecipe.get()).thenReturn(asList(deployment, pod));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(asList(deployment, pod));
 
     // when
     final KubernetesEnvironment k8sEnv =
@@ -305,7 +291,8 @@ public class KubernetesEnvironmentFactoryTest {
 
   @Test(expectedExceptions = ValidationException.class)
   public void exceptionOnRecipeLoadError() throws Exception {
-    when(loadedRecipe.get()).thenThrow(new KubernetesClientException("Could not parse recipe"));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class)))
+        .thenThrow(new ValidationException("Could not parse recipe"));
 
     k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
   }
@@ -316,7 +303,7 @@ public class KubernetesEnvironmentFactoryTest {
   public void exceptionOnObjectWithNoKindSpecified() throws Exception {
     HasMetadata object = mock(HasMetadata.class);
     when(object.getKind()).thenReturn(null);
-    when(loadedRecipe.get()).thenReturn(singletonList(object));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(singletonList(object));
 
     k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
   }
@@ -328,7 +315,7 @@ public class KubernetesEnvironmentFactoryTest {
     HasMetadata object = mock(HasMetadata.class);
     when(object.getKind()).thenReturn("MyObject");
     when(object.getMetadata()).thenReturn(null);
-    when(loadedRecipe.get()).thenReturn(singletonList(object));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(singletonList(object));
 
     k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
   }
@@ -340,7 +327,7 @@ public class KubernetesEnvironmentFactoryTest {
     HasMetadata object = mock(HasMetadata.class);
     when(object.getKind()).thenReturn("MyObject");
     when(object.getMetadata()).thenReturn(new ObjectMetaBuilder().withName(null).build());
-    when(loadedRecipe.get()).thenReturn(singletonList(object));
+    when(k8sRecipeParser.parse(any(InternalRecipe.class))).thenReturn(singletonList(object));
 
     k8sEnvFactory.doCreate(internalRecipe, emptyMap(), emptyList());
   }
@@ -353,10 +340,10 @@ public class KubernetesEnvironmentFactoryTest {
     final long secondMachineRamRequest = 512;
     when(machineConfig1.getAttributes()).thenReturn(new HashMap<>());
     when(machineConfig2.getAttributes()).thenReturn(new HashMap<>());
-    final Set<Pod> pods =
+    final Set<PodData> pods =
         ImmutableSet.of(
-            mockPod(MACHINE_NAME_1, firstMachineRamLimit, firstMachineRamRequest),
-            mockPod(MACHINE_NAME_2, secondMachineRamLimit, secondMachineRamRequest));
+            createPodData(MACHINE_NAME_1, firstMachineRamLimit, firstMachineRamRequest),
+            createPodData(MACHINE_NAME_2, secondMachineRamLimit, secondMachineRamRequest));
 
     k8sEnvFactory.addRamAttributes(machines, pods);
 
@@ -366,17 +353,14 @@ public class KubernetesEnvironmentFactoryTest {
         .provision(eq(machineConfig2), eq(secondMachineRamLimit), eq(secondMachineRamRequest));
   }
 
-  private static Pod mockPod(String machineName, long ramLimit, long ramRequest) {
+  private static PodData createPodData(String machineName, long ramLimit, long ramRequest) {
     final String containerName = "container_" + machineName;
     final Container containerMock = mock(Container.class);
     final ResourceRequirements resourcesMock = mock(ResourceRequirements.class);
     final Quantity limitQuantityMock = mock(Quantity.class);
     final Quantity requestQuantityMock = mock(Quantity.class);
-    final Pod podMock = mock(Pod.class);
     final PodSpec specMock = mock(PodSpec.class);
     final ObjectMeta metadataMock = mock(ObjectMeta.class);
-    when(podMock.getSpec()).thenReturn(specMock);
-    when(podMock.getMetadata()).thenReturn(metadataMock);
     when(limitQuantityMock.getAmount()).thenReturn(String.valueOf(ramLimit));
     when(requestQuantityMock.getAmount()).thenReturn(String.valueOf(ramRequest));
     when(resourcesMock.getLimits()).thenReturn(ImmutableMap.of("memory", limitQuantityMock));
@@ -387,6 +371,6 @@ public class KubernetesEnvironmentFactoryTest {
         .thenReturn(
             ImmutableMap.of(format(MACHINE_NAME_ANNOTATION_FMT, containerName), machineName));
     when(specMock.getContainers()).thenReturn(ImmutableList.of(containerMock));
-    return podMock;
+    return new PodData(specMock, metadataMock);
   }
 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileRecipeFormatException.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileRecipeFormatException.java
@@ -19,4 +19,8 @@ public class DevfileRecipeFormatException extends DevfileException {
   public DevfileRecipeFormatException(String message) {
     super(message);
   }
+
+  public DevfileRecipeFormatException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplier.java
@@ -15,6 +15,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
@@ -22,14 +23,16 @@ import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.inject.Inject;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.config.Command;
 import org.eclipse.che.api.devfile.model.Tool;
@@ -43,6 +46,7 @@ import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesRecipeParser;
 
 /**
  * Applies changes on workspace config according to the specified kubernetes/openshift tool.
@@ -52,6 +56,13 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 public class KubernetesToolToWorkspaceApplier implements ToolToWorkspaceApplier {
 
   @VisibleForTesting static final String YAML_CONTENT_TYPE = "application/x-yaml";
+
+  private final KubernetesRecipeParser objectsParser;
+
+  @Inject
+  public KubernetesToolToWorkspaceApplier(KubernetesRecipeParser objectsParser) {
+    this.objectsParser = objectsParser;
+  }
 
   /**
    * Applies changes on workspace config according to the specified kubernetes/openshift tool.
@@ -79,10 +90,10 @@ public class KubernetesToolToWorkspaceApplier implements ToolToWorkspaceApplier 
 
     String recipeFileContent = retrieveContent(k8sTool, contentProvider);
 
-    final KubernetesList list = unmarshal(k8sTool, recipeFileContent);
+    List<HasMetadata> list = unmarshal(k8sTool, recipeFileContent);
 
     if (!k8sTool.getSelector().isEmpty()) {
-      list.setItems(filter(list, k8sTool.getSelector()));
+      list = filter(list, k8sTool.getSelector());
     }
 
     estimateCommandsMachineName(workspaceConfig, k8sTool, list);
@@ -128,8 +139,16 @@ public class KubernetesToolToWorkspaceApplier implements ToolToWorkspaceApplier 
     return recipeFileContent;
   }
 
-  private List<HasMetadata> filter(KubernetesList list, Map<String, String> selector) {
-    return list.getItems().stream().filter(item -> matchLabels(item, selector)).collect(toList());
+  /**
+   * Returns a lists consisting of the elements of the specified list that match the given selector.
+   *
+   * @param list list to filter
+   * @param selector selector that should be matched with objects' labels
+   */
+  private List<HasMetadata> filter(List<HasMetadata> list, Map<String, String> selector) {
+    return list.stream()
+        .filter(item -> matchLabels(item, selector))
+        .collect(toCollection(ArrayList::new));
   }
 
   /**
@@ -160,7 +179,7 @@ public class KubernetesToolToWorkspaceApplier implements ToolToWorkspaceApplier 
    * <p>Machine name will be set only if the specified recipe objects has the only one container.
    */
   private void estimateCommandsMachineName(
-      WorkspaceConfig workspaceConfig, Tool tool, KubernetesList recipeObjects) {
+      WorkspaceConfig workspaceConfig, Tool tool, List<HasMetadata> recipeObjects) {
     List<? extends Command> toolCommands =
         workspaceConfig
             .getCommands()
@@ -175,7 +194,6 @@ public class KubernetesToolToWorkspaceApplier implements ToolToWorkspaceApplier 
     }
     List<Pod> pods =
         recipeObjects
-            .getItems()
             .stream()
             .filter(hasMetadata -> hasMetadata instanceof Pod)
             .map(hasMetadata -> (Pod) hasMetadata)
@@ -192,11 +210,11 @@ public class KubernetesToolToWorkspaceApplier implements ToolToWorkspaceApplier 
     toolCommands.forEach(c -> c.getAttributes().put(MACHINE_NAME_ATTRIBUTE, machineName));
   }
 
-  private KubernetesList unmarshal(Tool tool, String recipeContent)
+  private List<HasMetadata> unmarshal(Tool tool, String recipeContent)
       throws DevfileRecipeFormatException {
     try {
-      return Serialization.unmarshal(recipeContent, KubernetesList.class);
-    } catch (KubernetesClientException e) {
+      return objectsParser.parse(recipeContent);
+    } catch (Exception e) {
       throw new DevfileRecipeFormatException(
           format(
               "Error occurred during parsing list from file %s for tool '%s': %s",
@@ -204,14 +222,15 @@ public class KubernetesToolToWorkspaceApplier implements ToolToWorkspaceApplier 
     }
   }
 
-  private String asYaml(Tool tool, KubernetesList list) throws DevfileRecipeFormatException {
+  private String asYaml(Tool tool, List<HasMetadata> list) throws DevfileRecipeFormatException {
     try {
-      return Serialization.asYaml(list);
+      return Serialization.asYaml(new KubernetesListBuilder().withItems(list).build());
     } catch (KubernetesClientException e) {
       throw new DevfileRecipeFormatException(
           format(
               "Unable to deserialize specified local file content for tool '%s'. Error: %s",
-              tool.getName(), e.getMessage()));
+              tool.getName(), e.getMessage()),
+          e);
     }
   }
 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/exception/DevfileException.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/exception/DevfileException.java
@@ -14,7 +14,7 @@ package org.eclipse.che.api.devfile.server.exception;
 /** Describes general devfile exception. */
 public class DevfileException extends Exception {
 
-  public DevfileException(String message, Exception cause) {
+  public DevfileException(String message, Throwable cause) {
     super(message, cause);
   }
 

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplierTest.java
@@ -18,16 +18,21 @@ import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.TOOL_NAME_COMMAND_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.convert.tool.kubernetes.KubernetesToolToWorkspaceApplier.YAML_CONTENT_TYPE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.devfile.model.Tool;
 import org.eclipse.che.api.devfile.server.FileContentProvider.FetchNotSupportedProvider;
 import org.eclipse.che.api.devfile.server.exception.DevfileException;
@@ -35,11 +40,16 @@ import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesRecipeParser;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.testng.reporters.Files;
 
 /** @author Sergii Leshchenko */
+@Listeners(MockitoTestNGListener.class)
 public class KubernetesToolToWorkspaceApplierTest {
 
   public static final String LOCAL_FILENAME = "local.yaml";
@@ -48,10 +58,11 @@ public class KubernetesToolToWorkspaceApplierTest {
   private WorkspaceConfigImpl workspaceConfig;
 
   private KubernetesToolToWorkspaceApplier applier;
+  @Mock private KubernetesRecipeParser k8sRecipeParser;
 
   @BeforeMethod
   public void setUp() {
-    applier = new KubernetesToolToWorkspaceApplier();
+    applier = new KubernetesToolToWorkspaceApplier(k8sRecipeParser);
 
     workspaceConfig = new WorkspaceConfigImpl();
   }
@@ -86,6 +97,7 @@ public class KubernetesToolToWorkspaceApplierTest {
               + "': .*")
   public void shouldThrowExceptionWhenRecipeContentIsNotAValidYaml() throws Exception {
     // given
+    doThrow(new ValidationException("non valid")).when(k8sRecipeParser).parse(anyString());
     Tool tool =
         new Tool().withType(KUBERNETES_TOOL_TYPE).withLocal(LOCAL_FILENAME).withName(TOOL_NAME);
 
@@ -116,6 +128,7 @@ public class KubernetesToolToWorkspaceApplierTest {
       throws Exception {
     // given
     String yamlRecipeContent = getResource("petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
     Tool tool =
         new Tool()
             .withType(KUBERNETES_TOOL_TYPE)
@@ -135,12 +148,17 @@ public class KubernetesToolToWorkspaceApplierTest {
     assertNotNull(recipe);
     assertEquals(recipe.getType(), KUBERNETES_TOOL_TYPE);
     assertEquals(recipe.getContentType(), YAML_CONTENT_TYPE);
-    assertEquals(toK8SList(recipe.getContent()), toK8SList(yamlRecipeContent));
+
+    // it is expected that applier wrap original recipes objects in new Kubernetes list
+    KubernetesList expectedKubernetesList =
+        new KubernetesListBuilder().withItems(toK8SList(yamlRecipeContent).getItems()).build();
+    assertEquals(toK8SList(recipe.getContent()).getItems(), expectedKubernetesList.getItems());
   }
 
   @Test
   public void shouldUseLocalContentAsRecipeIfPresent() throws Exception {
     String yamlRecipeContent = getResource("petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
     Tool tool =
         new Tool()
             .withType(KUBERNETES_TOOL_TYPE)
@@ -159,7 +177,11 @@ public class KubernetesToolToWorkspaceApplierTest {
     assertNotNull(recipe);
     assertEquals(recipe.getType(), KUBERNETES_TOOL_TYPE);
     assertEquals(recipe.getContentType(), YAML_CONTENT_TYPE);
-    assertEquals(toK8SList(recipe.getContent()), toK8SList(yamlRecipeContent));
+
+    // it is expected that applier wrap original recipes objects in new Kubernetes list
+    KubernetesList expectedKubernetesList =
+        new KubernetesListBuilder().withItems(toK8SList(yamlRecipeContent).getItems()).build();
+    assertEquals(toK8SList(recipe.getContent()).getItems(), expectedKubernetesList.getItems());
   }
 
   @Test
@@ -167,6 +189,7 @@ public class KubernetesToolToWorkspaceApplierTest {
       throws Exception {
     // given
     String yamlRecipeContent = getResource("petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
     Tool tool =
         new Tool()
             .withType(OPENSHIFT_TOOL_TYPE)
@@ -186,7 +209,11 @@ public class KubernetesToolToWorkspaceApplierTest {
     assertNotNull(recipe);
     assertEquals(recipe.getType(), OPENSHIFT_TOOL_TYPE);
     assertEquals(recipe.getContentType(), YAML_CONTENT_TYPE);
-    assertEquals(toK8SList(recipe.getContent()), toK8SList(yamlRecipeContent));
+
+    // it is expected that applier wrap original recipes objects in new Kubernetes list
+    KubernetesList expectedKubernetesList =
+        new KubernetesListBuilder().withItems(toK8SList(yamlRecipeContent).getItems()).build();
+    assertEquals(toK8SList(recipe.getContent()).getItems(), expectedKubernetesList.getItems());
   }
 
   @Test
@@ -201,6 +228,7 @@ public class KubernetesToolToWorkspaceApplierTest {
             .withLocal(LOCAL_FILENAME)
             .withName(TOOL_NAME)
             .withSelector(selector);
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
 
     // when
     applier.apply(workspaceConfig, tool, s -> yamlRecipeContent);
@@ -224,6 +252,7 @@ public class KubernetesToolToWorkspaceApplierTest {
       throws Exception {
     // given
     String yamlRecipeContent = getResource("petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
 
     final Map<String, String> selector = singletonMap("app.kubernetes.io/component", "webapp");
     Tool tool =
@@ -250,6 +279,7 @@ public class KubernetesToolToWorkspaceApplierTest {
           throws Exception {
     // given
     String yamlRecipeContent = getResource("petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
 
     Tool tool =
         new Tool()


### PR DESCRIPTION
### What does this PR do?
Make Devfile parse k8s/os recipe content in the same way as infrastructures do. It allows support templates, list or single objects in k8s/OS recipe content; Note that as a side effect we do not store original K8s/OS tool into workspace config recipe, but we store objects from parsed content as List.
For example, if OpenShift tool has a template, then it will be processed and result objects will be stored in kubernetes list. 
Or if Kuberentes tool contains Deployment object, then recipe will contain a list with only one object that is provided Deployment.

It also contains a fixing of ram attribute propagating. Previously, only attributes for Pods were propagated but not for Deployments. Not attributes are propagated for PodsData list that includes deployments + bare pods.

### Is this PR tested?

YES! 
This PR is tested locally with the following factories
Che-in-che where k8s tool contains List http://che-eclipse-che.192.168.99.100.nip.io/f?url=https://github.com/eclipse

Che-in-che where k8s tool contains single Deployment object http://che-eclipse-che.192.168.99.100.nip.io/f?url=https://github.com/sleshchenko/che/tree/devfileSingleObject

Che-in-che where k8s tool contains Template http://che-eclipse-che.192.168.99.100.nip.io/f?url=https://github.com/sleshchenko/che/tree/devfileTemplate

### What issues does this PR fix or reference?
These changes are not really needed for https://github.com/eclipse/che/issues/12719 but it was done during work on it.
It fixes https://github.com/eclipse/che/issues/12592

#### Release Notes
N/A

#### Docs PR
N/A