### PR TITLE
Add workaround for handling unexpected pop ups during redirection maven build to editor

### DIFF
--- a/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/e2e/files/happy-path/happy-path-workspace.yaml
@@ -50,7 +50,7 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && mvn package >> build-output.txt && echo "#!/bin/bash\nfor i in {0..100} ;\ndo\nif [[ ! -z \"$(tail -n 40 /projects/petclinic/build-output.txt | grep \'BUILD SUCCESS\')\"]]\nthen\necho \"BUILD SUCCESS\" > /projects/petclinic/build-success.txt;\nexit 0\nfi\nsleep 10\ndone" > /projects/petclinic/wait-success-build.sh
+        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result.txt
         workdir: /projects/petclinic
   - name: run
     actions:

--- a/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/e2e/files/happy-path/happy-path-workspace.yaml
@@ -6,7 +6,7 @@ projects:
   - name: petclinic
     source:
       type: git
-      location: 'https://github.com/spring-projects/spring-petclinic.git'
+      location: "https://github.com/spring-projects/spring-petclinic.git"
 components:
   - type: cheEditor
     id: eclipse/che-theia/next
@@ -28,8 +28,8 @@ components:
   - type: dockerimage
     alias: maven-container
     image: bujhtr5555/maven-with-artifacts:latest
-    command: ['sleep']
-    args: ['infinity']
+    command: ["sleep"]
+    args: ["infinity"]
     env:
       - name: MAVEN_CONFIG
         value: /home/user/.m2
@@ -50,7 +50,7 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result.txt
+        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && mvn package >> build-output.txt && tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result.txt
         workdir: /projects/petclinic
   - name: run
     actions:

--- a/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/e2e/files/happy-path/happy-path-workspace.yaml
@@ -50,7 +50,7 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && mvn package >> build-output.txt && for i in {0..100} ; do if [[ ! -z "$(tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS')"]] ; then echo "BUILD SUCCESS" > /projects/petclinic/build-success.txt; exit 0; fi sleep 10; done;
+        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && mvn package >> build-output.txt && echo "#!/bin/bash\nfor i in {0..100} ;\ndo\nif [[ ! -z \"$(tail -n 40 /projects/petclinic/build-output.txt | grep \'BUILD SUCCESS\')\"]]\nthen\necho \"BUILD SUCCESS\" > /projects/petclinic/build-success.txt;\nexit 0\nfi\nsleep 10\ndone" > /projects/petclinic/wait-success-build.sh
         workdir: /projects/petclinic
   - name: run
     actions:

--- a/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/e2e/files/happy-path/happy-path-workspace.yaml
@@ -50,7 +50,7 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: 'mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && mvn package >> build-output.txt'
+        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && mvn package >> build-output.txt && for i in {0..100} ; do if [[ ! -z "$(tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS')"]] ; then echo "BUILD SUCCESS" > /projects/petclinic/build-success.txt; exit 0; fi sleep 10; done;
         workdir: /projects/petclinic
   - name: run
     actions:

--- a/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/e2e/files/happy-path/happy-path-workspace.yaml
@@ -44,13 +44,13 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: mvn clean package >> build.txt
+        command: mvn clean package >> build.txt && tail -n 40 /projects/petclinic/build.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build.txt
         workdir: /projects/petclinic
   - name: build-file-output
     actions:
       - type: exec
         component: maven-container
-        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && mvn package >> build-output.txt && tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result.txt
+        command: mkdir -p /projects/petclinic/?/.m2 && cp -r /.m2/* /projects/petclinic/?/.m2 && cd /projects/petclinic && mvn package >> build-output.txt && tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build-output.txt
         workdir: /projects/petclinic
   - name: run
     actions:

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -147,8 +147,13 @@ suite('Language server validation', async () => {
 suite('Validation of workspace build and run', async () => {
     test('Build application', async () => {
         await runTask('che: build-file-output');
-        await projectTree.expandPathAndOpenFileInAssociatedWorkspace(projectName, 'build-output.txt');
-        await editor.followAndWaitForText('build-output.txt', '[INFO] BUILD SUCCESS', 300000, 10000);
+
+        //workaround for issue: https://github.com/eclipse/che/issues/14771
+        
+        // await projectTree.expandPathAndOpenFileInAssociatedWorkspace(projectName, 'build-output.txt');
+        await projectTree.expandPathAndOpenFileInAssociatedWorkspace(projectName, 'result-build-output.txt', 220000);
+        await editor.waitText('result-build-output.txt', '[INFO] BUILD SUCCESS');
+        // await editor.followAndWaitForText('build-output.txt', '[INFO] BUILD SUCCESS', 300000, 10000);
     });
 
     test('Run application', async () => {
@@ -188,11 +193,18 @@ suite('Display source code changes in the running application', async () => {
 
     test('Build application with changes', async () => {
         await runTask('che: build');
-        await projectTree.expandPathAndOpenFileInAssociatedWorkspace(projectName, 'build.txt');
+        await projectTree.expandPathAndOpenFileInAssociatedWorkspace(projectName, 'result-build.txt', 300000);
+        await editor.waitText('result-build.txt', '[INFO] BUILD SUCCESS');
+        
+        //workaround for issue: https://github.com/eclipse/che/issues/14771
+
+        /*await projectTree.expandPathAndOpenFileInAssociatedWorkspace(projectName, 'build.txt');
         await editor.waitEditorAvailable('build.txt');
         await editor.clickOnTab('build.txt');
         await editor.waitTabFocused('build.txt');
-        await editor.followAndWaitForText('build.txt', '[INFO] BUILD SUCCESS', 300000, 5000);
+        await editor.followAndWaitForText('build.txt', '[INFO] BUILD SUCCESS', 300000, 5000);*/
+
+
     });
 
     test('Run application with changes', async () => {


### PR DESCRIPTION
### What does this PR do?
* For tracking maven build output in the IDE we redirect output to a file. Then we open file and read log from editor. But after new issues: 
* https://github.com/eclipse-theia/theia/issues/5820
* https://github.com/eclipse/che/issues/14771
during adding new lines into editor, looks like sometimes filewatcher detect events incorrectly (the file from editor is not changed but filewatcher detect like changed).
For workaround we changed `exec` commands in DevFile. After finishing maven build we grep last lines in a log  file and check maven build was success or not. In this way, we do not redirect output to the editor and problem is not reproduced.

### What issues does this PR fix or reference?

* https://github.com/eclipse-theia/theia/issues/5820
* https://github.com/eclipse/che/issues/14771
