### PR TITLE
Remove/update deprecated machine start timeout env var in templates

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -30,7 +30,7 @@ data:
   CHE_DEBUG_SERVER: "true"
   CHE_INFRASTRUCTURE_ACTIVE: "kubernetes"
   CHE_INFRA_KUBERNETES_INGRESS_DOMAIN: {{ .Values.global.ingressDomain }}
-  CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN: "5"
+  CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN: "5"
   CHE_INFRA_KUBERNETES_MASTER__URL: ""
 {{- if and .Values.global.tls .Values.global.tls.enabled }}
   CHE_INFRA_KUBERNETES_TLS__ENABLED: {{ .Values.global.tls.enabled | quote}}

--- a/deploy/openshift/templates/che-server-template.yaml
+++ b/deploy/openshift/templates/che-server-template.yaml
@@ -104,7 +104,7 @@ objects:
             value: "openshift"
           - name: CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL
             value: "${PROTOCOL}://che-${NAMESPACE}.${ROUTING_SUFFIX}/agent-binaries/linux_amd64/bootstrapper/bootstrapper"
-          - name: CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN
+          - name: CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN
             value: "5"
           - name: CHE_INFRA_KUBERNETES_MASTER__URL
             value: "${CHE_INFRA_KUBERNETES_MASTER__URL}"

--- a/selenium/che-selenium-test/src/test/resources/projects/nodejs-with-yaml/deployment.yaml
+++ b/selenium/che-selenium-test/src/test/resources/projects/nodejs-with-yaml/deployment.yaml
@@ -87,8 +87,6 @@ spec:
             - name: CHE_INFRA_KUBERNETES_BOOTSTRAPPER_BINARY__URL
               value: >-
                 http://che-${NAMESPACE}.172.0.0.1.nip.io/agent-binaries/linux_amd64/bootstrapper/bootstrapper
-            - name: CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN
-              value: '5'
             - name: CHE_INFRA_KUBERNETES_OAUTH__TOKEN
             - name: CHE_INFRA_KUBERNETES_USERNAME
             - name: CHE_INFRA_KUBERNETES_PASSWORD


### PR DESCRIPTION
### What does this PR do?
Remove or update deprecated property `CHE_INFRA_KUBERNETES_MACHINE__START__TIMEOUT__MIN` in templates. 

- For deploy templates, I've updated it to the replacement `CHE_INFRA_KUBERNETES_WORKSPACE__START__TIMEOUT__MIN`
- For the selenium tests folder, I simply removed the env var altogether as the default [8 minutes](https://github.com/eclipse/che/blob/1c5c92147f7886ec4c7cd1a2348815d1198876d7/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties#L269) seems to be working fine.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13559
