### PR TITLE
[keycloak] Rename environment variables.

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -36,15 +36,15 @@ spec:
             value: postgres
       containers:
       - env:
-        - name: POSTGRES_PORT_5432_TCP_ADDR
+        - name: DB_ADDR
           value: postgres
-        - name: POSTGRES_PORT_5432_TCP_PORT
+        - name: DB_PORT
           value: "5432"
-        - name: POSTGRES_DATABASE
+        - name: DB_DATABASE
           value: keycloak
-        - name: POSTGRES_USER
+        - name: DB_USER
           value: keycloak
-        - name: POSTGRES_PASSWORD
+        - name: DB_PASSWORD
           value: keycloak
         - name: KEYCLOAK_USER
           value: admin

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
             value: postgres
       containers:
       - env:
+        - name: DB_VENDOR
+          value: POSTGRES
         - name: DB_ADDR
           value: postgres
         - name: DB_PORT

--- a/deploy/openshift/templates/multi/keycloak-template.yaml
+++ b/deploy/openshift/templates/multi/keycloak-template.yaml
@@ -38,15 +38,15 @@ objects:
                 fieldPath: metadata.namespace
           - name: PROXY_ADDRESS_FORWARDING
             value: "true"
-          - name: POSTGRES_PORT_5432_TCP_ADDR
+          - name: DB_ADDR
             value: postgres
-          - name: POSTGRES_PORT_5432_TCP_PORT
+          - name: DB_PORT
             value: "5432"
-          - name: POSTGRES_DATABASE
+          - name: DB_DATABASE
             value: keycloak
-          - name: POSTGRES_USER
+          - name: DB_USER
             value: keycloak
-          - name: POSTGRES_PASSWORD
+          - name: DB_PASSWORD
             value: keycloak
           - name: KEYCLOAK_USER
             value: "${KEYCLOAK_USER}"

--- a/deploy/openshift/templates/multi/keycloak-template.yaml
+++ b/deploy/openshift/templates/multi/keycloak-template.yaml
@@ -38,6 +38,8 @@ objects:
                 fieldPath: metadata.namespace
           - name: PROXY_ADDRESS_FORWARDING
             value: "true"
+          - name: DB_VENDOR
+            value: POSTGRES
           - name: DB_ADDR
             value: postgres
           - name: DB_PORT

--- a/dockerfiles/keycloak/kc_realm_user.sh
+++ b/dockerfiles/keycloak/kc_realm_user.sh
@@ -40,10 +40,14 @@ if [ "${CHE_SELF__SIGNED__CERT}" != "" ]; then
     /opt/jboss/keycloak/bin/jboss-cli.sh --file=/scripts/cli/add_openshift_certificate.cli && rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
 fi
 
+# POSTGRES_PORT is assigned by Kubernetes controller
+# and it isn't fit to docker-entrypoin.sh.
+unset POSTGRES_PORT
+
 echo "Starting Keycloak server..."
 
-/opt/jboss/keycloak/bin/standalone.sh -Dkeycloak.migration.action=import \
-                                      -Dkeycloak.migration.provider=dir \
-                                      -Dkeycloak.migration.strategy=IGNORE_EXISTING \
-                                      -Dkeycloak.migration.dir=/scripts/ \
-                                      -Djboss.bind.address=0.0.0.0
+exec /opt/jboss/docker-entrypoint.sh -Dkeycloak.migration.action=import \
+                                     -Dkeycloak.migration.provider=dir \
+                                     -Dkeycloak.migration.strategy=IGNORE_EXISTING \
+                                     -Dkeycloak.migration.dir=/scripts/ \
+                                     -Djboss.bind.address=0.0.0.0


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

I noticed when I deployed `eclipse/che-keycloak:nightly` NOT by using Helm nor Openshift.
So this patch is not tested well. But I believe multiuser deployments will be failed without this patch.

I can't determine if this is critical or not. As this is only critical for users who want to the multiuser env.

### What does this PR do?

Renames environment variables applying to the `che-keycloak` instance.

PORTGRES_PORT_5432_TCP_ADDR to POSTGRES_ADDR .
POSTGRES_PORT_5432_TCP_PORT to POSTGRES_PORT .

### What issues does this PR fix or reference?

refs #13625