### PR TITLE
Restore account linking on newest keycloak versions in Che 6.x

### DIFF
--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakServiceClient.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakServiceClient.java
@@ -85,8 +85,7 @@ public class KeycloakServiceClient {
       @SuppressWarnings("rawtypes") Jwt token, String oauthProvider, String redirectAfterLogin) {
 
     DefaultClaims claims = (DefaultClaims) token.getBody();
-    final String clientId = claims.getAudience();
-
+    final String clientId = claims.get("azp", String.class);
     final String sessionState = claims.get("session_state", String.class);
     MessageDigest md;
     try {


### PR DESCRIPTION
### What does this PR do?
It's cherry-pick of commit from PR to restore account linking on newest keycloak versions https://github.com/eclipse/che/pull/13398 into 6.19.x

### What issues does this PR fix or reference?
- https://issues.jboss.org/browse/CRW-281
- https://github.com/eclipse/che/issues/13380
