### PR TITLE
Use newer che-plugin-broker with che-theia remote runtime injection

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -607,8 +607,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.21
-che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.21
+che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.22
+che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.22
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
### What does this PR do?
Use newer che-plugin-broker with che-theia remote runtime injection. P.S. runtime injection begin work when  we will merge init container for che-theia editor https://github.com/eclipse/che-plugin-registry/pull/233, otherwise che-theia works in an old way.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13387

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>