### PR TITLE
Update plugins brokers version to v0.13.0

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -542,10 +542,10 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.12.0
-che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.12.0
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.12.0
-che.workspace.plugin_broker.vscode.image=eclipse/che-vscode-extension-broker:v0.12.0
+che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.13.0
+che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.13.0
+che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.13.0
+che.workspace.plugin_broker.vscode.image=eclipse/che-vscode-extension-broker:v0.13.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
### What does this PR do?
Update plugins brokers version to v0.13.0 https://github.com/eclipse/che-plugin-broker/releases/tag/v0.13.0

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
