### PR TITLE
Fix of Vert.x E2E test (#14924)

### DIFF
--- a/e2e/tests/e2e/JavaVertx.spec.ts
+++ b/e2e/tests/e2e/JavaVertx.spec.ts
@@ -122,7 +122,7 @@ suite('Java Vert.x test', async () => {
 
     suite('Validation of project build', async () => {
         test('Build application', async () => {
-            let taskName: string = 'che: maven build';
+            let taskName: string = 'maven build';
             await runTask(taskName);
             await quickOpenContainer.clickOnContainerItem('Continue without scanning the task output');
             await ide.waitNotification('Task ' + taskName + ' has exited with code 0.', 60000);


### PR DESCRIPTION
### What does this PR do?
It's cherry-pick of PR commit https://github.com/eclipse/che/pull/14924, which fixed had expected task: from `che: maven build` -> `maven build`.
![screenshot-Build_application (1)](https://user-images.githubusercontent.com/1197777/67092438-dcf71400-f1b7-11e9-8c08-5add65a51e15.png)

