### PR TITLE
Use che-plugin-broker images 0.24

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -625,8 +625,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.22
-che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.22
+che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.24
+che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.24
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
### What does this PR do?

Use che-plugin-broker images 0.24 to don't override entrypoint for remote plugin endpoint binary.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13387
https://github.com/eclipse/che/issues/15099

#### Docs PR
https://github.com/eclipse/che-docs/pull/879


Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>