### PR TITLE
Statistic from PostgreSQL database

### DIFF
--- a/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/DbTablesMetrics.java
+++ b/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/DbTablesMetrics.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.core.metrics;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.db.DatabaseTableMetrics;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.sql.DataSource;
+
+@Singleton
+public class DbTablesMetrics implements MeterBinder {
+
+  @Inject
+  public DbTablesMetrics(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  private final DataSource dataSource;
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    try (Connection connection = dataSource.getConnection()) {
+      DatabaseMetaData md = connection.getMetaData();
+      try (ResultSet rs = md.getTables(null, null, "%", null)) {
+        while (rs.next()) {
+          String tableName = rs.getString(3);
+          if (!tableName.startsWith("pg_")) {
+            DatabaseTableMetrics.monitor(registry, rs.getString(3), "che-datasource", dataSource);
+          }
+        }
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/MetricsModule.java
+++ b/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/MetricsModule.java
@@ -55,5 +55,6 @@ public class MetricsModule extends AbstractModule {
     meterMultibinder.addBinding().to(ApiResponseCounter.class);
     meterMultibinder.addBinding().to(ProcessMemoryMetrics.class);
     meterMultibinder.addBinding().to(ProcessThreadMetrics.class);
+    meterMultibinder.addBinding().toProvider(PostgreSQLDatabaseMetricsProvider.class);
   }
 }

--- a/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/MetricsModule.java
+++ b/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/MetricsModule.java
@@ -55,6 +55,7 @@ public class MetricsModule extends AbstractModule {
     meterMultibinder.addBinding().to(ApiResponseCounter.class);
     meterMultibinder.addBinding().to(ProcessMemoryMetrics.class);
     meterMultibinder.addBinding().to(ProcessThreadMetrics.class);
+    meterMultibinder.addBinding().to(DbTablesMetrics.class);
     meterMultibinder.addBinding().toProvider(PostgreSQLDatabaseMetricsProvider.class);
   }
 }

--- a/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/PostgreSQLDatabaseMetricsProvider.java
+++ b/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/PostgreSQLDatabaseMetricsProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.core.metrics;
+
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.db.PostgreSQLDatabaseMetrics;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class PostgreSQLDatabaseMetricsProvider implements Provider<MeterBinder> {
+  private final PostgreSQLDatabaseMetrics postgreSQLDatabaseMetrics;
+
+  @Inject
+  public PostgreSQLDatabaseMetricsProvider(DataSource dataSource) {
+    try (Connection connection = dataSource.getConnection()) {
+      this.postgreSQLDatabaseMetrics = new PostgreSQLDatabaseMetrics(dataSource, connection.getCatalog());
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public PostgreSQLDatabaseMetrics get() {
+    return postgreSQLDatabaseMetrics;
+  }
+}

--- a/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/PostgreSQLDatabaseMetricsProvider.java
+++ b/core/che-core-metrics-core/src/main/java/org/eclipse/che/core/metrics/PostgreSQLDatabaseMetricsProvider.java
@@ -14,14 +14,11 @@ package org.eclipse.che.core.metrics;
 import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.core.instrument.binder.db.PostgreSQLDatabaseMetrics;
 import java.sql.Connection;
-import java.sql.DatabaseMetaData;
 import java.sql.SQLException;
 import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import javax.sql.DataSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Singleton
 public class PostgreSQLDatabaseMetricsProvider implements Provider<MeterBinder> {
@@ -30,7 +27,8 @@ public class PostgreSQLDatabaseMetricsProvider implements Provider<MeterBinder> 
   @Inject
   public PostgreSQLDatabaseMetricsProvider(DataSource dataSource) {
     try (Connection connection = dataSource.getConnection()) {
-      this.postgreSQLDatabaseMetrics = new PostgreSQLDatabaseMetrics(dataSource, connection.getCatalog());
+      this.postgreSQLDatabaseMetrics =
+          new PostgreSQLDatabaseMetrics(dataSource, connection.getCatalog());
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### What does this PR do?
Statistic from PostgreSQL database
```
# HELP postgres_transactions_total Total number of transactions executed (commits + rollbacks)
# TYPE postgres_transactions_total counter
postgres_transactions_total{database="dbche",} 18859.0
# HELP postgres_rows_deleted_total Number of rows deleted from the db
# TYPE postgres_rows_deleted_total counter
postgres_rows_deleted_total{database="dbche",} 3032.0
# HELP postgres_buffers_backend_total Number of buffers written directly by a backend
# TYPE postgres_buffers_backend_total counter
postgres_buffers_backend_total{database="dbche",} 2660.0
# HELP postgres_temp_writes_bytes_total The total amount of temporary writes to disk to execute queries
# TYPE postgres_temp_writes_bytes_total counter
postgres_temp_writes_bytes_total{database="dbche",} 0.0
# HELP postgres_checkpoints_timed_total Number of checkpoints timed
# TYPE postgres_checkpoints_timed_total counter
postgres_checkpoints_timed_total{database="dbche",} 24.0
# HELP postgres_rows_inserted_total Number of rows inserted from the db
# TYPE postgres_rows_inserted_total counter
postgres_rows_inserted_total{database="dbche",} 7918.0
# HELP postgres_rows_dead Total number of dead rows in the current database
# TYPE postgres_rows_dead gauge
postgres_rows_dead{database="dbche",} 0.0
# HELP postgres_blocks_reads_total Number of disk blocks read in this database
# TYPE postgres_blocks_reads_total counter
postgres_blocks_reads_total{database="dbche",} 965.0
# HELP postgres_blocks_hits_total Number of times disk blocks were found already in the buffer cache, so that a read was not necessary
# TYPE postgres_blocks_hits_total counter
postgres_blocks_hits_total{database="dbche",} 253592.0
# HELP postgres_connections Number of active connections to the given db
# TYPE postgres_connections gauge
postgres_connections{database="dbche",} 2.0
# HELP postgres_buffers_checkpoint_total Number of buffers written during checkpoints
# TYPE postgres_buffers_checkpoint_total counter
postgres_buffers_checkpoint_total{database="dbche",} 1879.0
# HELP postgres_locks Number of locks on the given db
# TYPE postgres_locks gauge
postgres_locks{database="dbche",} 1.0
# HELP postgres_buffers_clean_total Number of buffers written by the background writer
# TYPE postgres_buffers_clean_total counter
postgres_buffers_clean_total{database="dbche",} 0.0
# HELP postgres_rows_fetched_total Number of rows fetched from the db
# TYPE postgres_rows_fetched_total counter
postgres_rows_fetched_total{database="dbche",} 93363.0
# HELP postgres_size The database size
# TYPE postgres_size gauge
postgres_size{database="dbche",} 1.1606552E7
# HELP postgres_rows_updated_total Number of rows updated from the db
# TYPE postgres_rows_updated_total counter
postgres_rows_updated_total{database="dbche",} 2265.0
# HELP postgres_checkpoints_requested_total Number of checkpoints requested
# TYPE postgres_checkpoints_requested_total counter
postgres_checkpoints_requested_total{database="dbche",} 4.0
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13223
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a


#### Docs PR
n/a
