### PR TITLE
Add an ability to enable ephemeral mode with devfile

### DIFF
--- a/wsmaster/che-core-api-devfile/README.md
+++ b/wsmaster/che-core-api-devfile/README.md
@@ -250,6 +250,42 @@ Devfile allows to specify commands set to be available for execution in workspac
          workdir: /projects/spring-petclinic
 ```
 
+### Devfile attributes
+
+Devfile attributes may be used to configure some features.
+
+#### Editor free
+If editor is not specified Devfile then default one will be provided. In case when no editor is needed `editorFree` attribute should be used.
+Default value is `false` and means that Devfile needs default editor to be provisioned if no one is defined.
+Example of Devfile without editor
+```yaml
+specVersion: 0.0.1
+name: petclinic-dev-environment
+components:
+  - name: myApp
+    type: kubernetes
+    local: my-app.yaml
+attributes:
+  editorFree: true
+```
+
+#### Ephemeral mode
+By default volumes and PVCs specified in Devfile are bound to host folder to persist data even after container restart.
+Sometimes it may be needed to disable data persistence for some reasons, like when volume backend is incredibly slow and it is needed to make workspace faster.
+To achieve it the `persistVolumes` devfile attribute should be used. Default value is `true`, and in case of `false` `emptyDir` volumes will be used for configured volumes and PVC.
+Example of Devfile with ephemeral mode enabled
+```yaml
+specVersion: 0.0.1
+name: petclinic-dev-environment
+projects:
+  - name: petclinic
+    source:
+      type: git
+      location: 'https://github.com/che-samples/web-java-spring-petclinic.git'
+attributes:
+  persistVolumes: false
+```
+
 ### Live working examples
 
   - [NodeJS simple "Hello World" example](https://che.openshift.io/f?url=https://raw.githubusercontent.com/redhat-developer/devfile/master/samples/web-nodejs-sample/devfile.yaml)

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/DevfileConverter.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/convert/DevfileConverter.java
@@ -152,6 +152,8 @@ public class DevfileConverter {
       config.getProjects().add(projectConfig);
     }
 
+    config.getAttributes().putAll(devfile.getAttributes());
+
     return config;
   }
 

--- a/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
+++ b/wsmaster/che-core-api-devfile/src/main/resources/schema/devfile.json
@@ -509,8 +509,13 @@
       "type": "object",
       "editorFree": {
         "type": "boolean",
-        "description": "Defines that no editor is needed and default one should not be provisioned.",
+        "description": "Defines that no editor is needed and default one should not be provisioned. Defaults to `false`.",
         "default": "false"
+      },
+      "persistVolumes": {
+        "type": "boolean",
+        "description": "Defines whether volumes should be stored or not. Defaults to `true`. In case of `false` workspace volumes will be created as `emptyDir`. The data in the `emptyDir` volume is deleted forever when a workspace Pod is removed for any reason(pod is crashed, workspace is restarted).",
+        "default": "true"
       },
       "additionalProperties": {
         "type": "string"

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DefaultEditorProvisionerTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DefaultEditorProvisionerTest.java
@@ -20,7 +20,6 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.DevfileImpl;
@@ -175,7 +174,7 @@ public class DefaultEditorProvisionerTest {
             DEFAULT_EDITOR_REF, new String[] {DEFAULT_TERMINAL_PLUGIN_REF});
 
     DevfileImpl devfile = new DevfileImpl();
-    devfile.setAttributes(ImmutableMap.of(EDITOR_FREE_DEVFILE_ATTRIBUTE, "true"));
+    devfile.getAttributes().put(EDITOR_FREE_DEVFILE_ATTRIBUTE, "true");
 
     // when
     defaultEditorProvisioner.apply(devfile);

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DevfileConverterTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DevfileConverterTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.devfile.server.convert;
 
 import static org.eclipse.che.api.devfile.server.Constants.CURRENT_SPEC_VERSION;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -21,6 +22,8 @@ import static org.testng.Assert.assertSame;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
+import java.util.Map;
 import org.eclipse.che.api.devfile.server.FileContentProvider;
 import org.eclipse.che.api.devfile.server.convert.component.ComponentProvisioner;
 import org.eclipse.che.api.devfile.server.convert.component.ComponentToWorkspaceApplier;
@@ -181,6 +184,27 @@ public class DevfileConverterTest {
 
     // then
     verify(defaultEditorToolApplier).apply(devfile);
+  }
+
+  @Test
+  public void
+      shouldProvisionDevfileAttributesAsConfigAttributesDuringConvertingDevfileToWorkspaceConfig()
+          throws Exception {
+    // given
+    FileContentProvider fileContentProvider = mock(FileContentProvider.class);
+    Map<String, String> devfileAttributes = new HashMap<>();
+    devfileAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");
+    devfileAttributes.put("anotherAttribute", "value");
+
+    DevfileImpl devfile = newDevfile("petclinic");
+    devfile.getAttributes().putAll(devfileAttributes);
+
+    // when
+    WorkspaceConfigImpl config =
+        devfileConverter.devFileToWorkspaceConfig(devfile, fileContentProvider);
+
+    // then
+    assertEquals(config.getAttributes(), devfileAttributes);
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
This PR adds an ability to enable ephemeral mode with devfile.
Example of Devfile with ephemeral mode enabled
```yaml
specVersion: 0.0.1
name: ephemeral
projects:
- name: revapi
  source:
    type: git
    location: https://github.com/revapi/revapi.git
components:
- name: theia
  type: cheEditor
  id: org.eclipse.che.editor.theia:1.0.0
- name: exec
  type: chePlugin
  id: che-machine-exec-plugin:0.0.1
attributes:
  persistVolumes: false
```

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
Current PR already contain needed docs changes.