### PR TITLE
Set default Che Theia vesrsion to 7.0.0-rc-3.0

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -642,7 +642,7 @@ che.wsagent.cors.enabled=true
 ## Factory defaults.
 # Editor and plugin which will be used for factories which are created from remote git repository
 # which doesn't contain any Che-specific workspace descriptors (like .devfile of .factory.json)
-che.factory.default_editor=eclipse/che-theia/next
+che.factory.default_editor=eclipse/che-theia/7.0.0-rc-3.0
 # multiple plugins must be comma-separated, for example:
 # pluginFooPublisher/pluginFooName/pluginFooVersion,pluginBarPublisher/pluginBarName/pluginBarVersion
 che.factory.default_plugins=eclipse/che-machine-exec-plugin/0.0.1
@@ -654,7 +654,7 @@ che.factory.default_plugins=eclipse/che-machine-exec-plugin/0.0.1
 # Default Editor that should be provisioned into Devfile if there is no specified Editor
 # Format is `editorPublisher/editorName/editorVersion` value.
 # `NULL` or absence of value means that default editor should not be provisioned.
-che.workspace.devfile.default_editor=eclipse/che-theia/next
+che.workspace.devfile.default_editor=eclipse/che-theia/7.0.0-rc-3.0
 
 # Default Plugins which should be provisioned for Default Editor.
 # All the plugins from this list that are not explicitly mentioned in the user-defined devfile


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Release preparation.
Set default Che Theia version to `7.0.0-rc-3.0`.
Will return back to `next` after release

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
