### PR TITLE
Fixed matching of command to plugin/editor tools from custom plugin registry

### DIFF
--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/editor/EditorToolToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/editor/EditorToolToWorkspaceApplier.java
@@ -59,10 +59,20 @@ public class EditorToolToWorkspaceApplier implements ToolToWorkspaceApplier {
 
     workspaceConfig.getAttributes().put(EDITOR_TOOL_ALIAS_WORKSPACE_ATTRIBUTE, editorToolName);
 
+    String editorIdVersion = resolveIdAndVersion(editorTool.getId());
     workspaceConfig
         .getCommands()
         .stream()
         .filter(c -> c.getAttributes().get(TOOL_NAME_COMMAND_ATTRIBUTE).equals(editorToolName))
-        .forEach(c -> c.getAttributes().put(PLUGIN_ATTRIBUTE, editorTool.getId()));
+        .forEach(c -> c.getAttributes().put(PLUGIN_ATTRIBUTE, editorIdVersion));
+  }
+
+  private String resolveIdAndVersion(String ref) {
+    int lastSlashPosition = ref.lastIndexOf("/");
+    if (lastSlashPosition < 0) {
+      return ref;
+    } else {
+      return ref.substring(lastSlashPosition + 1);
+    }
   }
 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/plugin/PluginToolToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/plugin/PluginToolToWorkspaceApplier.java
@@ -71,6 +71,7 @@ public class PluginToolToWorkspaceApplier implements ToolToWorkspaceApplier {
             PLUGINS_TOOLS_ALIASES_WORKSPACE_ATTRIBUTE,
             append(pluginsAliases, pluginTool.getId() + "=" + pluginTool.getName()));
 
+    String pluginIdVersion = resolveIdAndVersion(pluginTool.getId());
     for (CommandImpl command : workspaceConfig.getCommands()) {
       String commandTool = command.getAttributes().get(TOOL_NAME_COMMAND_ATTRIBUTE);
 
@@ -83,7 +84,16 @@ public class PluginToolToWorkspaceApplier implements ToolToWorkspaceApplier {
         continue;
       }
 
-      command.getAttributes().put(PLUGIN_ATTRIBUTE, pluginTool.getId());
+      command.getAttributes().put(PLUGIN_ATTRIBUTE, pluginIdVersion);
+    }
+  }
+
+  private String resolveIdAndVersion(String ref) {
+    int lastSlashPosition = ref.lastIndexOf("/");
+    if (lastSlashPosition < 0) {
+      return ref;
+    } else {
+      return ref.substring(lastSlashPosition + 1);
     }
   }
 

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/editor/EditorToolToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/editor/EditorToolToWorkspaceApplierTest.java
@@ -76,4 +76,28 @@ public class EditorToolToWorkspaceApplierTest {
         workspaceConfig.getCommands().get(0).getAttributes().get(PLUGIN_ATTRIBUTE),
         "org.eclipse.che.super-editor:0.0.1");
   }
+
+  @Test
+  public void shouldProvisionPluginCommandAttributeWhenIdIsURLToCustomPluginRegistry()
+      throws Exception {
+    // given
+    Tool superPluginTool = new Tool();
+    superPluginTool.setName("editor");
+    superPluginTool.setId(
+        "https://custom-plugin.registry/plugins/org.eclipse.che.super-editor:0.0.1");
+    superPluginTool.setType(EDITOR_TOOL_TYPE);
+
+    WorkspaceConfigImpl workspaceConfig = new WorkspaceConfigImpl();
+    CommandImpl command = new CommandImpl();
+    command.getAttributes().put(TOOL_NAME_COMMAND_ATTRIBUTE, "editor");
+    workspaceConfig.getCommands().add(command);
+
+    // when
+    editorToolApplier.apply(workspaceConfig, superPluginTool, null);
+
+    // then
+    assertEquals(
+        workspaceConfig.getCommands().get(0).getAttributes().get(PLUGIN_ATTRIBUTE),
+        "org.eclipse.che.super-editor:0.0.1");
+  }
 }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/plugin/PluginToolToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/plugin/PluginToolToWorkspaceApplierTest.java
@@ -89,4 +89,28 @@ public class PluginToolToWorkspaceApplierTest {
         workspaceConfig.getCommands().get(0).getAttributes().get(PLUGIN_ATTRIBUTE),
         "org.eclipse.che.super-plugin:0.0.1");
   }
+
+  @Test
+  public void shouldProvisionPluginCommandAttributeWhenIdIsURLToCustomPluginRegistry()
+      throws Exception {
+    // given
+    Tool superPluginTool = new Tool();
+    superPluginTool.setName("super-plugin");
+    superPluginTool.setId(
+        "https://custom-plugin.registry/plugins/org.eclipse.che.super-plugin:0.0.1");
+    superPluginTool.setType(PLUGIN_TOOL_TYPE);
+
+    WorkspaceConfigImpl workspaceConfig = new WorkspaceConfigImpl();
+    CommandImpl command = new CommandImpl();
+    command.getAttributes().put(TOOL_NAME_COMMAND_ATTRIBUTE, "super-plugin");
+    workspaceConfig.getCommands().add(command);
+
+    // when
+    pluginToolApplier.apply(workspaceConfig, superPluginTool, null);
+
+    // then
+    assertEquals(
+        workspaceConfig.getCommands().get(0).getAttributes().get(PLUGIN_ATTRIBUTE),
+        "org.eclipse.che.super-plugin:0.0.1");
+  }
 }


### PR DESCRIPTION
### What does this PR do?
Fixed matching of command to plugin/editor tools from custom plugin registry.

It would be better to evaluate plugin id and version from URL in the place where it is already done https://github.com/eclipse/che/blob/master/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/PluginMetaRetriever.java#L148
But it requires some refactoring. I think these changes are OK since there is no much code duplication and later we won't convert Devfile to WorkspaceConfig (this code will be removed).

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12765

#### How to test this PR
Create a workspace from the following Devfile and check that commands are matched to correct machines
<details>

<summary>Devfile with Editor and Plugin from custom plugin registry</summary>

```yaml
specVersion: 0.0.1
name: test
tools:
  - name: theia
    type: cheEditor
    id: https://che-plugin-registry.openshift.io/plugins/org.eclipse.che.editor.theia:1.0.0
  - name: exec-plugin
    type: chePlugin
    id: https://che-plugin-registry.openshift.io/plugins/che-machine-exec-plugin:0.0.1
commands:
  - name: Hello from Theia
    actions:
      - type: exec
        tool: theia
        command: echo Hello from Theia
  - name: Hello from Exec Plugin
    actions:
      - type: exec
        tool: exec-plugin
        command: echo Hello from Exec Plugin

```
</details>

#### Release Notes
N/A

#### Docs PR
N/A