### PR TITLE
[regression] Fix provisioning volume for ephemeral-mode workspaces.

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/UniqueWorkspacePVCStrategyTest.java
@@ -251,11 +251,11 @@ public class UniqueWorkspacePVCStrategyTest {
     verify(pvcs, never()).delete(any());
   }
 
-  private static PersistentVolumeClaim newPVC(String name) {
+  static PersistentVolumeClaim newPVC(String name) {
     return newPVC(name, new HashMap<>());
   }
 
-  private static PersistentVolumeClaim newPVC(String name, Map<String, String> labels) {
+  static PersistentVolumeClaim newPVC(String name, Map<String, String> labels) {
     return new PersistentVolumeClaimBuilder()
         .withNewMetadata()
         .withName(name)


### PR DESCRIPTION
### What does this PR do?
Fixes provisioning of volumes for ephemeral workspaces (https://github.com/eclipse/che/issues/14749).

It also brings the `EphemeralWorkspaceAdapter` more in line with `UniqueWorkspacePVCProvisioner`, which I think is an overall good change.

### Background
PR https://github.com/eclipse/che/pull/14539 modified the way that certain volumes are stored in the environment: it removed adding plugin volumes to the plugin's corresponding machine and instead placed them in the pod's container directly in order to support ephemeral mode volumes for workspace plugins. This means that the `plugins` volume added for every sidecar is no longer in the machine and instead attached to each container.

The `EphemeralWorkspaceAdapter` was working off a previous assumption -- that all workspace volumes could be found in the list of machines in the environment -- and used that fact to reconcile workspace volumes (for each volume in machine, update the corresponding pod to use emptyDir). This meant that the `plugins` volume was not being provisioned at all (and thus had no subpath assigned).

This PR changes `EphemeralWorkspaceAdapter` to be more in line with `UniqueWorkspacePVCProvisioner`, basically doing the same thing and then converting all PVCs to EmptyDir volumes.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14749