### PR TITLE
fix(helm): Keep helm labels sync with che-operator so chectl is able to deploy multiuser without errors

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -11,6 +11,8 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   labels:
+    app: che
+    component: keycloak
     io.kompose.service: keycloak
   name: keycloak
 spec:
@@ -18,6 +20,8 @@ spec:
   template:
     metadata:
       labels:
+        app: che
+        component: keycloak
         io.kompose.service: keycloak
     spec:
       initContainers:

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/keycloak-serviceaccount.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/keycloak-serviceaccount.yaml
@@ -11,5 +11,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    app: che-keycloak
+    app: che
+    component: keycloak
   name: che-keycloak

--- a/deploy/kubernetes/helm/che/custom-charts/che-postgres/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-postgres/templates/deployment.yaml
@@ -13,6 +13,8 @@ kind: Deployment
 metadata:
   creationTimestamp: null
   labels:
+    app: che
+    component: postgres
     io.kompose.service: postgres
   name: postgres
 spec:
@@ -20,6 +22,8 @@ spec:
   template:
     metadata:
       labels:
+        app: che
+        component: postgres
         io.kompose.service: postgres
     spec:
       securityContext:

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -12,6 +12,7 @@ kind: ConfigMap
 metadata:
   labels:
     app: che
+    component: che
   name: che
 data:
   CHE_HOST: {{ template "cheHost" . }}

--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -12,6 +12,7 @@ kind: Deployment
 metadata:
   labels:
     app: che
+    component: che
   name: che
 spec:
   replicas: 1
@@ -25,6 +26,7 @@ spec:
     metadata:
       labels:
         app: che
+        component: che
     spec:
       securityContext:
         fsGroup: {{ .Values.global.securityContext.fsGroup }}

--- a/deploy/kubernetes/helm/che/templates/pvc.yaml
+++ b/deploy/kubernetes/helm/che/templates/pvc.yaml
@@ -13,6 +13,7 @@ kind: PersistentVolumeClaim
 metadata:
   labels:
     app: che
+    component: che
   name: che-data-volume
 spec:
   accessModes:

--- a/deploy/kubernetes/helm/che/templates/service.yaml
+++ b/deploy/kubernetes/helm/che/templates/service.yaml
@@ -12,6 +12,7 @@ kind: Service
 metadata:
   labels:
     app: che
+    component: che
   name: che-host
 spec:
   ports:
@@ -25,3 +26,4 @@ spec:
     targetPort: 8087
   selector:
     app: che
+    component: che

--- a/deploy/kubernetes/helm/che/templates/serviceaccount.yaml
+++ b/deploy/kubernetes/helm/che/templates/serviceaccount.yaml
@@ -12,4 +12,5 @@ kind: ServiceAccount
 metadata:
   labels:
     app: che
+    component: che
   name: che


### PR DESCRIPTION
### What does this PR do?
It adds extra labels to helm templates

It is related to documentation for Remote Che as part of EndGame 7.0.0 
Else I'm not able to deploy it using chectl (and then write documentation)

```
$ chectl server:start --platform=k8s --installer=helm --domain=my-server.aws.my-ide.cloud --tls --multiuser
  ✔ ✈️  Kubernetes preflight checklist
    ✔ Verify if kubectl is installed
    ✔ Verify remote kubernetes status...done.
    ✔ Verify domain is set...set to my-serve.my-ide.cloud.
  ✔ 🏃‍  Running Helm to install Che
    ✔ Verify if helm is installed
    ✔ Create Tiller Role Binding...it already exist.
    ✔ Create Tiller Service Account...it already exist.
    ✔ Create Tiller RBAC
    ✔ Create Tiller Service...it already exist.
    ✔ Preparing Che Helm Chart...done.
    ✔ Updating Helm Chart dependencies...done.
    ✔ Deploying Che Helm Chart...done.
  ✔ ✅  Post installation checklist
    ✔ PostgreSQL pod bootstrap
      ✔ scheduling...done.
      ✔ downloading images...done.
      ✔ starting...done.
    ✔ Keycloak pod bootstrap
      ✔ scheduling...done.
      ✔ downloading images...done.
      ✔ starting...done.
    ✔ Che pod bootstrap
      ✔ scheduling...done.
      ✔ downloading images...done.
      ✔ starting...done.
    ✔ Retrieving Che Server URL...https://my-server.my-ide.cloud
    ✔ Che status check
Command server:start has completed successfully.

```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13637

Change-Id: I9456187a5fb04574c1a9e40e004156a4c45810a9
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
