### PR TITLE
Various improvements of Jenkins pipeline to run Che E2E Happy path tests on PR check 

### DIFF
--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -263,6 +263,8 @@ pipeline {
                   mkdir -p $LOGS_AND_CONFIGS/docker
                   docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
                   docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
+
+                  sleep 30000
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -193,7 +193,7 @@ pipeline {
                        -d "grant_type=password" \\
                        -d "client_id=che-public" | jq -r .access_token)
 
-                    ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL --access-token "${USER_ACCESS_TOKEN}"
+                    ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL --access-token "\$USER_ACCESS_TOKEN"
                 """
             }
         }
@@ -254,7 +254,7 @@ pipeline {
     
                   mkdir -p $LOGS_AND_CONFIGS/che-logs
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-server.log || true
-                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che-operator | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-operator.log || true
+                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che-operator- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-operator.log || true
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep devfile-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/devfile-registry.log || true
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep plugin-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/plugin-registry.log || true
                     

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -14,27 +14,35 @@ pipeline {
         PATH = "/tmp:/qa/tools/opt/apache-maven-3.5.4/bin:$PATH"
         JENKINS_BUILD = "true"
 
-        DEVFILE_URL = "${WORKSPACE}/e2e/files/happy-path/happy-path-workspace.yaml"
         SUCCESS_THRESHOLD = 5
-
-        CHE_IMAGE_REPO = "maxura/che-server"
-        CHE_IMAGE_TAG = "${ghprbPullId}"
 
         LOGS_AND_CONFIGS="${WORKSPACE}/logs-and-configs"
     }
 
     parameters {
-        string(name: 'ghprbPullId',
-                defaultValue: "master",
-                description: 'Tag of Che images')
+        string(name: 'cheImageRepo',
+                defaultValue: "maxura/che-server",
+                description: 'Repo of Che server image')
 
-        string(name: 'ghprbSourceBranch',
-                defaultValue: "master",
-                description: 'Branch of Che to check')
+        string(name: 'cheImageTag',
+                defaultValue: "$ghprbPullId",
+                description: 'Tag of Che server image')
+
+        booleanParam(name: 'buildChe',
+                defaultValue: true,
+                description: 'Should build Che server')
 
         string(name: 'e2eTestToRun',
                 defaultValue: "test-happy-path",
                 description: 'TypeScript E2E test to run')
+        
+        string(name: 'testWorkspaceDevfileUrl',
+                defaultValue: "https://raw.githubusercontent.com/eclipse/che/${ghprbSourceBranch}/e2e/files/happy-path/happy-path-workspace.yaml",
+                description: 'URL of devfile of test workspace')
+
+        string(name: 'cheCustomResourceUrl',
+                defaultValue: "http://raw.githubusercontent.com/eclipse/che-operator/${ghprbSourceBranch}/deploy/crds/org_v1_che_cr.yaml",
+                description: 'URL of Che custom resource yaml')
     }
 
     stages {
@@ -86,6 +94,10 @@ pipeline {
                 }
 
                 stage("Build Che including upstream projects") {
+                    when {
+                        expression { return $buildChe }
+                    }
+
                     steps {
                         echo "Build branch ${ghprbSourceBranch} of upstream projects"
                         sh """
@@ -117,8 +129,8 @@ pipeline {
                         sh """
                             wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
                             
-                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            sed -i "s|cheImage: ''|cheImage: '${cheImageRepo}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${cheImageTag}'|" ${WORKSPACE}/org_v1_che_cr.yaml
                             sed -i "s|cheLogLevel: INFO|cheLogLevel: DEBUG|" ${WORKSPACE}/org_v1_che_cr.yaml
                         """
                     }
@@ -127,13 +139,17 @@ pipeline {
         }
 
         stage("Build and push che-server image") {
+            when {
+                expression { return $buildChe }
+            }
+
             steps {
                 withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
                     sh """
                         ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:nightly --dockerfile:Dockerfile
-                        docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                        docker tag ${cheImageRepo}:${cheImageTag} docker.io/${cheImageRepo}:${cheImageTag}
                         docker login -u maxura -p ${maxura_docker_password}
-                        docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                        docker push docker.io/${cheImageRepo}:${cheImageTag}
                     """
                 }
             }
@@ -183,6 +199,10 @@ pipeline {
         }
 
         stage("Create test workspace") {
+            when {
+                expression { return $testWorkspaceDevfileUrl != null && $testWorkspaceDevfileUrl != "" }
+            }
+
             steps {
                 sh """
                     KEYCLOAK_URL=\$(kubectl get ingress/keycloak -n che -o jsonpath='{.spec.rules[0].host}')
@@ -195,7 +215,9 @@ pipeline {
                        -d "grant_type=password" \\
                        -d "client_id=che-public" | jq -r .access_token)
 
-                    ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL --access-token "\$USER_ACCESS_TOKEN"
+                    wget $testWorkspaceDevfileUrl -O ${WORKSPACE}/test-workspace-devfile.yaml
+
+                    ${WORKSPACE}/chectl workspace:start --devfile=${WORKSPACE}/test-workspace-devfile.yaml --access-token "\$USER_ACCESS_TOKEN"
                 """
             }
         }
@@ -248,7 +270,10 @@ pipeline {
                 kubectl --namespace=che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
 
                 mkdir -p $LOGS_AND_CONFIGS/che-config
+
                 cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
+                cp ${WORKSPACE}/test-workspace-devfile.yaml $LOGS_AND_CONFIGS/che-config || true
+
                 kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml
                 kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
                 kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
@@ -262,9 +287,9 @@ pipeline {
                 done
 
                 mkdir -p $LOGS_AND_CONFIGS/workspace-logs
-                export WS_POD=\$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}')
+                export WS_POD=\$(kubectl get pod --namespace=che | grep ".workspace-" | awk '{print \$1}')
                 for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do \\
-                    kubectl logs \$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/workspace-logs/"\${c}".container.log || true; \\
+                    kubectl logs \$(kubectl get pod --namespace=che | grep ".workspace-" | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/workspace-logs/"\${c}".container.log || true; \\
                 done
                 kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
 

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -114,14 +114,14 @@ pipeline {
             }
         }
 
-        stage("Push Che artifacts to docker.io") {
+        stage("Build and push che-server image") {
             steps {
                 withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
                     sh """
                         ${WORKSPACE}/dockerfiles/che/build.sh --dockerfile:Dockerfile
-                        docker tag \$(docker images | grep 'eclipse/che-server' | awk '{print \$3}') docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-                        docker login -u maxura -p ${maxura_docker_password}
-                        docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                        # docker tag \$(docker images | grep 'eclipse/che-server' | awk '{print \$3}') docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                        # docker login -u maxura -p ${maxura_docker_password}
+                        # docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
                     """
                 }
             }
@@ -236,6 +236,7 @@ pipeline {
     
                   mkdir -p $LOGS_AND_CONFIGS/che-config
                   cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
+                  kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml
                   kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
                   kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
                   kubectl get pods --namespace=che >$LOGS_AND_CONFIGS/che-config/pods.txt || true

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -201,8 +201,7 @@ pipeline {
 
         stage("Create test workspace") {
             when {
-                expression { return params.testWorkspaceDevfileUrl != null 
-                                && params.testWorkspaceDevfileUrl != "" }
+                expression { return params.testWorkspaceDevfileUrl != null && params.testWorkspaceDevfileUrl != "" }
             }
 
             steps {

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -251,6 +251,10 @@ pipeline {
                   export WS_POD=\$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}')
                   for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do kubectl logs \$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/workspace-logs/"\${c}"-container.log || true; done
                   kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
+
+                  mkdir -p $LOGS_AND_CONFIGS/docker
+                  docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
+                  docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
             steps {
                 sh """
                     ${WORKSPACE}/chectl server:start \\
-                    --k8spodreadytimeout=180000 \\
+                    --k8spodreadytimeout=350000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
                     --platform=minikube \\

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -199,7 +199,7 @@ pipeline {
                        -d "grant_type=password" \\
                        -d "client_id=che-public" | jq -r .access_token)
 
-                  ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL"
+                  ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL --access-token "${USER_ACCESS_TOKEN}"
                 """
             }
         }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -54,6 +54,8 @@ pipeline {
                     steps {
                         // TO-DO use option "--install-path" https://github.com/eclipse/che/pull/14182
                         sh """
+                           env
+
                            curl -sL  https://www.eclipse.org/che/chectl/ > install_chectl.sh
                            chmod +x install_chectl.sh
                            sudo PATH=$PATH ./install_chectl.sh --channel=next
@@ -163,7 +165,8 @@ pipeline {
                     --installer=operator \\
                     --listr-renderer=verbose \\
                     --platform=minikube \\
-                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml \\
+                    --domain="\$(minikube ip).nip.io"
                 """
 
                 // wait che-server to be available
@@ -274,7 +277,7 @@ pipeline {
                 cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
                 cp ${WORKSPACE}/test-workspace-devfile.yaml $LOGS_AND_CONFIGS/che-config || true
 
-                kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml
+                kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml || true
                 kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
                 kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
                 kubectl get pods --namespace=che >$LOGS_AND_CONFIGS/che-config/pods.txt || true

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -145,7 +145,8 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube
+                    --platform=minikube \\
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
                 // wait che-server to be available
@@ -253,7 +254,7 @@ pipeline {
                   kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
     
                   mkdir -p $LOGS_AND_CONFIGS/che-logs
-                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-server.log || true
+                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che- | grep -v "che-operator" | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-server.log || true
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che-operator- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-operator.log || true
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep devfile-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/devfile-registry.log || true
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep plugin-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/plugin-registry.log || true

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -244,27 +244,35 @@ pipeline {
 
         cleanup {
             sh """                      
-                  mkdir -p $LOGS_AND_CONFIGS/kubectl
-                  kubectl --namespace=che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
-    
-                  mkdir -p $LOGS_AND_CONFIGS/che-config
-                  cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
-                  kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml
-                  kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
-                  kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
-                  kubectl get pods --namespace=che >$LOGS_AND_CONFIGS/che-config/pods.txt || true
-                  kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
-    
-                  mkdir -p $LOGS_AND_CONFIGS/che-logs
-                  export WS_POD=\$(kubectl get pod --namespace=che | awk 'NR>1 {print \$1}')
-                  for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do kubectl logs \$(kubectl get pod --namespace=che | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/che-logs/"\${c}"-pod.log || true; done
-                  kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
+                mkdir -p $LOGS_AND_CONFIGS/kubectl
+                kubectl --namespace=che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
 
-                  mkdir -p $LOGS_AND_CONFIGS/docker
-                  docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
-                  docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
+                mkdir -p $LOGS_AND_CONFIGS/che-config
+                cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
+                kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml
+                kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
+                kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
+                kubectl get pods --namespace=che >$LOGS_AND_CONFIGS/che-config/pods.txt || true
+                kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
 
-                  sleep 30000
+                mkdir -p $LOGS_AND_CONFIGS/che-logs
+                export PODS=\$(kubectl get pod --namespace=che | awk 'NR>1 {print \$1}')
+                for pod in \$PODS ; do \
+                    kubectl logs --namespace=che "\${pod}" -n che > $LOGS_AND_CONFIGS/che-logs/"\${pod}".pod.log || true; \
+                done
+
+                mkdir -p $LOGS_AND_CONFIGS/workspace-logs
+                export WS_POD=\$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}')
+                for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do \\
+                    kubectl logs \$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/workspace-logs/"\${c}".container.log || true; \\
+                done
+                kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
+
+                mkdir -p $LOGS_AND_CONFIGS/docker
+                docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
+                docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
+
+                sleep 30000
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -115,10 +115,10 @@ pipeline {
                 stage("Patch Che custom-resource.yaml") {
                     steps {
                         sh """
-                            crYamlPath=${WORKSPACE}/chectl/templates/che-operator/crds/org_v1_che_cr.yaml 
-                            cat \$crYamlPath                           
-                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" \$crYamlPath
-                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" \$crYamlPath
+                            wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
+                            
+                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
                         """
                     }
                 }
@@ -246,6 +246,7 @@ pipeline {
                   kubectl --namespace=che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
     
                   mkdir -p $LOGS_AND_CONFIGS/che-config
+                  cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
                   kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
                   kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
                   kubectl get pods --namespace=che >$LOGS_AND_CONFIGS/che-config/pods.txt || true

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -85,47 +85,59 @@ pipeline {
                     }
                 }
 
-                stage("Build Che including upstream projects") {
-                    steps {
-                        echo "Build branch ${ghprbSourceBranch} of upstream projects"
-                        sh """
-                            project_list=(
-                                eclipse/che-parent
-                                eclipse/che-docs
-                            )
+                // stage("Build Che including upstream projects") {
+                //     steps {
+                //         echo "Build branch ${ghprbSourceBranch} of upstream projects"
+                //         sh """
+                //             project_list=(
+                //                 eclipse/che-parent
+                //                 eclipse/che-docs
+                //             )
                             
-                            for project in \${project_list[@]};
-                            do
-                                result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
-                                if [[ \$result == *"refs"* ]]; then
-                                    echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
-                                    git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
-                                    mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
-                                else
-                                    echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
-                                fi
-                            done
-                        """
+                //             for project in \${project_list[@]};
+                //             do
+                //                 result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
+                //                 if [[ \$result == *"refs"* ]]; then
+                //                     echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
+                //                     git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
+                //                     mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
+                //                 else
+                //                     echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
+                //                 fi
+                //             done
+                //         """
 
-                        echo "Build Che"
-                        sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
+                //         echo "Build Che"
+                //         sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
+                //     }
+                // }
+
+                stage("Download and patch Che custom-resource.yaml") {
+                    steps {
+                        sh """
+                            wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
+                            
+                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            sed -i "s|cheLogLevel: INFO|cheLogLevel: DEBUG|" ${WORKSPACE}/org_v1_che_cr.yaml
+                        """
                     }
                 }
             }
         }
 
-        stage("Build and push che-server image") {
-            steps {
-                withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
-                    sh """
-                        ${WORKSPACE}/dockerfiles/che/build.sh --dockerfile:Dockerfile
-                        # docker tag \$(docker images | grep 'eclipse/che-server' | awk '{print \$3}') docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-                        # docker login -u maxura -p ${maxura_docker_password}
-                        # docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-                    """
-                }
-            }
-        }
+        // stage("Build and push che-server image") {
+        //     steps {
+        //         withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
+        //             sh """
+        //                 ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:nightly --dockerfile:Dockerfile
+        //                 docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+        //                 docker login -u maxura -p ${maxura_docker_password}
+        //                 docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+        //             """
+        //         }
+        //     }
+        // }
 
         stage("Start Single Che") {
             steps {
@@ -134,7 +146,8 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube
+                    --platform=minikube \\
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
                 // wait che-server to be available

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -146,7 +146,6 @@ pipeline {
                     --installer=operator \\
                     --listr-renderer=verbose \\
                     --platform=minikube \\
-                    --multiuser \\
                     --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -145,8 +145,7 @@ pipeline {
                     --k8spodreadytimeout=800000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube \\
-                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
+                    --platform=minikube
                 """
 
                 // wait che-server to be available
@@ -253,6 +252,7 @@ pipeline {
     
                   mkdir -p $LOGS_AND_CONFIGS/che-logs
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-server.log || true
+                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che-operator | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-operator.log || true
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep devfile-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/devfile-registry.log || true
                   kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep plugin-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/plugin-registry.log || true
                     

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -118,8 +118,8 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
                     sh """
-                        ${WORKSPACE}/dockerfiles/che/build.sh --organization:eclipse --tag:nightly --dockerfile:Dockerfile
-                        docker tag eclipse/che-server:nightly docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                        ${WORKSPACE}/dockerfiles/che/build.sh --dockerfile:Dockerfile
+                        docker tag \$(docker images | grep 'eclipse/che-server' | awk '{print \$3}') docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
                         docker login -u maxura -p ${maxura_docker_password}
                         docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
                     """

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -146,8 +146,7 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube \\
-                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
+                    --platform=minikube
                 """
 
                 // wait che-server to be available
@@ -256,7 +255,7 @@ pipeline {
                   kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
     
                   mkdir -p $LOGS_AND_CONFIGS/che-logs
-                  export WS_POD=\$(kubectl get pod --namespace=che | awk 'NR>0 {print \$1}')
+                  export WS_POD=\$(kubectl get pod --namespace=che | awk 'NR>1 {print \$1}')
                   for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do kubectl logs \$(kubectl get pod --namespace=che | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/che-logs/"\${c}"-pod.log || true; done
                   kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
 

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -131,7 +131,10 @@ pipeline {
                             
                             sed -i "s|cheImage: ''|cheImage: '${cheImageRepo}'|" ${WORKSPACE}/org_v1_che_cr.yaml
                             sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${cheImageTag}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+
                             sed -i "s|cheLogLevel: INFO|cheLogLevel: DEBUG|" ${WORKSPACE}/org_v1_che_cr.yaml
+
+                            sed -i "s|ingressDomain: '192.168.99.101.nip.io'|ingressDomain: '\$(minikube ip).nip.io'|" ${WORKSPACE}/org_v1_che_cr.yaml
                         """
                     }
                 }
@@ -163,8 +166,7 @@ pipeline {
                     --installer=operator \\
                     --listr-renderer=verbose \\
                     --platform=minikube \\
-                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml \\
-                    --domain="\$(minikube ip).nip.io"
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
                 // wait che-server to be available

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -146,7 +146,7 @@ pipeline {
                     --installer=operator \\
                     --listr-renderer=verbose \\
                     --platform=minikube \\
-                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
+                    --cheimage=${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
                 """
 
                 // wait che-server to be available

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -134,8 +134,8 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
                     sh """
-                        ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:nightly --dockerfile:Dockerfile
-                        docker tag ${cheImageRepo}:${cheImageTag} docker.io/${cheImageRepo}:${cheImageTag}
+                        ${WORKSPACE}/dockerfiles/che/build.sh --dockerfile:Dockerfile
+                        docker tag eclipse/che-server:nightly docker.io/${cheImageRepo}:${cheImageTag}
                         docker login -u maxura -p ${maxura_docker_password}
                         docker push docker.io/${cheImageRepo}:${cheImageTag}
                     """

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -146,7 +146,8 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube
+                    --platform=minikube \\
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
                 // wait che-server to be available

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -85,58 +85,47 @@ pipeline {
                     }
                 }
 
-                // stage("Build Che including upstream projects") {
-                //     steps {
-                //         echo "Build branch ${ghprbSourceBranch} of upstream projects"
-                //         sh """
-                //             project_list=(
-                //                 eclipse/che-parent
-                //                 eclipse/che-docs
-                //             )
-                            
-                //             for project in \${project_list[@]};
-                //             do
-                //                 result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
-                //                 if [[ \$result == *"refs"* ]]; then
-                //                     echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
-                //                     git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
-                //                     mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
-                //                 else
-                //                     echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
-                //                 fi
-                //             done
-                //         """
-
-                //         echo "Build Che"
-                //         sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
-                //     }
-                // }
-
-                stage("Patch Che custom-resource.yaml") {
+                stage("Build Che including upstream projects") {
                     steps {
+                        echo "Build branch ${ghprbSourceBranch} of upstream projects"
                         sh """
-                            wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
+                            project_list=(
+                                eclipse/che-parent
+                                eclipse/che-docs
+                            )
                             
-                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            for project in \${project_list[@]};
+                            do
+                                result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
+                                if [[ \$result == *"refs"* ]]; then
+                                    echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
+                                    git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
+                                    mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
+                                else
+                                    echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
+                                fi
+                            done
                         """
+
+                        echo "Build Che"
+                        sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
                     }
                 }
             }
         }
 
-        // stage("Push Che artifacts to docker.io") {
-        //     steps {
-        //         withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
-        //             sh """
-        //                 ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:${CHE_IMAGE_TAG} --dockerfile:Dockerfile
-        //                 docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-        //                 docker login -u maxura -p ${maxura_docker_password}
-        //                 docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-        //             """
-        //         }
-        //     }
-        // }
+        stage("Push Che artifacts to docker.io") {
+            steps {
+                withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
+                    sh """
+                        ${WORKSPACE}/dockerfiles/che/build.sh --organization:eclipse --tag:nightly --dockerfile:Dockerfile
+                        docker tag eclipse/che-server:nightly docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                        docker login -u maxura -p ${maxura_docker_password}
+                        docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                    """
+                }
+            }
+        }
 
         stage("Start Single Che") {
             steps {
@@ -145,8 +134,7 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube \\
-                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
+                    --platform=minikube
                 """
 
                 // wait che-server to be available

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -146,8 +146,7 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube \\
-                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
+                    --platform=minikube
                 """
 
                 // wait che-server to be available

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -146,8 +146,7 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube \\
-                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
+                    --platform=minikube
                 """
 
                 // wait che-server to be available
@@ -271,8 +270,6 @@ pipeline {
                 mkdir -p $LOGS_AND_CONFIGS/docker
                 docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
                 docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
-
-                sleep 30000
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -117,8 +117,8 @@ pipeline {
                         sh """
                             wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
                             
-                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|"
-                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|"
+                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
                         """
                     }
                 }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -125,18 +125,18 @@ pipeline {
             }
         }
 
-        stage("Push Che artifacts to docker.io") {
-            steps {
-                withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
-                    sh """
-                        ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:${CHE_IMAGE_TAG} --dockerfile:Dockerfile
-                        docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-                        docker login -u maxura -p ${maxura_docker_password}
-                        docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-                    """
-                }
-            }
-        }
+        // stage("Push Che artifacts to docker.io") {
+        //     steps {
+        //         withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
+        //             sh """
+        //                 ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:${CHE_IMAGE_TAG} --dockerfile:Dockerfile
+        //                 docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+        //                 docker login -u maxura -p ${maxura_docker_password}
+        //                 docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+        //             """
+        //         }
+        //     }
+        // }
 
         stage("Start Single Che") {
             steps {

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -117,8 +117,8 @@ pipeline {
                         sh """
                             wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
                             
-                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            #sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                            #sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
                         """
                     }
                 }
@@ -145,12 +145,13 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube
+                    --platform=minikube \\
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
                 // wait che-server to be available
                 sh """
-                     CHE_URL=\$(kubectl get ingress che-ingress -n=che -o=jsonpath={'.spec.rules[0].host'})
+                     CHE_URL=\$(kubectl get ingress che -n=che -o=jsonpath={'.spec.rules[0].host'})
                      
                      COUNTER=0;
                      SUCCESS_RATE_COUNTER=0;
@@ -193,7 +194,7 @@ pipeline {
                        -d "grant_type=password" \\
                        -d "client_id=che-public" | jq -r .access_token)
 
-                  ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL --access-token "${USER_ACCESS_TOKEN}"
+                    ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL --access-token "${USER_ACCESS_TOKEN}"
                 """
             }
         }
@@ -203,7 +204,7 @@ pipeline {
                 sh """
                      docker pull eclipse/che-e2e:nightly
                      
-                     CHE_HOST=\$(kubectl get ingress che-ingress -n=che -o=jsonpath={'.spec.rules[0].host'})
+                     CHE_HOST=\$(kubectl get ingress che -n=che -o=jsonpath={'.spec.rules[0].host'})
                      CHE_URL=http://\${CHE_HOST}
                      docker run --shm-size=256m --net=host --ipc=host \\
                        -e TS_SELENIUM_HEADLESS='true' \\

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -95,7 +95,7 @@ pipeline {
 
                 stage("Build Che including upstream projects") {
                     when {
-                        expression { return buildChe }
+                        expression { params.buildChe }
                     }
 
                     steps {
@@ -140,7 +140,7 @@ pipeline {
 
         stage("Build and push che-server image") {
             when {
-                expression { return buildChe }
+                expression { params.buildChe }
             }
 
             steps {
@@ -201,7 +201,8 @@ pipeline {
 
         stage("Create test workspace") {
             when {
-                expression { return testWorkspaceDevfileUrl != null && testWorkspaceDevfileUrl != "" }
+                expression { return params.testWorkspaceDevfileUrl != null 
+                                && params.testWorkspaceDevfileUrl != "" }
             }
 
             steps {

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -146,7 +146,8 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube
+                    --platform=minikube \\
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
                 // wait che-server to be available
@@ -255,7 +256,7 @@ pipeline {
                   kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
     
                   mkdir -p $LOGS_AND_CONFIGS/che-logs
-                  export WS_POD=\$(kubectl get pod --namespace=che | awk '{print \$1}')
+                  export WS_POD=\$(kubectl get pod --namespace=che | awk 'NR>0 {print \$1}')
                   for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do kubectl logs \$(kubectl get pod --namespace=che | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/che-logs/"\${c}"-pod.log || true; done
                   kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
 

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -142,7 +142,7 @@ pipeline {
             steps {
                 sh """
                     ${WORKSPACE}/chectl server:start \\
-                    --k8spodreadytimeout=800000 \\
+                    --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
                     --platform=minikube

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -54,9 +54,7 @@ pipeline {
                     steps {
                         // TO-DO use option "--install-path" https://github.com/eclipse/che/pull/14182
                         sh """
-                           env
-
-                           curl -sL  https://www.eclipse.org/che/chectl/ > install_chectl.sh
+                           curl -sL https://www.eclipse.org/che/chectl/ > install_chectl.sh
                            chmod +x install_chectl.sh
                            sudo PATH=$PATH ./install_chectl.sh --channel=next
                            sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
@@ -97,7 +95,7 @@ pipeline {
 
                 stage("Build Che including upstream projects") {
                     when {
-                        expression { return $buildChe }
+                        expression { return buildChe }
                     }
 
                     steps {
@@ -142,7 +140,7 @@ pipeline {
 
         stage("Build and push che-server image") {
             when {
-                expression { return $buildChe }
+                expression { return buildChe }
             }
 
             steps {
@@ -203,7 +201,7 @@ pipeline {
 
         stage("Create test workspace") {
             when {
-                expression { return $testWorkspaceDevfileUrl != null && $testWorkspaceDevfileUrl != "" }
+                expression { return testWorkspaceDevfileUrl != null && testWorkspaceDevfileUrl != "" }
             }
 
             steps {
@@ -299,6 +297,8 @@ pipeline {
                 mkdir -p $LOGS_AND_CONFIGS/docker
                 docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
                 docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
+
+                env
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -269,6 +269,8 @@ pipeline {
                   mkdir -p $LOGS_AND_CONFIGS/docker
                   docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
                   docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
+
+                  sleep 100000
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -43,6 +43,10 @@ pipeline {
         string(name: 'cheCustomResourceUrl',
                 defaultValue: "http://raw.githubusercontent.com/eclipse/che-operator/${ghprbSourceBranch}/deploy/crds/org_v1_che_cr.yaml",
                 description: 'URL of Che custom resource yaml')
+
+        text(name: 'customResource',
+              description: 'Custom resource yaml content'
+        )
     }
 
     stages {

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -85,43 +85,43 @@ pipeline {
                     }
                 }
 
-                stage("Build Che including upstream projects") {
-                    steps {
-                        echo "Build branch ${ghprbSourceBranch} of upstream projects"
-                        sh """
-                            project_list=(
-                                eclipse/che-parent
-                                eclipse/che-docs
-                            )
+                // stage("Build Che including upstream projects") {
+                //     steps {
+                //         echo "Build branch ${ghprbSourceBranch} of upstream projects"
+                //         sh """
+                //             project_list=(
+                //                 eclipse/che-parent
+                //                 eclipse/che-docs
+                //             )
                             
-                            for project in \${project_list[@]};
-                            do
-                                result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
-                                if [[ \$result == *"refs"* ]]; then
-                                    echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
-                                    git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
-                                    mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
-                                else
-                                    echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
-                                fi
-                            done
-                        """
+                //             for project in \${project_list[@]};
+                //             do
+                //                 result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
+                //                 if [[ \$result == *"refs"* ]]; then
+                //                     echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
+                //                     git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
+                //                     mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
+                //                 else
+                //                     echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
+                //                 fi
+                //             done
+                //         """
 
-                        echo "Build Che"
-                        sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
-                    }
-                }
+                //         echo "Build Che"
+                //         sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
+                //     }
+                // }
 
-                stage("Download and patch Che custom-resource.yaml") {
-                    steps {
-                        sh """
-                            wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
+                // stage("Download and patch Che custom-resource.yaml") {
+                //     steps {
+                //         sh """
+                //             wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
                             
-                            #sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                            #sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                        """
-                    }
-                }
+                //             sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                //             sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                //         """
+                //     }
+                // }
             }
         }
 

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -112,16 +112,16 @@ pipeline {
                 //     }
                 // }
 
-                // stage("Download and patch Che custom-resource.yaml") {
-                //     steps {
-                //         sh """
-                //             wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
-                            
-                //             sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                //             sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                //         """
-                //     }
-                // }
+                stage("Patch Che custom-resource.yaml") {
+                    steps {
+                        sh """
+                            crYamlPath=${WORKSPACE}/chectl/templates/che-operator/crds/org_v1_che_cr.yaml 
+                            cat \$crYamlPath                           
+                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|" \$crYamlPath
+                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|" \$crYamlPath
+                        """
+                    }
+                }
             }
         }
 
@@ -145,8 +145,7 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube \\
-                    --cheimage=${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                    --platform=minikube
                 """
 
                 // wait che-server to be available
@@ -249,6 +248,7 @@ pipeline {
                   mkdir -p $LOGS_AND_CONFIGS/che-config
                   kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
                   kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
+                  kubectl get pods --namespace=che >$LOGS_AND_CONFIGS/che-config/pods.txt || true
                   kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
     
                   mkdir -p $LOGS_AND_CONFIGS/che-logs

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -100,7 +100,7 @@ pipeline {
                                 if [[ \$result == *"refs"* ]]; then
                                     echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
                                     git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
-                                    mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -Dmaven.repo.local=${WORKSPACE}/.repository
+                                    mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
                                 else
                                     echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
                                 fi

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -85,32 +85,32 @@ pipeline {
                     }
                 }
 
-                // stage("Build Che including upstream projects") {
-                //     steps {
-                //         echo "Build branch ${ghprbSourceBranch} of upstream projects"
-                //         sh """
-                //             project_list=(
-                //                 eclipse/che-parent
-                //                 eclipse/che-docs
-                //             )
+                stage("Build Che including upstream projects") {
+                    steps {
+                        echo "Build branch ${ghprbSourceBranch} of upstream projects"
+                        sh """
+                            project_list=(
+                                eclipse/che-parent
+                                eclipse/che-docs
+                            )
                             
-                //             for project in \${project_list[@]};
-                //             do
-                //                 result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
-                //                 if [[ \$result == *"refs"* ]]; then
-                //                     echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
-                //                     git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
-                //                     mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
-                //                 else
-                //                     echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
-                //                 fi
-                //             done
-                //         """
+                            for project in \${project_list[@]};
+                            do
+                                result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
+                                if [[ \$result == *"refs"* ]]; then
+                                    echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
+                                    git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
+                                    mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -DskipTests
+                                else
+                                    echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
+                                fi
+                            done
+                        """
 
-                //         echo "Build Che"
-                //         sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
-                //     }
-                // }
+                        echo "Build Che"
+                        sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
+                    }
+                }
 
                 stage("Download and patch Che custom-resource.yaml") {
                     steps {
@@ -126,18 +126,18 @@ pipeline {
             }
         }
 
-        // stage("Build and push che-server image") {
-        //     steps {
-        //         withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
-        //             sh """
-        //                 ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:nightly --dockerfile:Dockerfile
-        //                 docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-        //                 docker login -u maxura -p ${maxura_docker_password}
-        //                 docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-        //             """
-        //         }
-        //     }
-        // }
+        stage("Build and push che-server image") {
+            steps {
+                withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
+                    sh """
+                        ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:nightly --dockerfile:Dockerfile
+                        docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                        docker login -u maxura -p ${maxura_docker_password}
+                        docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                    """
+                }
+            }
+        }
 
         stage("Start Single Che") {
             steps {
@@ -146,7 +146,8 @@ pipeline {
                     --k8spodreadytimeout=180000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
-                    --platform=minikube
+                    --platform=minikube \\
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
                 // wait che-server to be available

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -1,11 +1,11 @@
 #!groovy
 
 pipeline {
-    agent { label 'codenvy-slave9' }
+    agent { label "${jenkinsNodeLabel}" }
 
     options {
         timestamps()
-        timeout(time: 15, unit: 'MINUTES')
+        timeout(time: 30, unit: 'MINUTES')
         buildDiscarder(logRotator(artifactDaysToKeepStr: '',
                 artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '100'))
     }
@@ -23,57 +23,107 @@ pipeline {
         LOGS_AND_CONFIGS="${WORKSPACE}/logs-and-configs"
     }
 
-    stages {
-        stage("Cleanup") {
-            steps {
-                script() {
-                    sh "/usr/local/bin/minikube delete || true"
-                }
-            }
-        }
+    parameters {
+        string(name: 'jenkinsNodeLabel',
+                defaultValue: 'minikube-rhel7-24gb',
+                description: 'Label of Jenkins node which will be used to run the tests')
 
+        string(name: 'ghprbPullId',
+                defaultValue: "master",
+                description: 'Tag of Che images')
+
+        string(name: 'ghprbSourceBranch',
+                defaultValue: "master",
+                description: 'Branch of Che to check')
+
+        string(name: 'e2eTestToRun',
+                defaultValue: "test-happy-path",
+                description: 'TypeScript E2E test to run')
+    }
+
+    stages {
         stage("Prepare to start Che on K8S") {
             failFast true
 
             parallel {
                 stage("Download chectl") {
                     steps {
-                        script {
-                            // TO-DO use option "--install-path" https://github.com/eclipse/che/pull/14182
-                            sh """
-                               curl -sL  https://www.eclipse.org/che/chectl/ > install_chectl.sh
-                               chmod +x install_chectl.sh
-                               sudo PATH=$PATH ./install_chectl.sh --channel=next
-                               sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
-                               sudo chmod +x ${WORKSPACE}/chectl
-                            """
-                        }
+                        // TO-DO use option "--install-path" https://github.com/eclipse/che/pull/14182
+                        sh """
+                           curl -sL  https://www.eclipse.org/che/chectl/ > install_chectl.sh
+                           chmod +x install_chectl.sh
+                           sudo PATH=$PATH ./install_chectl.sh --channel=next
+                           sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
+                           sudo chmod +x ${WORKSPACE}/chectl
+                        """
                     }
                 }
 
                 stage("Start Kubernetes") {
                     steps {
-                        script {
-                            sh """
-                              /usr/local/bin/minikube start \\
-                                --vm-driver=none \\
-                                --cpus 4 \\
-                                --memory 12288 \\
-                                --logtostderr
-                            
-                              sudo chmod g+r -R /home/codenvy/.minikube
-                              sudo chmod g+r -R /home/codenvy/.kube
-                              sudo chmod g+r /var/lib/kubeadm.yaml
-                            """
-                        }
+                        echo "Workaround k8s error https://github.com/eclipse/che/issues/14902"
+                        sh """
+                            cat /etc/sysctl.conf
+                            echo "net.bridge.bridge-nf-call-iptables = 1" | sudo tee -a /etc/sysctl.conf
+                            sudo sysctl -p
+                        """
+
+                        sh """
+                            # https://github.com/kubernetes/minikube/blob/master/docs/vmdriver-none.md
+                            export MINIKUBE_WANTUPDATENOTIFICATION=false
+                            export MINIKUBE_WANTREPORTERRORPROMPT=false
+                            export MINIKUBE_HOME=\$HOME
+                            export CHANGE_MINIKUBE_NONE_USER=true
+                            export KUBECONFIG=\$HOME/.kube/config
+                            export DOCKER_CONFIG=\$HOME/.docker
+
+                            mkdir -p \$HOME/.kube \$HOME/.minikube
+                            touch \$KUBECONFIG
+
+                            sudo -E /usr/local/bin/minikube start \\
+                            --vm-driver=none \\
+                            --cpus 4 \\
+                            --memory 13000 \\
+                            --logtostderr
+                        """
                     }
                 }
 
-                stage("Build Che") {
+                stage("Build Che including upstream projects") {
                     steps {
-                        script {
-                            sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
-                        }
+                        echo "Build branch ${ghprbSourceBranch} of upstream projects"
+                        sh """
+                            project_list=(
+                                eclipse/che-parent
+                                eclipse/che-docs
+                            )
+                            
+                            for project in \${project_list[@]};
+                            do
+                                result=\$(git ls-remote --heads https://github.com/\${project}.git ${ghprbSourceBranch})
+                                if [[ \$result == *"refs"* ]]; then
+                                    echo "[PRE-BUILD CHECK] found upstream project: \${project} with same branch name: ${ghprbSourceBranch}"
+                                    git clone -b ${ghprbSourceBranch} https://github.com/\${project} \${project}
+                                    mvn clean install -f ${WORKSPACE}/\${project}/pom.xml -Dmaven.repo.local=${WORKSPACE}/.repository
+                                else
+                                    echo "[PRE-BUILD CHECK] skip build upstream project: \$project, unable to find branch: ${ghprbSourceBranch}."
+                                fi
+                            done
+                        """
+
+                        echo "Build Che"
+                        sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
+                    }
+                }
+
+                stage("Download and patch Che custom-resource.yaml") {
+                    steps {
+                        sh """
+                            wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
+                            
+                            sed -i "s|cheImage: ''|cheImage: '${CHE_IMAGE_REPO}'|"
+                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${CHE_IMAGE_TAG}'|"
+                        """
                     }
                 }
             }
@@ -82,157 +132,142 @@ pipeline {
         stage("Push Che artifacts to docker.io") {
             steps {
                 withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
-                    script {
-                        sh """
-                          ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:${CHE_IMAGE_TAG} --dockerfile:Dockerfile
-                          docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-                          docker login -u maxura -p ${maxura_docker_password}
-                          docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-                        """
-                    }
+                    sh """
+                        ${WORKSPACE}/dockerfiles/che/build.sh --organization:maxura --tag:${CHE_IMAGE_TAG} --dockerfile:Dockerfile
+                        docker tag ${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG} docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                        docker login -u maxura -p ${maxura_docker_password}
+                        docker push docker.io/${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
+                    """
                 }
             }
         }
 
         stage("Start Single Che") {
             steps {
-                script {
-                    sh """
-                      ${WORKSPACE}/chectl server:start \\
-                        --k8spodreadytimeout=180000 \\
-                        -t=${WORKSPACE}/deploy/ \\
-                        --listr-renderer=verbose \\
-                        --platform=minikube \\
-                        --cheimage=${CHE_IMAGE_REPO}:${CHE_IMAGE_TAG}
-                    """
+                sh """
+                    ${WORKSPACE}/chectl server:start \\
+                    --k8spodreadytimeout=180000 \\
+                    --installer=operator \\
+                    --listr-renderer=verbose \\
+                    --platform=minikube \\
+                    --multiuser \\
+                    --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
+                """
 
-                    // wait che-server to be available
-                    sh """
-                         CHE_URL=\$(kubectl get ingress che-ingress -n=che -o=jsonpath={'.spec.rules[0].host'})
-                         
-                         COUNTER=0;
-                         SUCCESS_RATE_COUNTER=0;
-                         while true; do
-                          if [ \$COUNTER -gt 180 ]; then
-                          echo "Unable to get stable route. Exiting"
-                            exit 1
-                          fi
-                          
-                          ((COUNTER+=1))
-                          
-                          
-                          STATUS_CODE=\$(curl -sL -w "%{http_code}" -I \${CHE_URL} -o /dev/null; true) || true
-                          
-                          echo "Try \${COUNTER}. Status code: \${STATUS_CODE}"
-                          if [ "\$STATUS_CODE" == "200" ]; then 
-                            ((SUCCESS_RATE_COUNTER+=1))
-                          fi
-                          sleep 1;
-                        
-                          if [ \$SUCCESS_RATE_COUNTER == \$SUCCESS_THRESHOLD ]; then 
-                            echo "Route is stable enough. Continuing running tests"
-                            break
-                          fi
-                         done
-                    """
-                }
+                // wait che-server to be available
+                sh """
+                     CHE_URL=\$(kubectl get ingress che-ingress -n=che -o=jsonpath={'.spec.rules[0].host'})
+                     
+                     COUNTER=0;
+                     SUCCESS_RATE_COUNTER=0;
+                     while true; do
+                      if [ \$COUNTER -gt 180 ]; then
+                      echo "Unable to get stable route. Exiting"
+                        exit 1
+                      fi
+                      
+                      ((COUNTER+=1))
+                      
+                      
+                      STATUS_CODE=\$(curl -sL -w "%{http_code}" -I \${CHE_URL} -o /dev/null; true) || true
+                      
+                      echo "Try \${COUNTER}. Status code: \${STATUS_CODE}"
+                      if [ "\$STATUS_CODE" == "200" ]; then 
+                        ((SUCCESS_RATE_COUNTER+=1))
+                      fi
+                      sleep 1;
+                    
+                      if [ \$SUCCESS_RATE_COUNTER == \$SUCCESS_THRESHOLD ]; then 
+                        echo "Route is stable enough. Continuing running tests"
+                        break
+                      fi
+                     done
+                """
             }
         }
 
         stage("Create test workspace") {
             steps {
-                script {
-                    sh "${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL"
-                }
+                sh """
+                    KEYCLOAK_URL=\$(kubectl get ingress/keycloak -n che -o jsonpath='{.spec.rules[0].host}')
+                    KEYCLOAK_BASE_URL="http://\${KEYCLOAK_URL}/auth"
+
+                    USER_ACCESS_TOKEN=\$(curl -X POST \$KEYCLOAK_BASE_URL/realms/che/protocol/openid-connect/token \\
+                       -H "Content-Type: application/x-www-form-urlencoded" \\
+                       -d "username=admin" \\
+                       -d "password=admin" \\
+                       -d "grant_type=password" \\
+                       -d "client_id=che-public" | jq -r .access_token)
+
+                  ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_URL"
+                """
             }
         }
 
         stage("Run E2E Happy path tests") {
             steps {
-                script {
-                    sh """
-                         docker pull eclipse/che-e2e:nightly
-                         
-                         CHE_HOST=\$(kubectl get ingress che-ingress -n=che -o=jsonpath={'.spec.rules[0].host'})
-                         CHE_URL=http://\${CHE_HOST}
-                         docker run --shm-size=256m --net=host --ipc=host \\
-                           -e TS_SELENIUM_HEADLESS='true' \\
-                           -e TS_SELENIUM_DEFAULT_TIMEOUT=300000 \\
-                           -e TS_SELENIUM_LOAD_PAGE_TIMEOUT=240000 \\
-                           -e TS_SELENIUM_WORKSPACE_STATUS_POLLING=20000 \\
-                           -e TS_SELENIUM_BASE_URL=\${CHE_URL} \\
-                           -e TS_SELENIUM_LOG_LEVEL='DEBUG' \\
-                           -v ${WORKSPACE}/e2e:/tmp/e2e:Z \\
-                           eclipse/che-e2e:nightly
-                    """
-                }
+                sh """
+                     docker pull eclipse/che-e2e:nightly
+                     
+                     CHE_HOST=\$(kubectl get ingress che-ingress -n=che -o=jsonpath={'.spec.rules[0].host'})
+                     CHE_URL=http://\${CHE_HOST}
+                     docker run --shm-size=256m --net=host --ipc=host \\
+                       -e TS_SELENIUM_HEADLESS='true' \\
+                       -e TS_SELENIUM_DEFAULT_TIMEOUT=300000 \\
+                       -e TS_SELENIUM_LOAD_PAGE_TIMEOUT=240000 \\
+                       -e TS_SELENIUM_WORKSPACE_STATUS_POLLING=20000 \\
+                       -e TS_SELENIUM_BASE_URL=\${CHE_URL} \\
+                       -e TS_SELENIUM_LOG_LEVEL='DEBUG' \\
+                       -e TS_SELENIUM_MULTIUSER="true" \\
+                       -e TS_SELENIUM_USERNAME="admin" \\
+                       -e TS_SELENIUM_PASSWORD="admin" \\
+                       -e TEST_SUITE="${e2eTestToRun}" \\
+                       -v ${WORKSPACE}/e2e:/tmp/e2e:Z \\
+                       eclipse/che-e2e:nightly
+                """
             }
         }
     }
 
     post {
         failure {
-            script {
-                echo "Create screencast from $WORKSPACE/e2e/report/executionScreencast files."
-                sh """
-                    command -v ffmpeg >/dev/null 2>&1 && if ls $WORKSPACE/e2e/report/executionScreencast/*.png 1> /dev/null 2>&1; then
-                      cd $WORKSPACE/e2e/report/executionScreencast
+            echo "Create screencast from $WORKSPACE/e2e/report/executionScreencast files."
+            sh """
+                command -v ffmpeg >/dev/null 2>&1 && if ls $WORKSPACE/e2e/report/executionScreencast/*.png 1> /dev/null 2>&1; then
+                  cd $WORKSPACE/e2e/report/executionScreencast
 
-                      # remove first screenshot which has lower resolution 800x600 and breaks screencast video
-                      sudo rm -f 00100001* || true
-                      
-                      sudo ffmpeg -framerate 1 -pattern_type glob -i '*.png' -c:v libx264 -r 30 -pix_fmt yuv420p $WORKSPACE/e2e/report/screencast.mp4
-                      cd $WORKSPACE/e2e/report/
-                      sudo rm -rf $WORKSPACE/e2e/report/executionScreencast
-                    fi
-                """
-            }
+                  # remove first screenshot which has lower resolution 800x600 and breaks screencast video
+                  sudo rm -f 00100001* || true
+                  
+                  sudo ffmpeg -framerate 1 -pattern_type glob -i '*.png' -c:v libx264 -r 30 -pix_fmt yuv420p $WORKSPACE/e2e/report/screencast.mp4
+                  cd $WORKSPACE/e2e/report/
+                  sudo rm -rf $WORKSPACE/e2e/report/executionScreencast
+                fi
+            """
         }
 
         cleanup {
-            script {
-                sh """                      
-                      mkdir -p $LOGS_AND_CONFIGS/kubectl
-                      kubectl --namespace=che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
-
-                      mkdir -p $LOGS_AND_CONFIGS/che-config
-                      kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
-                      kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
-                      kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
-
-                      mkdir -p $LOGS_AND_CONFIGS/che-logs
-                      kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-server.log || true
-                      kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep devfile-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/devfile-registry.log || true
-                      kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep plugin-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/plugin-registry.log || true
-                        
-                      mkdir -p $LOGS_AND_CONFIGS/workspace-logs
-                      export WS_POD=\$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}')
-                      for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do kubectl logs \$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/workspace-logs/"\${c}"-container.log || true; done
-                      kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
-                """
-
-                sh """
-                      /usr/local/bin/minikube stop || true
+            sh """                      
+                  mkdir -p $LOGS_AND_CONFIGS/kubectl
+                  kubectl --namespace=che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
+    
+                  mkdir -p $LOGS_AND_CONFIGS/che-config
+                  kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
+                  kubectl get ingresses --namespace=che > $LOGS_AND_CONFIGS/che-config/ingresses.txt || true
+                  kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
+    
+                  mkdir -p $LOGS_AND_CONFIGS/che-logs
+                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-server.log || true
+                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep devfile-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/devfile-registry.log || true
+                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep plugin-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/plugin-registry.log || true
                     
-                      sudo umount \$(mount | grep "kubelet" | awk '{if(NR>0) print \$3}') || true
-                      sudo rm -rf `sudo find /tmp -name 'hostpath-provisioner' 2>/dev/null` || true
-                    
-                      docker volume rm \$(docker volume ls -q -f dangling=true) || true
-                      
-                      docker rm -f \$(sudo docker ps --all | awk 'NR>0 {print \$1;}') || true
-                      
-                      if [[ \$(docker images | grep '${CHE_IMAGE_REPO}') != "" ]]; then
-                        docker rmi -f \$(docker images | grep '${CHE_IMAGE_REPO}') || true
-                      fi
-                """
+                  mkdir -p $LOGS_AND_CONFIGS/workspace-logs
+                  export WS_POD=\$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}')
+                  for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do kubectl logs \$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/workspace-logs/"\${c}"-container.log || true; done
+                  kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
+            """
 
-                archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"
-
-                sh "sudo rm -rf ${WORKSPACE}/e2e"
-                sh "sudo rm -rf ${WORKSPACE}/logs-and-configs"
-            }
-
-            cleanWs notFailBuild: true, disableDeferredWipeout: true, deleteDirs: true
+            archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"
         }
 
     }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -123,21 +123,6 @@ pipeline {
                         sh "mvn clean install -f ${WORKSPACE}/pom.xml -T 4 -U -DskipTests -Dskip-enforce -Dskip-validate-sources"
                     }
                 }
-
-                stage("Download and patch Che custom-resource.yaml") {
-                    steps {
-                        sh """
-                            wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
-                            
-                            sed -i "s|cheImage: ''|cheImage: '${cheImageRepo}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                            sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${cheImageTag}'|" ${WORKSPACE}/org_v1_che_cr.yaml
-
-                            sed -i "s|cheLogLevel: INFO|cheLogLevel: DEBUG|" ${WORKSPACE}/org_v1_che_cr.yaml
-
-                            sed -i "s|ingressDomain: '192.168.99.101.nip.io'|ingressDomain: '\$(minikube ip).nip.io'|" ${WORKSPACE}/org_v1_che_cr.yaml
-                        """
-                    }
-                }
             }
         }
 
@@ -158,8 +143,21 @@ pipeline {
             }
         }
 
-        stage("Start Single Che") {
+        stage("Start Che") {
             steps {
+                echo "Download and patch Che custom-resource.yaml"
+                sh """
+                    wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml
+                    
+                    sed -i "s|cheImage: ''|cheImage: '${cheImageRepo}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                    sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${cheImageTag}'|" ${WORKSPACE}/org_v1_che_cr.yaml
+
+                    sed -i "s|cheLogLevel: INFO|cheLogLevel: DEBUG|" ${WORKSPACE}/org_v1_che_cr.yaml
+
+                    sed -i "s|ingressDomain: '192.168.99.101.nip.io'|ingressDomain: '\$(minikube ip).nip.io'|" ${WORKSPACE}/org_v1_che_cr.yaml
+                """
+
+                echo "Install Che"
                 sh """
                     ${WORKSPACE}/chectl server:start \\
                     --k8spodreadytimeout=180000 \\
@@ -169,7 +167,7 @@ pipeline {
                     --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
-                // wait che-server to be available
+                echo "Wait che-server to be available"
                 sh """
                      CHE_URL=\$(kubectl get ingress che -n=che -o=jsonpath={'.spec.rules[0].host'})
                      

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -256,21 +256,13 @@ pipeline {
                   kubectl get all -n che -o yaml > $LOGS_AND_CONFIGS/che-config/all.yaml || true
     
                   mkdir -p $LOGS_AND_CONFIGS/che-logs
-                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che- | grep -v "che-operator" | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-server.log || true
-                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep che-operator- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/che-operator.log || true
-                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep devfile-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/devfile-registry.log || true
-                  kubectl logs --namespace=che \$(kubectl get pods --namespace=che | grep plugin-registry- | awk {'print \$1'})>$LOGS_AND_CONFIGS/che-logs/plugin-registry.log || true
-                    
-                  mkdir -p $LOGS_AND_CONFIGS/workspace-logs
-                  export WS_POD=\$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}')
-                  for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do kubectl logs \$(kubectl get pod --namespace=che | grep  workspace | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/workspace-logs/"\${c}"-container.log || true; done
+                  export WS_POD=\$(kubectl get pod --namespace=che | awk '{print \$1}')
+                  for c in \$(kubectl get pod --namespace=che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do kubectl logs \$(kubectl get pod --namespace=che | awk '{print \$1}') "\${c}" -n che > $LOGS_AND_CONFIGS/che-logs/"\${c}"-pod.log || true; done
                   kubectl describe pod --namespace=che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
 
                   mkdir -p $LOGS_AND_CONFIGS/docker
                   docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
                   docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
-
-                  sleep 100000
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -1,7 +1,7 @@
 #!groovy
 
 pipeline {
-    agent { label "${jenkinsNodeLabel}" }
+    agent { label "minikube-rhel7-24gb" }
 
     options {
         timestamps()
@@ -24,10 +24,6 @@ pipeline {
     }
 
     parameters {
-        string(name: 'jenkinsNodeLabel',
-                defaultValue: 'minikube-rhel7-24gb',
-                description: 'Label of Jenkins node which will be used to run the tests')
-
         string(name: 'ghprbPullId',
                 defaultValue: "master",
                 description: 'Tag of Che images')

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
         buildDiscarder(logRotator(artifactDaysToKeepStr: '',
                 artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '100'))
     }
@@ -142,7 +142,7 @@ pipeline {
             steps {
                 sh """
                     ${WORKSPACE}/chectl server:start \\
-                    --k8spodreadytimeout=350000 \\
+                    --k8spodreadytimeout=800000 \\
                     --installer=operator \\
                     --listr-renderer=verbose \\
                     --platform=minikube \\

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -14,7 +14,6 @@ pipeline {
         PATH = "/tmp:/qa/tools/opt/apache-maven-3.5.4/bin:$PATH"
         JENKINS_BUILD = "true"
 
-        DEVFILE_PATH = "${WORKSPACE}/e2e/files/happy-path/happy-path-workspace.yaml"
         SUCCESS_THRESHOLD = 5
 
         LOGS_AND_CONFIGS="${WORKSPACE}/logs-and-configs"

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
         PATH = "/tmp:/qa/tools/opt/apache-maven-3.5.4/bin:$PATH"
         JENKINS_BUILD = "true"
 
+        DEVFILE_PATH = "${WORKSPACE}/e2e/files/happy-path/happy-path-workspace.yaml"
         SUCCESS_THRESHOLD = 5
 
         LOGS_AND_CONFIGS="${WORKSPACE}/logs-and-configs"
@@ -36,17 +37,9 @@ pipeline {
                 defaultValue: "test-happy-path",
                 description: 'TypeScript E2E test to run')
         
-        string(name: 'testWorkspaceDevfileUrl',
-                defaultValue: "https://raw.githubusercontent.com/eclipse/che/${ghprbSourceBranch}/e2e/files/happy-path/happy-path-workspace.yaml",
-                description: 'URL of devfile of test workspace')
-
-        string(name: 'cheCustomResourceUrl',
-                defaultValue: "http://raw.githubusercontent.com/eclipse/che-operator/${ghprbSourceBranch}/deploy/crds/org_v1_che_cr.yaml",
-                description: 'URL of Che custom resource yaml')
-
-        text(name: 'customResource',
-              description: 'Custom resource yaml content'
-        )
+        booleanParam(name: 'createTestWorkspace',
+                defaultValue: true,
+                description: 'Should create test workspace')
     }
 
     stages {
@@ -205,7 +198,7 @@ pipeline {
 
         stage("Create test workspace") {
             when {
-                expression { return params.testWorkspaceDevfileUrl != null && params.testWorkspaceDevfileUrl != "" }
+                expression { params.createTestWorkspace }
             }
 
             steps {
@@ -222,7 +215,7 @@ pipeline {
 
                     wget $testWorkspaceDevfileUrl -O ${WORKSPACE}/test-workspace-devfile.yaml
 
-                    ${WORKSPACE}/chectl workspace:start --devfile=${WORKSPACE}/test-workspace-devfile.yaml --access-token "\$USER_ACCESS_TOKEN"
+                    ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_PATH --access-token "\$USER_ACCESS_TOKEN"
                 """
             }
         }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -213,8 +213,6 @@ pipeline {
                        -d "grant_type=password" \\
                        -d "client_id=che-public" | jq -r .access_token)
 
-                    wget $testWorkspaceDevfileUrl -O ${WORKSPACE}/test-workspace-devfile.yaml
-
                     ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_PATH --access-token "\$USER_ACCESS_TOKEN"
                 """
             }

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -163,10 +163,15 @@ pipeline {
                     --che-operator-cr-yaml=${WORKSPACE}/org_v1_che_cr.yaml
                 """
 
+                script {
+                    cheHost = sh(
+                            script: "kubectl get ingress che -n=che -o=jsonpath={'.spec.rules[0].host'}",
+                            returnStdout: true
+                    ).trim()
+                }
+
                 echo "Wait che-server to be available"
                 sh """
-                     CHE_URL=\$(kubectl get ingress che -n=che -o=jsonpath={'.spec.rules[0].host'})
-                     
                      COUNTER=0;
                      SUCCESS_RATE_COUNTER=0;
                      while true; do
@@ -178,7 +183,7 @@ pipeline {
                       ((COUNTER+=1))
                       
                       
-                      STATUS_CODE=\$(curl -sL -w "%{http_code}" -I \${CHE_URL} -o /dev/null; true) || true
+                      STATUS_CODE=\$(curl -sL -w "%{http_code}" -I ${cheHost} -o /dev/null; true) || true
                       
                       echo "Try \${COUNTER}. Status code: \${STATUS_CODE}"
                       if [ "\$STATUS_CODE" == "200" ]; then 
@@ -226,8 +231,7 @@ pipeline {
                 sh """
                      docker pull eclipse/che-e2e:nightly
                      
-                     CHE_HOST=\$(kubectl get ingress che -n=che -o=jsonpath={'.spec.rules[0].host'})
-                     CHE_URL=http://\${CHE_HOST}
+                     CHE_URL=http://${cheHost}
                      docker run --shm-size=256m --net=host --ipc=host \\
                        -e TS_SELENIUM_HEADLESS='true' \\
                        -e TS_SELENIUM_DEFAULT_TIMEOUT=300000 \\

--- a/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/e2e/jenkins/crw-ci/pr-check/k8s/Jenkinsfile
@@ -37,9 +37,9 @@ pipeline {
                 defaultValue: "test-happy-path",
                 description: 'TypeScript E2E test to run')
         
-        booleanParam(name: 'createTestWorkspace',
-                defaultValue: true,
-                description: 'Should create test workspace')
+        string(name: 'testWorkspaceDevfileUrl',
+                defaultValue: "https://raw.githubusercontent.com/eclipse/che/${ghprbSourceBranch}/e2e/files/happy-path/happy-path-workspace.yaml",
+                description: 'URL of devfile of test workspace')
     }
 
     stages {
@@ -198,11 +198,13 @@ pipeline {
 
         stage("Create test workspace") {
             when {
-                expression { params.createTestWorkspace }
+                expression { return testWorkspaceDevfileUrl != null && testWorkspaceDevfileUrl != "" }
             }
 
             steps {
                 sh """
+                    wget $testWorkspaceDevfileUrl -O ${WORKSPACE}/test-workspace-devfile.yaml
+
                     KEYCLOAK_URL=\$(kubectl get ingress/keycloak -n che -o jsonpath='{.spec.rules[0].host}')
                     KEYCLOAK_BASE_URL="http://\${KEYCLOAK_URL}/auth"
 
@@ -213,7 +215,9 @@ pipeline {
                        -d "grant_type=password" \\
                        -d "client_id=che-public" | jq -r .access_token)
 
-                    ${WORKSPACE}/chectl workspace:start --devfile=$DEVFILE_PATH --access-token "\$USER_ACCESS_TOKEN"
+                    ${WORKSPACE}/chectl workspace:start \\
+                       --devfile=${WORKSPACE}/test-workspace-devfile.yaml \\
+                       --access-token "\$USER_ACCESS_TOKEN"
                 """
             }
         }
@@ -268,7 +272,7 @@ pipeline {
                 mkdir -p $LOGS_AND_CONFIGS/che-config
 
                 cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
-                cp ${WORKSPACE}/test-workspace-devfile.yaml $LOGS_AND_CONFIGS/che-config || true
+                cp ${WORKSPACE}/test-workspace-devfile.yaml $LOGS_AND_CONFIGS || true
 
                 kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml || true
                 kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
@@ -293,7 +297,8 @@ pipeline {
                 docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true
                 docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
 
-                env
+                env > $LOGS_AND_CONFIGS/env.output.txt || true
+                ${WORKSPACE}/chectl --help > $LOGS_AND_CONFIGS/chectl.version.txt || true
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "e2e/report/**, logs-and-configs/**"


### PR DESCRIPTION
### What does this PR do?

1) Build upstream projects che-parent, che-docs.
2) Build on upstream slave instead of cloud-slave9.
3) Apply workaround to start K8S issue #14902. 
4) Start and test Multiuser Che assembly.
5) Add next parameters to make it possible to reuse pipeline in nightly and pre-release testing jobs: 
- `cheImageRepo` - Repo of Che server image
- `cheImageTag` - Tag of Che server image
- `buildChe` - to turn off building of Che 
- `e2eTestToRun` - test suite to be run
- `createTestWorkspace` - to turn off creation of test workspace

### What issues does this PR fix or reference?
#14902, #14941, #13473, #15284, #15291