### PR TITLE
replace sed delimiters to be able to use / in docker image buildscript

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -128,7 +128,11 @@ build() {
 build_image() {
   printf "${BOLD}Building Docker Image ${IMAGE_NAME} from $DIR directory with tag $TAG${NC}\n"
   # Replace macros in Dockerfiles
-  cat ${DIR}/${DOCKERFILE} | sed s/\$\{BUILD_ORGANIZATION\}/${ORGANIZATION}/ | sed s/\$\{BUILD_PREFIX\}/${PREFIX}/ | sed s/\$\{BUILD_TAG\}/${TAG}/ > ${DIR}/.Dockerfile
+  cat ${DIR}/${DOCKERFILE} | sed \
+    -e "s;\${BUILD_ORGANIZATION};${ORGANIZATION};" \
+    -e "s;\${BUILD_PREFIX};${PREFIX};" \
+    -e "s;\${BUILD_TAG};${TAG};" \
+    > ${DIR}/.Dockerfile
   cd "${DIR}" && docker build -f ${DIR}/.Dockerfile -t ${IMAGE_NAME} ${BUILD_ARGS} .
   DOCKER_BUILD_STATUS=$?
   rm ${DIR}/.Dockerfile


### PR DESCRIPTION
### What does this PR do?
Replaces `sed` delimiters in docker image build script. It will be now possible to use `/` in it's params. It has no effect to current behavior.

I use it like this `sh -x build.sh --organization:quay.io/mvala --prefix:che --name:server --tag:feature1 --dockerfile:Dockerfile` to build my custom `quay.io/mvala/che-server:feature1` image.

### What issues does this PR fix or reference?
n/a