### PR TITLE
Provision name and email from user profile if preferences are empty

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
@@ -46,12 +46,10 @@ public final class Warnings {
       "Unable to provision git configuration into runtime. "
           + "Json object in user preferences is not a valid representation for an object of type map: '%s'";
 
-  public static final int
-      INTERNAL_SERVER_ERROR_OCCURRED_DURING_OPERATING_WITH_USER_PREFERENCES_WARNING_CODE = 4109;
-  public static final String
-      INTERNAL_SERVER_ERROR_OCCURRED_DURING_OPERATING_WITH_USER_PREFERENCES_MESSAGE_FMT =
-          "Unable to provision git configuration into runtime. "
-              + "Internal server error occurred during operating with user preferences: '%s'";
+  public static final int EXCEPTION_IN_USER_MANAGEMENT_DURING_GIT_PROVISION_WARNING_CODE = 4109;
+  public static final String EXCEPTION_IN_USER_MANAGEMENT_DURING_GIT_PROVISION_MESSAGE_FMT =
+      "Unable to provision git configuration into runtime. "
+          + "Internal server error occurred during operating with user management: '%s'";
 
   private Warnings() {}
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GitUserProfileProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GitUserProfileProvisioner.java
@@ -13,10 +13,10 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Optional.empty;
 import static java.util.Optional.of;
-import static java.util.Optional.ofNullable;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
@@ -35,12 +35,16 @@ import java.util.Map;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import org.eclipse.che.api.core.NotFoundException;
 import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.user.User;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.user.server.PreferenceManager;
+import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Warnings;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
@@ -58,61 +62,74 @@ public class GitUserProfileProvisioner implements ConfigurationProvisioner<Kuber
   private static final String CONFIG_MAP_VOLUME_NAME = "gitconfigvolume";
 
   private PreferenceManager preferenceManager;
+  private UserManager userManager;
 
   @Inject
-  public GitUserProfileProvisioner(PreferenceManager preferenceManager) {
+  public GitUserProfileProvisioner(PreferenceManager preferenceManager, UserManager userManager) {
     this.preferenceManager = preferenceManager;
+    this.userManager = userManager;
   }
 
   @Override
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
+
     try {
-      doInternalProvision(k8sEnv, identity);
-    } catch (ServerException e) {
-      String warnMsg =
+      Pair<String, String> userAndEmail = getUserFromPreferences();
+
+      if (userAndEmail == null) {
+        userAndEmail = getUserFromUserManager();
+      }
+
+      prepareAndProvisionGitConfiguration(
+          userAndEmail.first, userAndEmail.second, k8sEnv, identity);
+    } catch (ServerException | NotFoundException e) {
+      reportWarning(
+          k8sEnv,
+          Warnings.EXCEPTION_IN_USER_MANAGEMENT_DURING_GIT_PROVISION_WARNING_CODE,
           format(
-              Warnings
-                  .INTERNAL_SERVER_ERROR_OCCURRED_DURING_OPERATING_WITH_USER_PREFERENCES_MESSAGE_FMT,
-              e.getMessage());
-      k8sEnv
-          .getWarnings()
-          .add(
-              new WarningImpl(
-                  Warnings
-                      .INTERNAL_SERVER_ERROR_OCCURRED_DURING_OPERATING_WITH_USER_PREFERENCES_WARNING_CODE,
-                  warnMsg));
+              Warnings.EXCEPTION_IN_USER_MANAGEMENT_DURING_GIT_PROVISION_MESSAGE_FMT,
+              e.getMessage()));
     } catch (JsonSyntaxException e) {
-      String warnMsg =
+      reportWarning(
+          k8sEnv,
+          Warnings.JSON_IS_NOT_A_VALID_REPRESENTATION_FOR_AN_OBJECT_OF_TYPE_WARNING_CODE,
           format(
               Warnings.JSON_IS_NOT_A_VALID_REPRESENTATION_FOR_AN_OBJECT_OF_TYPE_MESSAGE_FMT,
-              e.getMessage());
-      k8sEnv
-          .getWarnings()
-          .add(
-              new WarningImpl(
-                  Warnings.JSON_IS_NOT_A_VALID_REPRESENTATION_FOR_AN_OBJECT_OF_TYPE_WARNING_CODE,
-                  warnMsg));
+              e.getMessage()));
     }
   }
 
