### PR TITLE
Fix handling no-environment in workspace config, introduced in Che7

### DIFF
--- a/dashboard/src/app/workspaces/workspaces.service.ts
+++ b/dashboard/src/app/workspaces/workspaces.service.ts
@@ -78,12 +78,13 @@ export class WorkspacesService {
       return false;
     }
     const config = workspace.config;
-    const machines = config.environments[config.defaultEnv].machines;
 
     let version: number;
-    if (!Object.keys(machines).length || config.attributes.editor || config.attributes.plugins) {
+    //Checking no-environment and editor or plugin attributes, that were introduced in Che7:
+    if (!workspace.config.defaultEnv || config.attributes.editor || config.attributes.plugins) {
       version = 7;
     } else {
+      const machines = config.environments[config.defaultEnv].machines;
       for (const key in machines) {
         const installers = machines[key].installers;
         if (installers && installers.length !== 0) {


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Returns back handling the workspace config with no environment.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13413

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
