### PR TITLE
Add the ability for the DtoFactory to accept an instance implementing

### DIFF
--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/generator/DtoImpl.java
@@ -19,7 +19,9 @@ import java.io.StringWriter;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
+import java.lang.reflect.WildcardType;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -353,8 +355,20 @@ abstract class DtoImpl {
   }
 
   public static Class<?> getRawClass(Type type) {
-    return (Class<?>)
-        ((type instanceof ParameterizedType) ? ((ParameterizedType) type).getRawType() : type);
+    if (type instanceof Class) {
+      return (Class<?>) type;
+    } else if (type instanceof ParameterizedType) {
+      return getRawClass(((ParameterizedType) type).getRawType());
+    } else if (type instanceof WildcardType) {
+      WildcardType wType = (WildcardType) type;
+      if (wType.getLowerBounds().length > 0) {
+        return Object.class;
+      } else {
+        return getRawClass(wType.getUpperBounds()[0]);
+      }
+    } else {
+      return (Class<?>) type;
+    }
   }
 
   /**
@@ -436,4 +450,8 @@ abstract class DtoImpl {
 
   /** @return String representing the source definition for the DTO impl as an inner class. */
   abstract String serialize();
+
+  List<Class<?>> getAllCopyConstructorParameterTypes() {
+    return Collections.singletonList(dtoInterface);
+  }
 }

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoFactory.java
@@ -154,6 +154,35 @@ public final class DtoFactory {
   }
 
   /**
+   * Creates a deep copy of the DTO from an instance of some class with which the DTO shares a super
+   * type. It is assumed that the common super type declares at least some getters needed to
+   * initialize the DTO instance. Typically, the DTO interface will inherit all its getters from
+   * this super type that the instance also implements.
+   *
+   * <p>Note that not all fields of the DTO will be initialized from the instance.
+   *
+   * @param instance the instance to copy the DTO from
+   * @param dtoInterface the intended type of the DTO
+   * @param <D> the DTO interface type
+   * @return an initialized instance
+   * @throws IllegalArgumentException if the provided instance is not of a type using which the DTO
+   *     can be constructed.
+   */
+  public <D> D cloneFrom(Object instance, Class<D> dtoInterface) {
+    DtoProvider<D> provider = getDtoProvider(dtoInterface);
+    return provider.cloneFrom(instance);
+  }
+
+  /**
+   * Shortcut for {@code DtoFactory.getInstance().cloneFrom(instance, dtoInterface}.
+   *
+   * @see #cloneFrom(Object, Class)
+   */
+  public static <D> D newDtoFrom(Object instance, Class<D> dtoInterface) {
+    return getInstance().cloneFrom(instance, dtoInterface);
+  }
+
+  /**
    * Shortcut for {@code DtoFactory.getInstance().clone(T dtoObject)}
    *
    * @see #clone(Object)

--- a/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoProvider.java
+++ b/core/che-core-api-dto/src/main/java/org/eclipse/che/dto/server/DtoProvider.java
@@ -28,4 +28,8 @@ public interface DtoProvider<DTO> {
   DTO newInstance();
 
   DTO clone(DTO origin);
+
+  default DTO cloneFrom(Object other) throws IllegalArgumentException {
+    throw new IllegalArgumentException("cloneFrom() not implemented by default.");
+  }
 }

--- a/core/che-core-api-dto/src/test/java/org/eclipse/che/dto/ServerDtoTest.java
+++ b/core/che-core-api-dto/src/test/java/org/eclipse/che/dto/ServerDtoTest.java
@@ -32,6 +32,7 @@ import org.eclipse.che.dto.definitions.DtoWithAny;
 import org.eclipse.che.dto.definitions.DtoWithDelegate;
 import org.eclipse.che.dto.definitions.DtoWithFieldNames;
 import org.eclipse.che.dto.definitions.SimpleDto;
+import org.eclipse.che.dto.definitions.model.CustomModelImpl;
 import org.eclipse.che.dto.definitions.model.Model;
 import org.eclipse.che.dto.definitions.model.ModelComponentDto;
 import org.eclipse.che.dto.definitions.model.ModelDto;
@@ -446,5 +447,19 @@ public class ServerDtoTest {
           "interface org.eclipse.che.dto.definitions.DTOHierarchy\\$GrandchildWithoutDto is not a DTO type")
   public void shouldThrowExceptionWhenInterfaceIsNotAnnotatedAsDto() {
     DtoFactory.newDto(DTOHierarchy.GrandchildWithoutDto.class);
+  }
+
+  @Test
+  public void shouldContainCopyConstructorFromNonDtoSuperClassWithAllGetters() {
+    ModelDto dto = DtoFactory.getInstance().cloneFrom(new CustomModelImpl(), ModelDto.class);
+
+    assertEquals(
+        new CustomModelImpl().getComponents().get(0).getName(),
+        dto.getComponents().get(0).getName());
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void shouldFailToCopyFromInstanceWithNoMatchingGetters() {
+    DtoFactory.getInstance().cloneFrom(new Object(), ModelDto.class);
   }
 }

--- a/core/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/model/CustomModelImpl.java
+++ b/core/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/model/CustomModelImpl.java
@@ -11,19 +11,24 @@
  */
 package org.eclipse.che.dto.definitions.model;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Test interface serves as base model, should be extended with dto interface
