### PR TITLE
Integrate Che Server with Devfile Registry

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -575,6 +575,11 @@ che.workspace.plugin_broker.wait_timeout_min=3
 # In case Che plugins tooling is not needed value 'NULL' should be used
 che.workspace.plugin_registry_url=https://che-plugin-registry.openshift.io/v3
 
+# Devfile Registry endpoint. Should be a valid HTTP URL.
+# Example: http://che-devfile-registry-eclipse-che.192.168.65.2.nip.io
+# In case Che plugins tooling is not needed value 'NULL' should be used
+che.workspace.devfile_registry_url=https://che-devfile-registry.openshift.io/
+
 # Configures in which way secure servers will be protected with authentication.
 # Suitable values:
 #   - 'default': no additionally authentication system will be enabled.

--- a/deploy/openshift/templates/che-devfile-registry.yml
+++ b/deploy/openshift/templates/che-devfile-registry.yml
@@ -1,0 +1,100 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: che-devfile-registry
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    labels:
+      app: che-devfile-registry
+    name: che-devfile-registry
+  spec:
+    replicas: 1
+    selector:
+      app: che-devfile-registry
+      deploymentconfig: che-devfile-registry
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        labels:
+          app: che-devfile-registry
+          deploymentconfig: che-devfile-registry
+      spec:
+        containers:
+        - image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: "${PULL_POLICY}"
+          name: che-devfile-registry
+          ports:
+          - containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /devfiles/
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: /devfiles/
+              port: 8080
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            timeoutSeconds: 3
+          resources:
+            limits:
+              memory: ${MEMORY_LIMIT}
+    triggers:
+    - type: ConfigChange
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: che-devfile-registry
+  spec:
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 8080
+    selector:
+      deploymentconfig: che-devfile-registry
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: che-devfile-registry
+  spec:
+    to:
+      kind: Service
+      name: che-devfile-registry
+parameters:
+- name: IMAGE
+  value: eclipse/che-devfile-registry
+  displayName: Eclipse Che devfile registry image
+  description: Che devfile registry Docker image. Defaults to eclipse/che-devfile-registry
+- name: IMAGE_TAG
+  value: latest
+  displayName: Eclipse Che devfile registry version
+  description: Eclipse Che devfile registry version which defaults to latest
+- name: MEMORY_LIMIT
+  value: 256Mi
+  displayName: Memory Limit
+  description: Maximum amount of memory the container can use. Defaults 256Mi
+- name: PULL_POLICY
+  value: Always
+  displayName: Eclipse Che devfile registry image pull policy
+  description: Always pull by default. Can be IfNotPresent

--- a/deploy/openshift/templates/che-devfile-registry.yml
+++ b/deploy/openshift/templates/che-devfile-registry.yml
@@ -83,9 +83,9 @@ objects:
       name: che-devfile-registry
 parameters:
 - name: IMAGE
-  value: eclipse/che-devfile-registry
+  value: quay.io/openshiftio/che-devfile-registry
   displayName: Eclipse Che devfile registry image
-  description: Che devfile registry Docker image. Defaults to eclipse/che-devfile-registry
+  description: Che devfile registry Docker image. Defaults to quay.io/openshiftio/che-devfile-registry.
 - name: IMAGE_TAG
   value: latest
   displayName: Eclipse Che devfile registry version

--- a/deploy/openshift/templates/che-server-template.yaml
+++ b/deploy/openshift/templates/che-server-template.yaml
@@ -163,6 +163,8 @@ objects:
                 optional: true
           - name: CHE_WORKSPACE_PLUGIN__REGISTRY__URL
             value: "${CHE_WORKSPACE_PLUGIN__REGISTRY__URL}"
+          - name: CHE_WORKSPACE_DEVFILE__REGISTRY__URL
+            value: "${CHE_WORKSPACE_DEVFILE__REGISTRY__URL}"
           - name: CHE_TRACING_ENABLED
             value: "${CHE_TRACING_ENABLED}"
           - name: CHE_METRICS_ENABLED
@@ -328,6 +330,10 @@ parameters:
 - name: CHE_WORKSPACE_PLUGIN__REGISTRY__URL
   displayName: Eclipse Che plugin registry URL
   description: Url that used to get meta information about Eclipse Che tooling
