### PR TITLE
Added an ability to use Devfile as workspace configuration as an alternative to WorkspaceConfig

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/BadRequestException.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/BadRequestException.java
@@ -26,6 +26,10 @@ public class BadRequestException extends ApiException {
     super(message);
   }
 
+  public BadRequestException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
   public BadRequestException(ServiceError serviceError) {
     super(serviceError);
   }

--- a/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/local/projects/LocalProjectsMigrator.java
+++ b/infrastructures/docker/infrastructure/src/main/java/org/eclipse/che/workspace/infrastructure/docker/local/projects/LocalProjectsMigrator.java
@@ -83,7 +83,7 @@ public class LocalProjectsMigrator {
       for (WorkspaceImpl workspace :
           iterate(
               (maxItems, skipCount) -> workspaceDao.getWorkspaces(false, maxItems, skipCount))) {
-        result.put(workspace.getId(), workspace.getConfig().getName());
+        result.put(workspace.getId(), workspace.getName());
       }
       return result;
     } catch (ServerException e) {

--- a/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/local/projects/LocalProjectMigratorTest.java
+++ b/infrastructures/docker/infrastructure/src/test/java/org/eclipse/che/workspace/infrastructure/docker/local/projects/LocalProjectMigratorTest.java
@@ -27,7 +27,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.che.api.core.Page;
-import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.commons.lang.IoUtil;
@@ -89,10 +88,8 @@ public class LocalProjectMigratorTest {
       String workspaceId = "ws_id_" + namePrefix + i;
 
       WorkspaceImpl workspace = mock(WorkspaceImpl.class);
-      WorkspaceConfigImpl workspaceConfig = mock(WorkspaceConfigImpl.class);
       when(workspace.getId()).thenReturn(workspaceId);
-      when(workspace.getConfig()).thenReturn(workspaceConfig);
-      when(workspace.getConfig().getName()).thenReturn(workspaceName);
+      when(workspace.getName()).thenReturn(workspaceName);
 
       result.add(workspace);
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceUtility.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/EphemeralWorkspaceUtility.java
@@ -15,11 +15,13 @@ import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATT
 
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.model.workspace.devfile.Devfile;
 
 public class EphemeralWorkspaceUtility {
 
   /**
-   * @param workspaceAttributes
+   * @param workspaceAttributes workspace config or devfile attributes to check is ephemeral mode is
+   *     enabled
    * @return true if `persistVolumes` attribute exists and set to 'false'. In this case regardless
    *     of the PVC strategy, workspace volumes would be created as `emptyDir`. When a workspace Pod
    *     is removed for any reason, the data in the `emptyDir` volume is deleted forever
@@ -30,20 +32,26 @@ public class EphemeralWorkspaceUtility {
   }
 
   /**
-   * @param workspace
+   * @param workspace workspace to check is ephemeral mode is enabled
    * @return true if workspace config contains `persistVolumes` attribute which is set to false. In
    *     this case regardless of the PVC strategy, workspace volumes would be created as `emptyDir`.
    *     When a workspace Pod is removed for any reason, the data in the `emptyDir` volume is
    *     deleted forever
    */
   public static boolean isEphemeral(Workspace workspace) {
+    Devfile devfile = workspace.getDevfile();
+    if (devfile != null) {
+      return isEphemeral(devfile.getAttributes());
+    }
+
     return isEphemeral(workspace.getConfig().getAttributes());
   }
 
   /**
    * Change workspace attributes such that future calls to {@link isEphemeral} will return true.
    *
-   * @param workspaceAttributes
+   * @param workspaceAttributes workspace config or devfile attributes to which ephemeral mode
+   *     configuration should be provisioned
    */
   public static void makeEphemeral(Map<String, String> workspaceAttributes) {
     workspaceAttributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");

--- a/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/usage/tracker/RamResourceUsageTracker.java
+++ b/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/usage/tracker/RamResourceUsageTracker.java
@@ -27,6 +27,7 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.multiuser.resource.api.ResourceUsageTracker;
 import org.eclipse.che.multiuser.resource.api.type.RamResourceType;
@@ -72,14 +73,17 @@ public class RamResourceUsageTracker implements ResourceUsageTracker {
       if (WorkspaceStatus.STARTING.equals(activeWorkspace.getStatus())) {
         // starting workspace may not have all machine in runtime
         // it is need to calculate ram from environment config
-        final EnvironmentImpl startingEnvironment =
-            activeWorkspace
-                .getConfig()
-                .getEnvironments()
-                .get(activeWorkspace.getRuntime().getActiveEnv());
-        if (startingEnvironment != null) {
-          currentlyUsedRamMB += environmentRamCalculator.calculate(startingEnvironment);
+        WorkspaceConfigImpl config = activeWorkspace.getConfig();
+
+        if (config != null) {
+          final EnvironmentImpl startingEnvironment =
+              config.getEnvironments().get(activeWorkspace.getRuntime().getActiveEnv());
+          if (startingEnvironment != null) {
+            currentlyUsedRamMB += environmentRamCalculator.calculate(startingEnvironment);
+          }
         }
+        // Estimation of memory for starting workspace with Devfile is not implemented yet
+        // just ignore such
       } else {
         currentlyUsedRamMB += environmentRamCalculator.calculate(activeWorkspace.getRuntime());
       }

--- a/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManager.java
+++ b/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManager.java
@@ -32,9 +32,11 @@ import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.DevfileToWorkspaceConfigConverter;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
 import org.eclipse.che.api.workspace.server.WorkspaceValidator;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.commons.annotation.Nullable;
@@ -81,8 +83,10 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
       @Named("che.limits.workspace.env.ram") String maxRamPerEnv,
       EnvironmentRamCalculator environmentRamCalculator,
       ResourceManager resourceManager,
-      ResourcesLocks resourcesLocks) {
-    super(workspaceDao, runtimes, eventService, accountManager, workspaceValidator);
+      ResourcesLocks resourcesLocks,
+      DevfileToWorkspaceConfigConverter devfileConverter) {
+    super(
+        workspaceDao, runtimes, eventService, accountManager, workspaceValidator, devfileConverter);
     this.environmentRamCalculator = environmentRamCalculator;
     this.maxRamPerEnvMB = "-1".equals(maxRamPerEnv) ? -1 : Size.parseSizeToMegabytes(maxRamPerEnv);
     this.resourceManager = resourceManager;
@@ -111,12 +115,14 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
       throws NotFoundException, ServerException, ConflictException {
     WorkspaceImpl workspace = this.getWorkspace(workspaceId);
     String accountId = workspace.getAccount().getId();
+    WorkspaceConfigImpl config = workspace.getConfig();
 
     try (@SuppressWarnings("unused")
         Unlocker u = resourcesLocks.lock(accountId)) {
       checkRuntimeResourceAvailability(accountId);
-      checkRamResourcesAvailability(
-          accountId, workspace.getNamespace(), workspace.getConfig(), envName);
+      if (config != null) {
+        checkRamResourcesAvailability(accountId, workspace.getNamespace(), config, envName);
+      }
 
       return super.startWorkspace(workspaceId, envName, options);
     }
@@ -133,7 +139,9 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
         Unlocker u = resourcesLocks.lock(accountId)) {
       checkWorkspaceResourceAvailability(accountId);
       checkRuntimeResourceAvailability(accountId);
-      checkRamResourcesAvailability(accountId, namespace, config, null);
+      if (config != null) {
+        checkRamResourcesAvailability(accountId, namespace, config, null);
+      }
 
       return super.startWorkspace(config, namespace, isTemporary, options);
     }
@@ -142,7 +150,9 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
   @Override
   public WorkspaceImpl updateWorkspace(String id, Workspace update)
       throws ConflictException, ServerException, NotFoundException, ValidationException {
-    checkMaxEnvironmentRam(update.getConfig());
+    if (update.getConfig() != null) {
+      checkMaxEnvironmentRam(update.getConfig());
+    }
 
     WorkspaceImpl workspace = this.getWorkspace(id);
     String accountId = workspace.getAccount().getId();
@@ -185,7 +195,6 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
   void checkRamResourcesAvailability(
       String accountId, String namespace, WorkspaceConfig config, @Nullable String envName)
       throws NotFoundException, ServerException, ConflictException {
-
     if (config.getEnvironments().isEmpty()) {
       return;
     }

--- a/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -269,6 +269,7 @@ public class LimitsCheckingWorkspaceManagerTest {
               maxRamPerEnv,
               environmentRamCalculator,
               resourceManager,
+              null,
               null));
     }
 

--- a/multiuser/integration-tests/che-multiuser-cascade-removal/pom.xml
+++ b/multiuser/integration-tests/che-multiuser-cascade-removal/pom.xml
@@ -90,6 +90,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-model</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-ssh</artifactId>
             <scope>test</scope>
         </dependency>

--- a/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
+++ b/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
@@ -75,6 +75,7 @@ import org.eclipse.che.api.user.server.spi.ProfileDao;
 import org.eclipse.che.api.user.server.spi.UserDao;
 import org.eclipse.che.api.workspace.server.DefaultWorkspaceLockService;
 import org.eclipse.che.api.workspace.server.DefaultWorkspaceStatusCache;
+import org.eclipse.che.api.workspace.server.DevfileToWorkspaceConfigConverter;
 import org.eclipse.che.api.workspace.server.WorkspaceLockService;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.WorkspaceSharedPool;
@@ -261,6 +262,14 @@ public class JpaEntitiesCascadeRemovalTest {
                     .annotatedWith(Names.named("che.auth.reserved_user_names"))
                     .toInstance(new String[0]);
                 bind(RemoveOrganizationOnLastUserRemovedEventSubscriber.class).asEagerSingleton();
+
+                // is not used in a scope of integration tests
+                // but instance is needed for setting WorkspaceManager up
+                bind(DevfileToWorkspaceConfigConverter.class)
+                    .toInstance(
+                        devfile -> {
+                          throw new UnsupportedOperationException("Operation is not implemented");
+                        });
 
                 Multibinder.newSetBinder(binder(), ResourceLockKeyProvider.class);
                 Multibinder.newSetBinder(binder(), ResourceUsageTracker.class);

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaWorkspaceDao.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaWorkspaceDao.java
@@ -74,7 +74,7 @@ public class MultiuserJpaWorkspaceDao implements WorkspaceDao {
       throw new ConflictException(
           format(
               "Workspace with id '%s' or name '%s' in namespace '%s' already exists",
-              workspace.getId(), workspace.getConfig().getName(), workspace.getNamespace()));
+              workspace.getId(), workspace.getName(), workspace.getNamespace()));
     } catch (RuntimeException x) {
       throw new ServerException(x.getMessage(), x);
     }
@@ -91,7 +91,7 @@ public class MultiuserJpaWorkspaceDao implements WorkspaceDao {
       throw new ConflictException(
           format(
               "Workspace with name '%s' in namespace '%s' already exists",
-              update.getConfig().getName(), update.getNamespace()));
+              update.getName(), update.getNamespace()));
     } catch (RuntimeException x) {
       throw new ServerException(x.getMessage(), x);
     }

--- a/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileModule.java
+++ b/wsmaster/che-core-api-devfile/src/main/java/org/eclipse/che/api/devfile/server/DevfileModule.java
@@ -22,6 +22,7 @@ import static org.eclipse.che.api.devfile.server.Constants.PLUGIN_COMPONENT_TYPE
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
+import org.eclipse.che.api.devfile.server.convert.DevfileConverter;
 import org.eclipse.che.api.devfile.server.convert.component.ComponentProvisioner;
 import org.eclipse.che.api.devfile.server.convert.component.ComponentToWorkspaceApplier;
 import org.eclipse.che.api.devfile.server.convert.component.dockerimage.DockerimageComponentProvisioner;
@@ -33,6 +34,7 @@ import org.eclipse.che.api.devfile.server.convert.component.kubernetes.Kubernete
 import org.eclipse.che.api.devfile.server.convert.component.plugin.PluginComponentToWorkspaceApplier;
 import org.eclipse.che.api.devfile.server.convert.component.plugin.PluginProvisioner;
 import org.eclipse.che.api.devfile.server.validator.DevfileSchemaValidator;
+import org.eclipse.che.api.workspace.server.DevfileToWorkspaceConfigConverter;
 
 /** @author Sergii Leshchenko */
 public class DevfileModule extends AbstractModule {
@@ -66,5 +68,7 @@ public class DevfileModule extends AbstractModule {
     componentToWorkspaceApplier
         .addBinding(DOCKERIMAGE_COMPONENT_TYPE)
         .to(DockerimageComponentToWorkspaceApplier.class);
+
+    bind(DevfileToWorkspaceConfigConverter.class).to(DevfileConverter.class);
   }
 }

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DevfileConverterTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/convert/DevfileConverterTest.java
@@ -14,7 +14,10 @@ package org.eclipse.che.api.devfile.server.convert;
 import static org.eclipse.che.api.devfile.server.Constants.CURRENT_SPEC_VERSION;
 import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -24,9 +27,13 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
 import java.util.Map;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.devfile.server.FileContentProvider;
+import org.eclipse.che.api.devfile.server.URLFetcher;
 import org.eclipse.che.api.devfile.server.convert.component.ComponentProvisioner;
 import org.eclipse.che.api.devfile.server.convert.component.ComponentToWorkspaceApplier;
+import org.eclipse.che.api.devfile.server.exception.DevfileException;
 import org.eclipse.che.api.devfile.server.exception.DevfileFormatException;
 import org.eclipse.che.api.devfile.server.exception.WorkspaceExportException;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
@@ -51,6 +58,7 @@ public class DevfileConverterTest {
   @Mock private ComponentProvisioner componentProvisioner;
   @Mock private ComponentToWorkspaceApplier componentToWorkspaceApplier;
   @Mock private DefaultEditorProvisioner defaultEditorToolApplier;
+  @Mock private URLFetcher urlFetcher;
 
   private DevfileConverter devfileConverter;
 
@@ -62,7 +70,8 @@ public class DevfileConverterTest {
             commandConverter,
             ImmutableSet.of(componentProvisioner),
             ImmutableMap.of(COMPONENT_TYPE, componentToWorkspaceApplier),
-            defaultEditorToolApplier);
+            defaultEditorToolApplier,
+            urlFetcher);
   }
 
   @Test
@@ -296,6 +305,31 @@ public class DevfileConverterTest {
 
     // when
     devfileConverter.devFileToWorkspaceConfig(devfile, fileContentProvider);
+  }
+
+  @Test
+  public void shouldConvertDevfileToWorkspaceConfig() throws Exception {
+    devfileConverter = spy(devfileConverter);
+    WorkspaceConfigImpl wsConfig = new WorkspaceConfigImpl();
+    wsConfig.setName("converted");
+    wsConfig.getAttributes().put("att", "value");
+    doReturn(wsConfig).when(devfileConverter).devFileToWorkspaceConfig(any(), any());
+
+    WorkspaceConfig converted = devfileConverter.convert(new DevfileImpl());
+
+    assertEquals(converted, wsConfig);
+  }
+
+  @Test(expectedExceptions = ServerException.class, expectedExceptionsMessageRegExp = "error")
+  public void
+      shouldThrowServerExceptionIfAnyDevfileExceptionOccursOnConvertingDevfileToWorkspaceConfig()
+          throws Exception {
+    devfileConverter = spy(devfileConverter);
+    doThrow(new DevfileException("error"))
+        .when(devfileConverter)
+        .devFileToWorkspaceConfig(any(), any());
+
+    devfileConverter.convert(new DevfileImpl());
   }
 
   private DevfileImpl newDevfile(String name) {

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/FactoryService.java
@@ -289,13 +289,17 @@ public class FactoryService extends Service {
     @ApiResponse(code = 200, message = "Response contains requested factory JSON"),
     @ApiResponse(code = 400, message = "Missed required parameters, parameters are not valid"),
     @ApiResponse(code = 404, message = "Workspace not found"),
+    @ApiResponse(code = 409, message = "Workspace can not be exported as factory"),
     @ApiResponse(code = 500, message = "Internal server error")
   })
   public Response getFactoryJson(
       @ApiParam(value = "Workspace identifier") @PathParam("ws-id") String wsId,
       @ApiParam(value = "Project path") @QueryParam("path") String path)
-      throws BadRequestException, NotFoundException, ServerException {
+      throws BadRequestException, NotFoundException, ServerException, ConflictException {
     final WorkspaceImpl workspace = workspaceManager.getWorkspace(wsId);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException("Workspace created with Devfile can not be exported as Factory.");
+    }
     excludeProjectsWithoutLocation(workspace, path);
     final FactoryDto factoryDto =
         DtoFactory.newDto(FactoryDto.class)

--- a/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
+++ b/wsmaster/che-core-api-factory/src/test/java/org/eclipse/che/api/factory/server/DefaultFactoryParameterResolverTest.java
@@ -92,7 +92,8 @@ public class DefaultFactoryParameterResolverTest {
             new CommandConverter(),
             componentProvisioners,
             appliers,
-            new DefaultEditorProvisioner(null, new String[] {}));
+            new DefaultEditorProvisioner(null, new String[] {}),
+            new URLFetcher());
 
     WorkspaceManager workspaceManager = mock(WorkspaceManager.class);
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DevfileToWorkspaceConfigConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DevfileToWorkspaceConfigConverter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.workspace.server;
+
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
+import org.eclipse.che.api.core.model.workspace.devfile.Devfile;
+
+/**
+ * Converts Devfile to WorkspaceConfig.
+ *
+ * @author Sergii Leshchenko
+ */
+public interface DevfileToWorkspaceConfigConverter {
+
+  /**
+   * Converts Devfile to workspace config.
+   *
+   * <p>Converted workspace config should be used for Workspace start only and should not be
+   * persisted.
+   *
+   * @param devfile the devfile to convert
+   * @return converted workspace config
+   * @throws ServerException if the specified devfile can not be converted to workspace config for
+   *     some reasons
+   */
+  WorkspaceConfig convert(Devfile devfile) throws ServerException;
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceLinksGenerator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceLinksGenerator.java
@@ -25,9 +25,9 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import javax.ws.rs.core.UriBuilder;
 import org.eclipse.che.api.core.ServerException;
-import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.rest.ServiceContext;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
 
@@ -52,7 +52,7 @@ public class WorkspaceLinksGenerator {
   }
 
   /** Returns 'rel -> url' map of links for the given workspace. */
-  public Map<String, String> genLinks(Workspace workspace, ServiceContext serviceContext)
+  public Map<String, String> genLinks(WorkspaceImpl workspace, ServiceContext serviceContext)
       throws ServerException {
     final UriBuilder uriBuilder = serviceContext.getServiceUriBuilder();
     final LinkedHashMap<String, String> links = new LinkedHashMap<>();
@@ -70,7 +70,7 @@ public class WorkspaceLinksGenerator {
             .clone()
             .replacePath("")
             .path(workspace.getNamespace())
-            .path(workspace.getConfig().getName())
+            .path(workspace.getName())
             .build()
             .toString());
     if (workspace.getStatus() != WorkspaceStatus.STOPPED) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -438,6 +438,10 @@ public class WorkspaceService extends Service {
           ForbiddenException {
     requiredNotNull(newCommand, "Command");
     WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     workspace.getConfig().getCommands().add(new CommandImpl(newCommand));
     return asDtoWithLinksAndToken(doUpdate(id, workspace));
   }
@@ -465,6 +469,10 @@ public class WorkspaceService extends Service {
           ForbiddenException {
     requiredNotNull(update, "Command update");
     WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     List<CommandImpl> commands = workspace.getConfig().getCommands();
     if (!commands.removeIf(cmd -> cmd.getName().equals(cmdName))) {
       throw new NotFoundException(
@@ -491,6 +499,10 @@ public class WorkspaceService extends Service {
       throws ServerException, BadRequestException, NotFoundException, ConflictException,
           ForbiddenException {
     WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     if (workspace
         .getConfig()
         .getCommands()
@@ -525,6 +537,10 @@ public class WorkspaceService extends Service {
     requiredNotNull(envName, "New environment name");
     relativizeRecipeLinks(newEnvironment);
     WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     workspace.getConfig().getEnvironments().put(envName, new EnvironmentImpl(newEnvironment));
     return asDtoWithLinksAndToken(doUpdate(id, workspace));
   }
@@ -552,6 +568,10 @@ public class WorkspaceService extends Service {
     requiredNotNull(update, "Environment description");
     relativizeRecipeLinks(update);
     final WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     EnvironmentImpl previous =
         workspace.getConfig().getEnvironments().put(envName, new EnvironmentImpl(update));
     if (previous == null) {
@@ -578,6 +598,10 @@ public class WorkspaceService extends Service {
       throws ServerException, BadRequestException, NotFoundException, ConflictException,
           ForbiddenException {
     final WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     if (workspace.getConfig().getEnvironments().remove(envName) != null) {
       doUpdate(id, workspace);
     }
@@ -605,6 +629,10 @@ public class WorkspaceService extends Service {
           ForbiddenException {
     requiredNotNull(newProject, "New project config");
     final WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     workspace.getConfig().getProjects().add(new ProjectConfigImpl(newProject));
     return asDtoWithLinksAndToken(doUpdate(id, workspace));
   }
@@ -631,6 +659,10 @@ public class WorkspaceService extends Service {
           ForbiddenException {
     requiredNotNull(update, "Project config");
     final WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     final List<ProjectConfigImpl> projects = workspace.getConfig().getProjects();
     final String normalizedPath = path.startsWith("/") ? path : '/' + path;
     if (!projects.removeIf(project -> project.getPath().equals(normalizedPath))) {
@@ -658,6 +690,10 @@ public class WorkspaceService extends Service {
       throws ServerException, BadRequestException, NotFoundException, ConflictException,
           ForbiddenException {
     final WorkspaceImpl workspace = workspaceManager.getWorkspace(id);
+    if (workspace.getConfig() == null) {
+      throw new ConflictException(
+          "This method can not be invoked for workspace created from Devfile. Use update workspace method instead.");
+    }
     final String normalizedPath = path.startsWith("/") ? path : '/' + path;
     if (workspace
         .getConfig()

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDao.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDao.java
@@ -60,14 +60,10 @@ public class JpaWorkspaceDao implements WorkspaceDao {
     try {
       doCreate(workspace);
     } catch (DuplicateKeyException dkEx) {
-      String name =
-          workspace.getConfig() != null
-              ? workspace.getConfig().getName()
-              : workspace.getDevfile().getName();
       throw new ConflictException(
           format(
               "Workspace with id '%s' or name '%s' in namespace '%s' already exists",
-              workspace.getId(), name, workspace.getNamespace()));
+              workspace.getId(), workspace.getName(), workspace.getNamespace()));
     } catch (RuntimeException x) {
       throw new ServerException(x.getMessage(), x);
     }
@@ -81,12 +77,10 @@ public class JpaWorkspaceDao implements WorkspaceDao {
     try {
       return new WorkspaceImpl(doUpdate(update));
     } catch (DuplicateKeyException dkEx) {
-      String name =
-          update.getConfig() != null ? update.getConfig().getName() : update.getDevfile().getName();
       throw new ConflictException(
           format(
               "Workspace with name '%s' in namespace '%s' already exists",
-              name, update.getNamespace()));
+              update.getName(), update.getNamespace()));
     } catch (RuntimeException x) {
       throw new ServerException(x.getMessage(), x);
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
@@ -217,6 +217,17 @@ public class WorkspaceImpl implements Workspace {
     return null;
   }
 
+  /** Returns the name of workspace. It can be stored by workspace config or devfile. */
+  public String getName() {
+    if (devfile != null) {
+      return devfile.getName();
+    } else if (config != null) {
+      return config.getName();
+    } else {
+      return null;
+    }
+  }
+
   public void setAccount(AccountImpl account) {
     this.account = account;
   }
@@ -341,15 +352,9 @@ public class WorkspaceImpl implements Workspace {
         + '}';
   }
 
-  /** Syncs {@link #name} with config name. */
+  /** Syncs {@link #name} with config name or devfile name. */
   private void syncName() {
-    if (devfile != null) {
-      name = devfile.getName();
-    } else if (config != null) {
-      name = config.getName();
-    } else {
-      name = null;
-    }
+    name = getName();
   }
 
   /**

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProvider.java
@@ -41,7 +41,7 @@ public class WorkspaceNameEnvVarProvider implements EnvVarProvider {
   public Pair<String, String> get(RuntimeIdentity runtimeIdentity) throws InfrastructureException {
     try {
       WorkspaceImpl workspace = workspaceDao.get(runtimeIdentity.getWorkspaceId());
-      return Pair.of(CHE_WORKSPACE_NAME, workspace.getConfig().getName());
+      return Pair.of(CHE_WORKSPACE_NAME, workspace.getName());
     } catch (NotFoundException | ServerException e) {
       throw new InfrastructureException(
           "Not able to get workspace name for workspace with id "

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceLinksGeneratorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceLinksGeneratorTest.java
@@ -17,7 +17,6 @@ import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_IDE_URL;
 import static org.eclipse.che.api.workspace.shared.Constants.LINK_REL_SELF;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
@@ -27,10 +26,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.ws.rs.core.UriBuilder;
-import org.eclipse.che.api.core.model.workspace.Workspace;
-import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.rest.ServiceContext;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
 import org.everrest.core.impl.uri.UriBuilderImpl;
 import org.mockito.Mock;
@@ -48,7 +46,7 @@ public class WorkspaceLinksGeneratorTest {
 
   @Mock private WorkspaceRuntimes runtimes;
 
-  @Mock private Workspace workspace;
+  @Mock private WorkspaceImpl workspace;
 
   @Mock private RuntimeContext runtimeCtx;
 
@@ -60,8 +58,7 @@ public class WorkspaceLinksGeneratorTest {
   public void setUp() throws Exception {
     when(workspace.getId()).thenReturn("wside-123877234580");
     when(workspace.getNamespace()).thenReturn("my-namespace");
-    when(workspace.getConfig()).thenReturn(mock(WorkspaceConfig.class));
-    when(workspace.getConfig().getName()).thenReturn("my-name");
+    when(workspace.getName()).thenReturn("my-name");
 
     when(runtimeCtx.getOutputChannel()).thenReturn(URI.create("ws://localhost/output/websocket"));
     when(runtimes.getRuntimeContext(workspace.getId())).thenReturn(Optional.of(runtimeCtx));

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDaoTest.java
@@ -111,7 +111,7 @@ public class JpaWorkspaceDaoTest {
     manager.getTransaction().commit();
 
     // make conflict update
-    workspace2.getConfig().setName(workspace1.getConfig().getName());
+    workspace2.getConfig().setName(workspace1.getName());
     manager.getTransaction().begin();
     manager.merge(workspace2);
     manager.getTransaction().commit();

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/provision/env/WorkspaceNameEnvVarProviderTest.java
@@ -51,8 +51,7 @@ public class WorkspaceNameEnvVarProviderTest {
     // given
     when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-id111");
     doReturn(workspace).when(workspaceDao).get(Mockito.eq("ws-id111"));
-    when(workspace.getConfig()).thenReturn(config);
-    when(config.getName()).thenReturn("ws-name");
+    when(workspace.getName()).thenReturn("ws-name");
 
     // when
     Pair<String, String> actual = provider.get(runtimeIdentity);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -172,7 +172,7 @@ public class WorkspaceDaoTest {
     final WorkspaceImpl workspace = workspaces[0];
 
     assertEquals(
-        workspaceDao.get(workspace.getConfig().getName(), workspace.getNamespace()),
+        workspaceDao.get(workspace.getName(), workspace.getNamespace()),
         new WorkspaceImpl(workspace));
   }
 
@@ -197,7 +197,7 @@ public class WorkspaceDaoTest {
       throws Exception {
     final WorkspaceImpl workspace = workspaces[0];
 
-    workspaceDao.get(workspace.getConfig().getName(), "non-existing-namespace");
+    workspaceDao.get(workspace.getName(), "non-existing-namespace");
   }
 
   @Test(expectedExceptions = NotFoundException.class)
@@ -206,7 +206,7 @@ public class WorkspaceDaoTest {
     final WorkspaceImpl workspace1 = workspaces[0];
     final WorkspaceImpl workspace2 = workspaces[2];
 
-    workspaceDao.get(workspace1.getConfig().getName(), workspace2.getNamespace());
+    workspaceDao.get(workspace1.getName(), workspace2.getNamespace());
   }
 
   @Test(expectedExceptions = NullPointerException.class)
@@ -218,7 +218,7 @@ public class WorkspaceDaoTest {
   @Test(expectedExceptions = NullPointerException.class)
   public void shouldThrowNpeWhenGettingWorkspaceByNameAndNamespaceWhereNamespaceIsNull()
       throws Exception {
-    workspaceDao.get(workspaces[0].getConfig().getName(), null);
+    workspaceDao.get(workspaces[0].getName(), null);
   }
 
   @Test(
@@ -625,7 +625,7 @@ public class WorkspaceDaoTest {
     final WorkspaceImpl workspace1 = workspaces[0];
     final WorkspaceImpl workspace2 = workspaces[1];
 
-    workspace1.getConfig().setName(workspace2.getConfig().getName());
+    workspace1.getConfig().setName(workspace2.getName());
 
     workspaceDao.update(workspace1);
   }

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
@@ -67,6 +67,7 @@ import org.eclipse.che.api.workspace.activity.WorkspaceActivityDao;
 import org.eclipse.che.api.workspace.activity.inject.WorkspaceActivityModule;
 import org.eclipse.che.api.workspace.server.DefaultWorkspaceLockService;
 import org.eclipse.che.api.workspace.server.DefaultWorkspaceStatusCache;
+import org.eclipse.che.api.workspace.server.DevfileToWorkspaceConfigConverter;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
 import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
 import org.eclipse.che.api.workspace.server.WorkspaceSharedPool;
@@ -239,6 +240,14 @@ public class CascadeRemovalTest {
                 install(new WorkspaceActivityModule());
                 install(new JpaKubernetesRuntimeCacheModule());
                 bind(WorkspaceManager.class);
+
+                // is not used in a scope of integration tests
+                // but instance is needed for setting WorkspaceManager up
+                bind(DevfileToWorkspaceConfigConverter.class)
+                    .toInstance(
+                        devfile -> {
+                          throw new UnsupportedOperationException("Operation is not implemented");
+                        });
 
                 RuntimeInfrastructure infra = mock(RuntimeInfrastructure.class);
                 doReturn(emptySet()).when(infra).getRecipeTypes();


### PR DESCRIPTION
### What does this PR do?
Adds an ability to use Devfile as workspace configuration as an alternative to WorkspaceConfig.
PR contains separated commits that can be used reviewed independently.
1. To avoid duplicating of code where name is found in a proper way: `workspace#getConfig#getName` if defined or `workspace#getDevfile#getName`, the following method `#getName` is added to `WorkspaceImpl` class. Note that `Workspace` interface is not changed.
2. Deny using REST methods which are workspace config specific for workspace with Devfile.
3. Add an ability to create and start a workspace from Devfile (spi only).
In a few words, WorkspaceRuntimes now requires `Environment, List<Command>, Map<String, String>` instead of `WorkspaceConfig, String envName`. WorkspaceManager is guy who converts Devfile to parameters needed for `WorkspaceRuntimes`.
4. Add REST method to create a workspace from Devfile.
POST /api/workspace/devfile DevfileDto method is added for creating a workspace with Devfile.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13079

### How test this PR
UI is not adapted yet to work with the made changes. To test these changes I added a small workaround to make clients handle such workspaces properly https://github.com/sleshchenko/che/commit/3562867a50997c374e19f9815a913c8717f49c69
It is not included to this PR, so on the master branch, it is not able to test these changes.
I pushed docker image that contains workaround and can be used for testing `sleschehnko/che-server:devfile`. The demo how it works https://youtu.be/v8pyH51Oh7k

<details>
<summary>Used devfile</summary>

```yaml
specVersion: 0.0.1
name: test-devfile
projects:
  - name: nodejs-mongo-app
    source:
      type: git
      location: 'https://github.com/ijason/NodeJS-Sample-App.git'
components:
  - alias: theia-editor
    type: cheEditor
    id: org.eclipse.che.editor.theia:1.0.0
  - alias: exec-plugin
    type: chePlugin
    id: che-machine-exec-plugin:0.0.1
  - alias: mongodb
    type: dockerimage
    image: mongo
    endpoints:
      - name: mongo
        port: 27017
        attributes:
          public: "false"
          discoverable: "true"
    mountSources: false
    volumes:
      - name: mongo-storage
        containerPath: /data/db
    memoryLimit: 250Mi
  - name: nodejs-app
    type: openshift
    reference: node-js.yaml
    referenceContent: |
      apiVersion: v1
      kind: List
      items:
      -
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: web
          labels:
            app: nodejs
        spec:
          replicas: 2
          selector:
            name: web
          template:
            metadata:
              labels:
                app: nodejs
              name: web-controller
            spec:
              containers:
              - image: node:0.10.40
                command: ['tail', '-f', '/dev/null']
                args: []
                name: web
                ports:
                - containerPort: 3000
                  name: http-server
                volumeMounts:
                 - mountPath: /projects
                   name: projects
              volumes:
               - name: projects
                 persistentVolumeClaim:
                   claimName: projects
      - apiVersion: v1
        kind: PersistentVolumeClaim
        metadata:
          name: projects
        spec:
          accessModes:
           - ReadWriteOnce
          resources:
            requests:
              storage: 2Gi
      -
        apiVersion: v1
        kind: Service
        metadata:
          name: web
          labels:
            name: web
        spec:
          type: LoadBalancer
          ports:
            - name: web
              port: 80
              targetPort: 3000
              protocol: TCP
          selector:
            app: nodejs
      - apiVersion: v1
        kind: Route
        metadata:
          name: che
        spec:
          to:
            kind: Service
            name: web
          port:
            targetPort: web
commands:
  - name: run
    actions:
      - type: exec
        component: nodejs-app
        command: cd ${CHE_PROJECTS_ROOT}/nodejs-mongo-app/EmployeeDB/ && npm install && node app.js
```
</details>

The WIP PR to adapt Dashboard: https://github.com/eclipse/che/pull/13198
The issue to adapt WorkspaceLoader https://github.com/eclipse/che/issues/13201
The issue to adapt Theia https://github.com/eclipse/che/issues/13112

#### Release Notes
N/A

#### Docs PR
N/A