### PR TITLE
Update screencatcher in the e2e folder for avoiding errors

### DIFF
--- a/e2e/utils/ScreenCatcher.ts
+++ b/e2e/utils/ScreenCatcher.ts
@@ -19,8 +19,9 @@ export class ScreenCatcher {
 
     async catchMethodScreen(methodName: string, methodIndex: number, screenshotIndex: number) {
         const executionScreenCastDir = `${TestConstants.TS_SELENIUM_REPORT_FOLDER}/executionScreencast`;
-        const formattedMethodIndex: string = new Intl.NumberFormat('en-us', {minimumIntegerDigits: 3}).format(methodIndex);
-        const formattedScreenshotIndex: string = new Intl.NumberFormat('en-us', {minimumIntegerDigits: 5}).format(screenshotIndex).replace(/,/g, '');
+        const executionScreenCastErrorsDir = `${TestConstants.TS_SELENIUM_REPORT_FOLDER}/executionScreencastErrors`;
+        const formattedMethodIndex: string = new Intl.NumberFormat('en-us', { minimumIntegerDigits: 3 }).format(methodIndex);
+        const formattedScreenshotIndex: string = new Intl.NumberFormat('en-us', { minimumIntegerDigits: 5 }).format(screenshotIndex).replace(/,/g, '');
 
         if (!fs.existsSync(TestConstants.TS_SELENIUM_REPORT_FOLDER)) {
             fs.mkdirSync(TestConstants.TS_SELENIUM_REPORT_FOLDER);
@@ -31,11 +32,21 @@ export class ScreenCatcher {
         }
 
         const date: Date = new Date();
-        const timeStr: string = date.toLocaleTimeString('en-us', {hour12: false}) + '.' + new Intl.NumberFormat('en-us', {minimumIntegerDigits: 3}).format(date.getMilliseconds());
+        const timeStr: string = date.toLocaleTimeString('en-us', { hour12: false }) + '.' + new Intl.NumberFormat('en-us', { minimumIntegerDigits: 3 }).format(date.getMilliseconds());
 
         const screenshotPath: string = `${executionScreenCastDir}/${formattedMethodIndex}${formattedScreenshotIndex}--(${timeStr}): ${methodName}.png`;
 
-        await this.catchScreen(screenshotPath);
+        try {
+            await this.catchScreen(screenshotPath);
+        } catch (err) {
+            if (!fs.existsSync(executionScreenCastErrorsDir)) {
+                fs.mkdirSync(executionScreenCastErrorsDir);
+            }
+
+            let errorLogFilePath: string = screenshotPath.replace('.png', '.txt');
+            errorLogFilePath = errorLogFilePath.replace(executionScreenCastDir, executionScreenCastErrorsDir);
+            await this.writeErrorLog(errorLogFilePath, err);
+        }
     }
 
     async catchScreen(screenshotPath: string) {
@@ -43,6 +54,18 @@ export class ScreenCatcher {
         const screenshotStream = fs.createWriteStream(screenshotPath);
         screenshotStream.write(new Buffer(screenshot, 'base64'));
         screenshotStream.end();
+    }
+
+    async writeErrorLog(errorLogPath: string, err: Error) {
+        let errorLog: string;
+        console.log(`Failed to save screenshot, additional information in the ${errorLogPath}`);
+
+        if (err.stack) {
+            errorLog = err.stack;
+            const screenshotStream = fs.createWriteStream(errorLogPath);
+            screenshotStream.write(new Buffer(errorLog, 'utf8'));
+            screenshotStream.end();
+        }
     }
 
 }

--- a/e2e/utils/ScreenCatcher.ts
+++ b/e2e/utils/ScreenCatcher.ts
@@ -61,9 +61,8 @@ export class ScreenCatcher {
         console.log(`Failed to save screenshot, additional information in the ${errorLogPath}`);
 
         if (err.stack) {
-            errorLog = err.stack;
             const screenshotStream = fs.createWriteStream(errorLogPath);
-            screenshotStream.write(new Buffer(errorLog, 'utf8'));
+            screenshotStream.write(new Buffer(err.stack, 'utf8'));
             screenshotStream.end();
         }
     }

--- a/e2e/utils/ScreenCatcher.ts
+++ b/e2e/utils/ScreenCatcher.ts
@@ -57,7 +57,6 @@ export class ScreenCatcher {
     }
 
     async writeErrorLog(errorLogPath: string, err: Error) {
-        let errorLog: string;
         console.log(`Failed to save screenshot, additional information in the ${errorLogPath}`);
 
         if (err.stack) {


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Update screencatcher in the e2e folder for avoiding errors

If screenshots store without errors, all works as before
![Screenshot from 2019-08-30 13-06-46](https://user-images.githubusercontent.com/22724619/64013002-8e1dee00-cb27-11e9-8bda-a5de1e52f4b9.png)

If error happens, the error interrupts and stack trace stores in the separated folder and file
![Screenshot from 2019-08-30 13-05-33](https://user-images.githubusercontent.com/22724619/64013070-b7d71500-cb27-11e9-86e7-944a494e3024.png)
  

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/14384
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
