### PR TITLE
[e2e] Fix che-theia version to :7.0.0 until tests are adapted to :next

### DIFF
--- a/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/e2e/files/happy-path/happy-path-workspace.yaml
@@ -36,6 +36,8 @@ components:
     id: redhat/java/latest
   - type: chePlugin
     id: redhat/vscode-yaml/latest
+  - type: cheEditor
+    id: eclipse/che-theia/7.0.0
 commands:
   - name: build
     actions:

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -96,6 +96,11 @@ pipeline {
         stage("Start Single Che") {
             steps {
                 script {
+                    //temporary workaround because of https://github.com/eclipse/che/pull/14247
+                    sh """
+                        echo Workaround for https://github.com/eclipse/che/pull/14247
+                        sed -i 's|image: quay.io/eclipse/che-plugin-registry:nightly|image: quay.io/eclipse/che-plugin-registry:7.0.0|g' ${WORKSPACE}/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
+                    """
                     sh """
                       ${WORKSPACE}/chectl server:start \\
                         --k8spodreadytimeout=180000 \\


### PR DESCRIPTION
Fixes PR check tests after merging https://github.com/eclipse/che/pull/14247.

This is a temporary workaround and Che QE team is working on adapting the e2e tests to be compatible with latest che-theia:next version.