### PR TITLE
#13547 add servers on 3000, 9000, & 8080

### DIFF
--- a/ide/che-core-ide-stacks/src/main/resources/stacks.json
+++ b/ide/che-core-ide-stacks/src/main/resources/stacks.json
@@ -264,7 +264,20 @@
               "attributes": {
                 "memoryLimitBytes": "536870912"
               },
-              "servers": {},
+              "servers": {
+                "9000/tcp": {
+                  "port": "9000",
+                  "protocol": "http"
+                },
+                "8080/tcp": {
+                  "port": "8080",
+                  "protocol": "http"
+                },
+                "3000/tcp": {
+                  "port": "3000",
+                  "protocol": "http"
+                }
+              },
               "volumes": {
                 "projects": {
                   "path": "/projects"


### PR DESCRIPTION
#13547 add server on ports 3000, 9000, and 8080 so the sample projects associated with che7-preview stack will have working preview URLs

Signed-off-by: nickboldt <nboldt@redhat.com>