### PR TITLE
[dashboard] Use latest 8.x version to build dashboard@

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -12,7 +12,7 @@
 # Build step: $ docker build -t eclipse-che-dashboard
 # It builds an archive file that can be used by doing later
 #  $ docker run --rm eclipse-che-dashboard | tar -C target/ -zxf -
-FROM node:8.10.0
+FROM node:8.15.1
 
 RUN apt-get update && \
     apt-get install -y git \


### PR DESCRIPTION
### What does this PR do?

This one is using debian stretch (the previous one jessie which is now too old)

Change-Id: Iae6a95f45b0e38e2d86d35e48f13e8dc1301d721
Signed-off-by: Florent Benoit <fbenoit@redhat.com>


### What issues does this PR fix or reference?
ci-test errors

