### PR TITLE
Add yarn.lock to UD sources jar

### DIFF
--- a/dashboard/pom.xml
+++ b/dashboard/pom.xml
@@ -106,6 +106,7 @@
                         <include>*.json</include>
                         <include>*.js</include>
                         <include>.*</include>
+                        <include>yarn.lock</include>
                     </includes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
### What does this PR do?
Add yarn.lock to UD sources jar because it needed 
in downstream projects to recompile UD properly.

### What issues does this PR fix or reference?
Related to https://github.com/redhat-developer/rh-che/issues/1325

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
