### PR TITLE
fix gwt-ide loader to not to fail if workspace runtime is missed

### DIFF
--- a/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/IDE.html
+++ b/ide/che-ide-gwt-app/src/main/resources/org/eclipse/che/ide/public/IDE.html
@@ -191,6 +191,9 @@
                         return;
                     }
                     var workspace = JSON.parse(this.responseText);
+                    if (!workspace || !workspace.runtime) {
+                        return;
+                    }
                     var machines = workspace.runtime.machines;
                     for (var machineName in machines) {
                         var servers = machines[machineName].servers;
@@ -210,7 +213,7 @@
                                 return;
                             }
                         }
-                    }                            
+                    }
                 };
                 //GWT IDE Loading
                 setTimeout(() => {


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes gwt-ide loader in order not to fail if a workspace is stopped.

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>