### PR TITLE
Use different secrets for TLS and self-signed-cert

### DIFF
--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -80,8 +80,8 @@ spec:
         - name: CHE_SELF__SIGNED__CERT
           valueFrom:
             secretKeyRef:
-              key: tls.crt
-              name: {{ .Values.global.tls.secretName  }}
+              key: ca.crt
+              name: {{ .Values.global.tls.selfSignedCertSecretName }}
               optional: false
         {{- end }}
 

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -46,8 +46,9 @@ global:
     secretName: che-tls
 
     ## If self-signed certificate is enabled
-    ## then certificate from `tls.secretName` will be propagated to Che components' trust stores
+    ## then certificate from `tls.selfSignedCertSecretName` will be propagated to Che components' trust stores
     useSelfSignedCerts: false
+    selfSignedCertSecretName: self-signed-cert
 
   gitHubClientID: ""
   gitHubClientSecret: ""


### PR DESCRIPTION
### What does this PR do?
It's like a best practice to generate CA certificate, propagate it to clients to configure their trust stores.
And generate another non-CA certificate based on CA for establishing https connection.
See https://wiki.mozilla.org/SecurityEngineering/x509Certs
https://gist.github.com/fntlnz/cf14feb5a46b2eda428e000157447309
So, this PR adds an ability to configure TLS cert for ingresses and CA cert for trust stores separately.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14035

#### Release Notes
N/A

#### Docs PR
N/A