### PR TITLE
Publish PluginBroker pod events as runtime log

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeLogsPublisher.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeLogsPublisher.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import java.util.Set;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.event.PodEventHandler;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.RuntimeEventsPublisher;
+
+/** Listens pod events and publish them as runtime logs. */
+public class RuntimeLogsPublisher implements PodEventHandler {
+
+  private final RuntimeEventsPublisher eventPublisher;
+  private final RuntimeIdentity runtimeIdentity;
+  private final Set<String> pods;
+
+  public RuntimeLogsPublisher(
+      RuntimeEventsPublisher eventPublisher, RuntimeIdentity runtimeIdentity, Set<String> pods) {
+    this.eventPublisher = eventPublisher;
+    this.pods = pods;
+    this.runtimeIdentity = runtimeIdentity;
+  }
+
+  @Override
+  public void handle(PodEvent event) {
+    final String podName = event.getPodName();
+    if (pods.contains(podName)) {
+      eventPublisher.sendRuntimeLogEvent(
+          event.getMessage(), event.getCreationTimeStamp(), runtimeIdentity);
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/RuntimeEventsPublisher.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/RuntimeEventsPublisher.java
@@ -94,6 +94,14 @@ public class RuntimeEventsPublisher {
             .withTime(time));
   }
 
+  public void sendRuntimeLogEvent(String text, String time, RuntimeIdentity runtimeId) {
+    eventService.publish(
+        DtoFactory.newDto(RuntimeLogEvent.class)
+            .withRuntimeId(DtoConverter.asDto(runtimeId))
+            .withText(text)
+            .withTime(time));
+  }
+
   public void sendAbnormalStoppedEvent(RuntimeIdentity runtimeId, String reason) {
     eventService.publish(new RuntimeAbnormalStoppedEvent(runtimeId, reason));
   }


### PR DESCRIPTION
### What does this PR do?
Publish PluginBroker pod events as runtime log.
See gifs instead of reading =)
**Factory accepting**:
![factory](https://user-images.githubusercontent.com/5887312/68930587-612cbf00-0797-11ea-90b0-c9329044bae9.gif)

**Workspace start**:
![workspace_start](https://user-images.githubusercontent.com/5887312/68930588-61c55580-0797-11ea-9ff2-a59f05241516.gif)


### What issues does this PR fix or reference?
#14854 

#### Release Notes
N/A

#### Docs PR
N/A