### PR TITLE
Fix Vert.x stack test

### DIFF
--- a/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -101,7 +101,7 @@ suite('Language server validation', async () => {
                 throw err;
             }
 
-            console.log("Known flakiness has occurred https://github.com/eclipse/che/issues/14944");
+            console.log('Known flakiness has occurred https://github.com/eclipse/che/issues/14944');
             await driverHelper.reloadPage();
             await ide.waitStatusBarContains('Starting Java Language Server');
         }


### PR DESCRIPTION
# What does this PR do?
Fix Vert.x test - Codenavigation part. The code is copy-pasted from the HappyPath test. I tried locally and works. The console is spammed by some unhandled exception, but it is not preventing the test to pass. Leaving it this way as this PR should be merged ASAP (blocking 7.3.1 release). The Vert.x stack test can be cleaned in the next version.
