### PR TITLE
Update default Theia IDE version to 'next'

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -624,7 +624,7 @@ che.wsagent.cors.enabled=true
 ## Factory defaults.
 # Editor and plugin which will be used for factories which are created from remote git repository
 # which doesn't contain any Che-specific workspace descriptors (like .devfile of .factory.json)
-che.factory.default_editor=eclipse/che-theia/1.0.0
+che.factory.default_editor=eclipse/che-theia/next
 # multiple plugins must be comma-separated, for example:
 # pluginFooPublisher/pluginFooName/pluginFooVersion,pluginBarPublisher/pluginBarName/pluginBarVersion
 che.factory.default_plugins=eclipse/che-machine-exec-plugin/0.0.1
@@ -636,7 +636,7 @@ che.factory.default_plugins=eclipse/che-machine-exec-plugin/0.0.1
 # Default Editor that should be provisioned into Devfile if there is no specified Editor
 # Format is `editorPublisher/editorName/editorVersion` value.
 # `NULL` or absence of value means that default editor should not be provisioned.
-che.workspace.devfile.default_editor=eclipse/che-theia/1.0.0
+che.workspace.devfile.default_editor=eclipse/che-theia/next
 
 # Default Plugins which should be provisioned for Default Editor.
 # All the plugins from this list that are not explicitly mentioned in the user-defined devfile

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -215,7 +215,7 @@
       ],
       "attributes": {
         "plugins": "eclipse/che-machine-exec-plugin/0.0.1",
-        "editor": "eclipse/che-theia/1.0.0"
+        "editor": "eclipse/che-theia/next"
       },
       "links": []
     },
@@ -284,7 +284,7 @@
       "projects": [],
       "attributes": {
         "plugins": "eclipse/che-machine-exec-plugin/0.0.1",
-        "editor": "eclipse/che-theia/1.0.0"
+        "editor": "eclipse/che-theia/next"
       },
       "commands": [],
       "links": []
@@ -358,7 +358,7 @@
       "projects": [],
       "attributes": {
         "plugins": "eclipse/che-machine-exec-plugin/0.0.1",
-        "editor": "eclipse/che-theia/1.0.0"
+        "editor": "eclipse/che-theia/next"
       },
       "commands": [],
       "links": []
@@ -431,7 +431,7 @@
       "projects": [],
       "attributes": {
         "plugins": "eclipse/che-machine-exec-plugin/0.0.1",
-        "editor": "eclipse/che-theia/1.0.0"
+        "editor": "eclipse/che-theia/next"
       },
       "commands": [
         {

--- a/wsmaster/che-core-api-devfile/README.md
+++ b/wsmaster/che-core-api-devfile/README.md
@@ -33,7 +33,7 @@ projects:
 components:
   - alias: theia-editor
     type: cheEditor
-    id: eclipse/che-theia/1.0.0
+    id: eclipse/che-theia/next
   - alias: exec-plugin
     type: chePlugin
     id: eclipse/che-machine-exec-plugin/0.0.1
@@ -108,7 +108,7 @@ Devfile can only contain one component with `cheEditor` type.
 components:
   - alias: theia-editor
     type: cheEditor
-    id: eclipse/che-theia/1.0.0
+    id: eclipse/che-theia/next
 ```
 
 If it is missing then a default editor will be provided along with its default plugins.


### PR DESCRIPTION
### What does this PR do?
Update default Theia IDE version to 'next'.
It's needed since commands in Theia IDE 1.0.0 are not working anymore. Error message `No information found` appear.

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
N/A