### PR TITLE
Do not inherit pod name by plugins machines

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import java.util.Map;
 import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil;
 
 /**
  * Helps to work with Kubernetes objects names.
@@ -49,6 +50,12 @@ public class Names {
    */
   public static String machineName(PodData podData, Container container) {
     return machineName(podData.getMetadata(), container);
+  }
+
+  public static void putMachineName(
+      ObjectMeta objectMeta, String containerName, String machineName) {
+    KubernetesObjectUtil.putAnnotation(
+        objectMeta, format(MACHINE_NAME_ANNOTATION_FMT, containerName), machineName);
   }
 
   /**

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtil.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtil.java
@@ -72,6 +72,11 @@ public class KubernetesObjectUtil {
       target.setMetadata(metadata = new ObjectMeta());
     }
 
+    putAnnotation(metadata, key, value);
+  }
+
+  /** Adds annotation to target ObjectMeta object. */
+  public static void putAnnotation(ObjectMeta metadata, String key, String value) {
     Map<String, String> annotations = metadata.getAnnotations();
     if (annotations == null) {
       metadata.setAnnotations(annotations = new HashMap<>());

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -200,7 +200,8 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
 
     Container k8sContainer = k8sContainerResolver.resolve();
 
-    String machineName = Names.machineName(pod, k8sContainer);
+    String machineName = k8sContainer.getName();
+    Names.putMachineName(pod.getMetadata(), k8sContainer.getName(), machineName);
     pod.getSpec().getContainers().add(k8sContainer);
 
     MachineResolver machineResolver =

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -156,8 +156,7 @@ public class KubernetesPluginsToolingApplierTest {
     assertEquals(envCommand.getType(), "custom");
     assertEquals(
         envCommand.getAttributes().get(WORKING_DIRECTORY_ATTRIBUTE), pluginCommand.getWorkingDir());
-    assertEquals(
-        envCommand.getAttributes().get(MACHINE_NAME_ATTRIBUTE), POD_NAME + "/plugin-container");
+    assertEquals(envCommand.getAttributes().get(MACHINE_NAME_ATTRIBUTE), "plugin-container");
   }
 
   @Test
@@ -181,8 +180,7 @@ public class KubernetesPluginsToolingApplierTest {
     assertEquals(envCommand.getType(), pluginCommand.getType());
     assertEquals(envCommand.getCommandLine(), pluginCommand.getCommandLine());
     assertEquals(envCommand.getAttributes().get("plugin"), pluginRef);
-    assertEquals(
-        envCommand.getAttributes().get(MACHINE_NAME_ATTRIBUTE), POD_NAME + "/plugin-container");
+    assertEquals(envCommand.getAttributes().get(MACHINE_NAME_ATTRIBUTE), "plugin-container");
   }
 
   @Test
@@ -262,6 +260,24 @@ public class KubernetesPluginsToolingApplierTest {
 
     // then
     assertTrue(internalEnvironment.getWarnings().isEmpty());
+  }
+
+  @Test
+  public void shouldUsePluginNameAndContainerNameForForMachinesNames() throws Exception {
+    // given
+    internalEnvironment.getMachines().clear();
+
+    ChePlugin chePlugin1 = createChePlugin("plugin1", createContainer("container1"));
+    ChePlugin chePlugin2 = createChePlugin("plugin2", createContainer("container2"));
+
+    // when
+    applier.apply(runtimeIdentity, internalEnvironment, asList(chePlugin1, chePlugin2));
+
+    // then
+    Map<String, InternalMachineConfig> machines = internalEnvironment.getMachines();
+    assertEquals(machines.size(), 2);
+    assertTrue(machines.containsKey("plugin1-container1"));
+    assertTrue(machines.containsKey("plugin2-container2"));
   }
 
   @Test(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -263,7 +263,7 @@ public class KubernetesPluginsToolingApplierTest {
   }
 
   @Test
-  public void shouldUsePluginNameAndContainerNameForForMachinesNames() throws Exception {
+  public void shouldUsePluginNameAndContainerNameForMachinesNames() throws Exception {
     // given
     internalEnvironment.getMachines().clear();
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
@@ -72,7 +72,7 @@ public class DirectUrlFactoryWithSpecificBranchTest {
   @Test
   public void factoryWithDirectUrlWithSpecificBranch() {
     String repositoryName = testAuxiliaryRepo.getName();
-    final String wsTheiaIdeTerminalTitle = "che-workspace-pod/theia-ide terminal 0";
+    final String wsTheiaIdeTerminalTitle = "theia-ide terminal 0";
     List<String> expectedItemsAfterCloning = Arrays.asList("my-lib", "my-webapp", "src", "pom.xml");
 
     testFactoryWithSpecificBranch.authenticateAndOpen();
@@ -98,7 +98,7 @@ public class DirectUrlFactoryWithSpecificBranchTest {
         });
 
     // check specific branch
-    openTerminalByProposal("che-workspace-pod/theia-ide");
+    openTerminalByProposal("theia-ide");
     theiaTerminal.waitTab(wsTheiaIdeTerminalTitle);
     theiaTerminal.clickOnTab(wsTheiaIdeTerminalTitle);
     theiaTerminal.performCommand("cd " + repositoryName);


### PR DESCRIPTION
### What does this PR do?
Do not inherit pod name by plugins machines.
**Before:**
![Screenshot_20190424_104341](https://user-images.githubusercontent.com/5887312/56641340-d743ca00-667d-11e9-857d-5981e7557132.png)

**After:**
![Screenshot_20190424_103112](https://user-images.githubusercontent.com/5887312/56640658-3bfe2500-667c-11e9-8c2f-2ef29b40bd6b.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13095

#### Release Notes
N/A

#### Docs PR
N/A