### PR TITLE
Add an ability to list available k8s namespaces

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -386,6 +386,24 @@ che.infra.kubernetes.ingress.domain=
 # Ignored for OpenShift infra. Use `che.infra.openshift.project` instead
 che.infra.kubernetes.namespace=
 
+# Defines Kubernetes default namespace in which user's workspaces are created
+# if user does not override it.
+# It's possible to use <username> and <userid> placeholders (e.g.: che-workspace-<username>).
+# In that case, new namespace will be created for each user.
+# Is used by OpenShift infra as well to specify Project
+#
+# BETA It's not fully supported by infra.
+# Use che.infra.kubernetes.namespace to configure workspaces' namespace
+che.infra.kubernetes.namespace.default=<username>-che
+
+# Defines if a user is able to specify Kubernetes namespace different from default.
+# It's NOT RECOMMENDED to configured true without OAuth configured.
+# Is used by OpenShift infra as well to allows users choose Project
+#
+# BETA It's not fully supported by infra.
+# Use che.infra.kubernetes.namespace to configure workspaces' namespace
+che.infra.kubernetes.namespace.allow_user_defined=false
+
 # Defines Kubernetes Service Account name which should be specified to be bound to all workspaces pods.
 # Note that Kubernetes Infrastructure won't create the service account and it should exist.
 # OpenShift infrastructure will check if project is predefined(if `che.infra.openshift.project` is not empty):

--- a/infrastructures/kubernetes/pom.xml
+++ b/infrastructures/kubernetes/pom.xml
@@ -22,6 +22,9 @@
     </parent>
     <artifactId>infrastructure-kubernetes</artifactId>
     <name>Infrastructure :: Kubernetes</name>
+    <properties>
+        <dto-generator-out-directory>${project.build.directory}/generated-sources/dto/</dto-generator-out-directory>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -78,6 +81,10 @@
         <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>javax.annotation</groupId>
@@ -186,6 +193,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.jayway.restassured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-account</artifactId>
             <scope>test</scope>
@@ -216,6 +228,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.everrest</groupId>
+            <artifactId>everrest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
             <scope>test</scope>
@@ -243,6 +260,79 @@
     </dependencies>
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.eclipse.che.core</groupId>
+                <artifactId>che-core-api-dto-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.eclipse.che.infrastructure</groupId>
+                        <artifactId>infrastructure-kubernetes</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+                <configuration>
+                    <dtoPackages>
+                        <package>org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.dto</package>
+                    </dtoPackages>
+                    <outputDirectory>${dto-generator-out-directory}</outputDirectory>
+                    <genClassName>org.eclipse.che.workspace.infrastructure.kubernetes.api.server.dto.DtoServerImpls</genClassName>
+                    <impl>server</impl>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>pre-compile</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-resource</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>add-resource</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>${dto-generator-out-directory}/META-INF</directory>
+                                    <targetPath>META-INF</targetPath>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${dto-generator-out-directory}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!-- Create the test jar -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -40,6 +40,7 @@ import org.eclipse.che.api.workspace.server.wsplugins.ChePluginsApplier;
 import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironment;
 import org.eclipse.che.workspace.infrastructure.docker.environment.dockerimage.DockerImageEnvironmentFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.KubernetesNamespaceService;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesRuntimeCacheModule;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.DockerimageComponentToWorkspaceApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesComponentToWorkspaceApplier;
