### PR TITLE
Add an ability to specify Devfile in Stack

### DIFF
--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/stack/MultiuserStackLoader.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/stack/MultiuserStackLoader.java
@@ -25,6 +25,7 @@ import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.workspace.server.model.impl.stack.StackImpl;
 import org.eclipse.che.api.workspace.server.spi.StackDao;
 import org.eclipse.che.api.workspace.server.stack.StackLoader;
+import org.eclipse.che.api.workspace.server.stack.StackValidator;
 import org.eclipse.che.api.workspace.server.stack.image.StackIcon;
 import org.eclipse.che.api.workspace.shared.stack.Stack;
 import org.eclipse.che.core.db.DBInitializer;
@@ -54,10 +55,11 @@ public class MultiuserStackLoader extends StackLoader {
   public MultiuserStackLoader(
       @Named("che.predefined.stacks.reload_on_start") boolean reloadStacksOnStart,
       @Named(CHE_PREDEFINED_STACKS) Map<String, String> stacks2images,
+      StackValidator stackValidator,
       StackDao stackDao,
       JpaStackPermissionsDao permissionsDao,
       DBInitializer dbInitializer) {
-    super(reloadStacksOnStart, stacks2images, stackDao, dbInitializer);
+    super(reloadStacksOnStart, stacks2images, stackValidator, stackDao, dbInitializer);
     this.permissionsDao = permissionsDao;
   }
 

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/JpaStackPermissionsDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/JpaStackPermissionsDaoTest.java
@@ -65,8 +65,8 @@ public class JpaStackPermissionsDaoTest {
 
     stacks =
         new StackImpl[] {
-          new StackImpl("stack1", "st1", null, null, null, null, null, null, null),
-          new StackImpl("stack2", "st2", null, null, null, null, null, null, null)
+          new StackImpl("stack1", "st1", null, null, null, null, null, null, null, null),
+          new StackImpl("stack2", "st2", null, null, null, null, null, null, null, null)
         };
 
     Injector injector = Guice.createInjector(new WorkspaceTckModule());

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserJpaStackDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserJpaStackDaoTest.java
@@ -52,11 +52,29 @@ public class MultiuserJpaStackDaoTest {
     stacks =
         new StackImpl[] {
           new StackImpl(
-              "stack1", "st1", null, null, null, Arrays.asList("tag1", "tag2"), null, null, null),
-          new StackImpl("stack2", "st2", null, null, null, null, null, null, null),
+              "stack1",
+              "st1",
+              null,
+              null,
+              null,
+              Arrays.asList("tag1", "tag2"),
+              null,
+              null,
+              null,
+              null),
+          new StackImpl("stack2", "st2", null, null, null, null, null, null, null, null),
           new StackImpl(
-              "stack3", "st3", null, null, null, Arrays.asList("tag1", "tag2"), null, null, null),
-          new StackImpl("stack4", "st4", null, null, null, null, null, null, null)
+              "stack3",
+              "st3",
+              null,
+              null,
+              null,
+              Arrays.asList("tag1", "tag2"),
+              null,
+              null,
+              null,
+              null),
+          new StackImpl("stack4", "st4", null, null, null, null, null, null, null, null)
         };
 
     Injector injector = Guice.createInjector(new WorkspaceTckModule());

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/tck/StackPermissionsDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/tck/StackPermissionsDaoTest.java
@@ -76,8 +76,8 @@ public class StackPermissionsDaoTest {
     wCfg.setDescription("description");
     stackRepository.createAll(
         asList(
-            new StackImpl("stack1", "st1", null, null, null, null, wCfg, null, null),
-            new StackImpl("stack2", "st2", null, null, null, null, wCfg, null, null)));
+            new StackImpl("stack1", "st1", null, null, null, null, wCfg, null, null, null),
+            new StackImpl("stack2", "st2", null, null, null, null, wCfg, null, null, null)));
 
     permissionsRepository.createAll(
         Stream.of(permissions).map(StackPermissionsImpl::new).collect(Collectors.toList()));

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/stack/StackDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/stack/StackDto.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.eclipse.che.api.core.rest.shared.dto.Hyperlinks;
 import org.eclipse.che.api.core.rest.shared.dto.Link;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
