### PR TITLE
Updating codeowners for Che 7 endgame code reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Global Owners
-* @vparfonov
+* @vparfonov @l0rd @rhopp @nickboldt
 
 # dashboard
 dashboard/** @ashumilova @benoitf


### PR DESCRIPTION
Adding @l0rd @rhopp @nickboldt as global code reviewers as required by https://github.com/eclipse/che/issues/13637