### PR TITLE
Show the warning message in the case with deprecated plugins

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -14,16 +14,18 @@
 #  $ docker run --rm eclipse-che-dashboard | tar -C target/ -zxf -
 FROM node:8.16.0
 
-RUN apt-get update && \
-    apt-get install -y git \
+RUN apt-get update \
+    && apt-get install -y git \
     && apt-get -y clean \
     && rm -rf /var/lib/apt/lists/*
+
 COPY package.json /dashboard/
 COPY yarn.lock /dashboard/
 COPY typings.json /dashboard/
 WORKDIR /dashboard
 RUN yarn install --ignore-optional
 COPY . /dashboard/
+
 RUN yarn build && yarn test
 RUN cd /dashboard/target/ && tar zcf /tmp/dashboard.tar.gz dist/
 

--- a/dashboard/src/app/factories/factory-details/factory-details.html
+++ b/dashboard/src/app/factories/factory-details/factory-details.html
@@ -11,8 +11,8 @@
       Red Hat, Inc. - initial API and implementation
 
 -->
-<che-description ng-hide="factoryDetailsController.isSupportedVersion()" class="workspace-details-warning-info">
-  This factory is using old workspace definition format which is not compatible anymore. 
+<che-description ng-hide="!factoryDetailsController.factory || factoryDetailsController.isSupportedVersion()" class="workspace-details-warning-info">
+  This factory is using old workspace definition format which is not compatible anymore.
   Please follow the <a ng-href="{{branding.docs.workspace}}" target="_blank">documentation</a> to update the definition of the workspace and benefits from the latest capabilities.
 </che-description>
 <che-toolbar

--- a/dashboard/src/app/index.styl
+++ b/dashboard/src/app/index.styl
@@ -75,7 +75,7 @@ label
   font-weight normal !important
 
 md-divider
-  border-top-color #353E5D !important
+  border-top-color #353E5D
   margin 0 10px
 
 md-toolbar
@@ -107,11 +107,15 @@ md-option:hover
       max-height calc(100vh - 30px)
 
 .progress-line
-  position absolute
-  left 0
-  right 0
-  height 5px
+  position relative
   z-index 80
+  width 100%
+  max-height 5px
+  md-progress-linear
+   position absolute
+   left 0
+   right 0
+   height 5px
 
 .main-page-loader
   position absolute

--- a/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/edit-project.styl
+++ b/dashboard/src/app/workspaces/create-workspace/project-source-selector/edit-project/edit-project.styl
@@ -1,32 +1,22 @@
 .edit-project
-
   md-divider
-    border-top-color $box-border-color !important
-    margin 0
-    margin-top 21px
-
-.edit-project
-
+    border-top-color $box-border-color
   .edit-project-button
+    button
+      margin 6px
 
-    che-button-primary button.md-button.che-button.md-accent,
-    che-button-cancel-flat button.md-button.che-button.md-accent,
-    che-button-danger button.md-button.md-danger-theme.md-accent
-      padding-top 2px
-      margin 6px !important
+    che-button-cancel-flat,
+    che-button-danger
+      button
+        background-color $white-color !important
+        box-shadow none !important
+        border none
+        &[disabled]
+          color $disabled-color
 
-    che-button-cancel-flat button.md-button.che-button.md-accent,
-    che-button-danger button.md-button.md-danger-theme.md-accent
-      background-color $che-white-color !important
-      border none !important
-      box-shadow none !important
+    che-button-cancel-flat button
+      color $grey-input-label-color
 
-      &[disabled] span
-        color $disabled-color !important
-
-    che-button-cancel-flat button.md-button.che-button.md-accent span
-      color $grey-input-label-color !important
-
-    che-button-danger button.md-button.md-danger-theme.md-accent span
+    che-button-danger button
       color $error-color !important
 

--- a/dashboard/src/app/workspaces/list-workspaces/list-workspaces.html
+++ b/dashboard/src/app/workspaces/list-workspaces/list-workspaces.html
@@ -14,9 +14,9 @@
 <che-toolbar che-title="Workspaces" border-none></che-toolbar>
 <che-description che-link-title="Learn more." che-link="{{branding.docs.workspace}}">A workspace is where your projects live and run. Create workspaces from stacks that define projects, runtimes, and commands.</che-description>
 <md-content md-scroll-y flex layout="column" md-theme="maincontent-theme">
-  <md-progress-linear md-mode="indeterminate" class="progress-line"
+  <div class="progress-line"><md-progress-linear md-mode="indeterminate"
                       ng-show="listWorkspacesCtrl.isInfoLoading || listWorkspacesCtrl.isRequestPending"></md-progress-linear>
-  <md-content flex class="workspace-list-content" ng-hide="listWorkspacesCtrl.isInfoLoading">
+  <md-content flex class="workspace-list-content" ng-hide="listWorkspacesCtrl.isInfoLoading"><div>
     <che-list-header che-input-placeholder="Search"
                      che-search-model="listWorkspacesCtrl.workspaceFilter.config.name"
                      che-on-search-change="listWorkspacesCtrl.onSearchChanged(str)"

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
@@ -210,17 +210,43 @@ describe(`WorkspaceDetailsController >`, () => {
         this.getSupportedRecipeTypes = () => {
           return ['dockerimage', 'dockerfile', 'compose'];
         };
+        this.fetchWorkspaceSettings = (): any => {
+          // todo: rework to use Angular promise instead of native one
+          return Promise.resolve({
+            cheWorkspacePluginRegistryUrl: 'cheWorkspacePluginRegistryUrl'
+          });
+        };
         this.getWorkspaceSettings = () => {
           return {};
         };
-
         this.getWorkspaceDataManager = () => {
           return {
             getName(data: che.IWorkspace): string {
               return 'name';
+            },
+            getEditor() {
+              return '';
+            },
+            getPlugins() {
+              return [];
             }
           };
         };
+      })
+      .factory('pluginRegistry', function () {
+        return {
+          fetchPlugins: (url: string) => {
+            return $q.when([]);
+          }
+        }
+      })
+      .factory('cheBranding', function () {
+        return {
+          getDocs: () => {
+            const converting = 'converting-a-che-6-workspace-to-a-che-7-devfile';
+            return {converting};
+          }
+        }
       })
       // terminal directives which prevent to execute an original ones
       .directive('mdTab', function () {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -1,6 +1,6 @@
-<che-description ng-hide="workspaceDetailsController.isSupportedVersion()" class="workspace-details-warning-info">
-  This workspace is using old definition format which is not compatible anymore. 
-  Please follow the <a ng-href="{{branding.docs.workspace}}" target="_blank">documentation</a> to update the definition of the workspace and benefits from the latest capabilities.
+<che-description class="workspace-details-warning-info"
+                 ng-show="workspaceDetailsController.hasWarningMessage===true">
+  <span  ng-bind-html="workspaceDetailsController.warningMessage"></span>
 </che-description>
 <che-row-toolbar che-title="{{workspaceDetailsController.workspaceName}}" link-href="#/workspaces"
   link-title="Workspaces" class="workspace-details-toolbar">
@@ -22,9 +22,9 @@
   </div>
 </che-row-toolbar>
 
-<div><md-progress-linear class="progress-line" md-mode="indeterminate"
-                      ng-show="workspaceDetailsController.loading"></md-progress-linear></div>
-
+<div class="progress-line">
+  <md-progress-linear md-mode="indeterminate" ng-show="workspaceDetailsController.loading===true"></md-progress-linear>
+</div>
 <md-content ng-if="workspaceDetailsController.workspaceDetails" md-scroll-y flex
             class="workspace-details-content" md-theme="default">
   <md-tabs md-dynamic-height md-stretch-tabs="auto"
@@ -90,7 +90,7 @@
     </md-tab>
 
     <!-- Env Variables -->
-    <md-tab ng-if="workspaceDetailsController.workspaceDetails.config" 
+    <md-tab ng-if="workspaceDetailsController.workspaceDetails.config"
       md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Env_Variables);">
       <md-tab-label>
         <span class="che-tab-label-title">Env Variables</span>
@@ -124,7 +124,7 @@
     </md-tab>
 
     <!-- Config tab -->
-    <md-tab ng-if="workspaceDetailsController.workspaceDetails.config" 
+    <md-tab ng-if="workspaceDetailsController.workspaceDetails.config"
       md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Config); isConfigActive = true"
       md-on-deselect="isConfigActive = false">
       <md-tab-label>
@@ -158,8 +158,10 @@
 
     <!-- Plugins tab -->
     <md-tab ng-if="workspaceDetailsController.pluginRegistry"
-      md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Plugins);">
+            md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Plugins);">
       <md-tab-label>
+        <i ng-show="workspaceDetailsController.hasSelectedDeprecatedPlugins===true"
+           class="warning-state fa fa-exclamation-circle" aria-hidden="true"></i>
         <span class="che-tab-label-title">Plugins</span>
       </md-tab-label>
       <md-tab-body>
@@ -174,6 +176,8 @@
     <md-tab ng-if="workspaceDetailsController.pluginRegistry"
       md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Editors);">
       <md-tab-label>
+        <i ng-show="workspaceDetailsController.hasSelectedDeprecatedEditor===true"
+           class="warning-state fa fa-exclamation-circle" aria-hidden="true"></i>
         <span class="che-tab-label-title">Editors</span>
       </md-tab-label>
       <md-tab-body>
@@ -185,7 +189,7 @@
     </md-tab>
 
      <!-- Devfile tab -->
-     <md-tab ng-if="workspaceDetailsController.workspaceDetails.devfile" 
+     <md-tab ng-if="workspaceDetailsController.workspaceDetails.devfile"
      md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Devfile); isDevfileActive = true"
      md-on-deselect="isDevfileActive = false">
      <md-tab-label>

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.service.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.service.spec.ts
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import {IPlugin} from '../../../components/api/plugin-registry.factory';
+import {WorkspaceDetailsService} from './workspace-details.service';
+import {CheHttpBackend} from '../../../components/api/test/che-http-backend';
+
+/**
+ * WorkspaceDetailsService tests.
+ *
+ * @author Oleksii Orel
+ */
+describe(`WorkspaceDetailsService >`, () => {
+
+  /**
+   * Service to test.
+   */
+  let workspaceDetailsService: WorkspaceDetailsService;
+
+  let cheHttpBackend: CheHttpBackend;
+
+  let $httpBackend: ng.IHttpBackendService;
+
+  function getPlugins(): Array<IPlugin> {
+    return [{
+      id: 'camel-tooling/vscode-apache-camel/0.0.14',
+      deprecate: {
+        automigrate: true,
+        migrateTo: 'camel-tooling/vscode-apache-camel/latest'
+      },
+      name: 'vscode-apache-camel',
+      publisher: 'camel-tooling',
+      displayName: 'Language Support for Apache Camel',
+      type: 'VS Code extension'
+    }, {
+      id: 'camel-tooling/vscode-apache-camel/latest',
+      name: 'vscode-apache-camel',
+      publisher: 'camel-tooling',
+      displayName: 'Language Support for Apache Camel',
+      type: 'VS Code extension'
+    }, {
+      id: 'eclipse/che-theia/7.2.0',
+      deprecate: {
+        automigrate: true,
+        migrateTo: 'eclipse/che-theia/latest'
+      },
+      name: 'che-theia',
+      publisher: 'eclipse',
+      displayName: 'theia-ide',
+      type: 'Che Editor'
+    }, {
+      id: 'eclipse/che-theia/latest',
+      name: 'che-theia',
+      publisher: 'eclipse',
+      displayName: 'theia-ide',
+      type: 'Che Editor'
+    }];
+  }
+
+  function getNewWorkspace(): che.IWorkspace {
+    return {
+      devfile: {
+        metadata: {
+          name: 'wksp-i8cb55'
+        },
+        apiVersion: '1.0.0',
+        components: [
+          {
+            id: 'eclipse/che-theia/latest',
+            type: 'cheEditor'
+          }, {
+            id: 'camel-tooling/vscode-apache-camel/latest',
+            type: 'chePlugin'
+          }
+        ]
+      },
+      id: 'workspacefbymkrh72ptwudud',
+      namespace: 'che'
+    }
+  }
+
+  function getWorkspaceWithDeprecatedPlugins(): che.IWorkspace {
+    return {
+      devfile: {
+        metadata: {
+          name: 'wksp-i8cb55'
+        },
+        apiVersion: '1.0.0',
+        components: [
+          {
+            id: 'eclipse/che-theia/latest',
+            type: 'cheEditor'
+          }, {
+            id: 'camel-tooling/vscode-apache-camel/0.0.14',
+            type: 'chePlugin'
+          }
+        ]
+      },
+      id: 'workspacefbymkrh72ptwudud',
+      namespace: 'che'
+    }
+  }
+
+  function getWorkspaceWithDeprecatedEditor(): che.IWorkspace {
+    return {
+      devfile: {
+        metadata: {
+          name: 'wksp-i8cb55'
+        },
+        apiVersion: '1.0.0',
+        components: [
+          {
+            id: 'eclipse/che-theia/7.2.0',
+            type: 'cheEditor'
+          }, {
+            id: 'camel-tooling/vscode-apache-camel/latest',
+            type: 'chePlugin'
+          }
+        ]
+      },
+      id: 'workspacefbymkrh72ptwudud',
+      namespace: 'che'
+    }
+  }
+
+  /**
+   * Setup module
+   */
+  beforeEach(() => {
+    angular.mock.module('userDashboard');
+  });
+
+  beforeEach(inject((_workspaceDetailsService_: WorkspaceDetailsService,
+                     _cheHttpBackend_: CheHttpBackend) => {
+
+    workspaceDetailsService = _workspaceDetailsService_;
+    cheHttpBackend = _cheHttpBackend_;
+    $httpBackend = cheHttpBackend.getHttpBackend();
+
+    cheHttpBackend.setPlugins(getPlugins());
+    cheHttpBackend.setup();
+
+    $httpBackend.flush();
+  }));
+
+  /**
+   * Check assertion after the test
+   */
+  afterEach(() => {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  describe(`deprecated workspace plugins >`, () => {
+
+    it(`returns an empty array if workspace doesn't have any selected deprecated plugin`, () => {
+      const newWorkspace = getNewWorkspace();
+
+      expect(workspaceDetailsService.getSelectedDeprecatedPlugins(newWorkspace)).toEqual([]);
+    });
+
+    it(`returns an array with deprecated plugins which is selected in the workspace`, () => {
+      const workspaceWithDeprecatedPlugins = getWorkspaceWithDeprecatedPlugins();
+
+      expect(workspaceDetailsService.getSelectedDeprecatedPlugins(workspaceWithDeprecatedPlugins)).toEqual(['camel-tooling/vscode-apache-camel/0.0.14']);
+    });
+
+  });
+
+  describe(`deprecated workspace editor >`, () => {
+
+    it(`returns an empty string if workspace doesn't have a selected deprecated editor`, () => {
+      const newWorkspace = getNewWorkspace();
+
+      expect(workspaceDetailsService.getSelectedDeprecatedEditor(newWorkspace)).toEqual('');
+    });
+
+    it(`returns a string with editorId if workspace has a selected deprecated editor`, () => {
+      const workspaceWithDeprecatedEditor = getWorkspaceWithDeprecatedEditor();
+
+      expect(workspaceDetailsService.getSelectedDeprecatedEditor(workspaceWithDeprecatedEditor)).toEqual('eclipse/che-theia/7.2.0');
+    });
+
+  });
+});

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.styl
@@ -74,11 +74,10 @@ div.workspace-details-warning-info
     button
       padding-left 40px !important
       text-align right
-      span
-        font-size 12px
-        font-weight bold
-        text-transform none
-        &:before
+      font-size 12px
+      font-weight bold
+      text-transform none
+      &:before
           position absolute
           display inline
           font-size 35px

--- a/dashboard/src/app/workspaces/workspace-details/workspace-editors/workspace-editors.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-editors/workspace-editors.html
@@ -1,5 +1,5 @@
 <md-progress-linear ng-show="workspaceEditorsController.isLoading" md-mode="indeterminate"></md-progress-linear>
-<div flex layout="column" md-theme="maincontent-theme" class="plugins-page">
+<div flex layout="column" md-theme="maincontent-theme" class="workspace-editors-page">
   <div class="che-scroll-list" ng-hide="workspaceEditorsController.editors.length === 0">
     <div>
       <div>
@@ -37,7 +37,11 @@
                    plugin-item-name="{{editor.displayName}}"
                    plugin-item-version="{{editor.version}}"
                    class="che-list-item-row">
-                <div layout="row" layout-align="center center" class="che-list-item-checkbox"></div>
+                <div layout="row" layout-align="center center" class="che-list-item-checkbox">
+                   <span ng-show="(editor.isEnabled && editor.isDeprecated)===true" class="fa fa-warning"
+                         tooltip-append-to-body="true"
+                         uib-tooltip-html="workspaceEditorsController.getWarningMessage()"></span>
+                </div>
                 <div flex layout="row" layout-align="start center">
                   <!-- isEnabled -->
                   <div flex="10">
@@ -58,7 +62,7 @@
                   <div flex="15">
                     <select class="che-version-dropdown" ng-model="editor.selected"
                             ng-change="workspaceEditorsController.updateSelectedEditorVersion(editor)"
-                            ng-init="editor.selected" ng-options="ver for ver in editor.versions">
+                            ng-init="editor.selected" ng-options="ver.value as ver.label for ver in editor.versions">
                     </select>
                   </div>
                   <!-- Description -->

--- a/dashboard/src/app/workspaces/workspace-details/workspace-editors/workspace-editors.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-editors/workspace-editors.styl
@@ -1,32 +1,34 @@
-md-tab-content .plugins-page
+md-tab-content .workspace-editors-page
   margin 0 25px
 
-md-tab-content .plugins-page:first-of-type
-  margin-top 25px  
+md-tab-content .workspace-editors-page:first-of-type
+  margin-top 25px
 
 md-tab-content .plugin-page-separator
   margin-left 25px
   margin-right 25px
 
-.plugins-page
-  .che-list-header-additional-parts
-      padding-left 0
-      padding-right 0
-      padding-bottom 10px
-    md-item
-      border-top none
-    .che-list-header-content
-      *
-        margin-left 0
-        margin-right 0
-      div.che-list-item-row
-        min-height 47px
-        line-height 47px
-        background-color $cat-gray-color
-        border 1px solid $very-light-grey-color
-      .che-list-item-checkbox
-        min-width 50px
-        height inherit
+.workspace-editors-page
+  padding-top 55px
+  .che-list-item-checkbox
+    font-size 18px
+    .fa-warning
+      color $warning-color
+      cursor pointer
+  md-item
+    border-top none
+  .che-list-header-content
+    *
+      margin-left 0
+      margin-right 0
+    div.che-list-item-row
+      min-height 47px
+      line-height 47px
+      background-color $cat-gray-color
+      border 1px solid $very-light-grey-color
+    .che-list-item-checkbox
+      min-width 50px
+      height inherit
 
   div.che-list-header-column
     line-height inherit
@@ -60,9 +62,13 @@ md-tab-content .plugin-page-separator
         .che-list-item-checkbox
           min-width 50px
           height inherit
+      & .md-checked
+        div.md-thumb
+          background-color rgb(74,144,226)
+        div.md-bar
+          background-color rgba(74,144,226,0.5)
       .che-version-dropdown
-        width:80%;
-        border-color: transparent;
-        background-colur: #e4e4e4;
-          
-
+        width 80%
+        white-space nowrap
+        background #e4e4e4
+        border-color transparent

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.controller.ts
@@ -10,13 +10,9 @@
  *   Red Hat, Inc. - initial API and implementation
  */
 'use strict';
-import {IPlugin, PluginRegistry, IPluginRow} from '../../../../components/api/plugin-registry.factory';
+import {IPlugin, IPluginRow, PluginRegistry} from '../../../../components/api/plugin-registry.factory';
 import {CheNotification} from '../../../../components/notification/che-notification.factory';
 import {CheWorkspace} from '../../../../components/api/workspace/che-workspace.factory';
-
-const PLUGIN_SEPARATOR = ',';
-const PLUGIN_VERSION_SEPARATOR = ':';
-const EDITOR_TYPE = 'Che Editor';
 
 /**
  * @ngdoc controller
@@ -25,7 +21,7 @@ const EDITOR_TYPE = 'Che Editor';
  * @author Ann Shumilova
  */
 export class WorkspacePluginsController {
-  static $inject = ['pluginRegistry', 'cheListHelperFactory', '$scope', 'cheNotification', 'cheWorkspace'];
+  static $inject = ['pluginRegistry', 'cheListHelperFactory', '$scope', 'cheNotification', 'cheWorkspace', '$sce'];
 
   workspace: che.IWorkspace;
   pluginRegistryLocation: string;
@@ -33,14 +29,17 @@ export class WorkspacePluginsController {
   pluginRegistry: PluginRegistry;
   cheNotification: CheNotification;
   cheWorkspace: CheWorkspace;
+  $sce: ng.ISCEService;
+
   onChange: Function;
   isLoading: boolean;
 
   pluginOrderBy = 'displayName';
   plugins: Map<string, IPluginRow> = new Map(); // the key is publisher/name
   selectedPlugins: Array<string> = [];
+  deprecatedPluginsInfo: Map<string, {automigrate: boolean; migrateTo: string;}> = new Map();
 
-  pluginFilter: any;
+  private pluginFilter: {displayName: string};
 
   private cheListHelper: che.widget.ICheListHelper;
 
@@ -48,10 +47,11 @@ export class WorkspacePluginsController {
    * Default constructor that is using resource
    */
   constructor(pluginRegistry: PluginRegistry, cheListHelperFactory: che.widget.ICheListHelperFactory, $scope: ng.IScope,
-              cheNotification: CheNotification, cheWorkspace: CheWorkspace) {
+              cheNotification: CheNotification, cheWorkspace: CheWorkspace, $sce: ng.ISCEService) {
     this.pluginRegistry = pluginRegistry;
     this.cheNotification = cheNotification;
     this.cheWorkspace = cheWorkspace;
+    this.$sce = $sce;
 
     const helperId = 'workspace-plugins';
     this.cheListHelper = cheListHelperFactory.getHelper(helperId);
@@ -60,7 +60,7 @@ export class WorkspacePluginsController {
       cheListHelperFactory.removeHelper(helperId);
     });
 
-    this.pluginFilter = { displayName: '' };
+    this.pluginFilter = {displayName: ''};
 
     const deRegistrationFn = $scope.$watch(() => {
       return this.workspace;
@@ -85,25 +85,31 @@ export class WorkspacePluginsController {
    */
   loadPlugins(): void {
     this.plugins = new Map();
+    this.deprecatedPluginsInfo = new Map();
     this.isLoading = true;
-    this.pluginRegistry.fetchPlugins(this.pluginRegistryLocation).then((result: Array<IPluginRow>) => {
+    this.pluginRegistry.fetchPlugins(this.pluginRegistryLocation).then((result: Array<IPlugin>) => {
       this.isLoading = false;
-      result.forEach((item: IPluginRow) => {
-        if (item.type !== EDITOR_TYPE) {
+      result.filter(item => item.type !== PluginRegistry.EDITOR_TYPE).forEach((item: IPlugin) => {
+        // since plugin registry returns an array of plugins/editors with a single version we need to unite the plugin versions into one
+        const pluginID = `${item.publisher}/${item.name}`;
+        // set the default selected to latest
+        const selected = 'latest';
 
-          // since plugin registry returns an array of plugins/editors with a single version we need to unite the plugin versions into one
-          const pluginID = `${item.publisher}/${item.name}`;
+        if (!this.plugins.has(pluginID)) {
+          const {name, displayName, description, publisher} = item;
+          const versions = [];
+          const id =  `${pluginID}/${selected}`;
+          this.plugins.set(pluginID, {id, name, displayName, description, publisher, selected, versions});
+        }
 
-          item.selected = 'latest'; // set the default selected to latest
-
-          if (this.plugins.has(pluginID)) {
-            const foundPlugin = this.plugins.get(pluginID);
-            foundPlugin.versions.push(item.version);
-          } else {
-            item.versions = [item.version];
-            this.plugins.set(pluginID, item);
+        const value = item.version;
+        const label = !item.deprecate ? item.version : `${item.version}  [DEPRECATED]`;
+        this.plugins.get(pluginID).versions.push({value, label});
+        if (item.deprecate) {
+          this.deprecatedPluginsInfo.set(item.id, item.deprecate);
+          if (selected === item.version) {
+            this.plugins.get(pluginID).isDeprecated = true;
           }
-
         }
       });
 
@@ -117,6 +123,7 @@ export class WorkspacePluginsController {
           const foundPlugin = this.plugins.get(pluginID);
           foundPlugin.id = plugin;
           foundPlugin.selected = version;
+          foundPlugin.isDeprecated = this.isDeprecatedPlugin(plugin);
         }
       });
 
@@ -143,22 +150,19 @@ export class WorkspacePluginsController {
    * @param {IPlugin} plugin
    */
   updatePlugin(plugin: IPluginRow): void {
-    if (plugin.type !== EDITOR_TYPE) {
+    const pluginID = `${plugin.publisher}/${plugin.name}`;
+    const pluginIDWithVersion = `${plugin.publisher}/${plugin.name}/${plugin.selected}`;
 
-      const pluginID = `${plugin.publisher}/${plugin.name}`;
-      const pluginIDWithVersion = `${plugin.publisher}/${plugin.name}/${plugin.selected}`;
+    this.plugins.get(pluginID).selected = plugin.selected;
+    this.plugins.get(pluginID).id = pluginIDWithVersion;
 
-      this.plugins.get(pluginID).selected = plugin.selected;
-      this.plugins.get(pluginID).id = pluginIDWithVersion;
-
-      if (plugin.isEnabled) {
-        this.selectedPlugins.push(pluginIDWithVersion);
-      } else {
-        this.selectedPlugins.splice(this.selectedPlugins.indexOf(plugin.id), 1);
-      }
-
-      this.cheWorkspace.getWorkspaceDataManager().setPlugins(this.workspace, this.selectedPlugins);
+    if (plugin.isEnabled) {
+      this.selectedPlugins.push(pluginIDWithVersion);
+    } else {
+      this.selectedPlugins.splice(this.selectedPlugins.indexOf(plugin.id), 1);
     }
+
+    this.cheWorkspace.getWorkspaceDataManager().setPlugins(this.workspace, this.selectedPlugins);
 
     this.onChange();
   }
@@ -169,23 +173,80 @@ export class WorkspacePluginsController {
    * @param {IPlugin} plugin
    */
   updateSelectedPlugin(plugin: IPluginRow): void {
-    if (plugin.type !== EDITOR_TYPE) {
-      const pluginID = `${plugin.publisher}/${plugin.name}`;
-      const pluginIDWithVersion = `${pluginID}/${plugin.selected}`;
+    const pluginID = `${plugin.publisher}/${plugin.name}`;
+    const pluginIDWithVersion = `${pluginID}/${plugin.selected}`;
 
-      this.plugins.get(pluginID).selected = plugin.selected;
-      this.plugins.get(pluginID).id = pluginIDWithVersion;
+    this.plugins.get(pluginID).isDeprecated = this.isDeprecatedPlugin(pluginIDWithVersion);
+    this.plugins.get(pluginID).selected = plugin.selected;
+    this.plugins.get(pluginID).id = pluginIDWithVersion;
 
-      const currentlySelectedPlugins = this.cheWorkspace.getWorkspaceDataManager().getPlugins(this.workspace);
+    const currentlySelectedPlugins = this.cheWorkspace.getWorkspaceDataManager().getPlugins(this.workspace);
 
-      if (plugin.isEnabled) {
-        currentlySelectedPlugins.splice(this.selectedPlugins.indexOf(plugin.id), 1, pluginIDWithVersion);
-      } else {
-        currentlySelectedPlugins.push(pluginIDWithVersion);
-      }
-      this.cheWorkspace.getWorkspaceDataManager().setPlugins(this.workspace, currentlySelectedPlugins);
-      this.selectedPlugins = currentlySelectedPlugins;
+    if (plugin.isEnabled) {
+      currentlySelectedPlugins.splice(this.selectedPlugins.indexOf(plugin.id), 1, pluginIDWithVersion);
+    } else {
+      currentlySelectedPlugins.push(pluginIDWithVersion);
     }
+
+    this.cheWorkspace.getWorkspaceDataManager().setPlugins(this.workspace, currentlySelectedPlugins);
+    this.selectedPlugins = currentlySelectedPlugins;
+
+    this.onChange();
+  }
+
+  /**
+   * Returns a warning message for the plugin.
+   *
+   * @param {string} pluginId
+   * @returns {any} warning message
+   */
+  getWarningMessage(pluginId: string): any {
+    let warningMessage = 'This plugin is deprecated.';
+    const deprecatedInfo = this.deprecatedPluginsInfo.get(pluginId);
+    if (deprecatedInfo && deprecatedInfo.migrateTo) {
+      const {publisher, name} = this.splitPluginId(pluginId);
+      const pluginToMigrate = this.splitPluginId(deprecatedInfo.migrateTo);
+      if (pluginToMigrate.publisher === publisher && pluginToMigrate.name === name) {
+        warningMessage += ' Select a newer version in the dropdown list.';
+      } else {
+        const targetPlugin = this.plugins.get(`${pluginToMigrate.publisher}/${pluginToMigrate.name}`);
+        if (targetPlugin) {
+          warningMessage += ` Use <b>${targetPlugin.displayName} (${targetPlugin.publisher} publisher)</b>.`;
+        }
+      }
+    }
+    return this.$sce.trustAsHtml(warningMessage);
+  }
+
+  /**
+   * Returns true if the plugin deprecated.
+   *
+   * @param {string} pluginId
+   */
+  isDeprecatedPlugin(pluginId: string): boolean {
+    return this.deprecatedPluginsInfo.has(pluginId);
+  }
+
+  /**
+   * Auto-migrate plugins.
+   *
+   * @param {string[]} plugins
+   */
+  private autoMigratePlugins(plugins: string[]): void {
+    const currentlySelectedPlugins = this.cheWorkspace.getWorkspaceDataManager().getPlugins(this.workspace);
+    plugins.forEach((pluginId: string) => {
+      const deprecatedInfo = this.deprecatedPluginsInfo.get(pluginId);
+      if (deprecatedInfo && deprecatedInfo.automigrate && deprecatedInfo.migrateTo) {
+        if (this.selectedPlugins.indexOf(deprecatedInfo.migrateTo) === -1) {
+          currentlySelectedPlugins.splice(this.selectedPlugins.indexOf(pluginId), 1, deprecatedInfo.migrateTo);
+        } else {
+          currentlySelectedPlugins.splice(this.selectedPlugins.indexOf(pluginId), 1);
+        }
+      }
+    });
+    this.cheWorkspace.getWorkspaceDataManager().setPlugins(this.workspace, currentlySelectedPlugins);
+    this.selectedPlugins = currentlySelectedPlugins;
+
     this.onChange();
   }
 
@@ -200,7 +261,8 @@ export class WorkspacePluginsController {
       plugin.isEnabled = !!selectedPluginId;
       if (selectedPluginId) {
         plugin.id = selectedPluginId;
-        const {publisher, name, version} = this.splitPluginId(selectedPluginId);
+        plugin.isDeprecated = this.isDeprecatedPlugin(plugin.id);
+        const {version} = this.splitPluginId(selectedPluginId);
         plugin.selected = version;
       }
     });

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.html
@@ -46,7 +46,11 @@
                    plugin-item-name="{{plugin.displayName}}"
                    plugin-item-version="{{plugin.version}}"
                    class="che-list-item-row">
-                <div layout="row" layout-align="center center" class="che-list-item-checkbox"></div>
+                <div layout="row" layout-align="center center" class="che-list-item-checkbox">
+                    <span ng-show="(plugin.isEnabled && plugin.isDeprecated)===true" class="fa fa-warning"
+                          uib-tooltip-html="workspacePluginsController.getWarningMessage(plugin.id)"
+                          tooltip-append-to-body="true"></span>
+                </div>
                 <div flex layout="row" layout-align="start center">
                   <!-- isEnabled -->
                   <div flex="10">
@@ -67,7 +71,7 @@
                   <div flex="15">
                     <select class="che-version-dropdown" ng-model="plugin.selected"
                             ng-change="workspacePluginsController.updateSelectedPlugin(plugin)"
-                            ng-init="plugin.selected" ng-options="ver for ver in plugin.versions">
+                            ng-init="plugin.selected" ng-options="ver.value as ver.label for ver in plugin.versions">
                     </select>
                   </div>
                   <!-- Description -->

--- a/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-plugins/workspace-plugins.styl
@@ -2,14 +2,22 @@ md-tab-content .plugins-page
   margin 0 25px
 
 md-tab-content .plugins-page:first-of-type
-  margin-top 25px  
+  margin-top 15px
 
 md-tab-content .plugin-page-separator
   margin-left 25px
   margin-right 25px
 
 .plugins-page
+  #auto-migrate-plugins-button button
+    margin 0 10px 0 0
+  .che-list-item-checkbox
+    font-size 18px
+    .fa-warning
+      color $warning-color
+      cursor pointer
   .che-list-header-additional-parts
+      padding-top 5px
       padding-left 0
       padding-right 0
       padding-bottom 10px
@@ -61,9 +69,10 @@ md-tab-content .plugin-page-separator
           min-width 50px
           height inherit
       .che-version-dropdown
-        width:80%;
-        border-color: transparent;
-        background-colur: #e4e4e4;
+        width 80%
+        white-space nowrap
+        background #e4e4e4
+        border-color transparent
 
 .plugin-page-separator
   margin-top 40px

--- a/dashboard/src/app/workspaces/workspaces.service.spec.ts
+++ b/dashboard/src/app/workspaces/workspaces.service.spec.ts
@@ -11,12 +11,11 @@
  */
 'use strict';
 
-import {CheWorkspace} from '../../components/api/workspace/che-workspace.factory';
 import {WorkspacesService} from './workspaces.service';
 
 /**
  * WorkspacesService tests.
- * 
+ *
  * @author Oleksii Orel
  */
 describe(`WorkspacesService >`, () => {
@@ -25,7 +24,6 @@ describe(`WorkspacesService >`, () => {
    * Service to test.
    */
   let workspacesService: WorkspacesService;
-  let cheWorkspace: CheWorkspace;
 
   function getCHE6Workspace(recipeType?: string): che.IWorkspace {
     return {
@@ -36,7 +34,7 @@ describe(`WorkspacesService >`, () => {
         'environments': {
           'default': {
             'recipe': {
-              'type': recipeType ? recipeType : 'dockerimage', 
+              'type': recipeType ? recipeType : 'dockerimage',
               'content': 'eclipse/ubuntu_jdk8'
             },
             'machines': {
@@ -120,14 +118,30 @@ describe(`WorkspacesService >`, () => {
       .service('cheWorkspace', function () {
         this.getSupportedRecipeTypes = (): string[] => {
           return ['kubernetes','dockerimage','no-environment'];
-        }
+        };
+        this.fetchWorkspaceSettings = (): any => {
+          // todo: rework to use Angular promise instead of native one
+          return Promise.resolve({
+            cheWorkspacePluginRegistryUrl: 'cheWorkspacePluginRegistryUrl'
+          });
+        };
+        this.getWorkspaceDataManager = () => {
+          return {
+            getEditor() {
+              return '';
+            },
+            getPlugins() {
+              return [];
+            }
+          };
+        };
       });
     angular.mock.module('workspacesServiceMock');
   });
 
-  beforeEach(inject((_workspacesService_: WorkspacesService,
-                     _cheWorkspace_: CheWorkspace) => {
-    cheWorkspace = _cheWorkspace_;
+  beforeEach(inject((
+    _workspacesService_: WorkspacesService
+  ) => {
     workspacesService = _workspacesService_;
   }));
 

--- a/dashboard/src/components/api/plugin-registry.factory.ts
+++ b/dashboard/src/components/api/plugin-registry.factory.ts
@@ -15,46 +15,79 @@ export interface IPlugin {
   id: string;
   name: string;
   publisher: string;
-  deprecate: {
-    autoMigrate: boolean;
+  deprecate?: {
+    automigrate: boolean;
     migrateTo: string;
   };
   displayName: string;
   type: string;
-  version: string;
+  version?: string;
   description?: string;
-  isEnabled: boolean;
+  isEnabled?: boolean;
 }
 
-export interface IPluginRow extends IPlugin {
+export interface IPluginRow {
+  id: string;
+  name: string;
+  displayName: string;
+  description: string;
+  publisher: string;
+  isEnabled?: boolean;
+  isDeprecated?: boolean;
   selected: string;
-  versions: string[];
+  versions: {
+    value: string;
+    label: string;
+  }[];
 }
-
 
 /**
  * This class is handling plugin registry api
  * @author Ann Shumilova
  */
 export class PluginRegistry {
-  static $inject = ['$http'];
+  static $inject = ['$http', '$q'];
 
   /**
    * Angular Http service.
    */
   private $http: ng.IHttpService;
+  /**
+   * Angular promise service.
+   */
+  private $q: ng.IQService;
+
+  private plugins = new Map<string, Array<IPlugin>>();
 
   /**
    * Default constructor that is using resource
    */
-  constructor($http: ng.IHttpService) {
+  constructor($http: ng.IHttpService, $q: ng.IQService) {
     this.$http = $http;
+    this.$q = $q;
+  }
+
+  static get EDITOR_TYPE(): string {
+    return 'Che Editor';
   }
 
   fetchPlugins(location: string): ng.IPromise<Array<IPlugin>> {
-    let promise = this.$http({ 'method': 'GET', 'url': location + '/plugins/' });
-    return promise.then((result: any) => {
-      return result.data;
+    return this.$http({'method': 'GET', 'url': location + '/plugins/'}).then(result => {
+      this.plugins.set(location, <Array<IPlugin>>result.data);
+      return this.$q.when(result.data);
+    }, (error: any) => {
+      if (error && error.status === 304) {
+        return this.$q.when(this.plugins.get(location));
+      }
+      return this.$q.reject(error);
     });
+  }
+
+  getPlugins(location: string): Array<IPlugin> {
+    return this.plugins.get(location);
+  }
+
+  hasPlugins(location: string): boolean {
+    return this.plugins.has(location);
   }
 }

--- a/dashboard/src/components/branding/che-branding.factory.ts
+++ b/dashboard/src/components/branding/che-branding.factory.ts
@@ -81,7 +81,7 @@ export class CheBranding {
   private $rootScope: che.IRootScopeService;
   private $http: ng.IHttpService;
   private cheService: CheService;
-  private brandingData: IBranding;
+  private branding: IBranding;
   private callbacks: Map<string, Function> = new Map();
 
   /**
@@ -91,9 +91,27 @@ export class CheBranding {
     this.$http = $http;
     this.$rootScope = $rootScope;
     this.cheService = cheService;
-    this.brandingData = {};
+    this.branding = {};
     this.updateData();
     this.updateVersion();
+
+    this.$rootScope.branding = {
+      title: this.getProductName(),
+      name: this.getName(),
+      logoURL: this.getProductLogo(),
+      logoText: this.getProductLogoText(),
+      favicon: this.getProductFavicon(),
+      loaderURL: this.getLoaderUrl(),
+      websocketContext: this.getWebsocketContext(),
+      helpPath: this.getProductHelpPath(),
+      helpTitle: this.getProductHelpTitle(),
+      footer: this.getFooter(),
+      supportEmail: this.getProductSupportEmail(),
+      oauthDocs: this.getOauthDocs(),
+      cli: this.getCLI(),
+      docs: this.getDocs(),
+      workspace: this.getWorkspace()
+    };
   }
 
   /**
@@ -110,30 +128,9 @@ export class CheBranding {
    * Update branding data.
    */
   updateData(): void {
-    this.$http.get(ASSET_PREFIX + 'product.json').then((branding: { data: any }) => {
-      return branding && branding.data ? branding.data : {};
-    }, () => {
-      return {};
-    }).then((brandingData: IBranding) => {
-      this.brandingData = brandingData;
-      this.$rootScope.branding = {
-        title: this.getProductName(),
-        name: this.getName(),
-        logoURL: this.getProductLogo(),
-        logoText: this.getProductLogoText(),
-        favicon: this.getProductFavicon(),
-        loaderURL: this.getLoaderUrl(),
-        websocketContext: this.getWebsocketContext(),
-        helpPath: this.getProductHelpPath(),
-        helpTitle: this.getProductHelpTitle(),
-        footer: this.getFooter(),
-        supportEmail: this.getProductSupportEmail(),
-        oauthDocs: this.getOauthDocs(),
-        cli: this.getCLI(),
-        docs: this.getDocs(),
-        workspace: this.getWorkspace()
-      };
-      this.callbacks.forEach((callback: Function) => {
+    this.$http.get(ASSET_PREFIX + 'product.json').then(res => res.data).then((branding: IBranding) => {
+      this.branding = branding;
+      this.callbacks.forEach(callback => {
         if (angular.isFunction(callback)) {
           callback(this.$rootScope.branding);
         }
@@ -169,7 +166,7 @@ export class CheBranding {
    * @returns {string}
    */
   getName(): string {
-    return this.brandingData.name ? this.brandingData.name : DEFAULT_NAME;
+    return this.branding.name ? this.branding.name : DEFAULT_NAME;
   }
 
   /**
@@ -177,7 +174,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductName(): string {
-    return  this.brandingData.title ? this.brandingData.title : DEFAULT_PRODUCT_NAME;
+    return  this.branding.title ? this.branding.title : DEFAULT_PRODUCT_NAME;
   }
 
   /**
@@ -185,7 +182,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductLogo(): string {
-    return this.brandingData.logoFile ? ASSET_PREFIX + this.brandingData.logoFile : ASSET_PREFIX + DEFAULT_PRODUCT_LOGO;
+    return this.branding.logoFile ? ASSET_PREFIX + this.branding.logoFile : ASSET_PREFIX + DEFAULT_PRODUCT_LOGO;
   }
 
   /**
@@ -193,7 +190,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductFavicon(): string {
-    return this.brandingData.favicon ? ASSET_PREFIX + this.brandingData.favicon : ASSET_PREFIX + DEFAULT_PRODUCT_FAVICON;
+    return this.branding.favicon ? ASSET_PREFIX + this.branding.favicon : ASSET_PREFIX + DEFAULT_PRODUCT_FAVICON;
   }
 
   /**
@@ -201,7 +198,7 @@ export class CheBranding {
    * @returns {string}
    */
   getLoaderUrl(): string {
-    return this.brandingData.loader ? ASSET_PREFIX + this.brandingData.loader : ASSET_PREFIX + DEFAULT_LOADER;
+    return this.branding.loader ? ASSET_PREFIX + this.branding.loader : ASSET_PREFIX + DEFAULT_LOADER;
   }
 
   /**
@@ -209,7 +206,7 @@ export class CheBranding {
    * @returns {string}
    */
   getWebsocketContext(): string {
-    return this.brandingData.websocketContext ? this.brandingData.websocketContext : DEFAULT_WEBSOCKET_CONTEXT;
+    return this.branding.websocketContext ? this.branding.websocketContext : DEFAULT_WEBSOCKET_CONTEXT;
   }
 
   /**
@@ -217,7 +214,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductHelpPath(): string {
-    return this.brandingData.helpPath ? this.brandingData.helpPath : null;
+    return this.branding.helpPath ? this.branding.helpPath : null;
   }
 
   /**
@@ -225,7 +222,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductHelpTitle(): string {
-    return this.brandingData.helpTitle ? this.brandingData.helpTitle : null;
+    return this.branding.helpTitle ? this.branding.helpTitle : null;
   }
 
   /**
@@ -233,7 +230,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductLogoText(): string {
-    return this.brandingData.logoTextFile ? ASSET_PREFIX + this.brandingData.logoTextFile : ASSET_PREFIX + DEFAULT_PRODUCT_LOGO_TEXT;
+    return this.branding.logoTextFile ? ASSET_PREFIX + this.branding.logoTextFile : ASSET_PREFIX + DEFAULT_PRODUCT_LOGO_TEXT;
   }
 
   /**
@@ -241,7 +238,7 @@ export class CheBranding {
    * @returns {string}
    */
   getOauthDocs(): string {
-    return this.brandingData.oauthDocs ? this.brandingData.oauthDocs : DEFAULT_OAUTH_DOCS;
+    return this.branding.oauthDocs ? this.branding.oauthDocs : DEFAULT_OAUTH_DOCS;
   }
 
   /**
@@ -249,7 +246,7 @@ export class CheBranding {
    * @returns {string}
    */
   getProductSupportEmail(): string {
-    return this.brandingData.supportEmail ? this.brandingData.supportEmail : null;
+    return this.branding.supportEmail ? this.branding.supportEmail : null;
   }
 
   /**
@@ -259,9 +256,9 @@ export class CheBranding {
    */
   getFooter():  {content?: string; links?: Array<{title: string, location: string}>; email: {title: string, address: string, subject: string}} {
     return {
-      content: this.brandingData.footer && this.brandingData.footer.content ? this.brandingData.footer.content : '',
-      links: this.brandingData.footer && this.brandingData.footer.links ? this.brandingData.footer.links : [],
-      email: this.brandingData.footer && this.brandingData.footer.email ? this.brandingData.footer.email : null
+      content: this.branding.footer && this.branding.footer.content ? this.branding.footer.content : '',
+      links: this.branding.footer && this.branding.footer.links ? this.branding.footer.links : [],
+      email: this.branding.footer && this.branding.footer.email ? this.branding.footer.email : null
     };
   }
 
@@ -271,8 +268,8 @@ export class CheBranding {
    */
   getCLI(): { configName: string; name: string } {
     return {
-      configName: this.brandingData.cli && this.brandingData.cli.configName ? this.brandingData.cli.configName : DEFAULT_CLI_CONFIG_NAME,
-      name: this.brandingData.cli && this.brandingData.cli.name ? this.brandingData.cli.name : DEFAULT_CLI_NAME
+      configName: this.branding.cli && this.branding.cli.configName ? this.branding.cli.configName : DEFAULT_CLI_CONFIG_NAME,
+      name: this.branding.cli && this.branding.cli.name ? this.branding.cli.name : DEFAULT_CLI_NAME
     };
   }
 
@@ -282,12 +279,12 @@ export class CheBranding {
    */
   getDocs(): { devfile: string; workspace: string; factory: string; organization: string; general: string, converting: string} {
     return {
-      devfile: this.brandingData.docs && this.brandingData.docs.devfile ? this.brandingData.docs.devfile : DEFAULT_DOCS_DEVFILE,
-      workspace: this.brandingData.docs && this.brandingData.docs.workspace ? this.brandingData.docs.workspace : DEFAULT_DOCS_WORKSPACE,
-      factory: this.brandingData.docs && this.brandingData.docs.factory ? this.brandingData.docs.factory : DEFAULT_DOCS_FACTORY,
-      organization: this.brandingData.docs && this.brandingData.docs.organization ? this.brandingData.docs.organization : DEFAULT_DOCS_ORGANIZATION,
-      general: this.brandingData.docs && this.brandingData.docs.general ? this.brandingData.docs.general : DEFAULT_DOCS_GENERAL,
-      converting: this.brandingData.docs && this.brandingData.docs.converting ? this.brandingData.docs.converting : DEFAULT_DOCS_CONVERTING
+      devfile: this.branding.docs && this.branding.docs.devfile ? this.branding.docs.devfile : DEFAULT_DOCS_DEVFILE,
+      workspace: this.branding.docs && this.branding.docs.workspace ? this.branding.docs.workspace : DEFAULT_DOCS_WORKSPACE,
+      factory: this.branding.docs && this.branding.docs.factory ? this.branding.docs.factory : DEFAULT_DOCS_FACTORY,
+      organization: this.branding.docs && this.branding.docs.organization ? this.branding.docs.organization : DEFAULT_DOCS_ORGANIZATION,
+      general: this.branding.docs && this.branding.docs.general ? this.branding.docs.general : DEFAULT_DOCS_GENERAL,
+      converting: this.branding.docs && this.branding.docs.converting ? this.branding.docs.converting : DEFAULT_DOCS_CONVERTING
     };
   }
 
@@ -297,9 +294,9 @@ export class CheBranding {
    */
   getWorkspace(): { priorityStacks: Array<string>; defaultStack: string, creationLink: string} {
     return {
-      priorityStacks: this.brandingData.workspace && this.brandingData.workspace.priorityStacks ? this.brandingData.workspace.priorityStacks : DEFAULT_WORKSPACE_PRIORITY_STACKS,
-      defaultStack: this.brandingData.workspace && this.brandingData.workspace.defaultStack ? this.brandingData.workspace.defaultStack : DEFAULT_WORKSPACE_DEFAULT_STACK,
-      creationLink: this.brandingData.workspace && this.brandingData.workspace.creationLink ? this.brandingData.workspace.creationLink : DEFAULT_WORKSPACE_CREATION_LINK
+      priorityStacks: this.branding.workspace && this.branding.workspace.priorityStacks ? this.branding.workspace.priorityStacks : DEFAULT_WORKSPACE_PRIORITY_STACKS,
+      defaultStack: this.branding.workspace && this.branding.workspace.defaultStack ? this.branding.workspace.defaultStack : DEFAULT_WORKSPACE_DEFAULT_STACK,
+      creationLink: this.branding.workspace && this.branding.workspace.creationLink ? this.branding.workspace.creationLink : DEFAULT_WORKSPACE_CREATION_LINK
     };
   }
 }


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add implementation of the warning message in the case with deprecated plugins and the possibility to auto-migrate plugins by pressing the button.

### What issues does this PR fix or reference?
Needed for https://github.com/eclipse/che/issues/13021
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
 - show a warning message in the case with deprecated editor or plugins.
 - add a possibility to migrate by pressing the button.

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
![Screenshot from 2019-10-06 20-55-32](https://user-images.githubusercontent.com/6310786/66273711-01c9be00-e87f-11e9-9dce-893890a44cba.png)
![Screenshot from 2019-10-06 20-56-19](https://user-images.githubusercontent.com/6310786/66273712-07270880-e87f-11e9-988b-cc8cdb72b7a2.png)

https://youtu.be/7U00YxALrFE