### PR TITLE
Use single unified plugin broker for all the plugins

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -542,10 +542,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.image=eclipse/che-plugin-broker:v0.14.0
-che.workspace.plugin_broker.theia.image=eclipse/che-theia-plugin-broker:v0.14.0
 che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.14.0
-che.workspace.plugin_broker.vscode.image=eclipse/che-vscode-extension-broker:v0.14.0
+che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.15.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -543,7 +543,7 @@ che.singleport.wildcard_domain.ipless=false
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
 che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.14.0
-che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.15.0
+che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.15.1
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -19,12 +19,10 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.server.externa
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostIngressExternalServerExposer.SINGLE_HOST_STRATEGY;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
-import com.google.inject.name.Names;
 import java.util.Map;
 import org.eclipse.che.api.system.server.ServiceTermination;
 import org.eclipse.che.api.workspace.server.NoEnvironmentFactory;
@@ -170,24 +168,5 @@ public class KubernetesInfraModule extends AbstractModule {
 
     bind(SidecarToolingProvisioner.class)
         .to(new TypeLiteral<SidecarToolingProvisioner<KubernetesEnvironment>>() {});
-
-    MapBinder<String, String> pluginBrokers =
-        MapBinder.newMapBinder(
-            binder(),
-            String.class,
-            String.class,
-            Names.named("che.workspace.plugin_broker.images"));
-    pluginBrokers
-        .addBinding("Che Plugin")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.image")));
-    pluginBrokers
-        .addBinding("Che Editor")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.image")));
-    pluginBrokers
-        .addBinding("Theia plugin")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.theia.image")));
-    pluginBrokers
-        .addBinding("VS Code extension")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.vscode.image")));
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResult.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResult.java
@@ -57,7 +57,7 @@ public class BrokersResult {
    *
    * @param toolingFromBroker tooling evaluated by a broker that needs to be added into a workspace
    * @throws InfrastructureException if called second time which indicates incorrect usage of the
-   *     {@link BrokersResult}
+   * {@link BrokersResult}
    * @throws IllegalStateException if called before the call of {@link #get(long, TimeUnit)}
    */
   public void setResult(List<ChePlugin> toolingFromBroker) throws InfrastructureException {
@@ -67,7 +67,7 @@ public class BrokersResult {
     }
     if (future.isDone()) {
       throw new InfrastructureException(
-          "Broker result is submitted when no more results are expected");
+          "Plugins brokering result is unexpectedly submitted more than one time. This indicates unexpected behavior of the system");
     }
     future.complete(new ArrayList<>(toolingFromBroker));
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResult.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResult.java
@@ -57,7 +57,7 @@ public class BrokersResult {
    *
    * @param toolingFromBroker tooling evaluated by a broker that needs to be added into a workspace
    * @throws InfrastructureException if called second time which indicates incorrect usage of the
-   * {@link BrokersResult}
+   *     {@link BrokersResult}
    * @throws IllegalStateException if called before the call of {@link #get(long, TimeUnit)}
    */
   public void setResult(List<ChePlugin> toolingFromBroker) throws InfrastructureException {
@@ -76,9 +76,9 @@ public class BrokersResult {
    * Waits for the tooling that needs to be injected into a workspace being submitted by a call of
    * {@link #setResult(List)}.
    *
-   * <p>If provided timeout elapses before needed call of {@link #setResult(List)} method ends
-   * with an exception. This method is based on {@link CompletableFuture#get(long, TimeUnit)} so it
-   * also inherits parameters and thrown exception.
+   * <p>If provided timeout elapses before needed call of {@link #setResult(List)} method ends with
+   * an exception. This method is based on {@link CompletableFuture#get(long, TimeUnit)} so it also
+   * inherits parameters and thrown exception.
    *
    * @return tooling submitted by broker that needs to be injected into a workspace
    * @throws IllegalStateException if called more than one time

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResult.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResult.java
@@ -60,7 +60,7 @@ public class BrokersResult {
    *     {@link BrokersResult}
    * @throws IllegalStateException if called before the call of {@link #get(long, TimeUnit)}
    */
-  public void brokerResult(List<ChePlugin> toolingFromBroker) throws InfrastructureException {
+  public void setResult(List<ChePlugin> toolingFromBroker) throws InfrastructureException {
     if (!started.get()) {
       throw new IllegalStateException(
           "Submitting a broker result is not allowed before calling BrokerResult#get");
@@ -74,9 +74,9 @@ public class BrokersResult {
 
   /**
    * Waits for the tooling that needs to be injected into a workspace being submitted by a call of
-   * {@link #brokerResult(List)}.
+   * {@link #setResult(List)}.
    *
-   * <p>If provided timeout elapses before needed call of {@link #brokerResult(List)} method ends
+   * <p>If provided timeout elapses before needed call of {@link #setResult(List)} method ends
    * with an exception. This method is based on {@link CompletableFuture#get(long, TimeUnit)} so it
    * also inherits parameters and thrown exception.
    *

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResult.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResult.java
@@ -14,14 +14,12 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 import com.google.common.annotations.Beta;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
 
@@ -30,32 +28,11 @@ import org.eclipse.che.api.workspace.server.wsplugins.model.ChePlugin;
 public class BrokersResult {
 
   private final CompletableFuture<List<ChePlugin>> future;
-  private final AtomicInteger brokersNumber;
   private final AtomicBoolean started;
-  private final List<ChePlugin> plugins;
 
   public BrokersResult() {
     future = new CompletableFuture<>();
-    brokersNumber = new AtomicInteger();
     started = new AtomicBoolean();
-    plugins = Collections.synchronizedList(new ArrayList<>());
-  }
-
-  /**
-   * Notifies {@code BrokerResult} that one more broker will be launched and we need to wait
-   * response from it.
-   *
-   * <p>It should be called before the call of {@link #get(long, TimeUnit)}, otherwise {@link
-   * IllegalStateException} would be thrown
-   *
-   * @throws IllegalStateException if called after call of {@link #get(long, TimeUnit)}
-   */
-  public void oneMoreBroker() {
-    if (started.get()) {
-      throw new IllegalStateException(
-          "Call of BrokerResult#oneMoreBroker is not allowed after call BrokerResult#get");
-    }
-    brokersNumber.incrementAndGet();
   }
 
   /**
@@ -76,42 +53,34 @@ public class BrokersResult {
   }
 
   /**
-   * Submits a result of a broker execution.
-   *
-   * <p>It also count down the number of brokers that are waited for the result submission.
+   * Submits the result of a broker execution.
    *
    * @param toolingFromBroker tooling evaluated by a broker that needs to be added into a workspace
-   * @throws InfrastructureException if called more times than {@link #oneMoreBroker()} which
-   *     indicates incorrect usage of the {@link BrokersResult}
+   * @throws InfrastructureException if called second time which indicates incorrect usage of the
+   *     {@link BrokersResult}
    * @throws IllegalStateException if called before the call of {@link #get(long, TimeUnit)}
    */
-  public void addResult(List<ChePlugin> toolingFromBroker) throws InfrastructureException {
+  public void brokerResult(List<ChePlugin> toolingFromBroker) throws InfrastructureException {
     if (!started.get()) {
       throw new IllegalStateException(
           "Submitting a broker result is not allowed before calling BrokerResult#get");
     }
-    int previousBrokersNumber = brokersNumber.getAndDecrement();
-    if (previousBrokersNumber == 0) {
+    if (future.isDone()) {
       throw new InfrastructureException(
           "Broker result is submitted when no more results are expected");
     }
-    plugins.addAll(toolingFromBroker);
-    if (previousBrokersNumber == 1) {
-      future.complete(new ArrayList<>(plugins));
-    }
+    future.complete(new ArrayList<>(toolingFromBroker));
   }
 
   /**
-   * Waits for the tooling that needs to be injected into a workspace being submitted by calls of
-   * {@link #addResult(List)}.
+   * Waits for the tooling that needs to be injected into a workspace being submitted by a call of
+   * {@link #brokerResult(List)}.
    *
-   * <p>Number of calls of {@link #addResult(List)} needs to be the same as number of calls of
-   * {@link #oneMoreBroker()}. Returned list is a combination of lists submitted to {@link
-   * #addResult(List)}. If provided timeout elapses before all needed calls of {@link
-   * #addResult(List)} method ends with an exception. This method is based on {@link
-   * CompletableFuture#get(long, TimeUnit)} so it also inherits parameters and thrown exception.
+   * <p>If provided timeout elapses before needed call of {@link #brokerResult(List)} method ends
+   * with an exception. This method is based on {@link CompletableFuture#get(long, TimeUnit)} so it
+   * also inherits parameters and thrown exception.
    *
-   * @return tooling submitted by one or several brokers that needs to be injected into a workspace
+   * @return tooling submitted by broker that needs to be injected into a workspace
    * @throws IllegalStateException if called more than one time
    * @see CompletableFuture#get(long, TimeUnit)
    */

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/KubernetesBrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/KubernetesBrokerEnvironmentFactory.java
@@ -14,7 +14,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphas
 import static java.util.Collections.singletonMap;
 
 import com.google.common.annotations.Beta;
-import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.workspace.server.spi.provision.env.AgentAuthEnableEnvVarProvider;
@@ -39,13 +38,13 @@ public class KubernetesBrokerEnvironmentFactory
       AgentAuthEnableEnvVarProvider authEnableEnvVarProvider,
       MachineTokenEnvVarProvider machineTokenEnvVarProvider,
       @Named("che.workspace.plugin_broker.init.image") String initBrokerImage,
-      @Named("che.workspace.plugin_broker.images") Map<String, String> pluginTypeToImage) {
+      @Named("che.workspace.plugin_broker.unified.image") String unifiedBrokerImage) {
     super(
         cheWebsocketEndpoint,
         brokerPullPolicy,
         authEnableEnvVarProvider,
         machineTokenEnvVarProvider,
-        pluginTypeToImage,
+        unifiedBrokerImage,
         initBrokerImage);
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListener.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListener.java
@@ -69,7 +69,7 @@ public class BrokerStatusListener implements EventSubscriber<BrokerEvent> {
             return;
           }
           try {
-            brokersResult.brokerResult(tooling);
+            brokersResult.setResult(tooling);
           } catch (InfrastructureException e) {
             LOG.error(e.getLocalizedMessage(), e);
           }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListener.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListener.java
@@ -69,7 +69,7 @@ public class BrokerStatusListener implements EventSubscriber<BrokerEvent> {
             return;
           }
           try {
-            brokersResult.addResult(tooling);
+            brokersResult.brokerResult(tooling);
           } catch (InfrastructureException e) {
             LOG.error(e.getLocalizedMessage(), e);
           }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResultTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResultTest.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 
-import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.testng.Assert.assertEquals;
@@ -61,38 +60,32 @@ public class BrokersResultTest {
       expectedExceptionsMessageRegExp =
           "Submitting a broker result is not allowed before calling BrokerResult#get")
   public void shouldThrowExceptionOnCallingAddResultBeforeCallGet() throws Exception {
-    brokersResult.addResult(emptyList());
+    brokersResult.brokerResult(emptyList());
   }
 
   @Test(
       expectedExceptions = InfrastructureException.class,
       expectedExceptionsMessageRegExp =
           "Broker result is submitted when no more results are expected")
-  public void shouldThrowExceptionIfNumberOfAddResultCallsIsBiggerThanExpected() throws Exception {
+  public void shouldThrowExceptionIfResultIsSubmittedSecondTime() throws Exception {
     // given
-    brokersResult.oneMoreBroker();
-    brokersResult.oneMoreBroker();
-    brokersResult.oneMoreBroker();
     executeBrokerGet();
     waitBrokerGetCalled();
 
     // when
-    brokersResult.addResult(singletonList(new ChePlugin()));
-    brokersResult.addResult(singletonList(new ChePlugin()));
-    brokersResult.addResult(singletonList(new ChePlugin()));
+    brokersResult.brokerResult(singletonList(new ChePlugin()));
 
     // then
-    brokersResult.addResult(singletonList(new ChePlugin()));
+    brokersResult.brokerResult(singletonList(new ChePlugin()));
   }
 
   @Test
-  public void shouldReturnResultOfOneBroker() throws Exception {
+  public void shouldReturnResultOfBroker() throws Exception {
     // given
-    brokersResult.oneMoreBroker();
     ChePlugin chePlugin = new ChePlugin();
     executeWhenResultIsStarted(
         () -> {
-          brokersResult.addResult(singletonList(chePlugin));
+          brokersResult.brokerResult(singletonList(chePlugin));
           return null;
         });
 
@@ -101,27 +94,6 @@ public class BrokersResultTest {
 
     // then
     assertEquals(chePlugins, singletonList(chePlugin));
-  }
-
-  @Test
-  public void shouldCombineResultsOfSeveralBrokers() throws Exception {
-    // given
-    brokersResult.oneMoreBroker();
-    ChePlugin chePlugin = new ChePlugin();
-    brokersResult.oneMoreBroker();
-    ChePlugin chePlugin2 = new ChePlugin();
-    executeWhenResultIsStarted(
-        () -> {
-          brokersResult.addResult(singletonList(chePlugin));
-          brokersResult.addResult(singletonList(chePlugin2));
-          return null;
-        });
-
-    // when
-    List<ChePlugin> chePlugins = brokersResult.get(2, TimeUnit.SECONDS);
-
-    // then
-    assertEquals(chePlugins, asList(chePlugin, chePlugin2));
   }
 
   @Test(
@@ -136,24 +108,7 @@ public class BrokersResultTest {
 
   @Test(expectedExceptions = TimeoutException.class)
   public void shouldThrowTimeoutExceptionIfResultIsNotSubmitted() throws Exception {
-    brokersResult.oneMoreBroker();
-
     brokersResult.get(1, TimeUnit.MILLISECONDS);
-  }
-
-  @Test(expectedExceptions = TimeoutException.class)
-  public void shouldThrowTimeoutExceptionIfNotAllResultsAreSubmitted() throws Exception {
-    // given
-    brokersResult.oneMoreBroker();
-    brokersResult.oneMoreBroker();
-    executeWhenResultIsStarted(
-        () -> {
-          brokersResult.addResult(singletonList(new ChePlugin()));
-          return null;
-        });
-
-    // when
-    brokersResult.get(1, TimeUnit.SECONDS);
   }
 
   @Test
@@ -165,30 +120,6 @@ public class BrokersResultTest {
           return null;
         });
     // given
-    brokersResult.oneMoreBroker();
-    try {
-      brokersResult.get(3, TimeUnit.SECONDS);
-    } catch (ExecutionException e) {
-      // then
-      assertEquals(e.getCause().getClass(), InfrastructureException.class);
-      assertEquals(e.getCause().getMessage(), "test");
-      return;
-    }
-    fail();
-  }
-
-  @Test
-  public void shouldThrowExceptionIfErrorIsSubmittedAfterOneOfTheResults() throws Exception {
-    executeWhenResultIsStarted(
-        () -> {
-          // when
-          brokersResult.addResult(singletonList(new ChePlugin()));
-          brokersResult.error(new InfrastructureException("test"));
-          return null;
-        });
-    // given
-    brokersResult.oneMoreBroker();
-    brokersResult.oneMoreBroker();
     try {
       brokersResult.get(3, TimeUnit.SECONDS);
     } catch (ExecutionException e) {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResultTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResultTest.java
@@ -60,7 +60,7 @@ public class BrokersResultTest {
       expectedExceptionsMessageRegExp =
           "Submitting a broker result is not allowed before calling BrokerResult#get")
   public void shouldThrowExceptionOnCallingAddResultBeforeCallGet() throws Exception {
-    brokersResult.brokerResult(emptyList());
+    brokersResult.setResult(emptyList());
   }
 
   @Test(
@@ -73,10 +73,10 @@ public class BrokersResultTest {
     waitBrokerGetCalled();
 
     // when
-    brokersResult.brokerResult(singletonList(new ChePlugin()));
+    brokersResult.setResult(singletonList(new ChePlugin()));
 
     // then
-    brokersResult.brokerResult(singletonList(new ChePlugin()));
+    brokersResult.setResult(singletonList(new ChePlugin()));
   }
 
   @Test
@@ -85,7 +85,7 @@ public class BrokersResultTest {
     ChePlugin chePlugin = new ChePlugin();
     executeWhenResultIsStarted(
         () -> {
-          brokersResult.brokerResult(singletonList(chePlugin));
+          brokersResult.setResult(singletonList(chePlugin));
           return null;
         });
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResultTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/BrokersResultTest.java
@@ -66,7 +66,7 @@ public class BrokersResultTest {
   @Test(
       expectedExceptions = InfrastructureException.class,
       expectedExceptionsMessageRegExp =
-          "Broker result is submitted when no more results are expected")
+          "Plugins brokering result is unexpectedly submitted more than one time. This indicates unexpected behavior of the system")
   public void shouldThrowExceptionIfResultIsSubmittedSecondTime() throws Exception {
     // given
     executeBrokerGet();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactoryTest.java
@@ -19,14 +19,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
-import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import java.util.Collection;
 import java.util.List;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.provision.env.AgentAuthEnableEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.MachineTokenEnvVarProvider;
 import org.eclipse.che.api.workspace.server.wsplugins.model.PluginMeta;
@@ -46,8 +44,8 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class BrokerEnvironmentFactoryTest {
 
-  private static final String SUPPORTED_TYPE = "Test type 1";
   private static final String INIT_IMAGE = "init:image";
+  private static final String UNIFIED_BROKER_IMAGE = "unified:image";
   private static final String IMAGE_PULL_POLICY = "Never";
   private static final String PUSH_ENDPOINT = "http://localhost:8080";
 
@@ -66,8 +64,7 @@ public class BrokerEnvironmentFactoryTest {
                 IMAGE_PULL_POLICY,
                 authEnableEnvVarProvider,
                 machineTokenEnvVarProvider,
-                ImmutableMap.of(
-                    SUPPORTED_TYPE, "testRepo/image:tag", "Test type 2", "testRepo/image2:tag2"),
+                UNIFIED_BROKER_IMAGE,
                 INIT_IMAGE) {
               @Override
               protected KubernetesEnvironment doCreate(BrokersConfigs brokersConfigs) {
@@ -84,33 +81,10 @@ public class BrokerEnvironmentFactoryTest {
     when(runtimeId.getWorkspaceId()).thenReturn("wsid");
   }
 
-  @Test(
-      expectedExceptions = InfrastructureException.class,
-      expectedExceptionsMessageRegExp = "Plugin '.*:.*' has invalid type 'null'")
-  public void shouldThrowExceptionIfBrokerTypeIsMissing() throws Exception {
-    // given
-    Collection<PluginMeta> metas = singletonList(new PluginMeta());
-
-    // when
-    factory.create(metas, runtimeId, new BrokersResult());
-  }
-
-  @Test(
-      expectedExceptions = InfrastructureException.class,
-      expectedExceptionsMessageRegExp =
-          "Plugin '.*:.*' has unsupported type 'Unsupported test type'")
-  public void shouldThrowExceptionIfImageForBrokerIsNonFound() throws Exception {
-    // given
-    Collection<PluginMeta> metas = singletonList(new PluginMeta().type("Unsupported test type"));
-
-    // when
-    factory.create(metas, runtimeId, new BrokersResult());
-  }
-
   @Test
   public void testInitBrokerContainer() throws Exception {
     // given
-    Collection<PluginMeta> metas = singletonList(new PluginMeta().type(SUPPORTED_TYPE));
+    Collection<PluginMeta> metas = singletonList(new PluginMeta());
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
@@ -145,7 +119,7 @@ public class BrokerEnvironmentFactoryTest {
   @Test
   public void shouldNameContainersAfterPluginBrokerImage() throws Exception {
     // given
-    Collection<PluginMeta> metas = singletonList(new PluginMeta().type(SUPPORTED_TYPE));
+    Collection<PluginMeta> metas = singletonList(new PluginMeta());
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
@@ -162,6 +136,6 @@ public class BrokerEnvironmentFactoryTest {
 
     List<Container> containers = brokerPodSpec.getContainers();
     assertEquals(containers.size(), 1);
-    assertEquals(containers.get(0).getName(), "testrepo-image-tag");
+    assertEquals(containers.get(0).getName(), "unified-image");
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
@@ -89,7 +89,7 @@ public class BrokerStatusListenerTest {
     brokerStatusListener.onEvent(event);
 
     // then
-    verify(brokersResult).addResult(emptyList());
+    verify(brokersResult).brokerResult(emptyList());
   }
 
   @Test
@@ -124,7 +124,7 @@ public class BrokerStatusListenerTest {
     brokerStatusListener.onEvent(event);
 
     // then
-    verify(brokersResult, never()).addResult(anyList());
+    verify(brokersResult, never()).brokerResult(anyList());
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/events/BrokerStatusListenerTest.java
@@ -89,7 +89,7 @@ public class BrokerStatusListenerTest {
     brokerStatusListener.onEvent(event);
 
     // then
-    verify(brokersResult).brokerResult(emptyList());
+    verify(brokersResult).setResult(emptyList());
   }
 
   @Test
@@ -124,7 +124,7 @@ public class BrokerStatusListenerTest {
     brokerStatusListener.onEvent(event);
 
     // then
-    verify(brokersResult, never()).brokerResult(anyList());
+    verify(brokersResult, never()).setResult(anyList());
   }
 
   @Test

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -16,12 +16,10 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.UniqueWorkspacePVCStrategy.UNIQUE_STRATEGY;
 
 import com.google.inject.AbstractModule;
-import com.google.inject.Key;
 import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
-import com.google.inject.name.Names;
 import org.eclipse.che.api.system.server.ServiceTermination;
 import org.eclipse.che.api.workspace.server.NoEnvironmentFactory;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
@@ -148,24 +146,5 @@ public class OpenShiftInfraModule extends AbstractModule {
 
     bind(new TypeLiteral<KubernetesEnvironmentProvisioner<OpenShiftEnvironment>>() {})
         .to(OpenShiftEnvironmentProvisioner.class);
-
-    MapBinder<String, String> pluginBrokers =
-        MapBinder.newMapBinder(
-            binder(),
-            String.class,
-            String.class,
-            Names.named("che.workspace.plugin_broker.images"));
-    pluginBrokers
-        .addBinding("Che Plugin")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.image")));
-    pluginBrokers
-        .addBinding("Che Editor")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.image")));
-    pluginBrokers
-        .addBinding("Theia plugin")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.theia.image")));
-    pluginBrokers
-        .addBinding("VS Code extension")
-        .to(Key.get(String.class, Names.named("che.workspace.plugin_broker.vscode.image")));
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
@@ -14,7 +14,6 @@ package org.eclipse.che.workspace.infrastructure.openshift.wsplugins.brokerphase
 import static java.util.Collections.singletonMap;
 
 import com.google.common.annotations.Beta;
-import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.workspace.server.spi.provision.env.AgentAuthEnableEnvVarProvider;
@@ -41,13 +40,13 @@ public class OpenshiftBrokerEnvironmentFactory
       AgentAuthEnableEnvVarProvider authEnableEnvVarProvider,
       MachineTokenEnvVarProvider machineTokenEnvVarProvider,
       @Named("che.workspace.plugin_broker.init.image") String initBrokerImage,
-      @Named("che.workspace.plugin_broker.images") Map<String, String> pluginTypeToImage) {
+      @Named("che.workspace.plugin_broker.unified.image") String unifiedBrokerImage) {
     super(
         cheWebsocketEndpoint,
         brokerPullPolicy,
         authEnableEnvVarProvider,
         machineTokenEnvVarProvider,
-        pluginTypeToImage,
+        unifiedBrokerImage,
         initBrokerImage);
   }
 


### PR DESCRIPTION
### What does this PR do?
Use single unified plugin broker for all the plugins.
Cleanup code that is not needed anymore.

### What issues does this PR fix or reference?
Closes https://github.com/redhat-developer/rh-che/issues/1306


<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Deprecate and remove usage of plugin brokers that process plugins of a certain type.
Instead of that a single plugin broker is used that processes plugins of all types.
Because of that properties and corresponding environment variables are removed:
`che.workspace.plugin_broker.image`
`che.workspace.plugin_broker.theia.image`
`che.workspace.plugin_broker.vscode.image`
And new one is added:
`che.workspace.plugin_broker.unified.image`

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
