### PR TITLE
Add the jwt-proxy memory as a part of stack's globalMemoryLimit

### DIFF
--- a/dashboard/src/app/stacks/list-stacks/list-stacks.controller.ts
+++ b/dashboard/src/app/stacks/list-stacks/list-stacks.controller.ts
@@ -24,10 +24,9 @@ const DEFAULT_COLUMN = 'displayName';
  */
 export class ListStacksController {
 
-  static $inject = ['$scope', '$filter', 'cheWorkspace', '$location', 'devfileRegistry', 'cheListHelperFactory'];
+  static $inject = ['$scope', 'cheWorkspace', '$location', 'devfileRegistry', 'cheListHelperFactory'];
 
   private $location: ng.ILocationService;
-  private $filter: ng.IFilterService;
 
   private cheWorkspace: CheWorkspace;
   private devfileRegistry: DevfileRegistry;
@@ -44,12 +43,10 @@ export class ListStacksController {
    * Default constructor that is using resource
    */
   constructor($scope: ng.IScope,
-               $filter: ng.IFilterService,
                cheWorkspace: CheWorkspace,
                $location: ng.ILocationService,
                devfileRegistry: DevfileRegistry,
                cheListHelperFactory: che.widget.ICheListHelperFactory) {
-    this.$filter = $filter;
     this.$location = $location;
     this.cheWorkspace = cheWorkspace;
     this.devfileRegistry = devfileRegistry;
@@ -73,11 +70,9 @@ export class ListStacksController {
     this.pluginRegistryUrl = this.cheWorkspace.getWorkspaceSettings().cheWorkspaceDevfileRegistryUrl;
     this.devfileRegistry.fetchDevfiles(this.pluginRegistryUrl).then((data: Array<IDevfileMetaData>) => {
       const devfileMetaDatas = data.map((devfileMetaData: IDevfileMetaData) => {
-        const globalMemoryLimit = this.$filter('changeMemoryUnit')(devfileMetaData.globalMemoryLimit, ['MB','GB']);
-        devfileMetaData.globalMemoryLimit = globalMemoryLimit;
 
         // todo remove this after cheListHelper improvement
-        devfileMetaData[this.searchBy]= `${devfileMetaData.displayName} ${devfileMetaData.description} ${globalMemoryLimit}`;
+        devfileMetaData[this.searchBy]= `${devfileMetaData.displayName} ${devfileMetaData.description} ${devfileMetaData.globalMemoryLimit}`;
 
         return devfileMetaData;
       });

--- a/dashboard/src/app/workspaces/create-workspace/devfile-selector/devfile-selector.html
+++ b/dashboard/src/app/workspaces/create-workspace/devfile-selector/devfile-selector.html
@@ -56,7 +56,7 @@
                   </div>
                    <!-- Memory -->
                    <div flex="10">
-                    <span class="che-list-item-secondary" devfile-memory="{{devfile.globalMemoryLimit}}">{{devfile.globalMemoryLimit | changeMemoryUnit:['MB','GB']}}</span>
+                    <span class="che-list-item-secondary" devfile-memory="{{devfile.globalMemoryLimit}}">{{devfile.globalMemoryLimit}}</span>
                   </div>
                 </div>
               </div>

--- a/dashboard/src/components/api/devfile-registry.factory.ts
+++ b/dashboard/src/components/api/devfile-registry.factory.ts
@@ -10,6 +10,7 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 'use strict';
+import {CheKeycloak} from './che-keycloak.factory';
 
 export interface IDevfileMetaData {
   displayName: string;
@@ -20,33 +21,54 @@ export interface IDevfileMetaData {
   tags: Array<string>;
 }
 
+enum MemoryUnit { 'B', 'Ki', 'Mi', 'Gi' }
+
+const DEFAULT_JWTPROXY_MEMORY_LIMIT = '128Mi';// default value for che.server.secure_exposer.jwtproxy.memory_limit
 
 /**
  * This class is handling devfile registry api
  * @author Ann Shumilova
  */
 export class DevfileRegistry {
-  static $inject = ['$http'];
+  static $inject = ['$http', '$filter', 'cheKeycloak'];
 
   /**
    * Angular Http service.
    */
   private $http: ng.IHttpService;
 
+  private $filter: ng.IFilterService;
+
   private devfilesMap: Map<string, che.IWorkspaceDevfile>;
+
+  private isKeycloackPresent: boolean;
+
+  private jwtproxyMemoryLimitNumber: number;
 
   /**
    * Default constructor that is using resource
    */
-  constructor($http: ng.IHttpService) {
+  constructor($http: ng.IHttpService, $filter: ng.IFilterService, cheKeycloak: CheKeycloak) {
     this.$http = $http;
+    this.$filter = $filter;
+
     this.devfilesMap = new Map<string, che.IWorkspaceDevfile>();
+    this.isKeycloackPresent = cheKeycloak.isPresent();
+    this.jwtproxyMemoryLimitNumber = this.getMemoryLimit(DEFAULT_JWTPROXY_MEMORY_LIMIT);
   }
 
   fetchDevfiles(location: string): ng.IPromise<Array<IDevfileMetaData>> {
     let promise = this.$http({ 'method': 'GET', 'url': location + '/devfiles/index.json' });
     return promise.then((result: any) => {
-      return result.data;
+      return result.data.map((devfileMetaData: IDevfileMetaData) => {
+        let globalMemoryLimitNumber = this.getMemoryLimit(devfileMetaData.globalMemoryLimit);
+        // todo remove this after fixing https://github.com/eclipse/che/issues/11424
+        if (this.isKeycloackPresent) {
+          globalMemoryLimitNumber += this.jwtproxyMemoryLimitNumber;
+        }
+        devfileMetaData.globalMemoryLimit = this.$filter('changeMemoryUnit')(globalMemoryLimitNumber, ['B','GB']);
+        return devfileMetaData;
+      });
     });
   }
 
@@ -85,5 +107,27 @@ export class DevfileRegistry {
       return jsyaml.load(yaml);
     } catch (e) {
     }
+  }
+
+   /**
+   * Returns memory limit.
+   * @param {string} memoryLimit
+   * @returns {number}
+   */
+  getMemoryLimit(memoryLimit: string): number {
+    if (!memoryLimit) {
+      return -1;
+    }
+    const regExpExecArray = /^([0-9]+)([a-zA-Z]{1,3})$/.exec(memoryLimit);
+    if (regExpExecArray === null) {
+      return -1;
+    }
+    const [, memoryLimitNumber, memoryLimitUnit] = regExpExecArray;
+    const power = MemoryUnit[memoryLimitUnit];
+    if (!power) {
+      return -1;
+    }
+
+    return parseInt(memoryLimitNumber, 10) * Math.pow(1024, power);
   }
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add the 'jwt-proxy' memory as a part of stack's globalMemoryLimit for all stack lists for UD.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14001
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

