### PR TITLE
increase registries memory limit to 256Mi in helm charts

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
@@ -10,5 +10,5 @@
 cheDevfileRegistry:
   image: quay.io/eclipse/che-devfile-registry:nightly
   imagePullPolicy: Always
-  memoryLimit: 32Mi
+  memoryLimit: 256Mi
   memoryRequests: 16Mi

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
@@ -10,5 +10,5 @@
 chePluginRegistry:
   image: quay.io/eclipse/che-plugin-registry:nightly
   imagePullPolicy: Always
-  memoryLimit: 32Mi
+  memoryLimit: 256Mi
   memoryRequests: 16Mi


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

### What does this PR do?
Increase memory limit in helm charts for registries to 256Mi. This is to keep it consistent with Openshift operator (#14093).

### What issues does this PR fix or reference?
#14100 
