### PR TITLE
Adding owners for `e2e` directory.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,3 +67,6 @@ deploy/openshift/templates/che-monitoring.yaml @skabashnyuk @metlos
 
 # selenium tests
 selenium/** @musienko-maxim @dmytro-ndp @Ohrimenko1988
+
+# e2e tests
+e2e/**  @musienko-maxim @Ohrimenko1988 @rhopp


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Adds owners for `e2e` folder containing Hapy Path E2E tests.

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
