### PR TITLE
Set postgres deployment to use recreate deployment strategy

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-postgres/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-postgres/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
     matchLabels:
       app: che
       component: postgres
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Tom George <tg82490@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Set a default update strategy of `Recreate` for the Postgres deployment in Che

### What issues does this PR fix or reference?

#14166

Title of the issue is a bit misleading, we now think `Recreate` is the correct way to go. 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

Set postgres deployment to use recreate deployment strategy

#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
