### PR TITLE
Change grafana configuration to match hosted che configuration

### DIFF
--- a/deploy/openshift/deploy_che.sh
+++ b/deploy/openshift/deploy_che.sh
@@ -513,6 +513,7 @@ deployMetrics(){
     if [ "${CHE_METRICS_ENABLED}" == "true" ]; then
       echo "Deploying Grafana and Prometheus..."
       ${OC_BINARY} apply -f ${BASE_DIR}/templates/monitoring/grafana-dashboards.yaml
+      ${OC_BINARY} apply -f ${BASE_DIR}/templates/monitoring/grafana-dashboard-provider.yaml
       ${OC_BINARY} apply -f ${BASE_DIR}/templates/monitoring/grafana-datasources.yaml
       ${OC_BINARY} apply -f ${BASE_DIR}/templates/monitoring/prometheus-config.yaml
       ${OC_BINARY} new-app -f ${BASE_DIR}/templates/monitoring/che-monitoring.yaml

--- a/deploy/openshift/templates/monitoring/che-monitoring.yaml
+++ b/deploy/openshift/templates/monitoring/che-monitoring.yaml
@@ -83,8 +83,10 @@ objects:
           volumeMounts:
           - mountPath: /etc/grafana/provisioning/datasources
             name: volume-datasources
-          - mountPath: /etc/grafana/provisioning/dashboards
+          - mountPath: /grafana-dashboard-definitions/0
             name: volume-dashboards
+          - mountPath: /etc/grafana/provisioning/dashboards
+            name: volume-dashboard-provider
           readinessProbe:
             httpGet:
               path: /api/health
@@ -106,8 +108,12 @@ objects:
           name: volume-datasources
         - configMap:
             defaultMode: 420
-            name: grafana-dashboards
+            name: che-grafana-dashboards
           name: volume-dashboards
+        - configMap:
+            defaultMode: 420
+            name: grafana-dashboard-provider
+          name: volume-dashboard-provider
     test: false
     triggers:
       - type: ConfigChange

--- a/deploy/openshift/templates/monitoring/che-monitoring.yaml
+++ b/deploy/openshift/templates/monitoring/che-monitoring.yaml
@@ -83,7 +83,7 @@ objects:
           volumeMounts:
           - mountPath: /etc/grafana/provisioning/datasources
             name: volume-datasources
-          - mountPath: /grafana-dashboard-definitions/0
+          - mountPath: /etc/grafana/provisioning/dashboards/che
             name: volume-dashboards
           - mountPath: /etc/grafana/provisioning/dashboards
             name: volume-dashboard-provider

--- a/deploy/openshift/templates/monitoring/grafana-dashboard-provider.yaml
+++ b/deploy/openshift/templates/monitoring/grafana-dashboard-provider.yaml
@@ -11,7 +11,7 @@ data:
                 "folder": "",
                 "name": "0",
                 "options": {
-                    "path": "/grafana-dashboard-definitions/0"
+                    "path": "/etc/grafana/provisioning/dashboards/che"
                 },
                 "orgId": 1,
                 "type": "file"

--- a/deploy/openshift/templates/monitoring/grafana-dashboard-provider.yaml
+++ b/deploy/openshift/templates/monitoring/grafana-dashboard-provider.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+data:
+  dashboards.yaml: |-
+    {
+        "apiVersion": 1,
+        "providers": [
+            {
+                "folder": "",
+                "name": "0",
+                "options": {
+                    "path": "/grafana-dashboard-definitions/0"
+                },
+                "orgId": 1,
+                "type": "file"
+            }
+        ]
+    }
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
+

--- a/deploy/openshift/templates/monitoring/grafana-dashboard-provider.yaml
+++ b/deploy/openshift/templates/monitoring/grafana-dashboard-provider.yaml
@@ -1,4 +1,7 @@
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: grafana-dashboard-provider
 data:
   dashboards.yaml: |-
     {
@@ -15,7 +18,4 @@ data:
             }
         ]
     }
-kind: ConfigMap
-metadata:
-  name: grafana-dashboard-provider
 

--- a/deploy/openshift/templates/monitoring/grafana-dashboards.yaml
+++ b/deploy/openshift/templates/monitoring/grafana-dashboards.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: grafana-dashboards
+  name: che-grafana-dashboards
 data:
   che-master-jvm.json: |-
     {
@@ -6977,14 +6977,3 @@ data:
       "uid": "sL0Klq_mz",
       "version": 1
     }
-  dashboards.yaml: |-
-    apiVersion: 1
-    providers:
-    - name: 'default'
-      orgId: 1
-      folder: ''
-      type: file
-      disableDeletion: false
-      updateIntervalSeconds: 10000
-      options:
-        path: /etc/grafana/provisioning/dashboards


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

- Removes the dashboard provider yaml from `grafana-dashboards.yaml`
- Changes the name of `grafana-dashboards` `ConfigMap` to `che-grafana-dashboards`
- Create a `grafana-dashboard-provider` `ConfigMap`, that has a JSON spec (not yaml) defining the grafana dashboard provider, which looks like how hosted Che does it
- Change `che-monitoring.yaml` to mount the `grafana-dashboard-provider` `ConfigMap` at `/etc/grafana/provisioning/dashboards`, and to mount the `che-grafana-dashboards` `ConfigMap` at `/grafana-dashboard-definitions/0`

### What issues does this PR fix or reference?
#14652 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->

To deploy:

```shell
oc apply -f grafana-dashboard-provider.yaml -f grafana-dashboards.yaml -f grafana-datasources.yaml -f prometheus-config.yaml
oc process -f che-monitoring.yaml | oc apply -f -
```

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
https://github.com/eclipse/che-docs/pull/835

EDIT: Added doc PR link
