### PR TITLE
Set wildcard '*' host name if key name start from 'default-' according to the the https://github.com/eclipse/che/issues/13494#issuecomment-512761661

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
@@ -104,7 +104,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
       StringBuilder sshConfigData = new StringBuilder();
 
       for (SshPair sshPair : sshPairs) {
-        doProvisionSshKey(sshPair, k8sEnv);
+        doProvisionSshKey(sshPair, k8sEnv, identity.getWorkspaceId());
 
         sshConfigData.append(buildConfig(sshPair.getName()));
       }
@@ -116,7 +116,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
     }
   }
 
-  private void doProvisionSshKey(SshPair sshPair, KubernetesEnvironment k8sEnv) {
+  private void doProvisionSshKey(SshPair sshPair, KubernetesEnvironment k8sEnv, String wsId) {
     if (isNullOrEmpty(sshPair.getName()) || isNullOrEmpty(sshPair.getPrivateKey())) {
       return;
     }
@@ -127,7 +127,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
                 Base64.getEncoder().encodeToString(sshPair.getPrivateKey().getBytes()))
             .withType(SECRET_TYPE_SSH)
             .withNewMetadata()
-            .withName(getValidNameForSecret(sshPair.getName()))
+            .withName(wsId + "-" + getValidNameForSecret(sshPair.getName()))
             .endMetadata()
             .build();
 
@@ -136,10 +136,11 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
     k8sEnv
         .getPodsData()
         .values()
-        .forEach(p -> mountSshKeySecret(secret.getMetadata().getName(), p.getSpec()));
+        .forEach(
+            p -> mountSshKeySecret(secret.getMetadata().getName(), sshPair.getName(), p.getSpec()));
   }
 
