### PR TITLE
[E2E] Stop and remove workspace on failed test

### DIFF
--- a/e2e/TestConstants.ts
+++ b/e2e/TestConstants.ts
@@ -157,5 +157,5 @@ export const TestConstants = {
     /**
      * Stop and remove workspace if a test fails.
      */
-    DELETE_WORKSPACE_ON_FAILED_TEST: process.env.DELETE_WORKSPACE_ON_FAILED_TEST || 'false'
+    DELETE_WORKSPACE_ON_FAILED_TEST: process.env.DELETE_WORKSPACE_ON_FAILED_TEST === 'true'
 };

--- a/e2e/TestConstants.ts
+++ b/e2e/TestConstants.ts
@@ -152,5 +152,10 @@ export const TestConstants = {
     /**
      * Remote driver URL.
      */
-    TS_SELENIUM_REMOTE_DRIVER_URL: process.env.TS_SELENIUM_REMOTE_DRIVER_URL || ''
+    TS_SELENIUM_REMOTE_DRIVER_URL: process.env.TS_SELENIUM_REMOTE_DRIVER_URL || '',
+
+    /**
+     * Stop and remove workspace if a test fails.
+     */
+    DELETE_WORKSPACE_ON_FAILED_TEST: process.env.DELETE_WORKSPACE_ON_FAILED_TEST || 'false'
 };

--- a/e2e/driver/CheReporter.ts
+++ b/e2e/driver/CheReporter.ts
@@ -17,12 +17,14 @@ import { TestConstants } from '../TestConstants';
 import { logging } from 'selenium-webdriver';
 import { DriverHelper } from '../utils/DriverHelper';
 import { ScreenCatcher } from '../utils/ScreenCatcher';
+import { ITestWorkspaceUtil } from '../utils/workspace/ITestWorkspaceUtil';
 
 const driver: IDriver = e2eContainer.get(TYPES.Driver);
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 const screenCatcher: ScreenCatcher = e2eContainer.get(CLASSES.ScreenCatcher);
 let methodIndex: number = 0;
 let deleteScreencast: boolean = true;
+let testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
 
 class CheReporter extends mocha.reporters.Spec {
   constructor(runner: mocha.Runner, options: mocha.MochaOptions) {
@@ -153,6 +155,15 @@ class CheReporter extends mocha.reporters.Spec {
       const browserLogsStream = fs.createWriteStream(browserLogsFileName);
       browserLogsStream.write(new Buffer(browserLogs));
       browserLogsStream.end();
+
+      // stop and remove running workspace
+      if (TestConstants.DELETE_WORKSPACE_ON_FAILED_TEST) {
+        console.log("Property DELETE_WORKSPACE_ON_FAILED_TEST se to true - trying to stop and delete running workspace.")
+        let namespace = TestConstants.TS_SELENIUM_USERNAME;
+        let workspaceId = await testWorkspaceUtil.getIdOfRunningWorkspace(namespace);
+        testWorkspaceUtil.stopWorkspaceById(workspaceId);
+        testWorkspaceUtil.removeWorkspaceById(workspaceId);
+      }
     });
   }
 }

