### PR TITLE
[Selenium] Fix Java selenium tests to run against Che with next version for default plugins

### DIFF
--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
@@ -57,11 +57,11 @@ public class TheiaIde {
     String ABOUT_DIALOG_CONTENT_XPATH = ABOUT_DIALOG_XPATH + "//div[@class='dialogContent']";
     String ABOUT_DIALOG_OK_BUTTON_XPATH = ABOUT_DIALOG_XPATH + "//button";
     String NOTIFICATION_MESSAGE_EQUALS_TO_XPATH_TEMPLATE =
-        "//div[@class='theia-NotificationsContainer']//p[text()='%s']";
+        "//div[@class='theia-notification-list-item']//div[@class='theia-notification-message']//span[text()='%s']";
     String NOTIFICATION_MESSAGE_CONTAINS_XPATH_TEMPLATE =
-        "//div[@class='theia-NotificationsContainer']//p[contains(text(), '%s')]";
+        "//div[@class='theia-notification-list-item']//div[@class='theia-notification-message']//span[contains(text(), '%s')]";
     String NOTIFICATION_CLOSE_BUTTON =
-        "//div[@class='theia-NotificationsContainer']//button[text()='Close']";
+        "//div[@class='theia-notification-buttons']//button[@data-action='Close']";
     String BRANCH_NAME_XPATH = "//div[@id='theia-statusBar']//div[contains(@title,'Git')]";
   }
 

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
@@ -28,7 +28,6 @@ import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.By;
-import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -209,12 +208,7 @@ public class TheiaIde {
     seleniumWebDriverHelper.waitVisibility(By.xpath(ideWindowXpath), PREPARING_WS_TIMEOUT_SEC);
 
     // switch to IDE frame
-    try {
-      seleniumWebDriverHelper.waitAndSwitchToFrame(By.id(ideFrameId), PREPARING_WS_TIMEOUT_SEC);
-      waitTheiaIde();
-    } catch (TimeoutException ex) {
-      seleniumWebDriverHelper.waitAndSwitchToFrame(By.id(ideFrameId), PREPARING_WS_TIMEOUT_SEC);
-    }
+    seleniumWebDriverHelper.waitAndSwitchToFrame(By.id(ideFrameId), PREPARING_WS_TIMEOUT_SEC);
   }
 
   public void pressKeyCombination(CharSequence... combination) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaIde.java
@@ -28,6 +28,7 @@ import org.eclipse.che.selenium.core.SeleniumWebDriver;
 import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.core.webdriver.SeleniumWebDriverHelper;
 import org.openqa.selenium.By;
