### PR TITLE
Add printing warnings if workspace resources cannot be estimated properly

### DIFF
--- a/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/usage/tracker/RamResourceUsageTracker.java
+++ b/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/usage/tracker/RamResourceUsageTracker.java
@@ -88,15 +88,16 @@ public class RamResourceUsageTracker implements ResourceUsageTracker {
           }
           if (SidecarToolingWorkspaceUtil.isSidecarBasedWorkspace(config.getAttributes())) {
             LOG.warn(
-                "Sidecar based workspace `{}` is starting, memory of its plugins is not taken in "
-                    + "account while workspace is starting. Set memory resources limits may work incorrectly");
+                "Memory consumption of plugins in a sidecar-based workspace `{}` is not taken"
+                    + " into account while the workspace is starting. The memory limits may not be"
+                    + " applied correctly.");
           }
         } else {
           // Estimation of memory for starting workspace with Devfile is not implemented yet
           // just ignore such
           LOG.warn(
-              "Devfile based workspace `{}` is starting, its memory is not taken in account "
-                  + "while workspace is starting. Set memory resources limits may work incorrectly");
+              "Memory consumption is not taken into account while a devfile-based workspace"
+                  + " `{}` is starting. The memory limits may not be applied correctly.");
         }
       } else {
         currentlyUsedRamMB += environmentRamCalculator.calculate(activeWorkspace.getRuntime());

--- a/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManager.java
+++ b/multiuser/api/che-multiuser-api-resource/src/main/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManager.java
@@ -174,7 +174,8 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
       checkMaxEnvironmentRam(workspace.getId(), workspace.getConfig());
     } else {
       LOG.warn(
-          "Can not estimate memory needed for devfile based workspace {}. Set environment memory limits may work incorrectly",
+          "Can not estimate memory needed for devfile based workspace `{}`."
+              + " The environment memory limits may not be applied correctly.",
           workspace.getId());
     }
   }
@@ -191,7 +192,8 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
 
     if (SidecarToolingWorkspaceUtil.isSidecarBasedWorkspace(config.getAttributes())) {
       LOG.warn(
-          "Can not estimate memory needed for sidecar based workspace{}. Set environment memory limits may work incorrectly",
+          "Cannot estimate the memory requirements of a devfile-based workspace `{}`."
+              + " The memory limits may not be applied correctly.",
           workspaceId == null ? "" : ' ' + workspaceId);
     }
 
@@ -223,7 +225,8 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
           accountId, namespace, workspace.getId(), workspace.getConfig(), envName);
     } else {
       LOG.warn(
-          "Can not estimate memory needed for devfile based workspace {}. Set memory resources limits may work incorrectly",
+          "Cannot estimate the memory requirements of a devfile-based workspace `{}`."
+              + " The memory limits may not be applied correctly.",
           workspace.getId());
     }
   }
@@ -242,8 +245,8 @@ public class LimitsCheckingWorkspaceManager extends WorkspaceManager {
 
     if (SidecarToolingWorkspaceUtil.isSidecarBasedWorkspace(config.getAttributes())) {
       LOG.warn(
-          "Sidecar memory of plugins of workspace `{}` is not taken in account. "
-              + "Set memory resources limits may work incorrectly",
+          "The memory requirements for the plugin sidecars of workspace `{}` are not taken"
+              + " into account. The memory limits may not be applied correctly.",
           workspaceId);
     }
 

--- a/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/type/AbstractExhaustibleResourceTest.java
+++ b/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/type/AbstractExhaustibleResourceTest.java
@@ -141,7 +141,7 @@ public class AbstractExhaustibleResourceTest {
     resourceType.aggregate(resourceA, resourceB);
   }
 
-  @DataProvider(name = "resources")
+  @DataProvider(name = "getResources")
   public Object[][] getResources() {
     return new Object[][] {
       {

--- a/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManagerTest.java
+++ b/multiuser/api/che-multiuser-api-resource/src/test/java/org/eclipse/che/multiuser/resource/api/workspace/LimitsCheckingWorkspaceManagerTest.java
@@ -70,7 +70,7 @@ public class LimitsCheckingWorkspaceManagerTest {
     String envToStart = config.getDefaultEnv();
 
     // when
-    manager.checkRamResourcesAvailability(ACCOUNT_ID, NAMESPACE, config, envToStart);
+    manager.checkRamResourcesAvailability(ACCOUNT_ID, NAMESPACE, "ws123", config, envToStart);
 
     // then
     verify(environmentRamCalculator).calculate(config.getEnvironments().get(envToStart));
@@ -95,7 +95,7 @@ public class LimitsCheckingWorkspaceManagerTest {
     WorkspaceConfig config = createConfig("3gb");
 
     // when
-    manager.checkRamResourcesAvailability(ACCOUNT_ID, NAMESPACE, config, null);
+    manager.checkRamResourcesAvailability(ACCOUNT_ID, NAMESPACE, "ws123", config, null);
 
     // then
     verify(environmentRamCalculator)
@@ -137,7 +137,7 @@ public class LimitsCheckingWorkspaceManagerTest {
     WorkspaceConfig config = createConfig("3gb");
 
     // when
-    manager.checkRamResourcesAvailability(ACCOUNT_ID, NAMESPACE, config, null);
+    manager.checkRamResourcesAvailability(ACCOUNT_ID, NAMESPACE, "ws123", config, null);
   }
 
   @Test
@@ -227,7 +227,7 @@ public class LimitsCheckingWorkspaceManagerTest {
             .setEnvironmentRamCalculator(environmentRamCalculator)
             .build();
 
-    manager.checkMaxEnvironmentRam(config);
+    manager.checkMaxEnvironmentRam("ws123", config);
   }
 
   @Test
@@ -239,7 +239,7 @@ public class LimitsCheckingWorkspaceManagerTest {
             .setEnvironmentRamCalculator(environmentRamCalculator)
             .build();
 
-    manager.checkMaxEnvironmentRam(config);
+    manager.checkMaxEnvironmentRam("ws123", config);
 
     verify(environmentRamCalculator, never()).calculate(any(Environment.class));
   }


### PR DESCRIPTION
### What does this PR do?
It's following the discussion that took place in already merged PR https://github.com/eclipse/che/pull/13185#discussion_r277561687

This PR adds printing warnings if workspace resources cannot be estimated properly.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/13185#discussion_r277561687

#### Release Notes
N/A

#### Docs PR
N/A