### PR TITLE
Upgrade dashboard dependencies

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -116,8 +116,8 @@
     "bootstrap-styl": "4.0.5",
     "codemirror": "5.19.0",
     "font-awesome": "4.5.0",
-    "jquery": "3.3.1",
-    "js-yaml": "3.6.1",
+    "jquery": "3.4.0",
+    "js-yaml": "3.13.1",
     "jsonlint": "1.6.0",
     "ng-lodash": "0.2.3"
   }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -116,7 +116,7 @@
     "bootstrap-styl": "4.0.5",
     "codemirror": "5.19.0",
     "font-awesome": "4.5.0",
-    "jquery": "3.4.0",
+    "jquery": "3.4.1",
     "js-yaml": "3.13.1",
     "jsonlint": "1.6.0",
     "ng-lodash": "0.2.3"

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -6075,10 +6075,10 @@ jest@^22.2.1:
     import-local "^1.0.0"
     jest-cli "^22.4.4"
 
-jquery@3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
-  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
+jquery@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.1.tgz#714f1f8d9dde4bdfa55764ba37ef214630d80ef2"
+  integrity sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==
 
 js-base64@^2.1.9:
   version "2.4.9"

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -6075,10 +6075,10 @@ jest@^22.2.1:
     import-local "^1.0.0"
     jest-cli "^22.4.4"
 
-jquery@3.3.1:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.3.1.tgz#958ce29e81c9790f31be7792df5d4d95fc57fbca"
-  integrity sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==
+jquery@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.4.0.tgz#8de513fa0fa4b2c7d2e48a530e26f0596936efdf"
+  integrity sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ==
 
 js-base64@^2.1.9:
   version "2.4.9"
@@ -6100,20 +6100,20 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
+js-yaml@3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@3.4.5:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.4.5.tgz#c3403797df12b91866574f2de23646fe8cafb44d"
   integrity sha1-w0A3l98SuRhmV08t4jZG/oyvtE0=
   dependencies:
     argparse "^1.0.2"
-    esprima "^2.6.0"
-
-js-yaml@3.6.1:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
-  integrity sha1-bl/mfYsgXOTSL60Ft3geja3MSzA=
-  dependencies:
-    argparse "^1.0.7"
     esprima "^2.6.0"
 
 js-yaml@3.x, js-yaml@^3.7.0:


### PR DESCRIPTION
### What does this PR do?
Upgrades `jquery` to `3.4.0` and `js-yaml` to `3.13.1` to fix CVE warnings