+import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
@@ -208,7 +209,12 @@ public class TheiaIde {
     seleniumWebDriverHelper.waitVisibility(By.xpath(ideWindowXpath), PREPARING_WS_TIMEOUT_SEC);
 
     // switch to IDE frame
-    seleniumWebDriverHelper.waitAndSwitchToFrame(By.id(ideFrameId), PREPARING_WS_TIMEOUT_SEC);
+    try {
+      seleniumWebDriverHelper.waitAndSwitchToFrame(By.id(ideFrameId), PREPARING_WS_TIMEOUT_SEC);
+      waitTheiaIde();
+    } catch (TimeoutException ex) {
+      seleniumWebDriverHelper.waitAndSwitchToFrame(By.id(ideFrameId), PREPARING_WS_TIMEOUT_SEC);
+    }
   }
 
   public void pressKeyCombination(CharSequence... combination) {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaProjectTree.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaProjectTree.java
@@ -62,8 +62,7 @@ public class TheiaProjectTree {
     String COLLAPSED_ITEM_XPATH_TEMPLATE =
         "//div[@data-node-id='/projects:/projects/%s' and contains(@class, 'theia-mod-collapsed')]";
     String EXPAND_ITEM_ICON_XPATH_TEMPLATE = "//div[@data-node-id='/projects:/projects/%s']";
-    String FILES_TAB_XPATH =
-        "//div[contains(@class, 'theia-app-left')]//ul[@class='p-TabBar-content']//li[@title='Explorer']";
+    String FILES_TAB_XPATH = "shell-tab-explorer-view-container";
     String OPEN_WORKSPACE_BUTTON_XPATH = "//button[@class='open-workspace-button']";
   }
 
@@ -77,12 +76,12 @@ public class TheiaProjectTree {
 
   public void clickOnFilesTab() {
     seleniumWebDriverHelper.waitNoExceptions(
-        () -> seleniumWebDriverHelper.waitAndClick(By.xpath(FILES_TAB_XPATH)),
+        () -> seleniumWebDriverHelper.waitAndClick(By.id(FILES_TAB_XPATH)),
         WebDriverException.class);
   }
 
   public void waitFilesTab() {
-    seleniumWebDriverHelper.waitVisibility(By.xpath(FILES_TAB_XPATH));
+    seleniumWebDriverHelper.waitVisibility(By.id(FILES_TAB_XPATH));
   }
 
   public void waitProjectAreaOpened() {

--- a/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaProjectTree.java
+++ b/selenium/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/theia/TheiaProjectTree.java
@@ -13,7 +13,7 @@ package org.eclipse.che.selenium.pageobject.theia;
 
 import static java.lang.String.format;
 import static org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree.Locators.EXPAND_ITEM_ICON_XPATH_TEMPLATE;
-import static org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree.Locators.FILES_TAB_XPATH;
+import static org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree.Locators.FILES_TAB_ID;
 import static org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree.Locators.OPEN_WORKSPACE_BUTTON_XPATH;
 import static org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree.Locators.PROJECT_TREE_CONTAINER_ID;
 import static org.eclipse.che.selenium.pageobject.theia.TheiaProjectTree.Locators.ROOT_PROJECTS_FOLDER_ID;
@@ -62,7 +62,7 @@ public class TheiaProjectTree {
     String COLLAPSED_ITEM_XPATH_TEMPLATE =
         "//div[@data-node-id='/projects:/projects/%s' and contains(@class, 'theia-mod-collapsed')]";
     String EXPAND_ITEM_ICON_XPATH_TEMPLATE = "//div[@data-node-id='/projects:/projects/%s']";
-    String FILES_TAB_XPATH = "shell-tab-explorer-view-container";
+    String FILES_TAB_ID = "shell-tab-explorer-view-container";
     String OPEN_WORKSPACE_BUTTON_XPATH = "//button[@class='open-workspace-button']";
   }
 
@@ -76,12 +76,11 @@ public class TheiaProjectTree {
 
   public void clickOnFilesTab() {
     seleniumWebDriverHelper.waitNoExceptions(
-        () -> seleniumWebDriverHelper.waitAndClick(By.id(FILES_TAB_XPATH)),
-        WebDriverException.class);
+        () -> seleniumWebDriverHelper.waitAndClick(By.id(FILES_TAB_ID)), WebDriverException.class);
   }
 
   public void waitFilesTab() {
-    seleniumWebDriverHelper.waitVisibility(By.id(FILES_TAB_XPATH));
+    seleniumWebDriverHelper.waitVisibility(By.id(FILES_TAB_ID));
   }
 
   public void waitProjectAreaOpened() {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -97,9 +97,7 @@ public class CreateAndDeleteProjectsTest {
     // switch to the IDE and wait for workspace is ready to use
     theiaIde.switchToIdeFrame();
     theiaIde.waitTheiaIde();
-
     theiaIde.waitLoaderInvisibility();
-
     theiaIde.waitTheiaIdeTopPanel();
     theiaProjectTree.waitFilesTab();
     theiaProjectTree.clickOnFilesTab();

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/CreateAndDeleteProjectsTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
 import static org.eclipse.che.selenium.pageobject.dashboard.workspaces.WorkspaceDetails.WorkspaceDetailsTab.PROJECTS;
 
@@ -37,7 +36,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
-@Test(groups = UNDER_REPAIR)
 public class CreateAndDeleteProjectsTest {
 
   private static final String WORKSPACE = generate("workspace", 4);
@@ -99,13 +97,14 @@ public class CreateAndDeleteProjectsTest {
     // switch to the IDE and wait for workspace is ready to use
     theiaIde.switchToIdeFrame();
     theiaIde.waitTheiaIde();
+
     theiaIde.waitLoaderInvisibility();
+
     theiaIde.waitTheiaIdeTopPanel();
     theiaProjectTree.waitFilesTab();
+    theiaProjectTree.clickOnFilesTab();
 
     // wait for projects in the tree
-    theiaProjectTree.clickOnFilesTab();
-    theiaProjectTree.waitProjectsRootItem();
     theiaProjectTree.waitProjectAreaOpened();
     theiaProjectTree.waitItem(CONSOLE_JAVA_SIMPLE);
     theiaProjectTree.waitItem(SECOND_CONSOLE_JAVA_SIMPLE_PROJECT_NAME);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportMavenProjectFromGitTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportMavenProjectFromGitTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.GIT;
 
 import com.google.inject.Inject;
@@ -36,7 +35,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Andrey Chizhikov */
-@Test(groups = UNDER_REPAIR)
 public class ImportMavenProjectFromGitTest {
 
   private final String WORKSPACE = generate("ImtMvnPrjGit", 4);
@@ -101,8 +99,6 @@ public class ImportMavenProjectFromGitTest {
 
     // wait the project in the tree
     theiaProjectTree.clickOnFilesTab();
-    theiaProjectTree.waitProjectsRootItem();
-    theiaProjectTree.waitProjectAreaOpened();
     theiaProjectTree.waitItem(testProjectName);
   }
 }

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.GITHUB;
 import static org.testng.AssertJUnit.assertTrue;
@@ -41,7 +40,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Test(groups = UNDER_REPAIR)
 public class ImportProjectFromGitHubTest {
   private static final String WORKSPACE =
       generate(ImportProjectFromGitHubTest.class.getSimpleName(), 4);
@@ -125,8 +123,6 @@ public class ImportProjectFromGitHubTest {
 
     // wait the project in the tree
     theiaProjectTree.clickOnFilesTab();
-    theiaProjectTree.waitProjectsRootItem();
-    theiaProjectTree.waitProjectAreaOpened();
     theiaProjectTree.waitItem(projectName);
   }
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolderTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolderTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.selenium.factory;
 
 import static org.eclipse.che.selenium.core.TestGroup.GITHUB;
 import static org.eclipse.che.selenium.core.TestGroup.OPENSHIFT;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
 
 import com.google.inject.Inject;
@@ -33,7 +32,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Musienko Maxim */
-@Test(groups = {GITHUB, OPENSHIFT, UNDER_REPAIR})
+@Test(groups = {GITHUB, OPENSHIFT})
 public class DirectUrlFactoryWithRootFolderTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(DirectUrlFactoryWithRootFolderTest.class);
@@ -97,7 +96,6 @@ public class DirectUrlFactoryWithRootFolderTest {
 
     theiaProjectTree.waitFilesTab();
     theiaProjectTree.clickOnFilesTab();
-    theiaProjectTree.waitProjectsRootItem();
     theiaProjectTree.waitItem(repositoryName);
     theiaProjectTree.expandItem(repositoryName);
 

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
@@ -14,7 +14,6 @@ package org.eclipse.che.selenium.factory;
 import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.AUXILIARY;
 import static org.eclipse.che.selenium.core.TestGroup.GITHUB;
 import static org.eclipse.che.selenium.core.TestGroup.OPENSHIFT;
-import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -37,7 +36,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Test(groups = {GITHUB, OPENSHIFT, UNDER_REPAIR})
+@Test(groups = {GITHUB, OPENSHIFT})
 public class DirectUrlFactoryWithSpecificBranchTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(DirectUrlFactoryWithSpecificBranchTest.class);
@@ -97,7 +96,6 @@ public class DirectUrlFactoryWithSpecificBranchTest {
 
     theiaProjectTree.waitFilesTab();
     theiaProjectTree.clickOnFilesTab();
-    theiaProjectTree.waitProjectsRootItem();
 
     theiaProjectTree.waitItem(repositoryName);
     theiaProjectTree.expandItem(repositoryName);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/theia/TheiaBuildPluginTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/theia/TheiaBuildPluginTest.java
@@ -99,7 +99,6 @@ public class TheiaBuildPluginTest {
     // prepare project tree
     theiaProjectTree.waitFilesTab();
     theiaProjectTree.clickOnFilesTab();
-    theiaProjectTree.waitProjectsRootItem();
     theiaIde.waitNotificationDisappearance(
         "Che Workspace: Finished cloning projects.", UPDATING_PROJECT_TIMEOUT_SEC);
 


### PR DESCRIPTION
### What does this PR do?
After **Che** master has been switched to ```Che Theia``` next which based on **Theia** master branch, we need to adapt Java selenium test to be executed against Theia from master branch.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14325


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
