### PR TITLE
Use a default message of original exception does not have any

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -417,8 +417,8 @@ if [ "${CHE_DEBUG_SERVER}" == "true" ]; then
   ${OC_BINARY}  expose service che-debug
   NodePort=$(oc get service che-debug -o jsonpath='{.spec.ports[0].nodePort}')
   printInfo "Remote wsmaster debugging URL: ${CLUSTER_IP}:${NodePort}"
-  printInfo "Removing liveness and readiness probes from Che deployment"
-  oc set probe dc/che --remove --readiness --liveness
+  printInfo "Increasing failure threshold for probes of Che deployment"
+  oc set probe dc/che --readiness --liveness --failure-threshold=99999
 fi
 }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -853,7 +853,12 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
     } catch (InfrastructureException rethrow) {
       throw rethrow;
     } catch (Throwable cause) {
-      throw new InternalInfrastructureException(cause.getMessage(), cause);
+      String message = cause.getMessage();
+      if (message == null) {
+        // set a default message if there is no any
+        message = "An exception occurred.";
+      }
+      throw new InternalInfrastructureException(message, cause);
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
The main purpose of this PR is using a default message of original exception does not have any.
It allows avoiding WorkspaceLoader hanging, and in case of error without any exception (like NPE) we will get the following 
![Screenshot_20190402_123741](https://user-images.githubusercontent.com/5887312/55393354-c48a1980-5545-11e9-8619-91a24c77b5fa.png)
instead of 
![Screenshot_20190402_122217](https://user-images.githubusercontent.com/5887312/55393362-c7850a00-5545-11e9-9bff-c09ccba65ced.png)

But also contains a small improvement for deploy script. When Che Server needs to be debugged then it is better to increase the failure threshold to some really big value instead of removing probes at all. It will prevent redirecting to pod which is not fully started.

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
N/A