### PR TITLE
Selenium: Disable java selenium e2e test from test suite

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.selenium.factory;
 import static org.eclipse.che.selenium.core.CheSeleniumSuiteModule.AUXILIARY;
 import static org.eclipse.che.selenium.core.TestGroup.GITHUB;
 import static org.eclipse.che.selenium.core.TestGroup.OPENSHIFT;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.core.constant.TestTimeoutsConstants.UPDATING_PROJECT_TIMEOUT_SEC;
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -36,7 +37,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-@Test(groups = {GITHUB, OPENSHIFT})
+@Test(groups = {GITHUB, OPENSHIFT, UNDER_REPAIR})
 public class DirectUrlFactoryWithSpecificBranchTest {
   private static final Logger LOG =
       LoggerFactory.getLogger(DirectUrlFactoryWithSpecificBranchTest.class);


### PR DESCRIPTION
### What does this PR do?
* Disable the java selenium E2E test _DirectUrlFactoryWithSpecificBranchTest_ from test suite
* It is a temporary solution to avoid blocking developer's PR
* The investigation of the reason failed test is in working  progress
* Related issue: https://github.com/eclipse/che/issues/14842
### What issues does this PR fix or reference?