@@ -78,6 +79,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.events.Brok
 public class KubernetesInfraModule extends AbstractModule {
   @Override
   protected void configure() {
+    bind(KubernetesNamespaceService.class);
+
     MapBinder<String, InternalEnvironmentFactory> factories =
         MapBinder.newMapBinder(binder(), String.class, InternalEnvironmentFactory.class);
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceService.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.api.server;
+
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+
+import com.google.common.annotations.Beta;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import org.eclipse.che.api.core.rest.Service;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.dto.KubernetesNamespaceMetaDto;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
+
+/** @author Sergii Leshchenko */
+@Api(
+    value = "kubernetes-namespace",
+    description = "Kubernetes REST API for working with Namespaces")
+@Path("/kubernetes/namespace")
+@Beta
+public class KubernetesNamespaceService extends Service {
+
+  private final KubernetesNamespaceFactory namespaceFactory;
+
+  @Inject
+  public KubernetesNamespaceService(KubernetesNamespaceFactory namespaceFactory) {
+    this.namespaceFactory = namespaceFactory;
+  }
+
+  @GET
+  @Produces(APPLICATION_JSON)
+  @ApiOperation(
+      value = "Get k8s namespaces where user is able to create workspaces",
+      notes =
+          "This operation can be performed only by authorized user."
+              + "This is under beta and may be significant changed",
+      response = String.class,
+      responseContainer = "List")
+  @ApiResponses({
+    @ApiResponse(code = 200, message = "The namespaces successfully fetched"),
+    @ApiResponse(code = 500, message = "Internal server error occurred during namespaces fetching")
+  })
+  public List<KubernetesNamespaceMetaDto> getNamespaces() throws InfrastructureException {
+    return namespaceFactory.list().stream().map(this::asDto).collect(Collectors.toList());
+  }
+
+  private KubernetesNamespaceMetaDto asDto(KubernetesNamespaceMeta kubernetesNamespaceMeta) {
+    return DtoFactory.newDto(KubernetesNamespaceMetaDto.class)
+        .withName(kubernetesNamespaceMeta.getName())
+        .withAttributes(kubernetesNamespaceMeta.getAttributes());
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/impls/KubernetesNamespaceMetaImpl.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/impls/KubernetesNamespaceMetaImpl.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+
+/** @author Sergii Leshchenko */
+public class KubernetesNamespaceMetaImpl implements KubernetesNamespaceMeta {
+
+  private String name;
+  private Map<String, String> attributes;
+
+  public KubernetesNamespaceMetaImpl(String name) {
+    this.name = name;
+  }
+
+  public KubernetesNamespaceMetaImpl(String name, Map<String, String> attributes) {
+    this.name = name;
+    if (attributes != null) {
+      this.attributes = new HashMap<>(attributes);
+    }
+  }
+
+  public KubernetesNamespaceMetaImpl(KubernetesNamespaceMeta namespaceMeta) {
+    this(namespaceMeta.getName(), namespaceMeta.getAttributes());
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public Map<String, String> getAttributes() {
+    if (attributes == null) {
+      attributes = new HashMap<>();
+    }
+    return attributes;
+  }
+
+  public void setAttributes(Map<String, String> attributes) {
+    this.attributes = attributes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof KubernetesNamespaceMetaImpl)) {
+      return false;
+    }
+    KubernetesNamespaceMetaImpl that = (KubernetesNamespaceMetaImpl) o;
+    return Objects.equals(getName(), that.getName())
+        && Objects.equals(getAttributes(), that.getAttributes());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getName(), getAttributes());
+  }
+
+  @Override
+  public String toString() {
+    return "KubernetesNamespaceMetaImpl{"
+        + "name='"
+        + name
+        + '\''
+        + ", attributes="
+        + attributes
+        + '}';
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/shared/KubernetesNamespaceMeta.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/shared/KubernetesNamespaceMeta.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.api.shared;
+
+import java.util.Map;
+
+/**
+ * Describes meta information about kubernetes namespace.
+ *
+ * @author Sergii Leshchenko
+ */
+public interface KubernetesNamespaceMeta {
+
+  /**
+   * Attribute that shows if k8s namespace is configured as default. Possible values: true/false.
+   * Absent value should be considered as false.
+   */
+  String DEFAULT_ATTRIBUTE = "default";
+
+  /**
+   * Attributes that contains information about current namespace status. Example values: Active,
+   * Terminating. Absent value indicates that namespace is not created yet.
+   */
+  String PHASE_ATTRIBUTE = "phase";
+
+  /**
+   * Returns the name of namespace.
+   *
+   * <p>Value may be not a name of existing namespace, but predicted name with placeholders inside,
+   * like <workspaceid>.
+   */
+  String getName();
+
+  /** Returns namespace attributes, which may contains additional info about it like description. */
+  Map<String, String> getAttributes();
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/shared/dto/KubernetesNamespaceMetaDto.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/shared/dto/KubernetesNamespaceMetaDto.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.dto;
+
+import java.util.Map;
+import org.eclipse.che.dto.shared.DTO;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+
+/** @author Sergii Leshchenko */
+@DTO
+public interface KubernetesNamespaceMetaDto extends KubernetesNamespaceMeta {
+  @Override
+  String getName();
+
+  void setName(String name);
+
+  KubernetesNamespaceMetaDto withName(String name);
+
+  @Override
+  Map<String, String> getAttributes();
+
+  void setAttributes(Map<String, String> attributes);
+
+  KubernetesNamespaceMetaDto withAttributes(Map<String, String> attributes);
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -11,20 +11,33 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import javax.inject.Named;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
 
 /**
  * Helps to create {@link KubernetesNamespace} instances.
@@ -42,6 +55,9 @@ public class KubernetesNamespaceFactory {
     NAMESPACE_NAME_PLACEHOLDERS.put("<userid>", Subject::getUserId);
   }
 
+  private final String defaultNamespaceName;
+  private final boolean allowUserDefinedNamespaces;
+
   private final String namespaceName;
   private final boolean isPredefined;
   private final String serviceAccountName;
@@ -53,12 +69,23 @@ public class KubernetesNamespaceFactory {
       @Nullable @Named("che.infra.kubernetes.namespace") String namespaceName,
       @Nullable @Named("che.infra.kubernetes.service_account_name") String serviceAccountName,
       @Nullable @Named("che.infra.kubernetes.cluster_role_name") String clusterRoleName,
-      KubernetesClientFactory clientFactory) {
+      @Nullable @Named("che.infra.kubernetes.namespace.default") String defaultNamespaceName,
+      @Named("che.infra.kubernetes.namespace.allow_user_defined")
+          boolean allowUserDefinedNamespaces,
+      KubernetesClientFactory clientFactory)
+      throws ConfigurationException {
     this.namespaceName = namespaceName;
     this.isPredefined = !isNullOrEmpty(namespaceName) && hasNoPlaceholders(this.namespaceName);
     this.serviceAccountName = serviceAccountName;
     this.clusterRoleName = clusterRoleName;
     this.clientFactory = clientFactory;
+    this.defaultNamespaceName = defaultNamespaceName;
+    this.allowUserDefinedNamespaces = allowUserDefinedNamespaces;
+    if (isNullOrEmpty(defaultNamespaceName) && !allowUserDefinedNamespaces) {
+      throw new ConfigurationException(
+          "che.infra.kubernetes.namespace.default or "
+              + "che.infra.kubernetes.namespace.allow_user_defined must be configured");
+    }
   }
 
   private boolean hasNoPlaceholders(String namespaceName) {
@@ -71,6 +98,139 @@ public class KubernetesNamespaceFactory {
    */
   public boolean isPredefined() {
     return isPredefined;
+  }
+
+  /**
+   * Creates a Kubernetes namespace for the specified workspace.
+   *
+   * <p>Namespace won't be prepared. This method should be used only in case workspace recovering.
+   *
+   * @param workspaceId identifier of the workspace
+   * @return created namespace
+   */
+  public KubernetesNamespace create(String workspaceId, String namespace) {
+    return doCreateNamespace(workspaceId, namespace);
+  }
+
+  @VisibleForTesting
+  KubernetesNamespace doCreateNamespace(String workspaceId, String name) {
+    return new KubernetesNamespace(clientFactory, name, workspaceId);
+  }
+
+  /** Returns list of k8s namespaces names where a user is able to run workspaces. */
+  public List<KubernetesNamespaceMeta> list() throws InfrastructureException {
+    if (!allowUserDefinedNamespaces) {
+      return singletonList(getDefaultNamespace());
+    }
+
+    // if user defined namespaces are allowed - fetch all available
+    List<KubernetesNamespaceMeta> namespaces = fetchNamespaces();
+
+    // propagate default namespace if it's configured
+    if (!isNullOrEmpty(defaultNamespaceName)) {
+      provisionDefaultNamespace(namespaces);
+    }
+    return namespaces;
+  }
+
+  /**
+   * Returns default namespace, it's based on existing namespace if there is such or just object
+   * holder if there is no such namespace on cluster.
+   */
+  private KubernetesNamespaceMeta getDefaultNamespace() throws InfrastructureException {
+    // the default namespace must be configured if user defined are not allowed
+    // so return only it
+    String evaluatedName =
+        evalDefaultNamespaceName(
+            defaultNamespaceName, EnvironmentContext.getCurrent().getSubject());
+
+    Optional<KubernetesNamespaceMeta> defaultNamespaceOpt = fetchNamespace(evaluatedName);
+
+    KubernetesNamespaceMeta defaultNamespace =
+        defaultNamespaceOpt
+            // if the predefined namespace does not exist - return dummy info and it will be created
+            // during the first workspace start
+            .orElseGet(() -> new KubernetesNamespaceMetaImpl(evaluatedName));
+
+    defaultNamespace.getAttributes().put(DEFAULT_ATTRIBUTE, "true");
+    return defaultNamespace;
+  }
+
+  /**
+   * Provision default namespace into the specified list. If default namespace is already there -
+   * just provision the corresponding attributes to it.
+   *
+   * @param namespaces list where default namespace should be provisioned
+   */
+  private void provisionDefaultNamespace(List<KubernetesNamespaceMeta> namespaces) {
+    String evaluatedName =
+        evalDefaultNamespaceName(
+            defaultNamespaceName, EnvironmentContext.getCurrent().getSubject());
+
+    Optional<KubernetesNamespaceMeta> defaultNamespaceOpt =
+        namespaces.stream().filter(n -> evaluatedName.equals(n.getName())).findAny();
+    KubernetesNamespaceMeta defaultNamespace;
+    if (defaultNamespaceOpt.isPresent()) {
+      defaultNamespace = defaultNamespaceOpt.get();
+    } else {
+      defaultNamespace = new KubernetesNamespaceMetaImpl(evaluatedName);
+      namespaces.add(defaultNamespace);
+    }
+
+    defaultNamespace.getAttributes().put(DEFAULT_ATTRIBUTE, "true");
+  }
+
+  /**
+   * Fetches the specified namespace from a cluster.
+   *
+   * @param name name of namespace that should be fetched.
+   * @return optional with kubernetes namespace meta
+   * @throws InfrastructureException when any error occurs during namespace fetching
+   */
+  protected Optional<KubernetesNamespaceMeta> fetchNamespace(String name)
+      throws InfrastructureException {
+    try {
+      Namespace namespace = clientFactory.create().namespaces().withName(name).get();
+      if (namespace == null) {
+        return Optional.empty();
+      } else {
+        return Optional.of(asNamespaceMeta(namespace));
+      }
+    } catch (KubernetesClientException e) {
+      throw new InfrastructureException(
+          "Error occurred when tried to fetch default namespace. Cause: " + e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Fetched namespace from a k8s cluster.
+   *
+   * @return list with available k8s namespace metas.
+   * @throws InfrastructureException when any error occurs during namespaces fetching
+   */
+  protected List<KubernetesNamespaceMeta> fetchNamespaces() throws InfrastructureException {
+    try {
+      return clientFactory
+          .create()
+          .namespaces()
+          .list()
+          .getItems()
+          .stream()
+          .map(this::asNamespaceMeta)
+          .collect(Collectors.toList());
+    } catch (KubernetesClientException e) {
+      throw new InfrastructureException(
+          "Error occurred when tried to list all available namespaces. Cause: " + e.getMessage(),
+          e);
+    }
+  }
+
+  private KubernetesNamespaceMeta asNamespaceMeta(Namespace namespace) {
+    Map<String, String> attributes = new HashMap<>(2);
+    if (namespace.getStatus() != null && namespace.getStatus().getPhase() != null) {
+      attributes.put(PHASE_ATTRIBUTE, namespace.getStatus().getPhase());
+    }
+    return new KubernetesNamespaceMetaImpl(namespace.getMetadata().getName(), attributes);
   }
 
   /**
@@ -117,21 +277,15 @@ public class KubernetesNamespaceFactory {
     }
   }
 
-  /**
-   * Creates a Kubernetes namespace for the specified workspace.
-   *
-   * <p>Namespace won't be prepared. This method should be used only in case workspace recovering.
-   *
-   * @param workspaceId identifier of the workspace
-   * @return created namespace
-   */
-  public KubernetesNamespace create(String workspaceId, String namespace) {
-    return doCreateNamespace(workspaceId, namespace);
-  }
-
-  @VisibleForTesting
-  KubernetesNamespace doCreateNamespace(String workspaceId, String name) {
-    return new KubernetesNamespace(clientFactory, name, workspaceId);
+  protected String evalDefaultNamespaceName(String defaultNamespace, Subject currentUser) {
+    checkArgument(!isNullOrEmpty(defaultNamespace));
+    String evaluated = defaultNamespace;
+    for (Entry<String, Function<Subject, String>> placeHolder :
+        NAMESPACE_NAME_PLACEHOLDERS.entrySet()) {
+      evaluated =
+          evaluated.replaceAll(placeHolder.getKey(), placeHolder.getValue().apply(currentUser));
+    }
+    return evaluated;
   }
 
   @VisibleForTesting

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceServiceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/api/server/KubernetesNamespaceServiceTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.api.server;
+
+import static com.jayway.restassured.RestAssured.given;
+import static java.util.Collections.singletonList;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
+import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
+import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import com.jayway.restassured.response.Response;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.che.api.core.rest.CheJsonProvider;
+import org.eclipse.che.dto.server.DtoFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.dto.KubernetesNamespaceMetaDto;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
+import org.everrest.assured.EverrestJetty;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link KubernetesNamespaceService}
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(value = {EverrestJetty.class, MockitoTestNGListener.class})
+public class KubernetesNamespaceServiceTest {
+
+  @SuppressWarnings("unused") // is declared for deploying by everrest-assured
+  private CheJsonProvider jsonProvider = new CheJsonProvider(Collections.emptySet());
+
+  @Mock private KubernetesNamespaceFactory namespaceFactory;
+
+  @InjectMocks private KubernetesNamespaceService service;
+
+  @Test
+  public void shouldReturnNamespaces() throws Exception {
+    KubernetesNamespaceMetaImpl namespaceMeta =
+        new KubernetesNamespaceMetaImpl(
+            "ws-namespace", ImmutableMap.of("phase", "active", "default", "true"));
+    when(namespaceFactory.list()).thenReturn(singletonList(namespaceMeta));
+
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/kubernetes/namespace");
+
+    assertEquals(response.getStatusCode(), 200);
+    List<KubernetesNamespaceMetaDto> namespaces =
+        unwrapDtoList(response, KubernetesNamespaceMetaDto.class);
+    assertEquals(namespaces.size(), 1);
+    assertEquals(new KubernetesNamespaceMetaImpl(namespaces.get(0)), namespaceMeta);
+    verify(namespaceFactory).list();
+  }
+
+  private static <T> List<T> unwrapDtoList(Response response, Class<T> dtoClass) {
+    return DtoFactory.getInstance().createListDtoFromJson(response.body().print(), dtoClass);
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -11,20 +11,40 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import io.fabric8.kubernetes.api.model.DoneableNamespace;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.NamespaceList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -36,12 +56,175 @@ import org.testng.annotations.Test;
 @Listeners(MockitoTestNGListener.class)
 public class KubernetesNamespaceFactoryTest {
   @Mock private KubernetesClientFactory clientFactory;
+
+  @Mock private KubernetesClient k8sClient;
+
+  @Mock
+  private NonNamespaceOperation<
+          Namespace, NamespaceList, DoneableNamespace, Resource<Namespace, DoneableNamespace>>
+      namespaceOperation;
+
   private KubernetesNamespaceFactory namespaceFactory;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    lenient().when(clientFactory.create()).thenReturn(k8sClient);
+    lenient().when(k8sClient.namespaces()).thenReturn(namespaceOperation);
+  }
+
+  @Test(
+      expectedExceptions = ConfigurationException.class,
+      expectedExceptionsMessageRegExp =
+          "che.infra.kubernetes.namespace.default or "
+              + "che.infra.kubernetes.namespace.allow_user_defined must be configured")
+  public void
+      shouldThrowExceptionIfNoDefaultNamespaceIsConfiguredAndUserDefinedNamespacesAreNotAllowed()
+          throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", null, false, clientFactory);
+  }
+
+  @Test
+  public void shouldReturnDefaultNamespaceWhenItExistsAndUserDefinedIsNotAllowed()
+      throws Exception {
+    prepareNamespaceToBeFoundByName(
+        "che-default",
+        new NamespaceBuilder()
+            .withNewMetadata()
+            .withName("che-default")
+            .endMetadata()
+            .withNewStatus("Active")
+            .build());
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", "che-default", false, clientFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+    assertEquals(availableNamespaces.size(), 1);
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+    assertEquals(defaultNamespace.getName(), "che-default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+  }
+
+  @Test
+  public void shouldReturnDefaultNamespaceWhenItDoesNotExistAndUserDefinedIsNotAllowed()
+      throws Exception {
+    prepareNamespaceToBeFoundByName("che-default", null);
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", "che-default", false, clientFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+    assertEquals(availableNamespaces.size(), 1);
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+    assertEquals(defaultNamespace.getName(), "che-default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertNull(
+        defaultNamespace
+            .getAttributes()
+            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error occurred when tried to fetch default namespace. Cause: connection refused")
+  public void shouldThrownExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", "che", false, clientFactory);
+    throwOnTryToGetNamespaceByName("che", new KubernetesClientException("connection refused"));
+
+    namespaceFactory.list();
+  }
+
+  @Test
+  public void shouldReturnListOfExistingNamespacesIfUserDefinedIsAllowed() throws Exception {
+    prepareListedNamespaces(
+        Arrays.asList(
+            createNamespace("my-for-ws", "Active"),
+            createNamespace("experimental", "Terminating")));
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", null, true, clientFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta experimental = availableNamespaces.get(1);
+    assertEquals(experimental.getName(), "experimental");
+    assertEquals(experimental.getAttributes().get(PHASE_ATTRIBUTE), "Terminating");
+  }
+
+  @Test
+  public void shouldReturnListOfExistingNamespacesAlongWithDefaultIfUserDefinedIsAllowed()
+      throws Exception {
+    prepareListedNamespaces(
+        Arrays.asList(
+            createNamespace("my-for-ws", "Active"), createNamespace("default", "Active")));
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", "default", true, clientFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+    assertEquals(defaultNamespace.getName(), "default");
+    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+  }
+
+  @Test
+  public void
+      shouldReturnListOfExistingNamespacesAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
+          throws Exception {
+    prepareListedNamespaces(singletonList(createNamespace("my-for-ws", "Active")));
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", "default", true, clientFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+    assertEquals(defaultNamespace.getName(), "default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertNull(
+        defaultNamespace
+            .getAttributes()
+            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error occurred when tried to list all available namespaces. Cause: connection refused")
+  public void shouldThrownExceptionWhenFailedToGetNamespaces() throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", null, true, clientFactory);
+    throwOnTryToGetNamespacesList(new KubernetesClientException("connection refused"));
+
+    namespaceFactory.list();
+  }
 
   @Test
   public void shouldReturnTrueIfNamespaceIsNotEmptyOnCheckingIfNamespaceIsPredefined() {
     // given
-    namespaceFactory = new KubernetesNamespaceFactory("predefined", "", "", clientFactory);
+    namespaceFactory =
+        new KubernetesNamespaceFactory("predefined", "", "", "che", false, clientFactory);
 
     // when
     boolean isPredefined = namespaceFactory.isPredefined();
@@ -53,7 +236,7 @@ public class KubernetesNamespaceFactoryTest {
   @Test
   public void shouldReturnTrueIfNamespaceIsEmptyOnCheckingIfNamespaceIsPredefined() {
     // given
-    namespaceFactory = new KubernetesNamespaceFactory("", "", "", clientFactory);
+    namespaceFactory = new KubernetesNamespaceFactory("", "", "", "che", false, clientFactory);
 
     // when
     boolean isPredefined = namespaceFactory.isPredefined();
@@ -65,7 +248,7 @@ public class KubernetesNamespaceFactoryTest {
   @Test
   public void shouldReturnTrueIfNamespaceIsNullOnCheckingIfNamespaceIsPredefined() {
     // given
-    namespaceFactory = new KubernetesNamespaceFactory(null, "", "", clientFactory);
+    namespaceFactory = new KubernetesNamespaceFactory(null, "", "", "che", false, clientFactory);
 
     // when
     boolean isPredefined = namespaceFactory.isPredefined();
@@ -77,7 +260,8 @@ public class KubernetesNamespaceFactoryTest {
   @Test
   public void shouldCreateAndPrepareNamespaceWithPredefinedValueIfItIsNotEmpty() throws Exception {
     // given
-    namespaceFactory = spy(new KubernetesNamespaceFactory("predefined", "", "", clientFactory));
+    namespaceFactory =
+        spy(new KubernetesNamespaceFactory("predefined", "", "", "che", false, clientFactory));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
 
@@ -94,7 +278,7 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldCreateAndPrepareNamespaceWithWorkspaceIdAsNameIfConfiguredNameIsNotPredefined()
       throws Exception {
     // given
-    namespaceFactory = spy(new KubernetesNamespaceFactory("", "", "", clientFactory));
+    namespaceFactory = spy(new KubernetesNamespaceFactory("", "", "", "che", false, clientFactory));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
 
@@ -112,7 +296,7 @@ public class KubernetesNamespaceFactoryTest {
       shouldCreateNamespaceAndDoNotPrepareNamespaceOnCreatingNamespaceWithWorkspaceIdAndNameSpecified()
           throws Exception {
     // given
-    namespaceFactory = spy(new KubernetesNamespaceFactory("", "", "", clientFactory));
+    namespaceFactory = spy(new KubernetesNamespaceFactory("", "", "", "che", false, clientFactory));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
 
@@ -129,7 +313,8 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndNamespaceIsNotPredefined()
       throws Exception {
     // given
-    namespaceFactory = spy(new KubernetesNamespaceFactory("", "serviceAccount", "", clientFactory));
+    namespaceFactory =
+        spy(new KubernetesNamespaceFactory("", "serviceAccount", "", "che", false, clientFactory));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
 
@@ -152,7 +337,7 @@ public class KubernetesNamespaceFactoryTest {
     namespaceFactory =
         spy(
             new KubernetesNamespaceFactory(
-                "namespace", "serviceAccount", "clusterRole", clientFactory));
+                "namespace", "serviceAccount", "clusterRole", "che", false, clientFactory));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
 
@@ -171,7 +356,7 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldNotPrepareWorkspaceServiceAccountIfItIsNotConfiguredAndProjectIsNotPredefined()
       throws Exception {
     // given
-    namespaceFactory = spy(new KubernetesNamespaceFactory("", "", "", clientFactory));
+    namespaceFactory = spy(new KubernetesNamespaceFactory("", "", "", "che", false, clientFactory));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespace(any(), any());
 
@@ -190,10 +375,52 @@ public class KubernetesNamespaceFactoryTest {
   public void testPlaceholder() {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>--", "", "", clientFactory);
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "",
+            "che",
+            false,
+            clientFactory);
     String namespace =
         namespaceFactory.evalNamespaceName(null, new SubjectImpl("JonDoe", "123", null, false));
 
     assertEquals(namespace, "blabol-123-JonDoe-123-JonDoe--");
+  }
+
+  private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception {
+    @SuppressWarnings("unchecked")
+    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
+    when(namespaceOperation.withName(name)).thenReturn(getNamespaceByNameOperation);
+
+    when(getNamespaceByNameOperation.get()).thenReturn(namespace);
+  }
+
+  private void throwOnTryToGetNamespaceByName(String namespaceName, Throwable e) throws Exception {
+    @SuppressWarnings("unchecked")
+    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
+    when(namespaceOperation.withName(namespaceName)).thenReturn(getNamespaceByNameOperation);
+
+    when(getNamespaceByNameOperation.get()).thenThrow(e);
+  }
+
+  private void prepareListedNamespaces(List<Namespace> namespaces) throws Exception {
+    @SuppressWarnings("unchecked")
+    NamespaceList namespaceList = mock(NamespaceList.class);
+    when(namespaceOperation.list()).thenReturn(namespaceList);
+
+    when(namespaceList.getItems()).thenReturn(namespaces);
+  }
+
+  private void throwOnTryToGetNamespacesList(Throwable e) throws Exception {
+    when(namespaceOperation.list()).thenThrow(e);
+  }
+
+  private Namespace createNamespace(String name, String phase) {
+    return new NamespaceBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .withNewStatus(phase)
+        .build();
   }
 }

--- a/infrastructures/openshift/pom.xml
+++ b/infrastructures/openshift/pom.xml
@@ -60,6 +60,10 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-core</artifactId>
         </dependency>
@@ -82,6 +86,10 @@
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-inject</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Constants.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/Constants.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift;
+
+/**
+ * Constants for OpenShift implementation of spi.
+ *
+ * @author Sergii Leshchenko
+ */
+public final class Constants {
+  private Constants() {}
+
+  /**
+   * Attribute name of {@link
+   * org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta} that
+   * stores project display name.
+   */
+  public static final String PROJECT_DISPLAY_NAME_ATTRIBUTE = "displayName";
+
+  /**
+   * Attribute name of {@link
+   * org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta} that
+   * stores project description.
+   */
+  public static final String PROJECT_DESCRIPTION_ATTRIBUTE = "description";
+
+  /**
+   * Annotation name of {@link io.fabric8.openshift.api.model.Project} that stores project display
+   * name.
+   */
+  public static final String PROJECT_DISPLAY_NAME_ANNOTATION = "openshift.io/display-name";
+
+  /**
+   * Annotation name of {@link io.fabric8.openshift.api.model.Project} that stores project
+   * description.
+   */
+  public static final String PROJECT_DESCRIPTION_ANNOTATION = "openshift.io/description";
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientConfigFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftClientConfigFactory.java
@@ -33,4 +33,12 @@ public class OpenShiftClientConfigFactory {
       throws InfrastructureException {
     return defaultConfig;
   }
+
+  /**
+   * Returns true if implementation personalizes config to the current subject, otherwise returns
+   * false if default config is always used.
+   */
+  public boolean isPersonalized() {
+    return false;
+  }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -40,6 +40,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.InconsistentRuntimesD
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientTermination;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironmentProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.KubernetesNamespaceService;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.jpa.JpaKubernetesRuntimeCacheModule;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.DockerimageComponentToWorkspaceApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesComponentToWorkspaceApplier;
@@ -83,6 +84,8 @@ import org.eclipse.che.workspace.infrastructure.openshift.wsplugins.brokerphases
 public class OpenShiftInfraModule extends AbstractModule {
   @Override
   protected void configure() {
+    bind(KubernetesNamespaceService.class);
+
     MapBinder<String, InternalEnvironmentFactory> factories =
         MapBinder.newMapBinder(binder(), String.class, InternalEnvironmentFactory.class);
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/multiuser/oauth/IdentityProviderConfigFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/multiuser/oauth/IdentityProviderConfigFactory.java
@@ -108,6 +108,12 @@ public class IdentityProviderConfigFactory extends OpenShiftClientConfigFactory 
     }
   }
 
+  @Override
+  public boolean isPersonalized() {
+    // config is personalized only if OAuth is configured and the current user is not anonymous
+    return oauthIdentityProvider != null;
+  }
+
   /**
    * Builds the OpenShift {@link Config} object based on a default {@link Config} object and an
    * optional workspace Id.

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/multiuser/oauth/IdentityProviderConfigFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/multiuser/oauth/IdentityProviderConfigFactory.java
@@ -19,10 +19,14 @@ import com.google.inject.Provider;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.openshift.client.OpenShiftConfig;
 import io.fabric8.openshift.client.OpenShiftConfigBuilder;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
 import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import javax.ws.rs.core.UriBuilder;
 import org.eclipse.che.api.core.BadRequestException;
 import org.eclipse.che.api.core.UnauthorizedException;
 import org.eclipse.che.api.workspace.server.WorkspaceRuntimes;
@@ -60,11 +64,8 @@ public class IdentityProviderConfigFactory extends OpenShiftClientConfigFactory 
   private final String oauthIdentityProvider;
 
   private final KeycloakServiceClient keycloakServiceClient;
-  private final KeycloakSettings keycloakSettings;
   private final Provider<WorkspaceRuntimes> workspaceRuntimeProvider;
   private final String messageToLinkAccount;
-
-  private String rootUrl;
 
   @Inject
   public IdentityProviderConfigFactory(
@@ -73,23 +74,9 @@ public class IdentityProviderConfigFactory extends OpenShiftClientConfigFactory 
       Provider<WorkspaceRuntimes> workspaceRuntimeProvider,
       @Nullable @Named("che.infra.openshift.oauth_identity_provider") String oauthIdentityProvider,
       @Named("che.api") String apiEndpoint) {
-    super();
     this.keycloakServiceClient = keycloakServiceClient;
-    this.keycloakSettings = keycloakSettings;
     this.workspaceRuntimeProvider = workspaceRuntimeProvider;
-
     this.oauthIdentityProvider = oauthIdentityProvider;
-    rootUrl = apiEndpoint;
-    if (rootUrl.endsWith("/")) {
-      rootUrl = rootUrl.substring(0, rootUrl.length() - 1);
-    }
-    if (rootUrl.endsWith("/api")) {
-      rootUrl = rootUrl.substring(0, rootUrl.length() - 4);
-    }
-
-    String referrer_uri =
-        rootUrl.replace("http://", "http%3A%2F%2F").replace("https://", "https%3A%2F%2F")
-            + "%2Fdashboard%2F?redirect_fragment%3D%2Fworkspaces";
 
     messageToLinkAccount =
         "You should link your account with the <strong>"
@@ -103,70 +90,117 @@ public class IdentityProviderConfigFactory extends OpenShiftClientConfigFactory 
             + "/account/identity?referrer="
             + keycloakSettings.get().get(CLIENT_ID_SETTING)
             + "&referrer_uri="
-            + referrer_uri
+            + buildReferrerURI(apiEndpoint)
             + "' target='_blank' rel='noopener noreferrer'><strong>Federated Identities</strong></a> page of your Che account";
   }
 
+  private String buildReferrerURI(String apiEndpoint) {
+    URI referrerURI =
+        UriBuilder.fromUri(apiEndpoint)
+            .replacePath("dashboard/")
+            .queryParam("redirect_fragment", "/workspaces")
+            .build();
+    try {
+      return URLEncoder.encode(referrerURI.toString(), "UTF-8");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(
+          "Error occurred during constructing Referrer URI. " + e.getMessage(), e);
+    }
+  }
+
   /**
-   * Builds the Openshift {@link Config} object based on a default {@link Config} object and an
+   * Builds the OpenShift {@link Config} object based on a default {@link Config} object and an
    * optional workspace Id.
    */
   public Config buildConfig(Config defaultConfig, @Nullable String workspaceId)
       throws InfrastructureException {
     Subject subject = EnvironmentContext.getCurrent().getSubject();
 
-    String workspaceOwnerId = null;
-    if (workspaceId != null) {
-      @SuppressWarnings("rawtypes")
-      Optional<RuntimeContext> context =
-          workspaceRuntimeProvider.get().getRuntimeContext(workspaceId);
-      workspaceOwnerId = context.map(c -> c.getIdentity().getOwnerId()).orElse(null);
+    if (oauthIdentityProvider == null) {
+      LOG.debug("OAuth Provider is not configured, default config is used.");
+      return defaultConfig;
     }
 
-    if (oauthIdentityProvider != null
-        && subject != Subject.ANONYMOUS
-        && (workspaceOwnerId == null || subject.getUserId().equals(workspaceOwnerId))) {
-      try {
-        KeycloakTokenResponse keycloakTokenInfos =
-            keycloakServiceClient.getIdentityProviderToken(oauthIdentityProvider);
-        if ("user:full".equals(keycloakTokenInfos.getScope())) {
-          return new OpenShiftConfigBuilder(OpenShiftConfig.wrap(defaultConfig))
-              .withOauthToken(keycloakTokenInfos.getAccessToken())
-              .build();
-        } else {
-          throw new InfrastructureException(
-              "Cannot retrieve user Openshift token: '"
-                  + oauthIdentityProvider
-                  + "' identity provider is not granted full rights: "
-                  + oauthIdentityProvider);
-        }
-      } catch (UnauthorizedException e) {
-        LOG.error("cannot retrieve User Openshift token from the identity provider", e);
+    if (subject == Subject.ANONYMOUS) {
+      LOG.debug(
+          "OAuth Provider is configured but default subject is anonymous, default config is used.");
+      return defaultConfig;
+    }
 
-        throw new InfrastructureException(messageToLinkAccount);
-      } catch (BadRequestException e) {
-        LOG.error(
-            "cannot retrieve User Openshift token from the '"
+    if (workspaceId == null) {
+      LOG.debug(
+          "OAuth Provider is configured and this request is not related to any workspace. OAuth token will be retrieved.");
+      return personalizeConfig(defaultConfig);
+    }
+
+    Optional<RuntimeContext> context =
+        workspaceRuntimeProvider.get().getRuntimeContext(workspaceId);
+    if (!context.isPresent()) {
+      // there is no cached info for this workspace in workspace API.
+      // it means that it's not started yet and it's initial call for preparing context
+      LOG.debug(
+          "There is no runtime context for the specified workspace '%s'. It's the first workspace "
+              + "related call, so context is personalized with OAuth token.");
+      return personalizeConfig(defaultConfig);
+    }
+    String workspaceOwnerId = context.map(c -> c.getIdentity().getOwnerId()).orElse(null);
+
+    boolean isRuntimeOwner = subject.getUserId().equals(workspaceOwnerId);
+
+    if (!isRuntimeOwner) {
+      LOG.debug(
+          "OAuth Provider is configured, but current subject is not runtime owner, default config is used."
+              + "Subject user id: '{}'. Runtime owner id: '{}'",
+          subject.getUserId(),
+          workspaceOwnerId);
+      return defaultConfig;
+    }
+
+    LOG.debug(
+        "OAuth Provider is configured and current subject is runtime owner. OAuth token will be retrieved.");
+    return personalizeConfig(defaultConfig);
+  }
+
+  private Config personalizeConfig(Config defaultConfig) throws InfrastructureException {
+    try {
+      KeycloakTokenResponse keycloakTokenInfos =
+          keycloakServiceClient.getIdentityProviderToken(oauthIdentityProvider);
+      if ("user:full".equals(keycloakTokenInfos.getScope())) {
+        return new OpenShiftConfigBuilder(OpenShiftConfig.wrap(defaultConfig))
+            .withOauthToken(keycloakTokenInfos.getAccessToken())
+            .build();
+      } else {
+        throw new InfrastructureException(
+            "Cannot retrieve user OpenShift token: '"
                 + oauthIdentityProvider
-                + "' identity provider",
-            e);
-        if (e.getMessage().endsWith("Invalid token.")) {
-          throw new InfrastructureException(
-              "Your session has expired. \nPlease "
-                  + "<a href='javascript:location.reload();' target='_top'>"
-                  + "login"
-                  + "</a> to Che again to get access to your Openshift account");
-        }
-        throw new InfrastructureException(e.getMessage(), e);
-      } catch (Exception e) {
-        LOG.error(
-            "cannot retrieve User Openshift token from the  '"
-                + oauthIdentityProvider
-                + "' identity provider",
-            e);
-        throw new InfrastructureException(e.getMessage(), e);
+                + "' identity provider is not granted full rights: "
+                + oauthIdentityProvider);
       }
+    } catch (UnauthorizedException e) {
+      LOG.error("Cannot retrieve User OpenShift token from the identity provider", e);
+
+      throw new InfrastructureException(messageToLinkAccount);
+    } catch (BadRequestException e) {
+      LOG.error(
+          "Cannot retrieve User OpenShift token from the '"
+              + oauthIdentityProvider
+              + "' identity provider",
+          e);
+      if (e.getMessage().endsWith("Invalid token.")) {
+        throw new InfrastructureException(
+            "Your session has expired. \nPlease "
+                + "<a href='javascript:location.reload();' target='_top'>"
+                + "login"
+                + "</a> to Che again to get access to your OpenShift account");
+      }
+      throw new InfrastructureException(e.getMessage(), e);
+    } catch (Exception e) {
+      LOG.error(
+          "Cannot retrieve User OpenShift token from the  '"
+              + oauthIdentityProvider
+              + "' identity provider",
+          e);
+      throw new InfrastructureException(e.getMessage(), e);
     }
-    return defaultConfig;
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -12,16 +12,31 @@
 package org.eclipse.che.workspace.infrastructure.openshift.project;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.openshift.api.model.Project;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.inject.Named;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
+import org.eclipse.che.workspace.infrastructure.openshift.Constants;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helps to create {@link OpenShiftProject} instances.
@@ -30,6 +45,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory
  */
 @Singleton
 public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(OpenShiftProjectFactory.class);
 
   private final OpenShiftClientFactory clientFactory;
 
@@ -38,8 +54,24 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
       @Nullable @Named("che.infra.openshift.project") String projectName,
       @Nullable @Named("che.infra.kubernetes.service_account_name") String serviceAccountName,
       @Nullable @Named("che.infra.kubernetes.cluster_role_name") String clusterRoleName,
-      OpenShiftClientFactory clientFactory) {
-    super(projectName, serviceAccountName, clusterRoleName, clientFactory);
+      @Nullable @Named("che.infra.kubernetes.namespace.default") String defaultNamespaceName,
+      @Named("che.infra.kubernetes.namespace.allow_user_defined")
+          boolean allowUserDefinedNamespaces,
+      OpenShiftClientFactory clientFactory,
+      OpenShiftClientConfigFactory clientConfigFactory) {
+    super(
+        projectName,
+        serviceAccountName,
+        clusterRoleName,
+        defaultNamespaceName,
+        allowUserDefinedNamespaces,
+        clientFactory);
+    if (allowUserDefinedNamespaces && !clientConfigFactory.isPersonalized()) {
+      LOG.warn(
+          "Users are allowed to list projects but Che server is configured with a service account. "
+              + "All users will receive the same list of projects. Consider configuring OpenShift "
+              + "OAuth to personalize credentials that will be used for cluster access.");
+    }
     this.clientFactory = clientFactory;
   }
 
@@ -92,5 +124,59 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
   OpenShiftWorkspaceServiceAccount doCreateServiceAccount(String workspaceId, String projectName) {
     return new OpenShiftWorkspaceServiceAccount(
         workspaceId, projectName, getServiceAccountName(), getClusterRoleName(), clientFactory);
+  }
+
+  @Override
+  protected Optional<KubernetesNamespaceMeta> fetchNamespace(String name)
+      throws InfrastructureException {
+    try {
+      Project project = clientFactory.createOC().projects().withName(name).get();
+      return Optional.of(asNamespaceMeta(project));
+    } catch (KubernetesClientException e) {
+      if (e.getCode() == 403) {
+        // 403 means that the project does not exist
+        // or a user really is not permitted to access it which is Che Server misconfiguration
+        return Optional.empty();
+      } else {
+        throw new InfrastructureException(
+            "Error occurred when tried to fetch default project. Cause: " + e.getMessage(), e);
+      }
+    }
+  }
+
+  @Override
+  protected List<KubernetesNamespaceMeta> fetchNamespaces() throws InfrastructureException {
+    try {
+      return clientFactory
+          .createOC()
+          .projects()
+          .list()
+          .getItems()
+          .stream()
+          .map(this::asNamespaceMeta)
+          .collect(Collectors.toList());
+    } catch (KubernetesClientException e) {
+      throw new InfrastructureException(
+          "Error occurred when tried to list all available projects. Cause: " + e.getMessage(), e);
+    }
+  }
+
+  private KubernetesNamespaceMeta asNamespaceMeta(io.fabric8.openshift.api.model.Project project) {
+    Map<String, String> attributes = new HashMap<>(4);
+    ObjectMeta metadata = project.getMetadata();
+    Map<String, String> annotations = metadata.getAnnotations();
+    String displayName = annotations.get(Constants.PROJECT_DISPLAY_NAME_ANNOTATION);
+    if (displayName != null) {
+      attributes.put(Constants.PROJECT_DISPLAY_NAME_ATTRIBUTE, displayName);
+    }
+    String description = annotations.get(Constants.PROJECT_DESCRIPTION_ANNOTATION);
+    if (description != null) {
+      attributes.put(Constants.PROJECT_DESCRIPTION_ATTRIBUTE, description);
+    }
+
+    if (project.getStatus() != null && project.getStatus().getPhase() != null) {
+      attributes.put(PHASE_ATTRIBUTE, project.getStatus().getPhase());
+    }
+    return new KubernetesNamespaceMetaImpl(metadata.getName(), attributes);
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -11,18 +11,46 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.project;
 
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.DoneableProject;
+import io.fabric8.openshift.api.model.Project;
+import io.fabric8.openshift.api.model.ProjectBuilder;
+import io.fabric8.openshift.api.model.ProjectList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.inject.ConfigurationException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -33,13 +61,210 @@ import org.testng.annotations.Test;
  */
 @Listeners(MockitoTestNGListener.class)
 public class OpenShiftProjectFactoryTest {
+
+  @Mock private OpenShiftClientConfigFactory configFactory;
   @Mock private OpenShiftClientFactory clientFactory;
+
+  @Mock
+  private NonNamespaceOperation<
+          Project, ProjectList, DoneableProject, Resource<Project, DoneableProject>>
+      projectOperation;
+
+  @Mock private OpenShiftClient osClient;
+
   private OpenShiftProjectFactory projectFactory;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    lenient().when(clientFactory.createOC()).thenReturn(osClient);
+    lenient().when(osClient.projects()).thenReturn(projectOperation);
+  }
+
+  @Test(
+      expectedExceptions = ConfigurationException.class,
+      expectedExceptionsMessageRegExp =
+          "che.infra.kubernetes.namespace.default or "
+              + "che.infra.kubernetes.namespace.allow_user_defined must be configured")
+  public void
+      shouldThrowExceptionIfNoDefaultNamespaceIsConfiguredAndUserDefinedNamespacesAreNotAllowed()
+          throws Exception {
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "projectName", "", "", null, false, clientFactory, configFactory);
+  }
+
+  @Test
+  public void shouldReturnDefaultProjectWhenItExistsAndUserDefinedIsNotAllowed() throws Exception {
+    prepareNamespaceToBeFoundByName(
+        "che-default",
+        new ProjectBuilder()
+            .withNewMetadata()
+            .withName("che-default")
+            .withAnnotations(
+                ImmutableMap.of(
+                    PROJECT_DISPLAY_NAME_ANNOTATION,
+                    "Default Che Project",
+                    PROJECT_DESCRIPTION_ANNOTATION,
+                    "some description"))
+            .endMetadata()
+            .withNewStatus("Active")
+            .build());
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined", "", "", "che-default", false, clientFactory, configFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+    assertEquals(availableNamespaces.size(), 1);
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+    assertEquals(defaultNamespace.getName(), "che-default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertEquals(
+        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
+        "Default Che Project");
+    assertEquals(
+        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+  }
+
+  @Test
+  public void shouldReturnDefaultProjectWhenItDoesNotExistAndUserDefinedIsNotAllowed()
+      throws Exception {
+    throwOnTryToGetProjectByName(
+        "che-default", new KubernetesClientException("forbidden", 403, null));
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined", "", "", "che-default", false, clientFactory, configFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+    assertEquals(availableNamespaces.size(), 1);
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+    assertEquals(defaultNamespace.getName(), "che-default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertNull(
+        defaultNamespace
+            .getAttributes()
+            .get(PHASE_ATTRIBUTE)); // no phase - means such project does not exist
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error occurred when tried to fetch default project. Cause: connection refused")
+  public void shouldThrownExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
+    throwOnTryToGetProjectByName(
+        "che-default", new KubernetesClientException("connection refused"));
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined", "", "", "che-default", false, clientFactory, configFactory);
+
+    projectFactory.list();
+  }
+
+  @Test
+  public void shouldReturnListOfExistingProjectsIfUserDefinedIsAllowed() throws Exception {
+    prepareListedProjects(
+        Arrays.asList(
+            createProject("my-for-ws", "Project for Workspaces", "some description", "Active"),
+            createProject("experimental", null, null, "Terminating")));
+
+    projectFactory =
+        new OpenShiftProjectFactory("predefined", "", "", null, true, clientFactory, configFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(
+        forWS.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE), "Project for Workspaces");
+    assertEquals(forWS.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+
+    KubernetesNamespaceMeta experimental = availableNamespaces.get(1);
+    assertEquals(experimental.getName(), "experimental");
+    assertEquals(experimental.getAttributes().get(PHASE_ATTRIBUTE), "Terminating");
+  }
+
+  @Test
+  public void shouldReturnListOfExistingProjectsAlongWithDefaultIfUserDefinedIsAllowed()
+      throws Exception {
+    prepareListedProjects(
+        Arrays.asList(
+            createProject("my-for-ws", "Project for Workspaces", "some description", "Active"),
+            createProject("default", "Default Che Project", "some description", "Active")));
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined", "", "", "default", true, clientFactory, configFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(
+        forWS.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE), "Project for Workspaces");
+    assertEquals(forWS.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+    assertEquals(defaultNamespace.getName(), "default");
+    assertEquals(
+        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
+        "Default Che Project");
+    assertEquals(
+        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+  }
+
+  @Test
+  public void shouldReturnListOfExistingProjectsAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
+      throws Exception {
+    prepareListedProjects(singletonList(createProject("my-for-ws", "", "", "Active")));
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined", "", "", "default", true, clientFactory, configFactory);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+    assertEquals(defaultNamespace.getName(), "default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertNull(
+        defaultNamespace
+            .getAttributes()
+            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error occurred when tried to list all available projects. Cause: connection refused")
+  public void shouldThrownExceptionWhenFailedToGetNamespaces() throws Exception {
+    throwOnTryToGetProjectsList(new KubernetesClientException("connection refused"));
+    projectFactory =
+        new OpenShiftProjectFactory("predefined", "", "", "", true, clientFactory, configFactory);
+
+    projectFactory.list();
+  }
 
   @Test
   public void shouldCreateAndPrepareProjectWithPredefinedValueIfItIsNotEmpty() throws Exception {
     // given
-    projectFactory = spy(new OpenShiftProjectFactory("projectName", "", "", clientFactory));
+    projectFactory =
+        spy(
+            new OpenShiftProjectFactory(
+                "projectName", "", "", "che", false, clientFactory, configFactory));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
     doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
 
@@ -56,7 +281,8 @@ public class OpenShiftProjectFactoryTest {
   public void shouldCreateAndPrepareProjectWithWorkspaceIdAsNameIfConfiguredValueIsEmtpy()
       throws Exception {
     // given
-    projectFactory = spy(new OpenShiftProjectFactory("", "", "", clientFactory));
+    projectFactory =
+        spy(new OpenShiftProjectFactory("", "", "", "che", false, clientFactory, configFactory));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
     doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
 
@@ -73,7 +299,10 @@ public class OpenShiftProjectFactoryTest {
   public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndProjectIsNotPredefined()
       throws Exception {
     // given
-    projectFactory = spy(new OpenShiftProjectFactory("", "serviceAccount", "", clientFactory));
+    projectFactory =
+        spy(
+            new OpenShiftProjectFactory(
+                "", "serviceAccount", "", "che", false, clientFactory, configFactory));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
     doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
 
@@ -95,7 +324,13 @@ public class OpenShiftProjectFactoryTest {
     projectFactory =
         spy(
             new OpenShiftProjectFactory(
-                "namespace", "serviceAccount", "clusterRole", clientFactory));
+                "namespace",
+                "serviceAccount",
+                "clusterRole",
+                "che",
+                false,
+                clientFactory,
+                configFactory));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
     doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
 
@@ -110,7 +345,8 @@ public class OpenShiftProjectFactoryTest {
   public void shouldNotPrepareWorkspaceServiceAccountIfItIsNotConfiguredAndProjectIsNotPredefined()
       throws Exception {
     // given
-    projectFactory = spy(new OpenShiftProjectFactory("", "", "", clientFactory));
+    projectFactory =
+        spy(new OpenShiftProjectFactory("", "", "", "che", false, clientFactory, configFactory));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
     doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
 
@@ -129,7 +365,13 @@ public class OpenShiftProjectFactoryTest {
     projectFactory =
         spy(
             new OpenShiftProjectFactory(
-                "projectName", "serviceAccountName", "clusterRole", clientFactory));
+                "projectName",
+                "serviceAccountName",
+                "clusterRole",
+                "che",
+                false,
+                clientFactory,
+                configFactory));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
     doReturn(toReturnProject).when(projectFactory).doCreateProject(any(), any());
 
@@ -140,5 +382,52 @@ public class OpenShiftProjectFactoryTest {
     assertEquals(toReturnProject, namespace);
     verify(projectFactory).doCreateProject("workspace123", "name");
     verify(toReturnProject, never()).prepare();
+  }
+
+  private void prepareNamespaceToBeFoundByName(String name, Project project) throws Exception {
+    @SuppressWarnings("unchecked")
+    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
+    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
+
+    when(getProjectByNameOperation.get()).thenReturn(project);
+  }
+
+  private void throwOnTryToGetProjectByName(String name, KubernetesClientException e)
+      throws Exception {
+    @SuppressWarnings("unchecked")
+    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
+    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
+
+    when(getProjectByNameOperation.get()).thenThrow(e);
+  }
+
+  private void prepareListedProjects(List<Project> projects) throws Exception {
+    @SuppressWarnings("unchecked")
+    ProjectList projectList = mock(ProjectList.class);
+    when(projectOperation.list()).thenReturn(projectList);
+
+    when(projectList.getItems()).thenReturn(projects);
+  }
+
+  private void throwOnTryToGetProjectsList(Throwable e) throws Exception {
+    when(projectOperation.list()).thenThrow(e);
+  }
+
+  private Project createProject(String name, String displayName, String description, String phase) {
+    Map<String, String> annotations = new HashMap<>();
+    if (displayName != null) {
+      annotations.put(PROJECT_DISPLAY_NAME_ANNOTATION, displayName);
+    }
+    if (description != null) {
+      annotations.put(PROJECT_DESCRIPTION_ANNOTATION, description);
+    }
+
+    return new ProjectBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .withAnnotations(annotations)
+        .endMetadata()
+        .withNewStatus(phase)
+        .build();
   }
 }


### PR DESCRIPTION
### What does this PR do?
It does not change the current workspace creating flow, but used namespace still managed by `che.infra.kubernetes.namespace`. See more how workspace creation flow will be changed https://github.com/eclipse/che/issues/14376#issuecomment-535511742.

And this PR introduces API that will be used by clients to provide an ability for users to see target namespace info, and choose one if multiple are available.

So, there are two configuration properties that are used for configuring a list of available namespaces:
1. 
``` 
# Defines Kubernetes default namespace in which user's workspaces are created
# if user does not override it.
# It's possible to use <username> and <userid> placeholders (e.g.: che-workspace-<username>).
# In that case, new namespace will be created for each user.
# Is used by OpenShift infra as well to specify Project
#
# BETA It's not fully supported by infra.
# Use che.infra.kubernetes.namespace to configure workspaces' namespace
che.infra.kubernetes.namespace.default=<username>-che
```
2. 
```
# Defines if a user is able to specify Kubernetes namespace different from default.
# It's NOT RECOMMENDED to configured true without OAuth configured.
# Is used by OpenShift infra as well to allows users choose Project
#
# BETA It's not fully supported by infra.
# Use che.infra.kubernetes.namespace to configure workspaces' namespace
che.infra.kubernetes.namespace.allow_user_defined=false
```
Example of the implemented API response:
```json
[
  {
    "name": "my-dev",
    "attributes": {
      "status": "Running"
  },
  {
    "name": "java-ws-dedicated",
    "attributes": {
      "status": "Terminating"
  },
  {
    "name": "sleshche-che-ws",
    "attributes": {
      "default": "true"
      // Note that status is missing - means that such namespace does not exist on Cluster and will be created on the first workspace start
    }
  }
]
```
### What can be improved later
1. User may not have permissions to create objects in some of the available namespaces. So, we could check if they have like deployment creation permissions before returning namespace. But it would require upgrading fabric8 k8s client(See K8s https://github.com/fabric8io/kubernetes-client/commit/d1f2e77267924ace316a31917c6ecd0daf0a3738), it's why I would like to do it in a separate issue if needed.
2. On K8s infrastructure, OAuth is not implemented yet. Just allowing to choose any available namespace would mean allowing users to access any k8s namespace, even system like `kube-system`. @metlos propose to introduce a dedicate property to configure selector for available namespaces like `che.infra.kubernetes.namespace.user_available_selector=app=che`.
3. In most OpenShift production cases - admin would need to precreate users' project and apply needed quotas there. So, the user would not be able to create new projects.
But on some tests environments like minikube, minishift, crc a user is able to create new namespaces... So, it may be useful (may be not) to implement an ability to type free namespace name value and then Che would create this on the first workspace start.
It may be implemented in two ways: checks automatically if a user is able to create a new namespace OR let che admin to configure such an ability with a dedicated configuration property.
API could expose such an ability by returning a special namespace holder, like:
```json
  {
    "name": "{new-namespace}"
  }
```
### Is this PR well-tested?
Not yet. It will be tested and as proof will be here screenshots for different configurations and infrastructures.
<details>

<summary>Tested configurations</summary>

#### Kubernetes: Single-User
1. Introduced parameters are default: 
`che.infra.kubernetes.namespace.default=<username>-che`
`che.infra.kubernetes.namespace.allow_user_defined=false`

Since in single-user mode there is only one `che` user, default namespace is `che-che`, which is not good but should not a big issue and may be handled by chectl - like override default namespace for single user to be the same as che namespace, it actully works in such way.
So, che-che namespace does not exist:
```json
[
  {
    "name": "che-che",
    "attributes": {
      "default": "true"
    }
  }
]
```

2. Introduced parameters are default: 
`che.infra.kubernetes.namespace.default=che`
`che.infra.kubernetes.namespace.allow_user_defined=false`
```json
[
  {
    "name": "che",
    "attributes": {
      "phase": "Active",
      "default": "true"
    }
  }
]
```

3. Introduced parameters are default: 
`che.infra.kubernetes.namespace.default=NULL`
`che.infra.kubernetes.namespace.allow_user_defined=true`
```json
[
  {
    "name": "che",
    "attributes": {
      "phase": "Active"
    }
  },
  {
    "name": "default",
    "attributes": {
      "phase": "Active"
    }
  },
  {
    "name": "kube-node-lease",
    "attributes": {
      "phase": "Active"
    }
  },
  {
    "name": "kube-public",
    "attributes": {
      "phase": "Active"
    }
  },
  {
    "name": "kube-system",
    "attributes": {
      "phase": "Active"
    }
  }
]
```

#### OpenShift - Multiuser
1. OAuth is configured and introduced parameters are default: `che.infra.kubernetes.namespace.default=<username>-che`
`che.infra.kubernetes.namespace.allow_user_defined=false`

Logged in as developer, developer-che exists:
```json
[
  {
    "name": "developer-che",
    "attributes": {
      "description": "A project to run Che Workspaces",
      "displayName": "Che Workspaces",
      "default": "true",
      "description": "A project to run Che Workspaces"
    }
  }
]
```

2. OAuth is configured and introduced parameters are: 
`che.infra.kubernetes.namespace.default=<username>-che`
`che.infra.kubernetes.namespace.allow_user_defined=true`

Logged in as developer, the user has developer-che and myproject projects:
```json
[
  {
    "name": "developer-che",
    "attributes": {
      "phase": "Active",
      "description": "A project to run Che Workspaces",
      "default": "true",
      "displayName": "Che Workspaces"
    }
  },
  {
    "name": "myproject",
    "attributes": {
      "phase": "Active",
      "description": "Initial developer project",
      "displayName": "My Project"
    }
  }
]
```

3. OAuth is configured and introduced parameters are: 
`che.infra.kubernetes.namespace.default=<username>-che`
`che.infra.kubernetes.namespace.allow_user_defined=true`

Logged in as developer, the user has myproject project only:
```json
[
  {
    "name": "developer-che",
    "attributes": {
      "default": "true"
    }
  },
  {
    "name": "myproject",
    "attributes": {
      "phase": "Active",
      "description": "Initial developer project",
      "displayName": "My Project"
    }
  }
]
```

4. OAuth is configured and introduced parameters are: 
`che.infra.kubernetes.namespace.default=NULL`
`che.infra.kubernetes.namespace.allow_user_defined=true`

Logged in as developer, the user has myproject project only:
```json
[
  {
    "name": "myproject",
    "attributes": {
      "phase": "Active",
      "description": "Initial developer project",
      "displayName": "My Project"
    }
  }
]
```
</details>

### What issues does this PR fix or reference?
It resolves https://github.com/eclipse/che/issues/14376

#### Release Notes
N/A

#### Docs PR
N/A
The workflow that user/admin would use is not complete yet, documentation will be provided in further PRs where workflow will be available.