### PR TITLE
Avoid using unsupported project's properties

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/project-metadata/project-metadata.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/project-metadata/project-metadata.service.ts
@@ -73,8 +73,6 @@ export class ProjectMetadataService implements IEditingProgress {
    * @return {che.IProjectTemplate}
    */
   getProjectTemplate(): che.IProjectTemplate {
-    this.projectTemplate.path = '/' +  this.projectTemplate.name.replace(/[^\w-_]/g, '_');
-
     return this.projectTemplate;
   }
 

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/project-source-selector.service.ts
@@ -92,7 +92,6 @@ export class ProjectSourceSelectorService {
       // update name and path
       const newName = this.getUniqueName(origName);
       projectTemplate.name = newName;
-      projectTemplate.path = '/' +  newName.replace(/[^\w-_]/g, '_');
     }
 
     this.projectTemplates.push(projectTemplate);

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.controller.ts
@@ -170,12 +170,10 @@ export class WorkspaceDetailsProjectsCtrl {
 
     projectTemplates.forEach((projectTemplate: che.IProjectTemplate) => {
       const origName = projectTemplate.name;
-
       if (this.isProjectNameUnique(origName) === false) {
         // update name, displayName and path
         const newName = this.getUniqueName(origName);
         projectTemplate.name = newName;
-        projectTemplate.path = '/' +  newName.replace(/[^\w-_]/g, '_');
       }
 
       if (!projectTemplate.type && projectTemplate.projectType) {

--- a/dashboard/src/components/api/workspace/workspace-data-manager.ts
+++ b/dashboard/src/components/api/workspace/workspace-data-manager.ts
@@ -124,7 +124,7 @@ export class WorkspaceDataManager {
       workspace.config.projects.push(projectTemplate);
     } else if (workspace.devfile) {
       let project = {
-        name: projectTemplate.displayName,
+        name: projectTemplate.name,
         source: {
           type: projectTemplate.source.type,
           location: projectTemplate.source.location

--- a/dashboard/src/components/github/github-service.ts
+++ b/dashboard/src/components/github/github-service.ts
@@ -124,10 +124,10 @@ export class GitHubService {
       .factory('gitHubTokenStore', function () {
         return {
           setToken: function (token: string) {
-            sessionStorage.githubToken = token;
+            sessionStorage.setItem('githubToken', token);
           },
           getToken: function () {
-            return sessionStorage.githubToken;
+            return sessionStorage.getItem('githubToken');
           }
         };
       }).factory('gitHubApiUtils', ['gitHubApiUrlRoot', function (gitHubApiUrlRoot: string) {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
- Avoid using unsupported "path" and "displayName" properties in projects
- Cleanups the console output from error: "Property 'githubToken' does not exist on type 'Storage'." 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13991

