### PR TITLE
Use random ingress/route name for Che-generated ingresses/routes

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/DefaultHostIngressExternalServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/DefaultHostIngressExternalServerExposer.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
 /**
@@ -76,7 +77,7 @@ public class DefaultHostIngressExternalServerExposer
       Map<String, ServerConfig> ingressesServers) {
     return new ExternalServerIngressBuilder()
         .withPath(generateExternalServerIngressPath(serviceName, servicePort))
-        .withName(generateExternalServerIngressName(serviceName, servicePort))
+        .withName(generateExternalServerIngressName())
         .withMachineName(machineName)
         .withServiceName(serviceName)
         .withAnnotations(ingressAnnotations)
@@ -85,8 +86,8 @@ public class DefaultHostIngressExternalServerExposer
         .build();
   }
 
-  private String generateExternalServerIngressName(String serviceName, ServicePort servicePort) {
-    return serviceName + '-' + servicePort.getName();
+  private String generateExternalServerIngressName() {
+    return Names.generateName("ingress");
   }
 
   private String generateExternalServerIngressPath(String serviceName, ServicePort servicePort) {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/DefaultHostIngressExternalServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/DefaultHostIngressExternalServerExposerTest.java
@@ -86,7 +86,6 @@ public class DefaultHostIngressExternalServerExposerTest {
         MACHINE_NAME,
         SERVICE_NAME,
         "http-server",
-        8080,
         servicePort,
         new ServerConfigImpl(httpServerConfig).withAttributes(ATTRIBUTES_MAP));
   }
@@ -121,14 +120,12 @@ public class DefaultHostIngressExternalServerExposerTest {
         MACHINE_NAME,
         SERVICE_NAME,
         "http-server",
-        8080,
         servicePort,
         new ServerConfigImpl(httpServerConfig).withAttributes(ATTRIBUTES_MAP));
     assertThatExternalServerIsExposed(
         MACHINE_NAME,
         SERVICE_NAME,
         "ws-server",
-        8080,
         servicePort,
         new ServerConfigImpl(wsServerConfig).withAttributes(ATTRIBUTES_MAP));
   }
@@ -138,12 +135,11 @@ public class DefaultHostIngressExternalServerExposerTest {
       String machineName,
       String serviceName,
       String serverNameRegex,
-      Integer port,
       ServicePort servicePort,
       ServerConfigImpl expected) {
 
     // ensure that required ingress is created
-    Ingress ingress = kubernetesEnvironment.getIngresses().get(serviceName + "-server-" + port);
+    Ingress ingress = kubernetesEnvironment.getIngresses().values().iterator().next();
     IngressRule ingressRule = ingress.getSpec().getRules().get(0);
     IngressBackend backend = ingressRule.getHttp().getPaths().get(0).getBackend();
     assertEquals(backend.getServiceName(), serviceName);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftExternalServerExposer.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftExternalServerExposer.java
@@ -18,6 +18,7 @@ import io.fabric8.openshift.api.model.Route;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 
@@ -97,7 +98,7 @@ public class OpenShiftExternalServerExposer
       Map<String, ServerConfig> externalServers) {
     Route route =
         new RouteBuilder()
-            .withName(serviceName + '-' + servicePort.getName())
+            .withName(Names.generateName("route"))
             .withMachineName(machineName)
             .withTargetPort(servicePort.getName())
             .withServers(externalServers)

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftExternalServerExposerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftExternalServerExposerTest.java
@@ -49,7 +49,8 @@ public class OpenShiftExternalServerExposerTest {
         servers);
 
     // then
-    Route route = osEnv.getRoutes().get("service123-servicePort");
+    assertEquals(1, osEnv.getRoutes().size());
+    Route route = osEnv.getRoutes().values().iterator().next();
     assertNotNull(route);
 
     assertEquals(route.getSpec().getTo().getName(), "service123");


### PR DESCRIPTION
### What does this PR do?
We used unsafe long names for ingresses/routes that we generated during workspace creation. This makes sure we use only short random names that cannot cause trouble.

At the same time, the `che.original_name` label has been kept in place so that users can still look up user-defined objects that we had to rename during workspace creation.

### What issues does this PR fix or reference?

#13040
