### PR TITLE
Ignore `.theia/` directories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,10 @@ test-output/
 maven-eclipse.xml
 .factorypath
 
+# Theia #
+##################
+.theia/
+
 # Idea #
 ##################
 *.iml


### PR DESCRIPTION

### What does this PR do?

Ignores `.theia/` directories from Git staging files.
At least in Google Cloud Shell, Theia generates `.theia/` as its project settings directory.

### What issues does this PR fix or reference?

None.
