### PR TITLE
[TS_SELENIUM] Implement workaround for avoiding the "#13427" ("Java LS "Classpath is incomplete" warning when loading petclinic")

### DIFF
--- a/e2e/files/happy-path/petclinic-classpath.txt
+++ b/e2e/files/happy-path/petclinic-classpath.txt
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -23,6 +23,7 @@ import { By, Key, error } from 'selenium-webdriver';
 import { Terminal } from '../../pageobjects/ide/Terminal';
 import { DebugView } from '../../pageobjects/ide/DebugView';
 import { WarningDialog } from '../../pageobjects/ide/WarningDialog';
+import * as fs from 'fs';
 
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
@@ -42,6 +43,7 @@ const workspaceName: string = TestConstants.TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAM
 const workspaceUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/dashboard/#/ide/${namespace}/${workspaceName}`;
 const pathToJavaFolder: string = `${projectName}/src/main/java/org/springframework/samples/petclinic`;
 const pathToChangedJavaFileFolder: string = `${projectName}/src/main/java/org/springframework/samples/petclinic/system`;
+const classPathFilename: string = '.classpath';
 const javaFileName: string = 'PetClinicApplication.java';
 const changedJavaFileName: string = 'CrashController.java';
 const textForErrorMessageChange: string = 'HHHHHHHHHHHHH';
@@ -252,13 +254,6 @@ suite('Validation of debug functionality', async () => {
     });
 });
 
-async function checkJavaPathCompletion() {
-    if (await ide.isNotificationPresent('Classpath is incomplete. Only syntax errors will be reported')) {
-        throw new Error('Known issue: https://github.com/eclipse/che/issues/13427 \n' +
-            '\"Java LS \"Classpath is incomplete\" warning when loading petclinic\"');
-    }
-}
-
 async function runTask(task: string) {
     await topMenu.selectOption('Terminal', 'Run Task...');
     try {
@@ -273,4 +268,29 @@ async function runTask(task: string) {
     }
 
     await quickOpenContainer.clickOnContainerItem(task);
+}
+
+async function checkJavaPathCompletion() {
+    if (await ide.isNotificationPresent('Classpath is incomplete. Only syntax errors will be reported')) {
+        const classpathText: string = fs.readFileSync('./files/happy-path/petclinic-classpath.txt', 'utf8');
+        const workaroundReportText: string = '\n############################## \n\n' +
+            'Known issue: https://github.com/eclipse/che/issues/13427 \n' +
+            '\"Java LS \"Classpath is incomplete\" warning when loading petclinic\" \n' +
+            '\".classpath\" will be configured with next settings: \n\n' +
+            classpathText + '\n' +
+            '############################## \n';
+
+        console.log(workaroundReportText);
+
+        await projectTree.expandPathAndOpenFile(projectName, classPathFilename);
+        await editor.waitEditorAvailable(classPathFilename);
+
+        await editor.type(classPathFilename, Key.chord(Key.CONTROL, 'a'), 1);
+        await editor.performKeyCombination(classPathFilename, Key.DELETE);
+
+        await editor.type(classPathFilename, classpathText, 1);
+        await editor.performKeyCombination(classPathFilename, Key.chord(Key.CONTROL, 's'));
+        await editor.waitTabWithSavedStatus(classPathFilename);
+    }
+
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Implement workaround for avoiding the "#13427" ("Java LS "Classpath is incomplete" warning when loading petclinic")

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/14104
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
