### PR TITLE
modify url to get index.json

### DIFF
--- a/dashboard/src/components/api/devfile-registry.factory.ts
+++ b/dashboard/src/components/api/devfile-registry.factory.ts
@@ -43,7 +43,7 @@ export class DevfileRegistry {
   }
 
   fetchDevfiles(location: string): ng.IPromise<Array<IDevfileMetaData>> {
-    let promise = this.$http({ 'method': 'GET', 'url': location + '/devfiles/' });
+    let promise = this.$http({ 'method': 'GET', 'url': location + '/devfiles/index.json' });
     return promise.then((result: any) => {
       return result.data;
     });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR resolves the issue #13634 .  By actually specifying the index file rather than just having it served up by a service, it means the registry can be as simple as a git repo that contains that file or as advanced as being a hosted service.  It gives more flexibiilty to users wanting to customise the location of the plugin templates


### What issues does this PR fix or reference?
#13634 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
