### PR TITLE
Backport Helm chart values fix to Che RC2

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -84,11 +84,13 @@ data:
 {{- if .Values.workspaceDefaultRamLimit }}
   CHE_WORKSPACE_DEFAULT_MEMORY_LIMIT_MB: {{ .Values.workspaceDefaultRamLimit }}
 {{- end }}
-{{- if .Values.che.workspace.devfileRegistryUrl }}
-  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.che.workspace.devfileRegistryUrl }}
-{{- end }}
-{{- if .Values.che.workspace.pluginRegistryUrl }}
-  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.che.workspace.pluginRegistryUrl }}
+{{- if and .Values.che .Values.che.workspace }}
+  {{- if .Values.che.workspace.devfileRegistryUrl }}
+  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.che.workspace.devfileRegistryUrl | quote}}
+  {{- end }}
+  {{- if .Values.che.workspace.pluginRegistryUrl }}
+  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.che.workspace.pluginRegistryUrl | quote}}
+  {{- end }}
 {{- end }}
 {{- if .Values.workspaceSidecarDefaultRamLimit }}
   CHE_WORKSPACE_SIDECAR_DEFAULT__MEMORY__LIMIT__MB: {{ .Values.workspaceSidecarDefaultRamLimit }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -67,7 +67,7 @@ global:
     fsGroup: 1724
   postgresDebugLogs: false
 
-#che:
+che: {}
 #  workspace:
 #    devfileRegistryUrl: "https://che-devfile-registry.openshift.io/"
 #    pluginRegistryUrl: "https://che-plugin-registry.openshift.io/v3"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Backports PR https://github.com/eclipse/che/pull/13598 to the RC2 branch. The RC2 version of Che still has this issue with the default values in the Helm chart. With RC2 being the latest pre-release version of Che 7, if users don't want to be using the latest/nightly version of Che, then they'll be hitting this issue with Helm.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13558

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->
