### PR TITLE
Fix bug where broker container name can exceed 63 characters

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Names.java
@@ -124,8 +124,8 @@ public class Names {
     if (containerName != null && containerName.length() > MAX_CONTAINER_NAME_LENGTH) {
       throw new IllegalArgumentException(
           format(
-              "The container name exceeds the allowed limit of %s characters.",
-              MAX_CONTAINER_NAME_LENGTH));
+              "The container name '%s' exceeds the allowed limit of %s characters.",
+              containerName, MAX_CONTAINER_NAME_LENGTH));
     }
 
     if (annotations != null

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
@@ -153,14 +153,25 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
     return NameGenerator.generate(suffix, 6);
   }
 
+  /**
+   * Generate a container name from an image reference. Since full image references can be over 63
+   * characters, we need to strip registry and organization from the image reference to limit name
+   * length.
+   */
+  @VisibleForTesting
+  protected String generateContainerNameFromImageRef(String image) {
+    return image.toLowerCase().replaceAll("[^/]*/", "").replaceAll("[^\\d\\w-]", "-");
+  }
+
   private Container newContainer(
       RuntimeIdentity runtimeId,
       List<EnvVar> envVars,
       String image,
       @Nullable String brokerVolumeName) {
+    String containerName = generateContainerNameFromImageRef(image);
     final ContainerBuilder cb =
         new ContainerBuilder()
-            .withName(image.toLowerCase().replaceAll("[^\\d\\w-]", "-"))
+            .withName(containerName)
             .withImage(image)
             .withArgs(
                 "-push-endpoint",

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactoryTest.java
@@ -42,6 +42,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -237,5 +238,25 @@ public class BrokerEnvironmentFactoryTest {
           String.format(
               "Missing field from serialized config: expected '%s' in '%s'", expect, config));
     }
+  }
+
+  @Test(dataProvider = "imageRefs")
+  public void testImageToContainerNameConversion(Object image, Object expected) {
+    String actual = factory.generateContainerNameFromImageRef((String) image);
+    assertEquals(
+        actual,
+        expected,
+        String.format("Should remove registry and organization from image '%s'.", image));
+  }
+
+  @DataProvider(name = "imageRefs")
+  public Object[][] imageRefs() {
+    return new Object[][] {
+      {"quay.io/eclipse/che-unified-plugin-broker:v0.20", "che-unified-plugin-broker-v0-20"},
+      {"very-long-registry-hostname-url.service/eclipse/image:tag", "image-tag"},
+      {"eclipse/che-unified-plugin-broker:v0.20", "che-unified-plugin-broker-v0-20"},
+      {"very-long-organization.name-eclipse-che/image:tag", "image-tag"},
+      {"very-long-registry-hostname-url.service/very-long-organization/image:tag", "image-tag"}
+    };
   }
 }


### PR DESCRIPTION
**This PR is a cherry-pick of the changes from https://github.com/eclipse/che/pull/14964**

## What does this PR do?
Strips docker registry hostname when creating a container name for plugin brokers.

The container name for the plugin broker is derived from its docker image reference. When this reference contains a registry, it's possible for this name to exceed the 63-character limit imposed by Kubernetes,
e.g.
```
  my-internal-registry/my-organization/che-unified-plugin-broker:v0.20
```
results in a broker container named
```
  my-internal-registry-my-organization-che-unified-plugin-broker-v0-20
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14958
