### PR TITLE
6 backport - Watch PVC `WaitForFirstConsumer` event to avoid deadlock (#14239)

### DIFF
--- a/typescript-dto/dto-pom.xml
+++ b/typescript-dto/dto-pom.xml
@@ -18,13 +18,13 @@
     <parent>
         <artifactId>maven-depmgt-pom</artifactId>
         <groupId>org.eclipse.che.depmgt</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>6.19.6-SNAPSHOT</version>
     </parent>
     <artifactId>dts-dto-typescript</artifactId>
     <packaging>pom</packaging>
     <name>Che TypeScript DTO</name>
     <properties>
-        <che.version>6.19.0-SNAPSHOT</che.version>
+        <che.version>6.19.6-SNAPSHOT</che.version>
     </properties>
     <repositories>
         <repository>

--- a/wsmaster/integration-tests/mysql-tck/pom.xml
+++ b/wsmaster/integration-tests/mysql-tck/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>integration-tests-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>6.19.6-SNAPSHOT</version>
     </parent>
     <artifactId>mysql-tck</artifactId>
     <packaging>jar</packaging>

--- a/wsmaster/integration-tests/postgresql-tck/pom.xml
+++ b/wsmaster/integration-tests/postgresql-tck/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>integration-tests-parent</artifactId>
         <groupId>org.eclipse.che.core</groupId>
-        <version>6.19.0-SNAPSHOT</version>
+        <version>6.19.6-SNAPSHOT</version>
     </parent>
     <artifactId>postgresql-tck</artifactId>
     <packaging>jar</packaging>


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
backport of https://github.com/eclipse/che/pull/14239 to Che 6

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13437

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
