### PR TITLE
Restore account linking on newest keycloak versions

### DIFF
--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakServiceClient.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakServiceClient.java
@@ -85,8 +85,7 @@ public class KeycloakServiceClient {
       @SuppressWarnings("rawtypes") Jwt token, String oauthProvider, String redirectAfterLogin) {
 
     DefaultClaims claims = (DefaultClaims) token.getBody();
-    final String clientId = claims.getAudience();
-
+    final String clientId = claims.get("azp", String.class);
     final String sessionState = claims.get("session_state", String.class);
     MessageDigest md;
     try {


### PR DESCRIPTION
### What does this PR do?
Since in newer Keycloak versions meaning of `aud` claim changed a little, so it is not contains name of the client who requested token anymore. This information is stored in the `azp` claim value, which is right place for it (see https://www.iana.org/assignments/jwt/jwt.xhtml). So we must read it from here.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13380

#### Release Notes
N/A

#### Docs PR
N/A