### PR TITLE
Dashboard: fail build when webpack has errors

### DIFF
--- a/dashboard/gulp/inject.js
+++ b/dashboard/gulp/inject.js
@@ -18,7 +18,7 @@ var conf = require('./conf');
 
 var $ = require('gulp-load-plugins')();
 
-gulp.task('inject', ['outputcolors', 'proxySettings', 'scripts', 'styles'], function () {
+function inject() {
   var injectStyles = gulp.src([
     path.join(conf.paths.tmp, '/serve/app/**/*.css'),
     path.join('!' + conf.paths.tmp, '/serve/app/vendor.css')
@@ -37,4 +37,8 @@ gulp.task('inject', ['outputcolors', 'proxySettings', 'scripts', 'styles'], func
     .pipe($.inject(injectStyles, injectOptions))
     .pipe($.inject(injectScripts, injectOptions))
     .pipe(gulp.dest(path.join(conf.paths.tmp, '/serve')));
-});
+}
+
+gulp.task('inject', ['outputcolors', 'proxySettings', 'scripts', 'styles'], inject);
+
+gulp.task('inject:watch', ['outputcolors', 'proxySettings', 'scripts:watch', 'styles'], inject);

--- a/dashboard/gulp/scripts.js
+++ b/dashboard/gulp/scripts.js
@@ -80,20 +80,24 @@ function webpackWrapper(watch, test, callback) {
     webpackOptions.devtool = 'inline-source-map';
   }
 
+  var callbackCalled = false;
+
   var webpackChangeHandler = function (err, stats) {
-    if (err) {
-      conf.errorHandler('Webpack')(err);
-    }
     $.util.log(stats.toString({
       colors: $.util.colors.supportsColor,
       chunks: false,
       hash: false,
       version: false
     }));
-    browserSync.reload();
-    if (watch) {
-      watch = false;
-      callback();
+
+    if (!watch && stats.hasErrors()) {
+      $.util.log($.util.colors.red('[Webpack task failed with errors]'));
+      process.exit(1);
+    }
+
+    if (watch && !callbackCalled) {
+        callbackCalled = true;
+        callback();
     }
   };
 
@@ -111,7 +115,7 @@ gulp.task('scripts', ['colors', 'proxySettings'], function () {
   return webpackWrapper(false, false);
 });
 
-gulp.task('scripts:watch', ['scripts'], function (callback) {
+gulp.task('scripts:watch', ['colors', 'proxySettings'], function (callback) {
   return webpackWrapper(true, false, callback);
 });
 

--- a/dashboard/gulp/watch.js
+++ b/dashboard/gulp/watch.js
@@ -22,9 +22,9 @@ function isOnlyChange(event) {
   return event.type === 'changed';
 }
 
-gulp.task('watch', ['scripts:watch', 'inject'], function () {
+gulp.task('watch', ['scripts:watch', 'inject:watch'], function () {
 
-  gulp.watch([path.join(conf.paths.src, '/*.html')], ['inject']);
+  gulp.watch([path.join(conf.paths.src, '/*.html')], ['inject:watch']);
 
   gulp.watch([
     path.join(conf.paths.src, '/app/**/*.css'),
@@ -35,8 +35,9 @@ gulp.task('watch', ['scripts:watch', 'inject'], function () {
     if(isOnlyChange(event)) {
       gulp.start('styles');
     } else {
-      gulp.start('inject');
+      gulp.start('inject:watch');
     }
+    browserSync.reload();
   });
 
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Changes the dashboard build so that when typescript compilation fails (or anything processed by webpack), the whole build fails too. The watch mode should not fail in case of webpack error. 

Note that this PR depends on resolving all current compilation problems (e.g https://github.com/eclipse/che/pull/12826)
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12902
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
