### PR TITLE
Allow multiple devfile registries to be specified

### DIFF
--- a/dashboard/src/components/api/devfile-registry.factory.ts
+++ b/dashboard/src/components/api/devfile-registry.factory.ts
@@ -17,6 +17,7 @@ export interface IDevfileMetaData {
   globalMemoryLimit: string;
   icon: string;
   links: any;
+  location: string;
 }
 
 


### PR DESCRIPTION
### What does this PR do?
This PR allows multiple devfile registries to be specified as a space separated list, for example in values.yml we can have:-
che: 
  workspace: 
    devfileRegistryUrl: "https://che-devfile-registry.openshift.io/ https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/"

The registry location is then stored so that the devfile can be read from the correct location.

### What issues does this PR fix or reference?

Fixes https://github.com/eclipse/che/issues/13961

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