--- a/e2e/driver/ContainerInitializer.ts
+++ b/e2e/driver/ContainerInitializer.ts
@@ -1,0 +1,77 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { Container } from 'inversify';
+import { IDriver } from './IDriver';
+import { TYPES, CLASSES } from '../inversify.types';
+import { ChromeDriver } from './ChromeDriver';
+import { DriverHelper } from '../utils/DriverHelper';
+import { ICheLoginPage } from '../pageobjects/login/ICheLoginPage';
+import { IOcpLoginPage } from '../pageobjects/login/IOcpLoginPage';
+import { SingleUserLoginPage } from '../pageobjects/login/SingleUserLoginPage';
+import { Dashboard } from '../pageobjects/dashboard/Dashboard';
+import { Workspaces } from '../pageobjects/dashboard/Workspaces';
+import { NewWorkspace } from '../pageobjects/dashboard/NewWorkspace';
+import { WorkspaceDetails } from '../pageobjects/dashboard/workspace-details/WorkspaceDetails';
+import { WorkspaceDetailsPlugins } from '../pageobjects/dashboard/workspace-details/WorkspaceDetailsPlugins';
+import { Ide } from '../pageobjects/ide/Ide';
+import { TestWorkspaceUtil } from '../utils/workspace/TestWorkspaceUtil';
+import { ProjectTree } from '../pageobjects/ide/ProjectTree';
+import { Editor } from '../pageobjects/ide/Editor';
+import { TopMenu } from '../pageobjects/ide/TopMenu';
+import { QuickOpenContainer } from '../pageobjects/ide/QuickOpenContainer';
+import { PreviewWidget } from '../pageobjects/ide/PreviewWidget';
+import { GitHubPlugin } from '../pageobjects/ide/GitHubPlugin';
+import { RightToolbar } from '../pageobjects/ide/RightToolbar';
+import { Terminal } from '../pageobjects/ide/Terminal';
+import { DebugView } from '../pageobjects/ide/DebugView';
+import { WarningDialog } from '../pageobjects/ide/WarningDialog';
+import { ScreenCatcher } from '../utils/ScreenCatcher';
+import { MultiUserLoginPage } from '../pageobjects/login/MultiUserLoginPage';
+import { TestConstants } from '../TestConstants';
+import { OcpLoginPage } from '../pageobjects/openshift/OcpLoginPage';
+import { OcpWebConsolePage } from '../pageobjects/openshift/OcpWebConsolePage';
+import { OcpLoginByTempAdmin } from '../pageobjects/login/OcpLoginByTempAdmin';
+import { ITestWorkspaceUtil } from '..';
+
+export function getContainer(): Container {
+    const e2eContainer = new Container();
+
+    e2eContainer.bind<IDriver>(TYPES.Driver).to(ChromeDriver).inSingletonScope();
+    e2eContainer.bind<ITestWorkspaceUtil>(TYPES.WorkspaceUtil).to(TestWorkspaceUtil).inSingletonScope();
+    e2eContainer.bind<IOcpLoginPage>(TYPES.OcpLogin).to(OcpLoginByTempAdmin).inSingletonScope();
+
+    if (TestConstants.TS_SELENIUM_MULTIUSER) {
+        e2eContainer.bind<ICheLoginPage>(TYPES.CheLogin).to(MultiUserLoginPage).inSingletonScope();
+    } else {
+        e2eContainer.bind<ICheLoginPage>(TYPES.CheLogin).to(SingleUserLoginPage).inSingletonScope();
+    }
+
+    e2eContainer.bind<DriverHelper>(CLASSES.DriverHelper).to(DriverHelper).inSingletonScope();
+    e2eContainer.bind<Dashboard>(CLASSES.Dashboard).to(Dashboard).inSingletonScope();
+    e2eContainer.bind<Workspaces>(CLASSES.Workspaces).to(Workspaces).inSingletonScope();
+    e2eContainer.bind<NewWorkspace>(CLASSES.NewWorkspace).to(NewWorkspace).inSingletonScope();
+    e2eContainer.bind<WorkspaceDetails>(CLASSES.WorkspaceDetails).to(WorkspaceDetails).inSingletonScope();
+    e2eContainer.bind<WorkspaceDetailsPlugins>(CLASSES.WorkspaceDetailsPlugins).to(WorkspaceDetailsPlugins).inSingletonScope();
+    e2eContainer.bind<Ide>(CLASSES.Ide).to(Ide).inSingletonScope();
+    e2eContainer.bind<ProjectTree>(CLASSES.ProjectTree).to(ProjectTree).inSingletonScope();
+    e2eContainer.bind<Editor>(CLASSES.Editor).to(Editor).inSingletonScope();
+    e2eContainer.bind<TopMenu>(CLASSES.TopMenu).to(TopMenu).inSingletonScope();
+    e2eContainer.bind<QuickOpenContainer>(CLASSES.QuickOpenContainer).to(QuickOpenContainer).inSingletonScope();
+    e2eContainer.bind<PreviewWidget>(CLASSES.PreviewWidget).to(PreviewWidget).inSingletonScope();
+    e2eContainer.bind<GitHubPlugin>(CLASSES.GitHubPlugin).to(GitHubPlugin).inSingletonScope();
+    e2eContainer.bind<RightToolbar>(CLASSES.RightToolbar).to(RightToolbar).inSingletonScope();
+    e2eContainer.bind<Terminal>(CLASSES.Terminal).to(Terminal).inSingletonScope();
+    e2eContainer.bind<DebugView>(CLASSES.DebugView).to(DebugView).inSingletonScope();
+    e2eContainer.bind<WarningDialog>(CLASSES.WarningDialog).to(WarningDialog).inSingletonScope();
+    e2eContainer.bind<ScreenCatcher>(CLASSES.ScreenCatcher).to(ScreenCatcher).inSingletonScope();
+    e2eContainer.bind<OcpLoginPage>(CLASSES.OcpLoginPage).to(OcpLoginPage).inSingletonScope();
+    e2eContainer.bind<OcpWebConsolePage>(CLASSES.OcpWebConsolePage).to(OcpWebConsolePage).inSingletonScope();
+    return e2eContainer;
+}

