### PR TITLE
[E2E] Fixing bug in opening file.

### DIFF
--- a/e2e/pageobjects/ide/ProjectTree.ts
+++ b/e2e/pageobjects/ide/ProjectTree.ts
@@ -131,15 +131,17 @@ export class ProjectTree {
     }
 
     async expandPathAndOpenFile(pathToItem: string, fileName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        let projectName: string = '';
+        let items:Array<string> = pathToItem.split('/');
+        let projectName: string = items[0];
         let paths: Array<string> = new Array();
+        paths.push(projectName);
 
         // make direct path for each project tree item
-        pathToItem.split('/')
-            .forEach(item => {
-                projectName = `${projectName}/${item}`;
-                paths.push(projectName);
-            });
+        for(let i = 1; i < items.length; i++){
+            let item = items[i];
+            projectName = `${projectName}/${item}`;
+            paths.push(projectName);
+        }
 
         // expand each project tree item
         for (const path of paths) {


### PR DESCRIPTION
### What does this PR do?
The last changes created a bug in ProjectTree.ts file. This PR is fixing them.
When calling the `expandPathAndOpenFile` method in ProjectTree.ts file, there was a problem with adding slashes, so the wrong css path was generated. Was: `/projects:/projects//console-java-simple`, should be: `/projects:/projects/console-java-simple`.
One slash was added in `expandPathAndOpenFile` method and the second slash was added in `getItemCss` method, which was called inside the first one.
As `getItemCss` method may be used in other methods, I decided to change a logic in `expandPathAndOpenFile`.
