### PR TITLE
Support `refspec` in the devfile to specify what should be checked out after a clone

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/SourceStorage.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/SourceStorage.java
@@ -16,6 +16,12 @@ import java.util.Map;
 /** @author gazarenkov */
 public interface SourceStorage {
 
+  /**
+   * The key with this name in the parameters designates the exact revision the source corresponds
+   * to. This can be a branch, tag, commit id or anything the particular VCS type understands.
+   */
+  String REFSPEC_PARAMETER_NAME = "refspec";
+
   String getType();
 
   String getLocation();

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -91,6 +91,11 @@
                 "examples": [
                   "git@github.com:spring-projects/spring-petclinic.git"
                 ]
+              },
+              "refspec": {
+                "type": "string",
+                "description": "The name of the refspec to check out after the clone. This can be a branch, tag, commit id or anything the particular source type understands.",
+                "examples": [ "master", "feature-42", "304df5a" ]
               }
             }
           }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/ProjectConverterTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/ProjectConverterTest.java
@@ -11,8 +11,10 @@
  */
 package org.eclipse.che.api.devfile.server.convert;
 
+import static org.eclipse.che.api.core.model.workspace.config.SourceStorage.REFSPEC_PARAMETER_NAME;
 import static org.testng.Assert.assertEquals;
 
+import com.google.common.collect.ImmutableMap;
 import org.eclipse.che.api.devfile.model.Project;
 import org.eclipse.che.api.devfile.model.Source;
 import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
@@ -36,7 +38,10 @@ public class ProjectConverterTest {
         new Project()
             .withName("myProject")
             .withSource(
-                new Source().withLocation("https://github.com/eclipse/che.git").withType("git"));
+                new Source()
+                    .withLocation("https://github.com/eclipse/che.git")
+                    .withType("git")
+                    .withRefspec("master"));
 
     ProjectConfigImpl workspaceProject = projectConverter.toWorkspaceProject(devfileProject);
 
@@ -45,23 +50,26 @@ public class ProjectConverterTest {
     SourceStorageImpl source = workspaceProject.getSource();
     assertEquals(source.getType(), "git");
     assertEquals(source.getLocation(), "https://github.com/eclipse/che.git");
+    assertEquals(source.getParameters().get(REFSPEC_PARAMETER_NAME), "master");
   }
 
   @Test
   public void testConvertingProjectConfigToDevfileProject() {
-    ProjectConfigImpl workpsaceProject = new ProjectConfigImpl();
-    workpsaceProject.setName("myProject");
-    workpsaceProject.setPath("/ignored");
+    ProjectConfigImpl workspaceProject = new ProjectConfigImpl();
+    workspaceProject.setName("myProject");
+    workspaceProject.setPath("/ignored");
     SourceStorageImpl sourceStorage = new SourceStorageImpl();
     sourceStorage.setType("git");
     sourceStorage.setLocation("https://github.com/eclipse/che.git");
-    workpsaceProject.setSource(sourceStorage);
+    sourceStorage.setParameters(ImmutableMap.of(REFSPEC_PARAMETER_NAME, "master"));
+    workspaceProject.setSource(sourceStorage);
 
-    Project devfileProject = projectConverter.toDevfileProject(workpsaceProject);
+    Project devfileProject = projectConverter.toDevfileProject(workspaceProject);
 
     assertEquals(devfileProject.getName(), "myProject");
     Source source = devfileProject.getSource();
     assertEquals(source.getType(), "git");
     assertEquals(source.getLocation(), "https://github.com/eclipse/che.git");
+    assertEquals(source.getRefspec(), "master");
   }
 }


### PR DESCRIPTION
### What does this PR do?
To support checking out a custom branch, tag or commit id, a new parameter called `refspec` has been added to the source specification in the devfile.

### What issues does this PR fix or reference?

#12775
