### PR TITLE
Fixed search stacks query

### DIFF
--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaStackDao.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaStackDao.java
@@ -51,7 +51,8 @@ public class MultiuserJpaStackDao implements StackDao {
       " SELECT stack FROM StackPermissions perm "
           + "        LEFT JOIN perm.stack stack  "
           + "        WHERE (perm.userId IS NULL OR perm.userId  = :userId) "
-          + "        AND 'search' MEMBER OF perm.actions";
+          + "        AND 'search' MEMBER OF perm.actions"
+          + "        GROUP BY stack.id";
 
   private static final String findByPermissionsAndTagsQuery =
       " SELECT stack FROM StackPermissions perm "


### PR DESCRIPTION
### What does this PR do?
There is a possible situation when the same stack has two permissions: related to a particular user and related to all users(`*`). In such the case stack will be returned twice. It's why grouping by stack id is needed.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12827

#### Release Notes
N/A

#### Docs PR
N/A