### PR TITLE
Add Host Key checking policy attribute to the ssh config

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
@@ -207,13 +207,15 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
   }
 
   /**
-   * Returns the ssh configuration entry which includes host and identity file location
+   * Returns the ssh configuration entry which includes host, identity file location and Host Key
+   * checking policy
    *
    * <p>Example of provided configuration:
    *
    * <pre>
    * host github.com
    * IdentityFile /etc/ssh/github-com/ssh-privatekey
+   * StrictHostKeyChecking = no
    * </pre>
    *
    * or
@@ -221,6 +223,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
    * <pre>
    * host *
    * IdentityFile /etc/ssh/default-123456/ssh-privatekey
+   * StrictHostKeyChecking = no
    * </pre>
    *
    * @param name the of key given during generate for vcs service we will consider it as host of
@@ -230,7 +233,8 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
    *     provide own name. Details see here:
    *     https://github.com/eclipse/che/issues/13494#issuecomment-512761661. Note: behavior can be
    *     improved in 7.x releases after 7.0.0
-   * @return the ssh configuration which include host and identity file location
+   * @return the ssh configuration which include host, identity file location and Host Key checking
+   *     policy
    */
   private String buildConfig(@NotNull String name) {
     String host = name.startsWith("default-") ? "*" : name;
@@ -241,6 +245,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
         + getValidNameForSecret(name)
         + "/"
         + SSH_PRIVATE_KEY
+        + "\nStrictHostKeyChecking = no"
         + "\n";
   }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
When executing a clone command via SSH url from the git plugin, the clone process fails if there is no related host in the `known_hosts` file. In order to this attribute host will be added automatically to the `known_hosts` file. SSH clone ends successfully in this case.

### What issues does this PR fix or reference?
#14288 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
