### PR TITLE
Simplify build of che artifacts by PR check pipeline job

### DIFF
--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                 stage("Build Che") {
                     steps {
                         script {
-                            sh "mvn clean install -f ${WORKSPACE}/pom.xml -U -T 4 -DskipTests -Dskip-enforce"
+                            sh "mvn clean install -f ${WORKSPACE}/pom.xml -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
                         }
                     }
                 }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                 stage("Build Che") {
                     steps {
                         script {
-                            sh "mvn clean install -f ${WORKSPACE}/pom.xml -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
+                            sh "mvn clean install -f ${WORKSPACE}/pom.xml -U -DskipTests -Dskip-enforce"
                         }
                     }
                 }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                 stage("Build Che") {
                     steps {
                         script {
-                            sh "mvn clean install -f ${WORKSPACE}/pom.xml -U -DskipTests -Dskip-enforce"
+                            sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
                         }
                     }
                 }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -194,6 +194,8 @@ pipeline {
                       sudo rm -rf `sudo find /tmp -name 'hostpath-provisioner' 2>/dev/null` || true
                     
                       docker volume rm \$(docker volume ls -q -f dangling=true) || true
+                      
+                      docker rm -f \$(sudo docker ps --all | awk 'NR>0 {print \$1;}') || true
                     """
 
                 sh "sudo rm -rf ${WORKSPACE}/e2e"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
                 stage("Build Che") {
                     steps {
                         script {
-                            sh "mvn clean install -f ${WORKSPACE}/pom.xml"
+                            sh "mvn clean install -f ${WORKSPACE}/pom.xml -U -T 4 -DskipTests -Dskip-enforce"
                         }
                     }
                 }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         stage("Cleanup") {
             steps {
                 script() {
-                    sh "/usr/local/bin/minikube delete"
+                    sh "/usr/local/bin/minikube delete || true"
                 }
             }
         }


### PR DESCRIPTION
### What does this PR do?
It improves building of Che binaries in time of checking PR using E2E Happy path tests:
- decreases time of building by running it in 4 threads, and disabling unit tests and dependency analysis (which is in turn the task of [Codenvy CI pr-build job](https://ci.codenvycorp.com/view/pr-builds/job/che-pullrequests-build/));
- makes it more consistent by enforcing an update of depending artifacts.

Che was built in **1 minutes 7 seconds** on slave9.

### What issues does this PR fix or reference?
#14202