### PR TITLE
workspace namespace/project placeholders

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -366,6 +366,9 @@ che.infra.kubernetes.ingress.domain=
 
 # Defines Kubernetes namespace in which all workspaces will be created.
 # If not set, every workspace will be created in a new namespace, where namespace = workspace id
+# It's possible to use <username> and <userid> placeholders (e.g.: che-workspace-<username>).
+# In that case, new namespace will be created for each user. Service account with permission
+# to create new namespace must be used.
 #
 # Ignored for OpenShift infra. Use `che.infra.openshift.project` instead
 che.infra.kubernetes.namespace=
@@ -574,6 +577,9 @@ che.infra.kubernetes.runtimes_consistency_check_period_min=-1
 
 # Defines OpenShift namespace in which all workspaces will be created.
 # If not set, every workspace will be created in a new project, where project name = workspace id
+# It's possible to use <username> and <userid> placeholders (e.g.: che-workspace-<username>).
+# In that case, new project will be created for each user. OpenShift oauth or service account with
+# permission to create new projects must be used.
 che.infra.openshift.project=
 
 # Single port mode wildcard domain host & port. nip.io is used by default

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -205,6 +205,11 @@ public class KubernetesNamespace {
           .done();
       waitDefaultServiceAccount(namespaceName, client);
     } catch (KubernetesClientException e) {
+      if (e.getCode() == 403) {
+        LOG.error(
+            "Unable to create new Kubernetes project due to lack of permissions."
+                + "When using workspace namespace placeholders, service account with lenient permissions (cluster-admin) must be used.");
+      }
       throw new KubernetesInfrastructureException(e);
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -102,7 +102,9 @@ public class KubernetesNamespaceFactory {
   }
 
   protected String evalNamespaceName(String workspaceId, Subject currentUser) {
-    if (isNullOrEmpty(this.namespaceName)) {
+    if (isPredefined) {
+      return this.namespaceName;
+    } else if (isNullOrEmpty(this.namespaceName)) {
       return workspaceId;
     } else {
       String tmpNamespaceName = this.namespaceName;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -55,24 +55,19 @@ public class KubernetesNamespaceFactory {
       @Nullable @Named("che.infra.kubernetes.cluster_role_name") String clusterRoleName,
       KubernetesClientFactory clientFactory) {
     this.namespaceName = namespaceName;
-    this.isPredefined = !isNullOrEmpty(namespaceName) && !hasPlaceholders(namespaceName);
+    this.isPredefined = !isNullOrEmpty(namespaceName) && hasNoPlaceholders(this.namespaceName);
     this.serviceAccountName = serviceAccountName;
     this.clusterRoleName = clusterRoleName;
     this.clientFactory = clientFactory;
   }
 
-  private boolean hasPlaceholders(String namespaceName) {
-    for (String placeholder : NAMESPACE_NAME_PLACEHOLDERS.keySet()) {
-      if (namespaceName.contains(placeholder)) {
-        return true;
-      }
-    }
-    return false;
+  private boolean hasNoPlaceholders(String namespaceName) {
+    return NAMESPACE_NAME_PLACEHOLDERS.keySet().stream().noneMatch(namespaceName::contains);
   }
 
   /**
-   * Returns true if namespace is predefined for all workspaces or false if each workspace will be
-   * provided with a new namespace.
+   * True if namespace is predefined for all workspaces. False if each workspace will be provided
+   * with a new namespace or provided for each user when using placeholders.
    */
   public boolean isPredefined() {
     return isPredefined;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -16,9 +16,14 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 import javax.inject.Named;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 
 /**
@@ -28,6 +33,14 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFacto
  */
 @Singleton
 public class KubernetesNamespaceFactory {
+
+  private static final Map<String, Function<Subject, String>> NAMESPACE_NAME_PLACEHOLDERS =
+      new HashMap<>();
+
+  static {
+    NAMESPACE_NAME_PLACEHOLDERS.put("<username>", Subject::getUserName);
+    NAMESPACE_NAME_PLACEHOLDERS.put("<userid>", Subject::getUserId);
+  }
 
   private final String namespaceName;
   private final boolean isPredefined;
@@ -42,10 +55,19 @@ public class KubernetesNamespaceFactory {
       @Nullable @Named("che.infra.kubernetes.cluster_role_name") String clusterRoleName,
       KubernetesClientFactory clientFactory) {
     this.namespaceName = namespaceName;
-    this.isPredefined = !isNullOrEmpty(namespaceName);
+    this.isPredefined = !isNullOrEmpty(namespaceName) && !hasPlaceholders(namespaceName);
     this.serviceAccountName = serviceAccountName;
     this.clusterRoleName = clusterRoleName;
     this.clientFactory = clientFactory;
+  }
+
+  private boolean hasPlaceholders(String namespaceName) {
+    for (String placeholder : NAMESPACE_NAME_PLACEHOLDERS.keySet()) {
+      if (namespaceName.contains(placeholder)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -67,7 +89,8 @@ public class KubernetesNamespaceFactory {
    * @throws InfrastructureException if any exception occurs during namespace preparing
    */
   public KubernetesNamespace create(String workspaceId) throws InfrastructureException {
-    final String namespaceName = isPredefined ? this.namespaceName : workspaceId;
+    final String namespaceName =
+        evalNamespaceName(workspaceId, EnvironmentContext.getCurrent().getSubject());
     KubernetesNamespace namespace = doCreateNamespace(workspaceId, namespaceName);
     namespace.prepare();
 
@@ -81,6 +104,20 @@ public class KubernetesNamespaceFactory {
     }
 
     return namespace;
+  }
+
+  protected String evalNamespaceName(String workspaceId, Subject currentUser) {
+    if (isNullOrEmpty(this.namespaceName)) {
+      return workspaceId;
+    } else {
+      String tmpNamespaceName = this.namespaceName;
+      for (String placeholder : NAMESPACE_NAME_PLACEHOLDERS.keySet()) {
+        tmpNamespaceName =
+            tmpNamespaceName.replaceAll(
+                placeholder, NAMESPACE_NAME_PLACEHOLDERS.get(placeholder).apply(currentUser));
+      }
+      return tmpNamespaceName;
+    }
   }
 
   /**
@@ -105,5 +142,13 @@ public class KubernetesNamespaceFactory {
       String workspaceId, String namespaceName) {
     return new KubernetesWorkspaceServiceAccount(
         workspaceId, namespaceName, serviceAccountName, clusterRoleName, clientFactory);
+  }
+
+  protected String getServiceAccountName() {
+    return serviceAccountName;
+  }
+
+  protected String getClusterRoleName() {
+    return clusterRoleName;
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -21,6 +21,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+import org.eclipse.che.commons.subject.SubjectImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -183,5 +184,16 @@ public class KubernetesNamespaceFactoryTest {
 
     // then
     verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
+  }
+
+  @Test
+  public void testPlaceholder() {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--", "", "", clientFactory);
+    String namespace =
+        namespaceFactory.evalNamespaceName(null, new SubjectImpl("JonDoe", "123", null, false));
+
+    assertEquals(namespace, "blabol-123-JonDoe-123-JonDoe--");
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -27,6 +27,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesP
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Defines an internal API for managing subset of objects inside {@link Project} instance.
@@ -34,6 +36,8 @@ import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory
  * @author Sergii Leshchenko
  */
 public class OpenShiftProject extends KubernetesNamespace {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OpenShiftProject.class);
 
   private final OpenShiftRoutes routes;
   private final OpenShiftClientFactory clientFactory;
@@ -115,6 +119,11 @@ public class OpenShiftProject extends KubernetesNamespace {
           .endMetadata()
           .done();
     } catch (KubernetesClientException e) {
+      if (e.getCode() == 403) {
+        LOG.error(
+            "Unable to create new OpenShift project due to lack of permissions."
+                + "HINT: When using workspace project name placeholders, os-oauth or service account with more lenient permissions (cluster-admin) must be used.");
+      }
       throw new KubernetesInfrastructureException(e);
     }
   }


### PR DESCRIPTION
### What does this PR do?
Adds possibility to use placeholders in namespace for workspace with current-user values. There are currently 2 placeholders `<username>` and `<userid>`.

`<something>` pattern is not definitive. Please comment in case of any concerns or better ideas.

### What issues does this PR fix or reference?
#13488 

#### Docs PR
no docs describing installation and workspace strategies exists yet.
