### PR TITLE
Fix handling supported versions based on the devfile introduction

### DIFF
--- a/dashboard/src/app/ide/ide.controller.ts
+++ b/dashboard/src/app/ide/ide.controller.ts
@@ -140,7 +140,8 @@ class IdeCtrl {
 
     this.workspaces = this.cheWorkspace.getWorkspaces();
     for (let i = 0; i < this.workspaces.length; i++) {
-      if (this.workspaces[i].config.name === this.selectedWorkspaceName) {
+      let name = this.cheWorkspace.getWorkspaceDataManager().getName(this.workspaces[i]);
+      if (name === this.selectedWorkspaceName) {
         this.selectedWorkspace = this.workspaces[i];
       }
     }

--- a/dashboard/src/app/ide/ide.service.ts
+++ b/dashboard/src/app/ide/ide.service.ts
@@ -145,7 +145,8 @@ class IdeSvc {
     let workspace = this.cheWorkspace.getWorkspaceById(workspaceId);
     this.openedWorkspace = workspace;
 
-    let workspaceLoaderUrl = this.cheWorkspace.getWorkspaceLoaderUrl(workspace.namespace, workspace.config.name);
+    let name = this.cheWorkspace.getWorkspaceDataManager().getName(workspace);
+    let workspaceLoaderUrl = this.cheWorkspace.getWorkspaceLoaderUrl(workspace.namespace, name);
     let ideUrlLink = workspaceLoaderUrl || workspace.links.ide;
 
     if (this.ideAction != null) {

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -331,7 +331,8 @@ export class NavbarRecentWorkspacesController {
     let workspace = this.cheWorkspace.getWorkspaceById(workspaceId);
 
     this.updateRecentWorkspace(workspaceId);
-    this.cheWorkspace.startWorkspace(workspace.id, workspace.config.defaultEnv).catch((error: any) => {
+    
+    this.cheWorkspace.startWorkspace(workspace.id, workspace.config ? workspace.config.defaultEnv: null).catch((error: any) => {
       this.$log.error(error);
       this.cheNotification.showError('Run workspace error.', error);
     });

--- a/dashboard/src/app/workspaces/workspaces.service.ts
+++ b/dashboard/src/app/workspaces/workspaces.service.ts
@@ -13,7 +13,7 @@
 
 import {CheWorkspace} from '../../components/api/workspace/che-workspace.factory';
 
-const MINIMAL_SUPORTED_VERSION = 7;
+const MINIMAL_SUPPORTED_VERSION = 7;
 
 /**
  * This is a helper class for workspaces.
@@ -58,13 +58,10 @@ export class WorkspacesService {
  /**
    *  Returns `true` if supported.
    * @param {che.IWorkspace} workspace
-   * @param {string=} envName environment name
    * @returns {boolean}
    */
-  isSupported(workspace: che.IWorkspace, envName?: string): boolean {
-    envName = envName || workspace.config.defaultEnv;
-
-    return this.isSupportedRecipeType(workspace, envName) && this.isSupportedVersion(workspace);
+  isSupported(workspace: che.IWorkspace): boolean {
+    return this.isSupportedRecipeType(workspace) && this.isSupportedVersion(workspace);
   }
 
    /**
@@ -73,11 +70,15 @@ export class WorkspacesService {
    * @returns {boolean}
    */
   isSupportedVersion(workspace: che.IWorkspace): boolean {
+    if (workspace.devfile) {
+      return true;
+    }
+    
     if (!workspace || !workspace.config) {
       return false;
     }
     const config = workspace.config;
-    const machines = config.environments[config.defaultEnv];
+    const machines = config.environments[config.defaultEnv].machines;
 
     let version: number;
     if (!Object.keys(machines).length || config.attributes.editor || config.attributes.plugins) {
@@ -92,7 +93,7 @@ export class WorkspacesService {
       }
     }
 
-    return version && version >= MINIMAL_SUPORTED_VERSION;
+    return version && version >= MINIMAL_SUPPORTED_VERSION;
   }
 
 }


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
As far as devfile support was recently introduced in UD, and workspace config can have null value, changes with the supported versions tracking had to be reviewed.
Also fixes start/open workspace with devfile from Recent workspace section. 


