### PR TITLE
Fixed accepting factory if GitHub repo URL contains trailing slash

### DIFF
--- a/plugins/plugin-github/che-plugin-github-factory-resolver/src/main/java/org/eclipse/che/plugin/github/factory/resolver/GithubURLParser.java
+++ b/plugins/plugin-github/che-plugin-github-factory-resolver/src/main/java/org/eclipse/che/plugin/github/factory/resolver/GithubURLParser.java
@@ -35,7 +35,7 @@ public class GithubURLParser {
    */
   protected static final Pattern GITHUB_PATTERN =
       Pattern.compile(
-          "^(?:http)(?:s)?(?:\\:\\/\\/)github.com/(?<repoUser>[^/]++)/(?<repoName>[^/]++)((?:/tree/(?<branchName>[^/]++)(?:/(?<subFolder>.*))?)|(/pull/(?<pullRequestId>[^/]++)))?$");
+          "^(?:http)(?:s)?(?:\\:\\/\\/)github.com/(?<repoUser>[^/]++)/(?<repoName>[^/]++)((/)|(?:/tree/(?<branchName>[^/]++)(?:/(?<subFolder>.*))?)|(/pull/(?<pullRequestId>[^/]++)))?$");
 
   /** Regexp to find repository and branch name from PR link */
   protected static final Pattern PR_DATA_PATTERN =

--- a/plugins/plugin-github/che-plugin-github-factory-resolver/src/test/java/org/eclipse/che/plugin/github/factory/resolver/GithubURLParserTest.java
+++ b/plugins/plugin-github/che-plugin-github-factory-resolver/src/test/java/org/eclipse/che/plugin/github/factory/resolver/GithubURLParserTest.java
@@ -72,6 +72,7 @@ public class GithubURLParserTest {
   public Object[][] urls() {
     return new Object[][] {
       {"https://github.com/eclipse/che"},
+      {"https://github.com/eclipse/che/"},
       {"https://github.com/eclipse/che/tree/4.2.x"},
       {"https://github.com/eclipse/che/tree/master/"},
       {"https://github.com/eclipse/che/tree/master/dashboard/"},
@@ -85,6 +86,7 @@ public class GithubURLParserTest {
   public Object[][] expectedParsing() {
     return new Object[][] {
       {"https://github.com/eclipse/che", "eclipse", "che", "master", null},
+      {"https://github.com/eclipse/che/", "eclipse", "che", "master", null},
       {"https://github.com/eclipse/che/tree/4.2.x", "eclipse", "che", "4.2.x", null},
       {
         "https://github.com/eclipse/che/tree/master/dashboard/",

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -106,7 +106,11 @@ public class URLFactoryBuilder {
               .withV(CURRENT_VERSION)
               .withWorkspace(DtoConverter.asDto(wsConfig)));
     } catch (DevfileException e) {
-      throw new BadRequestException(e.getMessage());
+      throw new BadRequestException(
+          "Error occurred during creation a workspace from devfile located at `"
+              + devfileLocation
+              + "`. Cause: "
+              + e.getMessage());
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
Fixes accepting factory if GitHub repo URL contains trailing slash, like http://che-eclipse-che.192.168.64.52.nip.io/f?url=https://github.com/eclipse/che/

Also, previously when URL is resolved incorrectly user saw the following error message 
```
Devfile schema validation failed. 
Error: /devfile instance type (string) does not match any allowed primitive type (allowed: ["object"])
````
Now user will see the following error message
```
Error occurred during creation a workspace from workspace located at `https://github.com/eclipse/che/`. 
Cause: Devfile schema validation failed. 
Error: /devfile instance type (string) does not match any allowed primitive type (allowed: ["object"])
```
### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
N/A