### PR TITLE
[Workspace Loader] Add missing async keyword

### DIFF
--- a/workspace-loader/src/workspace-loader.ts
+++ b/workspace-loader/src/workspace-loader.ts
@@ -305,7 +305,7 @@ export class WorkspaceLoader {
         }, 100);
     }
 
-    setAuthorizationHeader(xhr: XMLHttpRequest): Promise<XMLHttpRequest> {
+    async setAuthorizationHeader(xhr: XMLHttpRequest): Promise<XMLHttpRequest> {
         return new Promise((resolve, reject) => {
             if (this.keycloak && this.keycloak.token) {
                 this.keycloak.updateToken(5).success(() => {


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds missing `async` keyword into `setAuthorizationHeader` method in workspace loader.
