### PR TITLE
Use properties `che.api.{external,internal}` if exist.

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesCheApiExternalEnvVarProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesCheApiExternalEnvVarProvider.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -28,8 +30,14 @@ public class KubernetesCheApiExternalEnvVarProvider implements CheApiExternalEnv
   private final String cheServerEndpoint;
 
   @Inject
-  public KubernetesCheApiExternalEnvVarProvider(@Named("che.api") String cheServerEndpoint) {
-    this.cheServerEndpoint = cheServerEndpoint;
+  public KubernetesCheApiExternalEnvVarProvider(
+      @Named("che.api") String cheServerEndpoint,
+      @Named("che.api.external") String cheServerExternalEndpoint) {
+    if (isNullOrEmpty(cheServerExternalEndpoint)) {
+      this.cheServerEndpoint = cheServerEndpoint;
+    } else {
+      this.cheServerEndpoint = cheServerExternalEndpoint;
+    }
   }
 
   @Override

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesCheApiInternalEnvVarProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesCheApiInternalEnvVarProvider.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -28,8 +30,14 @@ public class KubernetesCheApiInternalEnvVarProvider implements CheApiInternalEnv
   private final String cheServerEndpoint;
 
   @Inject
-  public KubernetesCheApiInternalEnvVarProvider(@Named("che.api") String cheServerEndpoint) {
-    this.cheServerEndpoint = cheServerEndpoint;
+  public KubernetesCheApiInternalEnvVarProvider(
+      @Named("che.api") String cheServerEndpoint,
+      @Named("che.api.internal") String cheServerInternalEndpoint) {
+    if (isNullOrEmpty(cheServerInternalEndpoint)) {
+      this.cheServerEndpoint = cheServerEndpoint;
+    } else {
+      this.cheServerEndpoint = cheServerInternalEndpoint;
+    }
   }
 
   @Override


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>


### What does this PR do?

Uses properties `che.api.external` instead of `che.api`. `che.api.internal` also.

Che-Theia uses the environment variable CHE_API_INTERNAL to ~~avoid authentication issues~~ __reduce network traffic__ on the multi-user envs.
But che-host doesn't care `che.api.internal`.

### What issues does this PR fix or reference?

None.
