### PR TITLE
Removes header in different keycloak login theme pages.

### DIFF
--- a/dockerfiles/keycloak/che/login/login-reset-password.ftl
+++ b/dockerfiles/keycloak/che/login/login-reset-password.ftl
@@ -1,15 +1,11 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayInfo=true; section>
-    <#if section = "title">
-        ${msg("emailForgotTitle")}
-    <#elseif section = "header">
-        ${msg("emailForgotTitle")}
-    <#elseif section = "form">
+    <#if section = "form">
         <#include "logo.ftl">
 
         <form id="kc-reset-password-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">
             <div class="${properties.kcFormGroupClass!}">
-                <div class="kc-form-title">${msg("passwordRecover")}</div>
+                <div class="kc-form-title">${msg("passwordRecover")?no_esc}</div>
 
                 <div class="${properties.kcInputWrapperClass!}">
                     <input type="text" id="username" name="username" class="${properties.kcInputClass!}" autofocus placeholder="<#if !realm.loginWithEmailAllowed>${msg("username")}<#elseif !realm.registrationEmailAsUsername>${msg("usernameOrEmail")}<#else>${msg("email")}</#if>"/>

--- a/dockerfiles/keycloak/che/login/login-update-password.ftl
+++ b/dockerfiles/keycloak/che/login/login-update-password.ftl
@@ -1,10 +1,6 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayInfo=true; section>
-    <#if section = "title">
-        ${msg("updatePasswordTitle")}
-    <#elseif section = "header">
-        ${msg("updatePasswordTitle")}
-    <#elseif section = "form">
+    <#if section = "form">
         <#include "logo.ftl">
 
         <form id="kc-passwd-update-form" class="${properties.kcFormClass!}" action="${url.loginAction}" method="post">

--- a/dockerfiles/keycloak/che/login/login.ftl
+++ b/dockerfiles/keycloak/che/login/login.ftl
@@ -1,10 +1,6 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout displayInfo=social.displayInfo; section>
-    <#if section = "title">
-        ${msg("loginTitle",(realm.displayName!''))}
-    <#elseif section = "header">
-        ${msg("loginTitleHtml",(realm.displayNameHtml!''))}
-    <#elseif section = "form">
+    <#if section = "form">
         <#include "logo.ftl">
 
         <#if realm.password>

--- a/dockerfiles/keycloak/che/login/register.ftl
+++ b/dockerfiles/keycloak/che/login/register.ftl
@@ -1,10 +1,6 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout; section>
-    <#if section = "title">
-        ${msg("registerWithTitle",(realm.displayName!''))}
-    <#elseif section = "header">
-        ${msg("registerWithTitleHtml",(realm.displayNameHtml!''))?no_esc}
-    <#elseif section = "form">
+    <#if section = "form">
         <#include "logo.ftl">
 
         <form id="kc-register-form" class="${properties.kcFormClass!}" action="${url.registrationAction}" method="post">


### PR DESCRIPTION
Fixes #13818

Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Removes the header (which is broken in https://github.com/eclipse/che/issues/13818) completely.
IMHO it shouldn't even be there.
Screenshots of che theme after applying these changes:
![register](https://user-images.githubusercontent.com/1215011/67279462-5601ae80-f4cb-11e9-81cd-3a1f5cf17927.png)
![forgot](https://user-images.githubusercontent.com/1215011/67279463-5601ae80-f4cb-11e9-81fc-635c47bcfa22.png)
![login](https://user-images.githubusercontent.com/1215011/67279464-5601ae80-f4cb-11e9-8dd3-5a11c528be57.png)


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
