### PR TITLE
[E2E] Add test for Java Vertx workspace.

### DIFF
--- a/e2e/mocha-java-vertx.opts
+++ b/e2e/mocha-java-vertx.opts
@@ -1,0 +1,7 @@
+--timeout 2200000
+--reporter 'dist/driver/CheReporter.js'
+-u tdd 
+--bail
+--full-trace
+--spec dist/tests/e2e/JavaVertx.spec.js
+--require source-map-support/register

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,6 +11,7 @@
     "test-happy-path": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-happy-path.opts",
     "test-che-install": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-che-operatorhub.opts",
     "test-wkspc-creation-and-ls": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-wkspc-creation-and-ls.opts",
+    "test-java-vertx": "./generateIndex.sh && npm run lint && npm run tsc && mocha --opts mocha-java-vertx.opts",
     "lint": "tslint --fix -p .",
     "tsc": "tsc -p ."
   },

--- a/e2e/pageobjects/ide/ProjectTree.ts
+++ b/e2e/pageobjects/ide/ProjectTree.ts
@@ -131,13 +131,13 @@ export class ProjectTree {
     }
 
     async expandPathAndOpenFile(pathToItem: string, fileName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        let items:Array<string> = pathToItem.split('/');
+        let items: Array<string> = pathToItem.split('/');
         let projectName: string = items[0];
         let paths: Array<string> = new Array();
         paths.push(projectName);
 
         // make direct path for each project tree item
-        for(let i = 1; i < items.length; i++){
+        for (let i = 1; i < items.length; i++) {
             let item = items[i];
             projectName = `${projectName}/${item}`;
             paths.push(projectName);

--- a/e2e/tests/e2e/JavaVertx.spec.ts
+++ b/e2e/tests/e2e/JavaVertx.spec.ts
@@ -72,19 +72,7 @@ suite('RhChe E2E Java Vert.x test', async () => {
         });
 
         test('Wait project imported', async () => {
-            try {
-                await projectTree.waitProjectImported(sampleName, 'src');
-            } catch (err) {
-                if (!(err instanceof error.TimeoutError)) {
-                    throw err;
-                }
-                var rest: restClient.RestClient = new restClient.RestClient('user-agent');
-                const workspaceStatusApiUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/api/workspace/${namespace}:${workspaceName}`;
-
-                const response: restClient.IRestResponse<any> = await rest.get(workspaceStatusApiUrl);
-                console.log('WORKSPACE DEFINITION: ' + JSON.stringify(response.result));
-                throw err;
-            }
+            await projectTree.waitProjectImported(sampleName, 'src');
         });
 
     });

--- a/e2e/tests/e2e/JavaVertx.spec.ts
+++ b/e2e/tests/e2e/JavaVertx.spec.ts
@@ -1,0 +1,177 @@
+/*********************************************************************
+ * Copyright (c) 2019 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { NameGenerator } from '../../utils/NameGenerator';
+import { TestConstants } from '../../TestConstants';
+import { e2eContainer } from '../../inversify.config';
+import { ICheLoginPage } from '../../pageobjects/login/ICheLoginPage';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { NewWorkspace } from '../../pageobjects/dashboard/NewWorkspace';
+import { CLASSES, TYPES } from '../../inversify.types';
+import { Ide } from '../../pageobjects/ide/Ide';
+import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
+import { Editor } from '../../pageobjects/ide/Editor';
+import { TopMenu } from '../../pageobjects/ide/TopMenu';
+import { QuickOpenContainer } from '../../pageobjects/ide/QuickOpenContainer';
+import { Terminal } from '../../pageobjects/ide/Terminal';
+import 'reflect-metadata';
+import { error, Key } from 'selenium-webdriver';
+import * as restClient from 'typed-rest-client/RestClient';
+import { DriverHelper } from '../../utils/DriverHelper';
+
+const workspaceName: string = NameGenerator.generate('wksp-test-', 5);
+const namespace: string = TestConstants.TS_SELENIUM_USERNAME;
+const sampleName: string = 'java-web-vertx';
+const fileFolderPath: string = `${sampleName}/src/main/java/io/vertx/examples/spring`;
+const tabTitle: string = 'SpringExampleRunner.java';
+const codeNavigationClassName: string = 'ApplicationContext.class';
+
+const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const loginPage: ICheLoginPage = e2eContainer.get<ICheLoginPage>(TYPES.CheLogin);
+const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+const newWorkspace: NewWorkspace = e2eContainer.get(CLASSES.NewWorkspace);
+const ide: Ide = e2eContainer.get(CLASSES.Ide);
+const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
+const editor: Editor = e2eContainer.get(CLASSES.Editor);
+const topMenu: TopMenu = e2eContainer.get(CLASSES.TopMenu);
+const quickOpenContainer: QuickOpenContainer = e2eContainer.get(CLASSES.QuickOpenContainer);
+const terminal: Terminal = e2eContainer.get(CLASSES.Terminal);
+
+suite('RhChe E2E Java Vert.x test', async () => {
+    suite('Login and wait dashboard', async () => {
+        test('Login', async () => {
+            console.log('URL: ' + TestConstants.TS_SELENIUM_BASE_URL);
+            await driverHelper.navigateToUrl(TestConstants.TS_SELENIUM_BASE_URL);
+            await loginPage.login();
+        });
+    });
+
+    suite('Create Java Vert.x workspace ' + workspaceName, async () => {
+        test('Open \'New Workspace\' page', async () => {
+            await newWorkspace.openPageByUI();
+        });
+
+        test('Create and open workspace', async () => {
+            await newWorkspace.createAndOpenWorkspace(workspaceName, 'Java Vert.x');
+        });
+    });
+
+    suite('Work with IDE', async () => {
+        test('Wait IDE availability', async () => {
+            await ide.waitWorkspaceAndIde(namespace, workspaceName);
+        });
+
+        test('Open project tree container', async () => {
+            await projectTree.openProjectTreeContainer();
+        });
+
+        test('Wait project imported', async () => {
+            try {
+                await projectTree.waitProjectImported(sampleName, 'src');
+            } catch (err) {
+                if (!(err instanceof error.TimeoutError)) {
+                    throw err;
+                }
+                var rest: restClient.RestClient = new restClient.RestClient('user-agent');
+                const workspaceStatusApiUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/api/workspace/${namespace}:${workspaceName}`;
+
+                const response: restClient.IRestResponse<any> = await rest.get(workspaceStatusApiUrl);
+                console.log('WORKSPACE DEFINITION: ' + JSON.stringify(response.result));
+                throw err;
+            }
+        });
+
+    });
+
+    suite('Language server validation', async () => {
+        test('Expand project and open file in editor', async () => {
+            await projectTree.expandPathAndOpenFileInAssociatedWorkspace(fileFolderPath, tabTitle);
+            await editor.selectTab(tabTitle);
+        });
+
+        test('Java LS initialization', async () => {
+            await ide.checkLsInitializationStart('Starting Java Language Server');
+            await ide.waitStatusBarTextAbsence('Starting Java Language Server', 1800000);
+            await ide.waitStatusBarTextAbsence('Building workspace', 360000);
+        });
+
+        test('Suggestion invoking', async () => {
+            await ide.closeAllNotifications();
+            await editor.waitEditorAvailable(tabTitle);
+            await editor.clickOnTab(tabTitle);
+            await editor.waitEditorAvailable(tabTitle);
+            await editor.waitTabFocused(tabTitle);
+            await editor.moveCursorToLineAndChar(tabTitle, 19, 11);
+            await editor.pressControlSpaceCombination(tabTitle);
+            await editor.waitSuggestion(tabTitle, 'cancelTimer(long arg0) : boolean');
+        });
+
+        test('Error highlighting', async () => {
+            await editor.type(tabTitle, 'error', 21);
+            await editor.waitErrorInLine(21);
+            await editor.performKeyCombination(tabTitle, Key.chord(Key.BACK_SPACE, Key.BACK_SPACE, Key.BACK_SPACE, Key.BACK_SPACE, Key.BACK_SPACE));
+            await editor.waitErrorInLineDisappearance(21);
+        });
+
+        test('Autocomplete', async () => {
+            await editor.moveCursorToLineAndChar(tabTitle, 18, 15);
+            await editor.pressControlSpaceCombination(tabTitle);
+            await editor.waitSuggestionContainer();
+            await editor.waitSuggestion(tabTitle, 'Vertx - io.vertx.core');
+        });
+
+        test('Codenavigation', async () => {
+            await editor.moveCursorToLineAndChar(tabTitle, 17, 15);
+            await editor.performKeyCombination(tabTitle, Key.chord(Key.CONTROL, Key.F12));
+            await editor.waitEditorAvailable(codeNavigationClassName);
+        });
+
+    });
+
+    suite('Validation of project build', async () => {
+        test('Build application', async () => {
+            let taskName: string = 'che: maven build';
+            await runTask(taskName);
+            await quickOpenContainer.clickOnContainerItem('Continue without scanning the task output');
+            await ide.waitNotification('Task ' + taskName + ' has exited with code 0.', 60000);
+        });
+
+        test('Close the terminal tasks', async () => {
+            await terminal.closeTerminalTab('maven build');
+        });
+    });
+
+    suite('Stop and remove workspace', async () => {
+        test('Stop workspace', async () => {
+            await dashboard.stopWorkspaceByUI(workspaceName);
+        });
+
+        test('Delete workspace', async () => {
+            await dashboard.deleteWorkspaceByUI(workspaceName);
+        });
+
+    });
+
+    async function runTask(task: string) {
+        await topMenu.selectOption('Terminal', 'Run Task...');
+        try {
+            await quickOpenContainer.waitContainer();
+        } catch (err) {
+            if (err instanceof error.TimeoutError) {
+                console.warn(`After clicking to the "Terminal" -> "Run Task ..." the "Quick Open Container" has not been displayed, one more try`);
+
+                await topMenu.selectOption('Terminal', 'Run Task...');
+                await quickOpenContainer.waitContainer();
+            }
+        }
+
+        await quickOpenContainer.clickOnContainerItem(task);
+    }
+
+});

