### PR TITLE
Update default plugin brokers to v0.20 - support relative paths

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -570,8 +570,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.19
-che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.19
+che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.20
+che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.20
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
### What does this PR do?
Update default version of brokers to `v0.20` to correspond with [latest release](https://github.com/eclipse/che-plugin-broker/releases/tag/v0.20.0)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14163

#### Release Notes
N/A for now

#### Docs PR
Not ready for docs yet, since there's no established flow for relative path extension artifacts.