### PR TITLE
Use nightly che-machine-exec tag instead of deprecated next.

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -551,7 +551,7 @@ che.cors.allow_credentials=false
 che.factory.default_editor=eclipse/che-theia/next
 # multiple plugins must be comma-separated, for example:
 # pluginFooPublisher/pluginFooName/pluginFooVersion,pluginBarPublisher/pluginBarName/pluginBarVersion
-che.factory.default_plugins=eclipse/che-machine-exec-plugin/next
+che.factory.default_plugins=eclipse/che-machine-exec-plugin/nightly
 
 ## Devfile settings
 
@@ -568,4 +568,4 @@ che.workspace.devfile.default_editor=eclipse/che-theia/next
 # the same as the default one (even if in different version).
 # Format is comma-separated `pluginPublisher/pluginName/pluginVersion` values, for example
 # eclipse/che-theia-exec-plugin/0.0.1,eclipse/che-theia-terminal-plugin/0.0.1
-che.workspace.devfile.default_editor.plugins=eclipse/che-machine-exec-plugin/next
+che.workspace.devfile.default_editor.plugins=eclipse/che-machine-exec-plugin/nightly


### PR DESCRIPTION
### What does this PR do?
Use nightly che-machine-exec tag instead of deprecated next.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14887

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>