### PR TITLE
Add creation of k8s secrets during deploying of broker

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBroker.java
@@ -19,6 +19,7 @@ import com.google.common.annotations.Beta;
 import com.google.common.collect.ImmutableSet;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import java.util.List;
@@ -85,6 +86,10 @@ public class DeployBroker extends BrokerPhase {
         namespace.configMaps().create(configMap);
       }
 
+      for (Secret secret : brokerEnvironment.getSecrets().values()) {
+        namespace.secrets().create(secret);
+      }
+
       Pod pluginBrokerPod = getPluginBrokerPod(brokerEnvironment.getPodsCopy());
 
       if (factory.isConfigured()) {
@@ -111,6 +116,11 @@ public class DeployBroker extends BrokerPhase {
         deployments.delete();
       } catch (InfrastructureException e) {
         LOG.error("Brokers pod removal failed. Error: " + e.getLocalizedMessage(), e);
+      }
+      try {
+        namespace.secrets().delete();
+      } catch (InfrastructureException ex) {
+        LOG.error("Brokers secret removal failed. Error: " + ex.getLocalizedMessage(), ex);
       }
       try {
         namespace.configMaps().delete();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBrokerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/DeployBrokerTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableSet;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Secret;
 import io.opentracing.Tracer;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +36,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListener;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListenerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.BrokersResult;
@@ -59,9 +61,11 @@ public class DeployBrokerTest {
   @Mock private KubernetesNamespace k8sNamespace;
   @Mock private KubernetesDeployments k8sDeployments;
   @Mock private KubernetesConfigsMaps k8sConfigMaps;
+  @Mock private KubernetesSecrets k8sSecrets;
 
   @Mock private KubernetesEnvironment k8sEnvironment;
   @Mock private ConfigMap configMap;
+  @Mock private Secret tlsSecret;
   private Pod pod;
 
   @Mock private BrokersResult brokersResult;
@@ -90,10 +94,12 @@ public class DeployBrokerTest {
 
     when(k8sNamespace.configMaps()).thenReturn(k8sConfigMaps);
     when(k8sNamespace.deployments()).thenReturn(k8sDeployments);
+    when(k8sNamespace.secrets()).thenReturn(k8sSecrets);
 
     pod = new PodBuilder().withNewMetadata().withName(PLUGIN_BROKER_POD_NAME).endMetadata().build();
     when(k8sEnvironment.getPodsCopy()).thenReturn(ImmutableMap.of(PLUGIN_BROKER_POD_NAME, pod));
     when(k8sEnvironment.getConfigMaps()).thenReturn(ImmutableMap.of("configMap", configMap));
+    when(k8sEnvironment.getSecrets()).thenReturn(ImmutableMap.of("secret", tlsSecret));
 
     when(k8sDeployments.create(any())).thenReturn(pod);
   }
@@ -107,10 +113,12 @@ public class DeployBrokerTest {
     assertSame(result, plugins);
     verify(k8sConfigMaps).create(configMap);
     verify(k8sDeployments).create(pod);
+    verify(k8sSecrets).create(tlsSecret);
 
     verify(k8sDeployments).stopWatch();
     verify(k8sDeployments).delete();
     verify(k8sConfigMaps).delete();
+    verify(k8sSecrets).delete();
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Adds creation of k8s secrets during deploying of broker.

This PR fixes the only one of the issues during Che 7 start with self-signed certificate and with these changes the following error appears
![Screenshot_20190614_160204](https://user-images.githubusercontent.com/5887312/59510982-c6fddd80-8ebd-11e9-960e-3413378918e2.png)
Changes for plugin broker will be created in another PR.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/13433

#### Release Notes
N/A

#### Docs PR
N/A