### PR TITLE
Add machine token support for GWT-IDE

### DIFF
--- a/dockerfiles/gwt-ide/traefik.toml
+++ b/dockerfiles/gwt-ide/traefik.toml
@@ -53,22 +53,58 @@ defaultEntryPoints = ["http"]
         [backends.chemaster.servers.server1]
              url = "http://che-host:8080"
 [frontends]
-  [frontends.frontend2]
-    priority = 10
+  [frontends.liveness]
+    priority = 20
+    backend = "ide"
+    passHostHeader = true
+    entrypoints = ["http2"]
+    [frontends.liveness.routes.api_workspace]
+    rule = "PathPrefix:/api/liveness"
+  [frontends.api]
+    backend = "chemaster"
+    priority = 19
+    passHostHeader = true
+    [frontends.api.headers.customrequestheaders]
+      Authorization = 'Bearer che_machine_token_placeholder'
+    [frontends.api.routes.api]
+    rule = "PathPrefix:/api"
+  [frontends.api_entrypoint]
+    priority = 15
     backend = "chemaster"
     passHostHeader = true
-    [frontends.frontend2.routes.api]
-    rule = "PathPrefix:/api/"
+    [frontends.api_entrypoint.redirect]
+      regex = "^(http|https)://(.*)/gwt/ide/sidecar/entrypoint/api/(.*)"
+      replacement = "$1://$2/api/$3"
+    [frontends.api_entrypoint.routes.ide]
+      rule = "PathPrefix:/api/"
   [frontends.frontend1]
-    priority = 5
+    priority = 10
     backend = "ide"
     passHostHeader = true
     [frontends.frontend1.redirect]
       regex = "^(http|https)://(.*)/gwt/ide/sidecar/entrypoint"
       replacement = "$1://$2/che_workspace_namespace_placeholder/che_workspace_name_placeholder"
     [frontends.frontend1.routes.ide]
-    rule = "PathPrefix: /; AddPrefix: /ide"
-  [frontends.frontend3]
+      rule = "PathPrefix:/; AddPrefix:/ide"
+  [frontends.workspace-loader]
+    priority = 10
+    backend = "ide"
+    passHostHeader = true
+    [frontends.workspace-loader.redirect]
+      regex = "^(http|https)://(.*)/workspace-loader/che_workspace_namespace_placeholder/che_workspace_name_placeholder"
+      replacement = "$1://$2/che_workspace_namespace_placeholder/che_workspace_name_placeholder"
+    [frontends.workspace-loader.routes.ide]
+      rule = "PathPrefix:/; AddPrefix:/ide"
+  [frontends.loader]
+    priority = 5
+    backend = "ide"
+    passHostHeader = true
+    [frontends.loader.redirect]
+      regex = "^(http|https)://(.*)/_app/loader.html"
+      replacement = "$1://$2/"
+    [frontends.loader.routes.ide]
+      route = "PathPrefix:/"
+  [frontends.default]
     backend = "ide"
     passHostHeader = true
     entrypoints = ["http2"]

--- a/dockerfiles/gwt-ide/traefik_conf.sh
+++ b/dockerfiles/gwt-ide/traefik_conf.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 sed -i "s/che_workspace_namespace_placeholder/${CHE_WORKSPACE_NAMESPACE}/g" /home/user/agent/traefik/traefik.toml
 sed -i "s/che_workspace_name_placeholder/${CHE_WORKSPACE_NAME}/g" /home/user/agent/traefik/traefik.toml
+sed -i "s/che_machine_token_placeholder/${CHE_MACHINE_TOKEN}/g" /home/user/agent/traefik/traefik.toml

--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthModule.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthModule.java
@@ -81,6 +81,13 @@ public class MachineAuthModule extends AbstractModule {
         .addBinding()
         .toInstance(new MachineAuthenticatedResource("/activity", "active"));
 
+    machineAuthenticatedResources
+        .addBinding()
+        .toInstance(new MachineAuthenticatedResource("project-template", "getProjectTemplates"));
+    machineAuthenticatedResources
+        .addBinding()
+        .toInstance(new MachineAuthenticatedResource("/installer", "getInstallers"));
+
     bindConstant().annotatedWith(Names.named("che.auth.signature_key_size")).to(2048);
     bindConstant().annotatedWith(Names.named("che.auth.signature_key_algorithm")).to("RSA");
   }


### PR DESCRIPTION
### What does this PR do?

Enables to access API server via JWT-proxy from GWT-IDE. 

This is a first step.
Some more patches are required to run GWT-IDE with JWT-proxy.

### The overview of fixes.

Traefik related fixes are interim. Whole Traefik will be replaced to more lightweight one in the future.

* Fixes routing.
  * dockerfiles/gwt-ide/traefik.toml
* Adding `Authorization: Bearer ${CHE_MACHINE_TOKEN}` header to `/api` calls.
  * `dockerfiles/gwt-ide/traefik.toml`
  * `dockerfiles/gwt-ide/traefik_conf.sh`
* Enables to get `/api/project-template` and `/api/installer` by valid machine tokens.
  * `multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthModule.java`

The `/api/project-template` related fixes will be resolve a part of  #12273 .

### What issues does this PR fix or reference?

refs: #12243 #12273 #12956 #13099 