- *
- * @author Eugene Voevodin
- */
-public interface Model {
+public class CustomModelImpl implements Model {
 
-  List<? extends ModelComponent> getComponents();
+  @Override
+  public List<? extends ModelComponent> getComponents() {
+    return Collections.singletonList(() -> "custom");
+  }
 
-  Map<String, ? extends ModelComponent> getComponentMap();
+  @Override
+  public Map<String, ? extends ModelComponent> getComponentMap() {
+    return Collections.emptyMap();
+  }
 
-  ModelComponent getPrimary();
+  @Override
+  public ModelComponent getPrimary() {
+    return null;
+  }
 }

--- a/core/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/model/ModelDto.java
+++ b/core/che-core-api-dto/src/test/java/org/eclipse/che/dto/definitions/model/ModelDto.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.dto.definitions.model;
 
 import java.util.List;
+import java.util.Map;
 import org.eclipse.che.dto.shared.DTO;
 
 /**
@@ -28,6 +29,13 @@ public interface ModelDto extends Model {
   void setComponents(List<ModelComponentDto> components);
 
   ModelDto withComponents(List<ModelComponentDto> components);
+
+  @Override
+  Map<String, ModelComponentDto> getComponentMap();
+
+  void setComponentMap(Map<String, ModelComponentDto> componentMap);
+
+  ModelDto withComponentMap(Map<String, ModelComponentDto> componentMap);
 
   @Override
   ModelComponentDto getPrimary();


### PR DESCRIPTION
### What does this PR do?
Our DTO generator contains copy constructor and our `DtoFactory` is able to clone a DTO instance into a new deeply-copied one.

But when it comes to converting our JPA entities into the DTOs we use the very verbose `DtoConverter`s sprinkled around the codebase, hand-written and amounting to hundreds of lines of tedious, error-prone code each.

This PR tries to eliminate the need for the `DtoConverter`s by adding the ability to (partially) initialize the DTO instances also from instances implementing some common superinterface with the DTO (typically, our JPA entities implement a common interface with the DTOs) and adding a new `DtoFactory.cloneFrom()` method that tries to initialize a new DTO instance from an object by checking whether such conversion is possible at runtime.

What we gain by this is several thousands of lines of code potentially removed, if we replace our `DtoConverter`s with this. 

What we loose is a little bit of type safety where the check whether a conversion from a certain object to a DTO instance becomes manual and errors only pop up at runtime. On the other hand, our current approach is also error prone because we cannot enforce initialization of newly added properties in all the converters (this is a manual step now, which is automagically handled by this PR).

### What issues does this PR fix or reference?
none