-  private void mountSshKeySecret(String secretName, PodSpec podSpec) {
+  private void mountSshKeySecret(String secretName, String sshKeyName, PodSpec podSpec) {
     podSpec
         .getVolumes()
         .add(
@@ -155,7 +156,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
                   .withName(secretName)
                   .withNewReadOnly(false)
                   .withReadOnly(false)
-                  .withMountPath(SSH_BASE_CONFIG_PATH + secretName)
+                  .withMountPath(SSH_BASE_CONFIG_PATH + sshKeyName)
                   .build();
           container.getVolumeMounts().add(volumeMount);
         });
@@ -222,7 +223,11 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
    *
    * @param name the of key given during generate for vcs service we will consider it as host of
    *     version control service (e.g. github.com, gitlab.com and etc) if name starts from
-   *     "default-{anyString}" it will be replaced on wildcard "*" host name
+   *     "default-{anyString}" it will be replaced on wildcard "*" host name. Name with format
+   *     "default-{anyString}" will be generated on client side by Theia SSH Plugin, if user don't
+   *     provide own name. Details see here:
+   *     https://github.com/eclipse/che/issues/13494#issuecomment-512761661. Note: behavior can me
+   *     improved in 7.x releases after 7.0.0
    * @return the ssh configuration which include host and identity file location
    */
   private String buildConfig(@NotNull String name) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
@@ -224,9 +224,9 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
    * @param name the of key given during generate for vcs service we will consider it as host of
    *     version control service (e.g. github.com, gitlab.com and etc) if name starts from
    *     "default-{anyString}" it will be replaced on wildcard "*" host name. Name with format
-   *     "default-{anyString}" will be generated on client side by Theia SSH Plugin, if user don't
+   *     "default-{anyString}" will be generated on client side by Theia SSH Plugin, if user doesn't
    *     provide own name. Details see here:
-   *     https://github.com/eclipse/che/issues/13494#issuecomment-512761661. Note: behavior can me
+   *     https://github.com/eclipse/che/issues/13494#issuecomment-512761661. Note: behavior can be
    *     improved in 7.x releases after 7.0.0
    * @return the ssh configuration which include host and identity file location
    */

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
@@ -210,22 +210,28 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
    *
    * <pre>
    * host github.com
-   * HostName github.com
    * IdentityFile /etc/ssh/github-com/ssh-privatekey
    * </pre>
    *
-   * @param host the host of version control service (e.g. github.com, gitlab.com and etc)
+   * or
+   *
+   * <pre>
+   * host *
+   * IdentityFile /etc/ssh/default-123456/ssh-privatekey
+   * </pre>
+   *
+   * @param name the of key given during generate for vcs service we will consider it as host of
+   *     version control service (e.g. github.com, gitlab.com and etc) if name starts from
+   *     "default-{anyString}" it will be replaced on wildcard "*" host name
    * @return the ssh configuration which include host and identity file location
    */
-  private String buildConfig(@NotNull String host) {
+  private String buildConfig(@NotNull String name) {
+    String host = name.startsWith("default-") ? "*" : name;
     return "host "
-        + host
-        + "\n"
-        + "HostName "
         + host
         + "\nIdentityFile "
         + SSH_BASE_CONFIG_PATH
-        + getValidNameForSecret(host)
+        + getValidNameForSecret(name)
         + "/"
         + SSH_PRIVATE_KEY
         + "\n";

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -99,7 +99,7 @@ public class VcsSshKeySecretProvisionerTest {
     verify(podSpec, times(4)).getVolumes();
     verify(podSpec, times(4)).getContainers();
 
-    Secret secret = k8sEnv.getSecrets().get(keyName1);
+    Secret secret = k8sEnv.getSecrets().get("wksp-" + keyName1);
     assertNotNull(secret);
     assertEquals(secret.getType(), "kubernetes.io/ssh-auth");
 
@@ -126,5 +126,7 @@ public class VcsSshKeySecretProvisionerTest {
 
     assertTrue(sshConfig.contains("host github.com"));
     assertTrue(sshConfig.contains("IdentityFile /etc/ssh/github-com/ssh-privatekey"));
+
+    System.out.println(">>>>>>>>>>>>>  " + sshConfig);
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -126,7 +126,5 @@ public class VcsSshKeySecretProvisionerTest {
 
     assertTrue(sshConfig.contains("host github.com"));
     assertTrue(sshConfig.contains("IdentityFile /etc/ssh/github-com/ssh-privatekey"));
-
-    System.out.println(">>>>>>>>>>>>>  " + sshConfig);
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -84,17 +84,22 @@ public class VcsSshKeySecretProvisionerTest {
 
   @Test
   public void addSshKeysConfigInPod() throws Exception {
-    String keyName = UUID.randomUUID().toString();
+    String keyName1 = UUID.randomUUID().toString();
+    String keyName2 = "default-" + UUID.randomUUID().toString();
+    String keyName3 = "github.com";
     when(sshManager.getPairs(someUser, "vcs"))
         .thenReturn(
-            ImmutableList.of(new SshPairImpl(someUser, "vcs", keyName, "public", "private")));
+            ImmutableList.of(
+                new SshPairImpl(someUser, "vcs", keyName1, "public", "private"),
+                new SshPairImpl(someUser, "vcs", keyName2, "public", "private"),
+                new SshPairImpl(someUser, "vcs", keyName3, "public", "private")));
 
     vcsSshKeysProvisioner.provision(k8sEnv, runtimeIdentity);
 
-    verify(podSpec, times(2)).getVolumes();
-    verify(podSpec, times(2)).getContainers();
+    verify(podSpec, times(4)).getVolumes();
+    verify(podSpec, times(4)).getContainers();
 
-    Secret secret = k8sEnv.getSecrets().get(keyName);
+    Secret secret = k8sEnv.getSecrets().get(keyName1);
     assertNotNull(secret);
     assertEquals(secret.getType(), "kubernetes.io/ssh-auth");
 
@@ -113,8 +118,13 @@ public class VcsSshKeySecretProvisionerTest {
     assertTrue(mapData.containsKey("ssh_config"));
 
     String sshConfig = mapData.get("ssh_config");
-    assertTrue(sshConfig.contains("host " + keyName));
-    assertTrue(sshConfig.contains("HostName " + keyName));
-    assertTrue(sshConfig.contains("IdentityFile " + "/etc/ssh/" + keyName + "/ssh-privatekey"));
+    assertTrue(sshConfig.contains("host " + keyName1));
+    assertTrue(sshConfig.contains("IdentityFile " + "/etc/ssh/" + keyName1 + "/ssh-privatekey"));
+
+    assertTrue(sshConfig.contains("host *"));
+    assertTrue(sshConfig.contains("IdentityFile " + "/etc/ssh/" + keyName2 + "/ssh-privatekey"));
+
+    assertTrue(sshConfig.contains("host github.com"));
+    assertTrue(sshConfig.contains("IdentityFile /etc/ssh/github-com/ssh-privatekey"));
   }
 }


### PR DESCRIPTION

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Set wildcard '*' host name if key name start from 'default-' according to the the https://github.com/eclipse/che/issues/13494#issuecomment-512761661
Example: if generate ssh key has name 'default-12345' to the ssh_config will be added:
```
host * 
IdentityFile /etc/ssh/default-12345/ssh-privatekey
```

### What issues does this PR fix or reference?
#13494

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
