### PR TITLE
Add option to Che deployment.yaml to allow self-signed certificates for OIDC

### DIFF
--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -66,6 +66,14 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.global.tls.useSelfSignedCerts }}
+        - name: CHE_SELF__SIGNED__CERT
+          valueFrom:
+            secretKeyRef:
+              key: ca.crt
+              name: self-signed-certificate
+              optional: false
+        {{- end }}
         image: {{ .Values.cheImage }}
         imagePullPolicy: {{ .Values.cheImagePullPolicy }}
         livenessProbe:

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -42,6 +42,7 @@ global:
     useCertManager: true
     useStaging: true
     secretName: che-tls
+    useSelfSignedCerts: false
   gitHubClientID: ""
   gitHubClientSecret: ""
   pvcClaim: "1Gi"


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

### What does this PR do?
If Che is installed via Helm on to a Kubernetes cluster with self-signed certificates and multiuser is enabled, Eclipse Che will fail to start with the following error:
```
PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
```

This PR adds a `global.tls.useSelfSignedCerts` value to values.yaml. When enabled, it has the `CHE_SELF__SIGNED__CERT` environment variable added to Che's deployment.yaml, allowing the user to pass in the cluster's ca.crt into the `self-signed-certificate` secret.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12863


#### Release Notes
N/A


#### Docs PR
N/A