--- a/e2e/tests/e2e/JavaVertx.spec.ts
+++ b/e2e/tests/e2e/JavaVertx.spec.ts
@@ -22,7 +22,6 @@ import { QuickOpenContainer } from '../../pageobjects/ide/QuickOpenContainer';
 import { Terminal } from '../../pageobjects/ide/Terminal';
 import 'reflect-metadata';
 import { error, Key } from 'selenium-webdriver';
-import * as restClient from 'typed-rest-client/RestClient';
 import { DriverHelper } from '../../utils/DriverHelper';
 
 const workspaceName: string = NameGenerator.generate('wksp-test-', 5);
@@ -43,10 +42,9 @@ const topMenu: TopMenu = e2eContainer.get(CLASSES.TopMenu);
 const quickOpenContainer: QuickOpenContainer = e2eContainer.get(CLASSES.QuickOpenContainer);
 const terminal: Terminal = e2eContainer.get(CLASSES.Terminal);
 
-suite('RhChe E2E Java Vert.x test', async () => {
+suite('Java Vert.x test', async () => {
     suite('Login and wait dashboard', async () => {
         test('Login', async () => {
-            console.log('URL: ' + TestConstants.TS_SELENIUM_BASE_URL);
             await driverHelper.navigateToUrl(TestConstants.TS_SELENIUM_BASE_URL);
             await loginPage.login();
         });


### PR DESCRIPTION
### What does this PR do?
Add test for Java Vertx default worskpace with example project. 
Test will validate:
 - Workspace creation via UI
 - Language server validation
   - Expand project and open file in editor
   - Java LS initialization
   - Suggestion invoking
   - Error highlighting
   - Autocomplete
   - Codenavigation
 - Validation of project build
 - Close the terminal tasks
 - Stop workspace
 - Delete workspace

Test can be run via `npm run test-java-vertx`.

EDIT: The purpose of this test is to test default example stacks with their example project that user can create just by selecting it in UI.