### PR TITLE
Operator-related fix and openshift v4 support

### DIFF
--- a/dockerfiles/keycloak/Dockerfile
+++ b/dockerfiles/keycloak/Dockerfile
@@ -11,6 +11,10 @@ ADD che /opt/jboss/keycloak/themes/che
 ADD . /scripts/
 ADD cli /scripts/cli
 RUN ln -s /opt/jboss/tools/docker-entrypoint.sh
+RUN curl --location https://github.com/davidfestal/KEYCLOAK-10169-OpenShift4-User-Provider/releases/download/6.0.1-openshift-v4-provider/openshift4-extension-6.0.1.jar -o /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar
+RUN cd /opt/jboss/keycloak/themes/base/admin/resources/partials && \
+    unzip -j /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar theme-resources/resources/realm-identity-provider-openshift-v4.html && \
+    unzip -j /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar theme-resources/resources/realm-identity-provider-openshift-v4-ext.html
 
 USER root
 RUN chgrp -R 0 /scripts && \

--- a/dockerfiles/keycloak/Dockerfile
+++ b/dockerfiles/keycloak/Dockerfile
@@ -14,3 +14,5 @@ ADD cli /scripts/cli
 USER root
 RUN chgrp -R 0 /scripts && \
     chmod -R g+rwX /scripts
+
+USER 1000

--- a/dockerfiles/keycloak/Dockerfile
+++ b/dockerfiles/keycloak/Dockerfile
@@ -10,11 +10,10 @@ FROM jboss/keycloak:6.0.1
 ADD che /opt/jboss/keycloak/themes/che
 ADD . /scripts/
 ADD cli /scripts/cli
-RUN ln -s /opt/jboss/tools/docker-entrypoint.sh
-RUN curl --location https://github.com/davidfestal/KEYCLOAK-10169-OpenShift4-User-Provider/releases/download/6.0.1-openshift-v4-provider/openshift4-extension-6.0.1.jar -o /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar
-RUN cd /opt/jboss/keycloak/themes/base/admin/resources/partials && \
-    unzip -j /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar theme-resources/resources/realm-identity-provider-openshift-v4.html && \
-    unzip -j /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar theme-resources/resources/realm-identity-provider-openshift-v4-ext.html
+RUN ln -s /opt/jboss/tools/docker-entrypoint.sh && \
+    curl -sSL https://github.com/che-incubator/KEYCLOAK-10169-OpenShift4-User-Provider/releases/download/6.0.1-openshift-v4-provider/openshift4-extension-6.0.1.jar -o /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar && \
+    unzip -j /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar -d /opt/jboss/keycloak/themes/base/admin/resources/partials \
+    theme-resources/resources/realm-identity-provider-openshift-v4.html theme-resources/resources/realm-identity-provider-openshift-v4-ext.html
 
 USER root
 RUN chgrp -R 0 /scripts && \

--- a/dockerfiles/keycloak/Dockerfile
+++ b/dockerfiles/keycloak/Dockerfile
@@ -10,6 +10,7 @@ FROM jboss/keycloak:6.0.1
 ADD che /opt/jboss/keycloak/themes/che
 ADD . /scripts/
 ADD cli /scripts/cli
+RUN ln -s /opt/jboss/tools/docker-entrypoint.sh
 
 USER root
 RUN chgrp -R 0 /scripts && \


### PR DESCRIPTION
### What does this PR do?

This PR provides fixes to the `che-keycloak` image in order to allow the community Che operator
to successfully install a Che server integrated with the Openshift v4 OAuth authentication.

More precisely this PR:
- Restores the initial user that is set in the base Keycloak image (1000 => jboss user), instead of keeping the ROOT user as the docker image user, which brings problems in both Kubernetes or Openshift contexts in the Che operator use-cases.
- Fixes an incompatibility with the Che operator introduced by PR https://github.com/eclipse/che/pull/13429 : the reason is that the last Keycloak image has moved its entry-point. Since the Che operator overrides the entry-point and then delegates to the original one, Che operator was broken by this change. In order to provide compatibility of the Che operator with as many Che versions as possible, this PR add a link between the new and the old entry-point paths, so that the Che operator will be able to work with both.    
- Deploys the new Openshift-v4 identity provider implemented in the context of issues https://issues.jboss.org/browse/CRW-202 and https://issues.jboss.org/browse/KEYCLOAK-10169.
When this new provider will be integrated into the Keycloak product itself in a future Keycloak release, we'll be able to remove this last change.  

### What issues does this PR fix or reference?

This PR is involved in fixing issue: https://github.com/redhat-developer/rh-che/issues/1454,
and is also a followup of PR https://github.com/eclipse/che/pull/13429/files which had introduced a breaking change for the community Che operator.

