### PR TITLE
Fix ephemeral mode toggle in workspace overview page

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
@@ -71,7 +71,7 @@ export class WorkspaceDetailsOverviewController {
     this.namespaceId = routeParams.namespace;
     this.workspaceName = routeParams.workspaceName;
 
-    this.isEphemeralMode = this.workspaceDetails && this.workspaceDetails.config && this.workspaceDetails.config.attributes && this.workspaceDetails.config.attributes.persistVolumes ? JSON.parse(this.workspaceDetails.config.attributes.persistVolumes) : false;
+    this.isEphemeralMode = this.workspaceDetails && this.workspaceDetails.config && this.workspaceDetails.config.attributes && this.workspaceDetails.config.attributes.persistVolumes ? !JSON.parse(this.workspaceDetails.config.attributes.persistVolumes) : false;
     this.attributesCopy = angular.copy(this.workspaceDetails.config.attributes);
 
     this.fillInListOfUsedNames();

--- a/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
@@ -267,10 +267,10 @@ export class WorkspaceDetailsOverviewController {
    */
   onEphemeralModeChange(): void {
     if (this.isEphemeralMode) {
-      this.workspaceDetails.config.attributes.persistVolumes = 'true';
+      this.workspaceDetails.config.attributes.persistVolumes = 'false';
     } else {
       if (this.attributesCopy.persistVolumes) {
-        this.workspaceDetails.config.attributes.persistVolumes = 'false';
+        this.workspaceDetails.config.attributes.persistVolumes = 'true';
       } else {
         delete this.workspaceDetails.config.attributes.persistVolumes;
       }

--- a/dashboard/src/components/api/workspace/che-workspace.factory.ts
+++ b/dashboard/src/components/api/workspace/che-workspace.factory.ts
@@ -566,7 +566,7 @@ export class CheWorkspace {
    */
   notifyIfEphemeral(workspaceId: string): void {
     let workspace = this.workspacesById.get(workspaceId);
-    let isEphemeral = workspace && workspace.config && workspace.config.attributes && workspace.config.attributes.persistVolumes ? JSON.parse(workspace.config.attributes.persistVolumes) : false;
+    let isEphemeral = workspace && workspace.config && workspace.config.attributes && workspace.config.attributes.persistVolumes ? !JSON.parse(workspace.config.attributes.persistVolumes) : false;
     if (isEphemeral) {
       this.cheNotification.showWarning('Your are starting an ephemeral workspace. All changes to the source code will be lost when the workspace is stopped unless they are pushed to a source code repository.');
     }


### PR DESCRIPTION
### What does this PR do?
Logic was reversed on ephemeral mode toggle, resulting in enabling ephemeral mode setting `persistVolumes: 'true'`, and making it impossible to enable ephemeral mode via toggle.

Instead, changes toggle to set `persistVolumes: 'false'` as intended.