### PR TITLE
Store github token in session storage, remove on logout

### DIFF
--- a/dashboard/src/components/api/che-keycloak.factory.ts
+++ b/dashboard/src/components/api/che-keycloak.factory.ts
@@ -68,7 +68,8 @@ export class CheKeycloak {
   }
 
   logout(): void {
-	window.sessionStorage.setItem('oidcDashboardRedirectUrl', location.href);
+    window.sessionStorage.removeItem('githubToken');
+    window.sessionStorage.setItem('oidcDashboardRedirectUrl', location.href);
     this.keycloak.logout({});
   }
 

--- a/dashboard/src/components/github/github-service.ts
+++ b/dashboard/src/components/github/github-service.ts
@@ -124,10 +124,10 @@ export class GitHubService {
       .factory('gitHubTokenStore', function () {
         return {
           setToken: function (token: string) {
-            localStorage.setItem('gitHubToken', token); // jshint ignore:line
+            sessionStorage.githubToken = token;
           },
           getToken: function () {
-            return localStorage.getItem('gitHubToken'); // jshint ignore:line
+            return sessionStorage.githubToken;
           }
         };
       }).factory('gitHubApiUtils', ['gitHubApiUrlRoot', function (gitHubApiUrlRoot: string) {


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Avoids saving GitHub token in Local Storage, stores it in Session Storage instead + removes it on logout.
Token will be lost:
-  on logout, 
- on closing the tab/browser window. 
Token is not available on another opened tab, but on page refresh - it keeps stored.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13694
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


