### PR TITLE
Add support of multiple dockerimage tools in Devfile

### DIFF
--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.api.devfile.server;
 
+import org.eclipse.che.api.devfile.model.Endpoint;
+
 public class Constants {
 
   private Constants() {}
@@ -49,4 +51,11 @@ public class Constants {
 
   /** Workspace command attributes that indicates with which tool it is associated. */
   public static final String TOOL_NAME_COMMAND_ATTRIBUTE = "toolName";
+
+  /**
+   * {@link Endpoint} attribute name which can identify endpoint as public or internal. Attribute
+   * value {@code false} makes a endpoint internal, any other value or lack of the attribute makes
+   * the endpoint public.
+   */
+  public static final String PUBLIC_ENDPOINT_ATTRIBUTE = "public";
 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
@@ -58,4 +58,12 @@ public class Constants {
    * the endpoint public.
    */
   public static final String PUBLIC_ENDPOINT_ATTRIBUTE = "public";
+
+  /**
+   * {@link Endpoint} attribute name which can identify endpoint as discoverable(means that it is
+   * accessible by its name from workspace's containers). Attribute value {@code true} makes a
+   * endpoint discoverable, any other value or lack of the attribute makes the endpoint
+   * non-discoverable.
+   */
+  public static final String DISCOVERABLE_ENDPOINT_ATTRIBUTE = "discoverable";
 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolProvisioner.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolProvisioner.java
@@ -14,6 +14,7 @@ package org.eclipse.che.api.devfile.server.convert.tool.dockerimage;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.PUBLIC_ENDPOINT_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
 
 import java.util.HashMap;
@@ -167,7 +168,7 @@ public class DockerimageToolProvisioner implements ToolProvisioner {
 
     String isInternal = config.getAttributes().remove(ServerConfig.INTERNAL_SERVER_ATTRIBUTE);
     if ("true".equals(isInternal)) {
-      attributes.put("public", "false");
+      attributes.put(PUBLIC_ENDPOINT_ATTRIBUTE, "false");
     }
 
     return new Endpoint()

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolProvisioner.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolProvisioner.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.devfile.model.Devfile;
 import org.eclipse.che.api.devfile.model.Endpoint;
 import org.eclipse.che.api.devfile.model.Env;
@@ -163,6 +164,11 @@ public class DockerimageToolProvisioner implements ToolProvisioner {
     Map<String, String> attributes = new HashMap<>(config.getAttributes());
     putIfNotNull(attributes, "protocol", config.getProtocol());
     putIfNotNull(attributes, "path", config.getPath());
+
+    String isInternal = config.getAttributes().remove(ServerConfig.INTERNAL_SERVER_ATTRIBUTE);
+    if ("true".equals(isInternal)) {
+      attributes.put("public", "false");
+    }
 
     return new Endpoint()
         .withName(name)

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolToWorkspaceApplier.java
@@ -14,16 +14,24 @@ package org.eclipse.che.api.devfile.server.convert.tool.dockerimage;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
+import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
-import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.CONTAINER_ARGS_ATTRIBUTE;
-import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.CONTAINER_COMMAND_ATTRIBUTE;
-import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.PUBLIC_ENDPOINT_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_ORIGINAL_NAME_LABEL;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACHINE_NAME_ANNOTATION_FMT;
 
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
@@ -32,16 +40,14 @@ import org.eclipse.che.api.devfile.model.Tool;
 import org.eclipse.che.api.devfile.server.Constants;
 import org.eclipse.che.api.devfile.server.FileContentProvider;
 import org.eclipse.che.api.devfile.server.convert.tool.ToolToWorkspaceApplier;
+import org.eclipse.che.api.devfile.server.convert.tool.kubernetes.KubernetesEnvironmentProvisioner;
 import org.eclipse.che.api.devfile.server.exception.DevfileException;
-import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
-import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
-import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.util.EntryPointParser;
-import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSize;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
 
 /**
  * Applies changes on workspace config according to the specified dockerimage tool.
@@ -51,18 +57,25 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSize;
 public class DockerimageToolToWorkspaceApplier implements ToolToWorkspaceApplier {
 
   private final String projectFolderPath;
-  private final EntryPointParser entryPointParser;
+  private final KubernetesEnvironmentProvisioner k8sEnvProvisioner;
 
   @Inject
   public DockerimageToolToWorkspaceApplier(
       @Named("che.workspace.projects.storage") String projectFolderPath,
-      EntryPointParser entryPointParser) {
+      KubernetesEnvironmentProvisioner k8sEnvProvisioner) {
     this.projectFolderPath = projectFolderPath;
-    this.entryPointParser = entryPointParser;
+    this.k8sEnvProvisioner = k8sEnvProvisioner;
   }
 
   /**
    * Applies changes on workspace config according to the specified dockerimage tool.
+   *
+   * <p>Dockerimage tool is provisioned as Deployment in Kubernetes recipe.<br>
+   * Generated deployment contains container with environment variables, memory limit, docker image,
+   * arguments and commands specified in tool.<br>
+   * Also, environment is provisioned with machine config with volumes and servers specified, then
+   * Kubernetes infra will created needed PVC, Services, Ingresses, Routes according to specified
+   * configuration.
    *
    * @param workspaceConfig workspace config on which changes should be applied
    * @param dockerimageTool dockerimage tool that should be applied
@@ -84,13 +97,10 @@ public class DockerimageToolToWorkspaceApplier implements ToolToWorkspaceApplier
     checkArgument(
         DOCKERIMAGE_TOOL_TYPE.equals(dockerimageTool.getType()),
         format("Plugin must have `%s` type", DOCKERIMAGE_TOOL_TYPE));
-    if (workspaceConfig.getDefaultEnv() != null) {
-      throw new DevfileException("Workspace already contains environment");
-    }
 
     String machineName = dockerimageTool.getName();
-    MachineConfigImpl machineConfig = new MachineConfigImpl();
 
+    MachineConfigImpl machineConfig = new MachineConfigImpl();
     dockerimageTool
         .getEndpoints()
         .forEach(e -> machineConfig.getServers().put(e.getName(), toServerConfig(e)));
@@ -109,22 +119,24 @@ public class DockerimageToolToWorkspaceApplier implements ToolToWorkspaceApplier
           .put(PROJECTS_VOLUME_NAME, new VolumeImpl().withPath(projectFolderPath));
     }
 
-    machineConfig
-        .getAttributes()
-        .put(
-            MEMORY_LIMIT_ATTRIBUTE,
-            Long.toString(KubernetesSize.toBytes(dockerimageTool.getMemoryLimit())));
+    Deployment deployment =
+        buildDeployment(
+            machineName,
+            dockerimageTool.getImage(),
+            dockerimageTool.getMemoryLimit(),
+            dockerimageTool
+                .getEnv()
+                .stream()
+                .map(e -> new EnvVar(e.getName(), e.getValue(), null))
+                .collect(Collectors.toCollection(ArrayList::new)),
+            dockerimageTool.getCommand(),
+            dockerimageTool.getArgs());
 
-    setEntryPointAttribute(
-        machineConfig, CONTAINER_COMMAND_ATTRIBUTE, dockerimageTool.getCommand());
-    setEntryPointAttribute(machineConfig, CONTAINER_ARGS_ATTRIBUTE, dockerimageTool.getArgs());
-
-    RecipeImpl recipe =
-        new RecipeImpl(DockerImageEnvironment.TYPE, null, dockerimageTool.getImage(), null);
-    EnvironmentImpl environment =
-        new EnvironmentImpl(recipe, ImmutableMap.of(machineName, machineConfig));
-    workspaceConfig.getEnvironments().put(dockerimageTool.getName(), environment);
-    workspaceConfig.setDefaultEnv(dockerimageTool.getName());
+    k8sEnvProvisioner.provision(
+        workspaceConfig,
+        KubernetesEnvironment.TYPE,
+        singletonList(deployment),
+        ImmutableMap.of(machineName, machineConfig));
 
     workspaceConfig
         .getCommands()
@@ -137,16 +149,40 @@ public class DockerimageToolToWorkspaceApplier implements ToolToWorkspaceApplier
         .forEach(c -> c.getAttributes().put(MACHINE_NAME_ATTRIBUTE, machineName));
   }
 
-  private void setEntryPointAttribute(
-      MachineConfigImpl machineConfig, String attributeName, List<String> attributeValue) {
+  private Deployment buildDeployment(
+      String name,
+      String image,
+      String memoryLimit,
+      List<EnvVar> env,
+      List<String> command,
+      List<String> args) {
+    Container container =
+        new ContainerBuilder()
+            .withImage(image)
+            .withName(name)
+            .withEnv(env)
+            .withCommand(command)
+            .withArgs(args)
+            .build();
 
-    if (attributeValue == null) {
-      return;
-    }
-
-    String val = entryPointParser.serializeEntry(attributeValue);
-
-    machineConfig.getAttributes().put(attributeName, val);
+    Containers.addRamLimit(container, memoryLimit);
+    return new DeploymentBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .withNewSpec()
+        .withNewTemplate()
+        .withNewMetadata()
+        .withName(name)
+        .addToLabels(CHE_ORIGINAL_NAME_LABEL, name)
+        .addToAnnotations(String.format(MACHINE_NAME_ANNOTATION_FMT, name), name)
+        .endMetadata()
+        .withNewSpec()
+        .withContainers(container)
+        .endSpec()
+        .endTemplate()
+        .endSpec()
+        .build();
   }
 
   private ServerConfigImpl toServerConfig(Endpoint endpoint) {
@@ -159,7 +195,7 @@ public class DockerimageToolToWorkspaceApplier implements ToolToWorkspaceApplier
 
     String path = attributes.remove("path");
 
-    String isPublic = attributes.remove("public");
+    String isPublic = attributes.remove(PUBLIC_ENDPOINT_ATTRIBUTE);
     if ("false".equals(isPublic)) {
       attributes.put(ServerConfig.INTERNAL_SERVER_ATTRIBUTE, "true");
     }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesEnvironmentProvisioner.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesEnvironmentProvisioner.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.devfile.server.convert.tool.kubernetes;
+
+import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
+import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.utils.Serialization;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import javax.inject.Inject;
+import org.eclipse.che.api.devfile.server.DevfileRecipeFormatException;
+import org.eclipse.che.api.devfile.server.exception.DevfileException;
+import org.eclipse.che.api.devfile.server.exception.DevfileFormatException;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.commons.lang.Pair;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesRecipeParser;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+
+/**
+ * Provisions default K8s/OS environment with specified objects (K8s/OS objects, machines) into
+ * {@link WorkspaceConfigImpl}.
+ *
+ * @author Sergii Leshchenko
+ */
+public class KubernetesEnvironmentProvisioner {
+  @VisibleForTesting static final String YAML_CONTENT_TYPE = "application/x-yaml";
+
+  private final KubernetesRecipeParser objectsParser;
+
+  @Inject
+  public KubernetesEnvironmentProvisioner(KubernetesRecipeParser objectsParser) {
+    this.objectsParser = objectsParser;
+  }
+
+  /**
+   * Provisions default K8s/OS environment with specified objects (K8s/OS objects, machines) into
+   * {@link WorkspaceConfigImpl}.
+   *
+   * <p>If there is already a default environment with kubernetes/openshift recipe then content will
+   * be updated with result or merging existing objects and specified ones.
+   *
+   * @param workspaceConfig workspace where recipe should be provisioned
+   * @param environmentType type of environment that should be provisioned. Should be {@link
+   *     KubernetesEnvironment#TYPE} or {@link OpenShiftEnvironment#TYPE}
+   * @param toolObjects objects that should be provisioned into the workspace config
+   * @param machines machines that should be provisioned into the workspace config
+   * @throws DevfileRecipeFormatException if exception occurred during existing environment parsing
+   * @throws DevfileRecipeFormatException if exception occurred during kubernetes object
+   *     serialization
+   * @throws DevfileException if any other exception occurred
+   */
+  public void provision(
+      WorkspaceConfigImpl workspaceConfig,
+      String environmentType,
+      List<HasMetadata> toolObjects,
+      Map<String, MachineConfigImpl> machines)
+      throws DevfileException, DevfileRecipeFormatException {
+    String defaultEnv = workspaceConfig.getDefaultEnv();
+    EnvironmentImpl environment = workspaceConfig.getEnvironments().get(defaultEnv);
+    if (environment == null) {
+      checkItemsHasUniqueKindToName(toolObjects);
+
+      RecipeImpl recipe =
+          new RecipeImpl(environmentType, YAML_CONTENT_TYPE, asYaml(toolObjects), null);
+      String envName = "default";
+      EnvironmentImpl env = new EnvironmentImpl(recipe, emptyMap());
+      env.getMachines().putAll(machines);
+      workspaceConfig.getEnvironments().put(envName, env);
+      workspaceConfig.setDefaultEnv(envName);
+    } else {
+      RecipeImpl envRecipe = environment.getRecipe();
+
+      for (Entry<String, MachineConfigImpl> machineEntry : machines.entrySet()) {
+        if (environment.getMachines().put(machineEntry.getKey(), machineEntry.getValue()) != null) {
+          throw new DevfileException(
+              format("Environment already contains machine '%s'", machineEntry.getKey()));
+        }
+      }
+      environment.getMachines().putAll(machines);
+
+      // check if it is needed to update recipe type since
+      // kubernetes tool is compatible with openshift but not vice versa
+      if (OPENSHIFT_TOOL_TYPE.equals(environmentType)
+          && KubernetesEnvironment.TYPE.equals(envRecipe.getType())) {
+        envRecipe.setType(OpenShiftEnvironment.TYPE);
+      }
+
+      // workspace already has k8s/OS recipe
+      // it is needed to merge existing recipe objects with tool's ones
+      List<HasMetadata> envObjects = unmarshalObjects(envRecipe);
+      envObjects.addAll(toolObjects);
+
+      envRecipe.setContent(asYaml(envObjects));
+    }
+  }
+
+  private List<HasMetadata> unmarshalObjects(RecipeImpl k8sRecipe) throws DevfileException {
+    if (!OpenShiftEnvironment.TYPE.equals(k8sRecipe.getType())
+        && !KubernetesEnvironment.TYPE.equals(k8sRecipe.getType())) {
+      throw new DevfileException(
+          format(
+              "Kubernetes tool can only be applied to a workspace with either kubernetes or "
+                  + "openshift recipe type but workspace has a recipe of type '%s'",
+              k8sRecipe.getType()));
+    }
+
+    return unmarshal(k8sRecipe.getContent());
+  }
+
+  /**
+   * Makes sure that all items of the specified list have unique names per kind.
+   *
+   * @param list the list to check
+   * @throws DevfileFormatException if objects list contains item with no unique combination of kind
+   *     and name
+   */
+  private void checkItemsHasUniqueKindToName(List<HasMetadata> list) throws DevfileFormatException {
+    Set<Pair<String, String>> uniqueKindToName = new HashSet<>();
+    for (HasMetadata hasMeta : list) {
+      if (!uniqueKindToName.add(new Pair<>(hasMeta.getKind(), hasMeta.getMetadata().getName()))) {
+        throw new DevfileFormatException(
+            format(
+                "Tools can not have objects with the same name and kind but there are multiple objects with kind '%s' and name '%s'",
+                hasMeta.getKind(), hasMeta.getMetadata().getName()));
+      }
+    }
+  }
+
+  private String asYaml(List<HasMetadata> list) throws DevfileRecipeFormatException {
+    try {
+      return Serialization.asYaml(new KubernetesListBuilder().withItems(list).build());
+    } catch (KubernetesClientException e) {
+      throw new DevfileRecipeFormatException(
+          format(
+              "Unable to deserialize objects to store them in workspace config. Error: %s",
+              e.getMessage()),
+          e);
+    }
+  }
+
+  private List<HasMetadata> unmarshal(String recipeContent) throws DevfileRecipeFormatException {
+    try {
+      return objectsParser.parse(recipeContent);
+    } catch (Exception e) {
+      throw new DevfileRecipeFormatException(e.getMessage(), e);
+    }
+  }
+}

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidator.java
@@ -113,8 +113,6 @@ public class DevfileIntegrityValidator {
   private Set<String> validateTools(Devfile devfile) throws DevfileFormatException {
     Set<String> existingNames = new HashSet<>();
     Tool editorTool = null;
-    Tool dockerimageTool = null;
-    Tool k8sOSTool = null;
     for (Tool tool : devfile.getTools()) {
       if (!existingNames.add(tool.getName())) {
         throw new DevfileFormatException(format("Duplicate tool name found:'%s'", tool.getName()));
@@ -131,29 +129,10 @@ public class DevfileIntegrityValidator {
           break;
 
         case PLUGIN_TOOL_TYPE:
-          // do nothing
-          break;
-
         case KUBERNETES_TOOL_TYPE:
-          // fall through
         case OPENSHIFT_TOOL_TYPE:
-          if (dockerimageTool != null) {
-            throw new DevfileFormatException(
-                "Devfile cannot contain kubernetes/openshift and dockerimage tool at the same time");
-          }
-          k8sOSTool = tool;
-          break;
-
         case DOCKERIMAGE_TOOL_TYPE:
-          if (k8sOSTool != null) {
-            throw new DevfileFormatException(
-                "Devfile cannot contain kubernetes/openshift and dockerimage tool at the same time");
-          }
-          if (dockerimageTool != null) {
-            throw new DevfileFormatException(
-                "Devfile cannot contain multiple dockerimage tools at the same time");
-          }
-          dockerimageTool = tool;
+          // do nothing
           break;
 
         default:
@@ -290,7 +269,11 @@ public class DevfileIntegrityValidator {
     return content;
   }
 
-  private static String toYAML(Entrypoint ep) throws DevfileException {
-    return Serialization.asYaml(ep);
+  private String toYAML(Entrypoint ep) throws DevfileException {
+    try {
+      return Serialization.asYaml(ep);
+    } catch (Exception e) {
+      throw new DevfileException(e.getMessage(), e);
+    }
   }
 }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolProvisionerTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolProvisionerTest.java
@@ -15,6 +15,7 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
+import static org.eclipse.che.api.devfile.server.Constants.PUBLIC_ENDPOINT_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -158,7 +159,8 @@ public class DockerimageToolProvisionerTest {
     EnvironmentImpl dockerEnv = new EnvironmentImpl();
     dockerEnv.setRecipe(new RecipeImpl("dockerimage", null, "eclipse/ubuntu_jdk8:latest", null));
     ServerConfigImpl serverConfig =
-        new ServerConfigImpl("8080/TCP", "http", "/api", ImmutableMap.of("public", "true"));
+        new ServerConfigImpl(
+            "8080/TCP", "http", "/api", ImmutableMap.of(PUBLIC_ENDPOINT_ATTRIBUTE, "true"));
     dockerEnv
         .getMachines()
         .put(
@@ -187,7 +189,7 @@ public class DockerimageToolProvisionerTest {
     assertEquals(endpoint.getAttributes().size(), 3);
     assertEquals(endpoint.getAttributes().get("protocol"), "http");
     assertEquals(endpoint.getAttributes().get("path"), "/api");
-    assertEquals(endpoint.getAttributes().get("public"), "true");
+    assertEquals(endpoint.getAttributes().get(PUBLIC_ENDPOINT_ATTRIBUTE), "true");
   }
 
   @Test

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/dockerimage/DockerimageToolToWorkspaceApplierTest.java
@@ -13,34 +13,42 @@ package org.eclipse.che.api.devfile.server.convert.tool.dockerimage;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
-import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.CONTAINER_ARGS_ATTRIBUTE;
-import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.CONTAINER_COMMAND_ATTRIBUTE;
-import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.PUBLIC_ENDPOINT_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACHINE_NAME_ANNOTATION_FMT;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.devfile.model.Endpoint;
 import org.eclipse.che.api.devfile.model.Env;
 import org.eclipse.che.api.devfile.model.Tool;
 import org.eclipse.che.api.devfile.model.Volume;
-import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.devfile.server.convert.tool.kubernetes.KubernetesEnvironmentProvisioner;
 import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
-import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
-import org.eclipse.che.workspace.infrastructure.kubernetes.environment.util.EntryPointParser;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -55,17 +63,22 @@ public class DockerimageToolToWorkspaceApplierTest {
 
   private DockerimageToolToWorkspaceApplier dockerimageToolApplier;
 
-  @Mock private EntryPointParser entryPointParser;
+  @Mock private KubernetesEnvironmentProvisioner k8sEnvProvisioner;
+
+  @Captor private ArgumentCaptor<List<HasMetadata>> objectsCaptor;
+  @Captor private ArgumentCaptor<Map<String, MachineConfigImpl>> machinesCaptor;
 
   @BeforeMethod
   public void setUp() throws Exception {
     dockerimageToolApplier =
-        new DockerimageToolToWorkspaceApplier(PROJECTS_MOUNT_PATH, entryPointParser);
+        new DockerimageToolToWorkspaceApplier(PROJECTS_MOUNT_PATH, k8sEnvProvisioner);
     workspaceConfig = new WorkspaceConfigImpl();
   }
 
   @Test
-  public void shouldProvisionEnvironmentWithDockerimageRecipe() throws Exception {
+  public void
+      shouldProvisionK8sEnvironmentWithMachineConfigAndGeneratedDeploymentForSpecifiedDockerimage()
+          throws Exception {
     // given
     Tool dockerimageTool =
         new Tool()
@@ -78,21 +91,29 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    String defaultEnvName = workspaceConfig.getDefaultEnv();
-    assertNotNull(defaultEnvName);
-    EnvironmentImpl defaultEnv = workspaceConfig.getEnvironments().get(defaultEnvName);
-    RecipeImpl recipe = defaultEnv.getRecipe();
-    assertEquals(recipe.getType(), "dockerimage");
-    assertEquals(recipe.getContent(), "eclipse/ubuntu_jdk8:latest");
-
-    assertEquals(defaultEnv.getMachines().size(), 1);
-
-    MachineConfigImpl machineConfig = defaultEnv.getMachines().get("jdk");
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    MachineConfigImpl machineConfig = machinesCaptor.getValue().get("jdk");
     assertNotNull(machineConfig);
+
+    List<HasMetadata> objects = objectsCaptor.getValue();
+    assertEquals(objects.size(), 1);
+    assertTrue(objects.get(0) instanceof Deployment);
+    Deployment deployment = (Deployment) objects.get(0);
+    PodTemplateSpec podTemplate = deployment.getSpec().getTemplate();
+    Map<String, String> annotations = podTemplate.getMetadata().getAnnotations();
+    assertEquals(annotations.get(String.format(MACHINE_NAME_ANNOTATION_FMT, "jdk")), "jdk");
+    Container container = podTemplate.getSpec().getContainers().get(0);
+    assertEquals(container.getName(), "jdk");
+    assertEquals(container.getImage(), "eclipse/ubuntu_jdk8:latest");
   }
 
   @Test
-  public void shouldProvisionMachineConfigWithEnvVarSpecified() throws Exception {
+  public void shouldProvisionSpecifiedEnvVars() throws Exception {
     // given
     Tool dockerimageTool =
         new Tool()
@@ -106,15 +127,28 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
-    Map<String, String> envVars = machineConfig.getEnv();
-    assertEquals(envVars.size(), 1);
-    assertEquals(envVars.get("envName"), "envValue");
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    List<HasMetadata> objects = objectsCaptor.getValue();
+    assertEquals(objects.size(), 1);
+    assertTrue(objects.get(0) instanceof Deployment);
+    Deployment deployment = (Deployment) objects.get(0);
+    PodTemplateSpec podTemplate = deployment.getSpec().getTemplate();
+    assertEquals(podTemplate.getSpec().getContainers().size(), 1);
+    Container container = podTemplate.getSpec().getContainers().get(0);
+    int env = container.getEnv().size();
+    assertEquals(env, 1);
+    EnvVar containerEnvVar = container.getEnv().get(0);
+    assertEquals(containerEnvVar.getName(), "envName");
+    assertEquals(containerEnvVar.getValue(), "envValue");
   }
 
   @Test
-  public void shouldProvisionMachineConfigWithMemoryLimitAttributeServersSpecified()
-      throws Exception {
+  public void shouldProvisionContainerWithMemoryLimitSpecified() throws Exception {
     // given
     Tool dockerimageTool =
         new Tool()
@@ -127,8 +161,21 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
-    assertEquals(machineConfig.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE), "1000000000");
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    List<HasMetadata> objects = objectsCaptor.getValue();
+    assertEquals(objects.size(), 1);
+    assertTrue(objects.get(0) instanceof Deployment);
+    Deployment deployment = (Deployment) objects.get(0);
+    PodTemplateSpec podTemplate = deployment.getSpec().getTemplate();
+    assertEquals(podTemplate.getSpec().getContainers().size(), 1);
+    Container container = podTemplate.getSpec().getContainers().get(0);
+    Quantity memoryLimit = container.getResources().getLimits().get("memory");
+    assertEquals(memoryLimit.getAmount(), "1G");
   }
 
   @Test
@@ -144,12 +191,10 @@ public class DockerimageToolToWorkspaceApplierTest {
                     "http",
                     "path",
                     "/ls",
-                    "public",
+                    PUBLIC_ENDPOINT_ATTRIBUTE,
                     "false",
                     "secure",
-                    "false",
-                    "discoverable",
-                    "true"));
+                    "false"));
     Tool dockerimageTool =
         new Tool()
             .withName("jdk")
@@ -162,17 +207,23 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    MachineConfigImpl machineConfig = machinesCaptor.getValue().get("jdk");
+    assertNotNull(machineConfig);
     assertEquals(machineConfig.getServers().size(), 1);
     ServerConfigImpl serverConfig = machineConfig.getServers().get("jdk-ls");
     assertEquals(serverConfig.getProtocol(), "http");
     assertEquals(serverConfig.getPath(), "/ls");
     assertEquals(serverConfig.getPort(), "4923");
     Map<String, String> attributes = serverConfig.getAttributes();
-    assertEquals(attributes.size(), 3);
-    assertEquals(attributes.get("public"), "false");
+    assertEquals(attributes.size(), 2);
+    assertEquals(attributes.get(ServerConfig.INTERNAL_SERVER_ATTRIBUTE), "true");
     assertEquals(attributes.get("secure"), "false");
-    assertEquals(attributes.get("discoverable"), "true");
   }
 
   @Test
@@ -191,7 +242,14 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    MachineConfigImpl machineConfig = machinesCaptor.getValue().get("jdk");
+    assertNotNull(machineConfig);
     assertEquals(machineConfig.getServers().size(), 1);
     ServerConfigImpl serverConfig = machineConfig.getServers().get("jdk-ls");
     assertEquals(serverConfig.getProtocol(), "http");
@@ -213,7 +271,14 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    MachineConfigImpl machineConfig = machinesCaptor.getValue().get("jdk");
+    assertNotNull(machineConfig);
     VolumeImpl volume = machineConfig.getVolumes().get("data");
     assertNotNull(volume);
     assertEquals(volume.getPath(), "/tmp/data/");
@@ -234,7 +299,14 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    MachineConfigImpl machineConfig = machinesCaptor.getValue().get("jdk");
+    assertNotNull(machineConfig);
     VolumeImpl projectsVolume = machineConfig.getVolumes().get(PROJECTS_VOLUME_NAME);
     assertNotNull(projectsVolume);
     assertEquals(projectsVolume.getPath(), PROJECTS_MOUNT_PATH);
@@ -254,8 +326,15 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
-    Assert.assertFalse(machineConfig.getVolumes().containsKey(PROJECTS_VOLUME_NAME));
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    MachineConfigImpl machineConfig = machinesCaptor.getValue().get("jdk");
+    assertNotNull(machineConfig);
+    assertFalse(machineConfig.getVolumes().containsKey(PROJECTS_VOLUME_NAME));
   }
 
   @Test
@@ -263,12 +342,6 @@ public class DockerimageToolToWorkspaceApplierTest {
     // given
     List<String> command = singletonList("/usr/bin/rf");
     List<String> args = Arrays.asList("-r", "f");
-
-    String serializedCommand = command.toString();
-    String serializedArgs = args.toString();
-
-    doReturn(serializedCommand).when(entryPointParser).serializeEntry(eq(command));
-    doReturn(serializedArgs).when(entryPointParser).serializeEntry(eq(args));
 
     Tool dockerimageTool =
         new Tool()
@@ -283,24 +356,20 @@ public class DockerimageToolToWorkspaceApplierTest {
     dockerimageToolApplier.apply(workspaceConfig, dockerimageTool, null);
 
     // then
-    MachineConfigImpl machineConfig = getMachineConfig(workspaceConfig, "jdk");
-    Assert.assertEquals(
-        machineConfig.getAttributes().get(CONTAINER_COMMAND_ATTRIBUTE), serializedCommand);
-    Assert.assertEquals(
-        machineConfig.getAttributes().get(CONTAINER_ARGS_ATTRIBUTE), serializedArgs);
-  }
-
-  private MachineConfigImpl getMachineConfig(
-      WorkspaceConfigImpl workspaceConfig, String machineName) {
-    String defaultEnvName = workspaceConfig.getDefaultEnv();
-    assertNotNull(defaultEnvName);
-
-    EnvironmentImpl defaultEnv = workspaceConfig.getEnvironments().get(defaultEnvName);
-    assertNotNull(defaultEnv);
-
-    MachineConfigImpl machineConfig = defaultEnv.getMachines().get(machineName);
-    assertNotNull(machineConfig);
-
-    return machineConfig;
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    List<HasMetadata> objects = objectsCaptor.getValue();
+    assertEquals(objects.size(), 1);
+    assertTrue(objects.get(0) instanceof Deployment);
+    Deployment deployment = (Deployment) objects.get(0);
+    PodTemplateSpec podTemplate = deployment.getSpec().getTemplate();
+    assertEquals(podTemplate.getSpec().getContainers().size(), 1);
+    Container container = podTemplate.getSpec().getContainers().get(0);
+    assertEquals(container.getCommand(), command);
+    assertEquals(container.getArgs(), args);
   }
 }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesEnvironmentProvisionerTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesEnvironmentProvisionerTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.devfile.server.convert.tool.kubernetes;
+
+import static io.fabric8.kubernetes.client.utils.Serialization.unmarshal;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
+import static org.eclipse.che.api.devfile.server.convert.tool.kubernetes.KubernetesEnvironmentProvisioner.YAML_CONTENT_TYPE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceBuilder;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.che.api.devfile.server.exception.DevfileException;
+import org.eclipse.che.api.devfile.server.exception.DevfileFormatException;
+import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesRecipeParser;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.testng.reporters.Files;
+
+/**
+ * Tests {@link KubernetesEnvironmentProvisioner}
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class KubernetesEnvironmentProvisionerTest {
+
+  private WorkspaceConfigImpl workspaceConfig;
+
+  @Mock private KubernetesRecipeParser k8sRecipeParser;
+  @InjectMocks private KubernetesEnvironmentProvisioner k8sEnvProvisioner;
+
+  @BeforeMethod
+  public void setUp() {
+    workspaceConfig = new WorkspaceConfigImpl();
+  }
+
+  @Test
+  public void shouldProvisionEnvironmentWithCorrectRecipeTypeAndContentFromK8SList()
+      throws Exception {
+    // given
+    String yamlRecipeContent = getResource("petclinic.yaml");
+    List<HasMetadata> toolObjects = toK8SList(yamlRecipeContent).getItems();
+
+    // when
+    k8sEnvProvisioner.provision(
+        workspaceConfig, KubernetesEnvironment.TYPE, toolObjects, emptyMap());
+
+    // then
+    String defaultEnv = workspaceConfig.getDefaultEnv();
+    assertNotNull(defaultEnv);
+    EnvironmentImpl environment = workspaceConfig.getEnvironments().get(defaultEnv);
+    assertNotNull(environment);
+    RecipeImpl recipe = environment.getRecipe();
+    assertNotNull(recipe);
+    assertEquals(recipe.getType(), KUBERNETES_TOOL_TYPE);
+    assertEquals(recipe.getContentType(), YAML_CONTENT_TYPE);
+
+    // it is expected that applier wrap original recipes objects in new Kubernetes list
+    KubernetesList expectedKubernetesList =
+        new KubernetesListBuilder().withItems(toK8SList(yamlRecipeContent).getItems()).build();
+    assertEquals(toK8SList(recipe.getContent()).getItems(), expectedKubernetesList.getItems());
+  }
+
+  @Test(
+      expectedExceptions = DevfileException.class,
+      expectedExceptionsMessageRegExp = "Environment already contains machine 'machine'")
+  public void shouldThrowAnExceptionIfEnvironmentContainMachineWithSpecifiedName()
+      throws Exception {
+    // given
+    workspaceConfig.setDefaultEnv("default");
+    workspaceConfig.setEnvironments(
+        ImmutableMap.of(
+            "default",
+            new EnvironmentImpl(null, ImmutableMap.of("machine", new MachineConfigImpl()))));
+    // when
+    k8sEnvProvisioner.provision(
+        workspaceConfig,
+        KubernetesEnvironment.TYPE,
+        emptyList(),
+        ImmutableMap.of("machine", new MachineConfigImpl()));
+  }
+
+  @Test
+  public void shouldUpgradeKubernetesEnvironmentToOpenShiftTypeOnOpenShiftToolProvisioning()
+      throws Exception {
+    // given
+    workspaceConfig.setDefaultEnv("default");
+    RecipeImpl existingRecipe =
+        new RecipeImpl(KubernetesEnvironment.TYPE, "yaml", "existing-content", null);
+    workspaceConfig
+        .getEnvironments()
+        .put("default", new EnvironmentImpl(existingRecipe, emptyMap()));
+
+    List<HasMetadata> toolsObject = new ArrayList<>();
+    Deployment toolDeployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("web-app")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    toolsObject.add(new DeploymentBuilder(toolDeployment).build());
+    doReturn(new ArrayList<>()).when(k8sRecipeParser).parse(anyString());
+
+    // when
+    k8sEnvProvisioner.provision(
+        workspaceConfig, OpenShiftEnvironment.TYPE, toolsObject, emptyMap());
+
+    // then
+    EnvironmentImpl resultEnv =
+        workspaceConfig.getEnvironments().get(workspaceConfig.getDefaultEnv());
+    RecipeImpl resultRecipe = resultEnv.getRecipe();
+    assertEquals(resultRecipe.getType(), OpenShiftEnvironment.TYPE);
+  }
+
+  @Test
+  public void shouldProvisionToolObjectsIntoExistingKubernetesRecipe() throws Exception {
+    // given
+    workspaceConfig.setDefaultEnv("default");
+    RecipeImpl existingRecipe =
+        new RecipeImpl(KUBERNETES_TOOL_TYPE, "yaml", "existing-content", null);
+    workspaceConfig
+        .getEnvironments()
+        .put("default", new EnvironmentImpl(existingRecipe, emptyMap()));
+
+    List<HasMetadata> recipeObjects = new ArrayList<>();
+    Deployment recipeDeployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("db")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    recipeObjects.add(new DeploymentBuilder(recipeDeployment).build());
+    doReturn(recipeObjects).when(k8sRecipeParser).parse(anyString());
+
+    List<HasMetadata> toolsObject = new ArrayList<>();
+    Deployment toolDeployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("web-app")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    toolsObject.add(new DeploymentBuilder(toolDeployment).build());
+
+    // when
+    k8sEnvProvisioner.provision(
+        workspaceConfig, KubernetesEnvironment.TYPE, toolsObject, emptyMap());
+
+    // then
+    // it is expected that applier wrap original recipes objects in new Kubernetes list
+    KubernetesList expectedKubernetesList =
+        new KubernetesListBuilder()
+            .withItems(Arrays.asList(recipeDeployment, toolDeployment))
+            .build();
+    EnvironmentImpl resultEnv =
+        workspaceConfig.getEnvironments().get(workspaceConfig.getDefaultEnv());
+    assertEquals(
+        toK8SList(resultEnv.getRecipe().getContent()).getItems(),
+        expectedKubernetesList.getItems());
+  }
+
+  @Test(
+      expectedExceptions = DevfileException.class,
+      expectedExceptionsMessageRegExp =
+          "Kubernetes tool can only be applied to a workspace with either kubernetes or openshift "
+              + "recipe type but workspace has a recipe of type 'any'")
+  public void shouldThrowAnExceptionIfWorkspaceAlreadyContainNonK8sNorOSRecipe() throws Exception {
+    // given
+    workspaceConfig.setDefaultEnv("default");
+    RecipeImpl existingRecipe = new RecipeImpl("any", "yaml", "existing-content", null);
+    workspaceConfig
+        .getEnvironments()
+        .put("default", new EnvironmentImpl(existingRecipe, emptyMap()));
+
+    List<HasMetadata> toolsObject = new ArrayList<>();
+    Deployment toolDeployment =
+        new DeploymentBuilder()
+            .withNewMetadata()
+            .withName("db")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    toolsObject.add(new DeploymentBuilder(toolDeployment).build());
+
+    // when
+    k8sEnvProvisioner.provision(
+        workspaceConfig, KubernetesEnvironment.TYPE, toolsObject, emptyMap());
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Tools can not have objects with the same name and kind "
+              + "but there are multiple objects with kind 'Service' and name 'db'")
+  public void shouldThrowExceptionIfDifferentToolsHaveObjectsWithTheSameKindAndName()
+      throws Exception {
+    // given
+    List<HasMetadata> toolsObject = new ArrayList<>();
+    Service service1 =
+        new ServiceBuilder()
+            .withNewMetadata()
+            .withName("db")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    Service service2 =
+        new ServiceBuilder()
+            .withNewMetadata()
+            .withName("db")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    toolsObject.add(new ServiceBuilder(service1).build());
+    toolsObject.add(new ServiceBuilder(service2).build());
+
+    // when
+    k8sEnvProvisioner.provision(
+        workspaceConfig, KubernetesEnvironment.TYPE, toolsObject, emptyMap());
+  }
+
+  @Test(
+      expectedExceptions = DevfileFormatException.class,
+      expectedExceptionsMessageRegExp =
+          "Tools can not have objects with the same name and kind but there are multiple objects with kind 'Service' and name 'db'")
+  public void shouldThrowExceptionIfToolHasMultipleObjectsWithTheSameKindAndName()
+      throws Exception {
+    // given
+    List<HasMetadata> objects = new ArrayList<>();
+    Service service =
+        new ServiceBuilder()
+            .withNewMetadata()
+            .withName("db")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
+    objects.add(new ServiceBuilder(service).build());
+    objects.add(new ServiceBuilder(service).build());
+
+    // when
+    k8sEnvProvisioner.provision(workspaceConfig, KubernetesEnvironment.TYPE, objects, emptyMap());
+  }
+
+  private KubernetesList toK8SList(String content) {
+    return unmarshal(content, KubernetesList.class);
+  }
+
+  private String getResource(String resourceName) throws IOException {
+    return Files.readFile(getClass().getClassLoader().getResourceAsStream(resourceName));
+  }
+}

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/tool/kubernetes/KubernetesToolToWorkspaceApplierTest.java
@@ -20,27 +20,21 @@ import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NA
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.TOOL_NAME_COMMAND_ATTRIBUTE;
-import static org.eclipse.che.api.devfile.server.convert.tool.kubernetes.KubernetesToolToWorkspaceApplier.YAML_CONTENT_TYPE;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.ServiceBuilder;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
-import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -50,13 +44,13 @@ import org.eclipse.che.api.devfile.model.Entrypoint;
 import org.eclipse.che.api.devfile.model.Tool;
 import org.eclipse.che.api.devfile.server.FileContentProvider.FetchNotSupportedProvider;
 import org.eclipse.che.api.devfile.server.exception.DevfileException;
-import org.eclipse.che.api.devfile.server.exception.DevfileFormatException;
 import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
-import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
-import org.eclipse.che.api.workspace.server.model.impl.RecipeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesRecipeParser;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -75,10 +69,13 @@ public class KubernetesToolToWorkspaceApplierTest {
 
   private KubernetesToolToWorkspaceApplier applier;
   @Mock private KubernetesRecipeParser k8sRecipeParser;
+  @Mock private KubernetesEnvironmentProvisioner k8sEnvProvisioner;
+
+  @Captor private ArgumentCaptor<List<HasMetadata>> objectsCaptor;
 
   @BeforeMethod
   public void setUp() {
-    applier = new KubernetesToolToWorkspaceApplier(k8sRecipeParser);
+    applier = new KubernetesToolToWorkspaceApplier(k8sRecipeParser, k8sEnvProvisioner);
 
     workspaceConfig = new WorkspaceConfigImpl();
   }
@@ -156,217 +153,12 @@ public class KubernetesToolToWorkspaceApplierTest {
     applier.apply(workspaceConfig, tool, s -> yamlRecipeContent);
 
     // then
-    String defaultEnv = workspaceConfig.getDefaultEnv();
-    assertNotNull(defaultEnv);
-    EnvironmentImpl environment = workspaceConfig.getEnvironments().get(defaultEnv);
-    assertNotNull(environment);
-    RecipeImpl recipe = environment.getRecipe();
-    assertNotNull(recipe);
-    assertEquals(recipe.getType(), KUBERNETES_TOOL_TYPE);
-    assertEquals(recipe.getContentType(), YAML_CONTENT_TYPE);
-
-    // it is expected that applier wrap original recipes objects in new Kubernetes list
-    KubernetesList expectedKubernetesList =
-        new KubernetesListBuilder().withItems(toK8SList(yamlRecipeContent).getItems()).build();
-    assertEquals(toK8SList(recipe.getContent()).getItems(), expectedKubernetesList.getItems());
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Tools can not have objects with the same name and kind but there are multiple objects with kind 'Service' and name 'db'")
-  public void shouldThrowExceptionIfToolHasMultipleObjectsWithTheSameKindAndName()
-      throws Exception {
-    // given
-    List<HasMetadata> objects = new ArrayList<>();
-    Service service =
-        new ServiceBuilder()
-            .withNewMetadata()
-            .withName("db")
-            .endMetadata()
-            .withNewSpec()
-            .endSpec()
-            .build();
-    objects.add(new ServiceBuilder(service).build());
-    objects.add(new ServiceBuilder(service).build());
-    doReturn(objects).when(k8sRecipeParser).parse(anyString());
-    Tool tool =
-        new Tool()
-            .withType(KUBERNETES_TOOL_TYPE)
-            .withLocal(LOCAL_FILENAME)
-            .withName(TOOL_NAME)
-            .withSelector(new HashMap<>());
-
-    // when
-    applier.apply(workspaceConfig, tool, s -> "content");
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Tools can not have objects with the same name and kind "
-              + "but there are multiple objects with kind 'Service' and name 'db'")
-  public void shouldThrowExceptionIfDifferentToolsHaveObjectsWithTheSameKindAndName()
-      throws Exception {
-    // given
-    List<HasMetadata> objects = new ArrayList<>();
-    Service service1 =
-        new ServiceBuilder()
-            .withNewMetadata()
-            .withName("db")
-            .endMetadata()
-            .withNewSpec()
-            .endSpec()
-            .build();
-    Service service2 =
-        new ServiceBuilder()
-            .withNewMetadata()
-            .withName("db")
-            .endMetadata()
-            .withNewSpec()
-            .endSpec()
-            .build();
-    objects.add(new ServiceBuilder(service1).build());
-    objects.add(new ServiceBuilder(service2).build());
-    doReturn(objects).when(k8sRecipeParser).parse(anyString());
-    Tool tool =
-        new Tool()
-            .withType(KUBERNETES_TOOL_TYPE)
-            .withLocal(LOCAL_FILENAME)
-            .withName(TOOL_NAME)
-            .withSelector(new HashMap<>());
-
-    // when
-    applier.apply(workspaceConfig, tool, s -> "content");
-  }
-
-  @Test(
-      expectedExceptions = DevfileException.class,
-      expectedExceptionsMessageRegExp =
-          "Kubernetes tool can only be applied to a workspace with either kubernetes or openshift "
-              + "recipe type but workspace has a recipe of type 'any'")
-  public void shouldThrowAnExceptionIfWorkspaceAlreadyContainNonK8sNorOSRecipe() throws Exception {
-    // given
-    workspaceConfig.setDefaultEnv("default");
-    RecipeImpl existingRecipe = new RecipeImpl("any", "yaml", "existing-content", null);
-    workspaceConfig
-        .getEnvironments()
-        .put("default", new EnvironmentImpl(existingRecipe, emptyMap()));
-
-    List<HasMetadata> toolsObject = new ArrayList<>();
-    Deployment toolDeployment =
-        new DeploymentBuilder()
-            .withNewMetadata()
-            .withName("db")
-            .endMetadata()
-            .withNewSpec()
-            .endSpec()
-            .build();
-    toolsObject.add(new DeploymentBuilder(toolDeployment).build());
-    doReturn(toolsObject).when(k8sRecipeParser).parse(anyString());
-    Tool tool =
-        new Tool()
-            .withType(KUBERNETES_TOOL_TYPE)
-            .withLocal(LOCAL_FILENAME)
-            .withName(TOOL_NAME)
-            .withSelector(new HashMap<>());
-
-    // when
-    applier.apply(workspaceConfig, tool, s -> "content");
-  }
-
-  @Test
-  public void shouldProvisionToolObjectsIntoExistingKubernetesRecipe() throws Exception {
-    // given
-    workspaceConfig.setDefaultEnv("default");
-    RecipeImpl existingRecipe =
-        new RecipeImpl(KUBERNETES_TOOL_TYPE, "yaml", "existing-content", null);
-    workspaceConfig
-        .getEnvironments()
-        .put("default", new EnvironmentImpl(existingRecipe, emptyMap()));
-
-    List<HasMetadata> recipeObjects = new ArrayList<>();
-    Deployment recipeDeployment =
-        new DeploymentBuilder()
-            .withNewMetadata()
-            .withName("db")
-            .endMetadata()
-            .withNewSpec()
-            .endSpec()
-            .build();
-    recipeObjects.add(new DeploymentBuilder(recipeDeployment).build());
-
-    List<HasMetadata> toolsObject = new ArrayList<>();
-    Deployment toolDeployment =
-        new DeploymentBuilder()
-            .withNewMetadata()
-            .withName("web-app")
-            .endMetadata()
-            .withNewSpec()
-            .endSpec()
-            .build();
-    toolsObject.add(new DeploymentBuilder(toolDeployment).build());
-    doReturn(toolsObject).doReturn(recipeObjects).when(k8sRecipeParser).parse(anyString());
-    Tool tool =
-        new Tool()
-            .withType(KUBERNETES_TOOL_TYPE)
-            .withLocal(LOCAL_FILENAME)
-            .withName(TOOL_NAME)
-            .withSelector(new HashMap<>());
-
-    // when
-    applier.apply(workspaceConfig, tool, s -> "content");
-
-    // then
-    // it is expected that applier wrap original recipes objects in new Kubernetes list
-    KubernetesList expectedKubernetesList =
-        new KubernetesListBuilder()
-            .withItems(Arrays.asList(recipeDeployment, toolDeployment))
-            .build();
-    EnvironmentImpl resultEnv =
-        workspaceConfig.getEnvironments().get(workspaceConfig.getDefaultEnv());
-    assertEquals(
-        toK8SList(resultEnv.getRecipe().getContent()).getItems(),
-        expectedKubernetesList.getItems());
-  }
-
-  @Test
-  public void shouldUpgradeKubernetesEnvironmentToOpenShiftTypeOnOpenShiftToolProvisioning()
-      throws Exception {
-    // given
-    workspaceConfig.setDefaultEnv("default");
-    RecipeImpl existingRecipe =
-        new RecipeImpl(KUBERNETES_TOOL_TYPE, "yaml", "existing-content", null);
-    workspaceConfig
-        .getEnvironments()
-        .put("default", new EnvironmentImpl(existingRecipe, emptyMap()));
-
-    List<HasMetadata> toolsObject = new ArrayList<>();
-    Deployment toolDeployment =
-        new DeploymentBuilder()
-            .withNewMetadata()
-            .withName("web-app")
-            .endMetadata()
-            .withNewSpec()
-            .endSpec()
-            .build();
-    toolsObject.add(new DeploymentBuilder(toolDeployment).build());
-    doReturn(toolsObject).doReturn(new ArrayList<>()).when(k8sRecipeParser).parse(anyString());
-    Tool tool =
-        new Tool()
-            .withType(OPENSHIFT_TOOL_TYPE)
-            .withLocal(LOCAL_FILENAME)
-            .withName(TOOL_NAME)
-            .withSelector(new HashMap<>());
-
-    // when
-    applier.apply(workspaceConfig, tool, s -> "content");
-
-    // then
-    EnvironmentImpl resultEnv =
-        workspaceConfig.getEnvironments().get(workspaceConfig.getDefaultEnv());
-    RecipeImpl resultRecipe = resultEnv.getRecipe();
-    assertEquals(resultRecipe.getType(), OpenShiftEnvironment.TYPE);
+    verify(k8sEnvProvisioner)
+        .provision(
+            workspaceConfig,
+            KubernetesEnvironment.TYPE,
+            toK8SList(yamlRecipeContent).getItems(),
+            emptyMap());
   }
 
   @Test
@@ -383,19 +175,12 @@ public class KubernetesToolToWorkspaceApplierTest {
 
     applier.apply(workspaceConfig, tool, new FetchNotSupportedProvider());
 
-    String defaultEnv = workspaceConfig.getDefaultEnv();
-    assertNotNull(defaultEnv);
-    EnvironmentImpl environment = workspaceConfig.getEnvironments().get(defaultEnv);
-    assertNotNull(environment);
-    RecipeImpl recipe = environment.getRecipe();
-    assertNotNull(recipe);
-    assertEquals(recipe.getType(), KUBERNETES_TOOL_TYPE);
-    assertEquals(recipe.getContentType(), YAML_CONTENT_TYPE);
-
-    // it is expected that applier wrap original recipes objects in new Kubernetes list
-    KubernetesList expectedKubernetesList =
-        new KubernetesListBuilder().withItems(toK8SList(yamlRecipeContent).getItems()).build();
-    assertEquals(toK8SList(recipe.getContent()).getItems(), expectedKubernetesList.getItems());
+    verify(k8sEnvProvisioner)
+        .provision(
+            workspaceConfig,
+            KubernetesEnvironment.TYPE,
+            toK8SList(yamlRecipeContent).getItems(),
+            emptyMap());
   }
 
   @Test
@@ -415,19 +200,12 @@ public class KubernetesToolToWorkspaceApplierTest {
     applier.apply(workspaceConfig, tool, s -> yamlRecipeContent);
 
     // then
-    String defaultEnv = workspaceConfig.getDefaultEnv();
-    assertNotNull(defaultEnv);
-    EnvironmentImpl environment = workspaceConfig.getEnvironments().get(defaultEnv);
-    assertNotNull(environment);
-    RecipeImpl recipe = environment.getRecipe();
-    assertNotNull(recipe);
-    assertEquals(recipe.getType(), OPENSHIFT_TOOL_TYPE);
-    assertEquals(recipe.getContentType(), YAML_CONTENT_TYPE);
-
-    // it is expected that applier wrap original recipes objects in new Kubernetes list
-    KubernetesList expectedKubernetesList =
-        new KubernetesListBuilder().withItems(toK8SList(yamlRecipeContent).getItems()).build();
-    assertEquals(toK8SList(recipe.getContent()).getItems(), expectedKubernetesList.getItems());
+    verify(k8sEnvProvisioner)
+        .provision(
+            workspaceConfig,
+            OpenShiftEnvironment.TYPE,
+            toK8SList(yamlRecipeContent).getItems(),
+            emptyMap());
   }
 
   @Test
@@ -448,13 +226,13 @@ public class KubernetesToolToWorkspaceApplierTest {
     applier.apply(workspaceConfig, tool, s -> yamlRecipeContent);
 
     // then
-    String defaultEnv = workspaceConfig.getDefaultEnv();
-    assertNotNull(defaultEnv);
-    EnvironmentImpl environment = workspaceConfig.getEnvironments().get(defaultEnv);
-    assertNotNull(environment);
-    RecipeImpl recipe = environment.getRecipe();
-
-    List<HasMetadata> resultItemsList = toK8SList(recipe.getContent()).getItems();
+    verify(k8sEnvProvisioner)
+        .provision(
+            eq(workspaceConfig),
+            eq(OpenShiftEnvironment.TYPE),
+            objectsCaptor.capture(),
+            eq(emptyMap()));
+    List<HasMetadata> resultItemsList = objectsCaptor.getValue();
     assertEquals(resultItemsList.size(), 3);
     assertEquals(1, resultItemsList.stream().filter(it -> "Pod".equals(it.getKind())).count());
     assertEquals(1, resultItemsList.stream().filter(it -> "Service".equals(it.getKind())).count());
@@ -534,9 +312,9 @@ public class KubernetesToolToWorkspaceApplierTest {
     applier.apply(workspaceConfig, tool, s -> yamlRecipeContent);
 
     // then
-    RecipeImpl recipe = workspaceConfig.getEnvironments().get(TOOL_NAME).getRecipe();
-    KubernetesList list = toK8SList(recipe.getContent());
-    for (HasMetadata o : list.getItems()) {
+    verify(k8sEnvProvisioner).provision(any(), any(), objectsCaptor.capture(), any());
+    List<HasMetadata> list = objectsCaptor.getValue();
+    for (HasMetadata o : list) {
       if (o instanceof Pod) {
         Pod p = (Pod) o;
 

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileIntegrityValidatorTest.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.api.devfile.server.validator;
 
-import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.EDITOR_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.KUBERNETES_TOOL_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.OPENSHIFT_TOOL_TYPE;
@@ -74,50 +73,6 @@ public class DevfileIntegrityValidatorTest {
   public void shouldThrowExceptionOnDuplicateToolName() throws Exception {
     Devfile broken = copyOf(initialDevfile);
     broken.getTools().add(new Tool().withName(initialDevfile.getTools().get(0).getName()));
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Devfile cannot contain multiple dockerimage tools at the same time")
-  public void shouldThrowExceptionOnMultipleDockerimagesTools() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken.getCommands().clear();
-    broken.getTools().clear();
-    broken.getTools().add(new Tool().withName("dockerimage1").withType(DOCKERIMAGE_TOOL_TYPE));
-    broken.getTools().add(new Tool().withName("dockerimage2").withType(DOCKERIMAGE_TOOL_TYPE));
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Devfile cannot contain kubernetes/openshift and dockerimage tool at the same time")
-  public void shouldThrowExceptionIfDevfileContainK8sAndDockerimageTool() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken.getCommands().clear();
-    broken.getTools().clear();
-    broken.getTools().add(new Tool().withName("k8s").withType(KUBERNETES_TOOL_TYPE));
-    broken.getTools().add(new Tool().withName("dockerimage").withType(DOCKERIMAGE_TOOL_TYPE));
-
-    // when
-    integrityValidator.validateDevfile(broken);
-  }
-
-  @Test(
-      expectedExceptions = DevfileFormatException.class,
-      expectedExceptionsMessageRegExp =
-          "Devfile cannot contain kubernetes/openshift and dockerimage tool at the same time")
-  public void shouldThrowExceptionIfDevfileContainOpenShiftAndDockerimageTool() throws Exception {
-    Devfile broken = copyOf(initialDevfile);
-    broken.getCommands().clear();
-    broken.getTools().clear();
-    broken.getTools().add(new Tool().withName("openshift").withType(OPENSHIFT_TOOL_TYPE));
-    broken.getTools().add(new Tool().withName("dockerimage").withType(DOCKERIMAGE_TOOL_TYPE));
-
     // when
     integrityValidator.validateDevfile(broken);
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceValidator.java
@@ -47,7 +47,8 @@ public class WorkspaceValidator {
   private static final Pattern WS_NAME =
       Pattern.compile("[a-zA-Z0-9][-_.a-zA-Z0-9]{1,98}[a-zA-Z0-9]");
 
-  private static final Pattern VOLUME_NAME = Pattern.compile("[a-z][a-z0-9]{1,18}");
+  private static final Pattern VOLUME_NAME =
+      Pattern.compile("[a-zA-Z][a-zA-Z0-9-_.]{0,18}[a-zA-Z0-9]");
   private static final Pattern VOLUME_PATH = Pattern.compile("/.+");
 
   /**

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceValidatorTest.java
@@ -275,12 +275,14 @@ public class WorkspaceValidatorTest {
   @DataProvider(name = "illegalVolumeNameProvider")
   public static Object[][] illegalVolumeNameProvider() {
     return new Object[][] {
-      {"0volume"},
-      {"CAPITAL"},
+      {"0begin_with_number"},
+      {"begin_with_dot."},
+      {"begin_with_underscore_"},
+      {"begin_with_hyphen-"},
+      {"with_@_special_char"},
+      {"with_@_special_char"},
       {"veryveryveryveryveryveryverylongname"},
       {"volume/name"},
-      {"volume_name"},
-      {"volume-name"}
     };
   }
 


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is adding support of multiple dockerimage tools in Devfile and it contains several changes separated in different commits:
1. Allow different characters for Che Volumes names;
2. Fix internal endpoints in Devfile;
3. Add support of multiple Dockerimage tools in one Devfile;
It is done by generating kubernetes objects for dockerimage tool and injecting them Kubernetes recipe of WorkspaceConfig. MachineConfig is also injected not to duplicate Volumes/Endpoints related code and let Che Server generate needed objects according to server configuration.
Note that now Devfile may also contain different dockerimage and kubernetes/openshift tools.
4. Fix discoverable servers for dockerimage tool. It is done by generating the corresponding services.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12875

### How to test this PR
<details>
<summary>Devfile.yaml</summary>

```yaml
specVersion: 0.0.1
name: multiple-dockerimages
projects:
  - name: nodejs-mongo-app
    source:
      type: git
      location: 'https://github.com/ijason/NodeJS-Sample-App.git'
tools:
  - name: theia-editor
    type: cheEditor
    id: org.eclipse.che.editor.theia:1.0.0
  - name: exec-plugin
    type: chePlugin
    id: che-machine-exec-plugin:0.0.1
  - name: mongodb
    type: dockerimage
    image: mongo
    endpoints:
      - name: mongo
        port: 27017
        attributes:
          public: "false"
          discoverable: "true"
    mountSources: false
    volumes:
      - name: mongo-storage
        containerPath: /data/db
    memoryLimit: 250Mi
  - name: nodejs-app
    type: dockerimage
    image: node:0.10.40
    command: ['tail', '-f', '/dev/null']
    args: []
    endpoints:
      - name: app
        port: 3000
        attributes:
          public: "true"
    mountSources: true
    memoryLimit: 512Mi
commands:
  - name: run
    actions:
      - type: exec
        tool: nodejs-app
        command: cd ${CHE_PROJECTS_ROOT}/nodejs-mongo-app/EmployeeDB/ && npm install && node app.js
```
</details>

#### Release Notes
Added support of multiple dockerimage tools in Devfile

#### Docs PR
N/A