### PR TITLE
CHE-14398: Copy SSH keys with proper permissions

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeysProvisioner.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
+import javax.inject.Named;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.api.core.ConflictException;
 import org.eclipse.che.api.core.ServerException;
@@ -90,10 +91,13 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
   private static final Logger LOG = LoggerFactory.getLogger(VcsSshKeysProvisioner.class);
 
   private final SshManager sshManager;
+  private String jobImage;
 
   @Inject
-  public VcsSshKeysProvisioner(SshManager sshManager) {
+  public VcsSshKeysProvisioner(
+      SshManager sshManager, @Named("che.infra.kubernetes.pvc.jobs.image") String jobImage) {
     this.sshManager = sshManager;
+    this.jobImage = jobImage;
   }
 
   @Override
@@ -233,7 +237,7 @@ public class VcsSshKeysProvisioner implements ConfigurationProvisioner<Kubernete
     Container initContainer =
         new ContainerBuilder()
             .withName("ssh-private-keys-modifier")
-            .withImage("centos:centos7")
+            .withImage(jobImage)
             .withVolumeMounts(sshKeysVolumeMount, copiedSshKeysVolumeMount)
             .withCommand(
                 asList(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -68,6 +68,8 @@ public class VcsSshKeySecretProvisionerTest {
 
   private final String someUser = "someuser";
 
+  private final String jobImage = "centos:centos7";
+
   private VcsSshKeysProvisioner vcsSshKeysProvisioner;
 
   @BeforeMethod
@@ -85,7 +87,7 @@ public class VcsSshKeySecretProvisionerTest {
     when(podSpec.getSecurityContext()).thenReturn(podSecurityContext);
     when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
     k8sEnv.addPod(pod);
-    vcsSshKeysProvisioner = new VcsSshKeysProvisioner(sshManager);
+    vcsSshKeysProvisioner = new VcsSshKeysProvisioner(sshManager, jobImage);
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSshKeySecretProvisionerTest.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodSecurityContext;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.Secret;
 import java.util.ArrayList;
@@ -61,6 +62,8 @@ public class VcsSshKeySecretProvisionerTest {
 
   @Mock private PodSpec podSpec;
 
+  @Mock private PodSecurityContext podSecurityContext;
+
   @Mock private Container container;
 
   private final String someUser = "someuser";
@@ -77,6 +80,9 @@ public class VcsSshKeySecretProvisionerTest {
     when(pod.getSpec()).thenReturn(podSpec);
     when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
     when(podSpec.getContainers()).thenReturn(Collections.singletonList(container));
+    when(podSecurityContext.getFsGroup()).thenReturn((long) 999);
+    when(podSecurityContext.getRunAsUser()).thenReturn((long) 999);
+    when(podSpec.getSecurityContext()).thenReturn(podSecurityContext);
     when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
     k8sEnv.addPod(pod);
     vcsSshKeysProvisioner = new VcsSshKeysProvisioner(sshManager);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
The OpenSSH daemon requires 600 file mode access permissions for private keys.
Mounted keys have 640 permissions despite setting `DefaultMode` to 600.
As a workaround add an init container and set a command that copies the SSH keys to mounted to all workspace pod containers and manually set them needed permissions.

### What issues does this PR fix or reference?
#14398 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
