### PR TITLE
Use alias in devfile.yaml and remove component names.

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -6,13 +6,11 @@ projects:
       type: git
       location: 'https://github.com/eclipse/che.git'
 components:
-  - name: theia-editor
-    type: cheEditor
+  - type: cheEditor
     id: org.eclipse.che.editor.theia:1.0.0
-  - name: exec-plugin
-    type: chePlugin
+  - type: chePlugin
     id: che-machine-exec-plugin:0.0.1
-  - name: che-dev
+  - alias: che-dev
     type: kubernetes
     reference: .che-dev.yaml
 commands:


### PR DESCRIPTION
### What does this PR do?
Che 7.0.0-beta-4.0 is going to drop support for component names and replaces it with an alias. We need to update the devfile.yaml to take that into account.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13103