### PR TITLE
Allow registry passwords longer than 128 chars

### DIFF
--- a/dashboard/src/app/administration/docker-registry/docker-registry-list/edit-registry/edit-registry.html
+++ b/dashboard/src/app/administration/docker-registry/docker-registry-list/edit-registry/edit-registry.html
@@ -24,12 +24,10 @@
                  che-name="password"
                  che-label-name="Password"
                  che-place-holder="password"
-                 ng-maxlength="128"
                  type="password"
                  required
                  ng-model="editRegistryController.registry.password">
         <div ng-message="required">User Password is required.</div>
-        <div ng-message="maxlength">User Password should be less than 128 characters long.</div>
       </che-input>
     </div>
     <che-button-notice che-button-title="Close"


### PR DESCRIPTION
### What does this PR do?
This PR allows users to specify passwords for docker registry credentials that are longer than 128 characters. Myself and some other team members have access to docker registries that use 128 characters and longer tokens for authentication, and Che was not allowing us to specify the credentials for the registry. 

I've verified this change with both short and long tokens, including an 856 service account token used for pushing to an internal OpenShift registry

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/5678

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
Allow registry passwords longer than 128 chars
