### PR TITLE
Backport: Use newer version of Jgroups and EclipseLink to prevent PKIX errors on OCP 4.x

### DIFF
--- a/assembly/assembly-wsmaster-war/pom.xml
+++ b/assembly/assembly-wsmaster-war/pom.xml
@@ -353,7 +353,7 @@
         </dependency>
         <dependency>
             <groupId>org.jgroups.kubernetes</groupId>
-            <artifactId>kubernetes</artifactId>
+            <artifactId>jgroups-kubernetes</artifactId>
         </dependency>
         <dependency>
             <groupId>org.postgresql</groupId>
@@ -440,7 +440,7 @@
                                 <dep>org.eclipse.che.multiuser:che-multiuser-keycloak-token-provider</dep>
                                 <dep>org.eclipse.persistence:org.eclipse.persistence.extension</dep>
                                 <dep>org.eclipse.persistence:org.eclipse.persistence.jpa</dep>
-                                <dep>org.jgroups.kubernetes:kubernetes</dep>
+                                <dep>org.jgroups.kubernetes:jgroups-kubernetes</dep>
                                 <dep>org.postgresql:postgresql</dep>
                                 <dep>com.google.guava:guava</dep>
                                 <dep>org.everrest:everrest-core</dep>

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/jgroups/che-tcp.xml
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/jgroups/che-tcp.xml
@@ -21,16 +21,20 @@
     send_buf_size="1M"
     max_bundle_size="64K"
     enable_diagnostics="true"
+    log_discard_msgs="false"
     thread_naming_pattern="cl"
 
     thread_pool.min_threads="0"
     thread_pool.max_threads="500"
     thread_pool.keep_alive_time="30000" />
 
-  <kubernetes.KUBE_PING
-    labels="app=che" />
+  <org.jgroups.protocols.kubernetes.KUBE_PING
+    port_range="3"
+    namespace="${KUBERNETES_NAMESPACE:che}"
+    labels="${KUBERNETES_LABEL:app=che,component=che}"
+  />
 
-  <MERGE2 min_interval="10000"
+  <MERGE3 min_interval="10000"
     max_interval="30000"/>
   <FD_SOCK/>
   <FD timeout="3000" max_tries="3"/>
@@ -38,12 +42,9 @@
   <BARRIER/>
   <pbcast.NAKACK2 use_mcast_xmit="false"
     discard_delivered_msgs="true"/>
-  <UNICAST/>
   <pbcast.STABLE stability_delay="1000" desired_avg_gossip="50000"
     max_bytes="4M"/>
-  <pbcast.GMS print_local_addr="true" join_timeout="3000"
-
-    view_bundling="true"/>
+  <pbcast.GMS print_local_addr="true" join_timeout="3000" />
   <MFC max_credits="2M"
     min_threshold="0.4"/>
   <FRAG2 frag_size="60K"/>

--- a/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/cache/JGroupsWorkspaceStatusCache.java
+++ b/multiuser/api/che-multiuser-api-jgroups/src/main/java/org/eclipse/che/multiuser/api/distributed/cache/JGroupsWorkspaceStatusCache.java
@@ -40,8 +40,7 @@ public class JGroupsWorkspaceStatusCache implements WorkspaceStatusCache {
   @Inject
   public JGroupsWorkspaceStatusCache(@Named("jgroups.config.file") String confFile) {
     try {
-      JChannel channel = new JChannel(confFile);
-      channel.connect(CHANNEL_NAME);
+      JChannel channel = new JChannel(confFile).connect(CHANNEL_NAME);
       delegate = new ReplicatedHashMap<>(channel);
       delegate.setBlockingUpdates(true);
       delegate.start(5000);


### PR DESCRIPTION
### What does this PR do?

Use newer version of Jgroups, KUBE_PING and EclipseLink to prevent PKIX errors on OCP 4.x

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13607



#### Release Notes
N/A


#### Docs PR
N/A