### PR TITLE
explicitly include docker.io registry in...

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -625,8 +625,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.22
-che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.22
+che.workspace.plugin_broker.init.image=docker.io/eclipse/che-init-plugin-broker:v0.22
+che.workspace.plugin_broker.unified.image=docker.io/eclipse/che-unified-plugin-broker:v0.22
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
explicitly include docker.io registry in image paths so we can more easily grep for images we're supposed to be migrating to Quay

Change-Id: I193660167278e35df308d42ef340347433100bf7
Signed-off-by: nickboldt <nboldt@redhat.com>