### PR TITLE
Fix commands to download latest release version of chectl in E2E happy path tests PR job

### DIFF
--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -38,7 +38,8 @@ pipeline {
                     steps {
                         script {
                             sh """
-                              wget --no-verbose https://github.com/che-incubator/chectl/releases/latest/download/chectl-linux \\
+                               # wget --no-verbose https://github.com/che-incubator/chectl/releases/latest/download/chectl-linux
+                               wget --no-verbose https://github.com/che-incubator/chectl/releases/download/20190802065601/chectl-linux
                                 -O ${WORKSPACE}/chectl
 
                               sudo chmod +x ${WORKSPACE}/chectl

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -37,8 +37,11 @@ pipeline {
                 stage("Download chectl") {
                     steps {
                         script {
+                            // TO-DO use option "--install-path" https://github.com/eclipse/che/pull/14182
                             sh """
-                               sudo bash <(curl -sL  https://www.eclipse.org/che/chectl/) --channel=stable
+                               curl -sL  https://www.eclipse.org/che/chectl/ > install_chectl.sh
+                               chmod +x install_chectl.sh
+                               sudo PATH=$PATH ./install_chectl.sh -channel=stable
                                sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
                                sudo chmod +x ${WORKSPACE}/chectl
                             """

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -38,11 +38,9 @@ pipeline {
                     steps {
                         script {
                             sh """
-                               # wget --no-verbose https://github.com/che-incubator/chectl/releases/latest/download/chectl-linux
-                               wget --no-verbose https://github.com/che-incubator/chectl/releases/download/20190802065601/chectl-linux
-                                -O ${WORKSPACE}/chectl
-
-                              sudo chmod +x ${WORKSPACE}/chectl
+                               sudo bash <(curl -sL  https://www.eclipse.org/che/chectl/) --channel=stable
+                               sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
+                               sudo chmod +x ${WORKSPACE}/chectl
                             """
                         }
                     }
@@ -147,7 +145,7 @@ pipeline {
         stage("Run E2E Happy path tests") {
             steps {
                 script {
-                    // TODO switch to eclipse/che-e2e image
+                    // TO-DO (#14171) switch to eclipse/che-e2e image
 //                    sh """
 //                         CHE_HOST=\$(kubectl get ingress che-ingress -n=che -o=jsonpath={'.spec.rules[0].host'})
 //                         CHE_URL=http://\${CHE_HOST}


### PR DESCRIPTION
### What does this PR do?
It switches **Jenkinsfile** of E2E Happy path tests to use chectl of 20190802065601 version while there is no **chectl-linux** binary of latest release:
```
+ wget --no-verbose https://github.com/che-incubator/chectl/releases/latest/download/chectl-linux -O /home/codenvy/workspace/Single-Che-PR-check-E2E-Happy-path-tests-against-k8s-on-codenvy-slave9/chectl

https://github.com/che-incubator/chectl/releases/download/20190809114555/chectl-linux:
ERROR 404: Not Found.
```