### PR TITLE
Fix project clonePath is not considered on workspace creation

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
@@ -190,21 +190,13 @@ export class CreateWorkspaceSvc {
     let projects = [];
     let noProjectsFromDevfile = true;
     projectTemplates.forEach((template: che.IProjectTemplate) => {
-      let project = {
-        name: template.name,
-        source: {
-          type: template.source.type,
-          location: template.source.location
-        }
-      };
-      
       sourceDevfile.projects.forEach((project) => {
         if (project.name === template.name) {
           noProjectsFromDevfile = false;
         }
       });
 
-      projects.push(project);
+      projects.push(template);
     });     
     
     return this.checkEditingProgress().then(() => {

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-git-project/import-git-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-git-project/import-git-project.service.ts
@@ -68,13 +68,7 @@ export class ImportGitProjectService implements IEditingProgress {
     const props = {} as che.IProjectTemplate;
     const regExpExecArray = /.*\/([^\/]+?)(?:.git)?$/i.exec(this._location);
     const name = angular.isArray(regExpExecArray) && regExpExecArray.length > 1 ? regExpExecArray[1] : 'new-project';
-    const path = '/' +  name.replace(/[^\w-_]/g, '_');
     props.name = name;
-    props.displayName = name;
-    props.description = '';
-    props.path = path;
-    props.category = '';
-
     props.source = {
       type: 'git',
       location: this._location

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/add-import-project/import-github-project/import-github-project.service.ts
@@ -346,13 +346,7 @@ export class ImportGithubProjectService implements IEditingProgress {
       const props = {} as che.IProjectTemplate;
 
       const name = repository.owner.login + '-' + repository.name;
-      const path = '/' +  name.replace(/[^\w-_]/g, '_');
       props.name = name;
-      props.displayName = name;
-      props.description = repository.description || '';
-      props.path = path;
-      props.category = '';
-
       props.source = {
         type: 'git',
         location: repository.clone_url


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes the project's clonePath parameter defined in devfile is skipped on workspace creation.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13902

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

