### PR TITLE
Add PHP and PHP + MySQL Che-7 stacks with samples

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2944,5 +2944,166 @@
       "name": "type-che7.svg",
       "mediaType": "image/svg+xml"
     }
+  },
+  {
+    "id": "php",
+    "name": "PHP with Theia IDE",
+    "creator": "Valerii Svydenko",
+    "tags": [
+      "Theia",
+      "Debian",
+      "PHP",
+      "Apache"
+    ],
+    "scope": "general",
+    "description": "Default PHP Stack with PHP 7.1 and Theia IDE",
+    "components": [
+      {
+        "version": "9",
+        "name": "Debian"
+      },
+      {
+        "version": "7.1.29",
+        "name": "PHP"
+      },
+      {
+        "name": "Apache",
+        "version": "2.4"
+      }
+    ],
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "recipe": {
+            "content": "eclipse/php:7.1-che7",
+            "type": "dockerimage"
+          },
+          "machines": {
+            "php-container": {
+              "attributes": {
+                "memoryLimitBytes": "536870912"
+              },
+              "servers": {},
+              "volumes": {
+                "projects": {
+                  "path": "/projects"
+                },
+                "composer": {
+                  "path": "/home/user/.composer"
+                },
+                "symfony": {
+                  "path": "/home/user/.symfony"
+                }
+              },
+              "installers": [],
+              "env": {
+                "HOME": "/home/user",
+                "PS1": "$(echo ${0})\\$ "
+              }
+            }
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "attributes": {
+        "editor": "eclipse/che-theia/next",
+        "plugins": "eclipse/che-machine-exec-plugin/0.0.1"
+      },
+      "links": []
+    },
+    "stackIcon": {
+      "name": "type-che7.svg",
+      "mediaType": "image/svg+xml"
+    }
+  },
+  {
+    "id": "php+mysql",
+    "name": "PHP + MySQL with Theia IDE",
+    "creator": "Valerii Svydenko",
+    "tags": [
+      "Theia",
+      "Debian",
+      "PHP",
+      "Apache",
+      "MySQL"
+    ],
+    "scope": "general",
+    "description": "Default PHP Stack with PHP 7.1 + MySQL and Theia IDE",
+    "components": [
+      {
+        "version": "9",
+        "name": "Debian"
+      },
+      {
+        "version": "7.1.29",
+        "name": "PHP"
+      },
+      {
+        "name": "Apache",
+        "version": "2.4"
+      },
+      {
+        "name": "MySQL",
+        "version": "14.14"
+      }
+    ],
+    "workspaceConfig": {
+      "environments": {
+        "default": {
+          "recipe": {
+            "content": "kind: List\nitems:\n - \n  apiVersion: v1\n  kind: Pod\n  metadata:\n   name: web\n   labels:\n    type: db\n  spec:\n   containers:\n    - \n     image: eclipse/php:7.1-che7\n     name: php-container\n     ports:\n      - \n       containerPort: 8080\n       protocol: TCP\n     resources:\n      limits:\n       memory: 512Mi\n    - \n     image: centos/mysql-57-centos7\n     name: mysql\n     ports:\n      - \n       name: mysql\n       containerPort: 3306\n       protocol: TCP\n     env:\n      - \n       name: MYSQL_USER\n       value: homestead\n      - \n       name: MYSQL_ROOT_PASSWORD\n       value: secret\n      - \n       name: MYSQL_PASSWORD\n       value: secret\n      - \n       name: MYSQL_DATABASE\n       value: homestead\n     resources:\n      limits:\n       memory: 256Mi\n - \n  apiVersion: v1\n  kind: Service\n  metadata:\n   name: db\n  spec:\n   selector:\n    type: db\n   ports:\n    - \n     name: mysql\n     port: 3306\n     protocol: TCP\n     targetPort: mysql\n",
+            "type": "kubernetes",
+            "contentType": "application/x-yaml"
+          },
+          "machines": {
+            "web/php-container": {
+              "attributes": {
+                "memoryLimitBytes": "536870912"
+              },
+              "servers": {},
+              "volumes": {
+                "projects": {
+                  "path": "/projects"
+                },
+                "composer": {
+                  "path": "/home/user/.composer"
+                },
+                "symfony": {
+                  "path": "/home/user/.symfony"
+                }
+              },
+              "installers": [],
+              "env": {
+                "HOME": "/home/user",
+                "PS1": "$(echo ${0})\\$ "
+              }
+            },
+            "web/mysql": {
+              "attributes": {},
+              "servers": {
+                "mysql": {
+                  "attributes": {},
+                  "port": "3306",
+                  "protocol": "tcp"
+                }
+              },
+              "volumes": {},
+              "installers": [],
+              "env": {}
+            }
+          }
+        }
+      },
+      "name": "default",
+      "defaultEnv": "default",
+      "description": null,
+      "attributes": {
+        "editor": "eclipse/che-theia/next",
+        "plugins": "eclipse/che-machine-exec-plugin/0.0.1"
+      },
+      "links": []
+    }
   }
 ]

