### PR TITLE
Changes to Che Dockerfile to allow build on Ppc64le architecture

### DIFF
--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -22,11 +22,12 @@ FROM openjdk:8u191-jdk-alpine
 ENV LANG=C.UTF-8 \
     DOCKER_VERSION=1.6.0 \
     DOCKER_BUCKET=get.docker.com \
-    CHE_IN_CONTAINER=true
+    CHE_IN_CONTAINER=true \
+    ARCH="`arch`"
 
 RUN echo "http://dl-4.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories && \
     apk add --update curl openssl sudo bash && \
-    curl -sSL "https://${DOCKER_BUCKET}/builds/Linux/x86_64/docker-${DOCKER_VERSION}" -o /usr/bin/docker && \
+    curl -sSL "https://${DOCKER_BUCKET}/builds/Linux/$ARCH/docker-${DOCKER_VERSION}" -o /usr/bin/docker && \
     chmod +x /usr/bin/docker && \
     echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
     rm -rf /tmp/* /var/cache/apk/*


### PR DESCRIPTION
### What does this PR do?
Changing the hard coded x86 docker dependency in file 'che/dockerfiles/che/Dockerfile'
to allow build on other architectures like ppc64le as well.

### What issues does this PR fix or reference?
Enables the che-server docker image to be built on power (ppc64le) architectures.

#13492 