### PR TITLE
Add `securityContext.fsGroup`.

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -95,6 +95,8 @@ spec:
         - mountPath: /opt/jboss/keycloak/standalone/log
           name: keycloak-log
       restartPolicy: Always
+      securityContext:
+        fsGroup: 1000
       serviceAccountName: che-keycloak
       volumes:
       - name: keycloak-data

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -96,7 +96,12 @@ spec:
           name: keycloak-log
       restartPolicy: Always
       securityContext:
+        # `fsGroup`, `runAsGroup`, and `runAsUser` must be
+        # same values that `USER` in the container image.
         fsGroup: 1000
+        runAsGroup: 1000
+        runAsUser: 1000
+        runAsNonRoot: true
       serviceAccountName: che-keycloak
       volumes:
       - name: keycloak-data

--- a/dockerfiles/keycloak/Dockerfile
+++ b/dockerfiles/keycloak/Dockerfile
@@ -16,7 +16,7 @@ RUN ln -s /opt/jboss/tools/docker-entrypoint.sh && \
     theme-resources/resources/realm-identity-provider-openshift-v4.html theme-resources/resources/realm-identity-provider-openshift-v4-ext.html
 
 USER root
-RUN chgrp -R 0 /scripts && \
+RUN chown -R 1000:0 /scripts && \
     chmod -R g+rwX /scripts
 
-USER 1000
+USER 1000:1000


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?
 
Sets `securityContext.fsGroup` to 1000.
Since recent versions of Keycloak in `eclipse/che-keycloak` runs under user `jboss`
(uid/gid == 1000/1000), not the super user.
So Keycloak will be failed to boot up without `fsGroup`.

### What issues does this PR fix or reference?

refs #13625 
