### PR TITLE
Makes sure the workspace activity checker reconciles the workspaces with their true statuses.

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -140,6 +140,9 @@ che.workspace.activity_check_scheduler_period_s=60
 # run the cleanup job every hour.
 che.workspace.activity_cleanup_scheduler_period_s=3600
 
+# The delay after server startup to start the first activity clean up job.
+che.workspace.activity_cleanup_scheduler_initial_delay_s=60
+
 #
 # Delay before first workspace idleness check job started to avoid
 # mass suspend if ws master was unavailable for period close to

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -134,6 +134,12 @@ che.installer.registry.remote=NULL
 
 # Period of inactive workspaces suspend job execution.
 che.workspace.activity_check_scheduler_period_s=60
+
+# The period of the cleanup of the activity table. The activity table can contain invalid or stale data
+# if some unforeseen errors happen, like a server crash at a peculiar point in time. The default is to
+# run the cleanup job every hour.
+che.workspace.activity_cleanup_scheduler_period_s=3600
+
 #
 # Delay before first workspace idleness check job started to avoid
 # mass suspend if ws master was unavailable for period close to

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -11,8 +11,10 @@
  */
 package org.eclipse.che.api.workspace.activity;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import javax.inject.Singleton;
@@ -147,6 +149,11 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
     } else {
       workspaceActivities.put(activity.getWorkspaceId(), activity);
     }
+  }
+
+  @Override
+  public Set<WorkspaceActivity> getAll() {
+    return new HashSet<>(workspaceActivities.values());
   }
 
   private boolean isGreater(Long value, long threshold) {

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -11,12 +11,11 @@
  */
 package org.eclipse.che.api.workspace.activity;
 
-import java.util.HashSet;
+import static java.util.stream.Collectors.toList;
+
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.Page;
@@ -55,7 +54,7 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
         .stream()
         .filter(a -> a.getExpiration() != null && a.getExpiration() < timestamp)
         .map(WorkspaceActivity::getWorkspaceId)
-        .collect(Collectors.toList());
+        .collect(toList());
   }
 
   @Override
@@ -113,7 +112,7 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
                   }
                 })
             .map(WorkspaceActivity::getWorkspaceId)
-            .collect(Collectors.toList());
+            .collect(toList());
 
     int total = all.size();
     int from = skipCount > total ? total : (int) skipCount;
@@ -152,8 +151,12 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
   }
 
   @Override
-  public Set<WorkspaceActivity> getAll() {
-    return new HashSet<>(workspaceActivities.values());
+  public Page<WorkspaceActivity> getAll(int maxItems, long skipCount) {
+    return new Page<>(
+        workspaceActivities.values().stream().skip(skipCount).collect(toList()),
+        skipCount,
+        maxItems,
+        workspaceActivities.size());
   }
 
   private boolean isGreater(Long value, long threshold) {

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -153,7 +153,7 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
   @Override
   public Page<WorkspaceActivity> getAll(int maxItems, long skipCount) {
     return new Page<>(
-        workspaceActivities.values().stream().skip(skipCount).collect(toList()),
+        workspaceActivities.values().stream().skip(skipCount).limit(maxItems).collect(toList()),
         skipCount,
         maxItems,
         workspaceActivities.size());

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -15,6 +15,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.google.inject.persist.Transactional;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -202,6 +203,19 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
       return em.find(WorkspaceActivity.class, workspaceId);
     } catch (RuntimeException x) {
       throw new ServerException(x.getLocalizedMessage(), x);
+    }
+  }
+
+  @Override
+  @Transactional(rollbackOn = ServerException.class)
+  public Set<WorkspaceActivity> getAll() throws ServerException {
+    try {
+      EntityManager em = managerProvider.get();
+      return em.createNamedQuery("WorkspaceActivity.getAll", WorkspaceActivity.class)
+          .getResultStream()
+          .collect(Collectors.toSet());
+    } catch (RuntimeException e) {
+      throw new ServerException(e.getLocalizedMessage(), e);
     }
   }
 

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -77,6 +77,9 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
               + " WHERE a.status = org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING"
               + " AND a.lastStarting <= :time"),
   @NamedQuery(name = "WorkspaceActivity.getAll", query = "SELECT a FROM WorkspaceActivity a"),
+  @NamedQuery(
+      name = "WorkspaceActivity.getAllCount",
+      query = "SELECT COUNT(*) FROM WorkspaceActivity"),
 })
 public class WorkspaceActivity {
 

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -76,6 +76,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
           "SELECT COUNT(a) FROM WorkspaceActivity a"
               + " WHERE a.status = org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING"
               + " AND a.lastStarting <= :time"),
