### PR TITLE
Update Deployments yamls in helm charts to be compatible with k8s v1.16

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-jaeger/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-jaeger/templates/deployment.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: jaeger

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -17,6 +17,10 @@ metadata:
   name: keycloak
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: che
+      component: keycloak
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm/che/custom-charts/che-postgres/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-postgres/templates/deployment.yaml
@@ -8,7 +8,7 @@
 #
 
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -19,6 +19,10 @@ metadata:
   name: postgres
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: che
+      component: postgres
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
### What does this PR do?

Update Helm charts deployments yamls because otherwise Che deployment fails on latest
version of Kubernetes.

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/14697