--- a/e2e/index.ts
+++ b/e2e/index.ts
@@ -6,6 +6,7 @@ export * from './TestConstants';
 // driver
 export * from './driver/IDriver';
 export * from './driver/ChromeDriver';
+export * from './driver/ContainerInitializer';
 
 // pageobjects - dashboard
 export * from './pageobjects/dashboard/Dashboard';
@@ -44,3 +45,5 @@ export * from './pageobjects/openshift/OcpWebConsolePage';
 export * from './utils/DriverHelper';
 export * from './utils/NameGenerator';
 export * from './utils/workspace/TestWorkspaceUtil';
+export * from './utils/workspace/ITestWorkspaceUtil';
+export * from './utils/workspace/WorkspaceStatus';

--- a/e2e/inversify.types.ts
+++ b/e2e/inversify.types.ts
@@ -12,7 +12,8 @@
 const TYPES = {
     Driver: Symbol.for('Driver'),
     CheLogin: Symbol.for('CheLogin'),
-    OcpLogin: Symbol.for('OcpLogin')
+    OcpLogin: Symbol.for('OcpLogin'),
+    WorkspaceUtil: Symbol.for('WorkspaceUtil')
 };
 
 const CLASSES = {
@@ -23,7 +24,6 @@ const CLASSES = {
     WorkspaceDetails: 'WorkspaceDetails',
     WorkspaceDetailsPlugins: 'WorkspaceDetailsPlugins',
     Ide: 'Ide',
-    TestWorkspaceUtil: 'TestWorkspaceUtil',
     ProjectTree: 'ProjectTree',
     Editor: 'Editor',
     TopMenu: 'TopMenu',

--- a/e2e/pageobjects/dashboard/NewWorkspace.ts
+++ b/e2e/pageobjects/dashboard/NewWorkspace.ts
@@ -9,14 +9,14 @@
  **********************************************************************/
 import { injectable, inject } from 'inversify';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { CLASSES } from '../../inversify.types';
+import { CLASSES, TYPES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
 import { By } from 'selenium-webdriver';
 import 'reflect-metadata';
 import { Dashboard } from './Dashboard';
 import { Workspaces } from './Workspaces';
 import { WorkspaceDetails } from './workspace-details/WorkspaceDetails';
-import { TestWorkspaceUtil, Ide, WorkspaceStatus } from '../..';
+import { ITestWorkspaceUtil, Ide, WorkspaceStatus } from '../..';
 
 
 @injectable()
@@ -36,7 +36,7 @@ export class NewWorkspace {
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
         @inject(CLASSES.Dashboard) private readonly dashboard: Dashboard,
         @inject(CLASSES.Workspaces) private readonly workspaces: Workspaces,
-        @inject(CLASSES.TestWorkspaceUtil) private readonly testWorkspaceUtil: TestWorkspaceUtil,
+        @inject(TYPES.WorkspaceUtil) private readonly testWorkspaceUtil: ITestWorkspaceUtil,
         @inject(CLASSES.WorkspaceDetails) private readonly workspaceDetails: WorkspaceDetails) { }
 
     async createAndRunWorkspace(namespace: string, workspaceName: string, dataStackId: string) {

--- a/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
+++ b/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
@@ -9,12 +9,13 @@
  **********************************************************************/
 import { DriverHelper } from '../../../utils/DriverHelper';
 import { injectable, inject } from 'inversify';
-import { CLASSES } from '../../../inversify.types';
+import { CLASSES, TYPES } from '../../../inversify.types';
 import 'reflect-metadata';
 import { TestConstants } from '../../../TestConstants';
 import { By } from 'selenium-webdriver';
 import { Ide } from '../../ide/Ide';
-import { TestWorkspaceUtil, WorkspaceStatus } from '../../../utils/workspace/TestWorkspaceUtil';
+import { ITestWorkspaceUtil } from '../../../utils/workspace/ITestWorkspaceUtil';
+import { WorkspaceStatus } from '../../../utils/workspace/WorkspaceStatus';
 
 
 @injectable()
@@ -26,7 +27,7 @@ export class WorkspaceDetails {
     private static readonly WORKSPACE_DETAILS_LOADER_CSS: string = 'workspace-details-overview md-progress-linear';
 
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
-        @inject(CLASSES.TestWorkspaceUtil) private readonly testWorkspaceUtil: TestWorkspaceUtil) { }
+        @inject(TYPES.WorkspaceUtil) private readonly testWorkspaceUtil: ITestWorkspaceUtil) { }
 
     async waitLoaderDisappearance(attempts: number = TestConstants.TS_SELENIUM_DEFAULT_ATTEMPTS, polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING) {
         await this.driverHelper.waitDisappearance(By.css(WorkspaceDetails.WORKSPACE_DETAILS_LOADER_CSS), attempts, polling);

--- a/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetailsPlugins.ts
+++ b/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetailsPlugins.ts
@@ -10,18 +10,19 @@
 import { DriverHelper } from '../../../utils/DriverHelper';
 import { injectable, inject } from 'inversify';
 import 'reflect-metadata';
-import { CLASSES } from '../../../inversify.types';
+import { CLASSES, TYPES } from '../../../inversify.types';
 import { TestConstants } from '../../../TestConstants';
 import { By } from 'selenium-webdriver';
 import { WorkspaceDetails } from './WorkspaceDetails';
-import { TestWorkspaceUtil, WorkspaceStatus } from '../../../utils/workspace/TestWorkspaceUtil';
+import { ITestWorkspaceUtil } from '../../../utils/workspace/ITestWorkspaceUtil';
+import { WorkspaceStatus } from '../../../utils/workspace/WorkspaceStatus';
 
 
 @injectable()
 export class WorkspaceDetailsPlugins {
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
         @inject(CLASSES.WorkspaceDetails) private readonly workspaceDetails: WorkspaceDetails,
-        @inject(CLASSES.TestWorkspaceUtil) private readonly testWorkspaceUtil: TestWorkspaceUtil) { }
+        @inject(TYPES.WorkspaceUtil) private readonly testWorkspaceUtil: ITestWorkspaceUtil) { }
 
     async waitPluginListItem(pluginName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
         const pluginListItemLocator: By = By.css(this.getPluginListItemCssLocator(pluginName));

--- a/e2e/pageobjects/ide/Ide.ts
+++ b/e2e/pageobjects/ide/Ide.ts
@@ -9,10 +9,11 @@
  **********************************************************************/
 import { DriverHelper } from '../../utils/DriverHelper';
 import { injectable, inject } from 'inversify';
-import { CLASSES } from '../../inversify.types';
+import { CLASSES, TYPES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
 import { By, WebElement, error } from 'selenium-webdriver';
-import { TestWorkspaceUtil, WorkspaceStatus } from '../../utils/workspace/TestWorkspaceUtil';
+import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
+import { WorkspaceStatus } from '../../utils/workspace/WorkspaceStatus';
 
 export enum RightToolbarButton {
     Explorer = 'Explorer',
@@ -33,7 +34,7 @@ export class Ide {
 
     constructor(
         @inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
-        @inject(CLASSES.TestWorkspaceUtil) private readonly testWorkspaceUtil: TestWorkspaceUtil) { }
+        @inject(TYPES.WorkspaceUtil) private readonly testWorkspaceUtil: ITestWorkspaceUtil) { }
 
     async waitAndSwitchToIdeFrame(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
         await this.driverHelper.waitAndSwitchToFrame(By.css(Ide.IDE_IFRAME_CSS), timeout);

--- a/e2e/tslint.json
+++ b/e2e/tslint.json
@@ -67,7 +67,7 @@
       "no-unused-variable": true,
       "no-unreachable": true,
       "no-use-before-declare": true,
-      "no-var-requires": true,
+      "no-var-requires": false,
       "one-line": [
         true,
         "check-open-brace",

--- a/e2e/utils/workspace/ITestWorkspaceUtil.ts
+++ b/e2e/utils/workspace/ITestWorkspaceUtil.ts
@@ -1,0 +1,19 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { WorkspaceStatus } from './WorkspaceStatus';
+
+export interface ITestWorkspaceUtil {
+    waitWorkspaceStatus(namespace: string, workspaceName: string, expectedWorkspaceStatus: WorkspaceStatus) : void;
+    waitPluginAdding(namespace: string, workspaceName: string, pluginId: string) : void;
+    removeWorkspaceById(id: string) : void;
+    stopWorkspaceById(id: string) : void;
+    getIdOfRunningWorkspace(namespace: string): Promise<string>;
+}

--- a/e2e/utils/workspace/TestWorkspaceUtil.ts
+++ b/e2e/utils/workspace/TestWorkspaceUtil.ts
@@ -15,15 +15,12 @@ import { CLASSES } from '../../inversify.types';
 import 'reflect-metadata';
 import * as rm from 'typed-rest-client/RestClient';
 import { error } from 'selenium-webdriver';
-
-export enum WorkspaceStatus {
-    RUNNING = 'RUNNING',
-    STOPPED = 'STOPPED',
-    STARTING = 'STARTING'
-}
+import { WorkspaceStatus } from './WorkspaceStatus';
+import { ITestWorkspaceUtil } from './ITestWorkspaceUtil';
 
 @injectable()
-export class TestWorkspaceUtil {
+export class TestWorkspaceUtil implements ITestWorkspaceUtil {
+
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
         private readonly rest: rm.RestClient = new rm.RestClient('rest-samples')) { }
 
@@ -80,4 +77,15 @@ export class TestWorkspaceUtil {
         }
     }
 
+    public async getIdOfRunningWorkspace(namespace: string): Promise<string> {
+        throw new Error("Method not implemented.");
+    }
+    
+    removeWorkspaceById(id: string): void {
+        throw new Error("Method not implemented.");
+    }
+    
+    stopWorkspaceById(id: string): void {
+        throw new Error("Method not implemented.");
+    }
 }

--- a/e2e/utils/workspace/WorkspaceStatus.ts
+++ b/e2e/utils/workspace/WorkspaceStatus.ts
@@ -7,11 +7,9 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import * as path from 'path';
-import { Container } from 'inversify';
 
-let pathh = path.resolve('.');
-let containerInitializer = require(`${pathh}/dist/driver/ContainerInitializer.js`);
-let e2eContainer : Container = containerInitializer.getContainer();
-
-export { e2eContainer };
+ export enum WorkspaceStatus {
+    RUNNING = 'RUNNING',
+    STOPPED = 'STOPPED',
+    STARTING = 'STARTING'
+}


### PR DESCRIPTION
### What does this PR do?
Currently, when test is run in a `--bail` mode and fails, the workspace remains there. The goal of this PR is to create a mechanism that will stop and remove this workspace. 
Add environment variable DELETE_WORKSPACE_ON_FAILED_TEST to turn on/off workspace deletion on failed tests.
The logic of creating a container is abstracted from inversify.config.ts to ContainerInitializer. This is the way that would allow us to rebind some classes in upstream.
To be able to dynamicly include the correct ContainerInitializer, the dynamic injection was allowed (change configuration of tslint). 
Implementation of TestWorksapceUtil.ts binding were changed to use interface.

