### PR TITLE
Add -Duser.home parameter to maven opts in java-maven stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -782,7 +782,7 @@
               },
               "env": {
                 "MAVEN_CONFIG": "/home/user/.m2",
-                "MAVEN_OPTS": "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
+                "MAVEN_OPTS": "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user",
                 "JAVA_OPTS": "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
                 "JAVA_TOOL_OPTIONS": "-XX:MaxRAMPercentage=50 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true -Xms20m -Djava.security.egd=file:/dev/./urandom",
                 "PS1": "$(echo ${0})\\$ ",


### PR DESCRIPTION
### What does this PR do?
Adds parameter -Duser.home=/home/user to MAVEN_OPTS in the java-maven stack. This is necessary for workspaces running on OpenShift, which are started using an arbitrary UID which is not found in /etc/passwd.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13451

Tested on minishift locally and on che.openshift.io. Have not tested on kubernetes infrastructures, but it shouldn't be a problem.