### PR TITLE
[E2E] Change export logic

### DIFF
--- a/e2e/index.ts
+++ b/e2e/index.ts
@@ -1,4 +1,5 @@
-export * from './inversify.config';
+import * as inversifyConfig from './inversify.config';
+export { inversifyConfig };
 export * from './inversify.types';
 export * from './TestConstants';
 export * from './pageobjects/login/ILoginPage';


### PR DESCRIPTION
### What does this PR do?
Name inversify.config export to make it initialised at a time of usage. This change is needed to make inversify usable as a dependency. 
