### PR TITLE
Null workspace config on update if devfile is present

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -371,6 +371,9 @@ public class WorkspaceService extends Service {
       @ApiParam(value = "The workspace update", required = true) WorkspaceDto update)
       throws BadRequestException, ServerException, ForbiddenException, NotFoundException,
           ConflictException {
+    checkArgument(
+        update.getConfig() != null || update.getDevfile() != null,
+        "Required non-null workspace configuration or devfile update");
     if (update.getDevfile() != null) {
       // devfile is not null and config should be dropped since it's a stub with name only
       update.setConfig(null);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.api.workspace.server;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
@@ -372,9 +371,10 @@ public class WorkspaceService extends Service {
       @ApiParam(value = "The workspace update", required = true) WorkspaceDto update)
       throws BadRequestException, ServerException, ForbiddenException, NotFoundException,
           ConflictException {
-    checkArgument(
-        update.getConfig() != null ^ update.getDevfile() != null,
-        "Required non-null workspace configuration or devfile update but not both");
+    if (update.getDevfile() != null) {
+      // devfile is not null and config should be dropped since it's a stub with name only
+      update.setConfig(null);
+    }
     relativizeRecipeLinks(update.getConfig());
     return asDtoWithLinksAndToken(doUpdate(id, update));
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -745,29 +745,6 @@ public class WorkspaceServiceTest {
   }
 
   @Test
-  public void shouldNotUpdateTheWorkspaceWithConfigAndDevfileAtTheSameTime() throws Exception {
-    final WorkspaceDto workspaceDto =
-        newDto(WorkspaceDto.class)
-            .withId("workspace123")
-            .withConfig(newDto(WorkspaceConfigDto.class))
-            .withDevfile(newDto(DevfileDto.class));
-
-    final Response response =
-        given()
-            .auth()
-            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
-            .contentType("application/json")
-            .body(workspaceDto)
-            .when()
-            .put(SECURE_PATH + "/workspace/" + workspaceDto.getId());
-
-    assertEquals(response.getStatusCode(), 400);
-    assertEquals(
-        unwrapError(response),
-        "Required non-null workspace configuration or devfile update but not both");
-  }
-
-  @Test
   public void shouldNotUpdateTheWorkspaceWithoutConfigAndDevfile() throws Exception {
     final WorkspaceDto workspaceDto = newDto(WorkspaceDto.class).withId("workspace123");
 
@@ -782,8 +759,7 @@ public class WorkspaceServiceTest {
 
     assertEquals(response.getStatusCode(), 400);
     assertEquals(
-        unwrapError(response),
-        "Required non-null workspace configuration or devfile update but not both");
+        unwrapError(response), "Required non-null workspace configuration or devfile update");
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Null workspace config on update if devfile is present. It will be reverted when UI won't need stub workspace config.

### What issues does this PR fix or reference?
It's improvement for https://github.com/eclipse/che/pull/13243

#### Release Notes
N/A

#### Docs PR
N/A