### PR TITLE
[GWT-IDE] Don't touch Keycloak under Che7 environment.

### DIFF
--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -172,6 +172,11 @@ angular.element(document).ready(() => {
       /* tslint:disable */
       window['_keycloak'] = keycloak;
       /* tslint:enable */
+      windows.addEventListener('message', (event: any) => {
+        if ('get-id-token' === event.data) {
+          event.source.postMessage('id-token:' + window['_keycloak'].idToken, event.origin);
+        }
+      });
     });
   }).catch((error: any) => {
     console.error('Keycloak initialization failed with error: ', error);

--- a/ide/che-core-ide-app/src/main/resources/org/eclipse/che/public/activity.js
+++ b/ide/che-core-ide-app/src/main/resources/org/eclipse/che/public/activity.js
@@ -61,12 +61,20 @@ var ActivityTracker = new function () {
 
         var keycloak = window['_keycloak'];
         if (keycloak) {
-            keycloak.updateToken(5)
-                .success(function (refreshed) {
-                    var token = "Bearer " + keycloak.token;
-                    request.setRequestHeader("Authorization", token);
-                    request.send();
-                });
+            if (document.referrer === window.location.href) {
+                keycloak.updateToken(5)
+                    .success(function (refreshed) {
+                        var token = "Bearer " + keycloak.token;
+                        request.setRequestHeader("Authorization", token);
+                        request.send();
+                    });
+            } else {
+                /* The token will be from the parent window
+                 * and updated periodically. */
+                var token = "Bearer " + keycloak.token;
+                request.setRequestHeader("Authorization", token);
+                request.send();
+            }
         } else {
             request.send();
         }

--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/IDE.html
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/IDE.html
@@ -62,6 +62,29 @@
              * Load keycloak settings
              */
             this.loadKeycloakSettings = function() {
+                if (window.location.href !== document.referrer) {
+                    /*
+                     * Get token from the parent window.
+                     */
+                    window.addEventListener('messsage', (event) => {
+                        if (event.data &&
+                            event.data.startWith('id-token:') &&
+                            event.origin === window.parent.location) {
+                            keycloak = {
+                                token: event.data.subString(9)
+                            }
+                            window['_keycloak'] = keycloak;
+                            Loader.startLoading();
+                        }
+                    });
+                    window.postMessage('get-id-token', window.parent.location);
+                    setInterval(function() {
+                        window.postMessage('get-id-token', window.parent.location);
+                    }, 10000);
+
+                    return;
+                }
+
                 var msg = "Cannot load keycloak settings. This is normal for single-user mode.";
                 try {
                     if (window.parent && window.parent['_keycloak']) {


### PR DESCRIPTION
On multi-user/multi-host Che7 environments, the URL of IDE is differ from the URL of wsmaster.

So, on copying Keycloak object, web browsers throw DOMException  as the cross site scripting.

In addition, Keycloak can't respond requests for getting new token.
Because the URL of IDE is not listed in redirect_url.

### What does this PR do?

Pass the token (generated by Keycloak) to the IDE in <iframe> via `postMessage()`

### What issues does this PR fix or reference?

#12585 

