### PR TITLE
Update Openshift v4 provider download URL

### DIFF
--- a/dockerfiles/keycloak/Dockerfile
+++ b/dockerfiles/keycloak/Dockerfile
@@ -11,7 +11,7 @@ ADD che /opt/jboss/keycloak/themes/che
 ADD . /scripts/
 ADD cli /scripts/cli
 RUN ln -s /opt/jboss/tools/docker-entrypoint.sh && \
-    curl -sSL https://github.com/che-incubator/KEYCLOAK-10169-OpenShift4-User-Provider/releases/download/6.0.1-openshift-v4-provider/openshift4-extension-6.0.1.jar -o /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar && \
+    curl -sSL https://github.com/che-incubator/KEYCLOAK-10169-OpenShift4-User-Provider/releases/download/6.0.1-openshift-v4/openshift4-extension-6.0.1.jar -o /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar && \
     unzip -j /opt/jboss/keycloak/standalone/deployments/openshift4-extension-6.0.1.jar -d /opt/jboss/keycloak/themes/base/admin/resources/partials \
     theme-resources/resources/realm-identity-provider-openshift-v4.html theme-resources/resources/realm-identity-provider-openshift-v4-ext.html
 


### PR DESCRIPTION
### What does this PR do?

This PR updates the URL to the Openshift v4 Keycloak identity provider that should be included
into the `che-keycloak` image.
The new URL corresponds to a new release that fixes a bug in the `token-exchange` feature: https://github.com/che-incubator/KEYCLOAK-10169-OpenShift4-User-Provider/pull/1 

### What issues does this PR fix or reference?

https://github.com/che-incubator/KEYCLOAK-10169-OpenShift4-User-Provider/pull/1
