### PR TITLE
Selenium: Update the E2E selenium tests according to the changes on dashboard

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/Workspaces.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/Workspaces.java
@@ -74,7 +74,7 @@ public class Workspaces {
     String BULK_CHECKBOX = "//md-checkbox[@aria-label='Workspace list']";
     String SEARCH_WORKSPACE_FIELD = "//input[@ng-placeholder='Search']";
     String NO_WORKSPACE_FOUND = "//span[text()='No workspaces found.']";
-    String WORKSPACE_ITEM_NAME = "//div[@id='ws-name-%s']";
+    String WORKSPACE_ITEM_NAME = "//div[contains(@id, '/%s')]";
     String WORKSPACE_ITEM_FULL_NAME = "//div[@id='ws-full-name-%s']";
     String WORKSPACE_ITEM_CHECKBOX = "//div[@id='ws-name-%s']//md-checkbox";
     String WORKSPACE_ITEM_RAM = "//div[@id='ws-name-%s']//span[@name='workspace-ram-value']";

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/Workspaces.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/dashboard/workspaces/Workspaces.java
@@ -74,7 +74,7 @@ public class Workspaces {
     String BULK_CHECKBOX = "//md-checkbox[@aria-label='Workspace list']";
     String SEARCH_WORKSPACE_FIELD = "//input[@ng-placeholder='Search']";
     String NO_WORKSPACE_FOUND = "//span[text()='No workspaces found.']";
-    String WORKSPACE_ITEM_NAME = "//div[contains(@id, '/%s')]";
+    String WORKSPACE_ITEM_NAME = "//div[@class='workspace-name-clip' and contains(@id, '/%s')]";
     String WORKSPACE_ITEM_FULL_NAME = "//div[@id='ws-full-name-%s']";
     String WORKSPACE_ITEM_CHECKBOX = "//div[@id='ws-name-%s']//md-checkbox";
     String WORKSPACE_ITEM_RAM = "//div[@id='ws-name-%s']//span[@name='workspace-ram-value']";

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
@@ -46,6 +46,7 @@ public class TheiaIde {
   }
 
   public interface Locators {
+    String THEIA_CHE_DASHBOARD_XPATH = "//div[@class='che-dashboard']";
     String THEIA_IDE_ID = "theia-app-shell";
     String THEIA_IDE_TOP_PANEL_ID = "theia-top-panel";
     String LOADER_XPATH = "//div[@class='theia-preload theia-hidden']";
@@ -62,6 +63,9 @@ public class TheiaIde {
     String NOTIFICATION_CLOSE_BUTTON =
         "//div[@class='theia-NotificationsContainer']//button[text()='Close']";
   }
+
+  @FindBy(xpath = Locators.THEIA_CHE_DASHBOARD_XPATH)
+  WebElement theiaCheDashboard;
 
   @FindBy(id = Locators.THEIA_IDE_ID)
   WebElement theiaIde;
@@ -83,6 +87,10 @@ public class TheiaIde {
 
   @FindBy(xpath = Locators.ABOUT_DIALOG_OK_BUTTON_XPATH)
   WebElement aboutDialogOkButton;
+
+  public void openNavbarMenu() {
+    seleniumWebDriverHelper.waitAndClick(theiaCheDashboard);
+  }
 
   private String getNotificationEqualsToXpath(String messageText) {
     return format(NOTIFICATION_MESSAGE_EQUALS_TO_XPATH_TEMPLATE, messageText);

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaProjectTree.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaProjectTree.java
@@ -167,7 +167,6 @@ public class TheiaProjectTree {
   public void openItem(String itemPath) {
     clickOnItem(itemPath);
     waitItemSelected(itemPath);
-    doubleClickOnItem(itemPath);
   }
 
   public boolean isItemVisible(String itemPath) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaProposalForm.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaProposalForm.java
@@ -113,7 +113,7 @@ public class TheiaProposalForm {
     final String keyBindingContainerXpath =
         format(PROPOSAL_KEY_BINDING_XPATH_TEMPLATE, adoptedIndex);
 
-    if (isKeyBindingFieldExisted(proposalIndex)) {
+    if (isKeyBindingFieldExisted(adoptedIndex)) {
       return seleniumWebDriverHelper.waitVisibilityAndGetText(By.xpath(keyBindingContainerXpath));
     }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.WEB_JAVA_SPRING;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.WorkspaceDetailsTab.PROJECTS;
@@ -21,21 +20,18 @@ import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
-import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
-import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.MavenPluginStatusBar;
-import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
-import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.ToastLoader;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
+import org.eclipse.che.selenium.pageobject.dashboard.NavigationBar;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceProjects;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
+import org.eclipse.che.selenium.pageobject.theia.TheiaIde;
+import org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -53,17 +49,14 @@ public class CreateAndDeleteProjectsTest {
   @Inject private WorkspaceDetails workspaceDetails;
   @Inject private NewWorkspace newWorkspace;
   @Inject private ProjectSourcePage projectSourcePage;
-  @Inject private ProjectExplorer explorer;
   @Inject private SeleniumWebDriver seleniumWebDriver;
-  @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
   @Inject private DefaultTestUser defaultTestUser;
-  @Inject private NotificationsPopupPanel notificationsPopupPanel;
-  @Inject private MavenPluginStatusBar mavenPluginStatusBar;
   @Inject private Workspaces workspaces;
-  @Inject private Ide ide;
-  @Inject private ToastLoader toastLoader;
   @Inject private TestWorkspaceProvider testWorkspaceProvider;
+  @Inject private TheiaIde theiaIde;
+  @Inject private TheiaProjectTree theiaProjectTree;
+  @Inject private NavigationBar navigationBar;
 
   // it is used to read workspace logs on test failure
   private TestWorkspace testWorkspace;
@@ -84,6 +77,7 @@ public class CreateAndDeleteProjectsTest {
     dashboard.selectWorkspacesItemOnDashboard();
     workspaces.clickOnAddWorkspaceBtn();
     newWorkspace.waitToolbar();
+    dashboardWindow = seleniumWebDriver.getWindowHandle();
 
     // we are selecting 'Java' stack from the 'All Stack' tab for compatibility with OSIO
     newWorkspace.selectStack(Stack.JAVA_MAVEN);
@@ -106,25 +100,27 @@ public class CreateAndDeleteProjectsTest {
     testWorkspace = testWorkspaceProvider.getWorkspace(WORKSPACE, defaultTestUser);
 
     // switch to the IDE and wait for workspace is ready to use
-    dashboardWindow = seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
-    toastLoader.waitToastLoaderAndClickStartButton();
-    ide.waitOpenedWorkspaceIsReadyToUse();
+    theiaIde.switchToIdeFrame();
+    theiaIde.waitTheiaIde();
+    theiaIde.waitLoaderInvisibility();
+    theiaIde.waitTheiaIdeTopPanel();
+    theiaProjectTree.waitFilesTab();
 
-    // wait for projects initializing
-    explorer.waitItem(WEB_JAVA_SPRING);
-    explorer.waitItem(CONSOLE_JAVA_SIMPLE);
-    explorer.waitItem(SECOND_WEB_JAVA_SPRING_PROJECT_NAME);
-    notificationsPopupPanel.waitPopupPanelsAreClosed();
-    mavenPluginStatusBar.waitClosingInfoPanel();
-    explorer.waitDefinedTypeOfFolder(CONSOLE_JAVA_SIMPLE, PROJECT_FOLDER);
-    explorer.waitDefinedTypeOfFolder(WEB_JAVA_SPRING, PROJECT_FOLDER);
-    notificationsPopupPanel.waitPopupPanelsAreClosed();
+    // wait for projects in the tree
+    theiaProjectTree.clickOnFilesTab();
+    theiaProjectTree.waitProjectsRootItem();
+    theiaProjectTree.waitProjectAreaOpened();
+    theiaProjectTree.waitItem(WEB_JAVA_SPRING);
+    theiaProjectTree.waitItem(CONSOLE_JAVA_SIMPLE);
   }
 
   @Test(priority = 1)
   public void deleteProjectsFromDashboardTest() {
+    theiaIde.openNavbarMenu();
     seleniumWebDriver.switchTo().window(dashboardWindow);
+    navigationBar.waitNavigationBar();
     dashboard.selectWorkspacesItemOnDashboard();
+    workspaces.waitAddWorkspaceButton();
     workspaces.selectWorkspaceItemName(WORKSPACE);
     workspaceDetails.selectTabInWorkspaceMenu(PROJECTS);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportMavenProjectFromGitTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportMavenProjectFromGitTest.java
@@ -21,17 +21,15 @@ import java.nio.file.Paths;
 import org.eclipse.che.selenium.core.client.TestGitHubRepository;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
-import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
-import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.ToastLoader;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
+import org.eclipse.che.selenium.pageobject.theia.TheiaIde;
+import org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -43,17 +41,15 @@ public class ImportMavenProjectFromGitTest {
   private String testProjectName;
 
   @Inject private Dashboard dashboard;
-  @Inject private ProjectExplorer explorer;
   @Inject private NewWorkspace newWorkspace;
   @Inject private ProjectSourcePage projectSourcePage;
-  @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
   @Inject private TestWorkspaceProvider testWorkspaceProvider;
   @Inject private DefaultTestUser defaultTestUser;
   @Inject private Workspaces workspaces;
-  @Inject private Ide ide;
-  @Inject private ToastLoader toastLoader;
   @Inject private TestGitHubRepository testRepo;
+  @Inject private TheiaIde theiaIde;
+  @Inject private TheiaProjectTree theiaProjectTree;
 
   // it is used to read workspace logs on test failure
   private TestWorkspace testWorkspace;
@@ -96,10 +92,15 @@ public class ImportMavenProjectFromGitTest {
     // possible to read logs in case of test failure
     testWorkspace = testWorkspaceProvider.getWorkspace(WORKSPACE, defaultTestUser);
 
-    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
+    theiaIde.switchToIdeFrame();
+    theiaIde.waitTheiaIde();
+    theiaIde.waitLoaderInvisibility();
+    theiaIde.waitTheiaIdeTopPanel();
 
-    toastLoader.waitToastLoaderAndClickStartButton();
-    ide.waitOpenedWorkspaceIsReadyToUse();
-    explorer.waitItem(testProjectName);
+    // wait the project in the tree
+    theiaProjectTree.clickOnFilesTab();
+    theiaProjectTree.waitProjectsRootItem();
+    theiaProjectTree.waitProjectAreaOpened();
+    theiaProjectTree.waitItem(testProjectName);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
-import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.GITHUB;
 import static org.testng.AssertJUnit.assertTrue;
 
@@ -30,13 +29,13 @@ import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
 import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.ToastLoader;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
+import org.eclipse.che.selenium.pageobject.theia.TheiaIde;
+import org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -61,15 +60,15 @@ public class ImportProjectFromGitHubTest {
   @Inject private Dashboard dashboard;
   @Inject private Workspaces workspaces;
   @Inject private DefaultTestUser defaultTestUser;
-  @Inject private ProjectExplorer projectExplorer;
   @Inject private NewWorkspace newWorkspace;
-  @Inject private ToastLoader toastLoader;
   @Inject private ProjectSourcePage projectSourcePage;
   @Inject private SeleniumWebDriver seleniumWebDriver;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
   @Inject private TestWorkspaceProvider testWorkspaceProvider;
   @Inject private TestGitHubRepository testRepo;
+  @Inject private TheiaIde theiaIde;
+  @Inject private TheiaProjectTree theiaProjectTree;
 
   // it is used to read workspace logs on test failure
   private TestWorkspace testWorkspace;
@@ -117,11 +116,16 @@ public class ImportProjectFromGitHubTest {
     // possible to read logs in case of test failure
     testWorkspace = testWorkspaceProvider.getWorkspace(WORKSPACE, defaultTestUser);
 
-    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
-    toastLoader.waitToastLoaderAndClickStartButton();
-    ide.waitOpenedWorkspaceIsReadyToUse();
-    projectExplorer.waitItem(projectName);
-    projectExplorer.waitDefinedTypeOfFolder(projectName, PROJECT_FOLDER);
+    theiaIde.switchToIdeFrame();
+    theiaIde.waitTheiaIde();
+    theiaIde.waitLoaderInvisibility();
+    theiaIde.waitTheiaIdeTopPanel();
+
+    // wait the project in the tree
+    theiaProjectTree.clickOnFilesTab();
+    theiaProjectTree.waitProjectsRootItem();
+    theiaProjectTree.waitProjectAreaOpened();
+    theiaProjectTree.waitItem(projectName);
   }
 
   private void connectGithubAccount() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromZipTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromZipTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.ZIP;
+import static org.testng.Assert.fail;
 
 import com.google.inject.Inject;
 import java.io.IOException;
@@ -21,17 +22,16 @@ import java.nio.file.Paths;
 import org.eclipse.che.selenium.core.client.TestGitHubRepository;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
-import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
-import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.ToastLoader;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack;
 import org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
+import org.eclipse.che.selenium.pageobject.theia.TheiaIde;
+import org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree;
+import org.openqa.selenium.TimeoutException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -43,17 +43,15 @@ public class ImportProjectFromZipTest {
   private static final String PROJECT_NAME = "master";
 
   @Inject private Dashboard dashboard;
-  @Inject private ProjectExplorer explorer;
   @Inject private NewWorkspace newWorkspace;
   @Inject private ProjectSourcePage projectSourcePage;
-  @Inject private ToastLoader toastLoader;
-  @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
   @Inject private DefaultTestUser defaultTestUser;
   @Inject private Workspaces workspaces;
-  @Inject private Ide ide;
   @Inject private TestGitHubRepository testRepo;
   @Inject private TestWorkspaceProvider testWorkspaceProvider;
+  @Inject private TheiaIde theiaIde;
+  @Inject private TheiaProjectTree theiaProjectTree;
 
   // it is used to read workspace logs on test failure
   private TestWorkspace testWorkspace;
@@ -98,11 +96,24 @@ public class ImportProjectFromZipTest {
     // possible to read logs in case of test failure
     testWorkspace = testWorkspaceProvider.getWorkspace(WORKSPACE, defaultTestUser);
 
-    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
-    toastLoader.waitToastLoaderAndClickStartButton();
-    ide.waitOpenedWorkspaceIsReadyToUse();
-    explorer.waitItem(PROJECT_NAME);
-    explorer.waitAndSelectItem(PROJECT_NAME);
-    explorer.openContextMenuByPathSelectedItem(PROJECT_NAME);
+    theiaIde.switchToIdeFrame();
+    theiaIde.waitTheiaIde();
+    theiaIde.waitLoaderInvisibility();
+    theiaIde.waitTheiaIdeTopPanel();
+    theiaProjectTree.waitFilesTab();
+
+    // wait the project in the tree
+    theiaProjectTree.clickOnFilesTab();
+    theiaProjectTree.waitProjectsRootItem();
+    theiaProjectTree.waitProjectAreaOpened();
+    theiaIde.waitTheiaIdeTopPanel();
+    theiaProjectTree.waitFilesTab();
+
+    try {
+      theiaProjectTree.waitItem(PROJECT_NAME);
+    } catch (TimeoutException ex) {
+      // remove try-catch block after issue has been resolved
+      fail("Known permanent failure https://github.com/eclipse/che/issues/13579");
+    }
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromZipTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromZipTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.ZIP;
 import static org.testng.Assert.fail;
 
@@ -37,6 +38,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
+@Test(groups = UNDER_REPAIR)
 public class ImportProjectFromZipTest {
 
   private final String WORKSPACE = generate("ImptPrjFromZip", 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/CreateWorkspaceOnDashboardTest.java
@@ -12,11 +12,6 @@
 package org.eclipse.che.selenium.workspaces;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.CREATE_PROJECT;
-import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.STOP_WORKSPACE;
-import static org.eclipse.che.selenium.core.constant.TestMenuCommandsConstants.Workspace.WORKSPACE;
-import static org.eclipse.che.selenium.pageobject.ProjectExplorer.FolderTypes.PROJECT_FOLDER;
-import static org.eclipse.che.selenium.pageobject.Wizard.SamplesName.WEB_JAVA_SPRING;
 
 import com.google.inject.Inject;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
@@ -24,17 +19,14 @@ import org.eclipse.che.selenium.core.user.DefaultTestUser;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.eclipse.che.selenium.core.workspace.TestWorkspace;
 import org.eclipse.che.selenium.core.workspace.TestWorkspaceProvider;
-import org.eclipse.che.selenium.pageobject.CodenvyEditor;
-import org.eclipse.che.selenium.pageobject.Ide;
-import org.eclipse.che.selenium.pageobject.Menu;
-import org.eclipse.che.selenium.pageobject.NotificationsPopupPanel;
-import org.eclipse.che.selenium.pageobject.ProjectExplorer;
-import org.eclipse.che.selenium.pageobject.ToastLoader;
-import org.eclipse.che.selenium.pageobject.Wizard;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Stack;
 import org.eclipse.che.selenium.pageobject.dashboard.workspaces.Workspaces;
+import org.eclipse.che.selenium.pageobject.theia.TheiaIde;
+import org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree;
+import org.eclipse.che.selenium.pageobject.theia.TheiaProposalForm;
+import org.openqa.selenium.Keys;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
@@ -42,25 +34,20 @@ import org.testng.annotations.Test;
 public class CreateWorkspaceOnDashboardTest {
 
   private static final String WS_NAME = generate("workspace", 4);
-  private static final String PROJECT_NAME = "test-project";
-  private static final String PATH_TO_EXPAND = "/src/main/java/org.eclipse.che.examples";
-  private static final String PATH_JAVA_FILE =
-      "/src/main/java/org/eclipse/che/examples/GreetingController.java";
+  private static final String PROJECT_NAME = "web-java-spring";
+  private static final String WEB_JAVA_SPRING_SAMPLE_URL =
+      "https://github.com/che-samples/web-java-spring.git";
 
   @Inject private TestWorkspaceServiceClient workspaceServiceClient;
-  @Inject private NotificationsPopupPanel notificationsPopupPanel;
   @Inject private SeleniumWebDriverHelper seleniumWebDriverHelper;
-  @Inject private ProjectExplorer projectExplorer;
   @Inject private NewWorkspace newWorkspace;
   @Inject private DefaultTestUser defaultTestUser;
-  @Inject private ToastLoader toastLoader;
   @Inject private Workspaces workspaces;
-  @Inject private CodenvyEditor editor;
   @Inject private Dashboard dashboard;
-  @Inject private Wizard wizard;
-  @Inject private Menu menu;
-  @Inject private Ide ide;
   @Inject private TestWorkspaceProvider testWorkspaceProvider;
+  @Inject private TheiaIde theiaIde;
+  @Inject private TheiaProjectTree theiaProjectTree;
+  @Inject private TheiaProposalForm theiaProposalForm;
 
   // it is used to read workspace logs on test failure
   private TestWorkspace testWorkspace;
@@ -88,45 +75,29 @@ public class CreateWorkspaceOnDashboardTest {
     // possible to read logs in case of test failure
     testWorkspace = testWorkspaceProvider.getWorkspace(WS_NAME, defaultTestUser);
 
-    seleniumWebDriverHelper.switchToIdeFrameAndWaitAvailability();
+    // switch to the IDE and wait for workspace is ready to use
+    theiaIde.switchToIdeFrame();
+    theiaIde.waitTheiaIde();
+    theiaIde.waitLoaderInvisibility();
+    theiaIde.waitTheiaIdeTopPanel();
+    theiaProjectTree.waitFilesTab();
 
-    // wait that the workspace is started
-    ide.waitOpenedWorkspaceIsReadyToUse();
+    // wait the project explorer
+    theiaProjectTree.clickOnFilesTab();
+    theiaProjectTree.waitProjectsRootItem();
+    theiaProjectTree.waitProjectAreaOpened();
+    theiaIde.waitNotificationMessageContains("Do you want to exclude");
+    theiaIde.clickOnNotificationCloseButton();
+    theiaIde.waitNotificationPanelClosed();
 
-    // Import the "web-java-spring" project
-    menu.runCommand(WORKSPACE, CREATE_PROJECT);
-    wizard.selectProjectAndCreate(getSampleProjectName(), PROJECT_NAME);
-    notificationsPopupPanel.waitProgressPopupPanelClose();
-
-    // wait that type of the added project folder has PROJECT FOLDER status
-    projectExplorer.waitItem(PROJECT_NAME);
-    projectExplorer.waitDefinedTypeOfFolder(PROJECT_NAME, PROJECT_FOLDER);
-    projectExplorer.waitAndSelectItem(PROJECT_NAME);
-
-    // open a file in the Editor
-    projectExplorer.expandPathInProjectExplorer(PROJECT_NAME + getPathToExpand());
-    projectExplorer.openItemByPath(PROJECT_NAME + getPathJavaFile());
-    editor.waitActive();
-    editor.waitTabIsPresent(getTabName());
-
-    // stop the workspace
-    menu.runCommand(WORKSPACE, STOP_WORKSPACE);
-    toastLoader.waitExpectedTextInToastLoader("Workspace is not running");
-  }
-
-  protected String getSampleProjectName() {
-    return WEB_JAVA_SPRING;
-  }
-
-  protected String getPathToExpand() {
-    return PATH_TO_EXPAND;
-  }
-
-  protected String getPathJavaFile() {
-    return PATH_JAVA_FILE;
-  }
-
-  protected String getTabName() {
-    return "GreetingController";
+    // Import the sample "web-java-spring" project
+    theiaIde.pressKeyCombination(Keys.LEFT_CONTROL, Keys.LEFT_SHIFT, "p");
+    theiaProposalForm.waitForm();
+    theiaProposalForm.enterTextToSearchField(">clo");
+    theiaProposalForm.waitProposal("Git: Clone...");
+    theiaProposalForm.clickOnProposal("Git: Clone...");
+    theiaProposalForm.enterTextToSearchField(WEB_JAVA_SPRING_SAMPLE_URL);
+    seleniumWebDriverHelper.pressEnter();
+    theiaProjectTree.waitItem(PROJECT_NAME);
   }
 }

--- a/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheOneThreadTestsSuite.xml
@@ -37,6 +37,7 @@
             <class name="org.eclipse.che.selenium.git.PullRequestPluginTest"/>
             <class name="org.eclipse.che.selenium.git.PullRequestPluginWithForkTest"/>
             <class name="org.eclipse.che.selenium.git.PushingChangesTest"/>
+            <class name="org.eclipse.che.selenium.dashboard.ImportProjectFromGitHubTest"/>
             <class name="org.eclipse.che.selenium.factory.DirectUrlFactoryWithKeepDirectoryTest"/>
         </classes>
     </test>

--- a/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
+++ b/selenium/che-selenium-test/src/test/resources/suites/CheSuite.xml
@@ -34,6 +34,9 @@
           <class name="org.eclipse.che.selenium.languageserver.ApacheCamelFileEditingTest"/>
           <class name="org.eclipse.che.selenium.languageserver.YamlFileEditingTest"/>
           <class name="org.eclipse.che.selenium.languageserver.GolangFileEditingTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.CreateAndDeleteProjectsTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.ImportMavenProjectFromGitTest"/>
+          <class name="org.eclipse.che.selenium.dashboard.ImportProjectFromZipTest"/>
           <class name="org.eclipse.che.selenium.dashboard.CreateWorkspaceTest"/>
           <class name="org.eclipse.che.selenium.dashboard.FactoriesListTest"/>
           <class name="org.eclipse.che.selenium.dashboard.workspaces.NewWorkspacePageTest"/>
@@ -222,6 +225,7 @@
           <class name="org.eclipse.che.selenium.refactor.types.TestFailTest"/>
           <class name="org.eclipse.che.selenium.swagger.SwaggerTest"/>
           <class name="org.eclipse.che.selenium.workspaces.CheckStopStartWsTest"/>
+          <class name="org.eclipse.che.selenium.workspaces.CreateWorkspaceOnDashboardTest"/>
           <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterRefreshTest"/>
           <class name="org.eclipse.che.selenium.workspaces.ProjectStateAfterWorkspaceRestartTest"/>
           <class name="org.eclipse.che.selenium.theia.Che7PreviewStackStartTest"/>


### PR DESCRIPTION
### What does this PR do?
* Update E2E selenium tests according to the last changes on the dashboard (PR: #13469)
* Update the pageobjects according to adapted E2E selenium tests
* Update the tests suites 

### What issues does this PR fix or reference?
Related issue: https://github.com/eclipse/che/issues/13570