### PR TITLE
CRW-256 use yarn instead of npm to build...

### DIFF
--- a/workspace-loader/pom.xml
+++ b/workspace-loader/pom.xml
@@ -134,11 +134,11 @@
                                 <configuration>
                                     <target>
                                         <!-- install node modules -->
-                                        <exec dir="${basedir}" executable="npm" failonerror="true">
+                                        <exec dir="${basedir}" executable="yarn" failonerror="true">
                                             <arg value="install" />
                                         </exec>
                                         <!-- build workspace loader -->
-                                        <exec dir="${basedir}" executable="npm" failonerror="true">
+                                        <exec dir="${basedir}" executable="yarn" failonerror="true">
                                             <arg value="run" />
                                             <arg value="build" />
                                         </exec>
@@ -154,7 +154,7 @@
                                 <configuration>
                                     <target>
                                         <!-- test workspace loader -->
-                                        <exec dir="${basedir}" executable="npm" failonerror="true">
+                                        <exec dir="${basedir}" executable="yarn" failonerror="true">
                                             <arg value="run" />
                                             <arg value="test" />
                                         </exec>


### PR DESCRIPTION
CRW-256 use yarn instead of npm to build workspace-loader -- avoids 'TS2322: Type 'Timeout' is not assignable to type 'number'.'

Change-Id: Ib083d094311dc5945927c391a222cd802f94d699
Signed-off-by: nickboldt <nboldt@redhat.com>