### PR TITLE
Fix the startup failure on the non-root runtime.

### DIFF
--- a/dockerfiles/dashboard-dev/Dockerfile
+++ b/dockerfiles/dashboard-dev/Dockerfile
@@ -10,14 +10,31 @@
 
 FROM node:8.16.0
 
+USER root
 RUN apt-get update && \
-    apt-get install -y git \
+    apt-get install -y git sudo \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/* \
-    && echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf
-
-WORKDIR "/projects"
+    && echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf \
+    && usermod -aG root node \
+    && sed -e "s#^node:x.*#node:x:\${USER_ID}:\${GROUP_ID}::${HOME}:/bin/bash#g" \
+        /etc/passwd > /.passwd.template \
+    && sed -e 's#^node:.*#node:x:${GROUP_ID}:#g' \
+        /etc/group > /.group.template \
+    && echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
+    # The file permission must be fixed at /entrypoint.sh .
+    && mkdir -p /projects \
+    && for f in "${HOME}" /projects /etc/passwd /etc/group; do \
+           echo "Changing permissions on ${f}" && \
+           chgrp -R 0 ${f} && \
+           chmod -R g+rwX ${f}; \
+       done
 
 ADD src/entrypoint.sh /entrypoint.sh
+
+USER node
+WORKDIR "/projects"
+
 ENTRYPOINT ["/entrypoint.sh"]
+
 CMD tail -f /dev/null

--- a/dockerfiles/dashboard-dev/src/entrypoint.sh
+++ b/dockerfiles/dashboard-dev/src/entrypoint.sh
@@ -13,17 +13,28 @@
 
 export USER_ID=$(id -u)
 export GROUP_ID=$(id -g)
+
 if ! grep -Fq "${USER_ID}" /etc/passwd; then
     # current user is an arbitrary
     # user (its uid is not in the
     # container /etc/passwd). Let's fix that
-    cat ${HOME}/.passwd.template | \
-    sed "s/\${USER_ID}/${USER_ID}/g" | \
-    sed "s/\${GROUP_ID}/${GROUP_ID}/g" > /etc/passwd
+    sed \
+        -e "s/\${USER_ID}/${USER_ID}/g" \
+        -e "s/\${GROUP_ID}/${GROUP_ID}/g" \
+        -e "s/\${HOME}/\/home\/theia/g" \
+        /.passwd.template > /etc/passwd
+    sed \
+        -e "s/\${GROUP_ID}/${GROUP_ID}/g" \
+        /.group.template > /etc/group
 
-    cat ${HOME}/.group.template | \
-    sed "s/\${USER_ID}/${USER_ID}/g" | \
-    sed "s/\${GROUP_ID}/${GROUP_ID}/g" > /etc/group
+    # now the user `user` (that have uid:gid == $USER_ID,$GROUP_ID) can use `sudo`.
+fi
+
+# Grant access to projects volume in case of non root user with sudo rights
+if [ "$USER_ID" -ne 0 ] && command -v sudo >/dev/null 2>&1 && sudo -n true > /dev/null 2>&1; then
+    sudo chmod 644 /etc/passwd /etc/group
+    sudo chown root:root /etc/passwd /etc/group
+    sudo chown ${USER_ID}:${GROUP_ID} /projects ${HOME}
 fi
 
 exec "$@"


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Enables to run `dashboard-dev` container under non-root runtimes.

### What issues does this PR fix or reference?

fixes #13499 
