### PR TITLE
Fix the deployment failure with default `values.yaml`.

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -84,11 +84,13 @@ data:
 {{- if .Values.workspaceDefaultRamLimit }}
   CHE_WORKSPACE_DEFAULT_MEMORY_LIMIT_MB: {{ .Values.workspaceDefaultRamLimit }}
 {{- end }}
-{{- if .Values.che.workspace.devfileRegistryUrl }}
-  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.che.workspace.devfileRegistryUrl }}
-{{- end }}
-{{- if .Values.che.workspace.pluginRegistryUrl }}
-  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.che.workspace.pluginRegistryUrl }}
+{{- if and .Values.che .Values.che.workspace }}
+  {{- if .Values.che.workspace.devfileRegistryUrl }}
+  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.che.workspace.devfileRegistryUrl | quote}}
+  {{- end }}
+  {{- if .Values.che.workspace.pluginRegistryUrl }}
+  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.che.workspace.pluginRegistryUrl | quote}}
+  {{- end }}
 {{- end }}
 {{- if .Values.workspaceSidecarDefaultRamLimit }}
   CHE_WORKSPACE_SIDECAR_DEFAULT__MEMORY__LIMIT__MB: {{ .Values.workspaceSidecarDefaultRamLimit }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -67,7 +67,7 @@ global:
     fsGroup: 1724
   postgresDebugLogs: false
 
-#che:
+che: {}
 #  workspace:
 #    devfileRegistryUrl: "https://che-devfile-registry.openshift.io/"
 #    pluginRegistryUrl: "https://che-plugin-registry.openshift.io/v3"


### PR DESCRIPTION
This will fix eclipse/che#13558.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

- Checks if `nil` to places referencing `che.*`.
- Quotes some URL values
 
### What issues does this PR fix or reference?

Issue
- fixes #13558 

PR
- caused by #13455 
- closes #13560 (alternative)
