### PR TITLE
Update default plugin/devfile registries to use prod-preview

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -583,12 +583,12 @@ che.workspace.plugin_broker.wait_timeout_min=3
 # Workspace tooling plugins registry endpoint. Should be a valid HTTP URL.
 # Example: http://che-plugin-registry-eclipse-che.192.168.65.2.nip.io
 # In case Che plugins tooling is not needed value 'NULL' should be used
-che.workspace.plugin_registry_url=https://che-plugin-registry.openshift.io/v3
+che.workspace.plugin_registry_url=https://che-plugin-registry.prod-preview.openshift.io/v3
 
 # Devfile Registry endpoint. Should be a valid HTTP URL.
 # Example: http://che-devfile-registry-eclipse-che.192.168.65.2.nip.io
 # In case Che plugins tooling is not needed value 'NULL' should be used
-che.workspace.devfile_registry_url=https://che-devfile-registry.openshift.io/
+che.workspace.devfile_registry_url=https://che-devfile-registry.prod-preview.openshift.io/
 
 # Configures in which way secure servers will be protected with authentication.
 # Suitable values:


### PR DESCRIPTION
### What does this PR do?
Use https://che-plugin-registry.prod-preview.openshift.io and https://che-devfile-registry.prod-preview.openshift.io/ instead of their production equivalents.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14266, https://github.com/eclipse/che/issues/14261