### PR TITLE
Make code & test independent from environment and time of execution

### DIFF
--- a/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/FileStoresMeterBinder.java
+++ b/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/FileStoresMeterBinder.java
@@ -33,7 +33,11 @@ public class FileStoresMeterBinder implements MeterBinder {
   @Override
   public void bindTo(MeterRegistry registry) {
     for (FileStore fileStore : FileSystems.getDefault().getFileStores()) {
-      LOG.debug("Add gauge metric for {}", fileStore.name());
+      LOG.debug(
+          "Add gauge metric for {}, isReadOnly {}, type {}",
+          fileStore.name(),
+          fileStore.isReadOnly(),
+          fileStore.type());
       Iterable<Tag> tagsWithPath = Tags.concat(Tags.empty(), "path", fileStore.toString());
 
       Gauge.builder("disk.free", fileStore, exceptionToNonWrapper(FileStore::getUnallocatedSpace))

--- a/core/che-core-metrics-core/src/test/java/org/eclipse/che/core/metrics/FileStoresMeterTest.java
+++ b/core/che-core-metrics-core/src/test/java/org/eclipse/che/core/metrics/FileStoresMeterTest.java
@@ -16,39 +16,21 @@ import static org.testng.Assert.*;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.nio.file.FileStore;
-import java.nio.file.FileSystems;
 import java.util.Collection;
-import java.util.Iterator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
 public class FileStoresMeterTest {
-
-  private static final Logger LOG = LoggerFactory.getLogger(FileStoresMeterTest.class);
 
   @Test
   public void shouldBindFileStores() {
     MeterRegistry registry = new SimpleMeterRegistry();
 
     new FileStoresMeterBinder().bindTo(registry);
-    Collection<Gauge> dd = registry.get("disk.free").gauges();
+    Collection<Gauge> df = registry.get("disk.free").gauges();
 
-    assertNotNull(dd);
-    assertEquals(dd.size(), getSize());
-    assertTrue(registry.get("disk.free").gauge().value() >= 0);
-    assertTrue(registry.get("disk.total").gauge().value() >= 0);
-    assertTrue(registry.get("disk.usable").gauge().value() >= 0);
-  }
-
-  private int getSize() {
-    int i = 0;
-    Iterator<FileStore> it = FileSystems.getDefault().getFileStores().iterator();
-    while (it.hasNext()) {
-      LOG.debug("Found {} meter ", it.next().name());
-      i++;
-    }
-    return i;
+    assertNotNull(df);
+    assertTrue(df.size() > 0);
+    assertEquals(df.size(), registry.get("disk.total").gauges().size());
+    assertEquals(df.size(), registry.get("disk.usable").gauges().size());
   }
 }

--- a/core/che-core-metrics-core/src/test/resources/logback-test.xml
+++ b/core/che-core-metrics-core/src/test/resources/logback-test.xml
@@ -19,7 +19,8 @@
             <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
         </encoder>
     </appender>
-
+    <logger name="org.eclipse.che.core.metrics.FileStoresMeterTest" level="DEBUG"/>
+    <logger name="org.eclipse.che.core.metrics.FileStoresMeterBinder" level="DEBUG"/>
     <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>

--- a/core/che-core-metrics-core/src/test/resources/logback-test.xml
+++ b/core/che-core-metrics-core/src/test/resources/logback-test.xml
@@ -18,7 +18,8 @@
         <encoder>
             <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
         </encoder>
-    </appender>fix
+    </appender>
+    
     <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>

--- a/core/che-core-metrics-core/src/test/resources/logback-test.xml
+++ b/core/che-core-metrics-core/src/test/resources/logback-test.xml
@@ -18,9 +18,7 @@
         <encoder>
             <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
         </encoder>
-    </appender>
-    <logger name="org.eclipse.che.core.metrics.FileStoresMeterTest" level="DEBUG"/>
-    <logger name="org.eclipse.che.core.metrics.FileStoresMeterBinder" level="DEBUG"/>
+    </appender>fix
     <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>

--- a/core/che-core-metrics-core/src/test/resources/logback-test.xml
+++ b/core/che-core-metrics-core/src/test/resources/logback-test.xml
@@ -19,7 +19,7 @@
             <pattern>%-41(%date[%.15thread]) %-45([%-5level] [%.30logger{30} %L]) - %msg%n</pattern>
         </encoder>
     </appender>
-    
+
     <root level="INFO">
         <appender-ref ref="stdout"/>
     </root>


### PR DESCRIPTION
### What does this PR do?

Make code & test independent from result ```FileSystems.getDefault().getFileStores()``` since it may happen that it may change during test execution between FileStoresMeterBinder object creation and test code.
### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14202


#### Release Notes
n/a

#### Docs PR
n/a