### PR TITLE
Use v0.19 minor version of plugin broker image instead of bugfix

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -570,8 +570,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.19.0
-che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.19.0
+che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.19
+che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.19
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
### What does this PR do?
Use v0.19 minor version of plugin broker image instead of bugfix.

v0.19 contains needed fix for self-signed certificates https://github.com/eclipse/che-plugin-broker/pull/67

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14087

#### Release Notes
N/A

#### Docs PR
N/A