### PR TITLE
Use the hashed name for the path to each ssh-secret. (eclipse#14151).

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -20,12 +20,14 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.hash.Hashing;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Secret;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
@@ -124,12 +126,20 @@ public class VcsSshKeySecretProvisionerTest {
 
     String sshConfig = mapData.get("ssh_config");
     assertTrue(sshConfig.contains("host " + keyName1));
-    assertTrue(sshConfig.contains("IdentityFile " + "/etc/ssh/" + keyName1 + "/ssh-privatekey"));
+    assertTrue(
+        sshConfig.contains("IdentityFile /etc/ssh/" + getSha256(keyName1) + "/ssh-privatekey"));
 
     assertTrue(sshConfig.contains("host *"));
-    assertTrue(sshConfig.contains("IdentityFile " + "/etc/ssh/" + keyName2 + "/ssh-privatekey"));
+    assertTrue(
+        sshConfig.contains("IdentityFile /etc/ssh/" + getSha256(keyName2) + "/ssh-privatekey"));
 
-    assertTrue(sshConfig.contains("host github.com"));
-    assertTrue(sshConfig.contains("IdentityFile /etc/ssh/github-com/ssh-privatekey"));
+    assertTrue(sshConfig.contains("host " + keyName3));
+    assertTrue(
+        sshConfig.contains("IdentityFile /etc/ssh/" + getSha256(keyName3) + "/ssh-privatekey"));
+  }
+
+  /** Returns a sha256-hashed string value. */
+  private String getSha256(String value) {
+    return Hashing.sha256().hashString(value, StandardCharsets.UTF_8).toString();
   }
 }


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Uses the hashed name for the path to each ssh-secret.
As [I commented](https://github.com/eclipse/che/pull/14152#issuecomment-521509938), the name for key-pair can be contain characters that is not fit for file path.

### What issues does this PR fix or reference?

eclipse#14151 eclipse#14152 eclipse#14156 