### PR TITLE
Add Ssh Api methods to list of allowed requests signed with machine token

### DIFF
--- a/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthModule.java
+++ b/multiuser/machine-auth/che-multiuser-machine-authentication/src/main/java/org/eclipse/che/multiuser/machine/authentication/server/MachineAuthModule.java
@@ -62,7 +62,9 @@ public class MachineAuthModule extends AbstractModule {
                 "stop"));
     machineAuthenticatedResources
         .addBinding()
-        .toInstance(new MachineAuthenticatedResource("/ssh", "getPair", "generatePair"));
+        .toInstance(
+            new MachineAuthenticatedResource(
+                "/ssh", "getPair", "generatePair", "createPair", "getPairs", "removePair"));
     machineAuthenticatedResources
         .addBinding()
         .toInstance(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Che-theia SSH plugin uses `createPair`, `getPairs`, `removePair` API methods. Since the methods are not included to the list of allowed request that can be signed with machine token, the ssh plugin doesn't work properly.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/14332

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
