### PR TITLE
Reduce the chances that successfulCheckTest will fail

### DIFF
--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
@@ -36,7 +36,7 @@ public class ServerCheckerTest {
   private static final String MACHINE_NAME = "mach1";
   private static final String SERVER_REF = "ref1";
   private static final long PERIOD_MS = 10;
-  private static final long TIMEOUT_MS = 500;
+  private static final long TIMEOUT_MS = 5000;
   private static final int SUCCESS_THRESHOLD = 1;
 
   private Timer timer;
@@ -45,16 +45,7 @@ public class ServerCheckerTest {
   @BeforeMethod
   public void setUp() throws Exception {
     timer = new Timer(true);
-    checker =
-        spy(
-            new TestServerChecker(
-                MACHINE_NAME,
-                SERVER_REF,
-                PERIOD_MS,
-                TIMEOUT_MS,
-                SUCCESS_THRESHOLD,
-                TimeUnit.MILLISECONDS,
-                timer));
+
   }
 
   @AfterMethod
@@ -64,6 +55,16 @@ public class ServerCheckerTest {
 
   @Test(timeOut = TIMEOUT_MS)
   public void successfulCheckTest() throws Exception {
+    checker =
+            spy(
+                    new TestServerChecker(
+                            MACHINE_NAME,
+                            SERVER_REF,
+                            PERIOD_MS,
+                            TIMEOUT_MS,
+                            SUCCESS_THRESHOLD,
+                            TimeUnit.MILLISECONDS,
+                            timer));
     CompletableFuture<String> reportCompFuture = checker.getReportCompFuture();
     // not considered as available before start
     assertFalse(reportCompFuture.isDone());

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
@@ -36,7 +36,8 @@ public class ServerCheckerTest {
   private static final String MACHINE_NAME = "mach1";
   private static final String SERVER_REF = "ref1";
   private static final long PERIOD_MS = 10;
-  private static final long TIMEOUT_MS = 5000;
+  private static final long CHECKER_TIMEOUT_MS = 5000;
+  private static final long TEST_TIMEOUT_MS = CHECKER_TIMEOUT_MS + 1000;
   private static final int SUCCESS_THRESHOLD = 1;
 
   private Timer timer;
@@ -52,7 +53,7 @@ public class ServerCheckerTest {
     timer.cancel();
   }
 
-  @Test(timeOut = TIMEOUT_MS)
+  @Test(timeOut = TEST_TIMEOUT_MS)
   public void successfulCheckTest() throws Exception {
     checker =
         spy(
@@ -60,7 +61,7 @@ public class ServerCheckerTest {
                 MACHINE_NAME,
                 SERVER_REF,
                 PERIOD_MS,
-                TIMEOUT_MS,
+                CHECKER_TIMEOUT_MS,
                 SUCCESS_THRESHOLD,
                 TimeUnit.MILLISECONDS,
                 timer));
@@ -83,7 +84,7 @@ public class ServerCheckerTest {
     verify(checker, atLeast(2)).isAvailable();
   }
 
-  @Test(timeOut = TIMEOUT_MS)
+  @Test(timeOut = TEST_TIMEOUT_MS)
   public void checkTimeoutTest() throws Exception {
     checker =
         spy(

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
@@ -45,7 +45,6 @@ public class ServerCheckerTest {
   @BeforeMethod
   public void setUp() throws Exception {
     timer = new Timer(true);
-
   }
 
   @AfterMethod
@@ -56,15 +55,15 @@ public class ServerCheckerTest {
   @Test(timeOut = TIMEOUT_MS)
   public void successfulCheckTest() throws Exception {
     checker =
-            spy(
-                    new TestServerChecker(
-                            MACHINE_NAME,
-                            SERVER_REF,
-                            PERIOD_MS,
-                            TIMEOUT_MS,
-                            SUCCESS_THRESHOLD,
-                            TimeUnit.MILLISECONDS,
-                            timer));
+        spy(
+            new TestServerChecker(
+                MACHINE_NAME,
+                SERVER_REF,
+                PERIOD_MS,
+                TIMEOUT_MS,
+                SUCCESS_THRESHOLD,
+                TimeUnit.MILLISECONDS,
+                timer));
     CompletableFuture<String> reportCompFuture = checker.getReportCompFuture();
     // not considered as available before start
     assertFalse(reportCompFuture.isDone());


### PR DESCRIPTION
### What does this PR do?
The cause of the fail is that TestServerChecker has only 500msec to do the job correctly in successfulCheckTest. Since successfulCheckTest is the single testcase that used  TestServerChecker constructed in setUp it may occasionally fail if the time between setUp and     successfulCheckTest.checker.start();  are longer then 500msec

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13211

#### Release Notes
n/a
#### Docs PR
n/a