### PR TITLE
Add an ability to configure PVC strategy with helm chart

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -53,7 +53,7 @@ data:
   CHE_INFRA_KUBERNETES_NAMESPACE_DEFAULT: {{ .Values.global.cheWorkspacesNamespace | quote}}
   CHE_INFRA_KUBERNETES_SERVICE__ACCOUNT__NAME: {{ .Values.global.cheWorkspaceServiceAccount }}
   CHE_INFRA_KUBERNETES_TRUST__CERTS: "false"
-  CHE_INFRA_KUBERNETES_PVC_STRATEGY: "common"
+  CHE_INFRA_KUBERNETES_PVC_STRATEGY: "{{ .Values.global.cheWorkspacesPVCStrategy }}"
   CHE_INFRA_KUBERNETES_PVC_QUANTITY: {{ .Values.global.pvcClaim }}
   CHE_INFRA_KUBERNETES_PVC_PRECREATE__SUBPATHS: "true"
   CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_RUN__AS__USER: "{{ .Values.global.securityContext.runAsUser }}"

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -52,6 +52,8 @@ global:
 
   gitHubClientID: ""
   gitHubClientSecret: ""
+  # Possible values: common, per-workspace, unique
+  cheWorkspacesPVCStrategy: "common"
   pvcClaim: "1Gi"
   cheWorkspacesNamespace: "<username>-che"
   # Service account name that will be mounted to workspaces pods


### PR DESCRIPTION
### What does this PR do?
I've discovered that helm chart has hard-coded common PVC strategy.
I don't see any reason why we have to prevent users to configure PVC strategy with helm chart while we have such an ability with other installations methods like che-operator.

### What issues does this PR fix or reference?
https://github.com/eclipse/che-docs/pull/901 depends on this PR.

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->

#### Release Notes
N/A


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
