### PR TITLE
Add stub for WorkspaceConfig if workspace is created with Devfile

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -92,6 +92,9 @@ public final class DtoConverter {
 
     if (workspace.getDevfile() != null) {
       workspaceDto.setDevfile(asDto(workspace.getDevfile()));
+
+      workspaceDto.setConfig(
+          newDto(WorkspaceConfigDto.class).withName(workspace.getDevfile().getName()));
     }
 
     if (workspace.getRuntime() != null) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -195,8 +195,9 @@ public class WorkspaceServiceTest {
                     + "&attribute=custom:custom:value");
 
     assertEquals(response.getStatusCode(), 201);
-    assertEquals(
-        new WorkspaceImpl(unwrapDto(response, WorkspaceDto.class), TEST_ACCOUNT), workspace);
+    // null stub workspace config
+    WorkspaceDto workspaceDto = unwrapDto(response, WorkspaceDto.class).withConfig(null);
+    assertEquals(new WorkspaceImpl(workspaceDto, TEST_ACCOUNT), workspace);
     verify(wsManager)
         .createWorkspace(
             any(Devfile.class),


### PR DESCRIPTION
### What does this PR do?
Adds stub for WorkspaceConfig if workspace is created with Devfile

It is needed to make UI working somehow, otherwise, workspace created
with Devfile break UD and it's not even possible to remove such.

It should be reverted when clients will be able to handle workspace without workspace config properly.

### What issues does this PR fix or reference?
It's related to https://github.com/eclipse/che/issues/13079

#### Release Notes
N/A

#### Docs PR
N/A