### PR TITLE
factory will always use devfile generateName

### DIFF
--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -168,7 +168,7 @@ public class URLFactoryBuilder {
   /**
    * Help to generate default workspace devfile. Also initialise project in it
    *
-   * @param name the name of the workspace
+   * @param name the name that will be used as `generateName` in the devfile
    * @return a workspace devfile
    */
   public DevfileDto buildDefaultDevfile(String name) {
@@ -176,6 +176,6 @@ public class URLFactoryBuilder {
     // workspace configuration using the environment
     return newDto(DevfileDto.class)
         .withApiVersion(CURRENT_API_VERSION)
-        .withMetadata(newDto(MetadataDto.class).withName(name));
+        .withMetadata(newDto(MetadataDto.class).withGenerateName(name));
   }
 }

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -33,6 +33,7 @@ import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.DevfileImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.MetadataImpl;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.DevfileDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.MetadataDto;
@@ -88,7 +89,13 @@ public class URLFactoryBuilder {
   }
 
   /**
-   * Build a factory using the provided devfile
+   * Build a factory using the provided devfile.
+   *
+   * <p>We want factory to never fail due to name collision. Taking `generateName` with precedence.
+   * <br>
+   * If devfile has only `name`, we convert it to `generateName`. <br>
+   * If devfile has `name` and `generateName`, we remove `name` and use just `generateName`. <br>
+   * If devfile has `generateName`, we use that.
    *
    * @param remoteFactoryUrl parsed factory URL object
    * @param fileContentProvider service-specific devfile related file content provider
@@ -108,6 +115,7 @@ public class URLFactoryBuilder {
     try {
       DevfileImpl devfile = devfileManager.parseYaml(devfileYamlContent);
       devfileManager.resolveReference(devfile, fileContentProvider);
+      devfile = ensureToUseGenerateName(devfile);
 
       FactoryDto factoryDto =
           newDto(FactoryDto.class)
@@ -122,6 +130,23 @@ public class URLFactoryBuilder {
               + "`. Cause: "
               + e.getMessage());
     }
+  }
+
+  /**
+   * Creates devfile with only `generateName` and no `name`. We take `generateName` with precedence.
+   * See doc of {@link URLFactoryBuilder#createFactoryFromDevfile(RemoteFactoryUrl,
+   * FileContentProvider)} for explanation why.
+   */
+  private DevfileImpl ensureToUseGenerateName(DevfileImpl devfile) {
+    MetadataImpl devfileMetadata = new MetadataImpl(devfile.getMetadata());
+    if (isNullOrEmpty(devfileMetadata.getGenerateName())) {
+      devfileMetadata.setGenerateName(devfileMetadata.getName());
+    }
+    devfileMetadata.setName(null);
+
+    DevfileImpl devfileWithProperName = new DevfileImpl(devfile);
+    devfileWithProperName.setMetadata(devfileMetadata);
+    return devfileWithProperName;
   }
 
   /**

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/DtoConverter.java
@@ -422,7 +422,9 @@ public final class DtoConverter {
 
   /** Converts {@link Metadata} to {@link MetadataDto}. */
   public static MetadataDto asDto(Metadata metadata) {
-    return newDto(MetadataDto.class).withName(metadata.getName());
+    return newDto(MetadataDto.class)
+        .withName(metadata.getName())
+        .withGenerateName(metadata.getGenerateName());
   }
 
   private DtoConverter() {}


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes possible workspace name collision when using factory with devfile. It takes `generateName` with precedence and converts `name` into `generateName`, when only `name` is defined. With this, we should always create uniquely named workspace that will have 5 random characters suffix.
- When devfile has only `name`, it use it as generateName -> `nameYYYYY`
- When devfile has only `generateName`, it uses that -> `generateNameYYYY`
- When devfile has both `name` and `generateName`, it uses `generateName` -> `generateNameYYYY`
(Y is random [0-9a-z] characted)

I've choosen to take `generateName` over `name` here, because there is higher chance that it would generate nicer name. If you have other opinion, please comment.

### What issues does this PR fix or reference?
#13683

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
