### PR TITLE
Add trailing 0 to Happy path tests screencast png's

### DIFF
--- a/e2e/TestConstants.ts
+++ b/e2e/TestConstants.ts
@@ -112,7 +112,7 @@ export const TestConstants = {
     /**
      * Delay between screenshots catching in the milliseconds for the execution screencast.
      */
-    TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: Number(process.env.TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS) || 2000,
+    TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: Number(process.env.TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS) || 1000,
 
     /**
      * Path to folder with tests execution report.

--- a/e2e/driver/CheReporter.ts
+++ b/e2e/driver/CheReporter.ts
@@ -79,17 +79,6 @@ class CheReporter extends mocha.reporters.Spec {
       }
     });
 
-    runner.on('test end', async function (test: mocha.Test) {
-      if (!TestConstants.TS_SELENIUM_EXECUTION_SCREENCAST) {
-        return;
-      }
-
-      const currentMethodIndex: number = methodIndex;
-      let iterationIndex: number = 10000;
-
-      await screenCatcher.catchMethodScreen(test.title, currentMethodIndex, iterationIndex);
-    });
-
     runner.on('end', async function (test: mocha.Test) {
       // ensure that fired events done
       await driver.get().sleep(5000);

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                             sh """
                                curl -sL  https://www.eclipse.org/che/chectl/ > install_chectl.sh
                                chmod +x install_chectl.sh
-                               sudo PATH=$PATH ./install_chectl.sh --channel=stable
+                               sudo PATH=$PATH ./install_chectl.sh --channel=next
                                sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
                                sudo chmod +x ${WORKSPACE}/chectl
                             """

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -181,9 +181,24 @@ pipeline {
     }
 
     post {
-        always {
-            archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**"
+        failure {
+            script {
+                echo "Create screencast from $WORKSPACE/e2e/report/executionScreencast files."
+                sh """
+                    command -v ffmpeg >/dev/null 2>&1 && if [ -d $WORKSPACE/e2e/report/executionScreencast ]; then
+                      cd $WORKSPACE/e2e/report/executionScreencast
+                      ffmpeg -framerate 1 -start_number 1 -pattern_type glob -i '*.png' -c:v libx264 -r 30 -pix_fmt yuv420p ../screencast.mp4
+                      ffmpeg -i ../screencast.mp4 ../screencast.gif
+                      cd $WORKSPACE/e2e/report/
+                      rm -rf $WORKSPACE/e2e/report/executionScreencast
+                    fi
+                """
+            }
 
+            archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**"
+        }
+
+        cleanup {
             script {
                 sh """
                       kubectl get configmaps --namespace=che che -o yaml || true
@@ -196,7 +211,7 @@ pipeline {
                       docker volume rm \$(docker volume ls -q -f dangling=true) || true
                       
                       docker rm -f \$(sudo docker ps --all | awk 'NR>0 {print \$1;}') || true
-                    """
+                 """
 
                 sh "sudo rm -rf ${WORKSPACE}/e2e"
             }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -187,18 +187,18 @@ pipeline {
                 sh """
                     command -v ffmpeg >/dev/null 2>&1 && if [ -d $WORKSPACE/e2e/report/executionScreencast ]; then
                       cd $WORKSPACE/e2e/report/executionScreencast
-                      ffmpeg -framerate 1 -start_number 1 -pattern_type glob -i '*.png' -c:v libx264 -r 30 -pix_fmt yuv420p ../screencast.mp4
-                      ffmpeg -i ../screencast.mp4 ../screencast.gif
+                      ffmpeg -framerate 1 -pattern_type glob -i '*.png' -c:v libx264 -r 30 -pix_fmt yuv420p $WORKSPACE/e2e/report/screencast.mp4
+                      ffmpeg -i $WORKSPACE/e2e/report/screencast.mp4 $WORKSPACE/e2e/report/screencast.gif
                       cd $WORKSPACE/e2e/report/
                       rm -rf $WORKSPACE/e2e/report/executionScreencast
                     fi
                 """
             }
-
-            archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**"
         }
 
         cleanup {
+            archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**"
+
             script {
                 sh """
                       kubectl get configmaps --namespace=che che -o yaml || true

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -187,10 +187,13 @@ pipeline {
                 sh """
                     command -v ffmpeg >/dev/null 2>&1 && if [ -d $WORKSPACE/e2e/report/executionScreencast ]; then
                       cd $WORKSPACE/e2e/report/executionScreencast
-                      ffmpeg -framerate 1 -pattern_type glob -i '*.png' -c:v libx264 -r 30 -pix_fmt yuv420p $WORKSPACE/e2e/report/screencast.mp4
-                      ffmpeg -i $WORKSPACE/e2e/report/screencast.mp4 $WORKSPACE/e2e/report/screencast.gif
+
+                      # remove first screenshot which has lower resolution 800x600 and breaks screencast video
+                      sudo rm -f 00100001*
+                      
+                      sudo ffmpeg -framerate 1 -pattern_type glob -i '*.png' -c:v libx264 -r 30 -pix_fmt yuv420p $WORKSPACE/e2e/report/screencast.mp4
                       cd $WORKSPACE/e2e/report/
-                      rm -rf $WORKSPACE/e2e/report/executionScreencast
+                      sudo rm -rf $WORKSPACE/e2e/report/executionScreencast
                     fi
                 """
             }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -185,11 +185,11 @@ pipeline {
             script {
                 echo "Create screencast from $WORKSPACE/e2e/report/executionScreencast files."
                 sh """
-                    command -v ffmpeg >/dev/null 2>&1 && if [ -d $WORKSPACE/e2e/report/executionScreencast ] && [-e $WORKSPACE/e2e/report/executionScreencast/*.png] ; then
+                    command -v ffmpeg >/dev/null 2>&1 && if ls $WORKSPACE/e2e/report/executionScreencast/*.png 1> /dev/null 2>&1; then
                       cd $WORKSPACE/e2e/report/executionScreencast
 
                       # remove first screenshot which has lower resolution 800x600 and breaks screencast video
-                      sudo rm -f 00100001*
+                      sudo rm -f 00100001* || true
                       
                       sudo ffmpeg -framerate 1 -pattern_type glob -i '*.png' -c:v libx264 -r 30 -pix_fmt yuv420p $WORKSPACE/e2e/report/screencast.mp4
                       cd $WORKSPACE/e2e/report/

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
                             sh """
                                curl -sL  https://www.eclipse.org/che/chectl/ > install_chectl.sh
                                chmod +x install_chectl.sh
-                               sudo PATH=$PATH ./install_chectl.sh -channel=stable
+                               sudo PATH=$PATH ./install_chectl.sh --channel=stable
                                sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
                                sudo chmod +x ${WORKSPACE}/chectl
                             """
@@ -185,7 +185,7 @@ pipeline {
             script {
                 echo "Create screencast from $WORKSPACE/e2e/report/executionScreencast files."
                 sh """
-                    command -v ffmpeg >/dev/null 2>&1 && if [ -d $WORKSPACE/e2e/report/executionScreencast ]; then
+                    command -v ffmpeg >/dev/null 2>&1 && if [ -d $WORKSPACE/e2e/report/executionScreencast ] && [-e $WORKSPACE/e2e/report/executionScreencast/*.png] ; then
                       cd $WORKSPACE/e2e/report/executionScreencast
 
                       # remove first screenshot which has lower resolution 800x600 and breaks screencast video

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -246,7 +246,7 @@ suite('Validation of debug functionality', async () => {
         await topMenu.selectOption('View', 'Debug');
         await ide.waitRightToolbarButton(RightToolbarButton.Debug);
         await debugView.clickOnDebugConfigurationDropDown();
-        await debugView.clickOnDebugConfigurationItem('PROVOKE FAILURE');
+        await debugView.clickOnDebugConfigurationItem('Debug (Launch) - Current File');
         await debugView.clickOnRunDebugButton();
 
         await previewWidget.refreshPage();

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -246,7 +246,7 @@ suite('Validation of debug functionality', async () => {
         await topMenu.selectOption('View', 'Debug');
         await ide.waitRightToolbarButton(RightToolbarButton.Debug);
         await debugView.clickOnDebugConfigurationDropDown();
-        await debugView.clickOnDebugConfigurationItem('Debug (Launch) - Current File');
+        await debugView.clickOnDebugConfigurationItem('PROVOKE FAILURE');
         await debugView.clickOnRunDebugButton();
 
         await previewWidget.refreshPage();

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -62,6 +62,11 @@ const SpringAppLocators = {
 
 suite('Validation of workspace start', async () => {
     test('Open workspace', async () => {
+        // work around default size 800x600
+        await driverHelper.getDriver()
+            .manage()
+            .window()
+            .setSize(TestConstants.TS_SELENIUM_RESOLUTION_WIDTH, TestConstants.TS_SELENIUM_RESOLUTION_HEIGHT);
         await driverHelper.navigateAndWaitToUrl(workspaceUrl);
     });
 

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -62,11 +62,6 @@ const SpringAppLocators = {
 
 suite('Validation of workspace start', async () => {
     test('Open workspace', async () => {
-        // work around default size 800x600
-        await driverHelper.getDriver()
-            .manage()
-            .window()
-            .setSize(TestConstants.TS_SELENIUM_RESOLUTION_WIDTH, TestConstants.TS_SELENIUM_RESOLUTION_HEIGHT);
         await driverHelper.navigateAndWaitToUrl(workspaceUrl);
     });
 

--- a/e2e/utils/ScreenCatcher.ts
+++ b/e2e/utils/ScreenCatcher.ts
@@ -35,12 +35,15 @@ export class ScreenCatcher {
 
         const date: Date = new Date();
         const timeStamp: string = `(${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}:${date.getMilliseconds()})`;
-        const screenshotPath: string = `${screenshotDir}/${screenshotIndex}-${methodName}-${timeStamp}.png`;
 
-        await this.catcheScreen(screenshotPath);
+        // add trailing 0 to have screenshots list normally sorted by name, e.g. 00000009, 00000010, ...
+        const formattedIndex: string = new Intl.NumberFormat('en-us', {minimumIntegerDigits: 8}).format(screenshotIndex).replace(/,/g, "");
+        const screenshotPath: string = `${screenshotDir}/${formattedIndex}-${methodName}-${timeStamp}.png`;
+
+        await this.catchScreen(screenshotPath);
     }
 
-    async catcheScreen(screenshotPath: string) {
+    async catchScreen(screenshotPath: string) {
         const screenshot: string = await this.driverHelper.getDriver().takeScreenshot();
         const screenshotStream = fs.createWriteStream(screenshotPath);
         screenshotStream.write(new Buffer(screenshot, 'base64'));

--- a/e2e/utils/ScreenCatcher.ts
+++ b/e2e/utils/ScreenCatcher.ts
@@ -19,7 +19,8 @@ export class ScreenCatcher {
 
     async catchMethodScreen(methodName: string, methodIndex: number, screenshotIndex: number) {
         const executionScreenCastDir = `${TestConstants.TS_SELENIUM_REPORT_FOLDER}/executionScreencast`;
-        const screenshotDir: string = `${executionScreenCastDir}/${methodIndex}-${methodName}`;
+        const formattedMethodIndex: string = new Intl.NumberFormat('en-us', {minimumIntegerDigits: 2}).format(methodIndex);
+        const screenshotDir: string = `${executionScreenCastDir}/${formattedMethodIndex}-${methodName}`;
 
         if (!fs.existsSync(TestConstants.TS_SELENIUM_REPORT_FOLDER)) {
             fs.mkdirSync(TestConstants.TS_SELENIUM_REPORT_FOLDER);
@@ -34,11 +35,9 @@ export class ScreenCatcher {
         }
 
         const date: Date = new Date();
-        const timeStamp: string = `(${date.getHours()}:${date.getMinutes()}:${date.getSeconds()}:${date.getMilliseconds()})`;
+        const timeStr: string = date.toLocaleTimeString('en-us', {hour12: false}) + '.' + new Intl.NumberFormat('en-us', {minimumIntegerDigits: 3}).format(date.getMilliseconds());
 
-        // add trailing 0 to have screenshots list normally sorted by name, e.g. 00000009, 00000010, ...
-        const formattedIndex: string = new Intl.NumberFormat('en-us', {minimumIntegerDigits: 8}).format(screenshotIndex).replace(/,/g, "");
-        const screenshotPath: string = `${screenshotDir}/${formattedIndex}-${methodName}-${timeStamp}.png`;
+        const screenshotPath: string = `${screenshotDir}/${timeStr}_${formattedMethodIndex}-${methodName}.png`;
 
         await this.catchScreen(screenshotPath);
     }

--- a/e2e/utils/ScreenCatcher.ts
+++ b/e2e/utils/ScreenCatcher.ts
@@ -19,8 +19,8 @@ export class ScreenCatcher {
 
     async catchMethodScreen(methodName: string, methodIndex: number, screenshotIndex: number) {
         const executionScreenCastDir = `${TestConstants.TS_SELENIUM_REPORT_FOLDER}/executionScreencast`;
-        const formattedMethodIndex: string = new Intl.NumberFormat('en-us', {minimumIntegerDigits: 2}).format(methodIndex);
-        const screenshotDir: string = `${executionScreenCastDir}/${formattedMethodIndex}-${methodName}`;
+        const formattedMethodIndex: string = new Intl.NumberFormat('en-us', {minimumIntegerDigits: 3}).format(methodIndex);
+        const formattedScreenshotIndex: string = new Intl.NumberFormat('en-us', {minimumIntegerDigits: 5}).format(screenshotIndex).replace(/,/g, '');
 
         if (!fs.existsSync(TestConstants.TS_SELENIUM_REPORT_FOLDER)) {
             fs.mkdirSync(TestConstants.TS_SELENIUM_REPORT_FOLDER);
@@ -30,14 +30,10 @@ export class ScreenCatcher {
             fs.mkdirSync(executionScreenCastDir);
         }
 
-        if (!fs.existsSync(screenshotDir)) {
-            fs.mkdirSync(screenshotDir);
-        }
-
         const date: Date = new Date();
         const timeStr: string = date.toLocaleTimeString('en-us', {hour12: false}) + '.' + new Intl.NumberFormat('en-us', {minimumIntegerDigits: 3}).format(date.getMilliseconds());
 
-        const screenshotPath: string = `${screenshotDir}/${timeStr}_${formattedMethodIndex}-${methodName}.png`;
+        const screenshotPath: string = `${executionScreenCastDir}/${formattedMethodIndex}${formattedScreenshotIndex}--(${timeStr}): ${methodName}.png`;
 
         await this.catchScreen(screenshotPath);
     }


### PR DESCRIPTION
### What does this PR do?
It fixes screenshot files naming so that they been sorted normally by name:
```
00000001-Java LS initialization-(11:32:3:701).png
00000002-Java LS initialization-(11:32:6:143).png
00000003-Java LS initialization-(11:32:8:392).png
00000004-Java LS initialization-(11:32:10:640).png
00000005-Java LS initialization-(11:32:12:925).png
00000006-Java LS initialization-(11:32:15:171).png
00000007-Java LS initialization-(11:32:17:422).png
00000008-Java LS initialization-(11:32:19:691).png
00000009-Java LS initialization-(11:32:21:931).png
00000010-Java LS initialization-(11:32:24:176).png
00000011-Java LS initialization-(11:32:26:412).png
00000012-Java LS initialization-(11:32:29:805).png
```
PR is about adding trailing 0 to the file number to normalize sorting.

#### Before
How list of files looked previously https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/che-regular-tests/view/K8S/job/CHE-7-Happy-Path-Tests/1117/artifact/e2e/report/executionScreencast/4-Java%20LS%20initialization/:
![Screenshot from 2019-08-20 15-52-52](https://user-images.githubusercontent.com/1197777/63348828-befd6680-c362-11e9-8766-98f41e705d95.png)

#### After
![Screenshot from 2019-08-20 16-16-08](https://user-images.githubusercontent.com/1197777/63350295-d68a1e80-c365-11e9-819d-f9e8325c58f6.png)

As you can see, last screenshot file will be always last in the list, so that makes heading file starting from "10000" as redundant as well. 

Also, it makes it simple to create animated gif file - by one command within the the directory with screenshots:
```
ffmpeg -framerate 2 -pattern_type glob -i '*.png' -final_delay 100 out.gif
```

#### Updated "After"
![Screenshot from 2019-08-21 20-01-35](https://user-images.githubusercontent.com/1197777/63452617-66f05e00-c44f-11e9-997c-3a880363bce3.png)


### Related issue
https://github.com/eclipse/che/issues/14300