### PR TITLE
allow helm to set global.cheSystemAdmin

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -31,6 +31,7 @@ data:
   CHE_INFRA_KUBERNETES_INGRESS_DOMAIN: {{ .Values.global.ingressDomain }}
   CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN: "5"
   CHE_INFRA_KUBERNETES_MASTER__URL: ""
+  CHE_SYSTEM_ADMIN__NAME: {{ .Values.global.cheSystemAdmin }}
 {{- if and .Values.global.tls .Values.global.tls.enabled }}
   CHE_INFRA_KUBERNETES_TLS__ENABLED: {{ .Values.global.tls.enabled | quote}}
   CHE_INFRA_KUBERNETES_TLS__SECRET: {{ .Values.global.tls.secretName }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -32,6 +32,8 @@ global:
   #  This value can be passed if custom Oidc provider is used, and there is no need to deploy keycloak in multiuser mode
   #  default (if empty) is true
   #cheDedicatedKeycloak: false
+  # cheSystemAdmin cannot contain email address yet
+  cheSystemAdmin: admin
   ingressDomain: 192.168.99.100.nip.io
   # See --annotations-prefix flag (https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/cli-arguments.md)
   ingressAnnotationsPrefix: "nginx."

--- a/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/AdminPermissionInitializer.java
+++ b/multiuser/api/che-multiuser-api-permission/src/main/java/org/eclipse/che/multiuser/api/permission/server/AdminPermissionInitializer.java
@@ -63,7 +63,11 @@ public class AdminPermissionInitializer implements EventSubscriber<PostUserPersi
   @PostConstruct
   public void init() throws ServerException {
     try {
-      User adminUser = userManager.getByName(name);
+      if (name.contains("@")) {
+        User adminUser = userManager.getByEmail(name);
+      } else {
+        User adminUser = userManager.getByName(name);
+      }
       grantSystemPermissions(adminUser.getId());
     } catch (NotFoundException ex) {
       LOG.warn("Admin {} not found yet.", name);
@@ -79,7 +83,7 @@ public class AdminPermissionInitializer implements EventSubscriber<PostUserPersi
 
   @Override
   public void onEvent(PostUserPersistedEvent event) {
-    if (event.getUser().getName().equals(name)) {
+    if (event.getUser().getName().equals(name) || event.getUser().getEmail().equals(name)) {
       grantSystemPermissions(event.getUser().getId());
     }
   }


### PR DESCRIPTION
### Description

Need to set `CHE_SYSTEM_ADMIN__NAME` before deploying `Che` using `helm` on `Kubernetes`

### Reproduction Steps
Currently, this option is not available

### What does this PR do?

Allows users to set `CHE_SYSTEM_ADMIN__NAME` while installing che via helm by setting `global.cheSystemAdmin` in the command or `values.yaml` and then it'll set `CHE_SYSTEM_ADMIN__NAME` as per https://www.eclipse.org/che/docs/che-6/permissions.html

### What issues does this PR fix or reference?

<!-- #### Changelog -->
* Allow helm to set global.cheSystemAdmin


#### Release Notes
You should be able to include `--set global.cheSystemAdmin` in `helm` when deploying `Che`:
`helm upgrade --install <my-che-installation> --namespace <my-che-namespace> -f ./values/multi-user.yaml --set global.ingressDomain=<my-hostname> --set cheImage=<my-image> --set global.cheSystemAdmin=<my-username> ./`


#### Docs PR
[the docs repo](https://github.com/eclipse/che-docs/src/main/pages/che-6/setup-kubernetes/kubernetes-multi-user.adoc)

[PR](https://github.com/eclipse/che-docs/pull/702)