### PR TITLE
Enable to set the value `che.workspace.plugin_broker.wait_timeout_min`

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -101,6 +101,10 @@ data:
   CHE_WORKSPACE_PLUGIN__REGISTRY__URL: https://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
   {{- else }}
   CHE_WORKSPACE_PLUGIN__REGISTRY__URL: http://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
+{{- end }}
+{{- if .Values.che.workspace.pluginBroker }}
+  {{- if .Values.che.workspace.pluginBroker.waitTimeoutMin }}
+  CHE_WORKSPACE_PLUGIN__BROKER_WAIT__TIMEOUT__MIN: {{ .Values.che.workspace.pluginBroker.waitTimeoutMin | quote }}
   {{- end }}
 {{- end }}
 {{- if .Values.workspaceSidecarDefaultRamLimit }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -77,6 +77,8 @@ global:
 che:
   workspace: {}
 #    devfileRegistryUrl: "https://che-devfile-registry.openshift.io/"
+#    pluginBroker:
+#      waitTimeoutMin: "3"
 #    pluginRegistryUrl: "https://che-plugin-registry.openshift.io/v3"
 
 cheDevfileRegistry:


### PR DESCRIPTION

### What does this PR do?

Enables to set `che.workspace.plugin_broker.wait_timeout_min`.
In my experience, the default value `3` may be too short for instances that uses a slow file-system (like NFS, CIFS) as each workspace.

### What issues does this PR fix or reference?

None.
