### PR TITLE
Add sidecar based maven and gradle Java stacks

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -747,7 +747,7 @@
       "OpenJDK",
       "Maven",
       "Spring Boot v2",
-      "vert.x",
+      "Vert.x",
       "Debian"
     ],
     "components": [

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -746,7 +746,7 @@
       "Java",
       "OpenJDK",
       "Maven",
-      "spring boot v2",
+      "Spring Boot v2",
       "vert.x",
       "Debian"
     ],

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -829,7 +829,7 @@
       "Java",
       "OpenJDK",
       "Gradle",
-      "spring boot v2",
+      "Spring Boot v2",
       "Debian"
     ],
     "components": [

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -739,73 +739,66 @@
   {
     "id": "java-default",
     "creator": "ide",
-    "name": "Java",
-    "description": "Default Java Stack with JDK 8, Maven and Tomcat.",
+    "name": "Java Maven",
+    "description": "Default Java Stack with OpenJKD 11 and Maven 3.6",
     "scope": "general",
     "tags": [
       "Java",
-      "JDK",
+      "OpenJDK",
       "Maven",
-      "Tomcat"
+      "spring boot v2",
+      "vert.x",
+      "Debian"
     ],
     "components": [
       {
-        "name": "Ubuntu",
-        "version": "16.04"
+         "name": "Debian",
+         "version": "9.8"
       },
       {
-        "name": "JDK",
-        "version": "1.8.0_162"
+        "name": "OpenJDK",
+        "version": "11.0.2"
       },
       {
         "name": "Maven",
-        "version": "3.3.9"
-      },
-      {
-        "name": "Tomcat",
-        "version": "8.0.24"
+        "version": "3.6.0"
       }
     ],
     "workspaceConfig": {
       "environments": {
         "default": {
           "machines": {
-            "dev-machine": {
-              "installers": [
-                "org.eclipse.che.exec",
-                "org.eclipse.che.terminal",
-                "org.eclipse.che.ws-agent",
-                "org.eclipse.che.ls.java"
-              ],
+            "maven-container": {
               "servers": {
-                "tomcat8": {
+                "8080/tcp": {
                   "port": "8080",
-                  "protocol": "http"
-                },
-                "tomcat8-debug": {
-                  "port": "8000",
-                  "protocol": "http"
-                },
-                "codeserver": {
-                  "port": "9876",
                   "protocol": "http"
                 }
               },
               "attributes": {
-                "memoryLimitBytes": "2147483648"
+                "memoryLimitBytes": "512000000",
+                "containerCommand": "['sleep']",
+                "containerArgs": "['infinity']"
               },
               "volumes": {
                 "m2": {
                   "path": "/home/user/.m2"
                 },
-                "javadata": {
-                  "path": "/home/user/jdtls/data"
+                "projects": {
+                  "path": "/projects"
                 }
+              },
+              "env": {
+                "MAVEN_CONFIG": "/home/user/.m2",
+                "MAVEN_OPTS": "-XX:MaxRAM=150m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
+                "JAVA_OPTS": "-XX:MaxRAM=150m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
+                "PS1": "$(echo ${0})\\$",
+                "HOME": "/home/user"
               }
             }
           },
           "recipe": {
-            "content": "eclipse/ubuntu_jdk8",
+            "content": "maven:3.6.0-jdk-11",
             "type": "dockerimage"
           }
         }
@@ -813,17 +806,94 @@
       "name": "default",
       "defaultEnv": "default",
       "description": null,
-      "commands": [
-        {
-          "commandLine": "mvn clean install -f ${current.project.path}",
-          "name": "build",
-          "type": "mvn",
-          "attributes": {
-            "previewUrl": "",
-            "goal": "Build"
+      "attributes": {
+        "plugins": "che-machine-exec-plugin:0.0.1,org.eclipse.che.vscode-redhat.java:0.38.0",
+        "editor": "org.eclipse.che.editor.theia:next",
+        "sidecar.org.eclipse.che.vscode-redhat.java.memory_limit": "1024Mi",
+        "sidecar.org.eclipse.che.editor.theia.memory_limit": "512Mi"
+      },
+      "commands": []
+    },
+    "stackIcon": {
+      "name": "type-java.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "java-gradle",
+    "creator": "ide",
+    "name": "Java Gradle",
+    "description": "Java Stack with OpenJDK 11 and Gradle 5.2.1",
+    "scope": "general",
+    "tags": [
+      "Java",
+      "OpenJDK",
+      "Gradle",
+      "spring boot v2",
+      "Debian"
+    ],
+    "components": [
+      {
+        "name": "Debian",
+        "version": "9.8"
+     },
+     {
+        "name": "OpenJDK",
+        "version": "11.0.2"
+      },
+      {
+        "name": "Gradle",
+        "version": "5.2.1"
+      }
+    ],
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "gradle-container": {
+              "servers": {
+                "8080/tcp": {
+                  "port": "8080",
+                  "protocol": "http"
+                }
+              },
+              "attributes": {
+                "memoryLimitBytes": "512000000",
+                "containerCommand": "['sleep']",
+                "containerArgs": "['infinity']"
+              },
+              "volumes": {
+                "gradle": {
+                  "path": "/home/user/.gradle"
+                },
+                "projects": {
+                  "path": "/projects"
+                }
+              },
+              "env": {
+                "GRADLE_USER_HOME": "/home/user/.gradle",
+                "JAVA_OPTS": "-XX:MaxRAM=150m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
+                "PS1": "$(echo ${0})\\$",
+                "HOME": "/home/user"
+              }
+            }
+          },
+          "recipe": {
+            "content": "gradle:5.2.1-jdk11",
+            "type": "dockerimage"
           }
         }
-      ]
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "attributes": {
+        "plugins": "che-machine-exec-plugin:0.0.1,org.eclipse.che.vscode-redhat.java:0.38.0",
+        "editor": "org.eclipse.che.editor.theia:next",
+        "sidecar.org.eclipse.che.vscode-redhat.java.memory_limit": "1024Mi",
+        "sidecar.org.eclipse.che.editor.theia.memory_limit": "512Mi"
+      },
+      "commands": []
     },
     "stackIcon": {
       "name": "type-java.svg",

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -739,6 +739,100 @@
   {
     "id": "java-default",
     "creator": "ide",
+    "name": "Java",
+    "description": "Default Java Stack with JDK 8, Maven and Tomcat.",
+    "scope": "general",
+    "tags": [
+      "Java",
+      "JDK",
+      "Maven",
+      "Tomcat"
+    ],
+    "components": [
+      {
+        "name": "Ubuntu",
+        "version": "16.04"
+      },
+      {
+        "name": "JDK",
+        "version": "1.8.0_162"
+      },
+      {
+        "name": "Maven",
+        "version": "3.3.9"
+      },
+      {
+        "name": "Tomcat",
+        "version": "8.0.24"
+      }
+    ],
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "machines": {
+            "dev-machine": {
+              "installers": [
+                "org.eclipse.che.exec",
+                "org.eclipse.che.terminal",
+                "org.eclipse.che.ws-agent",
+                "org.eclipse.che.ls.java"
+              ],
+              "servers": {
+                "tomcat8": {
+                  "port": "8080",
+                  "protocol": "http"
+                },
+                "tomcat8-debug": {
+                  "port": "8000",
+                  "protocol": "http"
+                },
+                "codeserver": {
+                  "port": "9876",
+                  "protocol": "http"
+                }
+              },
+              "attributes": {
+                "memoryLimitBytes": "2147483648"
+              },
+              "volumes": {
+                "m2": {
+                  "path": "/home/user/.m2"
+                },
+                "javadata": {
+                  "path": "/home/user/jdtls/data"
+                }
+              }
+            }
+          },
+          "recipe": {
+            "content": "eclipse/ubuntu_jdk8",
+            "type": "dockerimage"
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "commands": [
+        {
+          "commandLine": "mvn clean install -f ${current.project.path}",
+          "name": "build",
+          "type": "mvn",
+          "attributes": {
+            "previewUrl": "",
+            "goal": "Build"
+          }
+        }
+      ]
+    },
+    "stackIcon": {
+      "name": "type-java.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "java-maven",
+    "creator": "ide",
     "name": "Java Maven",
     "description": "Default Java Stack with OpenJKD 11 and Maven 3.6",
     "scope": "general",
@@ -792,7 +886,7 @@
                 "MAVEN_CONFIG": "/home/user/.m2",
                 "MAVEN_OPTS": "-XX:MaxRAM=150m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
                 "JAVA_OPTS": "-XX:MaxRAM=150m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
-                "PS1": "$(echo ${0})\\$",
+                "PS1": "$(echo ${0})\\$ ",
                 "HOME": "/home/user"
               }
             }
@@ -809,13 +903,13 @@
       "attributes": {
         "plugins": "che-machine-exec-plugin:0.0.1,org.eclipse.che.vscode-redhat.java:0.38.0",
         "editor": "org.eclipse.che.editor.theia:next",
-        "sidecar.org.eclipse.che.vscode-redhat.java.memory_limit": "1024Mi",
+        "sidecar.org.eclipse.che.vscode-redhat.java.memory_limit": "1500Mi",
         "sidecar.org.eclipse.che.editor.theia.memory_limit": "512Mi"
       },
       "commands": []
     },
     "stackIcon": {
-      "name": "type-java.svg",
+      "name": "type-che7.svg",
       "mediaType": "image/svg+xml"
     }
   },
@@ -873,7 +967,7 @@
               "env": {
                 "GRADLE_USER_HOME": "/home/user/.gradle",
                 "JAVA_OPTS": "-XX:MaxRAM=150m -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
-                "PS1": "$(echo ${0})\\$",
+                "PS1": "$(echo ${0})\\$ ",
                 "HOME": "/home/user"
               }
             }
@@ -890,13 +984,13 @@
       "attributes": {
         "plugins": "che-machine-exec-plugin:0.0.1,org.eclipse.che.vscode-redhat.java:0.38.0",
         "editor": "org.eclipse.che.editor.theia:next",
-        "sidecar.org.eclipse.che.vscode-redhat.java.memory_limit": "1024Mi",
+        "sidecar.org.eclipse.che.vscode-redhat.java.memory_limit": "1500Mi",
         "sidecar.org.eclipse.che.editor.theia.memory_limit": "512Mi"
       },
       "commands": []
     },
     "stackIcon": {
-      "name": "type-java.svg",
+      "name": "type-che7.svg",
       "mediaType": "image/svg+xml"
     }
   },

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -554,9 +554,7 @@
     "links": [],
     "category": "Samples",
     "tags": [
-      "maven",
-      "spring",
-      "java"
+      "tomcat"
     ]
   },
   {
@@ -762,18 +760,36 @@
     },
     "commands": [
       {
-        "name": "build",
+        "name": "maven build",
         "type": "mvn",
-        "commandLine": "mvn -f ${current.project.path} clean install",
+        "commandLine": "mvn -Duser.home=${HOME} -f ${CHE_PROJECTS_ROOT}/console-java-simple clean install",
         "attributes": {
           "previewUrl": "",
           "goal": "Build"
         }
       },
       {
-        "name": "run",
+        "name": "maven build and run",
         "type": "mvn",
-        "commandLine": "mvn -f ${current.project.path} clean install \njava -jar ${current.project.path}/target/*.jar",
+        "commandLine": "mvn -Duser.home=${HOME} -f ${CHE_PROJECTS_ROOT}/console-java-simple clean install \njava -jar ${CHE_PROJECTS_ROOT}/console-java-simple/target/*.jar",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "gradle build",
+        "type": "gralde",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/console-java-simple; gradle build",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Build"
+        }
+      },
+      {
+        "name": "gradle run",
+        "type": "gradle",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/console-java-simple; gradle run",
         "attributes": {
           "previewUrl": "",
           "goal": "Run"
@@ -784,7 +800,8 @@
     "category": "Samples",
     "tags": [
       "java",
-      "maven"
+      "maven",
+      "gradle"
     ]
   },
   {
@@ -904,7 +921,26 @@
       "location": "https://github.com/openshiftio-vertx-boosters/vertx-http-booster",
       "parameters": {}
     },
-    "commands": [],
+    "commands": [
+      {
+        "name": "build",
+        "type": "mvn",
+        "commandLine": "mvn -Duser.home=${HOME} -f ${CHE_PROJECTS_ROOT}/vertx-http-booster clean package",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Build"
+        }
+      },
+      {
+        "name": "run",
+        "type": "mvn",
+        "commandLine": "mvn -Duser.home=${HOME} -f ${CHE_PROJECTS_ROOT}/vertx-http-booster vertx:run",
+        "attributes": {
+          "previewUrl": "${server.8080/tcp}",
+          "goal": "Run"
+        }
+      }
+    ],
     "links": [],
     "category": "Samples",
     "tags": [
@@ -930,7 +966,26 @@
       "location": "https://github.com/openshiftio-vertx-boosters/vertx-health-checks-booster",
       "parameters": {}
     },
-    "commands": [],
+    "commands": [
+      {
+        "name": "build",
+        "type": "mvn",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/vertx-health-checks-booster; mvn -Duser.home=${HOME} clean package",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Build"
+        }
+      },
+      {
+        "name": "run",
+        "type": "mvn",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/vertx-health-checks-booster; mvn -Duser.home=${HOME} vertx:run",
+        "attributes": {
+          "previewUrl": "${server.8080/tcp}",
+          "goal": "Run"
+        }
+      }
+    ],
     "links": [],
     "category": "Samples",
     "tags": [
@@ -987,6 +1042,69 @@
     "category": "Samples",
     "tags": [
       "spring boot"
+    ]
+  },
+  {
+    "name": "spring-boot-gs-rest-service",
+    "displayName": "spring-boot-gs-rest-service",
+    "path": "/gs-rest-service",
+    "description": "Spring Boot Guide to build a RESTful web service ",
+    "projectType": "maven",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "java"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/spring-guides/gs-rest-service",
+      "parameters": {}
+    },
+    "commands": [
+      {
+        "name": "mvn build",
+        "type": "mvn",
+        "commandLine": "mvn -Duser.home=${HOME} -f ${CHE_PROJECTS_ROOT}/gs-rest-service/complete clean package",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Build"
+        }
+      },
+      {
+        "name": "mvn run",
+        "type": "mvn",
+        "commandLine": "mvn -Duser.home=${HOME} -f ${CHE_PROJECTS_ROOT}/gs-rest-service/complete spring-boot:run",
+        "attributes": {
+          "previewUrl": "${server.8080/tcp}/greeting",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "gradle build",
+        "type": "gralde",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/gs-rest-service/complete; gradle build",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Build"
+        }
+      },
+      {
+        "name": "gradle run",
+        "type": "gradle",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/gs-rest-service/complete; gradle bootRun",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      }      
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "spring boot v2"
     ]
   },
   {

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -1104,7 +1104,7 @@
     "links": [],
     "category": "Samples",
     "tags": [
-      "spring boot v2"
+      "Spring Boot v2"
     ]
   },
   {

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -1048,7 +1048,7 @@
     "name": "spring-boot-gs-rest-service",
     "displayName": "spring-boot-gs-rest-service",
     "path": "/gs-rest-service",
-    "description": "Spring Boot Guide to build a RESTful web service ",
+    "description": "Spring Boot Guide to build a RESTful web service",
     "projectType": "maven",
     "mixins": [],
     "attributes": {


### PR DESCRIPTION
### What does this PR do?

- Add stack java-maven
- Add stack java-gradle
- Modify samples to work with the new stacks
- Add a new spring-boot sample using this [spring guide repo](https://github.com/spring-guides/gs-rest-service)

**Some choices made to build the new stacks**:

- `che-theia:next` is used instead of `latest`
- I am using the default DockerHub images as runtime with JDK11 on Debian (i.e. [maven](https://hub.docker.com/_/maven) and [gradle](https://hub.docker.com/_/gradle))
- The runtime images tag is specified (don't use latest). I wanted to use sha256 tags (more reliable) but stacks API complained about that. Will create an issue.
- Memory:
  - che-theia: 512MB
  - maven runtime: 512MB
  - jdt.ls: 1GB
- The `${current.project.path}` placeholder for commands doesn't work on Theia and I have replaced it with `${CHE_PROJECTS_ROOT}/<sample-name>` 

**Current Limitations**
- JDT LS loading issue (related to https://github.com/theia-ide/theia/issues/3970)
- Java Debugging is not working (we need multiple vscode ext on the same sidecar #12395)
- JDT LS files are not persisted in a volume (that's related to meta.yaml and che-plugin.yaml issue to be created)

This PR is related to https://github.com/che-samples/console-java-simple/pull/7

@rhopp with that PR the good old che 6 java stack is gone. I suspect this will have some side effects on QE...
