### PR TITLE
[E2E] Parametrize docker to set test suite

### DIFF
--- a/dockerfiles/e2e/README.md
+++ b/dockerfiles/e2e/README.md
@@ -26,11 +26,16 @@ You can run the tests inside this docker image. You have to set URL of running C
 docker run --shm-size=256m -e TS_SELENIUM_BASE_URL=$URL eclipse/che-e2e:nightly
 ```
 
-If you want to gather screenshots of fallen tests, you have to mount a volume to the docker file. Create a folder, when you want to have the screenshots saved. Then run
-a command:
+If you want to gather screenshots of fallen tests, you have to mount a volume to the docker file. Create a folder, when you want to have the screenshots saved. Then run a command:
 
 ```
 docker run --shm-size=256m -v /full/path/to/your/folder:/root/e2e/report:Z -e TS_SELENIUM_BASE_URL=$URL eclipse/che-e2e:nightly
+```
+
+Happy Path test suite will be run by default when executing a docker run command. If you want to run another test suite, you can specify that via variable ` TEST_SUITE `. Available tests are e.g. ` test-happy-path `, ` test-che-install ` and ` test-wkspc-creation-and-ls `.
+
+```
+docker run --shm-size=256m -e TEST_SUITE=test-happy-path -e TS_SELENIUM_BASE_URL=$URL eclipse/che-e2e:nightly
 ```
 
 ### Debugging

--- a/dockerfiles/e2e/entrypoint.sh
+++ b/dockerfiles/e2e/entrypoint.sh
@@ -7,6 +7,11 @@ if [ -z "$TS_SELENIUM_BASE_URL" ]; then
     exit 1
 fi
 
+# Set testing suite
+if [ -z "$TEST_SUITE" ]; then
+    TEST_SUITE=test-happy-path
+fi
+
 # Launch selenium server
 /usr/bin/supervisord --configuration /etc/supervisord.conf & \
 export TS_SELENIUM_REMOTE_DRIVER_URL=http://localhost:4444/wd/hub
@@ -42,5 +47,6 @@ else
 	cd /tmp/e2e || exit
 fi
 
+
 # Launch tests
-npm run test-happy-path
+npm run $TEST_SUITE

--- a/e2e/mocha-wkspc-creation-and-ls.opts
+++ b/e2e/mocha-wkspc-creation-and-ls.opts
@@ -1,0 +1,7 @@
+--timeout 2200000
+--reporter 'dist/driver/CheReporter.js'
+-u tdd 
+--bail
+--full-trace
+--spec dist/tests/e2e/WorkspaceCreationAndLsInitialization.spec.js
+--require source-map-support/register

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,6 +10,7 @@
     "test": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha.opts",
     "test-happy-path": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-happy-path.opts",
     "test-che-install": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-che-operatorhub.opts",
+    "test-wkspc-creation-and-ls": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-wkspc-creation-and-ls.opts",
     "lint": "tslint --fix -p .",
     "tsc": "tsc -p ."
   },


### PR DESCRIPTION
### What does this PR do?
Add `TEST_SUITE` variable to docker run command. Now user can set the command from package.json that specifies the suite that will be run. 
Add example of `TEST_SUITE` usage to README.md.

Is related to https://github.com/eclipse/che/issues/14027