### PR TITLE
Disable autosave on Devfile editor page

### DIFF
--- a/dashboard/src/app/admin/user-management/user-management.controller.ts
+++ b/dashboard/src/app/admin/user-management/user-management.controller.ts
@@ -144,7 +144,7 @@ export class AdminsUserManagementCtrl {
    */
   removeUser(event: MouseEvent, user: any): void {
     let content = 'Are you sure you want to remove \'' + user.email + '\'?';
-    let promise = this.confirmDialogService.showConfirmDialog('Remove user', content, 'Delete', 'Cancel');
+    let promise = this.confirmDialogService.showConfirmDialog('Remove user', content, { resolve: 'Delete', reject: 'Cancel' });
 
     promise.then(() => {
       this.isLoading = true;
@@ -231,7 +231,7 @@ export class AdminsUserManagementCtrl {
       content += 'user?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove users', content, 'Delete', 'Cancel');
+    return this.confirmDialogService.showConfirmDialog('Remove users', content, { resolve: 'Delete', reject: 'Cancel' });
   }
 
   /**

--- a/dashboard/src/app/administration/docker-registry/docker-registry-list/docker-registry-list.controller.ts
+++ b/dashboard/src/app/administration/docker-registry/docker-registry-list/docker-registry-list.controller.ts
@@ -163,7 +163,7 @@ export class DockerRegistryListController {
     } else {
       content += 'this selected registry?';
     }
-    return this.confirmDialogService.showConfirmDialog('Remove registries', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove registries', content, { resolve: 'Delete' });
   }
 
   /**

--- a/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
+++ b/dashboard/src/app/factories/factory-details/information-tab/factory-information/factory-information.controller.ts
@@ -218,7 +218,7 @@ export class FactoryInformationController {
 
     const title = 'Warning',
       content = `You have unsaved changes in JSON configuration. Would you like to save changes now?`;
-    return this.confirmDialogService.showConfirmDialog(title, content, 'Continue').then(() => {
+    return this.confirmDialogService.showConfirmDialog(title, content, { resolve: 'Continue' }).then(() => {
       this.updateFactoryContent();
     });
   }
@@ -296,7 +296,7 @@ export class FactoryInformationController {
    */
   deleteFactory(): void {
     let content = 'Please confirm removal for the factory \'' + (this.factory.name ? this.factory.name : this.factory.id) + '\'.';
-    let promise = this.confirmDialogService.showConfirmDialog('Remove the factory', content, 'Delete');
+    let promise = this.confirmDialogService.showConfirmDialog('Remove the factory', content, { resolve: 'Delete' });
 
     promise.then(() => {
       // remove it !

--- a/dashboard/src/app/factories/list-factories/list-factories.controller.ts
+++ b/dashboard/src/app/factories/list-factories/list-factories.controller.ts
@@ -227,6 +227,6 @@ export class ListFactoriesController {
     } else {
       content += 'this selected factory?';
     }
-    return this.confirmDialogService.showConfirmDialog('Remove factories', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove factories', content, { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/organizations/list-organizations/list-organizations.controller.ts
+++ b/dashboard/src/app/organizations/list-organizations/list-organizations.controller.ts
@@ -338,7 +338,7 @@ export class ListOrganizationsController {
       content += 'this selected organization?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Delete organizations', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Delete organizations', content, { resolve: 'Delete' });
   }
 
 }

--- a/dashboard/src/app/organizations/list-organizations/organizations-item/organizations-item.controller.ts
+++ b/dashboard/src/app/organizations/list-organizations/organizations-item/organizations-item.controller.ts
@@ -140,6 +140,6 @@ export class OrganizationsItemController {
    */
   confirmRemoval(): ng.IPromise<any> {
     return this.confirmDialogService.showConfirmDialog('Delete organization',
-      'Would you like to delete organization \'' + this.organization.name + '\'?', 'Delete');
+      'Would you like to delete organization \'' + this.organization.name + '\'?', { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/organizations/organization-details/organization-details.controller.ts
+++ b/dashboard/src/app/organizations/organization-details/organization-details.controller.ts
@@ -406,7 +406,7 @@ export class OrganizationDetailsController {
    */
   deleteOrganization(): void {
     let promise = this.confirmDialogService.showConfirmDialog('Delete organization',
-      'Would you like to delete organization \'' + this.organization.name + '\'?', 'Delete');
+      'Would you like to delete organization \'' + this.organization.name + '\'?', { resolve: 'Delete' });
 
     promise.then(() => {
       let promise = this.cheOrganization.deleteOrganization(this.organization.id);

--- a/dashboard/src/app/organizations/organization-details/organization-members/list-organization-members.controller.ts
+++ b/dashboard/src/app/organizations/organization-details/organization-members/list-organization-members.controller.ts
@@ -404,7 +404,7 @@ export class ListOrganizationMembersController {
    * @param member
    */
   removeMember(member: che.IMember): void {
-    let promise = this.confirmDialogService.showConfirmDialog('Remove member', 'Would you like to remove member  ' + member.email + ' ?', 'Delete');
+    let promise = this.confirmDialogService.showConfirmDialog('Remove member', 'Would you like to remove member  ' + member.email + ' ?', { resolve: 'Delete' });
 
     promise.then(() => {
       this.removePermissions(member);
@@ -507,6 +507,6 @@ export class ListOrganizationMembersController {
       confirmTitle += 'the selected member?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove members', confirmTitle, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove members', confirmTitle, { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/teams/list/list-teams.controller.ts
+++ b/dashboard/src/app/teams/list/list-teams.controller.ts
@@ -359,6 +359,6 @@ export class ListTeamsController {
       content += 'this selected team?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Delete teams', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Delete teams', content, { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/teams/list/team-item/team-item.controller.ts
+++ b/dashboard/src/app/teams/list/team-item/team-item.controller.ts
@@ -94,7 +94,7 @@ export class TeamItemController {
    */
   confirmRemoval(): ng.IPromise<any> {
     let promise = this.confirmDialogService.showConfirmDialog('Delete team',
-      'Would you like to delete team \'' + this.team.name + '\'?', 'Delete');
+      'Would you like to delete team \'' + this.team.name + '\'?', { resolve: 'Delete' });
     return promise;
   }
 }

--- a/dashboard/src/app/teams/team-details/team-details.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-details.controller.ts
@@ -315,7 +315,7 @@ tab: Object = Tab;
    */
   deleteTeam(event: MouseEvent): void {
     let promise = this.confirmDialogService.showConfirmDialog('Delete team',
-      'Would you like to delete team \'' + this.team.name + '\'?', 'Delete');
+      'Would you like to delete team \'' + this.team.name + '\'?', { resolve: 'Delete' });
 
     promise.then(() => {
       let promise = this.cheTeam.deleteTeam(this.team.id);
@@ -334,7 +334,7 @@ tab: Object = Tab;
    */
   leaveTeam(): void {
     let promise = this.confirmDialogService.showConfirmDialog('Leave team',
-      'Would you like to leave team \'' + this.team.name + '\'?', 'Leave');
+      'Would you like to leave team \'' + this.team.name + '\'?', { resolve: 'Leave' });
 
     promise.then(() => {
       let promise = this.chePermissions.removeOrganizationPermissions(this.team.id, this.cheUser.getUser().id);

--- a/dashboard/src/app/teams/team-details/team-members/list-team-members.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-members/list-team-members.controller.ts
@@ -554,6 +554,6 @@ export class ListTeamMembersController {
       confirmTitle += 'the selected member?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove members', confirmTitle, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove members', confirmTitle, { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/teams/team-details/team-members/member-item/member-item.controller.ts
+++ b/dashboard/src/app/teams/team-details/team-members/member-item/member-item.controller.ts
@@ -73,7 +73,7 @@ export class MemberItemController {
    * @param  event - the $event
    */
   removeMember(event: MouseEvent): void {
-    let promise = this.confirmDialogService.showConfirmDialog('Remove member', 'Would you like to remove member  ' + this.member.email + ' ?', 'Delete');
+    let promise = this.confirmDialogService.showConfirmDialog('Remove member', 'Would you like to remove member  ' + this.member.email + ' ?', { resolve: 'Delete' });
 
     promise.then(() => {
       if (this.member.isPending) {

--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
@@ -197,8 +197,8 @@ export class CreateWorkspaceSvc {
       });
 
       projects.push(template);
-    });     
-    
+    });
+
     return this.checkEditingProgress().then(() => {
       sourceDevfile.projects = projects;
 
@@ -206,7 +206,7 @@ export class CreateWorkspaceSvc {
       if (noProjectsFromDevfile) {
         sourceDevfile.commands = [];
       }
-      
+
       return this.cheWorkspace.createWorkspaceFromDevfile(namespaceId, sourceDevfile, attributes).then((workspace: che.IWorkspace) => {
         return this.cheWorkspace.fetchWorkspaces().then(() => this.cheWorkspace.getWorkspaceById(workspace.id));
       })
@@ -246,7 +246,7 @@ export class CreateWorkspaceSvc {
 
     const title = 'Warning',
           content = `You have project editing, that is not completed. Would you like to proceed to workspace creation without these changes?`;
-    return this.confirmDialogService.showConfirmDialog(title, content, 'Continue');
+    return this.confirmDialogService.showConfirmDialog(title, content, { resolve: 'Continue' });
   }
 
   /**
@@ -289,7 +289,7 @@ export class CreateWorkspaceSvc {
 
   /**
    * Returns name of the pointed workspace.
-   * 
+   *
    * @param workspace workspace
    */
   getWorkspaceName(workspace: che.IWorkspace): string {

--- a/dashboard/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
+++ b/dashboard/src/app/workspaces/list-workspaces/list-workspaces.controller.ts
@@ -305,7 +305,7 @@ export class ListWorkspacesCtrl {
       content += 'this selected workspace?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove workspaces', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove workspaces', content, { resolve: 'Delete' });
   }
 
   /**

--- a/dashboard/src/app/workspaces/share-workspace/share-workspace.controller.ts
+++ b/dashboard/src/app/workspaces/share-workspace/share-workspace.controller.ts
@@ -344,7 +344,7 @@ export class ShareWorkspaceController {
       content += 'this selected member?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove members', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove members', content, { resolve: 'Delete' });
   }
 
   /**

--- a/dashboard/src/app/workspaces/share-workspace/user-item/user-item.controller.ts
+++ b/dashboard/src/app/workspaces/share-workspace/user-item/user-item.controller.ts
@@ -43,7 +43,7 @@ export class UserItemController {
    */
   removeUser(): void {
     let content = 'Please confirm removal for the member \'' + this.user.email + '\'.';
-    let promise = this.confirmDialogService.showConfirmDialog('Remove the member', content, 'Delete');
+    let promise = this.confirmDialogService.showConfirmDialog('Remove the member', content, { resolve: 'Delete' });
 
     promise.then(() => {
       // callback is set in scope definition:

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-env-variables/list-env-variables.controller.ts
@@ -191,7 +191,7 @@ export class ListEnvVariablesController {
       content += 'this selected variable?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove variables', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove variables', content, { resolve: 'Delete' });
   }
 
 }

--- a/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/list-servers/list-servers.controller.ts
@@ -213,7 +213,7 @@ export class ListServersController {
       content += 'this selected server?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove servers', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove servers', content, { resolve: 'Delete' });
   }
 
 }

--- a/dashboard/src/app/workspaces/workspace-details/environments/machine-config/machine-config.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/environments/machine-config/machine-config.controller.ts
@@ -232,7 +232,7 @@ export class WorkspaceMachineConfigController {
   deleteMachine($event: MouseEvent): void {
     let promise;
     if (!this.machineConfig.isDev) {
-      promise = this.confirmDialogService.showConfirmDialog('Remove container', 'Would you like to delete this container?', 'Delete');
+      promise = this.confirmDialogService.showConfirmDialog('Remove container', 'Would you like to delete this container?', { resolve: 'Delete' });
     } else {
       promise = this.showDeleteDevMachineDialog($event);
     }

--- a/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/list-commands/list-commands.controller.ts
@@ -205,6 +205,6 @@ export class ListCommandsController {
       content += 'this selected command?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove commands', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove commands', content, { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -495,15 +495,21 @@ export class WorkspaceDetailsController {
     this.$scope.$broadcast('edit-workspace-details', { status: 'cancelled' });
   }
 
-  runWorkspace(): ng.IPromise<any> {
+  runWorkspace(): ng.IPromise<void> {
     this.errorMessage = '';
 
+    if (this.workspaceDetailsService.isWorkspaceModified(this.workspaceId)) {
+      return this.workspaceDetailsService.notifyUnsavedChangesDialog();
+    }
     return this.workspaceDetailsService.runWorkspace(this.workspaceDetails).catch((error: any) => {
       this.errorMessage = error.message;
     });
   }
 
-  stopWorkspace(): ng.IPromise<any> {
+  stopWorkspace(): ng.IPromise<void> {
+    if (this.workspaceDetailsService.isWorkspaceModified(this.workspaceId)) {
+      return this.workspaceDetailsService.notifyUnsavedChangesDialog();
+    }
     return this.workspaceDetailsService.stopWorkspace(this.workspaceDetails.id);
   }
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
@@ -281,12 +281,14 @@ describe(`WorkspaceDetailsController >`, () => {
     angular.mock.module('workspaceDetailsMock');
   });
 
-  beforeEach(inject((_$rootScope_: ng.IRootScopeService,
-                     _$compile_: ng.ICompileService,
-                     _cheHttpBackend_: CheHttpBackend,
-                     _$timeout_: ng.ITimeoutService,
-                     _$q_: ng.IQService,
-                     _cheWorkspace_: CheWorkspace) => {
+  beforeEach(inject((
+    _$rootScope_: ng.IRootScopeService,
+    _$compile_: ng.ICompileService,
+    _cheHttpBackend_: CheHttpBackend,
+    _$timeout_: ng.ITimeoutService,
+    _$q_: ng.IQService,
+    _cheWorkspace_: CheWorkspace
+  ) => {
     $scope = _$rootScope_.$new();
     $compile = _$compile_;
     $timeout = _$timeout_;
@@ -320,6 +322,12 @@ describe(`WorkspaceDetailsController >`, () => {
     $httpBackend.verifyNoOutstandingRequest();
   });
 
+  afterEach(() => {
+    compiledDirective = undefined;
+    cheWorkspace = undefined;
+    newWorkspace = undefined;
+  });
+
   describe(`overflow panel >`, () => {
 
     function getOverlayPanelEl(): ng.IAugmentedJQuery {
@@ -335,9 +343,20 @@ describe(`WorkspaceDetailsController >`, () => {
       return compiledDirective.find('.cancel-button button');
     }
 
-    it(`should be hidden initially >`, () => {
-      compileDirective();
-      expect(getOverlayPanelEl().children().length).toEqual(0);
+    describe('initially >', () => {
+
+      beforeEach(() => {
+        compileDirective();
+      });
+
+      it(`should be hidden >`, () => {
+        expect(getOverlayPanelEl().children().length).toEqual(0);
+      });
+
+      it('should not prevent to leave page', () => {
+        expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
+      });
+
     });
 
     describe(`when config is changed >`, () => {
@@ -349,10 +368,14 @@ describe(`WorkspaceDetailsController >`, () => {
           beforeEach(() => {
             compileDirective();
 
-            controller.workspaceDetails.config.name = 'wksp-new-name';
-            controller.checkEditMode(false);
+            (controller as any).workspaceDetails.config.name = 'wksp-new-name';
+            controller.checkEditMode();
             $scope.$digest();
             $timeout.flush();
+          });
+
+          it('should prevent to leave page', () => {
+            expect((controller as any).editOverlayConfig.preventPageLeave).toBeTruthy();
           });
 
           it(`the overflow panel should be shown >`, () => {
@@ -376,7 +399,10 @@ describe(`WorkspaceDetailsController >`, () => {
             beforeEach(() => {
               getCancelButton().click();
               $scope.$digest();
-              $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should be hidden >`, () => {
@@ -389,11 +415,15 @@ describe(`WorkspaceDetailsController >`, () => {
 
             beforeEach(() => {
               // set new workspace to publish
-              newWorkspace = angular.copy(controller.workspaceDetails);
+              newWorkspace = angular.copy((controller as any).workspaceDetails);
 
               getSaveButton().click();
               $scope.$digest();
               $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should be hidden >`, () => {
@@ -409,10 +439,14 @@ describe(`WorkspaceDetailsController >`, () => {
           beforeEach(() => {
             compileDirective();
 
-            controller.workspaceDetails.config.name = 'wksp-new-name';
-            controller.checkEditMode(true);
+            (controller as any).workspaceDetails.config.defaultEnv = 'new-env';
+            controller.checkEditMode();
             $scope.$digest();
             $timeout.flush();
+          });
+
+          it('should prevent to leave page', () => {
+            expect((controller as any).editOverlayConfig.preventPageLeave).toBeTruthy();
           });
 
           it(`the overflow panel should be shown >`, () => {
@@ -436,7 +470,10 @@ describe(`WorkspaceDetailsController >`, () => {
             beforeEach(() => {
               getCancelButton().click();
               $scope.$digest();
-              $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should be hidden >`, () => {
@@ -448,9 +485,14 @@ describe(`WorkspaceDetailsController >`, () => {
           describe(`and saveButton is clicked >`, () => {
 
             beforeEach(() => {
+              newWorkspace = angular.copy((controller as any).workspaceDetails);
               getSaveButton().click();
               $scope.$digest();
               $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should remain visible >`, () => {
@@ -475,11 +517,15 @@ describe(`WorkspaceDetailsController >`, () => {
 
             beforeEach(() => {
               // set new workspace to publish
-              newWorkspace = angular.copy(controller.workspaceDetails);
+              newWorkspace = angular.copy((controller as any).workspaceDetails);
 
               getApplyButton().click();
               $scope.$digest();
               $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should be hidden >`, () => {
@@ -498,15 +544,19 @@ describe(`WorkspaceDetailsController >`, () => {
           compileDirective();
 
           controller.stopWorkspace();
-          controller.workspaceDetails.config.name = 'wksp-new-name';
+          (controller as any).workspaceDetails.config.name = 'wksp-new-name';
         });
 
         describe(`and restart is not necessary >`, () => {
 
           beforeEach(() => {
-            controller.checkEditMode(false);
+            controller.checkEditMode();
             $scope.$digest();
             $timeout.flush();
+          });
+
+          it('should prevent to leave page', () => {
+            expect((controller as any).editOverlayConfig.preventPageLeave).toBeTruthy();
           });
 
           it(`the overflow panel should be shown >`, () => {
@@ -530,7 +580,10 @@ describe(`WorkspaceDetailsController >`, () => {
             beforeEach(() => {
               getCancelButton().click();
               $scope.$digest();
-              $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should be hidden >`, () => {
@@ -543,11 +596,15 @@ describe(`WorkspaceDetailsController >`, () => {
 
             beforeEach(() => {
               // set new workspace to publish
-              newWorkspace = angular.copy(controller.workspaceDetails);
+              newWorkspace = angular.copy((controller as any).workspaceDetails);
 
               getSaveButton().click();
               $scope.$digest();
               $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should be hidden >`, () => {
@@ -561,9 +618,13 @@ describe(`WorkspaceDetailsController >`, () => {
         describe(`and restart is necessary >`, () => {
 
           beforeEach(() => {
-            controller.checkEditMode(true);
+            controller.checkEditMode();
             $scope.$digest();
             $timeout.flush();
+          });
+
+          it('should prevent to leave page', () => {
+            expect((controller as any).editOverlayConfig.preventPageLeave).toBeTruthy();
           });
 
           it(`the overflow panel should be shown >`, () => {
@@ -587,7 +648,10 @@ describe(`WorkspaceDetailsController >`, () => {
             beforeEach(() => {
               getCancelButton().click();
               $scope.$digest();
-              $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should be hidden >`, () => {
@@ -600,11 +664,15 @@ describe(`WorkspaceDetailsController >`, () => {
 
             beforeEach(() => {
               // set new workspace to publish
-              newWorkspace = angular.copy(controller.workspaceDetails);
+              newWorkspace = angular.copy((controller as any).workspaceDetails);
 
               getSaveButton().click();
               $scope.$digest();
               $timeout.flush();
+            });
+
+            it('should not prevent to leave page', () => {
+              expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
             });
 
             it(`the overlay panel should be hidden >`, () => {
@@ -622,21 +690,25 @@ describe(`WorkspaceDetailsController >`, () => {
         beforeEach(() => {
           compileDirective();
 
-          controller.workspacesService.isSupported = jasmine.createSpy('workspaceDetailsController.isSupported')
+          (controller as any).workspacesService.isSupported = jasmine.createSpy('workspaceDetailsController.isSupported')
             .and
             .callFake(() => {
               return false;
             });
-          controller.workspacesService.isSupportedRecipeType = jasmine.createSpy('workspaceDetailsController.isSupportedRecipeType')
+          (controller as any).workspacesService.isSupportedRecipeType = jasmine.createSpy('workspaceDetailsController.isSupportedRecipeType')
             .and
             .callFake(() => {
               return false;
             });
 
-          controller.workspaceDetails.config.name = 'wksp-new-name';
-          controller.checkEditMode(false);
+          (controller as any).workspaceDetails.config.name = 'wksp-new-name';
+          controller.checkEditMode();
           $scope.$digest();
           $timeout.flush();
+        });
+
+        it('should not prevent to leave page', () => {
+          expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
         });
 
         it(`the overflow panel should be shown >`, () => {
@@ -660,7 +732,10 @@ describe(`WorkspaceDetailsController >`, () => {
           beforeEach(() => {
             getCancelButton().click();
             $scope.$digest();
-            $timeout.flush();
+          });
+
+          it('should not prevent to leave page', () => {
+            expect((controller as any).editOverlayConfig.preventPageLeave).toBeFalsy();
           });
 
           it(`the overlay panel should be hidden >`, () => {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.html
@@ -42,7 +42,7 @@
         <ng-form name="workspaceOverviewForm">
           <workspace-details-overview ng-init="workspaceDetailsController.setForm(workspaceDetailsController.tab.Overview, workspaceOverviewForm)"
                                       overview-form="workspaceOverviewForm"
-                                      on-change="workspaceDetailsController.checkEditMode(false)"
+                                      on-change="workspaceDetailsController.onWorkspaceChanged()"
                                       workspace-details="workspaceDetailsController.workspaceDetails"></workspace-details-overview>
         </ng-form>
       </md-tab-body>
@@ -56,7 +56,7 @@
       <md-tab-body>
         <workspace-details-projects
           workspace-details="workspaceDetailsController.workspaceDetails"
-          projects-on-change="workspaceDetailsController.checkEditMode(true)"></workspace-details-projects>
+          projects-on-change="workspaceDetailsController.checkEditMode()"></workspace-details-projects>
       </md-tab-body>
     </md-tab>
 
@@ -68,7 +68,7 @@
       </md-tab-label>
       <md-tab-body>
         <workspace-machines workspace-details="workspaceDetailsController.workspaceDetails"
-                            on-change="workspaceDetailsController.checkEditMode(true)"></workspace-machines>
+                            on-change="workspaceDetailsController.checkEditMode()"></workspace-machines>
       </md-tab-body>
     </md-tab>
 
@@ -81,7 +81,7 @@
       <md-tab-body>
         <che-machine-selector content-title="Servers"
                               workspace-details="workspaceDetailsController.workspaceDetails"
-                              on-change="workspaceDetailsController.checkEditMode(true)">
+                              on-change="workspaceDetailsController.checkEditMode()">
           <che-machine-servers environment-manager="environmentManager"
                                selected-machine="machine"
                                on-change="onChange()"></che-machine-servers>
@@ -98,7 +98,7 @@
       <md-tab-body>
         <che-machine-selector content-title="Environment variables"
                               workspace-details="workspaceDetailsController.workspaceDetails"
-                              on-change="workspaceDetailsController.checkEditMode(true)">
+                              on-change="workspaceDetailsController.checkEditMode()">
           <che-env-variables environment-manager="environmentManager"
                              selected-machine="machine"
                              on-change="onChange()"></che-env-variables>
@@ -115,7 +115,7 @@
       <md-tab-body>
         <che-machine-selector content-title="Volumes"
                               workspace-details="workspaceDetailsController.workspaceDetails"
-                              on-change="workspaceDetailsController.checkEditMode(true)">
+                              on-change="workspaceDetailsController.checkEditMode()">
           <che-machine-volumes environment-manager="environmentManager"
                              selected-machine="machine"
                              on-change="onChange()"></che-machine-volumes>
@@ -167,7 +167,7 @@
       <md-tab-body>
         <workspace-plugins workspace="workspaceDetailsController.workspaceDetails"
                            plugin-registry-location="workspaceDetailsController.pluginRegistry"
-                           on-change="workspaceDetailsController.checkEditMode(true)">
+                           on-change="workspaceDetailsController.checkEditMode()">
         </workspace-plugins>
       </md-tab-body>
     </md-tab>
@@ -183,31 +183,31 @@
       <md-tab-body>
         <workspace-editors workspace="workspaceDetailsController.workspaceDetails"
                            plugin-registry-location="workspaceDetailsController.pluginRegistry"
-                           on-change="workspaceDetailsController.checkEditMode(true)">
+                           on-change="workspaceDetailsController.checkEditMode()">
         </workspace-editors>
       </md-tab-body>
     </md-tab>
 
-     <!-- Devfile tab -->
-     <md-tab ng-if="workspaceDetailsController.workspaceDetails.devfile"
-     md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Devfile); isDevfileActive = true"
-     md-on-deselect="isDevfileActive = false">
-     <md-tab-label>
-       <i ng-show="workspaceDetailsController.checkFormsNotValid(workspaceDetailsController.tab.Devfile)"
-          class="error-state fa fa-exclamation-circle" aria-hidden="true"></i>
-       <span class="che-tab-label-title">Devfile</span>
-     </md-tab-label>
-     <md-tab-body>
-        <che-label-container che-label-name="Workspace">
-            <ng-form name="workspaceDevfileForm">
-              <workspace-devfile-editor
-                is-active="isDevfileActive"
-                workspace-devfile="workspaceDetailsController.workspaceDetails.devfile"
-                workspace-devfile-on-change="workspaceDetailsController.updateWorkspaceDevfile(devfile)"></workspace-devfile-editor>
-            </ng-form>
-          </che-label-container>
-     </md-tab-body>
-   </md-tab>
+    <!-- Devfile tab -->
+    <md-tab ng-if="workspaceDetailsController.workspaceDetails.devfile"
+            md-on-select="workspaceDetailsController.onSelectTab(workspaceDetailsController.tab.Devfile); isDevfileActive = true"
+            md-on-deselect="isDevfileActive = false">
+    <md-tab-label>
+      <i ng-show="workspaceDetailsController.checkFormsNotValid(workspaceDetailsController.tab.Devfile)"
+        class="error-state fa fa-exclamation-circle" aria-hidden="true"></i>
+      <span class="che-tab-label-title">Devfile</span>
+    </md-tab-label>
+    <md-tab-body>
+      <che-label-container che-label-name="Workspace">
+        <ng-form name="workspaceDevfileForm">
+          <workspace-devfile-editor
+            is-active="isDevfileActive"
+            workspace-devfile="workspaceDetailsController.workspaceDetails.devfile"
+            workspace-devfile-on-change="workspaceDetailsController.onWorkspaceChanged()"></workspace-devfile-editor>
+          </ng-form>
+        </che-label-container>
+      </md-tab-body>
+    </md-tab>
 
     <!-- Other tabs -->
     <md-tab ng-repeat="section in workspaceDetailsController.getPages()"

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
@@ -18,7 +18,7 @@ import {CheWorkspace, WorkspaceStatus} from '../../../components/api/workspace/c
 import {CheService} from '../../../components/api/che-service.factory';
 import {PluginRegistry} from '../../../components/api/plugin-registry.factory';
 import {WorkspaceDataManager} from '../../../components/api/workspace/workspace-data-manager';
-import {ConfirmDialogService} from '../../../../target/dist/components/service/confirm-dialog/confirm-dialog.service';
+import { ConfirmDialogService } from '../../../components/service/confirm-dialog/confirm-dialog.service';
 
 interface IPage {
   title: string;
@@ -462,7 +462,7 @@ export class WorkspaceDetailsService {
    * Shows modal window with notification about unsaved changes.
    */
   notifyUnsavedChangesDialog(): ng.IPromise<void> {
-    return this.confirmDialogService.showConfirmDialog('Unsaved Changes', `You're editing this workspace configuration. Please save or discard changes to be able to run or stop the workspace.`, 'Close');
+    return this.confirmDialogService.showConfirmDialog('Unsaved Changes', `You're editing this workspace configuration. Please save or discard changes to be able to run or stop the workspace.`, { reject: 'Close' });
   }
 
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
@@ -41,11 +41,16 @@ export interface IModifiedWorkspace {
 class ModifiedWorkspaces {
   workspaces: { [id: string]: IModifiedWorkspace } = {};
 
-  set(id: string, needRestart: boolean): void {
+  set(id: string, attrs: { isSaved?: boolean, needRestart?: boolean }): void {
     if (this.workspaces[id] === undefined) {
       this.workspaces[id] = { isSaved: false };
     }
-    this.workspaces[id].needRestart = needRestart;
+    if (angular.isDefined(attrs.isSaved)) {
+      this.workspaces[id].isSaved = attrs.isSaved;
+    }
+    if (angular.isDefined(attrs.needRestart)) {
+      this.workspaces[id].needRestart = attrs.needRestart;
+    }
   }
 
   isSaved(id: string): boolean {
@@ -337,7 +342,8 @@ export class WorkspaceDetailsService {
         return this.saveConfigChanges(workspace);
       })
       .then(() => {
-        this.cheWorkspace.startWorkspace(workspace.id, workspace.config.defaultEnv);
+        const envName = workspace.config ? workspace.config.defaultEnv : undefined;
+        this.cheWorkspace.startWorkspace(workspace.id, envName);
         return this.cheWorkspace.fetchStatusChange(workspace.id, WorkspaceStatus[WorkspaceStatus.RUNNING]);
       })
       .catch((error: any) => {
@@ -348,10 +354,9 @@ export class WorkspaceDetailsService {
 
   /**
    * Keep a workspace as one that is modified and may need restarting to apply changes.
-   * @param {string} id a workspace ID
    */
-  setModified(id: string, needRestart: boolean): void {
-    this.modifiedWorkspaces.set(id, needRestart);
+  setModified(id: string, attrs: { isSaved?: boolean, needRestart?: boolean }): void {
+    this.modifiedWorkspaces.set(id, attrs);
   }
 
   removeModified(id: string): void {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
@@ -12,13 +12,13 @@
 'use strict';
 import {CheNotification} from '../../../components/notification/che-notification.factory';
 import IdeSvc from '../../ide/ide.service';
-import {CreateWorkspaceSvc} from '../create-workspace/create-workspace.service';
 import {IObservable, IObservableCallbackFn, Observable} from '../../../components/utils/observable';
 import {WorkspaceDetailsProjectsService} from './workspace-projects/workspace-details-projects.service';
 import {CheWorkspace, WorkspaceStatus} from '../../../components/api/workspace/che-workspace.factory';
 import {CheService} from '../../../components/api/che-service.factory';
 import {PluginRegistry} from '../../../components/api/plugin-registry.factory';
 import {WorkspaceDataManager} from '../../../components/api/workspace/workspace-data-manager';
+import {ConfirmDialogService} from '../../../../target/dist/components/service/confirm-dialog/confirm-dialog.service';
 
 interface IPage {
   title: string;
@@ -28,9 +28,44 @@ interface IPage {
 }
 
 interface ISection {
- title: string;
- description: string;
- content: string;
+  title: string;
+  description: string;
+  content: string;
+}
+
+export interface IModifiedWorkspace {
+  isSaved: boolean;
+  needRestart?: boolean;
+}
+
+class ModifiedWorkspaces {
+  workspaces: { [id: string]: IModifiedWorkspace } = {};
+
+  set(id: string, needRestart: boolean): void {
+    if (this.workspaces[id] === undefined) {
+      this.workspaces[id] = { isSaved: false };
+    }
+    this.workspaces[id].needRestart = needRestart;
+  }
+
+  isSaved(id: string): boolean {
+    if (this.workspaces[id] === undefined) {
+      return true;
+    }
+    return this.workspaces[id].isSaved;
+  }
+
+  needRestart(id: string): boolean {
+    if (this.workspaces[id] === undefined) {
+      return false;
+    }
+    return this.workspaces[id].needRestart;
+  }
+
+  remove(id: string): void {
+    delete this.workspaces[id];
+  }
+
 }
 
 /**
@@ -41,7 +76,18 @@ interface ISection {
  */
 export class WorkspaceDetailsService {
 
-  static $inject = ['$log', '$q', 'cheWorkspace', 'cheNotification', 'ideSvc', 'createWorkspaceSvc', 'workspaceDetailsProjectsService', 'cheService', 'chePermissions', 'pluginRegistry'];
+  static $inject = [
+    '$log',
+    '$q',
+    'cheWorkspace',
+    'cheNotification',
+    'ideSvc',
+    'workspaceDetailsProjectsService',
+    'cheService',
+    'chePermissions',
+    'confirmDialogService',
+    'pluginRegistry'
+  ];
 
   /**
    * Logging service.
@@ -64,13 +110,13 @@ export class WorkspaceDetailsService {
    */
   private ideSvc: IdeSvc;
   /**
-   * Workspace creation service.
-   */
-  private createWorkspaceSvc: CreateWorkspaceSvc;
-  /**
    * Service for projects of workspace.
    */
   private workspaceDetailsProjectsService: WorkspaceDetailsProjectsService;
+  /**
+   * Confirm dialog service.
+   */
+  private confirmDialogService: ConfirmDialogService;
   /**
    * Instance of Observable.
    */
@@ -79,9 +125,9 @@ export class WorkspaceDetailsService {
   private pages: IPage[];
   private sections: ISection[];
   /**
-   * This workspaces should be restarted for new config to be applied.
+   * These workspaces should be restarted for new config to be applied.
    */
-  private restartToApply: string[] = [];
+  private modifiedWorkspaces: ModifiedWorkspaces = new ModifiedWorkspaces();
   /**
    * Array of deprecated editors.
    */
@@ -108,10 +154,10 @@ export class WorkspaceDetailsService {
     cheWorkspace: CheWorkspace,
     cheNotification: CheNotification,
     ideSvc: IdeSvc,
-    createWorkspaceSvc: CreateWorkspaceSvc,
     workspaceDetailsProjectsService: WorkspaceDetailsProjectsService,
     cheService: CheService,
     chePermissions: che.api.IChePermissions,
+    confirmDialogService: ConfirmDialogService,
     pluginRegistry: PluginRegistry
   ) {
     this.$log = $log;
@@ -119,9 +165,9 @@ export class WorkspaceDetailsService {
     this.cheWorkspace = cheWorkspace;
     this.cheNotification = cheNotification;
     this.ideSvc = ideSvc;
-    this.createWorkspaceSvc = createWorkspaceSvc;
     this.pluginRegistry = pluginRegistry;
     this.workspaceDetailsProjectsService = workspaceDetailsProjectsService;
+    this.confirmDialogService = confirmDialogService;
 
     this.observable =  new Observable<any>();
 
@@ -288,8 +334,6 @@ export class WorkspaceDetailsService {
         return this.cheWorkspace.fetchStatusChange(workspace.id, WorkspaceStatus[WorkspaceStatus.STOPPED]);
       })
       .then(() => {
-        this.removeRestartToApply(workspace.id);
-
         return this.saveConfigChanges(workspace);
       })
       .then(() => {
@@ -303,39 +347,40 @@ export class WorkspaceDetailsService {
   }
 
   /**
-   * Add workspace ID to the list of workspaces that should be restarted.
-   *
-   * @param {string} workspaceId
+   * Keep a workspace as one that is modified and may need restarting to apply changes.
+   * @param {string} id a workspace ID
    */
-  addRestartToApply(workspaceId: string): void {
-    if (this.restartToApply.indexOf(workspaceId) === -1) {
-      this.restartToApply.push(workspaceId);
-    }
+  setModified(id: string, needRestart: boolean): void {
+    this.modifiedWorkspaces.set(id, needRestart);
+  }
+
+  removeModified(id: string): void {
+    this.modifiedWorkspaces.remove(id);
   }
 
   /**
-   * Remove workspace ID from the list of workspaces that should be restarted.
-   *
-   * @param {string} workspaceId
+   * Returns `true` if workspace configuration has been already saved.
+   * @param id a workspace ID
    */
-  removeRestartToApply(workspaceId: string): void {
-    const index = this.restartToApply.indexOf(workspaceId);
-    if (index === -1) {
-      return;
-    }
-    this.restartToApply.splice(index, 1);
+  isWorkspaceConfigSaved(id: string): boolean {
+    return this.modifiedWorkspaces.isSaved(id);
   }
 
   /**
-   * Returns <code>true</code> if workspace ID belongs to the list of
-   * workspaces that should be restarted.
-   *
-   * @param {string} workspaceId
-   * @returns {boolean}
+   * Returns `true` if workspace configuration has been already applied.
+   * @param id a workspace ID
    */
-  getRestartToApply(workspaceId: string): boolean {
-    const index = this.restartToApply.indexOf(workspaceId);
-    return index !== -1;
+  doesWorkspaceConfigNeedRestart(id: string): boolean {
+    return this.modifiedWorkspaces.needRestart(id);
+  }
+
+  /**
+   * Returns `true` if workspace configuration was changed.
+   * @param id a workspace ID
+   */
+  isWorkspaceModified(id: string): boolean {
+    return this.modifiedWorkspaces.isSaved(id) === false
+      || this.modifiedWorkspaces.needRestart(id) === true;
   }
 
   /**
@@ -411,6 +456,13 @@ export class WorkspaceDetailsService {
 
       return this.$q.reject(error);
     });
+  }
+
+  /**
+   * Shows modal window with notification about unsaved changes.
+   */
+  notifyUnsavedChangesDialog(): ng.IPromise<void> {
+    return this.confirmDialogService.showConfirmDialog('Unsaved Changes', `You're editing this workspace configuration. Please save or discard changes to be able to run or stop the workspace.`, 'Close');
   }
 
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-env-variables/env-variables.controller.ts
@@ -190,7 +190,7 @@ export class EnvVariablesController {
    * @param variableName {string}
    */
   deleteEnvVariable(variableName: string): void {
-    const promise = this.confirmDialogService.showConfirmDialog('Remove variable', 'Would you like to delete this variable?', 'Delete');
+    const promise = this.confirmDialogService.showConfirmDialog('Remove variable', 'Would you like to delete this variable?', { resolve: 'Delete' });
     promise.then(() => {
       delete this.envVariables[variableName];
       this.environmentManager.setEnvVariables(this.selectedMachine, this.envVariables);
@@ -212,6 +212,6 @@ export class EnvVariablesController {
       content += 'this selected variable?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove variables', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove variables', content, { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-servers/machine-servers.controller.ts
@@ -204,7 +204,7 @@ export class MachineServersController {
    * @param reference {string}
    */
   deleteServer(reference: string): void {
-    const promise = this.confirmDialogService.showConfirmDialog('Remove server', 'Would you like to delete this server?', 'Delete');
+    const promise = this.confirmDialogService.showConfirmDialog('Remove server', 'Would you like to delete this server?', { resolve: 'Delete' });
     promise.then(() => {
       delete this.servers[reference];
       this.environmentManager.setServers(this.selectedMachine, this.servers);
@@ -225,6 +225,6 @@ export class MachineServersController {
       content += 'this selected server?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove servers', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove servers', content, { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/machine-volumes.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machine-volumes/machine-volumes.controller.ts
@@ -140,7 +140,7 @@ export class MachineVolumesController {
    * @param variableName {string}
    */
   deleteMachineVolume(variableName: string): void {
-    const promise = this.confirmDialogService.showConfirmDialog('Remove variable', 'Would you like to delete this variable?', 'Delete');
+    const promise = this.confirmDialogService.showConfirmDialog('Remove variable', 'Would you like to delete this variable?', { resolve: 'Delete' });
     promise.then(() => {
       delete this.machineVolumes[variableName];
       this.environmentManager.setMachineVolumes(this.selectedMachine, this.machineVolumes);
@@ -162,6 +162,6 @@ export class MachineVolumesController {
       content += 'this selected variable?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove variables', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove variables', content, { resolve: 'Delete' });
   }
 }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-machines/workspace-machines.controller.ts
@@ -218,7 +218,7 @@ export class WorkspaceMachinesController {
       content += 'these ' + selectedItems.length + ' machines?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove machines', content, 'Delete').then(() => {
+    return this.confirmDialogService.showConfirmDialog('Remove machines', content, { resolve: 'Delete' }).then(() => {
       return selectedItems;
     });
   }
@@ -276,7 +276,7 @@ export class WorkspaceMachinesController {
    * @param name {string}
    */
   deleteMachine(name: string): void {
-    this.confirmDialogService.showConfirmDialog('Remove machine', 'Would you like to delete this machine?', 'Delete').then(() => {
+    this.confirmDialogService.showConfirmDialog('Remove machine', 'Would you like to delete this machine?', { resolve: 'Delete' }).then(() => {
       this.machineOnDelete(name);
     });
   }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.controller.ts
@@ -272,7 +272,7 @@ export class WorkspaceDetailsOverviewController {
    */
   deleteWorkspace(): void {
     const content = 'Would you like to delete workspace \'' + this.cheWorkspace.getWorkspaceDataManager().getName(this.workspaceDetails) + '\'?';
-    this.confirmDialogService.showConfirmDialog('Delete workspace', content, 'Delete').then(() => {
+    this.confirmDialogService.showConfirmDialog('Delete workspace', content, { resolve: 'Delete' }).then(() => {
       if ([RUNNING, STARTING].indexOf(this.getWorkspaceStatus()) !== -1) {
         this.cheWorkspace.stopWorkspace(this.workspaceDetails.id);
       }

--- a/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.html
@@ -7,7 +7,7 @@
       che-name="name"
       che-place-holder="Name of the workspace"
       aria-label="Name of the workspace"
-      ng-model-options="{ allowInvalid: true }"
+      ng-model-options="{ allowInvalid: true, debounce: 300 }"
       ng-model="workspaceDetailsOverviewController.name"
       che-on-change="workspaceDetailsOverviewController.onNameChange()"
       required

--- a/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-projects/workspace-details-projects.controller.ts
@@ -256,7 +256,7 @@ export class WorkspaceDetailsProjectsCtrl {
       content += 'this selected project?';
     }
 
-    return this.confirmDialogService.showConfirmDialog('Remove projects', content, 'Delete');
+    return this.confirmDialogService.showConfirmDialog('Remove projects', content, { resolve: 'Delete' });
   }
 
   workspaceIsRunning(): boolean {

--- a/dashboard/src/components/service/confirm-dialog/che-confirm-dialog.html
+++ b/dashboard/src/components/service/confirm-dialog/che-confirm-dialog.html
@@ -2,11 +2,12 @@
   <div class="che-confirm-dialog-notification">
     <div>{{cheConfirmDialogController.content}}</div>
     <div layout="row" flex layout-align="end end">
-      <che-button-primary che-button-title="{{cheConfirmDialogController.resolveButtonTitle}}"
+      <che-button-primary ng-if="cheConfirmDialogController.buttons.resolve"
+                          che-button-title="{{cheConfirmDialogController.buttons.resolve}}"
                           id="ok-dialog-button"
                           ng-click="cheConfirmDialogController.hide()">
       </che-button-primary>
-      <che-button-notice che-button-title="{{cheConfirmDialogController.rejectButtonTitle}}"
+      <che-button-notice che-button-title="{{cheConfirmDialogController.buttons.reject}}"
                          id="cancel-dialog-button"
                          ng-click="cheConfirmDialogController.cancel()">
       </che-button-notice>

--- a/dashboard/src/components/service/confirm-dialog/confirm-dialog.service.ts
+++ b/dashboard/src/components/service/confirm-dialog/confirm-dialog.service.ts
@@ -34,12 +34,12 @@ export class ConfirmDialogService {
    *
    * @param title{string} popup title
    * @param content{string} dialog content
-   * @param resolveButtonTitle{string} title for resolve button
-   * @param rejectButtonTitle{string} title for reject button
+   * @param buttonTitles dialog buttons titles
    *
    * @returns {ng.IPromise<any>}
    */
-  showConfirmDialog(title: string, content: string, resolveButtonTitle: string, rejectButtonTitle?: string): ng.IPromise<any> {
+  showConfirmDialog(title: string, content: string, buttonTitles?: { resolve?: string, reject?: string }): ng.IPromise<any> {
+    buttonTitles.reject = buttonTitles.reject || 'Close';
     return this.$mdDialog.show({
       bindToController: true,
       clickOutsideToClose: true,
@@ -49,8 +49,7 @@ export class ConfirmDialogService {
         content: content,
         $mdDialog: this.$mdDialog,
         title: title,
-        resolveButtonTitle: resolveButtonTitle,
-        rejectButtonTitle: rejectButtonTitle ? rejectButtonTitle : 'Close'
+        buttons: buttonTitles
       },
       templateUrl: 'components/service/confirm-dialog/che-confirm-dialog.html'
     });

--- a/dashboard/src/components/widget/edit-mode-overlay/che-edit-mode-overlay.controller.ts
+++ b/dashboard/src/components/widget/edit-mode-overlay/che-edit-mode-overlay.controller.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import { ICheEditModeOverlayConfig } from './che-edit-mode-overlay.directive';
+import { ConfirmDialogService } from '../../../../target/dist/components/service/confirm-dialog/confirm-dialog.service';
+
+export class CheEditModeOverlayController {
+
+  static $inject = [
+    '$location',
+    '$scope',
+    'confirmDialogService'
+  ];
+  private $location: ng.ILocationService;
+  private $scope: ng.IScope;
+  private confirmDialogService: ConfirmDialogService;
+
+  private config: ICheEditModeOverlayConfig;
+
+  constructor(
+    $location: ng.ILocationService,
+    $scope: ng.IScope,
+    confirmDialogService: ConfirmDialogService
+  ) {
+    this.$location = $location;
+    this.$scope = $scope;
+    this.confirmDialogService = confirmDialogService;
+
+    this.$scope.$on('$locationChangeStart', (event: ng.IAngularEvent, newUrl: string, oldUrl: string) => {
+      if (this.config.preventPageLeave === false) {
+        return;
+      }
+
+      // check if path remains the same
+      const oldPath = this.extractPathname(oldUrl);
+      const newPath = this.extractPathname(newUrl);
+      if (oldPath === newPath) {
+        return;
+      }
+
+      event.preventDefault();
+
+      if (typeof this.config.onChangesDiscard !== 'function') {
+        return;
+      }
+      return this.discardUnsavedChangesDialog().then(() => {
+        return this.config.onChangesDiscard().then(() => {
+          const hash = newUrl.slice(newUrl.indexOf('#') + 1, newUrl.length);
+          this.$location.url(hash);
+        });
+      });
+    });
+  }
+
+  discardUnsavedChangesDialog(): ng.IPromise<void> {
+    return this.confirmDialogService.showConfirmDialog('Unsaved Changes', 'You have unsaved changes. You may go ahead and discard all changes, or close this window and save them.', 'Discard Changes', 'Cancel');
+  }
+
+
+  /**
+   * Returns Angular's path
+   * @param url
+   */
+  private extractPathname(url: string): string {
+      return url.slice(url.indexOf('#') + 1, url.indexOf('?') !== -1 ? url.indexOf('?') : url.length);
+  }
+
+}

--- a/dashboard/src/components/widget/edit-mode-overlay/che-edit-mode-overlay.controller.ts
+++ b/dashboard/src/components/widget/edit-mode-overlay/che-edit-mode-overlay.controller.ts
@@ -37,7 +37,7 @@ export class CheEditModeOverlayController {
     this.confirmDialogService = confirmDialogService;
 
     this.$scope.$on('$locationChangeStart', (event: ng.IAngularEvent, newUrl: string, oldUrl: string) => {
-      if (this.config.preventPageLeave === false) {
+      if (this.config && this.config.preventPageLeave === false) {
         return;
       }
 

--- a/dashboard/src/components/widget/edit-mode-overlay/che-edit-mode-overlay.controller.ts
+++ b/dashboard/src/components/widget/edit-mode-overlay/che-edit-mode-overlay.controller.ts
@@ -12,7 +12,7 @@
 'use strict';
 
 import { ICheEditModeOverlayConfig } from './che-edit-mode-overlay.directive';
-import { ConfirmDialogService } from '../../../../target/dist/components/service/confirm-dialog/confirm-dialog.service';
+import { ConfirmDialogService } from '../../service/confirm-dialog/confirm-dialog.service';
 
 export class CheEditModeOverlayController {
 
@@ -63,7 +63,7 @@ export class CheEditModeOverlayController {
   }
 
   discardUnsavedChangesDialog(): ng.IPromise<void> {
-    return this.confirmDialogService.showConfirmDialog('Unsaved Changes', 'You have unsaved changes. You may go ahead and discard all changes, or close this window and save them.', 'Discard Changes', 'Cancel');
+    return this.confirmDialogService.showConfirmDialog('Unsaved Changes', 'You have unsaved changes. You may go ahead and discard all changes, or close this window and save them.', { resolve: 'Discard Changes', reject: 'Cancel' });
   }
 
 

--- a/dashboard/src/components/widget/edit-mode-overlay/che-edit-mode-overlay.directive.ts
+++ b/dashboard/src/components/widget/edit-mode-overlay/che-edit-mode-overlay.directive.ts
@@ -17,24 +17,66 @@ export interface ICheEditModeOverlayMessage {
 }
 
 export interface ICheEditModeOverlayButton {
-  action: (args?: any) => void;
+  /**
+   * Listeners to be called on button click.
+   */
+  action: (...args: any[]) => void;
+  /**
+   * Set field to `true` to disable button.
+   */
   disabled?: boolean;
+  /**
+   * Button name attribute value.
+   */
   name?: string;
+  /**
+   * Button title
+   */
   title?: string;
 }
 
 export interface ICheEditModeOverlayConfig {
+  /**
+   * Set field to `true` to show the overlay.
+   */
   visible?: boolean;
+  /**
+   * Set field to `true` to disable all buttons.
+   */
   disabled?: boolean;
+  /**
+   * A message to show.
+   */
   message?: ICheEditModeOverlayMessage;
+  /**
+   * "Save" button.
+   */
   saveButton?: ICheEditModeOverlayButton;
+  /**
+   * "Apply" button.
+   */
   applyButton?: ICheEditModeOverlayButton;
+  /**
+   * "Cancel" button.
+   */
   cancelButton?: ICheEditModeOverlayButton;
+  /**
+   * If `true` then user cannot leave the pages if there are unsaved changes.
+   */
+  preventPageLeave?: boolean;
+  /**
+   * Listener to be called on `$locationChangeStart`.
+   */
+  onChangesDiscard?: () => ng.IPromise<void>;
 }
 
 export class CheEditModeOverlay implements ng.IDirective {
 
   restrict = 'E';
+
+  bindToController = true;
+  controller = 'CheEditModeOverlayController';
+  controllerAs = 'cheEditModeOverlayController';
 
   scope = {
     config: '='
@@ -44,37 +86,37 @@ export class CheEditModeOverlay implements ng.IDirective {
     return `
 <div class="che-edit-mode-overlay"
      layout="row" layout-align="center center"
-     ng-if="config.visible">
+     ng-if="cheEditModeOverlayController.config.visible">
   <div class="che-edit-mode-overlay-message">
-    <span ng-if="config.message && config.message.content && config.message.visible"
-          ng-bind-html="config.message.content"></span>
+    <span ng-if="cheEditModeOverlayController.config.message && cheEditModeOverlayController.config.message.content && cheEditModeOverlayController.config.message.visible"
+          ng-bind-html="cheEditModeOverlayController.config.message.content"></span>
   </div>
 
   <!-- 'Save' button -->
-  <div ng-if="config.saveButton">
-    <che-button-save-flat che-button-title="{{config.saveButton.title || 'Save'}}"
+  <div ng-if="cheEditModeOverlayController.config.saveButton">
+    <che-button-save-flat che-button-title="{{cheEditModeOverlayController.config.saveButton.title || 'Save'}}"
                           class="save-button"
-                          name="{{config.saveButton.name || 'save-button'}}"
-                          ng-disabled="config.disabled || config.saveButton.disabled"
-                          ng-click="config.saveButton.action()"></che-button-save-flat>
+                          name="{{cheEditModeOverlayController.config.saveButton.name || 'save-button'}}"
+                          ng-disabled="cheEditModeOverlayController.config.disabled || cheEditModeOverlayController.config.saveButton.disabled"
+                          ng-click="cheEditModeOverlayController.config.saveButton.action()"></che-button-save-flat>
   </div>
 
   <!-- 'Apply' button -->
-  <div ng-if="config.applyButton">
-    <che-button-save-flat che-button-title="{{config.applyButton.title || 'Apply'}}"
-                          name="{{config.applyButton.name || 'apply-button'}}"
+  <div ng-if="cheEditModeOverlayController.config.applyButton">
+    <che-button-save-flat che-button-title="{{cheEditModeOverlayController.config.applyButton.title || 'Apply'}}"
+                          name="{{cheEditModeOverlayController.config.applyButton.name || 'apply-button'}}"
                           class="apply-button"
-                          ng-disabled="config.disabled || config.applyButton.disabled"
-                          ng-click="config.applyButton.action()"></che-button-save-flat>
+                          ng-disabled="cheEditModeOverlayController.config.disabled || cheEditModeOverlayController.config.applyButton.disabled"
+                          ng-click="cheEditModeOverlayController.config.applyButton.action()"></che-button-save-flat>
   </div>
 
   <!-- 'Cancel' button -->
-  <div ng-if="config.cancelButton">
-    <che-button-cancel-flat che-button-title="{{config.cancelButton.title || 'Cancel'}}"
-                            name="{{config.cancelButton.name || 'cancel-button'}}"
+  <div ng-if="cheEditModeOverlayController.config.cancelButton">
+    <che-button-cancel-flat che-button-title="{{cheEditModeOverlayController.config.cancelButton.title || 'Cancel'}}"
+                            name="{{cheEditModeOverlayController.config.cancelButton.name || 'cancel-button'}}"
                             class="cancel-button"
-                            ng-disabled="config.cancelButton.disabled"
-                            ng-click="config.cancelButton.action()"></che-button-cancel-flat>
+                            ng-disabled="cheEditModeOverlayController.config.cancelButton.disabled"
+                            ng-click="cheEditModeOverlayController.config.cancelButton.action()"></che-button-cancel-flat>
   </div>
 
 </div>`;

--- a/dashboard/src/components/widget/widget-config.ts
+++ b/dashboard/src/components/widget/widget-config.ts
@@ -91,6 +91,7 @@ import {CheEditorController} from './editor/che-editor.controller';
 import {PagingButtons} from './paging-button/paging-button.directive';
 import {CheRowToolbar} from './toolbar/che-row-toolbar.directive';
 import {CheEditModeOverlay} from './edit-mode-overlay/che-edit-mode-overlay.directive';
+import { CheEditModeOverlayController } from './edit-mode-overlay/che-edit-mode-overlay.controller';
 
 export class WidgetConfig {
 
@@ -204,6 +205,7 @@ export class WidgetConfig {
     register.directive('cheTogglePopover', CheTogglePopover);
     register.directive('toggleButtonPopover', CheToggleButtonPopover);
     // edit overlay
+    register.controller('CheEditModeOverlayController', CheEditModeOverlayController);
     register.directive('cheEditModeOverlay', CheEditModeOverlay);
   }
 }


### PR DESCRIPTION

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR disables autosave feature on devfile editor page. 

Initially, autosave was added in order not to lose unsaved workspace configuration changes, mainly because of going to another Dashboard page. Now, if workspace has unsaved changes, user is not able to go to another Dashboard page nor start/stop workspace.

#### Demo

![Screen Recording 2019-10-17 at 11 28 58 2019-10-17 12_06_13](https://user-images.githubusercontent.com/16220722/66994847-a0072080-f0d6-11e9-9f73-b7c54740b99a.gif)

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/13982

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

