### PR TITLE
Improve ZipUtils tests.

### DIFF
--- a/core/commons/che-core-commons-lang/src/test/java/org/eclipse/che/commons/lang/ZipUtilsTest.java
+++ b/core/commons/che-core-commons-lang/src/test/java/org/eclipse/che/commons/lang/ZipUtilsTest.java
@@ -21,6 +21,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Random;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -33,19 +36,21 @@ import org.testng.annotations.Test;
 
 public class ZipUtilsTest {
 
+  public static final String FILE_NAME = "test";
   private File zipFile;
+  private byte[] testData;
 
   @BeforeMethod
   public void setUp() throws IOException {
     zipFile = File.createTempFile("test", "zip");
     zipFile.deleteOnExit();
 
-    byte[] testData = new byte[2048];
+    testData = new byte[2048];
     Random random = new Random();
     random.nextBytes(testData);
 
     try (ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(zipFile))) {
-      ZipEntry entry = new ZipEntry("test");
+      ZipEntry entry = new ZipEntry(FILE_NAME);
       entry.setSize(testData.length);
       zos.putNextEntry(entry);
       zos.write(testData);
@@ -69,5 +74,14 @@ public class ZipUtilsTest {
         new ZipFile(testJar.getFile()), Pattern.compile(".*[//]?codenvy/[^//]+[.]json"), consumer);
 
     verify(consumer, times(2)).accept(any(InputStream.class));
+  }
+
+  @Test
+  public void testUnzipFile() throws Exception {
+    Path targetDir = Paths.get(zipFile.getParent());
+    ZipUtils.unzip(zipFile, targetDir.toFile());
+    Path unzippedFile = Paths.get(targetDir.toString(), FILE_NAME);
+    Assert.assertEquals(testData, Files.readAllBytes(unzippedFile));
+    Files.delete(unzippedFile);
   }
 }

--- a/core/commons/che-core-commons-lang/src/test/java/org/eclipse/che/commons/lang/ZipUtilsWriteTest.java
+++ b/core/commons/che-core-commons-lang/src/test/java/org/eclipse/che/commons/lang/ZipUtilsWriteTest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Collection;
@@ -88,7 +89,7 @@ public class ZipUtilsWriteTest {
     }
     Collection<String> entries = listEntries(zipFile.toFile());
     assertTrue(entries.contains("foo.bar"));
-    assertTrue(entries.contains("inner/temp.bla"));
+    assertTrue(entries.contains(Paths.get("inner/temp.bla").toString()));
   }
 
   @Test
@@ -98,7 +99,7 @@ public class ZipUtilsWriteTest {
     }
     Collection<String> entries = listEntries(zipFile.toFile());
     String tempFileName = tempDir.getFileName().toString();
-    assertTrue(entries.contains(tempFileName + "/foo.bar"));
-    assertTrue(entries.contains(tempFileName + "/inner/temp.bla"));
+    assertTrue(entries.contains(Paths.get(tempFileName + "/foo.bar").toString()));
+    assertTrue(entries.contains(Paths.get(tempFileName + "/inner/temp.bla").toString()));
   }
 }


### PR DESCRIPTION
### What does this PR do?

Fix ZipUtilsWriteTest for Windows, slashes get converted inside
ZipUtils, this causes the tests to fail.

Add test for unzipping. This was not explicitely tested.

Signed-off-by: Gerben Oolbekkink <g.j.w.oolbekkink@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->


### What issues does this PR fix or reference?

N/A

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
N/A