### PR TITLE
Fixed MeteredExecutorServiceWrapperTest that is failing some Linux system

### DIFF
--- a/core/commons/che-core-commons-observability/src/test/java/org/eclipse/che/commons/observability/MeteredExecutorServiceWrapperTest.java
+++ b/core/commons/che-core-commons-observability/src/test/java/org/eclipse/che/commons/observability/MeteredExecutorServiceWrapperTest.java
@@ -86,11 +86,7 @@ public class MeteredExecutorServiceWrapperTest {
             "userTagValue");
     CountDownLatch runnableTaskStart = new CountDownLatch(1);
     // when
-    Future<?> future =
-        executor.submit(
-            () -> {
-              runnableTaskStart.countDown();
-            });
+    Future<?> future = executor.submit(runnableTaskStart::countDown);
     // then
     runnableTaskStart.await(10, TimeUnit.SECONDS);
     future.get(1, TimeUnit.MINUTES);
@@ -166,7 +162,7 @@ public class MeteredExecutorServiceWrapperTest {
             .tags(userTags)
             .gauge()
             .value(),
-        new Double(Integer.MAX_VALUE));
+        (double) Integer.MAX_VALUE);
     assertEquals(
         registry
             .get("executor")
@@ -197,13 +193,7 @@ public class MeteredExecutorServiceWrapperTest {
     CountDownLatch runnableTaskStart = new CountDownLatch(1);
     // when
     ((ScheduledExecutorService) executor)
-        .scheduleAtFixedRate(
-            () -> {
-              runnableTaskStart.countDown();
-            },
-            0,
-            100,
-            TimeUnit.SECONDS);
+        .scheduleAtFixedRate(runnableTaskStart::countDown, 0, 100, TimeUnit.SECONDS);
     // then
 
     runnableTaskStart.await(10, TimeUnit.SECONDS);
@@ -280,7 +270,7 @@ public class MeteredExecutorServiceWrapperTest {
             .tags(userTags)
             .gauge()
             .value(),
-        new Double(Integer.MAX_VALUE));
+        (double) Integer.MAX_VALUE);
     assertEquals(
         registry
             .get("executor")
@@ -326,11 +316,7 @@ public class MeteredExecutorServiceWrapperTest {
             "userTagValue");
     CountDownLatch runnableTaskStart = new CountDownLatch(1);
     // when
-    executor.schedule(
-        () -> {
-          runnableTaskStart.countDown();
-        },
-        new CronExpression(" * * * ? * * *"));
+    executor.schedule(runnableTaskStart::countDown, new CronExpression(" * * * ? * * *"));
     // then
     runnableTaskStart.await(10, TimeUnit.SECONDS);
     assertEquals(
@@ -447,7 +433,7 @@ public class MeteredExecutorServiceWrapperTest {
         1.0);
   }
 
-  public <V> void assertWithRetry(Supplier<V> predicate, V expected, int times, int pause_millis)
+  <V> void assertWithRetry(Supplier<V> predicate, V expected, int times, int pause_millis)
       throws InterruptedException {
     for (int i = 0; i <= times; i++) {
       V actual = predicate.get();

--- a/core/commons/che-core-commons-observability/src/test/java/org/eclipse/che/commons/observability/MeteredExecutorServiceWrapperTest.java
+++ b/core/commons/che-core-commons-observability/src/test/java/org/eclipse/che/commons/observability/MeteredExecutorServiceWrapperTest.java
@@ -132,14 +132,17 @@ public class MeteredExecutorServiceWrapperTest {
             .gauge()
             .value(),
         1.0);
-    assertEquals(
-        registry
-            .get("executor.completed")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .functionCounter()
-            .count(),
-        1.0);
+    assertWithRetry(
+        () ->
+            registry
+                .get("executor.completed")
+                .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
+                .tags(userTags)
+                .functionCounter()
+                .count(),
+        1.0,
+        10,
+        50);
     assertEquals(
         registry
             .get("executor.queued")


### PR DESCRIPTION
### What does this PR do?
Fixed MeteredExecutorServiceWrapperTest that is failing some Linux system.
### What issues does this PR fix or reference?
Failed test on ci https://ci.codenvycorp.com/job/che-pullrequests-build/8236/org.eclipse.che.core$che-core-commons-observability/
Also, it turns out that on @sleshchenko laptop it was reproducible with 5 times from 10. However, on my OSX it was ok 0 from 100000

#### Release Notes
n/a

#### Docs PR
n/a