### PR TITLE
Fix editor components alias attribute format to match plugins attribute format

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/editor/EditorComponentToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/editor/EditorComponentToWorkspaceApplier.java
@@ -71,12 +71,18 @@ public class EditorComponentToWorkspaceApplier implements ComponentToWorkspaceAp
     final String registryUrl = editorComponent.getRegistryUrl();
     final String memoryLimit = editorComponent.getMemoryLimit();
 
+    final ExtendedPluginFQN fqn = componentFQNParser.evaluateFQN(editorComponent, contentProvider);
     if (editorComponentAlias != null) {
       workspaceConfig
           .getAttributes()
-          .put(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE, editorComponentAlias);
+          .put(
+              EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE,
+              componentFQNParser.getCompositeId(
+                      fqn.getRegistry() != null ? fqn.getRegistry().toString() : null, fqn.getId())
+                  + "="
+                  + editorComponentAlias);
     }
-    final ExtendedPluginFQN fqn = componentFQNParser.evaluateFQN(editorComponent, contentProvider);
+
     if (!isNullOrEmpty(fqn.getReference())) {
       workspaceConfig.getAttributes().put(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE, fqn.getReference());
     } else {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/component/editor/EditorComponentToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/component/editor/EditorComponentToWorkspaceApplierTest.java
@@ -67,7 +67,8 @@ public class EditorComponentToWorkspaceApplierTest {
     // then
     assertEquals(workspaceConfig.getAttributes().get(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE), editorId);
     assertEquals(
-        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE), "editor");
+        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE),
+        editorId + "=" + editorComponent.getAlias());
     assertEquals(
         workspaceConfig
             .getAttributes()
@@ -98,7 +99,12 @@ public class EditorComponentToWorkspaceApplierTest {
         workspaceConfig.getAttributes().get(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE),
         registryUrl + "#" + editorId);
     assertEquals(
-        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE), "editor1");
+        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE),
+        registryUrl.substring(0, registryUrl.length() - 1)
+            + "#"
+            + editorId
+            + "="
+            + editorComponent.getAlias());
     assertEquals(
         workspaceConfig
             .getAttributes()
@@ -132,7 +138,8 @@ public class EditorComponentToWorkspaceApplierTest {
     assertEquals(
         workspaceConfig.getAttributes().get(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE), reference);
     assertEquals(
-        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE), "editor1");
+        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE),
+        "eclipse/super-editor/0.0.1" + "=" + editorComponent.getAlias());
     assertEquals(
         workspaceConfig
             .getAttributes()


### PR DESCRIPTION
### What does this PR do?
 Fixes format of the `id=alias` editor component attribute to match the same for plugin components.
Fixes bug when the alias of editor component set via reference not reflected in the runtime machines.

### What issues does this PR fix or reference?


#### Release Notes
N/A


#### Docs PR
N/A