### PR TITLE
Fix work of Devfile with multiple dockeimages components

### DIFF
--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/component/dockerimage/DockerimageComponentToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/component/dockerimage/DockerimageComponentToWorkspaceApplierTest.java
@@ -16,8 +16,8 @@ import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.devfile.server.Constants.DISCOVERABLE_ENDPOINT_ATTRIBUTE;
 import static org.eclipse.che.api.devfile.server.Constants.DOCKERIMAGE_COMPONENT_TYPE;
 import static org.eclipse.che.api.devfile.server.Constants.PUBLIC_ENDPOINT_ATTRIBUTE;
+import static org.eclipse.che.api.devfile.server.convert.component.dockerimage.DockerimageComponentToWorkspaceApplier.CHE_COMPONENT_NAME_LABEL;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_ORIGINAL_NAME_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.MACHINE_NAME_ANNOTATION_FMT;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -274,13 +274,13 @@ public class DockerimageComponentToWorkspaceApplierTest {
     assertTrue(objects.get(0) instanceof Deployment);
     Deployment deployment = (Deployment) objects.get(0);
     assertEquals(
-        deployment.getSpec().getTemplate().getMetadata().getLabels().get(CHE_ORIGINAL_NAME_LABEL),
+        deployment.getSpec().getTemplate().getMetadata().getLabels().get(CHE_COMPONENT_NAME_LABEL),
         "jdk");
 
     assertTrue(objects.get(1) instanceof Service);
     Service service = (Service) objects.get(1);
     assertEquals(service.getMetadata().getName(), "jdk-ls");
-    assertEquals(service.getSpec().getSelector(), ImmutableMap.of(CHE_ORIGINAL_NAME_LABEL, "jdk"));
+    assertEquals(service.getSpec().getSelector(), ImmutableMap.of(CHE_COMPONENT_NAME_LABEL, "jdk"));
     List<ServicePort> ports = service.getSpec().getPorts();
     assertEquals(ports.size(), 1);
     ServicePort port = ports.get(0);


### PR DESCRIPTION
### What does this PR do?
Fix work of Devfile with multiple dockeimages components.
Previously, `CHE_ORIGINAL_NAME_LABEL` was used for matching Deployment and Service that is used for a discoverable endpoint. And it was a mistake since it leads to further issues with machine names estimation. So, it is needed to use a separate label. 

### What issues does this PR fix or reference?
It fixed feature that is introduced here https://github.com/eclipse/che/pull/12967

#### Release Notes
N/A

#### Docs PR
N/A