### PR TITLE
Fix empty warning on workspace details page

### DIFF
--- a/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/warnings/workspace-warnings.controller.ts
@@ -32,7 +32,7 @@ export class WorkspaceWarningsController {
   constructor() {
     this.warnings = [];
 
-    if (this.workspace && this.workspace.runtime) {
+    if (this.workspace && this.workspace.runtime && this.workspace.runtime.warnings) {
       this.warnings = this.warnings.concat(this.workspace.runtime.warnings);
     }
   }


### PR DESCRIPTION
Signed-off-by: Anna Shumilova <ashumilo@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When warnings are missing or null - avoids return the array of one undefined element.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13673


