### PR TITLE
Used latest keycloak 6.0.1

### DIFF
--- a/dockerfiles/keycloak/Dockerfile
+++ b/dockerfiles/keycloak/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-FROM jboss/keycloak-openshift:3.4.3.Final
+FROM jboss/keycloak:6.0.1
 ADD che /opt/jboss/keycloak/themes/che
 ADD . /scripts/
 ADD cli /scripts/cli


### PR DESCRIPTION
### What does this PR do?
Used Keycloak with fresh security updates
Image jboss/keycloak-openshift:xxx - has been deprecated.
This will allow having new features, security updates, stay in sync with downstream projects.

### What issues does this PR fix or reference?
n/a

#### Release Notes
n/a

#### Docs PR
n/a