### PR TITLE
Implement clonePath in devfile.

### DIFF
--- a/wsmaster/che-core-api-devfile/README.md
+++ b/wsmaster/che-core-api-devfile/README.md
@@ -63,7 +63,32 @@ chectl workspace:start --devfile=devfile.yaml
 ```` 
 Please note that currently this way only works for the local (same machine) devfiles - URL can't be used here atm.
 
+### Project details
+A single devfile can specify several projects. For each project, one has to specify the type of the
+source repository, its location and optionally also the directory to which the project should be 
+cloned to.
 
+As an example, consider this devfile:
+
+```yaml
+specVersion: 0.0.1
+name: example-devfile
+projects:
+- name: frontend
+  source:
+    type: git
+    location: https://github.com/acmecorp/frontend.git
+- name: backend
+  clonePath: src/github.com/acmecorp/backend
+  source:
+    type: git
+    location: https://github.com/acmecorp/backend.git
+```
+
+In the example above, we see a devfile with 2 projects, `frontend` and `backend`, each located in
+its own repository on github. `backend` has a specific requirement to be cloned into the 
+`src/github.com/acmecorp/backend` directory under the source root (implicitly defined by the Che
+runtime) while frontend will be cloned into `frontend` directory under the source root.
  
 ### Supported component types
 There are currently four types of components supported. There is two simpler types, such as `cheEditor` and `chePlugin` and 

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/DevfileConverter.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 import org.eclipse.che.api.devfile.model.Command;
 import org.eclipse.che.api.devfile.model.Component;
 import org.eclipse.che.api.devfile.model.Devfile;
+import org.eclipse.che.api.devfile.model.Project;
 import org.eclipse.che.api.devfile.server.DevfileFactory;
 import org.eclipse.che.api.devfile.server.DevfileRecipeFormatException;
 import org.eclipse.che.api.devfile.server.FileContentProvider;
@@ -33,6 +34,7 @@ import org.eclipse.che.api.devfile.server.exception.DevfileException;
 import org.eclipse.che.api.devfile.server.exception.DevfileFormatException;
 import org.eclipse.che.api.devfile.server.exception.WorkspaceExportException;
 import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
+import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 
 /**
@@ -145,11 +147,10 @@ public class DevfileConverter {
       applier.apply(config, component, contentProvider);
     }
 
-    devfile
-        .getProjects()
-        .stream()
-        .map(projectConverter::toWorkspaceProject)
-        .forEach(project -> config.getProjects().add(project));
+    for (Project project : devfile.getProjects()) {
+      ProjectConfigImpl projectConfig = projectConverter.toWorkspaceProject(project);
+      config.getProjects().add(projectConfig);
+    }
 
     return config;
   }

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -98,6 +98,10 @@
                 "examples": [ "master", "feature-42", "304df5a" ]
               }
             }
+          },
+          "clonePath": {
+            "type": "string",
+            "description": "The path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name."
           }
         }
       }


### PR DESCRIPTION
### What does this PR do?
Adds a `clonePath` attribute to the project definition in the devfile. This can be used to alter the location under the projects root to which the project is cloned.

### What issues does this PR fix or reference?

#12557

Example devfile:

```yaml
specVersion: 0.0.1
name: che-plugin-broker
projects:
- name: che-plugin-broker
  clonePath: src/github.com/eclipse/che-plugin-broker
  source:
    type: git
    location: https://github.com/eclipse/che-plugin-broker.git
components:
- name: theia
  type: cheEditor
  id: org.eclipse.che.editor.theia:1.0.0
- name: exec
  type: chePlugin
  id: che-machine-exec-plugin:0.0.1
- name: golang
  type: dockerimage
  image: golang
  memoryLimit: 512M
  mountSources: true
  command: ['sleep', 'infinity']
  env:
  - name: GOPATH
    value: $(CHE_PROJECTS_ROOT)
  - name: GOCACHE
    value: $(GOPATH)/.cache
commands:
- name: build
  actions:
  - type: exec
    component: golang
    command: "cd $GOPATH/src/github.com/eclipse/che-plugin-broker && CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-w -s' -a -installsuffix cgo ./..."
- name: test
  actions:
  - type: exec
    component: golang
    command: "cd $GOPATH/src/github.com/eclipse/che-plugin-broker && go test -v -race ./..."

```
