### PR TITLE
compose plugin id

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ChePlugin.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ChePlugin.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.api.workspace.server.wsplugins.model;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
@@ -53,13 +51,7 @@ public class ChePlugin {
   }
 
   public String getId() {
-    if (!isNullOrEmpty(id)) {
-      return id;
-    } else if (!isNullOrEmpty(publisher) && !isNullOrEmpty(name) && !isNullOrEmpty(version)) {
-      return publisher + "/" + name + "/" + version;
-    } else {
-      return null;
-    }
+    return id;
   }
 
   public void setId(String id) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ChePlugin.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ChePlugin.java
@@ -56,7 +56,7 @@ public class ChePlugin {
     if (!isNullOrEmpty(id)) {
       return id;
     } else if (!isNullOrEmpty(publisher) && !isNullOrEmpty(name) && !isNullOrEmpty(version)) {
-      return String.format("%s/%s/%s", publisher, name, version);
+      return publisher + "/" + name + "/" + version;
     } else {
       return null;
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ChePlugin.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ChePlugin.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.api.workspace.server.wsplugins.model;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
@@ -51,7 +53,13 @@ public class ChePlugin {
   }
 
   public String getId() {
-    return id;
+    if (!isNullOrEmpty(id)) {
+      return id;
+    } else if (!isNullOrEmpty(publisher) && !isNullOrEmpty(name) && !isNullOrEmpty(version)) {
+      return String.format("%s/%s/%s", publisher, name, version);
+    } else {
+      return null;
+    }
   }
 
   public void setId(String id) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ExtendedPluginFQN.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ExtendedPluginFQN.java
@@ -34,13 +34,12 @@ public class ExtendedPluginFQN extends PluginFQN {
     this.version = version;
   }
 
-  /** In this constructor, {@link PluginFQN#id} is composed from given params */
+  /** In this constructor, id is composed from given params */
   public ExtendedPluginFQN(String reference, String publisher, String name, String version) {
-    super(reference);
+    super(reference, publisher + "/" + name + "/" + version);
     this.publisher = publisher;
     this.name = name;
     this.version = version;
-    this.id = publisher + "/" + name + "/" + version;
   }
 
   public ExtendedPluginFQN(String reference) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ExtendedPluginFQN.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ExtendedPluginFQN.java
@@ -39,7 +39,7 @@ public class ExtendedPluginFQN extends PluginFQN {
     this.publisher = publisher;
     this.name = name;
     this.version = version;
-    this.id = String.format("%s/%s/%s", publisher, name, version);
+    this.id = publisher + "/" + name + "/" + version;
   }
 
   public ExtendedPluginFQN(String reference) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ExtendedPluginFQN.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ExtendedPluginFQN.java
@@ -39,6 +39,7 @@ public class ExtendedPluginFQN extends PluginFQN {
     this.publisher = publisher;
     this.name = name;
     this.version = version;
+    this.id = String.format("%s/%s/%s", publisher, name, version);
   }
 
   public ExtendedPluginFQN(String reference) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ExtendedPluginFQN.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/ExtendedPluginFQN.java
@@ -34,6 +34,7 @@ public class ExtendedPluginFQN extends PluginFQN {
     this.version = version;
   }
 
+  /** In this constructor, {@link PluginFQN#id} is composed from given params */
   public ExtendedPluginFQN(String reference, String publisher, String name, String version) {
     super(reference);
     this.publisher = publisher;

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginFQN.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginFQN.java
@@ -18,7 +18,8 @@ import java.util.Objects;
 
 /**
  * Represents full information about plugin, including registry address and id, or direct reference
- * to plugin descriptor. Should NOT contain both reference and id simultaneously.
+ * to plugin descriptor. When {@link PluginFQN#reference} and {@link PluginFQN#id} are set
+ * simultaneously, {@link PluginFQN#reference} should take precedence.
  *
  * @author Max Shaposhnyk
  */
@@ -26,11 +27,16 @@ import java.util.Objects;
 public class PluginFQN {
 
   private URI registry;
-  protected String id;
+  private String id;
   private String reference;
 
   public PluginFQN(URI registry, String id) {
     this.registry = registry;
+    this.id = id;
+  }
+
+  protected PluginFQN(String reference, String id) {
+    this.reference = reference;
     this.id = id;
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginFQN.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/model/PluginFQN.java
@@ -26,7 +26,7 @@ import java.util.Objects;
 public class PluginFQN {
 
   private URI registry;
-  private String id;
+  protected String id;
   private String reference;
 
   public PluginFQN(URI registry, String id) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/wsplugins/PluginFQNParserTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/wsplugins/PluginFQNParserTest.java
@@ -61,6 +61,13 @@ public class PluginFQNParserTest {
         "PluginFQNParser should return empty list when attributes does not contain plugins or editors");
   }
 
+  @Test
+  public void shouldComposeIdWhenAllPartsGivenToTheConstructor() {
+    ExtendedPluginFQN pluginFQN =
+        new ExtendedPluginFQN("reference", "publisher", "name", "version");
+    assertEquals(pluginFQN.getId(), "publisher/name/version");
+  }
+
   @Test(dataProvider = "validAttributesProvider")
   public void shouldParseAllPluginsAndEditor(AttributeParsingTestCase testCase) throws Exception {
     Collection<PluginFQN> actual = parser.parsePlugins(testCase.attributes);


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

### What does this PR do?
Compose plugin id in `ExtendedPluginFQN` and `ChePlugin` when all parts are known. First caused NPE, second that task was not properly configured to one particular component, but was present in all components.

### What issues does this PR fix or reference?
#13842 

### How to test
<details>
<summary>here's simple devfile</summary>

```
---
apiVersion: 1.0.0
metadata:
  name: task-in-theia-test
components:
  -
    type: dockerimage
    alias: golang
    image: quay.io/eclipse/che-golang-1.10:nightly
    memoryLimit: 64Mi
  - 
    alias: theia-editor
    reference: >-
      https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/eclipse/che-theia/7.0.0-next/meta.yaml
    type: cheEditor
commands:
  -
    name: golang task
    actions:
      -
        type: exec
        component: golang
        command: "echo hello from golang component && ls /"
  -
    name: theia task
    actions:
      -
        type: exec
        component: theia-editor
        command: "echo hello from theia component && ls /"
```
</details>

che-server image with PR changes `quay.io/mvala/che-server:npefix`