### PR TITLE
Fix port for Jaeger ingress

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-jaeger/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-jaeger/templates/ingress.yaml
@@ -37,4 +37,4 @@ spec:
         - path: /
           backend:
               serviceName: jaeger-query
-              servicePort: 16686
+              servicePort: 80


### PR DESCRIPTION
### What does this PR do?

Fixes Jaeger kubernetes deployment to use correct service port in the ingress.

### What issues does this PR fix or reference?

- Jaeger was not accessible when deployed as is from the Helm chart.

#### Release Notes
N/A


#### Docs PR
N/A