### PR TITLE
Added provisioning of Default Editor into Devfile

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -623,3 +623,20 @@ che.factory.default_editor=org.eclipse.che.editor.theia:1.0.0
 # multiple plugins must be comma-separated, for example:
 # pluginFooName:pluginFooVersion,pluginBarName:pluginBarVersion
 che.factory.default_plugins=che-machine-exec-plugin:0.0.1
+
+## Devfile settings
+
+# Devfile defaults
+#
+# Default Editor that should be provisioned into Devfile if there is no other Editor specified
+# Format is `editorId:editorVersion` value.
+# `NULL` or absence of value means that default editor should not be provisioned.
+che.workspace.devfile.default_editor=org.eclipse.che.editor.theia:1.0.0
+
+# Default Plugins which should be provisioned for Default Editor.
+# All the plugins from this list that are not explicitly mentioned in the user-defined devfile
+# will be provisioned but only when the default editor is used or if the user-defined editor is
+# the same as the default one (even if in different version).
+# Format is comma-separated `pluginId:pluginVersion` values, for example
+# che-theia-exec-plugin:0.0.1,che-theia-terminal-plugin:0.0.1
+che.workspace.devfile.default_editor.plugins=che-machine-exec-plugin:0.0.1

--- a/wsmaster/che-core-api-devfile/pom.xml
+++ b/wsmaster/che-core-api-devfile/pom.xml
@@ -100,6 +100,10 @@
             <artifactId>che-core-commons-annotations</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.infrastructure</groupId>
             <artifactId>infrastructure-kubernetes</artifactId>
         </dependency>
@@ -203,8 +207,8 @@
                     <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
                     <targetPackage>org.eclipse.che.api.devfile.model</targetPackage>
                     <includeAdditionalProperties>false</includeAdditionalProperties>
-                    <includeHashcodeAndEquals>false</includeHashcodeAndEquals>
-                    <includeToString>false</includeToString>
+                    <includeHashcodeAndEquals>true</includeHashcodeAndEquals>
+                    <includeToString>true</includeToString>
                     <initializeCollections>true</initializeCollections>
                     <generateBuilders>true</generateBuilders>
                 </configuration>

--- a/wsmaster/che-core-api-devfile/pom.xml
+++ b/wsmaster/che-core-api-devfile/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>
@@ -94,10 +98,6 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.che.core</groupId>
-            <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.infrastructure</groupId>

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/Constants.java
@@ -67,4 +67,11 @@ public class Constants {
    * non-discoverable.
    */
   public static final String DISCOVERABLE_ENDPOINT_ATTRIBUTE = "discoverable";
+
+  /**
+   * The attribute of Devfile that should be devfile when no editor is needed and default one should
+   * not be provisioned. Attributes value {@code true} deactivates provisioning of default editor,
+   * any other value of lack of the attributes activates provisioning of default editor
+   */
+  public static final String EDITOR_FREE_DEVFILE_ATTRIBUTE = "editorFree";
 }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileFactory.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileFactory.java
