### PR TITLE
Avoid using DtoImpls directly

### DIFF
--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/multiuser/oauth/IdentityProviderConfigBuilderTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/multiuser/oauth/IdentityProviderConfigBuilderTest.java
@@ -31,12 +31,13 @@ import java.util.Optional;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.UnauthorizedException;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-import org.eclipse.che.api.core.server.dto.DtoServerImpls.ServiceErrorImpl;
+import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
 import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.RuntimeContext;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.dto.server.DtoFactory;
 import org.eclipse.che.multiuser.keycloak.server.KeycloakServiceClient;
 import org.eclipse.che.multiuser.keycloak.server.KeycloakSettings;
 import org.eclipse.che.multiuser.keycloak.shared.dto.KeycloakTokenResponse;
@@ -188,8 +189,11 @@ public class IdentityProviderConfigBuilderTest {
     assertEquals(resultConfig.getOauthToken(), ACCESS_TOKEN);
   }
 
+  @Test
   public void testRethrowOnUnauthorizedException() throws Exception {
-    doThrow(new UnauthorizedException(ServiceErrorImpl.make().withMessage("Any other message")))
+    doThrow(
+            new UnauthorizedException(
+                DtoFactory.newDto(ServiceError.class).withMessage("Any other message")))
         .when(keycloakServiceClient)
         .getIdentityProviderToken(anyString());
     try {
@@ -204,14 +208,19 @@ public class IdentityProviderConfigBuilderTest {
 
   @Test(expectedExceptions = {InfrastructureException.class})
   public void testRethrowOnBadRequestException() throws Exception {
-    doThrow(new BadRequestException(ServiceErrorImpl.make().withMessage("Any other message")))
+    doThrow(
+            new BadRequestException(
+                DtoFactory.newDto(ServiceError.class).withMessage("Any other message")))
         .when(keycloakServiceClient)
         .getIdentityProviderToken(anyString());
     configBuilder.buildConfig(defaultConfig, A_WORKSPACE_ID);
   }
 
+  @Test
   public void testRethrowOnInvalidTokenBadRequestException() throws Exception {
-    doThrow(new BadRequestException(ServiceErrorImpl.make().withMessage("Invalid token.")))
+    doThrow(
+            new BadRequestException(
+                DtoFactory.newDto(ServiceError.class).withMessage("Invalid token.")))
         .when(keycloakServiceClient)
         .getIdentityProviderToken(anyString());
     try {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -63,7 +63,6 @@ import org.eclipse.che.api.core.rest.shared.dto.ServiceError;
 import org.eclipse.che.api.workspace.server.devfile.DevfileManager;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileFormatException;
-import org.eclipse.che.api.workspace.server.dto.DtoServerImpls.DevfileDtoImpl;
 import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
 import org.eclipse.che.api.workspace.server.model.impl.EnvironmentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
@@ -188,7 +187,7 @@ public class WorkspaceServiceTest {
 
   @Test
   public void shouldCreateWorkspaceFromDevfile() throws Exception {
-    final DevfileDtoImpl devfileDto = createDevfileDto();
+    final DevfileDto devfileDto = createDevfileDto();
     final WorkspaceImpl workspace = createWorkspace(devfileDto);
 
     when(devfileManager.parseJson(any())).thenReturn(new DevfileImpl());
@@ -201,7 +200,7 @@ public class WorkspaceServiceTest {
             .auth()
             .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
             .contentType("application/json")
-            .body(devfileDto.toJson())
+            .body(devfileDto)
             .when()
             .post(
                 SECURE_PATH
@@ -228,7 +227,7 @@ public class WorkspaceServiceTest {
 
   @Test
   public void shouldAcceptYamlDevfileWhenCreatingWorkspace() throws Exception {
-    final DevfileDtoImpl devfileDto = createDevfileDto();
+    final DevfileDto devfileDto = createDevfileDto();
     final WorkspaceImpl workspace = createWorkspace(devfileDto);
 
     when(devfileManager.parseYaml(any())).thenReturn(new DevfileImpl());
@@ -267,7 +266,7 @@ public class WorkspaceServiceTest {
 
   @Test
   public void shouldReturnBadRequestOnInvalidDevfile() throws Exception {
-    final DevfileDtoImpl devfileDto = createDevfileDto();
+    final DevfileDto devfileDto = createDevfileDto();
     final WorkspaceImpl workspace = createWorkspace(devfileDto);
 
     when(devfileManager.parseJson(any())).thenThrow(new DevfileFormatException("boom"));
@@ -280,7 +279,7 @@ public class WorkspaceServiceTest {
             .auth()
             .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
             .contentType("application/json")
-            .body(devfileDto.toJson())
+            .body(devfileDto)
             .when()
             .post(
                 SECURE_PATH
@@ -1352,18 +1351,17 @@ public class WorkspaceServiceTest {
         .build();
   }
 
-  private DevfileDtoImpl createDevfileDto() {
-    return (DevfileDtoImpl)
-        newDto(DevfileDto.class)
-            .withApiVersion("0.0.1")
-            .withMetadata(newDto(MetadataDto.class).withName("ws"))
-            .withProjects(
-                singletonList(
-                    newDto(ProjectDto.class)
-                        .withName("project")
-                        .withSource(
-                            newDto(SourceDto.class)
-                                .withLocation("https://github.com/eclipse/che.git"))));
+  private DevfileDto createDevfileDto() {
+    return newDto(DevfileDto.class)
+        .withApiVersion("0.0.1")
+        .withMetadata(newDto(MetadataDto.class).withName("ws"))
+        .withProjects(
+            singletonList(
+                newDto(ProjectDto.class)
+                    .withName("project")
+                    .withSource(
+                        newDto(SourceDto.class)
+                            .withLocation("https://github.com/eclipse/che.git"))));
   }
 
   private static WorkspaceImpl createWorkspace(WorkspaceConfig configDto) {


### PR DESCRIPTION
### What does this PR do?
Avoid using DtoImpls directly.
It also enables tests in `IdentityProviderConfigBuilderTest` that did not have `@Test` annotations, probably by mistake because they pass just fine.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14318

#### Release Notes
N/A

#### Docs PR
N/A