### PR TITLE
[E2E] Add export for all classes so we can reuse them on RH-Che side.

### DIFF
--- a/e2e/index.ts
+++ b/e2e/index.ts
@@ -2,14 +2,45 @@ import * as inversifyConfig from './inversify.config';
 export { inversifyConfig };
 export * from './inversify.types';
 export * from './TestConstants';
-export * from './pageobjects/login/ICheLoginPage';
+
+// driver
 export * from './driver/IDriver';
-export * from './utils/DriverHelper';
+export * from './driver/ChromeDriver';
+
+// pageobjects - dashboard
 export * from './pageobjects/dashboard/Dashboard';
-export * from './utils/NameGenerator';
 export * from './pageobjects/dashboard/NewWorkspace';
+export * from './pageobjects/dashboard/Workspaces';
+
+// pageobjects - dashboard - worksapce details
+export * from './pageobjects/dashboard/workspace-details/WorkspaceDetails';
 export * from './pageobjects/dashboard/workspace-details/WorkspaceDetailsPlugins';
-export * from './pageobjects/ide/Ide';
-export * from './pageobjects/ide/ProjectTree';
+
+// pageobjects - login
+export * from './pageobjects/login/ICheLoginPage';
+export * from './pageobjects/login/IOcpLoginPage';
+export * from './pageobjects/login/MultiUserLoginPage';
+export * from './pageobjects/login/OcpLoginByTempAdmin';
+export * from './pageobjects/login/SingleUserLoginPage';
+
+// pageobjects - ide
+export * from './pageobjects/ide/DebugView';
 export * from './pageobjects/ide/Editor';
+export * from './pageobjects/ide/GitHubPlugin';
+export * from './pageobjects/ide/Ide';
+export * from './pageobjects/ide/PreviewWidget';
+export * from './pageobjects/ide/ProjectTree';
+export * from './pageobjects/ide/QuickOpenContainer';
+export * from './pageobjects/ide/RightToolbar';
+export * from './pageobjects/ide/Terminal';
+export * from './pageobjects/ide/TopMenu';
+export * from './pageobjects/ide/WarningDialog';
+
+// pageobjects - openshift
+export * from './pageobjects/openshift/OcpLoginPage';
+export * from './pageobjects/openshift/OcpWebConsolePage';
+
+// utils
+export * from './utils/DriverHelper';
+export * from './utils/NameGenerator';
 export * from './utils/workspace/TestWorkspaceUtil';


### PR DESCRIPTION
### What does this PR do?
Add all important classes to export, so they can be reused e.g. by RH-Che.

### What issues does this PR fix or reference?
Issue: https://github.com/redhat-developer/rh-che/issues/1536