### PR TITLE
Change 'Docker Registries' to 'Container Registries'

### DIFF
--- a/dashboard/src/app/administration/administration.html
+++ b/dashboard/src/app/administration/administration.html
@@ -17,7 +17,7 @@
   <md-tabs md-dynamic-height md-stretch-tabs="auto" md-no-ink-bar>
     <md-tab>
       <md-tab-label>
-        <span class="che-tab-label-title">Docker Registries</span>
+        <span class="che-tab-label-title">Container Registries</span>
       </md-tab-label>
       <md-tab-body>
         <docker-registry-list></docker-registry-list>


### PR DESCRIPTION
Signed-off-by: Tom George <tg82490@gmail.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Changes the text of the administration page in the dashboard to refer to 'Container Registries' instead of 'Docker Registries'

### What issues does this PR fix or reference?

#13169 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
