### PR TITLE
Make Che Plugin Broker use self-signed certificate

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -560,8 +560,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.18
-che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.18
+che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.19.0
+che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.19.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisioner.java
@@ -94,17 +94,24 @@ public class CertificateProvisioner implements ConfigurationProvisioner<Kubernet
         pod.getSpec().getVolumes().add(buildCertSecretVolume(selfSignedCertSecretName));
       }
 
-      for (Container container : pod.getSpec().getContainers()) {
-        Optional<VolumeMount> certVolumeMount =
-            container
-                .getVolumeMounts()
-                .stream()
-                .filter(vm -> vm.getName().equals(CHE_SELF_SIGNED_CERT_VOLUME))
-                .findAny();
-        if (!certVolumeMount.isPresent()) {
-          container.getVolumeMounts().add(buildCertVolumeMount());
-        }
+      for (Container container : pod.getSpec().getInitContainers()) {
+        provisionCertVolumeMountIfNeeded(container);
       }
+      for (Container container : pod.getSpec().getContainers()) {
+        provisionCertVolumeMountIfNeeded(container);
+      }
+    }
+  }
+
+  private void provisionCertVolumeMountIfNeeded(Container container) {
+    Optional<VolumeMount> certVolumeMount =
+        container
+            .getVolumeMounts()
+            .stream()
+            .filter(vm -> vm.getName().equals(CHE_SELF_SIGNED_CERT_VOLUME))
+            .findAny();
+    if (!certVolumeMount.isPresent()) {
+      container.getVolumeMounts().add(buildCertVolumeMount());
     }
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
@@ -49,6 +49,7 @@ import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
 
 /**
@@ -79,6 +80,7 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
   private final String unifiedBrokerImage;
   private final String initBrokerImage;
   private final String pluginRegistryUrl;
+  private final CertificateProvisioner certProvisioner;
 
   public BrokerEnvironmentFactory(
       String cheWebsocketEndpoint,
@@ -87,7 +89,8 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
       MachineTokenEnvVarProvider machineTokenEnvVarProvider,
       String unifiedBrokerImage,
       String initBrokerImage,
-      String pluginRegistryUrl) {
+      String pluginRegistryUrl,
+      CertificateProvisioner certProvisioner) {
     this.cheWebsocketEndpoint = cheWebsocketEndpoint;
     this.brokerPullPolicy = brokerPullPolicy;
     this.authEnableEnvVarProvider = authEnableEnvVarProvider;
@@ -95,6 +98,7 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
     this.unifiedBrokerImage = unifiedBrokerImage;
     this.initBrokerImage = initBrokerImage;
     this.pluginRegistryUrl = pluginRegistryUrl;
+    this.certProvisioner = certProvisioner;
   }
 
   /**
@@ -167,6 +171,8 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
                     runtimeId.getWorkspaceId(),
                     MoreObjects.firstNonNull(runtimeId.getEnvName(), ""),
                     runtimeId.getOwnerId()),
+                "-cacert",
+                certProvisioner.isConfigured() ? certProvisioner.getCertPath() : "",
                 "--registry-address",
                 Strings.nullToEmpty(pluginRegistryUrl))
             .withImagePullPolicy(brokerPullPolicy)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/KubernetesBrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/KubernetesBrokerEnvironmentFactory.java
@@ -20,6 +20,7 @@ import org.eclipse.che.api.workspace.server.spi.provision.env.AgentAuthEnableEnv
 import org.eclipse.che.api.workspace.server.spi.provision.env.MachineTokenEnvVarProvider;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
 
 /**
  * Extends {@link BrokerEnvironmentFactory} to be used in the kubernetes infrastructure.
@@ -40,7 +41,8 @@ public class KubernetesBrokerEnvironmentFactory
       MachineTokenEnvVarProvider machineTokenEnvVarProvider,
       @Named("che.workspace.plugin_broker.init.image") String initBrokerImage,
       @Named("che.workspace.plugin_broker.unified.image") String unifiedBrokerImage,
-      @Nullable @Named("che.workspace.plugin_registry_url") String pluginRegistryUrl) {
+      @Nullable @Named("che.workspace.plugin_registry_url") String pluginRegistryUrl,
+      CertificateProvisioner certProvisioner) {
     super(
         cheWebsocketEndpoint,
         brokerPullPolicy,
@@ -48,7 +50,8 @@ public class KubernetesBrokerEnvironmentFactory
         machineTokenEnvVarProvider,
         unifiedBrokerImage,
         initBrokerImage,
-        pluginRegistryUrl);
+        pluginRegistryUrl,
+        certProvisioner);
   }
 
   @Override

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/CertificateProvisionerTest.java
@@ -124,6 +124,11 @@ public class CertificateProvisionerTest {
     // then
     for (Pod pod : k8sEnv.getPodsCopy().values()) {
       verifyVolumeIsPresent(pod);
+
+      for (Container container : pod.getSpec().getInitContainers()) {
+        verifyVolumeMountIsPresent(container);
+      }
+
       for (Container container : pod.getSpec().getContainers()) {
         verifyVolumeMountIsPresent(container);
       }
@@ -176,6 +181,7 @@ public class CertificateProvisionerTest {
         .withName(podName)
         .endMetadata()
         .withNewSpec()
+        .withInitContainers(new ContainerBuilder().build())
         .withContainers(new ContainerBuilder().build(), new ContainerBuilder().build())
         .endSpec()
         .build();

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
@@ -19,6 +19,7 @@ import javax.inject.Named;
 import org.eclipse.che.api.workspace.server.spi.provision.env.AgentAuthEnableEnvVarProvider;
 import org.eclipse.che.api.workspace.server.spi.provision.env.MachineTokenEnvVarProvider;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.KubernetesBrokerEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
@@ -42,7 +43,8 @@ public class OpenshiftBrokerEnvironmentFactory
       MachineTokenEnvVarProvider machineTokenEnvVarProvider,
       @Named("che.workspace.plugin_broker.init.image") String initBrokerImage,
       @Named("che.workspace.plugin_broker.unified.image") String unifiedBrokerImage,
-      @Nullable @Named("che.workspace.plugin_registry_url") String pluginRegistryUrl) {
+      @Nullable @Named("che.workspace.plugin_registry_url") String pluginRegistryUrl,
+      CertificateProvisioner certProvisioner) {
     super(
         cheWebsocketEndpoint,
         brokerPullPolicy,
@@ -50,7 +52,8 @@ public class OpenshiftBrokerEnvironmentFactory
         machineTokenEnvVarProvider,
         unifiedBrokerImage,
         initBrokerImage,
-        pluginRegistryUrl);
+        pluginRegistryUrl,
+        certProvisioner);
   }
 
   @Override


### PR DESCRIPTION
### What does this PR do?
Makes Che Plugin Broker use a self-signed certificate to archive it was needed:
- upgrade Che Plugin Broker to v0.19.0 where it's possible to configure cacert https://github.com/eclipse/che-plugin-broker/releases/tag/v0.19.0;
- make Che Server configure cacert for PluginBroker if needed;

This is tested on local OCP deployed with `ocp.sh`:
```bash
./ocp.sh --run-ocp --deploy-che --multiuser --secure --no-pull --setup-ocp-oauth
```
https://youtu.be/8z8WXA82G28

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/12634

#### Release Notes
N/A

#### Docs PR
N/A