--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -3009,7 +3009,7 @@
       "description": null,
       "attributes": {
         "editor": "eclipse/che-theia/next",
-        "plugins": "eclipse/che-machine-exec-plugin/0.0.1"
+        "plugins": "eclipse/che-machine-exec-plugin/0.0.1, redhat/php/latest, redhat/php-debugger/latest"
       },
       "links": []
     },
@@ -3101,7 +3101,7 @@
       "description": null,
       "attributes": {
         "editor": "eclipse/che-theia/next",
-        "plugins": "eclipse/che-machine-exec-plugin/0.0.1"
+        "plugins": "eclipse/che-machine-exec-plugin/0.0.1, redhat/php/latest, redhat/php-debugger/latest"
       },
       "links": []
     }

--- a/ide/che-core-ide-templates/src/main/resources/samples.json
+++ b/ide/che-core-ide-templates/src/main/resources/samples.json
@@ -691,7 +691,26 @@
       "location": "https://github.com/che-samples/web-php-simple.git",
       "parameters": {}
     },
-    "commands": [],
+    "commands": [
+      {
+        "name": "Start Apache Web Server",
+        "type": "custom",
+        "commandLine": "service apache2 start",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Stop Apache Web Server",
+        "type": "custom",
+        "commandLine": "service apache2 stop",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      }
+    ],
     "links": [],
     "category": "Samples",
     "tags": [
@@ -734,6 +753,189 @@
     "category": "Samples",
     "tags": [
       "php"
+    ]
+  },
+  {
+    "name": "symfony-demo",
+    "displayName": "symfony-demo",
+    "path": "/symfony-demo",
+    "description": "Symfony Demo Application https://symfony.com/",
+    "projectType": "php",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "php"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/symfony/demo.git",
+      "parameters": {}
+    },
+    "commands": [
+      {
+        "name": "Start Symfony Web Server",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/symfony-demo && $HOME/.symfony/bin/symfony server:start",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Stop Symfony Web Server",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/symfony-demo && $HOME/.symfony/bin/symfony server:stop",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Install dependencies",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/symfony-demo && composer install && wget https://get.symfony.com/cli/installer -O - | bash",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "MySQL",
+      "PHP"
+    ]
+  },
+  {
+    "name": "laravel-realworld-example-app",
+    "displayName": "laravel-realworld-example-app",
+    "path": "/laravel-realworld-example-app",
+    "description": "Exemplary real world backend API built with Laravel https://realworld.io",
+    "projectType": "php",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "php"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/gothinkster/laravel-realworld-example-app.git",
+      "parameters": {}
+    },
+    "commands": [
+      {
+        "name": "Start Artisan Web Server",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/laravel-realworld-example-app && php artisan serve",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Install dependencies",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/laravel-realworld-example-app && composer install",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Copy the example env file and make the required configuration changes in the .env file",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/laravel-realworld-example-app && cp .env.example .env",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Generate a new application key",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/laravel-realworld-example-app && php artisan key:generate",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Generate a new JWT authentication secret key",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/laravel-realworld-example-app && php artisan jwt:generate",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Run the database migrations",
+        "type": "custom",
+        "commandLine": "cd ${CHE_PROJECTS_ROOT}/laravel-realworld-example-app && php artisan migrate",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "MySQL",
+      "PHP"
+    ]
+  },
+  {
+    "name": "crud-php",
+    "displayName": "pdo",
+    "path": "/pdo",
+    "description": "Code for the simple PHP and MySQL database app tutorial. https://www.taniarascia.com/create-a-simple-database-app-connecting-to-mysql-with-php/",
+    "projectType": "php",
+    "mixins": [],
+    "attributes": {
+      "language": [
+        "php"
+      ]
+    },
+    "modules": [],
+    "problems": [],
+    "source": {
+      "type": "git",
+      "location": "https://github.com/taniarascia/pdo.git",
+      "parameters": {}
+    },
+    "commands": [
+      {
+        "name": "Start Apache Web Server",
+        "type": "custom",
+        "commandLine": "service apache2 start",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      },
+      {
+        "name": "Stop Apache Web Server",
+        "type": "custom",
+        "commandLine": "service apache2 stop",
+        "attributes": {
+          "previewUrl": "",
+          "goal": "Run"
+        }
+      }
+    ],
+    "links": [],
+    "category": "Samples",
+    "tags": [
+      "MySQL",
+      "PHP"
     ]
   },
   {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/NewWorkspace.java
@@ -165,6 +165,8 @@ public class NewWorkspace {
     NODEJS_AND_POSTGRES("nodejs-postgres"),
     OPENSHIFT_SQL("openshift-sql"),
     PHP("php-default"),
+    PHP_CHE7("php"),
+    PHP_MYSQL_CHE7("php+mysql"),
     PHP_GAE("php-gae"),
     PHP_5_6("php5.6-default"),
     PLATFORMIO("platformio"),

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/workspaces/NewWorkspacePageTest.java
@@ -44,6 +44,8 @@ import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.K
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.NODE;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.NODEJS_AND_POSTGRES;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.PHP;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.PHP_CHE7;
+import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.PHP_MYSQL_CHE7;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.PYTHON;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.PYTHON_DEFAULT;
 import static org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack.RAILS;
@@ -103,6 +105,8 @@ public class NewWorkspacePageTest {
           JAVA_MAVEN,
           NODE,
           PHP,
+          PHP_MYSQL_CHE7,
+          PHP_CHE7,
           PYTHON_DEFAULT,
           PYTHON,
           RAILS);
@@ -127,6 +131,8 @@ public class NewWorkspacePageTest {
           JAVA_MAVEN,
           NODE,
           PHP,
+          PHP_CHE7,
+          PHP_MYSQL_CHE7,
           PYTHON_DEFAULT,
           PYTHON,
           RAILS);
@@ -148,6 +154,8 @@ public class NewWorkspacePageTest {
           JAVA_MAVEN,
           NODE,
           PHP,
+          PHP_CHE7,
+          PHP_MYSQL_CHE7,
           PYTHON_DEFAULT,
           PYTHON,
           RAILS,
@@ -181,6 +189,7 @@ public class NewWorkspacePageTest {
           KOTLIN,
           NODE,
           PHP,
+          PHP_CHE7,
           PYTHON_DEFAULT,
           PYTHON,
           RAILS,
@@ -214,6 +223,8 @@ public class NewWorkspacePageTest {
           KOTLIN,
           NODE,
           PHP,
+          PHP_CHE7,
+          PHP_MYSQL_CHE7,
           PYTHON_DEFAULT,
           PYTHON,
           RAILS,
@@ -244,13 +255,14 @@ public class NewWorkspacePageTest {
           KOTLIN,
           NODE,
           PHP,
+          PHP_CHE7,
           PYTHON_DEFAULT,
           PYTHON,
           RAILS,
           SPRING_BOOT);
 
   private static final List<NewWorkspace.Stack> EXPECTED_OPENSHIFT_MULTI_MACHINE_STACKS =
-      asList(JAVA_MYSQL_THEIA_ON_KUBERNETES, NODEJS_AND_POSTGRES);
+      asList(JAVA_MYSQL_THEIA_ON_KUBERNETES, NODEJS_AND_POSTGRES, PHP_MYSQL_CHE7);
 
   private static final List<NewWorkspace.Stack> EXPECTED_K8S_MULTI_MACHINE_STACKS =
       asList(JAVA_MYSQL_THEIA_ON_KUBERNETES, NODEJS_AND_POSTGRES);
@@ -266,6 +278,8 @@ public class NewWorkspacePageTest {
               RAILS,
               PYTHON,
               PYTHON_DEFAULT,
+              PHP_CHE7,
+              PHP_MYSQL_CHE7,
               PHP,
               NODE,
               JAVA_MAVEN,
@@ -291,6 +305,8 @@ public class NewWorkspacePageTest {
           PYTHON,
           PYTHON_DEFAULT,
           PHP,
+          PHP_CHE7,
+          PHP_MYSQL_CHE7,
           NODE,
           JAVA_MAVEN,
           JAVA_GRADLE,
@@ -316,6 +332,8 @@ public class NewWorkspacePageTest {
           RAILS,
           PYTHON,
           PYTHON_DEFAULT,
+          PHP_CHE7,
+          PHP_MYSQL_CHE7,
           PHP,
           NODE,
           JAVA_MAVEN,


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds PHP and PHP + MySQL Che-7 stacks which include next plugins:

- [php-intelephense](https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/php/latest/meta.yaml)
- [php debug](https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/redhat/php-debugger/latest/meta.yaml)

Adds samples:

- [Hello World](https://github.com/che-samples/web-php-simple)
- [Laravel Real World example App](https://github.com/gothinkster/laravel-realworld-example-app)
- [Symfony demo application](https://github.com/symfony/)
- [Sample CRUD PHP+MySQL](https://github.com/taniarascia/pdo/tree/master)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13307
