### PR TITLE
E2E: Change waiting timeout to increase reliability test

### DIFF
--- a/e2e/TestConstants.ts
+++ b/e2e/TestConstants.ts
@@ -30,9 +30,9 @@ export const TestConstants = {
     TS_SELENIUM_RESOLUTION_HEIGHT: Number(process.env.TS_SELENIUM_RESOLUTION_HEIGHT) || 1080,
 
     /**
-     * Timeout in milliseconds waiting for install Eclipse Che by OperatorHub UI, "480 000" by default.
+     * Timeout in milliseconds waiting for install Eclipse Che by OperatorHub UI, "600 000" by default.
      */
-    TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 480000,
+    TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 600000,
 
     /**
      * Timeout in milliseconds waiting for workspace start, "240 000" by default.

--- a/e2e/pageobjects/openshift/OcpWebConsolePage.ts
+++ b/e2e/pageobjects/openshift/OcpWebConsolePage.ts
@@ -45,7 +45,7 @@ export class OcpWebConsolePage {
 
     async clickOnEclipseCheOperatorIcon () {
         const catalogEclipseCheOperatorTitleLocator: By = By.css('a[data-test^=eclipse-che-preview-openshift]');
-        await this.driverHelper.waitAndClick(catalogEclipseCheOperatorTitleLocator);
+        await this.driverHelper.waitAndClick(catalogEclipseCheOperatorTitleLocator, TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
     async clickOnInstallEclipseCheButton () {
         const installEclipsCheOperatorButtonLocator: By = By.xpath('//button[text()=\'Install\']');


### PR DESCRIPTION
### What does this PR do?
* Change timeout waiting to increase reliability the  _InstallCheByOperatorHub.spec.ts_ test
* A several times launched ci-job (https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/Eclipse-Che7-install-by-operatorhub/) demonstrates that current timeout is not enough:

*job-build 27*
![jenkins-rhev-ci-vms-eng-rdu2-redhat-job-Eclipse-Che7-install-by-operatorhub-27-artifact-e2e-report](https://user-images.githubusercontent.com/5408906/62373967-99d7be00-b543-11e9-88a8-57b0e7b10fd8.png)

*job-build 32*
![job-Eclipse-Che7-install-by-operatorhub-32-artifact-e2e-report-E2E_Check_the_Eclipse_Che_is_ready_Wait_Keycloak_Admin_Console_URL](https://user-images.githubusercontent.com/5408906/62374256-3dc16980-b544-11e9-9048-105658f48e4c.png)



### What issues does this PR fix or reference?
#13929