### PR TITLE
 Fix TypeScript DTO generator

### DIFF
--- a/core/che-core-typescript-dto-maven-plugin/pom.xml
+++ b/core/che-core-typescript-dto-maven-plugin/pom.xml
@@ -204,6 +204,7 @@
                                     <goal>test</goal>
                                 </goals>
                                 <configuration>
+                                    <forkCount>0</forkCount>
                                     <systemPropertyVariables>
                                         <buildDirectory>${project.build.directory}</buildDirectory>
                                     </systemPropertyVariables>

--- a/core/che-core-typescript-dto-maven-plugin/src/it/resources/dto.spec.ts
+++ b/core/che-core-typescript-dto-maven-plugin/src/it/resources/dto.spec.ts
@@ -121,6 +121,10 @@ describe("DTO serialization tests", () => {
         expect(customDto.customMap["bar"].name).to.eql("foo");
     });
 
+    it("check Serializable type", () => {
+        const customDto: che.plugin.typescript.MyDtoWithSerializable = {
 
+        };
+    });
 
 });

--- a/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/main/java/org/eclipse/che/plugin/typescript/dto/DTOHelper.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.plugin.typescript.dto;
 
+import java.io.Serializable;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
@@ -139,6 +140,8 @@ public class DTOHelper {
       return "number";
     } else if (Boolean.class.equals(type) || Boolean.TYPE.equals(type)) {
       return "boolean";
+    } else if (Serializable.class.equals(type)) {
+      return "string | number | boolean";
     }
 
     return type.getTypeName();
@@ -210,6 +213,8 @@ public class DTOHelper {
       return "number";
     } else if (Boolean.class.equals(type) || Boolean.TYPE.equals(type)) {
       return "boolean";
+    } else if (Serializable.class.equals(type)) {
+      return "string | number | boolean";
     }
 
     String declarationPackage = convertToDTSPackageName((Class) containerType);

--- a/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MyDtoWithSerializableDTO.java
+++ b/core/che-core-typescript-dto-maven-plugin/src/test/java/org/eclipse/che/plugin/typescript/dto/MyDtoWithSerializableDTO.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.plugin.typescript.dto;
+
+import java.io.Serializable;
+import java.util.Map;
+import org.eclipse.che.dto.shared.DTO;
+
+@DTO
+public interface MyDtoWithSerializableDTO {
+  Map<String, Serializable> getPreferences();
+
+  void setPreferences(Map<String, Serializable> preferences);
+}

--- a/typescript-dto/build.sh
+++ b/typescript-dto/build.sh
@@ -12,6 +12,8 @@
 set -e
 set -u
 
+rm -f ./index.d.ts
+
 docker run -i --rm -v "$HOME/.m2:/root/.m2" \
                    -v "$(pwd)/dto-pom.xml:/usr/src/mymaven/pom.xml" \
                    -w /usr/src/mymaven maven:3.3-jdk-8 \

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/CommandDto.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/dto/CommandDto.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.api.core.factory.FactoryParameter.Obligation.OPTIO
 import java.util.Map;
 import org.eclipse.che.api.core.factory.FactoryParameter;
 import org.eclipse.che.api.core.model.workspace.config.Command;
+import org.eclipse.che.api.workspace.shared.dto.devfile.PreviewUrlDto;
 import org.eclipse.che.dto.shared.DTO;
 
 /** @author Alexander Garagatyi */
@@ -54,4 +55,11 @@ public interface CommandDto extends Command {
   void setAttributes(Map<String, String> attributes);
 
   CommandDto withAttributes(Map<String, String> attributes);
+
+  @Override
+  PreviewUrlDto getPreviewUrl();
+
+  void setPreviewUrl(PreviewUrlDto previewUrl);
+
+  CommandDto withPreviewUrl(PreviewUrlDto previewUrl);
 }


### PR DESCRIPTION
### What does this PR do?
This PR do next:

- Fix generation of TypeScript interface if original Java interface has `java.io. Serializable` as parameter or field type. All `java.io. Serializable` converted as `string | number | boolean` union type.
- Adds `getPreviewUrl` method in `CommandDto` interface. 

### What issues does this PR fix or reference?
#14756
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
