### PR TITLE
Get rid of non-working workaround to flakiness when Java LS server initialization failed

### DIFF
--- a/e2e/pageobjects/ide/Ide.ts
+++ b/e2e/pageobjects/ide/Ide.ts
@@ -213,26 +213,8 @@ export class Ide {
 
     async checkLsInitializationStart(expectedTextInStatusBar: string) {
         Logger.debug('Ide.checkLsInitializationStart');
-
-        try {
-            await this.waitStatusBarContains(expectedTextInStatusBar, 20000);
-        } catch (err) {
-            if (!(err instanceof error.TimeoutError)) {
-                throw err;
-            }
-
-            const workaroundReportText: string = '\n############################## \n\n' +
-                'Known issue: https://github.com/eclipse/che/issues/14944 \n' +
-                '"Java LS server initialization failed" \n' +
-                '############################## \n';
-
-            console.log(workaroundReportText);
-
-            await this.driverHelper.getDriver().navigate().refresh();
-            await this.waitAndSwitchToIdeFrame();
-            await this.waitStatusBarContains(expectedTextInStatusBar);
-        }
-
+        
+        await this.waitStatusBarContains(expectedTextInStatusBar, 20000);
     }
 
     async closeAllNotifications() {

--- a/e2e/pageobjects/ide/Ide.ts
+++ b/e2e/pageobjects/ide/Ide.ts
@@ -221,6 +221,13 @@ export class Ide {
                 throw err;
             }
 
+            const workaroundReportText: string = '\n############################## \n\n' +
+                'Known issue: https://github.com/eclipse/che/issues/14944 \n' +
+                '"Java LS server initialization failed" \n' +
+                '############################## \n';
+
+            console.log(workaroundReportText);
+
             await this.driverHelper.getDriver().navigate().refresh();
             await this.waitAndSwitchToIdeFrame();
             await this.waitStatusBarContains(expectedTextInStatusBar);

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -103,7 +103,7 @@ suite('Language server validation', async () => {
 
             console.log("Known flakiness has occurred https://github.com/eclipse/che/issues/14944");
             await driverHelper.reloadPage();
-            await ide.waitStatusBarContains(expectedTextInStatusBar);
+            await ide.waitStatusBarContains('Starting Java Language Server');
         }
 
         await ide.waitStatusBarTextAbsence('Starting Java Language Server', 1800000);

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -93,7 +93,14 @@ suite('Language server validation', async () => {
     test('Java LS initialization', async () => {
         await projectTree.expandPathAndOpenFileInAssociatedWorkspace(pathToJavaFolder, javaFileName);
         await editor.selectTab(javaFileName);
-        await ide.checkLsInitializationStart('Starting Java Language Server');
+
+        try {
+            await ide.checkLsInitializationStart('Starting Java Language Server');
+        } catch (err) {
+            console.log("Known flakiness https://github.com/eclipse/che/issues/14944");
+            throw err;
+        }
+
         await ide.waitStatusBarTextAbsence('Starting Java Language Server', 1800000);
         await checkJavaPathCompletion();
         await ide.waitStatusBarTextAbsence('Building workspace', 360000);

--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -97,8 +97,13 @@ suite('Language server validation', async () => {
         try {
             await ide.checkLsInitializationStart('Starting Java Language Server');
         } catch (err) {
-            console.log("Known flakiness https://github.com/eclipse/che/issues/14944");
-            throw err;
+            if (!(err instanceof error.TimeoutError)) {
+                throw err;
+            }
+
+            console.log("Known flakiness has occurred https://github.com/eclipse/che/issues/14944");
+            await driverHelper.reloadPage();
+            await ide.waitStatusBarContains(expectedTextInStatusBar);
         }
 
         await ide.waitStatusBarTextAbsence('Starting Java Language Server', 1800000);

--- a/e2e/utils/DriverHelper.ts
+++ b/e2e/utils/DriverHelper.ts
@@ -460,7 +460,7 @@ export class DriverHelper {
     }
 
     public async reloadPage() {
-        Logger.trace('DriverHelper.reloadPage');
+        Logger.debug('DriverHelper.reloadPage');
 
         await this.driver.navigate().refresh();
     }
@@ -473,7 +473,7 @@ export class DriverHelper {
     }
 
     public async navigateToUrl(url: string) {
-        Logger.trace(`DriverHelper.navigateToUrl ${url}`);
+        Logger.debug(`DriverHelper.navigateToUrl ${url}`);
 
         await this.driver.navigate().to(url);
     }
@@ -534,7 +534,7 @@ export class DriverHelper {
     }
 
     async switchToSecondWindow(mainWindowHandle: string) {
-        Logger.trace('DriverHelper.switchToSecondWindow');
+        Logger.debug('DriverHelper.switchToSecondWindow');
 
         await this.waitOpenningSecondWindow();
         const handles: string[] = await this.driver.getAllWindowHandles();


### PR DESCRIPTION
### What does this PR do?
It logs usage of workaround to failed check of LS server language initialization in E2E Happy path tests.

**_Update_**: it seems [existed workaround doesn't work, and has just hidden failure details](https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/Single-Che-PR-check-E2E-Happy-path-tests-against-k8s-on-codenvy-slave9/detail/Single-Che-PR-check-E2E-Happy-path-tests-against-k8s-on-codenvy-slave9/857/pipeline) .
So, that workaround has been removed https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/che-pr-tests/view/K8S/job/Single-Che-PR-check-E2E-Happy-path-tests-against-k8s-on-codenvy-slave9/862/console:
```
        ▼ Ide.waitStatusBarContains "Starting Java Language Server"
Known flakiness https://github.com/eclipse/che/issues/14944
    1) Java LS initialization


  3 passing (2m)
  1 failing

  1) Language server validation
       Java LS initialization:
     TimeoutError: Wait timed out after 21008ms
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14944, https://github.com/eclipse/che/issues/14283
