### PR TITLE
Enable to load GWT-IDE app on Multi-user with Multi-host env.

### DIFF
--- a/dashboard/src/app/ide/ide-iframe/ide-iframe.service.ts
+++ b/dashboard/src/app/ide/ide-iframe/ide-iframe.service.ts
@@ -72,6 +72,10 @@ class IdeIFrameSvc {
       } else if ('hide-navbar' === event.data) {
         $rootScope.hideNavbar = true;
         $mdSidenav('left').close();
+
+      } else if ('check-keycloak-available' === event.data) {
+        event.source.postMessage(event.data + ($window['_keycloak'] ? ':true' : ':false'), event.origin);
+
       }
 
     }, false);

--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/IDE.html
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/IDE.html
@@ -62,20 +62,46 @@
              * Load keycloak settings
              */
             this.loadKeycloakSettings = function() {
-                var msg = "Cannot load keycloak settings. This is normal for single-user mode.";
+                Loader.copyKeycloakSettings();
+            }
+
+            this.copyKeycloakSettings = function() {
                 try {
                     if (window.parent && window.parent['_keycloak']) {
                         window['_keycloak'] = window.parent['_keycloak'];
+                        /* Must be version 6 or prior. */
                         Loader.startLoading();
-                        return;
                     }
                 } catch (e) {
-                    // access to parent frame can be forbidden from the inner iframe,
-                    // in case if IDE.html would be loaded(for example sidecar)
-                    // from a different domain than parent frame.
-                    console.error(msg, e);
+                    Loader.checkMultiHostEnvironment();
                 }
-                
+            }
+
+            this.checkMultiHostEnvironment = function() {
+                /*
+                 * Get the machine token from the parent window.
+                 */
+                var callback = function (event) {
+                    var originHostname = new URL(event.origin).hostname
+                    var baseDomainOrigin = originHostname.substring(originHostname.indexOf('.') + 1);
+                    var baseDomainHere = window.location.hostname.substring(window.location.hostname.indexOf('.') + 1);
+                    if (baseDomainOrigin === baseDomainHere) {
+                        if (event.data === 'check-keycloak-available:true') {
+                            /* Must be Multi-host. */
+                            Loader.processLoading();
+                        } else if (event.data === 'check-keycloak-available:false') {
+                            console.error("Cannot load keycloak settings. This is normal for single-user mode.");
+                            /* Must be not Multi-host. */
+                            Loader.setupKeycloak();
+                        }
+                    }
+                    window.removeEventListener('message', callback);
+                };
+                window.addEventListener('message', callback);
+                window.top.postMessage('check-keycloak-available', '*');
+            }
+
+            this.setupKeycloak = function() {
                 try {
                     var request = new XMLHttpRequest();
 
@@ -186,14 +212,14 @@
                         return;
                     }
                     if (this.status !== 200) {
-                        var message;
+                        var response;
                         try {
-                            message = JSON.parse(this.responseText).message;
+                            response = JSON.parse(this.responseText);
                         } catch(e) {
                             /* Maybe plain text. */
-                            message = this.responseText;
+                            response = this.responseText;
                         }
-                        errorMessage = 'Failed to get the workspace: "' + message;
+                        errorMessage = 'Failed to get the workspace: "' + response.message;
                         return;
                     }
                     var workspace = JSON.parse(this.responseText);
@@ -214,13 +240,18 @@
                                 // Preconfigured IDE may use dedicated port. In this case Chrome browser fails
                                 // with error net::ERR_CONNECTION_REFUSED. Timer helps to open the URL without errors.
                                 setTimeout(function () {
-                                    window.location.href = url;
+                                    window.location.replace(url);
                                 }, 100);
                                 return;
                             }
                         }
                     }
                 };
+                Loader.processLoading();
+            };
+
+
+            this.processLoading = function() {
                 //GWT IDE Loading
                 setTimeout(() => {
                     document.getElementById("ide-loader").style.opacity = 1;

--- a/multiuser/keycloak/che-multiuser-keycloak-ide/src/main/java/org/eclipse/che/multiuser/keycloak/ide/Keycloak.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-ide/src/main/java/org/eclipse/che/multiuser/keycloak/ide/Keycloak.java
@@ -21,6 +21,16 @@ public final class Keycloak extends JavaScriptObject {
     super();
   }
 
+  public static native boolean isMultihostEnvironment() /*-{
+    try {
+      var dummy = $wnd.parent['_keycloak'];
+      return false;
+    } catch(e) {
+      // Will blocked by cross domain scripting.
+      return true;
+    }
+  }-*/;
+
   public static native boolean isConfigured() /*-{
     if ($wnd['_keycloak']) {
       return true;

--- a/multiuser/keycloak/che-multiuser-keycloak-ide/src/main/java/org/eclipse/che/multiuser/keycloak/ide/KeycloakProvider.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-ide/src/main/java/org/eclipse/che/multiuser/keycloak/ide/KeycloakProvider.java
@@ -41,6 +41,9 @@ public class KeycloakProvider {
 
   @Inject
   public KeycloakProvider(AppContext appContext) {
+    if (Keycloak.isMultihostEnvironment()) {
+      return;
+    }
     if (Keycloak.isConfigured()) {
       keycloak = Keycloak.get();
       return;


### PR DESCRIPTION
Alternative of #13026.

### What does this PR do?

In "Multi-user with Multi-host" environment, 

Some code in IDE.html must be skipped because they are done in loader.html.

IDE and dashboard cannot share (copy) Kyecloak settings because of the cross domain scripting.
So IDEs must check whether itself runs in cross domain and choose their machine-token or another way for calling `/api` endpoints in case it was required.
(This patch does not contain patches how to call `/api`. This is just for checking cross-domain  and setting Keycloak off. )


### What issues does this PR fix or reference?

Will fixes #13026 #12585
This may resolve some part of #12243.
After fixes by this PR, GWT-IDE will crashed by #12273.
#13137 is a part of the answer how to call `/api` from GWT-IDE.