+import org.eclipse.che.api.workspace.shared.dto.devfile.DevfileDto;
 import org.eclipse.che.api.workspace.shared.stack.Stack;
 import org.eclipse.che.dto.shared.DTO;
 
@@ -52,6 +53,13 @@ public interface StackDto extends Stack, Hyperlinks {
   void setWorkspaceConfig(WorkspaceConfigDto workspaceConfigDto);
 
   StackDto withWorkspaceConfig(WorkspaceConfigDto workspaceConfigDto);
+
+  @Override
+  DevfileDto getDevfile();
+
+  void setDevfile(DevfileDto devfile);
+
+  StackDto withDevfile(DevfileDto devfile);
 
   @Override
   List<StackComponentDto> getComponents();

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/stack/Stack.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/stack/Stack.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.shared.stack;
 
 import java.util.List;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
+import org.eclipse.che.api.core.model.workspace.devfile.Devfile;
 import org.eclipse.che.commons.annotation.Nullable;
 
 /**
@@ -55,11 +56,22 @@ public interface Stack {
   List<String> getTags();
 
   /**
-   * Return the {@link WorkspaceConfig} for creation workspace. This workspaceConfig can be used for
-   * store machine source, list predefined commands, projects etc.
+   * Return the {@link WorkspaceConfig} for creation workspace.
+   *
+   * <p>The only one format (workspace config or devfile) may be used for workspace at the same
+   * time.
    */
   @Nullable
   WorkspaceConfig getWorkspaceConfig();
+
+  /**
+   * Return the {@link Devfile} for creation workspace.
+   *
+   * <p>The only one format (workspace config or devfile) may be used for workspace at the same
+   * time.
+   */
+  @Nullable
+  Devfile getDevfile();
 
   /**
    * Return the list of the components that stack consist of.

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -243,6 +243,11 @@ public final class DtoConverter {
       workspaceConfigDto = asDto(stack.getWorkspaceConfig());
     }
 
+    DevfileDto devfileDto = null;
+    if (stack.getDevfile() != null) {
+      devfileDto = asDto(stack.getDevfile());
+    }
+
     List<StackComponentDto> componentsDto = null;
     if (stack.getComponents() != null) {
       componentsDto =
@@ -265,7 +270,8 @@ public final class DtoConverter {
         .withScope(stack.getScope())
         .withTags(stack.getTags())
         .withComponents(componentsDto)
-        .withWorkspaceConfig(workspaceConfigDto);
+        .withWorkspaceConfig(workspaceConfigDto)
+        .withDevfile(devfileDto);
   }
 
   /** Converts {@link ProjectConfig} to {@link ProjectConfigDto}. */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/devfile/ComponentImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/devfile/ComponentImpl.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.server.model.impl.devfile;
 
 import static java.util.stream.Collectors.toCollection;
 
+import com.google.gson.annotations.SerializedName;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,6 +47,7 @@ public class ComponentImpl implements Component {
   @Column(name = "id")
   private Long generatedId;
 
+  @SerializedName("id")
   @Column(name = "component_id", nullable = false)
   private String componentId;
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/stack/StackImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/stack/StackImpl.java
@@ -29,7 +29,9 @@ import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
+import org.eclipse.che.api.core.model.workspace.devfile.Devfile;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.DevfileImpl;
 import org.eclipse.che.api.workspace.server.stack.image.StackIcon;
 import org.eclipse.che.api.workspace.shared.stack.Stack;
 import org.eclipse.che.api.workspace.shared.stack.StackComponent;
@@ -86,6 +88,10 @@ public class StackImpl implements Stack {
   @JoinColumn(name = "workspaceconfig_id")
   private WorkspaceConfigImpl workspaceConfig;
 
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+  @JoinColumn(name = "devfile_id")
+  private DevfileImpl devfile;
+
   @ElementCollection
   @CollectionTable(name = "stack_components", joinColumns = @JoinColumn(name = "stack_id"))
   private List<StackComponentImpl> components;
@@ -103,6 +109,7 @@ public class StackImpl implements Stack {
         stack.getCreator(),
         stack.getTags(),
         stack.getWorkspaceConfig(),
+        stack.getDevfile(),
         stack.getComponents(),
         stack.getStackIcon());
   }
@@ -116,6 +123,7 @@ public class StackImpl implements Stack {
         stack.getCreator(),
         stack.getTags(),
         stack.getWorkspaceConfig(),
+        stack.getDevfile(),
         stack.getComponents(),
         null);
   }
@@ -128,6 +136,7 @@ public class StackImpl implements Stack {
       String creator,
       List<String> tags,
       WorkspaceConfig workspaceConfig,
+      Devfile devfile,
       List<? extends StackComponent> components,
       StackIcon stackIcon) {
     this.id = id;
@@ -143,6 +152,9 @@ public class StackImpl implements Stack {
     }
     if (workspaceConfig != null) {
       this.workspaceConfig = new WorkspaceConfigImpl(workspaceConfig);
+    }
+    if (devfile != null) {
+      this.devfile = new DevfileImpl(devfile);
     }
     if (components != null) {
       this.components = components.stream().map(StackComponentImpl::new).collect(toList());
@@ -216,6 +228,15 @@ public class StackImpl implements Stack {
   }
 
   @Override
+  public DevfileImpl getDevfile() {
+    return devfile;
+  }
+
+  public void setDevfile(DevfileImpl devfile) {
+    this.devfile = devfile;
+  }
+
+  @Override
   public List<StackComponentImpl> getComponents() {
     if (components == null) {
       components = new ArrayList<>();
@@ -251,6 +272,7 @@ public class StackImpl implements Stack {
         && Objects.equals(creator, that.creator)
         && getTags().equals(that.getTags())
         && Objects.equals(workspaceConfig, that.workspaceConfig)
+        && Objects.equals(devfile, that.devfile)
         && getComponents().equals(that.getComponents())
         && Objects.equals(stackIcon, that.stackIcon);
   }
@@ -265,6 +287,7 @@ public class StackImpl implements Stack {
     hash = 31 * hash + Objects.hashCode(creator);
     hash = 31 * hash + getTags().hashCode();
     hash = 31 * hash + Objects.hashCode(workspaceConfig);
+    hash = 31 * hash + Objects.hashCode(devfile);
     hash = 31 * hash + getComponents().hashCode();
     hash = 31 * hash + Objects.hashCode(stackIcon);
     return hash;
@@ -292,6 +315,8 @@ public class StackImpl implements Stack {
         + tags
         + ", workspaceConfig="
         + workspaceConfig
+        + ", devfile="
+        + devfile
         + ", components="
         + components
         + ", stackIcon="
@@ -308,6 +333,7 @@ public class StackImpl implements Stack {
     private String creator;
     private List<String> tags;
     private WorkspaceConfig workspaceConfig;
+    private Devfile devfile;
     private StackSource source;
     private List<? extends StackComponent> components;
     private StackIcon stackIcon;
@@ -352,6 +378,11 @@ public class StackImpl implements Stack {
       return this;
     }
 
+    public StackBuilder setDevfile(Devfile devfile) {
+      this.devfile = devfile;
+      return this;
+    }
+
     public StackBuilder setSource(StackSource source) {
       this.source = source;
       return this;
@@ -369,7 +400,16 @@ public class StackImpl implements Stack {
 
     public StackImpl build() {
       return new StackImpl(
-          id, name, description, scope, creator, tags, workspaceConfig, components, stackIcon);
+          id,
+          name,
+          description,
+          scope,
+          creator,
+          tags,
+          workspaceConfig,
+          devfile,
+          components,
+          stackIcon);
     }
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/stack/StackValidator.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.api.workspace.server.stack;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.BadRequestException;
@@ -37,23 +39,38 @@ public class StackValidator {
    * @throws BadRequestException if stack is not valid
    */
   public void check(Stack stack) throws BadRequestException, ServerException, NotFoundException {
-    if (stack == null) {
-      throw new BadRequestException("Required non-null stack");
+    checkArgument(stack != null, "Required non-null stack");
+
+    checkArgument(!isNullOrEmpty(stack.getName()), "Required non-null and non-empty stack name");
+
+    checkArgument(
+        stack.getScope() != null
+            && (stack.getScope().equals("general") || stack.getScope().equals("advanced")),
+        "Required non-null scope value: 'general' or 'advanced'");
+
+    checkArgument(
+        stack.getWorkspaceConfig() != null ^ stack.getDevfile() != null,
+        "Required non-null workspace configuration or devfile but not both");
+
+    if (stack.getWorkspaceConfig() != null) {
+      try {
+        wsValidator.validateConfig(stack.getWorkspaceConfig());
+      } catch (ValidationException x) {
+        throw new BadRequestException(x.getMessage());
+      }
     }
-    if (stack.getName() == null || stack.getName().isEmpty()) {
-      throw new BadRequestException("Required non-null and non-empty stack name");
-    }
-    if (stack.getScope() == null
-        || !stack.getScope().equals("general") && !stack.getScope().equals("advanced")) {
-      throw new BadRequestException("Required non-null scope value: 'general' or 'advanced'");
-    }
-    if (stack.getWorkspaceConfig() == null) {
-      throw new BadRequestException("Workspace config required");
-    }
-    try {
-      wsValidator.validateConfig(stack.getWorkspaceConfig());
-    } catch (ValidationException x) {
-      throw new BadRequestException(x.getMessage());
+  }
+
+  /**
+   * Checks the specified expression.
+   *
+   * @param expression the expression to check
+   * @param errorMessage error message that should be used if expression is false
+   * @throws BadRequestException when the expression is false
+   */
+  private void checkArgument(boolean expression, String errorMessage) throws BadRequestException {
+    if (!expression) {
+      throw new BadRequestException(String.valueOf(errorMessage));
     }
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceTckModule.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/jpa/WorkspaceTckModule.java
@@ -125,9 +125,12 @@ public class WorkspaceTckModule extends TckModule {
 
     @Override
     public void createAll(Collection<? extends StackImpl> entities) throws TckRepositoryException {
-      for (StackImpl stack : entities) {
-        stack.getWorkspaceConfig().getProjects().forEach(ProjectConfigImpl::prePersistAttributes);
-      }
+      entities
+          .stream()
+          .filter(s -> s.getWorkspaceConfig() != null)
+          .map(StackImpl::getWorkspaceConfig)
+          .flatMap(ws -> ws.getProjects().stream())
+          .forEach(ProjectConfigImpl::prePersistAttributes);
       super.createAll(entities);
     }
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/StackDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/StackDaoTest.java
@@ -286,43 +286,39 @@ public class StackDaoTest {
   }
 
   private static StackImpl createStackWithWsConfig(String id, String name) {
-    final StackImpl stack =
-        StackImpl.builder()
-            .setId(id)
-            .setName(name)
-            .setCreator("user123")
-            .setDescription(id + "-description")
-            .setScope(id + "-scope")
-            .setTags(asList(id + "-tag1", id + "-tag2"))
-            .setComponents(
-                asList(
-                    new StackComponentImpl(id + "-component1", id + "-component1-version"),
-                    new StackComponentImpl(id + "-component2", id + "-component2-version")))
-            .setStackIcon(
-                new StackIcon(id + "-icon", id + "-media-type", "0x1234567890abcdef".getBytes()))
-            .setWorkspaceConfig(createWorkspaceConfig("test"))
-            .build();
-    return stack;
+    return StackImpl.builder()
+        .setId(id)
+        .setName(name)
+        .setCreator("user123")
+        .setDescription(id + "-description")
+        .setScope(id + "-scope")
+        .setTags(asList(id + "-tag1", id + "-tag2"))
+        .setComponents(
+            asList(
+                new StackComponentImpl(id + "-component1", id + "-component1-version"),
+                new StackComponentImpl(id + "-component2", id + "-component2-version")))
+        .setStackIcon(
+            new StackIcon(id + "-icon", id + "-media-type", "0x1234567890abcdef".getBytes()))
+        .setWorkspaceConfig(createWorkspaceConfig("test"))
+        .build();
   }
 
   private static StackImpl createStackWithDevfile(String id, String name) {
-    final StackImpl stack =
-        StackImpl.builder()
-            .setId(id)
-            .setName(name)
-            .setCreator("user123")
-            .setDescription(id + "-description")
-            .setScope(id + "-scope")
-            .setTags(asList(id + "-tag1", id + "-tag2"))
-            .setComponents(
-                asList(
-                    new StackComponentImpl(id + "-component1", id + "-component1-version"),
-                    new StackComponentImpl(id + "-component2", id + "-component2-version")))
-            .setStackIcon(
-                new StackIcon(id + "-icon", id + "-media-type", "0x1234567890abcdef".getBytes()))
-            .setDevfile(createDevfile("test"))
-            .build();
-    return stack;
+    return StackImpl.builder()
+        .setId(id)
+        .setName(name)
+        .setCreator("user123")
+        .setDescription(id + "-description")
+        .setScope(id + "-scope")
+        .setTags(asList(id + "-tag1", id + "-tag2"))
+        .setComponents(
+            asList(
+                new StackComponentImpl(id + "-component1", id + "-component1-version"),
+                new StackComponentImpl(id + "-component2", id + "-component2-version")))
+        .setStackIcon(
+            new StackIcon(id + "-icon", id + "-media-type", "0x1234567890abcdef".getBytes()))
+        .setDevfile(createDevfile("test"))
+        .build();
   }
 
   private <T extends CascadeEvent> CascadeEventSubscriber<T> mockCascadeEventSubscriber() {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -846,7 +846,7 @@ public class WorkspaceDaoTest {
     return workspace;
   }
 
-  private static DevfileImpl createDevfile(String name) {
+  public static DevfileImpl createDevfile(String name) {
 
     SourceImpl source1 =
         new SourceImpl("type1", "http://location", "branch1", "point1", "tag1", "commit1");

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackLoaderTest.java
@@ -61,6 +61,8 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class StackLoaderTest {
 
+  @Mock private StackValidator stackValidator;
+
   @Mock private StackDao stackDao;
 
   @Mock private DBInitializer dbInitializer;
@@ -72,15 +74,20 @@ public class StackLoaderTest {
     when(dbInitializer.isBareInit()).thenReturn(true);
     stackLoader =
         new StackLoader(
-            false, ImmutableMap.of("stacks.json", "stack_img"), stackDao, dbInitializer);
+            false,
+            ImmutableMap.of("test-stacks.json", "stack_img"),
+            stackValidator,
+            stackDao,
+            dbInitializer);
   }
 
   @Test
   public void predefinedStackWithValidJsonShouldBeUpdated() throws Exception {
     stackLoader.start();
 
-    verify(stackDao, times(5)).update(any());
+    verify(stackDao, times(6)).update(any());
     verify(stackDao, never()).create(any());
+    verify(stackValidator, times(6)).check(any());
   }
 
   @Test
@@ -89,8 +96,9 @@ public class StackLoaderTest {
 
     stackLoader.start();
 
-    verify(stackDao, times(5)).update(any());
-    verify(stackDao, times(5)).create(any());
+    verify(stackDao, times(6)).update(any());
+    verify(stackDao, times(6)).create(any());
+    verify(stackValidator, times(6)).check(any());
   }
 
   @Test
@@ -99,8 +107,9 @@ public class StackLoaderTest {
 
     stackLoader.start();
 
-    verify(stackDao, times(5)).update(any());
+    verify(stackDao, times(6)).update(any());
     verify(stackDao, never()).create(any());
+    verify(stackValidator, times(6)).check(any());
   }
 
   @Test
@@ -110,20 +119,22 @@ public class StackLoaderTest {
 
     stackLoader.start();
 
-    verify(stackDao, times(5)).update(any());
-    verify(stackDao, times(5)).create(any());
+    verify(stackDao, times(6)).update(any());
+    verify(stackDao, times(6)).create(any());
+    verify(stackValidator, times(6)).check(any());
   }
 
   @Test
   public void testOverrideStacksWithoutImages() throws Exception {
     final Map<String, String> map = new HashMap<>();
-    map.put("stacks.json", null);
-    stackLoader = new StackLoader(true, map, stackDao, dbInitializer);
+    map.put("test-stacks.json", null);
+    stackLoader = new StackLoader(true, map, stackValidator, stackDao, dbInitializer);
 
     stackLoader.start();
 
-    verify(stackDao, times(5)).update(any());
+    verify(stackDao, times(6)).update(any());
     verify(stackDao, never()).create(any());
+    verify(stackValidator, times(6)).check(any());
   }
 
   @Test
@@ -134,10 +145,11 @@ public class StackLoaderTest {
 
     verify(stackDao, never()).update(any());
     verify(stackDao, never()).create(any());
+    verify(stackValidator, never()).check(any());
   }
 
   @Test
-  public void dtoShouldBeSerialized() throws Exception {
+  public void dtoShouldBeSerializedStackWithWsConfig() throws Exception {
     StackDto stackDtoDescriptor = newDto(StackDto.class).withName("nameWorkspaceConfig");
     StackComponentDto stackComponentDto =
         newDto(StackComponentDto.class).withName("java").withVersion("1.8");

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/stack/StackValidatorTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.workspace.server.WorkspaceValidator;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
+import org.eclipse.che.api.workspace.shared.dto.devfile.DevfileDto;
 import org.eclipse.che.api.workspace.shared.dto.stack.StackComponentDto;
 import org.eclipse.che.api.workspace.shared.dto.stack.StackDto;
 import org.mockito.InjectMocks;
@@ -47,7 +48,7 @@ public class StackValidatorTest {
   }
 
   @Test
-  public void shouldcheck() throws Exception {
+  public void shouldCheck() throws Exception {
     validator.check(createStack());
   }
 
@@ -96,16 +97,34 @@ public class StackValidatorTest {
     validator.check(createStack().withScope("not-valid"));
   }
 
-  @Test(
-      expectedExceptions = BadRequestException.class,
-      expectedExceptionsMessageRegExp = "Workspace config required")
-  public void shouldValidateIfSourceIsStackSourceAndWorkspaceConfigIsNull() throws Exception {
-    validator.check(createStack().withWorkspaceConfig(null));
+  @Test
+  public void shouldValidateIfStackWorkspaceConfigIsNotNull() throws Exception {
+    validator.check(
+        createStack().withDevfile(null).withWorkspaceConfig(newDto(WorkspaceConfigDto.class)));
   }
 
   @Test
-  public void shouldNotcheck() throws Exception {
-    validator.check(createStack());
+  public void shouldValidateIfStackDevfileIsNotNull() throws Exception {
+    validator.check(createStack().withWorkspaceConfig(null).withDevfile(newDto(DevfileDto.class)));
+  }
+
+  @Test(
+      expectedExceptions = BadRequestException.class,
+      expectedExceptionsMessageRegExp =
+          "Required non-null workspace configuration or devfile but not both")
+  public void shouldNotValidateIfWorkspaceConfigAndDevfileAreNull() throws Exception {
+    validator.check(createStack().withWorkspaceConfig(null));
+  }
+
+  @Test(
+      expectedExceptions = BadRequestException.class,
+      expectedExceptionsMessageRegExp =
+          "Required non-null workspace configuration or devfile but not both")
+  public void shouldNotValidateIfWorkspaceConfigAndDevfileAreSet() throws Exception {
+    validator.check(
+        createStack()
+            .withWorkspaceConfig(newDto(WorkspaceConfigDto.class))
+            .withDevfile(newDto(DevfileDto.class)));
   }
 
   private static StackDto createStack() {

--- a/wsmaster/che-core-api-workspace/src/test/resources/test-stacks.json
+++ b/wsmaster/che-core-api-workspace/src/test/resources/test-stacks.json
@@ -363,5 +363,57 @@
                 }
             ]
         }
+    },
+    {
+        "id": "che7-preview-devfile",
+        "creator": "ide",
+        "name": "Che 7",
+        "description": "Workspace.next sidecars and Theia as IDE",
+        "scope": "general",
+        "tags": [
+            "ws.next",
+            "Theia",
+            "Java",
+            "JDK",
+            "Node.JS",
+            "NPM",
+            "Yeoman"
+        ],
+        "components": [
+            {
+                "name": "Centos",
+                "version": "7"
+            },
+            {
+                "name": "OpenJDK",
+                "version": "1.8.0_181"
+            },
+            {
+                "name": "NodeJS",
+                "version": "8.12.0"
+            },
+            {
+                "name": "NPM",
+                "version": "6.4.1"
+            }
+        ],
+        "devfile": {
+            "specVersion": "0.0.1",
+            "name": "che7",
+            "components": [
+                {
+                    "type": "cheEditor",
+                    "id": "eclipse/che-theia/next"
+                },
+                {
+                    "type": "chePlugin",
+                    "id": "eclipse/che-machine-exec-plugin/0.0.1"
+                },
+                {
+                    "type": "kubernetes",
+                    "referenceContent": "kind: List\nitems:\n - \n  apiVersion: v1\n  kind: Pod\n  metadata:\n   name: ws\n  spec:\n   containers:\n    - \n     image: 'eclipse/che-dev:nightly'\n     name: dev\n     resources:\n      limits:\n       memory: 512Mi\n"
+                }
+            ]
+        }
     }
 ]

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/7.0.0-beta5.0/1__add_devfile_to_stack.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/7.0.0-beta5.0/1__add_devfile_to_stack.sql
@@ -1,0 +1,16 @@
+--
+-- Copyright (c) 2012-2019 Red Hat, Inc.
+-- This program and the accompanying materials are made
+-- available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+--
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+-----------------------------------------------------------------------------------------------------------------------------------
+
+-- add devfile into stack
+ALTER TABLE stack ADD COLUMN devfile_id BIGINT;

--- a/wsmaster/integration-tests/mysql-tck/src/test/java/MySqlTckModule.java
+++ b/wsmaster/integration-tests/mysql-tck/src/test/java/MySqlTckModule.java
@@ -337,9 +337,12 @@ public class MySqlTckModule extends TckModule {
 
     @Override
     public void createAll(Collection<? extends StackImpl> entities) throws TckRepositoryException {
-      for (StackImpl stack : entities) {
-        stack.getWorkspaceConfig().getProjects().forEach(ProjectConfigImpl::prePersistAttributes);
-      }
+      entities
+          .stream()
+          .filter(s -> s.getWorkspaceConfig() != null)
+          .map(StackImpl::getWorkspaceConfig)
+          .flatMap(ws -> ws.getProjects().stream())
+          .forEach(ProjectConfigImpl::prePersistAttributes);
       super.createAll(entities);
     }
   }

--- a/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
+++ b/wsmaster/integration-tests/postgresql-tck/src/test/java/PostgreSqlTckModule.java
@@ -328,9 +328,12 @@ public class PostgreSqlTckModule extends TckModule {
 
     @Override
     public void createAll(Collection<? extends StackImpl> entities) throws TckRepositoryException {
-      for (StackImpl stack : entities) {
-        stack.getWorkspaceConfig().getProjects().forEach(ProjectConfigImpl::prePersistAttributes);
-      }
+      entities
+          .stream()
+          .filter(s -> s.getWorkspaceConfig() != null)
+          .map(StackImpl::getWorkspaceConfig)
+          .flatMap(ws -> ws.getProjects().stream())
+          .forEach(ProjectConfigImpl::prePersistAttributes);
       super.createAll(entities);
     }
   }


### PR DESCRIPTION
### What does this PR do?
Add an ability to specify Devfile in Stack.

There is one part that is missed - validation of Devfile before storing it.
It should be done in StackValidator class. And it will be done after or in the scope of https://github.com/eclipse/che/issues/13315

With these changes, Che 7 stacks may be rewritten with Devfiles but it was not done since UD does not respect devfile in stacks. So, it should be done later. As an example, Che 7 stack rewritten with Devfile:

<details>
<summary>Stacks with Devfile in JSON format</summary>

```json
  {
    "id": "che7-preview",
    "creator": "ide",
    "name": "Che 7",
    "description": "Workspace.next sidecars and Theia as IDE",
    "scope": "general",
    "tags": [
      "ws.next",
      "Theia",
      "Java",
      "JDK",
      "Node.JS",
      "NPM",
      "Yeoman"
    ],
    "components": [
      {
        "name": "Centos",
        "version": "7"
      },
      {
        "name": "OpenJDK",
        "version": "1.8.0_181"
      },
      {
        "name": "NodeJS",
        "version": "8.12.0"
      },
      {
        "name": "NPM",
        "version": "6.4.1"
      }
    ],
    "devfile": {
      "name": "che7",
      "components": [
        {
          "type": "cheEditor",
          "id": "eclipse/che-theia/next"
        },
        {
          "type": "chePlugin",
          "id": "eclipse/che-machine-exec-plugin/0.0.1"
        },
        {
          "type": "kubernetes",
          "referenceContent": "kind: List\nitems:\n - \n  apiVersion: v1\n  kind: Pod\n  metadata:\n   name: ws\n  spec:\n   containers:\n    - \n     image: 'eclipse/che-dev:nightly'\n     name: dev\n     resources:\n      limits:\n       memory: 512Mi\n"
        }
      ]
    },
    "stackIcon": {
      "name": "type-che7.svg",
      "mediaType": "image/svg+xml"
    }
  }
```
</details>

<details>
<summary>Stacks with Devfile in YAML format</summary>

```yaml
---
id: che7-preview
creator: ide
name: Che 7
description: Workspace.next sidecars and Theia as IDE
scope: general
tags:
- ws.next
- Theia
- Java
- JDK
- Node.JS
- NPM
- Yeoman
components:
- name: Centos
  version: '7'
- name: OpenJDK
  version: 1.8.0_181
- name: NodeJS
  version: 8.12.0
- name: NPM
  version: 6.4.1
devfile:
  name: che7
  components:
  - type: cheEditor
    id: eclipse/che-theia/next
  - type: chePlugin
    id: eclipse/che-machine-exec-plugin/0.0.1
  - type: kubernetes
    referenceContent: |
      kind: List
      items:
      - 
      apiVersion: v1
      kind: Pod
      metadata:
        name: ws
      spec:
        containers:
        - image: 'eclipse/che-dev:nightly'
          name: dev
          resources:
            limits:
             memory: 512Mi
stackIcon:
  name: type-che7.svg
  mediaType: image/svg+xml
```
</details>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13338

#### Release Notes
N/A

#### Docs PR
N/A