### PR TITLE
[Cypress] Use an "Electron" browser for "headless" mode

### DIFF
--- a/cypress-tests/package.json
+++ b/cypress-tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "cypress:open": "cypress open",
-    "cypress:run-hidden": "cypress run",
+    "cypress:run-hidden": "cypress run --browser electron",
     "cypress:run": "cypress run --headed"
   },
   "author": "",


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Define the "Electron" browser as a browser for "headless" mode

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/13038
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
