### PR TITLE
Selenium: Disable selenium tests related to GitHub OAuth

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/dashboard/ImportProjectFromGitHubTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.dashboard;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.GITHUB;
 import static org.testng.AssertJUnit.assertTrue;
@@ -40,6 +41,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+@Test(groups = UNDER_REPAIR)
 public class ImportProjectFromGitHubTest {
   private static final String WORKSPACE =
       generate(ImportProjectFromGitHubTest.class.getSimpleName(), 4);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromDashboardTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/git/AuthorizeOnGithubFromDashboardTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.selenium.git;
 
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.utils.WaitUtils.sleepQuietly;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Sources.GITHUB;
 import static org.testng.Assert.assertEquals;
@@ -40,7 +41,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 /** @author Aleksandr Shmaraev */
-@Test(groups = TestGroup.GITHUB)
+@Test(groups = {TestGroup.GITHUB, UNDER_REPAIR})
 public class AuthorizeOnGithubFromDashboardTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(AuthorizeOnGithubFromDashboardTest.class);


### PR DESCRIPTION
 ### What does this PR do?
* Disable the java selenium tests related to the Github OAuth authorization
* This is a temporary solution, until create new test GitHub application and change the Client/Secret ID on the CI job
* Related selenium tests: _ImportProjectFromGitHubTest_, _AuthorizeOnGithubFromDashboardTest_
 
### What issues does this PR fix or reference?
#14711

