### PR TITLE
Use memory limit provided by meta.yaml in apache-camel stack

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -2931,8 +2931,7 @@
         "editor": "eclipse/che-theia/next",
         "plugins": "eclipse/che-machine-exec-plugin/0.0.1,redhat/vscode-xml/0.5.1,camel-tooling/vscode-apache-camel/0.0.14,redhat/java/latest",
         "sidecar.eclipse/che-theia.memory_limit": "512Mi",
-        "sidecar.redhat/vscode-xml.memory_limit": "128Mi",
-        "sidecar.camel-tooling/vscode-apache-camel.memory_limit": "128Mi"
+        "sidecar.redhat/vscode-xml.memory_limit": "128Mi"
       },
       "commands": [],
       "links": []


### PR DESCRIPTION
Signed-off-by: Valeriy Svydenko <vsvydenk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Updates memory limit for apache-camel stack. New value will come from `meta.yaml` - [plugin configuration file](https://github.com/eclipse/che-plugin-registry/blob/master/v3/plugins/camel-tooling/vscode-apache-camel/0.0.14/meta.yaml#L16). 

This PR should be merged after https://github.com/openshiftio/saas-openshiftio/pull/1308

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13225
