### PR TITLE
Fix mount path for case with '.' in host name

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
@@ -120,6 +120,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
     if (isNullOrEmpty(sshPair.getName()) || isNullOrEmpty(sshPair.getPrivateKey())) {
       return;
     }
+    String validNameForSecret = getValidNameForSecret(sshPair.getName());
     Secret secret =
         new SecretBuilder()
             .addToData(
@@ -127,7 +128,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
                 Base64.getEncoder().encodeToString(sshPair.getPrivateKey().getBytes()))
             .withType(SECRET_TYPE_SSH)
             .withNewMetadata()
-            .withName(wsId + "-" + getValidNameForSecret(sshPair.getName()))
+            .withName(wsId + "-" + validNameForSecret)
             .endMetadata()
             .build();
 
@@ -137,7 +138,8 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
         .getPodsData()
         .values()
         .forEach(
-            p -> mountSshKeySecret(secret.getMetadata().getName(), sshPair.getName(), p.getSpec()));
+            p ->
+                mountSshKeySecret(secret.getMetadata().getName(), validNameForSecret, p.getSpec()));
   }
 
   private void mountSshKeySecret(String secretName, String sshKeyName, PodSpec podSpec) {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -106,7 +106,7 @@ public class VcsSshKeySecretProvisionerTest {
     String key = secret.getData().get("ssh-privatekey");
     assertNotNull(key);
 
-    //check if key nave valid name '.' replaced to the '-'
+    // check if key nave valid name '.' replaced to the '-'
     Secret secret3 = k8sEnv.getSecrets().get("wksp-" + keyName3.replace('.', '-'));
     assertNotNull(secret3);
     assertEquals(secret3.getType(), "kubernetes.io/ssh-auth");

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -106,6 +106,11 @@ public class VcsSshKeySecretProvisionerTest {
     String key = secret.getData().get("ssh-privatekey");
     assertNotNull(key);
 
+    //check if key nave valid name '.' replaced to the '-'
+    Secret secret3 = k8sEnv.getSecrets().get("wksp-" + keyName3.replace('.', '-'));
+    assertNotNull(secret3);
+    assertEquals(secret3.getType(), "kubernetes.io/ssh-auth");
+
     Map<String, ConfigMap> configMaps = k8sEnv.getConfigMaps();
     assertNotNull(configMaps);
     assertTrue(configMaps.containsKey("wksp-sshconfigmap"));


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>


### What does this PR do?
Fix mount path for case with '.' in host name
`ssh -t -v git@github.com`
![che#14151_1](https://user-images.githubusercontent.com/1636592/62706720-c767b000-b9f8-11e9-8275-959e8a4ab688.png)

`ls /etc/ssh`
![che#14151_2](https://user-images.githubusercontent.com/1636592/62706721-c767b000-b9f8-11e9-8dc4-9298fb599c60.png)

`cat /etc/ssh/ssh_config`
![che#14151_3](https://user-images.githubusercontent.com/1636592/62706723-c767b000-b9f8-11e9-8a3c-71fcb8c3a056.png)



### What issues does this PR fix or reference?
#14151 

