### PR TITLE
Allow sidecar containers to list Kubernetes services by default

### DIFF
--- a/deploy/kubernetes/helm/che/templates/workspace-view-role.yaml
+++ b/deploy/kubernetes/helm/che/templates/workspace-view-role.yaml
@@ -19,6 +19,7 @@ rules:
   attributeRestrictions: null
   resources:
     - pods
+    - services
   verbs:
     - list
 {{- end }}

--- a/deploy/openshift/templates/che-workspace-service-account.yaml
+++ b/deploy/openshift/templates/che-workspace-service-account.yaml
@@ -41,6 +41,7 @@ objects:
     attributeRestrictions: null
     resources:
     - pods
+    - services
     verbs:
     - list
 - apiVersion: v1

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesWorkspaceServiceAccount.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesWorkspaceServiceAccount.java
@@ -120,7 +120,7 @@ public class KubernetesWorkspaceServiceAccount {
             .endMetadata()
             .withRules(
                 new KubernetesPolicyRuleBuilder()
-                    .withResources("pods")
+                    .withResources("pods", "services")
                     .withApiGroups("")
                     .withVerbs("list")
                     .build())

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftWorkspaceServiceAccount.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftWorkspaceServiceAccount.java
@@ -106,7 +106,8 @@ class OpenShiftWorkspaceServiceAccount {
             .withNewMetadata()
             .withName(name)
             .endMetadata()
-            .withRules(new PolicyRuleBuilder().withResources("pods").withVerbs("list").build())
+            .withRules(
+                new PolicyRuleBuilder().withResources("pods", "services").withVerbs("list").build())
             .build();
     osClient.roles().inNamespace(projectName).create(viewRole);
   }


### PR DESCRIPTION
Signed-off-by: John Collier <John.J.Collier@ibm.com>

### What does this PR do?
Allows sidecar containers to list Kubernetes services by default, in addition to pods (as it allows right now). It doesn't add any further permissions to the role, requiring the user to make those modifications if they need additional configuration. 

If `cheWorkspacesNamespace` is blank/null, then KubernetesWorkspaceServiceAccount.java creates the role and service account instead, so the same modification had to be made there too.

### What issues does this PR fix or reference?
Indirectly https://github.com/eclipse/che/issues/12972. 


#### Release Notes
Sidecar containers can now list Kubernetes services, in addition to pods.
