### PR TITLE
Fix TLS enabled typos

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout: "3600"
 {{- if .Values.global.tls.enabled }}
+{{- if .Values.global.tls.useCertManager }}
+    certmanager.k8s.io/cluster-issuer: "letsencrypt"
+{{- end }}
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/ssl-redirect: "true"
     kubernetes.io/tls-acme: "true"
 {{- else }}

--- a/deploy/kubernetes/helm/che/templates/cert-issuer.yaml
+++ b/deploy/kubernetes/helm/che/templates/cert-issuer.yaml
@@ -19,10 +19,10 @@ spec:
 {{- if .Values.global.tls.useStaging }}
     server: https://acme-staging.api.letsencrypt.org/directory
 {{- else }}
-    server: https://acme-v01.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
 {{- end }}
     # Email address used for ACME registration
-    email: user@example.com
+    email: {{ .Values.global.tls.email }}
     # Name of a secret used to store the ACME account private key
     privateKeySecretRef:
       name: letsencrypt

--- a/deploy/kubernetes/helm/che/templates/certificate.yaml
+++ b/deploy/kubernetes/helm/che/templates/certificate.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-{{- if .Values.global.tlsEnabled }}
+{{- if .Values.global.tls.enabled }}
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: Certificate
 metadata:
@@ -16,6 +16,7 @@ spec:
   secretName: {{ .Values.global.tls.secretName }}
   issuerRef:
     name: letsencrypt
+    kind: ClusterIssuer
   commonName: {{ .Values.global.cheDomain }}
   dnsNames:
       - {{ .Values.global.cheDomain }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -43,6 +43,7 @@ global:
     useStaging: true
     secretName: che-tls
     useSelfSignedCerts: false
+    email: user@example.com
   gitHubClientID: ""
   gitHubClientSecret: ""
   pvcClaim: "1Gi"


### PR DESCRIPTION
### What does this PR do?

Fix some typos around TLS enablement in Helm Template.
Plus add missing cert manager issuer in custom Keycloak ingress template.