-  private void doInternalProvision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
+  private void reportWarning(KubernetesEnvironment k8sEnv, int code, String message) {
+    k8sEnv.getWarnings().add(new WarningImpl(code, message));
+  }
+
+  private Pair<String, String> getUserFromPreferences()
       throws ServerException, JsonSyntaxException {
-    getPreferenceValue(PREFERENCES_KEY_FILTER)
+    String preferenceJson = getPreferenceJson(PREFERENCES_KEY_FILTER);
+    Map<String, Object> preferences = getMapFromJsonObject(preferenceJson);
+
+    String name = getStringValueOrNull(preferences, GIT_USER_NAME_PROPERTY);
+    String email = getStringValueOrNull(preferences, GIT_USER_EMAIL_PROPERTY);
+
+    return isNullOrEmpty(name) && isNullOrEmpty(email) ? null : Pair.of(name, email);
+  }
+
+  private Pair<String, String> getUserFromUserManager() throws NotFoundException, ServerException {
+    String userId = EnvironmentContext.getCurrent().getSubject().getUserId();
+    User user = userManager.getById(userId);
+
+    return Pair.of(user.getName(), user.getEmail());
+  }
+
+  private void prepareAndProvisionGitConfiguration(
+      String name, String email, KubernetesEnvironment k8sEnv, RuntimeIdentity identity) {
+    prepareGitConfigurationContent(name, email)
         .ifPresent(
-            preferenceJsonValue -> {
-              Map<String, Object> theiaPreferences = getMapFromJsonObject(preferenceJsonValue);
+            content -> {
+              String configMapName = identity.getWorkspaceId() + GIT_CONFIG_MAP_NAME_SUFFIX;
 
-              getGlobalGitConfigFileContent(
-                      getStringValueOrNull(theiaPreferences, GIT_USER_NAME_PROPERTY),
-                      getStringValueOrNull(theiaPreferences, GIT_USER_EMAIL_PROPERTY))
-                  .ifPresent(
-                      gitConfigFileContent -> {
-                        String gitConfigMapName =
-                            identity.getWorkspaceId() + GIT_CONFIG_MAP_NAME_SUFFIX;
-
-                        doProvisionGlobalGitConfig(gitConfigMapName, gitConfigFileContent, k8sEnv);
-                      });
+              doProvisionGitConfiguration(configMapName, content, k8sEnv);
             });
   }
 
@@ -123,6 +140,10 @@ public class GitUserProfileProvisioner implements ConfigurationProvisioner<Kuber
   }
 
   private Map<String, Object> getMapFromJsonObject(String json) throws JsonSyntaxException {
+    if (isNullOrEmpty(json)) {
+      return emptyMap();
+    }
+
     Type typeToken = new TypeToken<Map<String, Object>>() {}.getType();
 
     /*
@@ -134,14 +155,14 @@ public class GitUserProfileProvisioner implements ConfigurationProvisioner<Kuber
     return new Gson().fromJson(json, typeToken);
   }
 
-  private Optional<String> getPreferenceValue(String keyFilter) throws ServerException {
+  private String getPreferenceJson(String keyFilter) throws ServerException {
     String userId = EnvironmentContext.getCurrent().getSubject().getUserId();
     Map<String, String> preferencesMap = preferenceManager.find(userId, keyFilter);
 
-    return ofNullable(preferencesMap.get(keyFilter));
+    return preferencesMap.get(keyFilter);
   }
 
-  private Optional<String> getGlobalGitConfigFileContent(String userName, String userEmail) {
+  private Optional<String> prepareGitConfigurationContent(String userName, String userEmail) {
     if (isNullOrEmpty(userName) && isNullOrEmpty(userEmail)) {
       return empty();
     }
@@ -160,7 +181,7 @@ public class GitUserProfileProvisioner implements ConfigurationProvisioner<Kuber
     return of(config.toString());
   }
 
-  private void doProvisionGlobalGitConfig(
+  private void doProvisionGitConfiguration(
       String gitConfigMapName, String gitConfig, KubernetesEnvironment k8sEnv) {
     Map<String, String> gitConfigData = singletonMap(GIT_CONFIG, gitConfig);
     ConfigMap configMap =


### PR DESCRIPTION
### What does this PR do?
This changes proposal adds a behavior when user name and user email from user profile is taken to provision default git configuration, when user preferences are empty. But, when user preferences are contain information about user name and email, then user name and email from user profile is ignored.

Signed-off-by: Vlad Zhukovskyi <vzhukovs@redhat.com>

### What issues does this PR fix or reference?
#14416 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
Provision name and email from user profile if preferences are empty
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
