### PR TITLE
Stabilize part for waiting Dashboard in WorkspaceCreationAndLsInitialization test 

### DIFF
--- a/e2e/pageobjects/dashboard/Dashboard.ts
+++ b/e2e/pageobjects/dashboard/Dashboard.ts
@@ -48,8 +48,8 @@ export class Dashboard {
         await this.workspaces.waitWorkspaceListItemAbcence(workspaceName);
     }
 
-    async openDashboard(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
-          await this.driverHelper.getDriver().navigate().to(TestConstants.TS_SELENIUM_BASE_URL + '/dashboard/');
+    async openDashboard() {
+          await this.driverHelper.getDriver().navigate().to(TestConstants.TS_SELENIUM_BASE_URL);
           this.waitPage();
 
     }

--- a/e2e/pageobjects/dashboard/Dashboard.ts
+++ b/e2e/pageobjects/dashboard/Dashboard.ts
@@ -49,8 +49,9 @@ export class Dashboard {
     }
 
     async openDashboard(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
-        await this.driverHelper.navigateTo(TestConstants.TS_SELENIUM_BASE_URL);
-        await this.waitPage(timeout);
+          await this.driverHelper.getDriver().navigate().to(TestConstants.TS_SELENIUM_BASE_URL + '/dashboard/');
+          this.waitPage();
+
     }
 
     async waitPage(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {

--- a/e2e/pageobjects/dashboard/Dashboard.ts
+++ b/e2e/pageobjects/dashboard/Dashboard.ts
@@ -50,7 +50,7 @@ export class Dashboard {
 
     async openDashboard() {
           await this.driverHelper.getDriver().navigate().to(TestConstants.TS_SELENIUM_BASE_URL);
-          this.waitPage();
+          await this.waitPage();
 
     }
 


### PR DESCRIPTION
### What does this PR do?
Improve openDashboard method in the Dashboard page object. Before the `driverHelper.navigateTo(TestConstants.TS_SELENIUM_BASE_URL);` method compare `TestConstants.TS_SELENIUM_BASE_URL` and url from dashboard. But actually this url's can be not equal. Because after consuming the `TestConstants.TS_SELENIUM_BASE_URL` dashboard add `dashboard/#/` suffix to the TS_SELENIUM_BASE_URL. The reason what the test passed earlier - looks like Webdriver could  catch Dashboar url before redirection and urls matched.
This PR fix this problem.