### PR TITLE
[E2E] Publish package

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "e2e",
+  "name": "che-e2e",
   "version": "1.0.0",
   "description": "",
   "main": "dist/index.js",
@@ -7,7 +7,8 @@
     "test": "npm run lint && npm run tsc && mocha --opts mocha.opts",
     "test-happy-path": "npm run lint && npm run tsc && mocha --opts mocha-happy-path.opts",
     "lint": "tslint --fix -p .",
-    "tsc": "tsc -p ."
+    "tsc": "tsc -p .",
+    "publish-with-tag": "./publish.sh"
   },
   "author": "Ihor Okhrimenko (iokhrime@redhat.com)",
   "license": "ISC",

--- a/e2e/pom.xml
+++ b/e2e/pom.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019-2018 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>che-parent</artifactId>
+        <groupId>org.eclipse.che</groupId>
+        <version>7.0.0-rc-4.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <groupId>org.eclipse.che.e2e</groupId>
+    <artifactId>che-e2e</artifactId>
+    <name>Che e2e tests</name>
+    <inceptionYear>2019</inceptionYear>
+    <build>
+        <finalName>e2e-war</finalName>
+        <plugins>
+            <plugin>
+                <groupId>com.mycila</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <configuration>
+                    <useDefaultExcludes>false</useDefaultExcludes>
+                    <excludes>
+                        <exclude>**/.idea/**</exclude>
+                        <exclude>**/*.styl</exclude>
+                        <exclude>**/*.html</exclude>
+                        <exclude>**/*.ico</exclude>
+                        <exclude>**/*.ttf</exclude>
+                        <exclude>**/*.eot</exclude>
+                        <exclude>**/*.css</exclude>
+                        <exclude>**/*.woff</exclude>
+                        <exclude>src/app/colors/che-output-colors.constant.ts</exclude>
+                        <exclude>src/app/proxy/proxy-settings.constant.ts</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>remove-old-resources</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <exec dir="${basedir}" executable="docker" failonerror="true">
+                                    <arg value="run" />
+                                    <arg value="-v" />
+                                    <arg value="${basedir}/:/root/:Z" />
+                                    <arg value="node:10" />
+                                    <arg value="su" />
+                                    <arg value="-c" />
+                                    <arg value="cd /root; rm -rf dist node_modules" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-build-lint</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <!-- build tests and test them for lint -->
+                                <exec dir="${basedir}" executable="docker" failonerror="true">
+                                    <arg value="run" />
+                                    <arg value="-v" />
+                                    <arg value="${basedir}/:/root/:Z" />
+                                    <arg value="node:10" />
+                                    <arg value="su" />
+                                    <arg value="-c" />
+                                    <arg value="cd /root/; npm i; npm run tsc; npm run lint" />
+                                </exec>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>publish</id>
+            <activation>
+                <property>
+                    <!-- Run this profile if environment variable NPM_AUTH_TOKEN exists -->
+                    <name>env.NPM_AUTH_TOKEN</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>push</id>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <!-- set version and tag, publish package -->
+                                        <exec dir="${basedir}" executable="bash" failonerror="true">
+                                            <arg value="docker"/>
+                                            <arg value="run" />
+                                            <arg value="-v" />
+                                            <arg value="${basedir}/:/root/:Z" />
+                                            <arg value="-e" />
+                                            <arg value="CHE_VERSION=${che.version}" />
+                                            <arg value="node:10" />
+                                            <arg value="su" />
+                                            <arg value="-c" />
+                                            <arg value="cd /root; npm run publish-with-tag; " />
+                                        </exec>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/e2e/publish.sh
+++ b/e2e/publish.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+TIME=$(date +%s)
+
+if [[ $CHE_VERSION == *SNAPSHOT ]] ; then 
+    echo "Building and pushing latest E2E package version $CHE_VERSION"
+    VERSION=${CHE_VERSION%"-SNAPSHOT"}-$TIME
+    TAG="latest"
+else 
+    echo "Building and pushing E2E package release version $CHE_VERSION"
+    VERSION=$CHE_VERSION-$TIME
+    TAG=$CHE_VERSION
+fi
+
+npm version $VERSION
+npm publish --tag $TAG 

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,7 @@
         <module>workspace-loader</module>
         <module>assembly</module>
         <module>selenium</module>
+        <module>e2e</module>
     </modules>
     <scm>
         <connection>scm:git:git@github.com:eclipse/che.git</connection>


### PR DESCRIPTION
### What does this PR do?
Publish E2E tests as npm package. Push the image nightly and with release. The package will be named `che-e2e` - if you have any other better idea, please write a comment here.
This package will be pushed nightly with version `<che-version-without-snapshot>-<timestamp>` (e.g. 7.0.0.-rc-4.0-154829582) and with tag `latest`.
Released version will be pushed with the same version as nightly, but tag will be the version (e.g. 7.0.0-rc-4.0). 

There is a command run in `clean` phase, which removes `dist` and `node_modules` if they exists. I've tried to rewrite it to use `maven-clean-plugin` but I was not successful. The problem here is that these folders are create by root in a docker. So once they're created and plugin tries to remove them, it fails not having appropriate permissions. If anyone knows how to solve that - I would be glad.

If there is an environment variable `NPM_AUTH_TOKEN` set, the build package will be pushed.
