### PR TITLE
Set 600 file permissions to mounted SSH keys

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
@@ -160,7 +160,11 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
         .add(
             new VolumeBuilder()
                 .withName(secretName)
-                .withSecret(new SecretVolumeSourceBuilder().withSecretName(secretName).build())
+                .withSecret(
+                    new SecretVolumeSourceBuilder()
+                        .withSecretName(secretName)
+                        .withDefaultMode(0600)
+                        .build())
                 .build());
     List<Container> containers = podSpec.getContainers();
     containers.forEach(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
In order to avoid `UNPROTECTED PRIVATE KEY FILE` Error while ssh operations, set `600` file permissions level to all mounted SSH keys. 

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14398

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
