### PR TITLE
che #13553: Making Che 6 'MINIMAL_SUPPORTED_VERSION' which would allow starting existing Che 6 workspaces from User Dashboard

### DIFF
--- a/dashboard/src/app/workspaces/workspaces.service.spec.ts
+++ b/dashboard/src/app/workspaces/workspaces.service.spec.ts
@@ -139,10 +139,10 @@ describe(`WorkspacesService >`, () => {
       expect(workspacesService.isSupportedVersion(newCHE7Workspace)).toBeTruthy();
     });
 
-    it(`shouldn't support a CHE6 workspace >`, () => {
+    it(`should support a CHE6 workspace >`, () => {
       const oldCHE6Workspace = getCHE6Workspace();
-      expect(workspacesService.isSupported(oldCHE6Workspace)).toBeFalsy();
-      expect(workspacesService.isSupportedVersion(oldCHE6Workspace)).toBeFalsy();
+      expect(workspacesService.isSupported(oldCHE6Workspace)).toBeTruthy();
+      expect(workspacesService.isSupportedVersion(oldCHE6Workspace)).toBeTruthy();
     });
 
   });

--- a/dashboard/src/app/workspaces/workspaces.service.ts
+++ b/dashboard/src/app/workspaces/workspaces.service.ts
@@ -13,7 +13,7 @@
 
 import {CheWorkspace} from '../../components/api/workspace/che-workspace.factory';
 
-const MINIMAL_SUPPORTED_VERSION = 7;
+const MINIMAL_SUPPORTED_VERSION = 6;
 
 /**
  * This is a helper class for workspaces.


### PR DESCRIPTION
### What does this PR do?
Making Che 6 'MINIMAL_SUPPORTED_VERSION' which would allow starting existing Che 6 workspaces from User Dashboard.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13553

<!-- #### Changelog -->
Making Che 6 'MINIMAL_SUPPORTED_VERSION' which would allow starting existing Che 6 

#### Release Notes
Making Che 6 'MINIMAL_SUPPORTED_VERSION' which would allow starting existing Che 6 

#### Docs PR
N/A