### PR TITLE
[E2E] Adding script for generating index.ts file.

### DIFF
--- a/e2e/generateIndex.sh
+++ b/e2e/generateIndex.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+echo "Generating index.ts file..."
+echo "import * as inversifyConfig from './inversify.config';
+export { inversifyConfig };
+export * from './inversify.types';
+export * from './TestConstants';
+" > index.ts
+
+listOfDirs="driver utils pageobjects"
+listOfExcludes="./driver/CheReporter.ts"
+for dir in $listOfDirs
+do
+  files=$(find ./$dir -type f)
+  for file in $files
+  do  
+    case $file in *ts)
+      for excludedFile in $listOfExcludes
+      do
+        if [ $excludedFile == $file ]; then
+          continue
+        else
+          end=$((${#file}-3))
+          file_without_ending=${file:0:end}
+          echo "export * from '$file_without_ending';" >> index.ts
+        fi
+      done
+      ;;
+      *)
+      echo "Excluding file $file - not a typescript file"
+      ;;
+    esac
+  done
+done

--- a/e2e/index.ts
+++ b/e2e/index.ts
@@ -3,47 +3,36 @@ export { inversifyConfig };
 export * from './inversify.types';
 export * from './TestConstants';
 
-// driver
 export * from './driver/IDriver';
-export * from './driver/ChromeDriver';
 export * from './driver/ContainerInitializer';
-
-// pageobjects - dashboard
-export * from './pageobjects/dashboard/Dashboard';
-export * from './pageobjects/dashboard/NewWorkspace';
-export * from './pageobjects/dashboard/Workspaces';
-
-// pageobjects - dashboard - worksapce details
-export * from './pageobjects/dashboard/workspace-details/WorkspaceDetails';
-export * from './pageobjects/dashboard/workspace-details/WorkspaceDetailsPlugins';
-
-// pageobjects - login
-export * from './pageobjects/login/ICheLoginPage';
-export * from './pageobjects/login/IOcpLoginPage';
-export * from './pageobjects/login/MultiUserLoginPage';
-export * from './pageobjects/login/OcpLoginByTempAdmin';
-export * from './pageobjects/login/SingleUserLoginPage';
-
-// pageobjects - ide
+export * from './driver/ChromeDriver';
+export * from './utils/ScreenCatcher';
+export * from './utils/NameGenerator';
+export * from './utils/DriverHelper';
+export * from './utils/workspace/TestWorkspaceUtil';
+export * from './utils/workspace/WorkspaceStatus';
+export * from './utils/workspace/ITestWorkspaceUtil';
 export * from './pageobjects/ide/DebugView';
+export * from './pageobjects/ide/Terminal';
+export * from './pageobjects/ide/OpenWorkspaceWidget';
+export * from './pageobjects/ide/ProjectTree';
 export * from './pageobjects/ide/Editor';
+export * from './pageobjects/ide/TopMenu';
 export * from './pageobjects/ide/GitHubPlugin';
 export * from './pageobjects/ide/Ide';
-export * from './pageobjects/ide/PreviewWidget';
-export * from './pageobjects/ide/ProjectTree';
-export * from './pageobjects/ide/QuickOpenContainer';
 export * from './pageobjects/ide/RightToolbar';
-export * from './pageobjects/ide/Terminal';
-export * from './pageobjects/ide/TopMenu';
+export * from './pageobjects/ide/PreviewWidget';
 export * from './pageobjects/ide/WarningDialog';
-
-// pageobjects - openshift
-export * from './pageobjects/openshift/OcpLoginPage';
+export * from './pageobjects/ide/QuickOpenContainer';
 export * from './pageobjects/openshift/OcpWebConsolePage';
-
-// utils
-export * from './utils/DriverHelper';
-export * from './utils/NameGenerator';
-export * from './utils/workspace/TestWorkspaceUtil';
-export * from './utils/workspace/ITestWorkspaceUtil';
-export * from './utils/workspace/WorkspaceStatus';
+export * from './pageobjects/openshift/OcpLoginPage';
+export * from './pageobjects/dashboard/Workspaces';
+export * from './pageobjects/dashboard/Dashboard';
+export * from './pageobjects/dashboard/NewWorkspace';
+export * from './pageobjects/dashboard/workspace-details/WorkspaceDetailsPlugins';
+export * from './pageobjects/dashboard/workspace-details/WorkspaceDetails';
+export * from './pageobjects/login/OcpLoginByTempAdmin';
+export * from './pageobjects/login/ICheLoginPage';
+export * from './pageobjects/login/SingleUserLoginPage';
+export * from './pageobjects/login/MultiUserLoginPage';
+export * from './pageobjects/login/IOcpLoginPage';

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,9 +4,9 @@
   "description": "",
   "main": "dist/index.js",
   "scripts": {
-    "test": "npm run lint && npm run tsc && mocha --opts mocha.opts",
-    "test-happy-path": "npm run lint && npm run tsc && mocha --opts mocha-happy-path.opts",
-    "test-che-install": "npm run lint && npm run tsc && mocha --opts mocha-che-operatorhub.opts",
+    "test": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha.opts",
+    "test-happy-path": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-happy-path.opts",
+    "test-che-install": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-che-operatorhub.opts",
     "lint": "tslint --fix -p .",
     "tsc": "tsc -p ."
   },

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -286,7 +286,7 @@ async function runTask(task: string) {
 
     await quickOpenContainer.clickOnContainerItem(task);
 }
-//sometimes under high loading the forst click can be failed
+// sometimes under high loading the first click can be failed
 async function isureClickOnDebugMenu() {
     try { await topMenu.selectOption('Debug', 'Open Configurations'); } catch (e) {
         console.log(`After clicking to the Debug top menu the menu has been not opened, try to click again...`);


### PR DESCRIPTION
### What does this PR do?
The file index.ts contains all files that are exported from the project. These files then can be imported in other project and simply extended/overwritten. This will automate the process of addition files to index.ts.
There are folders defined from which the typescript files should be written to the index.ts. There is also list for excluded files, e.g. CheReporter. 
The index.ts file is generated each time the test is run. The execution time of generation of index.ts is quite short [1] so it should not negatively affect user experience when developing new tests.
![Screenshot from 2019-08-19 13-16-48](https://user-images.githubusercontent.com/29278800/63261373-a4a08b80-c283-11e9-9c0a-a508f35018af.png)