@@ -41,6 +41,9 @@ public class DevfileFactory {
    * @param devfile devfile where all maps (including nested objects) should be initialized
    */
   public static void initializeMaps(Devfile devfile) {
+    if (devfile.getAttributes() == null) {
+      devfile.setAttributes(new HashMap<>());
+    }
     devfile
         .getCommands()
         .stream()

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileManager.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileManager.java
@@ -49,10 +49,10 @@ import org.eclipse.che.commons.env.EnvironmentContext;
 public class DevfileManager {
 
   private final ObjectMapper objectMapper;
-  private DevfileSchemaValidator schemaValidator;
-  private DevfileIntegrityValidator integrityValidator;
-  private DevfileConverter devfileConverter;
-  private WorkspaceManager workspaceManager;
+  private final DevfileSchemaValidator schemaValidator;
+  private final DevfileIntegrityValidator integrityValidator;
+  private final DevfileConverter devfileConverter;
+  private final WorkspaceManager workspaceManager;
 
   @Inject
   public DevfileManager(

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/DefaultEditorProvisioner.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/DefaultEditorProvisioner.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.devfile.server.convert;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+import static org.eclipse.che.api.devfile.server.Constants.EDITOR_COMPONENT_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.EDITOR_FREE_DEVFILE_ATTRIBUTE;
+import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_COMPONENT_TYPE;
+
+import com.google.common.base.Strings;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.devfile.model.Component;
+import org.eclipse.che.api.devfile.model.Devfile;
+import org.eclipse.che.commons.lang.NameGenerator;
+
+/**
+ * Provision default editor if there is no any another editor and default plugins for it.
+ *
+ * @author Sergii Leshchenko
+ */
+public class DefaultEditorProvisioner {
+
+  private final String defaultEditorRef;
+  private final String defaultEditorId;
+  private final Map<String, String> defaultPluginsIdToRef;
+
+  @Inject
+  public DefaultEditorProvisioner(
+      @Named("che.workspace.devfile.default_editor") String defaultEditorRef,
+      @Named("che.workspace.devfile.default_editor.plugins") String[] defaultPluginsRefs) {
+    this.defaultEditorRef = Strings.isNullOrEmpty(defaultEditorRef) ? null : defaultEditorRef;
+    this.defaultEditorId = this.defaultEditorRef == null ? null : getId(this.defaultEditorRef);
+    this.defaultPluginsIdToRef =
+        Arrays.stream(defaultPluginsRefs).collect(toMap(this::getId, identity()));
+  }
+
+  /**
+   * Provision default editor if there is no any another editor and default plugins for it.
+   *
+   * @param devfile devfile where editor and plugins should be provisioned
+   */
+  public void apply(Devfile devfile) {
+    if (defaultEditorRef == null) {
+      // there is no default editor configured
+      return;
+    }
+
+    if ("true".equals(devfile.getAttributes().get(EDITOR_FREE_DEVFILE_ATTRIBUTE))) {
+      return;
+    }
+
+    List<Component> components = devfile.getComponents();
+    Set<String> componentsNames =
+        components.stream().map(Component::getName).collect(Collectors.toCollection(HashSet::new));
+
+    Optional<Component> editorOpt =
+        components.stream().filter(t -> EDITOR_COMPONENT_TYPE.equals(t.getType())).findFirst();
+
+    boolean isDefaultEditorUsed;
+    if (!editorOpt.isPresent()) {
+      components.add(
+          new Component()
+              .withName(findAvailableName(componentsNames, defaultEditorRef))
+              .withType(EDITOR_COMPONENT_TYPE)
+              .withId(defaultEditorRef));
+      isDefaultEditorUsed = true;
+    } else {
+      Component editor = editorOpt.get();
+      isDefaultEditorUsed = editor.getId().startsWith(defaultEditorId + ':');
+    }
+
+    if (isDefaultEditorUsed) {
+      provisionDefaultPlugins(components, componentsNames);
+    }
+  }
+
+  private void provisionDefaultPlugins(List<Component> components, Set<String> componentsNames) {
+    Map<String, String> missingPluginsIdToRef = new HashMap<>(defaultPluginsIdToRef);
+
+    components
+        .stream()
+        .filter(t -> PLUGIN_COMPONENT_TYPE.equals(t.getType()))
+        .forEach(t -> missingPluginsIdToRef.remove(getId(t.getId())));
+
+    missingPluginsIdToRef
+        .values()
+        .forEach(
+            pluginRef ->
+                components.add(
+                    new Component()
+                        .withType(PLUGIN_COMPONENT_TYPE)
+                        .withId(pluginRef)
+                        .withName(findAvailableName(componentsNames, pluginRef))));
+  }
+
+  /**
+   * Returns available name for component with the specified id.
+   *
+   * <p>Id without version is used as base name and generated part is added if it is already busy.
+   */
+  private String findAvailableName(Set<String> busyNames, String componentRef) {
+    String id = getId(componentRef);
+    String name = id;
+    while (!busyNames.add(name)) {
+      name = NameGenerator.generate(id, 5);
+    }
+    return name;
+  }
+
+  private String getId(String reference) {
+    return reference.split(":", 2)[0];
+  }
+}

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/DevfileConverter.java
@@ -47,17 +47,20 @@ public class DevfileConverter {
   private final CommandConverter commandConverter;
   private final Map<String, ComponentToWorkspaceApplier> componentTypeToApplier;
   private final Set<ComponentProvisioner> componentProvisioners;
+  private final DefaultEditorProvisioner defaultEditorProvisioner;
 
   @Inject
   public DevfileConverter(
       ProjectConverter projectConverter,
       CommandConverter commandConverter,
       Set<ComponentProvisioner> componentProvisioners,
-      Map<String, ComponentToWorkspaceApplier> componentTypeToApplier) {
+      Map<String, ComponentToWorkspaceApplier> componentTypeToApplier,
+      DefaultEditorProvisioner defaultEditorProvisioner) {
     this.projectConverter = projectConverter;
     this.commandConverter = commandConverter;
     this.componentProvisioners = componentProvisioners;
     this.componentTypeToApplier = componentTypeToApplier;
+    this.defaultEditorProvisioner = defaultEditorProvisioner;
   }
 
   /**
@@ -118,6 +121,9 @@ public class DevfileConverter {
     checkArgument(contentProvider != null, "Content provider must not be null");
 
     validateCurrentVersion(devfile);
+
+    defaultEditorProvisioner.apply(devfile);
+
     WorkspaceConfigImpl config = new WorkspaceConfigImpl();
 
     config.setName(devfile.getName());

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -30,8 +30,15 @@
   },
   "required": [
     "specVersion",
-    "name",
-    "components"
+    "name"
+  ],
+  "anyOf": [
+    {
+      "required": ["projects"]
+    },
+    {
+      "required": ["components"]
+    }
   ],
   "additionalProperties": false,
   "properties": {

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -195,6 +195,7 @@
           "id": {
             "type": "string",
             "description": "Describes the component FQN",
+            "pattern": "^[a-zA-Z0-9_\\-\\./]{1,}:[a-zA-Z0-9_\\-\\.]{1,}$",
             "examples": [
               "eclipse/maven-jdk8:1.0.0"
             ]

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -32,14 +32,6 @@
     "specVersion",
     "name"
   ],
-  "anyOf": [
-    {
-      "required": ["projects"]
-    },
-    {
-      "required": ["components"]
-    }
-  ],
   "additionalProperties": false,
   "properties": {
     "specVersion": {
@@ -486,6 +478,18 @@
           }
         }
       }
+    },
+    "attributes" : {
+      "type": "object",
+      "editorFree": {
+        "type": "boolean",
+        "description": "Defines that no editor is needed and default one should not be provisioned.",
+        "default": "false"
+      },
+      "additionalProperties": {
+        "type": "string"
+      },
+      "javaType": "java.util.Map<String, String>"
     }
   }
 }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DefaultEditorProvisionerTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DefaultEditorProvisionerTest.java
@@ -1,0 +1,323 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.devfile.server.convert;
+
+import static org.eclipse.che.api.devfile.server.Constants.EDITOR_COMPONENT_TYPE;
+import static org.eclipse.che.api.devfile.server.Constants.EDITOR_FREE_DEVFILE_ATTRIBUTE;
+import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_COMPONENT_TYPE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import org.eclipse.che.api.devfile.model.Component;
+import org.eclipse.che.api.devfile.model.Devfile;
+import org.eclipse.che.api.devfile.server.DevfileFactory;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link DefaultEditorProvisioner}.
+ *
+ * @author Sergii Leshchenko
+ */
+public class DefaultEditorProvisionerTest {
+
+  private static final String DEFAULT_EDITOR_ID = "org.eclipse.che.theia";
+  private static final String DEFAULT_EDITOR_VERSION = "1.0.0";
+  private static final String DEFAULT_EDITOR_REF = DEFAULT_EDITOR_ID + ":" + DEFAULT_EDITOR_VERSION;
+
+  private static final String DEFAULT_TERMINAL_PLUGIN_ID = "org.eclipse.che.theia-terminal";
+  private static final String DEFAULT_TERMINAL_PLUGIN_REF = DEFAULT_TERMINAL_PLUGIN_ID + ":0.0.4";
+
+  private static final String DEFAULT_COMMAND_PLUGIN_ID = "org.eclipse.che.theia-command";
+  private static final String DEFAULT_COMMAND_PLUGIN_REF = DEFAULT_COMMAND_PLUGIN_ID + ":v1.0.0";
+
+  private DefaultEditorProvisioner defaultEditorProvisioner;
+
+  @Test
+  public void shouldNotProvisionDefaultEditorIfItIsNotConfigured() {
+    // given
+    defaultEditorProvisioner = new DefaultEditorProvisioner(null, new String[] {});
+    Devfile devfile = DevfileFactory.newDevfile();
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    assertTrue(devfile.getComponents().isEmpty());
+  }
+
+  @Test
+  public void shouldProvisionDefaultEditorWithPluginsWhenDevfileDoNotHaveAny() {
+    // given
+    defaultEditorProvisioner =
+        new DefaultEditorProvisioner(
+            DEFAULT_EDITOR_REF,
+            new String[] {DEFAULT_TERMINAL_PLUGIN_REF, DEFAULT_COMMAND_PLUGIN_REF});
+    Devfile devfile = DevfileFactory.newDevfile();
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertEquals(components.size(), 3);
+    assertTrue(
+        components.contains(
+            new Component()
+                .withId(DEFAULT_EDITOR_REF)
+                .withName(DEFAULT_EDITOR_ID)
+                .withType(EDITOR_COMPONENT_TYPE)));
+    assertTrue(
+        components.contains(
+            new Component()
+                .withId(DEFAULT_COMMAND_PLUGIN_REF)
+                .withName(DEFAULT_COMMAND_PLUGIN_ID)
+                .withType(PLUGIN_COMPONENT_TYPE)));
+    assertTrue(
+        components.contains(
+            new Component()
+                .withId(DEFAULT_TERMINAL_PLUGIN_REF)
+                .withName(DEFAULT_TERMINAL_PLUGIN_ID)
+                .withType(PLUGIN_COMPONENT_TYPE)));
+  }
+
+  @Test
+  public void shouldProvisionDefaultPluginsIfTheyAreNotSpecifiedAndDefaultEditorIsConfigured() {
+    // given
+    defaultEditorProvisioner =
+        new DefaultEditorProvisioner(
+            DEFAULT_EDITOR_REF, new String[] {DEFAULT_TERMINAL_PLUGIN_REF});
+
+    Devfile devfile = DevfileFactory.newDevfile();
+    Component defaultEditorWithDifferentVersion =
+        new Component()
+            .withType(EDITOR_COMPONENT_TYPE)
+            .withName("my-editor")
+            .withId(DEFAULT_EDITOR_ID + ":latest");
+    devfile.getComponents().add(defaultEditorWithDifferentVersion);
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertEquals(components.size(), 2);
+
+    assertTrue(components.contains(defaultEditorWithDifferentVersion));
+
+    assertTrue(
+        components.contains(
+            new Component()
+                .withId(DEFAULT_TERMINAL_PLUGIN_REF)
+                .withName(DEFAULT_TERMINAL_PLUGIN_ID)
+                .withType(PLUGIN_COMPONENT_TYPE)));
+  }
+
+  @Test
+  public void shouldNotProvisionDefaultPluginsIfCustomEditorIsConfiguredWhichStartWithDefaultId() {
+    // given
+    defaultEditorProvisioner =
+        new DefaultEditorProvisioner(
+            DEFAULT_EDITOR_REF, new String[] {DEFAULT_TERMINAL_PLUGIN_REF});
+
+    Devfile devfile = DevfileFactory.newDevfile();
+    Component editorWithNameSimilarToDefault =
+        new Component()
+            .withType(EDITOR_COMPONENT_TYPE)
+            .withName("my-editor")
+            .withId(DEFAULT_EDITOR_ID + "-dev:dev-version");
+    devfile.getComponents().add(editorWithNameSimilarToDefault);
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertEquals(components.size(), 1);
+    assertTrue(components.contains(editorWithNameSimilarToDefault));
+    assertNull(findById(components, DEFAULT_EDITOR_ID));
+  }
+
+  @Test
+  public void shouldNotProvisionDefaultPluginsIfDevfileContainsEditorFreeAttribute() {
+    // given
+    defaultEditorProvisioner =
+        new DefaultEditorProvisioner(
+            DEFAULT_EDITOR_REF, new String[] {DEFAULT_TERMINAL_PLUGIN_REF});
+
+    Devfile devfile = DevfileFactory.newDevfile();
+    devfile.setAttributes(ImmutableMap.of(EDITOR_FREE_DEVFILE_ATTRIBUTE, "true"));
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertTrue(components.isEmpty());
+  }
+
+  @Test
+  public void
+      shouldProvisionDefaultPluginIfDevfileAlreadyContainPluginWithNameWhichStartWithDefaultOne() {
+    // given
+    defaultEditorProvisioner =
+        new DefaultEditorProvisioner(
+            DEFAULT_EDITOR_REF, new String[] {DEFAULT_TERMINAL_PLUGIN_REF});
+
+    Devfile devfile = DevfileFactory.newDevfile();
+    Component pluginWithNameSimilarToDefault =
+        new Component()
+            .withType(PLUGIN_COMPONENT_TYPE)
+            .withName("my-plugin")
+            .withId(DEFAULT_TERMINAL_PLUGIN_ID + "-dummy:latest");
+    devfile.getComponents().add(pluginWithNameSimilarToDefault);
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertEquals(components.size(), 3);
+    assertTrue(
+        components.contains(
+            new Component()
+                .withId(DEFAULT_EDITOR_REF)
+                .withName(DEFAULT_EDITOR_ID)
+                .withType(EDITOR_COMPONENT_TYPE)));
+    assertTrue(
+        components.contains(
+            new Component()
+                .withId(DEFAULT_TERMINAL_PLUGIN_REF)
+                .withName(DEFAULT_TERMINAL_PLUGIN_ID)
+                .withType(PLUGIN_COMPONENT_TYPE)));
+    assertTrue(components.contains(pluginWithNameSimilarToDefault));
+  }
+
+  @Test
+  public void shouldNotProvisionDefaultEditorOrDefaultPluginsIfDevfileAlreadyHasNonDefaultEditor() {
+    // given
+    defaultEditorProvisioner = new DefaultEditorProvisioner(DEFAULT_EDITOR_REF, new String[] {});
+    Devfile devfile = DevfileFactory.newDevfile();
+    Component nonDefaultEditor =
+        new Component()
+            .withType(EDITOR_COMPONENT_TYPE)
+            .withName("editor")
+            .withId("any:v" + DEFAULT_EDITOR_VERSION);
+    devfile.getComponents().add(nonDefaultEditor);
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertEquals(components.size(), 1);
+    assertTrue(components.contains(nonDefaultEditor));
+  }
+
+  @Test
+  public void shouldNonProvisionDefaultEditorIfDevfileAlreadyContainsSuchButWithDifferentVersion() {
+    // given
+    defaultEditorProvisioner = new DefaultEditorProvisioner(DEFAULT_EDITOR_REF, new String[] {});
+    Devfile devfile = DevfileFactory.newDevfile();
+    Component myTheiaEditor =
+        new Component()
+            .withType(EDITOR_COMPONENT_TYPE)
+            .withName("my-custom-theia")
+            .withId(DEFAULT_EDITOR_REF + ":my-custom");
+    devfile.getComponents().add(myTheiaEditor);
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertEquals(components.size(), 1);
+    assertTrue(components.contains(myTheiaEditor));
+  }
+
+  @Test
+  public void shouldNonProvisionDefaultPluginIfDevfileAlreadyContainsSuchButWithDifferentVersion() {
+    // given
+    defaultEditorProvisioner =
+        new DefaultEditorProvisioner(
+            DEFAULT_EDITOR_REF, new String[] {DEFAULT_TERMINAL_PLUGIN_REF});
+    Devfile devfile = DevfileFactory.newDevfile();
+    Component myTerminal =
+        new Component()
+            .withType(PLUGIN_COMPONENT_TYPE)
+            .withName("my-terminal")
+            .withId(DEFAULT_TERMINAL_PLUGIN_ID + ":my-custom");
+    devfile.getComponents().add(myTerminal);
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertEquals(components.size(), 2);
+    assertTrue(
+        components.contains(
+            new Component()
+                .withId(DEFAULT_EDITOR_REF)
+                .withName(DEFAULT_EDITOR_ID)
+                .withType(EDITOR_COMPONENT_TYPE)));
+    assertTrue(components.contains(myTerminal));
+  }
+
+  @Test
+  public void shouldGenerateDefaultPluginNameIfIdIsNotUnique() {
+    // given
+    defaultEditorProvisioner =
+        new DefaultEditorProvisioner(DEFAULT_EDITOR_REF, new String[] {"my-plugin:v2.0"});
+    Devfile devfile = DevfileFactory.newDevfile();
+    Component myPlugin =
+        new Component()
+            .withType(PLUGIN_COMPONENT_TYPE)
+            .withName("my-plugin")
+            .withId("my-custom-plugin:v0.0.3");
+    devfile.getComponents().add(myPlugin);
+
+    // when
+    defaultEditorProvisioner.apply(devfile);
+
+    // then
+    List<Component> components = devfile.getComponents();
+    assertEquals(components.size(), 3);
+    assertTrue(
+        components.contains(
+            new Component()
+                .withId(DEFAULT_EDITOR_REF)
+                .withName(DEFAULT_EDITOR_ID)
+                .withType(EDITOR_COMPONENT_TYPE)));
+    assertTrue(components.contains(myPlugin));
+    Component defaultPlugin = findByRef(components, "my-plugin:v2.0");
+    assertNotNull(defaultPlugin);
+    assertNotEquals("my-plugin", defaultPlugin.getName());
+    assertTrue(defaultPlugin.getName().startsWith("my-plugin"));
+  }
+
+  private Component findById(List<Component> components, String id) {
+    return components
+        .stream()
+        .filter(c -> c.getId() != null && c.getId().startsWith(id + ':'))
+        .findAny()
+        .orElse(null);
+  }
+
+  private Component findByRef(List<Component> components, String ref) {
+    return components.stream().filter(c -> ref.equals(c.getId())).findAny().orElse(null);
+  }
+}

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DevfileConverterTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DevfileConverterTest.java
@@ -48,6 +48,7 @@ public class DevfileConverterTest {
   @Mock private CommandConverter commandConverter;
   @Mock private ComponentProvisioner componentProvisioner;
   @Mock private ComponentToWorkspaceApplier componentToWorkspaceApplier;
+  @Mock private DefaultEditorProvisioner defaultEditorToolApplier;
 
   private DevfileConverter devfileConverter;
 
@@ -58,7 +59,8 @@ public class DevfileConverterTest {
             projectConverter,
             commandConverter,
             ImmutableSet.of(componentProvisioner),
-            ImmutableMap.of(COMPONENT_TYPE, componentToWorkspaceApplier));
+            ImmutableMap.of(COMPONENT_TYPE, componentToWorkspaceApplier),
+            defaultEditorToolApplier);
   }
 
   @Test
@@ -165,6 +167,20 @@ public class DevfileConverterTest {
 
     // then
     assertEquals(workspaceConfig.getName(), "petclinic");
+  }
+
+  @Test
+  public void shouldInvokeDefaultEditorProvisionerDuringConvertingDevfileToWorkrspaceConfig()
+      throws Exception {
+    // given
+    FileContentProvider fileContentProvider = mock(FileContentProvider.class);
+    Devfile devfile = newDevfile("petclinic");
+
+    // when
+    devfileConverter.devFileToWorkspaceConfig(devfile, fileContentProvider);
+
+    // then
+    verify(defaultEditorToolApplier).apply(devfile);
   }
 
   @Test

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -135,6 +135,16 @@ public class DevfileSchemaValidatorTest {
             + "/devfile/components/0 object instance has properties which are not allowed by the schema: [\"id\",\"local\"],"
             + "/devfile/components/0 object has missing required properties ([\"image\",\"memoryLimit\"])]"
       },
+      {
+        "editor_plugin_component/devfile_editor_component_without_version.yaml",
+        "Devfile schema validation failed. Error: "
+            + "/devfile/components/0/id ECMA 262 regex \"^[a-zA-Z0-9_\\-\\./]{1,}:[a-zA-Z0-9_\\-\\.]{1,}$\" does not match input string \"eclipse/theia\""
+      },
+      {
+        "editor_plugin_component/devfile_editor_component_with_multiple_colons_in_id.yaml",
+        "Devfile schema validation failed. Error: "
+            + "/devfile/components/0/id ECMA 262 regex \"^[a-zA-Z0-9_\\-\\./]{1,}:[a-zA-Z0-9_\\-\\.]{1,}$\" does not match input string \"eclipse/theia:dev:v1\""
+      },
       // kubernetes/openshift component model testing
       {
         "kubernetes_openshift_component/devfile_openshift_component_with_missing_local.yaml",

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/validator/DevfileSchemaValidatorTest.java
@@ -41,6 +41,7 @@ public class DevfileSchemaValidatorTest {
   public Object[][] validDevfiles() {
     return new Object[][] {
       {"editor_plugin_component/devfile_editor_plugins.yaml"},
+      {"component/devfile_without_any_component.yaml"},
       {"kubernetes_openshift_component/devfile_kubernetes_component_local.yaml"},
       {
         "kubernetes_openshift_component/devfile_kubernetes_component_local_and_content_as_block.yaml"

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/component/devfile_without_any_component.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/component/devfile_without_any_component.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+projects:
+projects:
+  - name: petclinic
+    source:
+      type: git
+      location: 'git@github.com:spring-projects/spring-petclinic.git'

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_component/devfile_editor_component_with_multiple_colons_in_id.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_component/devfile_editor_component_with_multiple_colons_in_id.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+components:
+  - name: theia-ide
+    type: cheEditor
+    id: eclipse/theia:dev:v1

--- a/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_component/devfile_editor_component_without_version.yaml
+++ b/wsmaster/che-core-api-devfile/src/test/resources/schema_test/editor_plugin_component/devfile_editor_component_without_version.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+specVersion: 0.0.1
+name: petclinic-dev-environment
+components:
+  - name: theia-ide
+    type: cheEditor
+    id: eclipse/theia

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
@@ -29,6 +29,7 @@ import org.eclipse.che.api.devfile.model.Component;
 import org.eclipse.che.api.devfile.server.DevfileManager;
 import org.eclipse.che.api.devfile.server.FileContentProvider;
 import org.eclipse.che.api.devfile.server.convert.CommandConverter;
+import org.eclipse.che.api.devfile.server.convert.DefaultEditorProvisioner;
 import org.eclipse.che.api.devfile.server.convert.DevfileConverter;
 import org.eclipse.che.api.devfile.server.convert.ProjectConverter;
 import org.eclipse.che.api.devfile.server.convert.component.ComponentProvisioner;
@@ -87,7 +88,11 @@ public class DefaultFactoryParameterResolverTest {
 
     DevfileConverter devfileConverter =
         new DevfileConverter(
-            new ProjectConverter(), new CommandConverter(), componentProvisioners, appliers);
+            new ProjectConverter(),
+            new CommandConverter(),
+            componentProvisioners,
+            appliers,
+            new DefaultEditorProvisioner(null, new String[] {}));
 
     WorkspaceManager workspaceManager = mock(WorkspaceManager.class);
 


### PR DESCRIPTION
### What does this PR do?
The purpose of this PR is provisioning Default Editor into Devfile if there is no another editor. Also default plugins are provided for default editor, even if it was not provisioned automatically but specified by user.

For instance, a user defines the following Devfile:
```yaml
---
specVersion: 0.0.1
name: petclinic-dev-environment
projects:
  - name: petclinic
    source:
      type: git
      location: 'git@github.com:spring-projects/spring-petclinic.git'
```
Then he will get workspace based on the following Devfile
```yaml
---
specVersion: 0.0.1
name: petclinic-dev-environment
projects:
  - name: petclinic
    source:
      type: git
      location: 'git@github.com:spring-projects/spring-petclinic.git'
components:
  - name: theia-editor
    type: cheEditor
    id: org.eclipse.che.editor.theia:1.0.0
  - name: exec-plugin
    type: chePlugin
    id: che-machine-exec-plugin:0.0.1
```
If the user wants to create a workspace without any editor, then he should specify a special attribute for Devfile with name `editorFree`, for example:
```yaml
---
specVersion: 0.0.1
name: petclinic-dev-environment
components:
  - name: myApp
    type: kubernetes
    local: my-app.yaml
attributes:
  - editorFree: true
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12835

#### Release Notes
Added provisioning of Default Editor into Devfile.

#### Docs PR
https://github.com/eclipse/che/pull/13029