### PR TITLE
load devfile schema for validation by it's apiVersion

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/Constants.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/Constants.java
@@ -11,13 +11,21 @@
  */
 package org.eclipse.che.api.workspace.server.devfile;
 
+import java.util.Collections;
+import java.util.List;
+
 public class Constants {
 
   private Constants() {}
 
-  public static final String SCHEMA_LOCATION = "schema/devfile.json";
+  public static final String SCHEMAS_LOCATION = "schema/";
+
+  public static final String SCHEMA_FILENAME = "devfile.json";
 
   public static final String CURRENT_API_VERSION = "1.0.0";
+
+  public static final List<String> SUPPORTED_VERSIONS =
+      Collections.singletonList(CURRENT_API_VERSION);
 
   public static final String EDITOR_COMPONENT_TYPE = "cheEditor";
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/DevfileService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/DevfileService.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.workspace.server.devfile;
 
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -52,7 +53,7 @@ public class DevfileService extends Service {
   })
   public Response getSchema() throws ServerException {
     try {
-      return Response.ok(schemaCachedProvider.getSchemaContent()).build();
+      return Response.ok(schemaCachedProvider.getSchemaContent(CURRENT_API_VERSION)).build();
     } catch (IOException e) {
       throw new ServerException(e);
     }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProvider.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.server.devfile.schema;
 
 import static org.eclipse.che.api.workspace.server.devfile.Constants.SCHEMAS_LOCATION;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.SCHEMA_FILENAME;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.SUPPORTED_VERSIONS;
 import static org.eclipse.che.commons.lang.IoUtil.getResource;
 import static org.eclipse.che.commons.lang.IoUtil.readAndCloseQuietly;
 
@@ -47,7 +48,15 @@ public class DevfileSchemaProvider {
   }
 
   private String loadFile(String version) throws IOException {
-    return readAndCloseQuietly(getResource(SCHEMAS_LOCATION + version + "/" + SCHEMA_FILENAME));
+    try {
+      return readAndCloseQuietly(getResource(SCHEMAS_LOCATION + version + "/" + SCHEMA_FILENAME));
+    } catch (IOException ioe) {
+      throw new IOException(
+          String.format(
+              "Unable to load devfile schema with version '%s'. Supported versions are '%s'",
+              version, SUPPORTED_VERSIONS),
+          ioe);
+    }
   }
 
   private String loadAndPut(String version) throws IOException {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProvider.java
@@ -11,35 +11,48 @@
  */
 package org.eclipse.che.api.workspace.server.devfile.schema;
 
-import static org.eclipse.che.api.workspace.server.devfile.Constants.SCHEMA_LOCATION;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.SCHEMAS_LOCATION;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.SCHEMA_FILENAME;
 import static org.eclipse.che.commons.lang.IoUtil.getResource;
 import static org.eclipse.che.commons.lang.IoUtil.readAndCloseQuietly;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.ref.SoftReference;
+import java.util.HashMap;
+import java.util.Map;
 import javax.inject.Singleton;
 
 /** Loads a schema content and stores it in soft reference. */
 @Singleton
 public class DevfileSchemaProvider {
 
-  private SoftReference<String> schemaRef = new SoftReference<>(null);
+  private Map<String, SoftReference<String>> schemas = new HashMap<>();
 
-  public String getSchemaContent() throws IOException {
-    String schema = schemaRef.get();
-    if (schema == null) {
-      schema = loadFile();
-      schemaRef = new SoftReference<>(schema);
+  public String getSchemaContent(String version) throws IOException {
+    if (schemas.containsKey(version)) {
+      String schema = schemas.get(version).get();
+      if (schema != null) {
+        return schema;
+      } else {
+        return loadAndPut(version);
+      }
+    } else {
+      return loadAndPut(version);
     }
+  }
+
+  public StringReader getAsReader(String version) throws IOException {
+    return new StringReader(getSchemaContent(version));
+  }
+
+  private String loadFile(String version) throws IOException {
+    return readAndCloseQuietly(getResource(SCHEMAS_LOCATION + version + "/" + SCHEMA_FILENAME));
+  }
+
+  private String loadAndPut(String version) throws IOException {
+    final String schema = loadFile(version);
+    schemas.put(version, new SoftReference<>(schema));
     return schema;
-  }
-
-  public StringReader getAsReader() throws IOException {
-    return new StringReader(getSchemaContent());
-  }
-
-  private String loadFile() throws IOException {
-    return readAndCloseQuietly(getResource(SCHEMA_LOCATION));
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidator.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.workspace.server.devfile.validator;
 
 import static java.lang.String.format;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.SUPPORTED_VERSIONS;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19,7 +20,9 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import javax.json.JsonReader;
@@ -37,7 +40,7 @@ public class DevfileSchemaValidator {
   private final JsonValidationService service = JsonValidationService.newInstance();
   private ObjectMapper yamlMapper;
   private ObjectMapper jsonMapper;
-  private JsonSchema schema;
+  private Map<String, JsonSchema> schemasByVersion;
   private ErrorMessageComposer errorMessageComposer;
 
   @Inject
@@ -46,7 +49,10 @@ public class DevfileSchemaValidator {
     this.jsonMapper = new ObjectMapper();
     this.errorMessageComposer = new ErrorMessageComposer();
     try {
-      this.schema = service.readSchema(schemaProvider.getAsReader());
+      this.schemasByVersion = new HashMap<>();
+      for (String version : SUPPORTED_VERSIONS) {
+        this.schemasByVersion.put(version, service.readSchema(schemaProvider.getAsReader(version)));
+      }
     } catch (IOException e) {
       throw new RuntimeException("Unable to read devfile json schema for validation.", e);
     }
@@ -75,6 +81,17 @@ public class DevfileSchemaValidator {
     try {
       List<Problem> validationErrors = new ArrayList<>();
       ProblemHandler handler = ProblemHandler.collectingTo(validationErrors);
+      if (!contentNode.hasNonNull("apiVersion")) {
+        throw new DevfileFormatException(
+            "Devfile schema validation failed. Error: The object must have a property whose name is \"apiVersion\".");
+      }
+      String apiVersion = contentNode.get("apiVersion").asText();
+
+      if (!schemasByVersion.containsKey(apiVersion)) {
+        throw new DevfileFormatException(
+            String.format("version '%s' of the devfile is not supported", apiVersion));
+      }
+      JsonSchema schema = schemasByVersion.get(apiVersion);
       try (JsonReader reader =
           service.createReader(
               new StringReader(jsonMapper.writeValueAsString(contentNode)), schema, handler)) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidator.java
@@ -89,7 +89,9 @@ public class DevfileSchemaValidator {
 
       if (!schemasByVersion.containsKey(apiVersion)) {
         throw new DevfileFormatException(
-            String.format("version '%s' of the devfile is not supported", apiVersion));
+            String.format(
+                "Version '%s' of the devfile is not supported. Supported versions are '%s'.",
+                apiVersion, SUPPORTED_VERSIONS));
       }
       JsonSchema schema = schemasByVersion.get(apiVersion);
       try (JsonReader reader =

--- a/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
+++ b/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
@@ -33,12 +33,8 @@
   "additionalProperties": false,
   "properties": {
     "apiVersion": {
-      "type": "string",
-      "title": "Devfile API Version",
-      "pattern": "1\\.0\\.0",
-      "examples": [
-        "1.0.0"
-      ]
+      "const": "1.0.0",
+      "title": "Devfile API Version"
     },
     "metadata": {
       "type": "object",

--- a/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
+++ b/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
@@ -35,6 +35,7 @@
     "apiVersion": {
       "type": "string",
       "title": "Devfile API Version",
+      "pattern": "1\\.0\\.0",
       "examples": [
         "1.0.0"
       ]

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/DevfileServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/DevfileServiceTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.workspace.server.devfile;
 
 import static com.jayway.restassured.RestAssured.given;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
 import static org.everrest.assured.JettyHttpServer.*;
 import static org.testng.Assert.assertEquals;
 
@@ -54,6 +55,7 @@ public class DevfileServiceTest {
             .get(SECURE_PATH + "/devfile");
 
     assertEquals(response.getStatusCode(), 200);
-    assertEquals(response.getBody().asString(), schemaProvider.getSchemaContent());
+    assertEquals(
+        response.getBody().asString(), schemaProvider.getSchemaContent(CURRENT_API_VERSION));
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProviderTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+package org.eclipse.che.api.workspace.server.devfile.schema;
+
+import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.StringReader;
+import org.testng.annotations.Test;
+
+public class DevfileSchemaProviderTest {
+
+  private final DevfileSchemaProvider devfileSchemaProvider = new DevfileSchemaProvider();
+
+  @Test
+  public void shouldGetProperDevfileSchemaContent() throws IOException {
+    String content = devfileSchemaProvider.getSchemaContent(CURRENT_API_VERSION);
+    assertNotNull(content);
+    assertTrue(content.contains("This schema describes the structure of the devfile object"));
+  }
+
+  @Test
+  public void shouldGetProperDevfileSchemaContentAsReader() throws IOException {
+    StringReader contentReader = devfileSchemaProvider.getAsReader(CURRENT_API_VERSION);
+    assertNotNull(contentReader);
+
+    StringBuilder contentBuilder = new StringBuilder();
+    int c;
+    while ((c = contentReader.read()) != -1) {
+      contentBuilder.append((char) c);
+    }
+    assertTrue(
+        contentBuilder
+            .toString()
+            .contains("This schema describes the structure of the devfile object"));
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void shouldThrowExceptionWhenInvalidVersionRequested() throws IOException {
+    devfileSchemaProvider.getSchemaContent("2");
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProviderTest.java
@@ -49,6 +49,6 @@ public class DevfileSchemaProviderTest {
 
   @Test(expectedExceptions = IOException.class)
   public void shouldThrowExceptionWhenInvalidVersionRequested() throws IOException {
-    devfileSchemaProvider.getSchemaContent("2");
+    devfileSchemaProvider.getSchemaContent("this_is_clearly_not_a_valid_schema_version");
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
@@ -85,6 +85,19 @@ public class DevfileSchemaValidatorTest {
     fail("DevfileFormatException expected to be thrown but is was not");
   }
 
+  @Test
+  public void shouldThrowExceptionWhenDevfileHasUnsupportedApiVersion() throws Exception {
+    try {
+      String devfile =
+          "---\n" + "apiVersion: 111.111\n" + "metadata:\n" + "  name: test-invalid-apiversion\n";
+      schemaValidator.validateYaml(devfile);
+    } catch (DevfileFormatException e) {
+      assertEquals(e.getMessage(), "version '111.111' of the devfile is not supported");
+      return;
+    }
+    fail("DevfileFormatException expected to be thrown but is was not");
+  }
+
   @DataProvider
   public Object[][] invalidDevfiles() {
     return new Object[][] {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
@@ -16,6 +16,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 import java.io.IOException;
+import org.eclipse.che.api.workspace.server.devfile.Constants;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileFormatException;
 import org.eclipse.che.api.workspace.server.devfile.schema.DevfileSchemaProvider;
 import org.testng.annotations.BeforeClass;
@@ -92,7 +93,12 @@ public class DevfileSchemaValidatorTest {
           "---\n" + "apiVersion: 111.111\n" + "metadata:\n" + "  name: test-invalid-apiversion\n";
       schemaValidator.validateYaml(devfile);
     } catch (DevfileFormatException e) {
-      assertEquals(e.getMessage(), "version '111.111' of the devfile is not supported");
+      assertEquals(
+          e.getMessage(),
+          "Version '111.111' of the devfile is not supported. "
+              + "Supported versions are '"
+              + Constants.SUPPORTED_VERSIONS
+              + "'.");
       return;
     }
     fail("DevfileFormatException expected to be thrown but is was not");


### PR DESCRIPTION
### What does this PR do?
Make it possible to have multiple devfile schemas for validation. The schema is now placed in directory named by version and supported versions are listed in `.devfile.Constants#SUPPORTED_VERSIONS`

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14824

