### PR TITLE
Fix printing of runtime output during factory accepting

### DIFF
--- a/dashboard/src/app/factories/load-factory/load-factory.controller.ts
+++ b/dashboard/src/app/factories/load-factory/load-factory.controller.ts
@@ -17,7 +17,7 @@ import {RouteHistory} from '../../../components/routing/route-history.service';
 import {CheJsonRpcApi} from '../../../components/api/json-rpc/che-json-rpc-api.factory';
 import {CheJsonRpcMasterApi} from '../../../components/api/json-rpc/che-json-rpc-master-api';
 
-const WS_AGENT_STEP: number = 3;
+const WS_AGENT_STEP: number = 4;
 
 /**
  * This class is handling the controller for the factory loading.


### PR DESCRIPTION
### What does this PR do?
This PR fixes printing of runtime output during factory accepting.
![Screenshot_20190514_143647](https://user-images.githubusercontent.com/5887312/57694998-daffb680-7655-11e9-8fcc-9b88ea916082.png)

`WSAGENT_STEP` index is increased since there is one more step added in the following PR https://github.com/eclipse/che/pull/12906/files#diff-b2a485d93b11a2f85b91a44d89faba8eR33
### What issues does this PR fix or reference?
It was discovered during work on Devfile Demo https://github.com/che-incubator/che-demos/pull/3

#### Release Notes
N/A

#### Docs PR
N/A