### PR TITLE
Helm chart deploy registries

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/Chart.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/Chart.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: "v1"
+name: "che-devfile-registry"
+version: "0.0.1"
+home: "https://github.com/eclipse/che-devfile-registry/"

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/README.md
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/README.md
@@ -1,0 +1,3 @@
+# Che devfile Registry Helm Chart
+
+This Helm Chart install [Che](https://github.com/eclipse/che) devfile Registry. More information about Che devfile Registry can be found [here](https://github.com/eclipse/che-devfile-registry).

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/deployment.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/deployment.yaml
@@ -11,14 +11,16 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: che-devfile-registry
-  name: che-devfile-registry
+    app: che
+    component: devfile-registry
+  name: devfile-registry
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: che-devfile-registry
+      app: che
+      component: devfile-registry
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -27,7 +29,8 @@ spec:
   template:
     metadata:
       labels:
-        app: che-devfile-registry
+        app: che
+        component: devfile-registry
     spec:
       containers:
       - image: {{ .Values.cheDevfileRegistry.image }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/deployment.yaml
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: che-devfile-registry
+  name: che-devfile-registry
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: che-devfile-registry
+  strategy:
+    type: RollingUpdate
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+  template:
+    metadata:
+      labels:
+        app: che-devfile-registry
+    spec:
+      containers:
+      - image: {{ .Values.cheDevfileRegistry.image }}
+        imagePullPolicy: {{ .Values.cheDevfileRegistry.imagePullPolicy }}
+        name: che-devfile-registry
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /devfiles/
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /devfiles/
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.cheDevfileRegistry.memoryLimit }}
+          requests:
+            memory: {{ .Values.cheDevfileRegistry.memoryRequests }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/deployment.yaml
@@ -21,12 +21,9 @@ spec:
       app: che-devfile-registry
   strategy:
     type: RollingUpdate
-    rollingParams:
-      intervalSeconds: 1
+    rollingUpdate:
       maxSurge: 25%
       maxUnavailable: 25%
-      timeoutSeconds: 600
-      updatePeriodSeconds: 1
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
@@ -12,7 +12,7 @@ kind: Ingress
 metadata:
   name: che-devfile-registry
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.cheDevfileRegistry.ingress.class }}
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: {{ printf .Values.global.cheDevfileRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
@@ -22,9 +22,9 @@ spec:
         backend:
           serviceName: che-devfile-registry
           servicePort: 8080
-{{- if .Values.cheDevfileRegistry.ingressSecretName }}
+{{- if .Values.global.tls.enabled }}
   tls:
   - hosts:
     - {{ printf .Values.global.cheDevfileRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
-    secretName: {{ .Values.cheDevfileRegistry.ingressSecretName }}
+    secretName: {{ .Values.global.tls.secretName }}
 {{- end -}}

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
@@ -10,7 +10,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: che-devfile-registry
+  name: devfile-registry
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:
@@ -20,7 +20,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: che-devfile-registry
+          serviceName: devfile-registry
           servicePort: 8080
 {{- if .Values.global.tls.enabled }}
   tls:

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: che-devfile-registry
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.cheDevfileRegistry.ingress.class }}
+spec:
+  rules:
+  - host: {{ printf .Values.global.cheDevfileRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: che-devfile-registry
+          servicePort: 8080
+{{- if .Values.cheDevfileRegistry.ingressSecretName }}
+  tls:
+  - hosts:
+    - {{ printf .Values.global.cheDevfileRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+    secretName: {{ .Values.cheDevfileRegistry.ingressSecretName }}
+{{- end -}}

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/service.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/service.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: che-devfile-registry
+  name: che-devfile-registry
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: che-devfile-registry

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/service.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/service.yaml
@@ -11,12 +11,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: che-devfile-registry
-  name: che-devfile-registry
+    app: che
+    component: devfile-registry
+  name: devfile-registry
 spec:
   ports:
     - protocol: TCP
       port: 8080
       targetPort: 8080
   selector:
-    app: che-devfile-registry
+    app: che
+    component: devfile-registry

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
@@ -8,7 +8,7 @@
 #
 
 cheDevfileRegistry:
-  image: quay.io/openshiftio/che-devfile-registry
+  image: quay.io/eclipse/che-devfile-registry:nightly
   imagePullPolicy: Always
   memoryLimit: 32Mi
   memoryRequests: 16Mi

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
@@ -12,6 +12,3 @@ cheDevfileRegistry:
   imagePullPolicy: Always
   memoryLimit: 32Mi
   memoryRequests: 16Mi
-  #ingressSecretName: che-tls
-  ingress:
-    class: 'nginx'

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+cheDevfileRegistry:
+  image: quay.io/openshiftio/che-devfile-registry
+  imagePullPolicy: Always
+  memoryLimit: 32Mi
+  memoryRequests: 16Mi
+  #ingressSecretName: che-tls
+  ingress:
+    class: 'nginx'

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/Chart.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/Chart.yaml
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: "v1"
+name: "che-plugin-registry"
+version: "0.0.1"
+home: "https://github.com/eclipse/che-plugin-registry/"

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/README.md
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/README.md
@@ -1,0 +1,3 @@
+# Che Plugin Registry Helm Chart
+
+This Helm Chart install [Che](https://github.com/eclipse/che) Plugin Registry. More information about Che Plugin Registry can be found [here](https://github.com/eclipse/che-plugin-registry).

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
@@ -11,14 +11,16 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: che-plugin-registry
-  name: che-plugin-registry
+    app: che
+    component: plugin-registry
+  name: plugin-registry
 spec:
   replicas: 1
   revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: che-plugin-registry
+      app: che
+      component: plugin-registry
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -27,7 +29,8 @@ spec:
   template:
     metadata:
       labels:
-        app: che-plugin-registry
+        app: che
+        component: plugin-registry
     spec:
       containers:
       - image: {{ .Values.chePluginRegistry.image }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
@@ -21,12 +21,9 @@ spec:
       app: che-plugin-registry
   strategy:
     type: RollingUpdate
-    rollingParams:
-      intervalSeconds: 1
+    rollingUpdate:
       maxSurge: 25%
       maxUnavailable: 25%
-      timeoutSeconds: 600
-      updatePeriodSeconds: 1
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
@@ -1,0 +1,61 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: che-plugin-registry
+  name: che-plugin-registry
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: che-plugin-registry
+  strategy:
+    type: RollingUpdate
+    rollingParams:
+      intervalSeconds: 1
+      maxSurge: 25%
+      maxUnavailable: 25%
+      timeoutSeconds: 600
+      updatePeriodSeconds: 1
+  template:
+    metadata:
+      labels:
+        app: che-plugin-registry
+    spec:
+      containers:
+      - image: {{ .Values.chePluginRegistry.image }}
+        imagePullPolicy: {{ .Values.chePluginRegistry.imagePullPolicy }}
+        name: che-plugin-registry
+        ports:
+        - containerPort: 8080
+        livenessProbe:
+          httpGet:
+            path: /plugins/
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /plugins/
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          timeoutSeconds: 3
+        resources:
+          limits:
+            memory: {{ .Values.chePluginRegistry.memoryLimit }}
+          requests:
+            memory: {{ .Values.chePluginRegistry.memoryRequests }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         - containerPort: 8080
         livenessProbe:
           httpGet:
-            path: /plugins/
+            path: /v3/plugins/
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30
@@ -48,7 +48,7 @@ spec:
           timeoutSeconds: 3
         readinessProbe:
           httpGet:
-            path: /plugins/
+            path: /v3/plugins/
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 3

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
@@ -10,7 +10,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: che-plugin-registry
+  name: plugin-registry
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:
@@ -20,7 +20,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: che-plugin-registry
+          serviceName: plugin-registry
           servicePort: 8080
 {{- if .Values.global.tls.enabled }}
   tls:

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
@@ -12,7 +12,7 @@ kind: Ingress
 metadata:
   name: che-plugin-registry
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.chePluginRegistry.ingress.class }}
+    kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   - host: {{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
@@ -22,9 +22,9 @@ spec:
         backend:
           serviceName: che-plugin-registry
           servicePort: 8080
-{{- if .Values.chePluginRegistry.ingressSecretName }}
-    tls:
-    - hosts:
-      - {{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
-      secretName: {{ .Values.chePluginRegistry.ingressSecretName }}
+{{- if .Values.global.tls.enabled }}
+  tls:
+  - hosts:
+    - {{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+    secretName: {{ .Values.global.tls.secretName }}
 {{- end -}}

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: che-plugin-registry
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.chePluginRegistry.ingress.class }}
+spec:
+  rules:
+  - host: {{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: che-plugin-registry
+          servicePort: 8080
+{{- if .Values.chePluginRegistry.ingressSecretName }}
+    tls:
+    - hosts:
+      - {{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+      secretName: {{ .Values.chePluginRegistry.ingressSecretName }}
+{{- end -}}

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/service.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/service.yaml
@@ -11,12 +11,14 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: che-plugin-registry
-  name: che-plugin-registry
+    app: che
+    component: plugin-registry
+  name: plugin-registry
 spec:
   ports:
     - protocol: TCP
       port: 8080
       targetPort: 8080
   selector:
-    app: che-plugin-registry
+    app: che
+    component: plugin-registry

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/service.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/service.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: che-plugin-registry
+  name: che-plugin-registry
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: 8080
+  selector:
+    app: che-plugin-registry

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
@@ -12,6 +12,3 @@ chePluginRegistry:
   imagePullPolicy: Always
   memoryLimit: 32Mi
   memoryRequests: 16Mi
-  #ingressSecretName: che-tls
-  ingress:
-    class: 'nginx'

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+chePluginRegistry:
+  image: quay.io/openshiftio/che-plugin-registry
+  imagePullPolicy: Always
+  memoryLimit: 32Mi
+  memoryRequests: 16Mi
+  #ingressSecretName: che-tls
+  ingress:
+    class: 'nginx'

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
@@ -8,7 +8,7 @@
 #
 
 chePluginRegistry:
-  image: quay.io/openshiftio/che-plugin-registry
+  image: quay.io/eclipse/che-plugin-registry:nightly
   imagePullPolicy: Always
   memoryLimit: 32Mi
   memoryRequests: 16Mi

--- a/deploy/kubernetes/helm/che/requirements.yaml
+++ b/deploy/kubernetes/helm/che/requirements.yaml
@@ -8,6 +8,14 @@
 #
 
 dependencies:
+  - name: che-devfile-registry
+    repository: file://./custom-charts/che-devfile-registry/
+    version: 0.0.1
+    condition: cheDevfileRegistry.deploy
+  - name: che-plugin-registry
+    repository: file://./custom-charts/che-plugin-registry/
+    version: 0.0.1
+    condition: chePluginRegistry.deploy
   - name: che-postgres
     repository: file://./custom-charts/che-postgres/
     version: 1.0.0

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -85,13 +85,15 @@ data:
 {{- if .Values.workspaceDefaultRamLimit }}
   CHE_WORKSPACE_DEFAULT_MEMORY_LIMIT_MB: {{ .Values.workspaceDefaultRamLimit }}
 {{- end }}
-{{- if and .Values.che .Values.che.workspace }}
-  {{- if .Values.che.workspace.devfileRegistryUrl }}
-  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.che.workspace.devfileRegistryUrl | quote}}
-  {{- end }}
-  {{- if .Values.che.workspace.pluginRegistryUrl }}
-  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.che.workspace.pluginRegistryUrl | quote}}
-  {{- end }}
+{{- if .Values.cheDevfileRegistry.url }}
+  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.cheDevfileRegistry.url | quote }}
+{{- else if .Values.cheDevfileRegistry.deploy }}
+  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: http://{{ printf .Values.global.cheDevfileRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+{{- end }}
+{{- if .Values.chePluginRegistry.url }}
+  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.chePluginRegistry.url | quote }}
+{{- else if .Values.chePluginRegistry.deploy }}
+  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: http://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
 {{- end }}
 {{- if .Values.workspaceSidecarDefaultRamLimit }}
   CHE_WORKSPACE_SIDECAR_DEFAULT__MEMORY__LIMIT__MB: {{ .Values.workspaceSidecarDefaultRamLimit }}

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -88,12 +88,20 @@ data:
 {{- if .Values.che.workspace.devfileRegistryUrl }}
   CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.che.workspace.devfileRegistryUrl | quote }}
 {{- else if .Values.cheDevfileRegistry.deploy }}
+  {{- if .Values.global.tls.enabled }}
+  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: https://{{ printf .Values.global.cheDevfileRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+  {{- else }}
   CHE_WORKSPACE_DEVFILE__REGISTRY__URL: http://{{ printf .Values.global.cheDevfileRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+  {{- end }}
 {{- end }}
 {{- if .Values.che.workspace.pluginRegistryUrl }}
   CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.che.workspace.pluginRegistryUrl | quote }}
 {{- else if .Values.chePluginRegistry.deploy }}
+  {{- if .Values.global.tls.enabled }}
+  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: https://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
+  {{- else }}
   CHE_WORKSPACE_PLUGIN__REGISTRY__URL: http://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
+  {{- end }}
 {{- end }}
 {{- if .Values.workspaceSidecarDefaultRamLimit }}
   CHE_WORKSPACE_SIDECAR_DEFAULT__MEMORY__LIMIT__MB: {{ .Values.workspaceSidecarDefaultRamLimit }}

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -85,13 +85,13 @@ data:
 {{- if .Values.workspaceDefaultRamLimit }}
   CHE_WORKSPACE_DEFAULT_MEMORY_LIMIT_MB: {{ .Values.workspaceDefaultRamLimit }}
 {{- end }}
-{{- if .Values.cheDevfileRegistry.url }}
-  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.cheDevfileRegistry.url | quote }}
+{{- if .Values.che.workspace.devfileRegistryUrl }}
+  CHE_WORKSPACE_DEVFILE__REGISTRY__URL: {{ .Values.che.workspace.devfileRegistryUrl | quote }}
 {{- else if .Values.cheDevfileRegistry.deploy }}
   CHE_WORKSPACE_DEVFILE__REGISTRY__URL: http://{{ printf .Values.global.cheDevfileRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
 {{- end }}
-{{- if .Values.chePluginRegistry.url }}
-  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.chePluginRegistry.url | quote }}
+{{- if .Values.che.workspace.pluginRegistryUrl }}
+  CHE_WORKSPACE_PLUGIN__REGISTRY__URL: {{ .Values.che.workspace.pluginRegistryUrl | quote }}
 {{- else if .Values.chePluginRegistry.deploy }}
   CHE_WORKSPACE_PLUGIN__REGISTRY__URL: http://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
 {{- end }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -69,15 +69,16 @@ global:
   cheDevfileRegistryUrlFormat: "che-devfile-registry-%s.%s"
   chePluginRegistryUrlFormat: "che-plugin-registry-%s.%s"
 
-che: {}
+che:
+  workspace: {}
+#    devfileRegistryUrl: "https://che-devfile-registry.openshift.io/"
+#    pluginRegistryUrl: "https://che-plugin-registry.openshift.io/v3"
 
 cheDevfileRegistry:
   deploy: true
-  #url: "https://che-devfile-registry.openshift.io/"
 
 chePluginRegistry:
   deploy: true
-  #url: "https://che-plugin-registry.openshift.io/v3"
 
 prometheus:
   alertmanager:

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -66,8 +66,8 @@ global:
     runAsUser: 1724
     fsGroup: 1724
   postgresDebugLogs: false
-  cheDevfileRegistryUrlFormat: "che-devfile-registry-%s.%s"
-  chePluginRegistryUrlFormat: "che-plugin-registry-%s.%s"
+  cheDevfileRegistryUrlFormat: "devfile-registry-%s.%s"
+  chePluginRegistryUrlFormat: "plugin-registry-%s.%s"
 
 che:
   workspace: {}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -66,11 +66,18 @@ global:
     runAsUser: 1724
     fsGroup: 1724
   postgresDebugLogs: false
+  cheDevfileRegistryUrlFormat: "che-devfile-registry-%s.%s"
+  chePluginRegistryUrlFormat: "che-plugin-registry-%s.%s"
 
 che: {}
-#  workspace:
-#    devfileRegistryUrl: "https://che-devfile-registry.openshift.io/"
-#    pluginRegistryUrl: "https://che-plugin-registry.openshift.io/v3"
+
+cheDevfileRegistry:
+  deploy: true
+  #url: "https://che-devfile-registry.openshift.io/"
+
+chePluginRegistry:
+  deploy: true
+  #url: "https://che-plugin-registry.openshift.io/v3"
 
 prometheus:
   alertmanager:


### PR DESCRIPTION
### What does this PR do?
Helm chart to deploy devfile and plugin registries with Che by default.

- registries charts are taken from their origin repos (https://github.com/eclipse/che-devfile-registry/tree/master/deploy/kubernetes/che-devfile-registry and https://github.com/eclipse/che-plugin-registry/tree/master/kubernetes/che-plugin-registry) and bit modified
- there are new helm values which make sense to be publically set:
  - `cheDevfileRegistry.deploy` and `chePluginRegistry.deploy` default to true
  - `cheDevfileRegistry.url` and `chePluginRegistry.url` default empty. When empty, they are composed by helm to work with local deployment.
- memory limits for registries were set based on @metlos experiments
- overrides url values set in `che.properties`. Only situation when it's used is when `deploy`s are set to false and `url`s are not set.
- works with `chectl`

### What issues does this PR fix or reference?
#13633 which is subtask of #13557

#### Release Notes
n/a

#### Docs PR
n/a
