### PR TITLE
[Happy Path] Sometimes the "Happy Path" test fails on "ProjectTree.expandPathAndOpenFile" step

### DIFF
--- a/e2e/pageobjects/ide/ProjectTree.ts
+++ b/e2e/pageobjects/ide/ProjectTree.ts
@@ -87,15 +87,26 @@ export class ProjectTree {
         const expandIconLocator: By = By.css(this.getExpandIconCssLocator(itemPath));
         const treeItemLocator: By = By.css(this.getTreeItemCssLocator(itemPath));
 
+        await this.driverHelper.getDriver().wait(async () => {
+            const classAttributeValue: string = await this.driverHelper.waitAndGetElementAttribute(expandIconLocator, 'class', timeout);
+            const isItemCollapsed: boolean = classAttributeValue.search('theia-mod-collapsed') > 0;
 
-        const classAttributeValue: string = await this.driverHelper.waitAndGetElementAttribute(expandIconLocator, 'class', timeout);
-        const isItemCollapsed: boolean = classAttributeValue.search('theia-mod-collapsed') > 0;
+            if (isItemCollapsed) {
+                await this.driverHelper.waitAndClick(treeItemLocator, timeout);
+            }
 
-        if (isItemCollapsed) {
-            await this.driverHelper.waitAndClick(treeItemLocator, timeout);
-        }
+            try {
+                await this.waitItemExpanded(itemPath, TestConstants.TS_SELENIUM_DEFAULT_POLLING);
+                return true;
+            } catch (err) {
+                if (!(err instanceof error.TimeoutError)) {
+                    throw err('Unexpected error during project tree expanding');
+                }
 
-        await this.waitItemExpanded(itemPath, timeout);
+                console.log(`The '${itemPath}' item has not been expanded, try again`);
+                await this.driverHelper.wait(TestConstants.TS_SELENIUM_DEFAULT_POLLING);
+            }
+        }, timeout);
     }
 
     async collapseItem(itemPath: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix problem with expanding project tree instability

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/14197
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
