### PR TITLE
Revert a part of 2a18d4d2. (applyed by #13105)

### DIFF
--- a/dashboard/src/components/api/che-profile.factory.ts
+++ b/dashboard/src/components/api/che-profile.factory.ts
@@ -87,9 +87,9 @@ export class CheProfile {
 
   /**
    * Gets the profile data
-   * @returns {ng.IPromise<che.IProfile>} the promise
+   * @returns profile
    */
-  fetchProfile(): ng.IPromise<che.IProfile> {
+  fetchProfile(): che.IProfile {
     if (this.profile && !this.profile.$resolved) {
       return this.profile;
     }


### PR DESCRIPTION
### What does this PR do?

Fixes the build error caused by 2a18d4d2.
I labeled this severity/P1 because recent nightly builds won't work well.

This issue is a hot-fix. We must resolve at least two issues after applied this.

1. Refactoring `fetchProfile()` to use `async/await` ( #13141 )
2. Make build failure on transpiling code in TypeScript. ( #13144 )

### What issues does this PR fix or reference?

#13105 