+  @NamedQuery(name = "WorkspaceActivity.getAll", query = "SELECT a FROM WorkspaceActivity a"),
 })
 public class WorkspaceActivity {
 

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -79,7 +79,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
   @NamedQuery(name = "WorkspaceActivity.getAll", query = "SELECT a FROM WorkspaceActivity a"),
   @NamedQuery(
       name = "WorkspaceActivity.getAllCount",
-      query = "SELECT COUNT(*) FROM WorkspaceActivity"),
+      query = "SELECT COUNT(a) FROM WorkspaceActivity a"),
 })
 public class WorkspaceActivity {
 

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
@@ -33,9 +33,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Is in charge of checking the validity of the workspace activity records. The sole important
- * method is {@link #validate()} which is run on a schedule to periodically check the validity of
- * the records and report the potential error conditions.
+ * Is in charge of checking the validity of the workspace activity records. The important methods
+ * are {@link #expire()} which is run on a schedule to periodically stop the expired workspaces and
+ * {@link #cleanup()} which will try to clean up and reconcile the possibly invalid activity
+ * records.
  *
  * @author Lukas Krejci
  */
@@ -84,13 +85,19 @@ public class WorkspaceActivityChecker {
       initialDelayParameterName = "che.workspace.activity_check_scheduler_delay_s",
       delayParameterName = "che.workspace.activity_check_scheduler_period_s")
   @VisibleForTesting
-  void validate() {
+  void expire() {
     try {
       stopAllExpired();
     } catch (ServerException e) {
       LOG.error(e.getLocalizedMessage(), e);
     }
+  }
 
+  @ScheduleDelay(
+      initialDelayParameterName = "che.workspace.activity_cleanup_scheduler_period_s",
+      delayParameterName = "che.workspace.activity_cleanup_scheduler_period_s")
+  @VisibleForTesting
+  void cleanup() {
     try {
       checkActivityRecordValidity();
     } catch (ServerException e) {
@@ -367,7 +374,7 @@ public class WorkspaceActivityChecker {
   /**
    * Makes sure the activity of a running workspace has a last running time. The activity won't have
    * a last running time very shortly after it was found running by the runtime before our event
-   * handler updated the activity record. If the schedule of the {@link #validate()} method precedes
+   * handler updated the activity record. If the schedule of the {@link #cleanup()} method precedes
    * or coincides with the event handler we might not see the value. Otherwise this can
    * theoretically also happen when the server is stopped at an unfortunate point in time while the
    * workspace is starting and/or running and before the event handler had a chance of updating the

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
@@ -94,7 +94,7 @@ public class WorkspaceActivityChecker {
   }
 
   @ScheduleDelay(
-      initialDelayParameterName = "che.workspace.activity_cleanup_scheduler_period_s",
+      initialDelayParameterName = "che.workspace.activity_cleanup_scheduler_initial_delay_s",
       delayParameterName = "che.workspace.activity_cleanup_scheduler_period_s")
   @VisibleForTesting
   void cleanup() {

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
@@ -21,6 +21,7 @@ import com.google.inject.Singleton;
 import java.time.Clock;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.Pages;
 import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
@@ -166,7 +167,7 @@ public class WorkspaceActivityChecker {
    * @throws ServerException or error
    */
   private void reconcileActivityStatuses() throws ServerException {
-    for (WorkspaceActivity a : activityDao.getAll()) {
+    for (WorkspaceActivity a : Pages.iterateLazily(activityDao::getAll, 200)) {
       WorkspaceStatus status = workspaceRuntimes.getStatus(a.getWorkspaceId());
       if (a.getStatus() != status) {
         if (LOG.isWarnEnabled()) {

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityDao.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.workspace.activity;
 
 import java.util.List;
+import java.util.Set;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.Page;
 import org.eclipse.che.api.core.ServerException;
@@ -126,4 +127,11 @@ public interface WorkspaceActivityDao {
    * @throws ServerException on other error
    */
   void createActivity(WorkspaceActivity activity) throws ConflictException, ServerException;
+
+  /**
+   * Returns all current workspace activities.
+   *
+   * @return the workspace activities for all workspaces
+   */
+  Set<WorkspaceActivity> getAll() throws ServerException;
 }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityDao.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.api.workspace.activity;
 
 import java.util.List;
-import java.util.Set;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.Page;
 import org.eclipse.che.api.core.ServerException;
@@ -131,7 +130,9 @@ public interface WorkspaceActivityDao {
   /**
    * Returns all current workspace activities.
    *
+   * @param maxItems the page size
+   * @param skipCount the number of records to skip
    * @return the workspace activities for all workspaces
    */
-  Set<WorkspaceActivity> getAll() throws ServerException;
+  Page<WorkspaceActivity> getAll(int maxItems, long skipCount) throws ServerException;
 }

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
@@ -215,6 +215,26 @@ public class WorkspaceActivityCheckerTest {
     verify(workspaceActivityDao, never()).setExpirationTime(anyString(), anyLong());
   }
 
+  @Test
+  public void shouldRestoreTrueStateOfWorkspaceIfActivityDoesntReflectThat() throws Exception {
+    // given
+    String wsId = "1";
+    WorkspaceActivity activity = new WorkspaceActivity();
+    activity.setCreated(clock.millis());
+    activity.setWorkspaceId(wsId);
+    activity.setStatus(WorkspaceStatus.STARTING);
+    activity.setLastStarting(clock.millis());
+    when(workspaceActivityDao.getAll()).thenReturn(singleton(activity));
+    when(workspaceRuntimes.getStatus(eq(wsId))).thenReturn(WorkspaceStatus.STOPPED);
+
+    // when
+    checker.validate();
+
+    // then
+    verify(workspaceActivityDao)
+        .setStatusChangeTime(eq(wsId), eq(WorkspaceStatus.STOPPED), eq(clock.millis()));
+  }
+
   private static final class ManualClock extends Clock {
 
     private Instant instant;

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
@@ -83,7 +83,7 @@ public class WorkspaceActivityCheckerTest {
   public void shouldStopAllExpiredWorkspaces() throws Exception {
     when(workspaceActivityDao.findExpired(anyLong())).thenReturn(Arrays.asList("1", "2", "3"));
 
-    checker.validate();
+    checker.expire();
 
     verify(workspaceActivityDao, times(3)).removeExpiration(anyString());
     verify(workspaceActivityDao).removeExpiration(eq("1"));
@@ -106,7 +106,7 @@ public class WorkspaceActivityCheckerTest {
 
     // when
     clock.forward(Duration.of(1, ChronoUnit.SECONDS));
-    checker.validate();
+    checker.cleanup();
 
     // then
     ArgumentCaptor<WorkspaceActivity> captor = ArgumentCaptor.forClass(WorkspaceActivity.class);
@@ -137,7 +137,7 @@ public class WorkspaceActivityCheckerTest {
                 .build());
 
     // when
-    checker.validate();
+    checker.cleanup();
 
     // then
     verify(workspaceActivityDao).setCreatedTime(eq(id), eq(15L));
@@ -156,7 +156,7 @@ public class WorkspaceActivityCheckerTest {
 
     // when
     clock.forward(Duration.of(1, ChronoUnit.SECONDS));
-    checker.validate();
+    checker.cleanup();
 
     // then
     verify(workspaceActivityDao, never()).setCreatedTime(eq(id), anyLong());
@@ -183,7 +183,7 @@ public class WorkspaceActivityCheckerTest {
 
     // when
     clock.forward(Duration.of(1, ChronoUnit.SECONDS));
-    checker.validate();
+    checker.cleanup();
 
     // then
     verify(workspaceActivityDao).setCreatedTime(eq(id), eq(15L));
@@ -204,7 +204,7 @@ public class WorkspaceActivityCheckerTest {
 
     // when
     clock.forward(Duration.of(1500, ChronoUnit.MILLIS));
-    checker.validate();
+    checker.cleanup();
 
     // then
     verify(workspaceActivityDao).setExpirationTime(eq(id), eq(lastRunning + DEFAULT_TIMEOUT));
@@ -222,7 +222,7 @@ public class WorkspaceActivityCheckerTest {
 
     // when
     clock.forward(Duration.of(900, ChronoUnit.MILLIS));
-    checker.validate();
+    checker.cleanup();
 
     // then
     verify(workspaceActivityDao, never()).setExpirationTime(anyString(), anyLong());
@@ -254,7 +254,7 @@ public class WorkspaceActivityCheckerTest {
     when(workspaceRuntimes.getStatus(eq(wsId))).thenReturn(WorkspaceStatus.STOPPED);
 
     // when
-    checker.validate();
+    checker.cleanup();
 
     // then
     verify(workspaceActivityDao)


### PR DESCRIPTION
### What does this PR do?
Because it seems like under heavy load we either loose or don't register workspace state transitions in the workspace activity checker, this PR makes sure that we go through all the current activity records and reconcile them with the actual workspace status as registered by the workspace runtimes.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14536