### PR TITLE
Increate test timeouts for ServersCheckerTest

### DIFF
--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServerCheckerTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.api.workspace.server.hc;
 
 import static java.lang.String.format;
-import static org.mockito.Mockito.timeout;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -34,7 +33,7 @@ public class ServerCheckerTest {
   private static final String SERVER_REF = "ref1";
   private static final long PERIOD_MS = 10;
   private static final long CHECKER_TIMEOUT_MS = 5000;
-  private static final long TEST_TIMEOUT_MS = CHECKER_TIMEOUT_MS + 1000;
+  private static final long TEST_TIMEOUT_MS = CHECKER_TIMEOUT_MS + 5000;
   private static final int SUCCESS_THRESHOLD = 1;
 
   private Timer timer;

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/hc/ServersCheckerTest.java
@@ -37,7 +37,6 @@ import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -65,7 +64,6 @@ public class ServersCheckerTest {
   @Mock private RuntimeIdentity runtimeIdentity;
   private Map<String, ServerImpl> servers;
 
-  private CompletableFuture<String> compFuture;
   private ServersChecker checker;
 
   @BeforeMethod
@@ -77,7 +75,7 @@ public class ServersCheckerTest {
             EXEC_AGENT_HTTP_SERVER, new ServerImpl().withUrl("http://localhost/exec-agent/process"),
             TERMINAL_SERVER, new ServerImpl().withUrl("http://localhost/terminal/pty")));
 
-    compFuture = new CompletableFuture<>();
+    CompletableFuture<String> compFuture = new CompletableFuture<>();
 
     when(connectionChecker.getReportCompFuture()).thenReturn(compFuture);
 
@@ -99,15 +97,7 @@ public class ServersCheckerTest {
     when(machineTokenProvider.getToken(anyString(), anyString())).thenReturn(MACHINE_TOKEN);
   }
 
-  @AfterMethod(timeOut = 1000)
-  public void tearDown() throws Exception {
-    try {
-      checker.await();
-    } catch (Exception ignored) {
-    }
-  }
-
-  @Test(timeOut = 1000)
+  @Test(timeOut = 5000)
   public void shouldUseMachineTokenWhenCallChecker() throws Exception {
     servers.clear();
     servers.put("wsagent/http", new ServerImpl().withUrl("http://localhost"));
@@ -123,7 +113,7 @@ public class ServersCheckerTest {
     assertEquals(tokenCaptor.getValue(), MACHINE_TOKEN);
   }
 
-  @Test(timeOut = 1000)
+  @Test(timeOut = 5000)
   public void shouldNotifyReadinessHandlerAboutEachServerReadiness() throws Exception {
     checker.startAsync(readinessHandler);
 
@@ -134,7 +124,7 @@ public class ServersCheckerTest {
     verify(readinessHandler, times(3)).accept("test_ref");
   }
 
-  @Test(timeOut = 1000)
+  @Test(timeOut = 5000)
   public void shouldThrowExceptionIfAServerIsUnavailable() throws Exception {
     checker.startAsync(readinessHandler);
 
@@ -149,7 +139,7 @@ public class ServersCheckerTest {
     }
   }
 
-  @Test(timeOut = 1000)
+  @Test(timeOut = 5000)
   public void shouldNotCheckNotConfiguredServers() throws Exception {
     servers.clear();
     servers.putAll(
@@ -164,7 +154,7 @@ public class ServersCheckerTest {
     verify(readinessHandler).accept("test_ref");
   }
 
-  @Test(timeOut = 1000)
+  @Test(timeOut = 5000)
   public void awaitShouldReturnOnFirstUnavailability() throws Exception {
     CompletableFuture<String> future1 = spy(new CompletableFuture<>());
     CompletableFuture<String> future2 = spy(new CompletableFuture<>());


### PR DESCRIPTION
### What does this PR do?
From time to time these tests fail on our CI job.
I'm able to reproduce this issue locally if my laptop is quite loaded with another process like maven build. And as we can see the first test takes the most time.
![Screenshot_20191030_155103](https://user-images.githubusercontent.com/5887312/67863731-1cfdb580-fb2d-11e9-8cc3-1229cd65cc6c.png)
I did not find any information about why it may happen but I assume that it's related to memory allocation.
I wrote a simple test that does nothing except N Objects
```
  private static final int N = 10_000_000;

  @Test(invocationCount = 40)
  public void doNothing() throws Exception {
    List<Object> list = new ArrayList<>();
    for(int i = 0; i< N; i++) {
      list.add(new Object());
    }
  }
```
and it's what I get:
1. N = 10_000
![Screenshot_20191030_154016](https://user-images.githubusercontent.com/5887312/67862910-9e544880-fb2b-11e9-8396-f67b936ebcac.png)
I assume that it's a situation similar to what we have in ServersCheckerTest.java, when not much memory is needed and the first test always takes the most time. I assume that the process during the first test allocates some amount of memory and further tests just reuse it.
2. N = 10_000_000
![Screenshot_20191030_153926](https://user-images.githubusercontent.com/5887312/67862970-b88e2680-fb2b-11e9-9bef-be7b2a4002f4.png)
I don't have a clear explanation of why 2nd and 3rd take the most time but it's not really needed.
My testing is not accurate at all and its purpose was just to show that using timeout needs additional care since invocation time may take different time depending on which it will be run(1,2,3,...), which time(a system is loaded, a garbage collector is active).

I believe 5 seconds should be even more than enough for tests to be stable.
In the pessimistic scenario (when there is an error in code or tests) we may pay 7*5=35 seconds of build time, but such a situation must happen only feature branch, where code is broken but not in master.


### What issues does this PR fix or reference?
N/A

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
N/A