+  value: 'NULL'
+- name: CHE_WORKSPACE_DEVFILE__REGISTRY__URL
+  displayName: Eclipse Che devfile registry URL
+  description: Url that used to get meta information about predefined devfiles for workspaces
   value: 'NULL'
 - name: CHE_WORKSPACE_SIDECAR_DEFAULT__MEMORY__LIMIT__MB
   displayName: Plugin sidecar default memory limit

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -43,11 +43,13 @@ public final class Constants {
 
   public static final String CHE_WORKSPACE_AUTO_START = "che.workspace.auto_start";
 
-  /**
-   * Property name for Che plugin registry url. Key name of api workspace/settings method results.
-   */
+  /** Property name for Che plugin registry url. */
   public static final String CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY =
       "che.workspace.plugin_registry_url";
+
+  /** Property name for Che Devfile Registry URL. */
+  public static final String CHE_WORKSPACE_DEVFILE_REGISTRY_URL_PROPERTY =
+      "che.workspace.devfile_registry_url";
 
   /** Name for environment variable of machine name */
   public static final String CHE_MACHINE_NAME_ENV_VAR = "CHE_MACHINE_NAME";

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -19,6 +19,7 @@ import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
 import static org.eclipse.che.api.workspace.server.WorkspaceKeyValidator.validateKey;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_DEVFILE_REGISTRY_URL_PROPERTY;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY;
 
 import com.google.common.annotations.Beta;
@@ -96,6 +97,7 @@ public class WorkspaceService extends Service {
   private final MachineTokenProvider machineTokenProvider;
   private final WorkspaceLinksGenerator linksGenerator;
   private final String pluginRegistryUrl;
+  private final String devfileRegistryUrl;
   private final String apiEndpoint;
   private final boolean cheWorkspaceAutoStart;
 
@@ -106,13 +108,15 @@ public class WorkspaceService extends Service {
       WorkspaceManager workspaceManager,
       MachineTokenProvider machineTokenProvider,
       WorkspaceLinksGenerator linksGenerator,
-      @Named(CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY) @Nullable String pluginRegistryUrl) {
+      @Named(CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY) @Nullable String pluginRegistryUrl,
+      @Named(CHE_WORKSPACE_DEVFILE_REGISTRY_URL_PROPERTY) @Nullable String devfileRegistryUrl) {
     this.apiEndpoint = apiEndpoint;
     this.cheWorkspaceAutoStart = cheWorkspaceAutoStart;
     this.workspaceManager = workspaceManager;
     this.machineTokenProvider = machineTokenProvider;
     this.linksGenerator = linksGenerator;
     this.pluginRegistryUrl = pluginRegistryUrl;
+    this.devfileRegistryUrl = devfileRegistryUrl;
   }
 
   @POST
@@ -794,6 +798,10 @@ public class WorkspaceService extends Service {
 
     if (pluginRegistryUrl != null) {
       settings.put("cheWorkspacePluginRegistryUrl", pluginRegistryUrl);
+    }
+
+    if (devfileRegistryUrl != null) {
+      settings.put("cheWorkspaceDevfileRegistryUrl", devfileRegistryUrl);
     }
 
     return settings.build();

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -114,6 +114,8 @@ public class WorkspaceServiceTest {
   private static final String USER_ID = "user123";
   private static final String API_ENDPOINT = "http://localhost:8080/api";
   private static final String CHE_WORKSPACE_PLUGIN_REGISTRY_ULR = "http://localhost:9898/plugins/";
+  private static final String CHE_WORKSPACE_DEVFILE_REGISTRY_ULR =
+      "http://localhost:9898/devfiles/";
   private static final Account TEST_ACCOUNT = new AccountImpl("anyId", NAMESPACE, "test");
 
   @SuppressWarnings("unused")
@@ -134,7 +136,8 @@ public class WorkspaceServiceTest {
             wsManager,
             machineTokenProvider,
             linksGenerator,
-            CHE_WORKSPACE_PLUGIN_REGISTRY_ULR);
+            CHE_WORKSPACE_PLUGIN_REGISTRY_ULR,
+            CHE_WORKSPACE_DEVFILE_REGISTRY_ULR);
   }
 
   @Test
@@ -1228,7 +1231,9 @@ public class WorkspaceServiceTest {
             Constants.CHE_WORKSPACE_AUTO_START,
             "true",
             "cheWorkspacePluginRegistryUrl",
-            CHE_WORKSPACE_PLUGIN_REGISTRY_ULR));
+            CHE_WORKSPACE_PLUGIN_REGISTRY_ULR,
+            "cheWorkspaceDevfileRegistryUrl",
+            CHE_WORKSPACE_DEVFILE_REGISTRY_ULR));
   }
 
   private static String unwrapError(Response response) {


### PR DESCRIPTION
### What does this PR do?
This PR Integrates Che Server with Devfile Registry.
Default Devfile Registry that is used is [https://che-devfile-registry.openshift.io/](https://che-devfile-registry.openshift.io/) (use [https://che-devfile-registry.openshift.io/devfiles/](https://che-devfile-registry.openshift.io/devfiles/) to get list of all available devfiles)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13355

#### Release Notes
N/A

#### Docs PR
N/A