### PR TITLE
Fix filter of the plugins list

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.controller.ts
@@ -16,7 +16,7 @@ import {CheNotification} from '../../../../components/notification/che-notificat
 
 const PLUGIN_SEPARATOR = ',';
 const PLUGIN_VERSION_SEPARATOR = ':';
-const PLUGIN_TYPE = 'Che Plugin';
+const EDITOR_TYPE = 'Che Editor';
 
 /**
  * @ngdoc controller
@@ -85,7 +85,7 @@ export class WorkspacePluginsController {
     this.pluginRegistry.fetchPlugins(this.pluginRegistryLocation).then((result: Array<IPlugin>) => {
       this.isLoading = false;
       result.forEach((item: IPlugin) => {
-        if (item.type === PLUGIN_TYPE) {
+        if (item.type !== EDITOR_TYPE) {
           this.plugins.push(item);
         }
       });  
@@ -115,7 +115,7 @@ export class WorkspacePluginsController {
   updatePlugin(plugin: IPlugin): void {
     let name = plugin.id + PLUGIN_VERSION_SEPARATOR + plugin.version;
 
-    if (plugin.type === PLUGIN_TYPE) {
+    if (plugin.type !== EDITOR_TYPE) {
       if (plugin.isEnabled) {
         this.selectedPlugins.push(name);
       } else {


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes the list of plugins that at the moment displays only plugins with type "Che Plugin", and skips others (ex. "VS Code extension",  ""Theia plugin""). 

### What issues does this PR fix or reference?
Fixes the result of this merge - https://github.com/eclipse/che/pull/13070
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

