### PR TITLE
dashboard: scripts refactored, unit tests enabled

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -9,7 +9,7 @@
 #   Red Hat, Inc. - initial API and implementation
 
 # This is a Dockerfile allowing to build dashboard by using a docker container.
-# Build step: $ docker build -t eclipse-che-dashboard
+# Build step: $ docker build -t eclipse-che-dashboard .
 # It builds an archive file that can be used by doing later
 #  $ docker run --rm eclipse-che-dashboard | tar -C target/ -zxf -
 FROM node:8.10.0
@@ -20,9 +20,9 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 COPY package.json /dashboard/
 COPY yarn.lock /dashboard/
-RUN cd /dashboard && npm i yarn && npx yarn install --ignore-scripts
+RUN cd /dashboard && npx yarn install
 COPY . /dashboard/
-RUN cd /dashboard  && npx yarn
+RUN cd /dashboard  && yarn build && yarn test
 RUN cd /dashboard && cd target/ && tar zcf /tmp/dashboard.tar.gz dist/
 
 CMD zcat /tmp/dashboard.tar.gz

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -91,7 +91,7 @@
     "node": ">=0.10.0"
   },
   "scripts": {
-    "postinstall": "yarn run typings && yarn run build",
+    "postinstall": "yarn run typings",
     "typings": "typings install",
     "build": "gulp build",
     "test": "gulp test"

--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -197,17 +197,17 @@
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>install-yarn</id>
+                                <id>install-deps</id>
                                 <phase>compile</phase>
                                 <goals>
                                     <goal>run</goal>
                                 </goals>
                                 <configuration>
                                     <target>
-                                        <!-- install yarn -->
-                                        <exec dir="${basedir}" executable="npm" failonerror="true">
-                                            <arg value="install" />
+                                        <!-- install dependencies -->
+                                        <exec dir="${basedir}" executable="npx" failonerror="true">
                                             <arg value="yarn" />
+                                            <arg value="install" />
                                         </exec>
                                     </target>
                                 </configuration>
@@ -221,8 +221,8 @@
                                 <configuration>
                                     <target>
                                         <!-- build user dashboard -->
-                                        <exec dir="${basedir}" executable="node_modules/yarn/bin/yarn" failonerror="true">
-                                            <arg value="install" />
+                                        <exec dir="${basedir}" executable="node_modules/.bin/yarn" failonerror="true">
+                                            <arg value="build" />
                                         </exec>
                                         <!-- Change base HREF of the application that will be hosted on /dashboard -->
                                         <replace file="${basedir}/target/dist/index.html">
@@ -233,7 +233,7 @@
                                 </configuration>
                             </execution>
                             <execution>
-                                <id>compilation</id>
+                                <id>test-dashboard</id>
                                 <phase>test</phase>
                                 <goals>
                                     <goal>run</goal>
@@ -241,8 +241,7 @@
                                 <configuration>
                                     <target unless="skipTests">
                                         <!-- Run unit tests -->
-                                        <exec dir="${basedir}" executable="node_modules/yarn/bin/yarn" failonerror="true">
-                                            <arg value="run" />
+                                        <exec dir="${basedir}" executable="node_modules/.bin/yarn" failonerror="true">
                                             <arg value="test" />
                                         </exec>
                                     </target>


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Running `mvn clean install` did not run unit test. This PR

1. changes npm scripts so that `npm install` only installs dependencies and doesn't run build
2. updates `pom.xml` so that it uses yarn binary correctly
3. updates the `Dockerfile` to call `npm install` just once, not to use `npx` unnecessarily and run unit tests

KNOWN ISSUE:
* yarn is installed in `Dockerfile` but the base image already contains yarn, the installed version is not used 
* possible solutions: don't run `npm i yarn` in `Dockerfile` and (optionally) remove it from `package.json` OR call yarn binary explicitly using whole path (`node_modules/.bin/yarn`) as it's done in `pom.xml`

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
