### PR TITLE
Reconfigure Gson to parse more complex theia preference object

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
@@ -40,5 +40,18 @@ public final class Warnings {
       COMMAND_IS_CONFIGURED_IN_PLUGIN_WITH_MULTIPLY_CONTAINERS_WARNING_MESSAGE_FMT =
           "There are configured commands for plugin '%s' that has multiply containers. Commands will be configured to be run in first container";
 
+  public static final int JSON_IS_NOT_A_VALID_REPRESENTATION_FOR_AN_OBJECT_OF_TYPE_WARNING_CODE =
+      4108;
+  public static final String JSON_IS_NOT_A_VALID_REPRESENTATION_FOR_AN_OBJECT_OF_TYPE_MESSAGE_FMT =
+      "Unable to provision git configuration into runtime. "
+          + "Json object in user preferences is not a valid representation for an object of type map: '%s'";
+
+  public static final int
+      INTERNAL_SERVER_ERROR_OCCURRED_DURING_OPERATING_WITH_USER_PREFERENCES_WARNING_CODE = 4109;
+  public static final String
+      INTERNAL_SERVER_ERROR_OCCURRED_DURING_OPERATING_WITH_USER_PREFERENCES_MESSAGE_FMT =
+          "Unable to provision git configuration into runtime. "
+              + "Internal server error occurred during operating with user preferences: '%s'";
+
   private Warnings() {}
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GitUserProfileProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GitUserProfileProvisionerTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
@@ -21,19 +22,30 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
-import io.fabric8.kubernetes.api.model.*;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.Warning;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.user.server.PreferenceManager;
+import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Warnings;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -78,6 +90,20 @@ public class GitUserProfileProvisionerTest {
   }
 
   @Test
+  public void testShouldDoNothingWhenGitPreferencesDoesNotContainsGitPreferences()
+      throws Exception {
+    Map<String, String> preferences =
+        singletonMap(
+            "theia-user-preferences",
+            "{\"chePlugins.repositories\":{\"Plugins\":\"http://url/\",\"my\":\"https://url/plugins.json\"}}");
+    when(preferenceManager.find(eq("id"), eq("theia-user-preferences"))).thenReturn(preferences);
+
+    gitUserProfileProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    verifyZeroInteractions(runtimeIdentity);
+  }
+
+  @Test
   public void testShouldDoNothingWhenGitPreferencesAreEmpty() throws Exception {
     Map<String, String> preferences = singletonMap("theia-user-preferences", "{}");
     when(preferenceManager.find(eq("id"), eq("theia-user-preferences"))).thenReturn(preferences);
@@ -88,8 +114,211 @@ public class GitUserProfileProvisionerTest {
   }
 
   @Test
+  public void testShouldExpectWarningWhenPreferenceManagerThrowsServerException() throws Exception {
+    when(preferenceManager.find(eq("id"), eq("theia-user-preferences")))
+        .thenThrow(new ServerException("message"));
+
+    gitUserProfileProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    verifyZeroInteractions(runtimeIdentity);
+
+    List<Warning> warnings = k8sEnv.getWarnings();
+
+    assertEquals(warnings.size(), 1);
+
+    Warning actualWarning = warnings.get(0);
+    String warnMsg =
+        format(
+            Warnings
+                .INTERNAL_SERVER_ERROR_OCCURRED_DURING_OPERATING_WITH_USER_PREFERENCES_MESSAGE_FMT,
+            "message");
+    Warning expectedWarning =
+        new WarningImpl(
+            Warnings
+                .INTERNAL_SERVER_ERROR_OCCURRED_DURING_OPERATING_WITH_USER_PREFERENCES_WARNING_CODE,
+            warnMsg);
+
+    assertEquals(expectedWarning, actualWarning);
+  }
+
+  @Test
+  public void testShouldExpectWarningWhenJsonObjectInPreferencesIsNotValid() throws Exception {
+    Map<String, String> preferences = singletonMap("theia-user-preferences", "{#$%}");
+    when(preferenceManager.find(eq("id"), eq("theia-user-preferences"))).thenReturn(preferences);
+
+    gitUserProfileProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    verifyZeroInteractions(runtimeIdentity);
+
+    List<Warning> warnings = k8sEnv.getWarnings();
+
+    assertEquals(warnings.size(), 1);
+
+    Warning actualWarning = warnings.get(0);
+    String warnMsg =
+        format(
+            Warnings.JSON_IS_NOT_A_VALID_REPRESENTATION_FOR_AN_OBJECT_OF_TYPE_MESSAGE_FMT,
+            "java.io.EOFException: End of input at line 1 column 6 path $.");
+    Warning expectedWarning =
+        new WarningImpl(
+            Warnings.JSON_IS_NOT_A_VALID_REPRESENTATION_FOR_AN_OBJECT_OF_TYPE_WARNING_CODE,
+            warnMsg);
+
+    assertEquals(expectedWarning, actualWarning);
+  }
+
+  @Test
   public void testShouldCheckIfPodHasMountAndK8HasConfigMapForGitConfig() throws Exception {
     String json = "{\"git.user.name\":\"user\",\"git.user.email\":\"email\"}";
+    Map<String, String> preferences = singletonMap("theia-user-preferences", json);
+    when(preferenceManager.find(eq("id"), eq("theia-user-preferences"))).thenReturn(preferences);
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("wksp");
+
+    ObjectMeta podMeta = new ObjectMetaBuilder().withName("wksp").build();
+    when(pod.getMetadata()).thenReturn(podMeta);
+    when(pod.getSpec()).thenReturn(podSpec);
+    when(podSpec.getContainers()).thenReturn(singletonList(container));
+
+    List<VolumeMount> volumeMounts = new ArrayList<>();
+
+    when(container.getVolumeMounts()).thenReturn(volumeMounts);
+    k8sEnv.addPod(pod);
+
+    gitUserProfileProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    assertEquals(volumeMounts.size(), 1);
+
+    VolumeMount mount = volumeMounts.get(0);
+
+    assertEquals(mount.getMountPath(), "/etc/gitconfig");
+    assertEquals(mount.getName(), "gitconfigvolume");
+    assertFalse(mount.getReadOnly());
+    assertEquals(mount.getSubPath(), "gitconfig");
+
+    assertEquals(k8sEnv.getConfigMaps().size(), 1);
+    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+
+    assertEquals(configMap.getData().size(), 1);
+    assertTrue(configMap.getData().containsKey("gitconfig"));
+
+    String gitconfig = configMap.getData().get("gitconfig");
+    String expectedGitconfig = "[user]\n\tname = user\n\temail = email\n";
+
+    assertEquals(gitconfig, expectedGitconfig);
+  }
+
+  @DataProvider(name = "invalidEmailValues")
+  public Object[][] invalidEmailValues() {
+    return new Object[][] {
+      {"{\"git.user.name\":\"user\",\"git.user.email\":{}}"},
+      {"{\"git.user.name\":\"user\",\"git.user.email\":true}"},
+      {"{\"git.user.name\":\"user\",\"git.user.email\":1}"},
+      {"{\"git.user.name\":\"user\",\"git.user.email\":[]}"},
+      {"{\"git.user.name\":\"user\",\"git.user.email\":null}"}
+    };
+  }
+
+  @Test(dataProvider = "invalidEmailValues")
+  public void testShouldParseOnlyNameWhenEmailIsNotAString(String json) throws Exception {
+    Map<String, String> preferences = singletonMap("theia-user-preferences", json);
+    when(preferenceManager.find(eq("id"), eq("theia-user-preferences"))).thenReturn(preferences);
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("wksp");
+
+    ObjectMeta podMeta = new ObjectMetaBuilder().withName("wksp").build();
+    when(pod.getMetadata()).thenReturn(podMeta);
+    when(pod.getSpec()).thenReturn(podSpec);
+    when(podSpec.getContainers()).thenReturn(singletonList(container));
+
+    List<VolumeMount> volumeMounts = new ArrayList<>();
+
+    when(container.getVolumeMounts()).thenReturn(volumeMounts);
+    k8sEnv.addPod(pod);
+
+    gitUserProfileProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    assertEquals(volumeMounts.size(), 1);
+
+    VolumeMount mount = volumeMounts.get(0);
+
+    assertEquals(mount.getMountPath(), "/etc/gitconfig");
+    assertEquals(mount.getName(), "gitconfigvolume");
+    assertFalse(mount.getReadOnly());
+    assertEquals(mount.getSubPath(), "gitconfig");
+
+    assertEquals(k8sEnv.getConfigMaps().size(), 1);
+    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+
+    assertEquals(configMap.getData().size(), 1);
+    assertTrue(configMap.getData().containsKey("gitconfig"));
+
+    String gitconfig = configMap.getData().get("gitconfig");
+    String expectedGitconfig = "[user]\n\tname = user\n";
+
+    assertEquals(gitconfig, expectedGitconfig);
+  }
+
+  @DataProvider(name = "invalidNameValues")
+  public Object[][] invalidNameValues() {
+    return new Object[][] {
+      {"{\"git.user.name\":{},\"git.user.email\":\"email\"}"},
+      {"{\"git.user.name\":true,\"git.user.email\":\"email\"}"},
+      {"{\"git.user.name\":1,\"git.user.email\":\"email\"}"},
+      {"{\"git.user.name\":[],\"git.user.email\":\"email\"}"},
+      {"{\"git.user.name\":null,\"git.user.email\":\"email\"}"}
+    };
+  }
+
+  @Test(dataProvider = "invalidNameValues")
+  public void testShouldParseOnlyEmailWhenNameIsNotAString(String json) throws Exception {
+    Map<String, String> preferences = singletonMap("theia-user-preferences", json);
+    when(preferenceManager.find(eq("id"), eq("theia-user-preferences"))).thenReturn(preferences);
+    when(runtimeIdentity.getWorkspaceId()).thenReturn("wksp");
+
+    ObjectMeta podMeta = new ObjectMetaBuilder().withName("wksp").build();
+    when(pod.getMetadata()).thenReturn(podMeta);
+    when(pod.getSpec()).thenReturn(podSpec);
+    when(podSpec.getContainers()).thenReturn(singletonList(container));
+
+    List<VolumeMount> volumeMounts = new ArrayList<>();
+
+    when(container.getVolumeMounts()).thenReturn(volumeMounts);
+    k8sEnv.addPod(pod);
+
+    gitUserProfileProvisioner.provision(k8sEnv, runtimeIdentity);
+
+    assertEquals(volumeMounts.size(), 1);
+
+    VolumeMount mount = volumeMounts.get(0);
+
+    assertEquals(mount.getMountPath(), "/etc/gitconfig");
+    assertEquals(mount.getName(), "gitconfigvolume");
+    assertFalse(mount.getReadOnly());
+    assertEquals(mount.getSubPath(), "gitconfig");
+
+    assertEquals(k8sEnv.getConfigMaps().size(), 1);
+    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+
+    assertEquals(configMap.getData().size(), 1);
+    assertTrue(configMap.getData().containsKey("gitconfig"));
+
+    String gitconfig = configMap.getData().get("gitconfig");
+    String expectedGitconfig = "[user]\n\temail = email\n";
+
+    assertEquals(gitconfig, expectedGitconfig);
+  }
+
+  @Test
+  public void
+      testShouldCheckIfPodHasMountAndK8HasConfigMapForGitConfigForDifferentTypeOfPreference()
+          throws Exception {
+    String json =
+        "{\"chePlugins.repositories\":{\"Plugins\":\"http://url/\",\"my\":\"https://url/plugins.json\"}, \"git.user.name\":\"user\",\"git.user.email\":\"email\"}";
     Map<String, String> preferences = singletonMap("theia-user-preferences", json);
     when(preferenceManager.find(eq("id"), eq("theia-user-preferences"))).thenReturn(preferences);
     when(runtimeIdentity.getWorkspaceId()).thenReturn("wksp");


### PR DESCRIPTION
## What does this PR do?
This changes proposal edits the rule which configure Gson parser to parse theia specific preferences. This mean that theia preferences not always contains simple structure `string:string`, but sometimes can be look like `string:object`. And could sometimes cause problem when workspace tried to start.

Signed-off-by: Vlad Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#14436 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
