### PR TITLE
prevent workspace restarting if user intentionally stopped it

### DIFF
--- a/workspace-loader/src/workspace-loader.ts
+++ b/workspace-loader/src/workspace-loader.ts
@@ -28,7 +28,7 @@ export class WorkspaceLoader {
 
     // `false` if workspace has been stopped intentionally
     // and workspace-loader should not restart it
-    private doRestart: boolean = true;
+    private allowRestart: boolean = true;
 
     constructor(
         private readonly loader: Loader,
@@ -210,7 +210,7 @@ export class WorkspaceLoader {
 
         if (message.status === 'STOPPING') {
             if (message.prevStatus === 'STARTING') {
-                this.doRestart = false;
+                this.allowRestart = false;
             }
         }
 
@@ -219,14 +219,14 @@ export class WorkspaceLoader {
                 this.loader.error('Workspace stopped.');
                 this.runtimeIsAccessible.reject('Workspace stopped.');
             }
-            if (message.prevStatus === 'STOPPING' && this.doRestart) {
+            if (message.prevStatus === 'STOPPING' && this.allowRestart) {
                 try {
                     await this.startWorkspace();
                 } catch (e) {
                     this.runtimeIsAccessible.reject(e);
                 }
             }
-            this.doRestart = true;
+            this.allowRestart = true;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Fix bug when user cannot interrupt a workspace start.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/14567

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

