### PR TITLE
che #14530 Changing 'che.workspace.pool.type' from 'fixed' to 'cached' by default

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -58,7 +58,7 @@ che.workspace.auto_start=true
 # operations that require asynchronous execution e.g. starting/stopping
 
 # possible values are 'fixed', 'cached'
-che.workspace.pool.type=fixed
+che.workspace.pool.type=cached
 
 # This property is ignored when pool type is different from 'fixed'.
 # Configures the exact size of the pool, if it's set multiplier property is ignored.


### PR DESCRIPTION
### What does this PR do?
Changing 'che.workspace.pool.type' from 'fixed' to 'cached' by default. This change will use CachedThreadPool:

> Creates a thread pool that creates new threads as needed, but will reuse previously constructed threads when they are available. These pools will typically improve the performance of programs that execute many short-lived asynchronous tasks. Calls to execute will reuse previously constructed threads if available. If no existing thread is available, a new thread will be created and added to the pool. Threads that have not been used for sixty seconds are terminated and removed from the cache. Thus, a pool that remains idle for long enough will not consume any resources. Note that pools with similar properties but different details (for example, timeout parameters) may be created using ThreadPoolExecutor constructors

Originally implemented for `5.1.0` in https://github.com/eclipse/che/pull/3701 the value has not been changed ever after. I suspect the default was applied mainly for local development and was overridden for codenvy.io / on-prem installations

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14614
Should also fix https://github.com/eclipse/che/issues/14530

#### Docs PR
I'm not sure if the doc PR is needed since the configuration of the workspace pool type is suppose to be an internal detail. It might be interesting to document the recommended setup as part of `Scalability, Performances and Working with high latency` Roadmap item

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
Changing 'che.workspace.pool.type' from 'fixed' to 'cached' by default

#### Release Notes
Changing 'che.workspace.pool.type' from 'fixed' to 'cached' by default


