### PR TITLE
Generate a new SSH key if no keys are registered while ssh mount

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -11,9 +11,10 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
@@ -73,13 +74,16 @@ public class VcsSshKeySecretProvisionerTest {
   }
 
   @Test
-  public void doNotDoAnythingIfNoSshKeys() throws Exception {
+  public void generateSshKeyIfNoSshKeys() throws Exception {
     when(sshManager.getPairs(someUser, "vcs")).thenReturn(Collections.emptyList());
+    when(sshManager.generatePair(eq(someUser), eq("vcs"), anyString()))
+        .thenReturn(
+            new SshPairImpl(
+                someUser, "vcs", "default-" + UUID.randomUUID().toString(), "public", "private"));
 
     vcsSshKeysProvisioner.provision(k8sEnv, runtimeIdentity);
 
-    assertTrue(k8sEnv.getSecrets().isEmpty());
-    verifyZeroInteractions(podSpec);
+    assertEquals(k8sEnv.getSecrets().size(), 1);
   }
 
   @Test


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
If no SSH keys are registered by user, a new SSH key will be automatically generated and mounted to all containers when a workspace starts.

### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/14411
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
