### PR TITLE
Extend the size of the pool that is handling workspace related operations

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -64,7 +64,7 @@ che.workspace.pool.type=fixed
 # Configures the exact size of the pool, if it's set multiplier property is ignored.
 # If this property is not set(0, < 0, NULL) then pool sized to number of cores,
 #it can be modified within multiplier
-che.workspace.pool.exact_size=NULL
+che.workspace.pool.exact_size=30
 
 # This property is ignored when pool type is different from 'fixed' or exact pool size is set.
 # If it's set the pool size will be N_CORES * multiplier


### PR DESCRIPTION
### What does this PR do?
Extend the size of the pool that is handling workspace related operations. Makes it independent from the number of the processors available for the Che server.

### What issues does this PR fix or reference?
Discovered during https://github.com/eclipse/che/issues/14600#issuecomment-541632456

#### Release Notes
n/a

#### Docs PR
n/a