### PR TITLE
Update the use of Machines in Che

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
@@ -77,7 +77,8 @@ public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironmen
           brokerEnvironment.getMachines().get(Names.machineName(brokerPod, container));
       if (brokerMachine == null) {
         throw new InfrastructureException(
-            String.format("Could not find appropriate place for broker container %s", container.getName()));
+            String.format(
+                "Could not find appropriate place for broker container %s", container.getName()));
       }
       workspaceEnvironment
           .getMachines()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
@@ -77,7 +77,7 @@ public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironmen
           brokerEnvironment.getMachines().get(Names.machineName(brokerPod, container));
       if (brokerMachine == null) {
         throw new InfrastructureException(
-            String.format("Could not find machine for broker container %s", container.getName()));
+            String.format("Could not find appropriate place for broker container %s", container.getName()));
       }
       workspaceEnvironment
           .getMachines()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesBrokerInitContainerApplier.java
@@ -78,7 +78,8 @@ public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironmen
       if (brokerMachine == null) {
         throw new InfrastructureException(
             String.format(
-                "Could not find appropriate place for broker container %s", container.getName()));
+                "Could not retrieve the specification of the plugin broker container %s",
+                container.getName()));
       }
       workspaceEnvironment
           .getMachines()

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServerChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServerChecker.java
@@ -119,8 +119,7 @@ public abstract class ServerChecker {
       if (isTimedOut()) {
         reportFuture.completeExceptionally(
             new InfrastructureException(
-                String.format(
-                    "Server '%s' in '%s' is not available.", serverRef, machineName)));
+                String.format("Server '%s' in '%s' is not available.", serverRef, machineName)));
       } else if (isAvailable()) {
         currentNumberOfSequentialSuccessfulPings++;
         if (currentNumberOfSequentialSuccessfulPings == successThreshold) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServerChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServerChecker.java
@@ -77,7 +77,7 @@ public abstract class ServerChecker {
   public void checkOnce(Consumer<String> readinessHandler) throws InfrastructureException {
     if (!isAvailable()) {
       throw new InfrastructureException(
-          String.format("Server '%s' in machine '%s' not available.", serverRef, machineName));
+          String.format("Server '%s' in container '%s' not available.", serverRef, machineName));
     }
     readinessHandler.accept(serverRef);
   }
@@ -119,7 +119,8 @@ public abstract class ServerChecker {
       if (isTimedOut()) {
         reportFuture.completeExceptionally(
             new InfrastructureException(
-                String.format("Server '%s' in '%s' is not available.", serverRef, machineName)));
+                String.format(
+                    "Server '%s' in container '%s' not available.", serverRef, machineName)));
       } else if (isAvailable()) {
         currentNumberOfSequentialSuccessfulPings++;
         if (currentNumberOfSequentialSuccessfulPings == successThreshold) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServerChecker.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/hc/ServerChecker.java
@@ -120,7 +120,7 @@ public abstract class ServerChecker {
         reportFuture.completeExceptionally(
             new InfrastructureException(
                 String.format(
-                    "Server '%s' in machine '%s' not available.", serverRef, machineName)));
+                    "Server '%s' in '%s' is not available.", serverRef, machineName)));
       } else if (isAvailable()) {
         currentNumberOfSequentialSuccessfulPings++;
         if (currentNumberOfSequentialSuccessfulPings == successThreshold) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
@@ -108,7 +108,7 @@ public class ServerCheckerTest {
       assertTrue(e.getCause() instanceof InfrastructureException);
       assertEquals(
           e.getCause().getMessage(),
-          format("Server '%s' in machine '%s' not available.", SERVER_REF, MACHINE_NAME));
+          format("Server '%s' in '%s' is not available.", SERVER_REF, MACHINE_NAME));
     }
   }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
@@ -108,7 +108,7 @@ public class ServerCheckerTest {
       assertTrue(e.getCause() instanceof InfrastructureException);
       assertEquals(
           e.getCause().getMessage(),
-          format("Server '%s' in '%s' is not available.", SERVER_REF, MACHINE_NAME));
+          format("Server '%s' in container '%s' not available.", SERVER_REF, MACHINE_NAME));
     }
   }
 


### PR DESCRIPTION
### What does this PR do?
As discussed here https://github.com/eclipse/che/issues/13703  Machine terminology is deprecated and should be updated. This pr replaces usage of ```machine``` word with appropriate analog in some exceptions that might be exposed to end user.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13703


#### Release Notes
n/a

#### Docs PR
n/a
