### PR TITLE
Support git operation for repos with self-signed SSL certs

### DIFF
--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -72,6 +72,25 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+
+
+        # If git-self-signed-cert is used then configure Che Server with certificate content
+        # to propagate it to the specified location and provide particular configuration for Git service
+        {{- if .Values.global.useGitSelfSignedCerts }}
+        - name: CHE_GIT_SELF__SIGNED__CERT
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Values.global.cheGitSelfSignedCertConfigMapName }}
+              key: ca.crt
+              optional: false
+        - name: CHE_GIT_SELF__SIGNED__CERT__HOST
+          valueFrom:
+            configMapKeyRef:
+              name: {{ .Values.global.cheGitSelfSignedCertConfigMapName }}
+              key: githost
+              optional: false
+        {{- end }}
+
         {{- if .Values.global.tls.enabled }}
 
         # If self-signed-cert is used then configure Che Server with certificate content

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -50,6 +50,13 @@ global:
     useSelfSignedCerts: false
     selfSignedCertSecretName: self-signed-cert
 
+
+  ## If using git self-signed certificate is enabled
+  ## then certificate from `cheGitSelfSignedCertConfigMapName` will be propagated to Che components'
+  ## and provide particular configuration for Git
+  useGitSelfSignedCerts: true
+  cheGitSelfSignedCertConfigMapName: che-git-self-signed-cert
+
   gitHubClientID: ""
   gitHubClientSecret: ""
   pvcClaim: "1Gi"

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -54,7 +54,7 @@ global:
   ## If using git self-signed certificate is enabled
   ## then certificate from `cheGitSelfSignedCertConfigMapName` will be propagated to Che components'
   ## and provide particular configuration for Git
-  useGitSelfSignedCerts: true
+  useGitSelfSignedCerts: false
   cheGitSelfSignedCertConfigMapName: che-git-self-signed-cert
 
   gitHubClientID: ""

--- a/deploy/openshift/templates/che-server-template.yaml
+++ b/deploy/openshift/templates/che-server-template.yaml
@@ -159,6 +159,18 @@ objects:
                 key: ca.crt
                 name: self-signed-certificate
                 optional: true
+          - name: CHE_GIT_SELF__SIGNED__CERT
+            valueFrom:
+              configMapKeyRef:
+                name: che-git-self-signed-cert
+                key: ca.crt
+                optional: true
+          - name: CHE_GIT_SELF__SIGNED__CERT__HOST
+            valueFrom:
+              configMapKeyRef:
+                name: che-git-self-signed-cert
+                key: githost
+                optional: true
           - name: CHE_WORKSPACE_PLUGIN__REGISTRY__URL
             value: "${CHE_WORKSPACE_PLUGIN__REGISTRY__URL}"
           - name: CHE_WORKSPACE_DEVFILE__REGISTRY__URL

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
@@ -21,7 +21,7 @@ import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitUserProfileProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ImagePullSecretProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.IngressTlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner;
@@ -31,6 +31,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SecurityCon
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSshKeysProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitRequestProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
@@ -73,8 +74,9 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
     private final ServiceAccountProvisioner serviceAccountProvisioner;
     private final CertificateProvisioner certificateProvisioner;
     private final VcsSshKeysProvisioner vcsSshKeysProvisioner;
-    private final GitUserProfileProvisioner gitUserProfileProvisioner;
+    private final GitConfigProvisioner gitConfigProvisioner;
     private final PreviewUrlExposer<KubernetesEnvironment> previewUrlExposer;
+    private final VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
 
     @Inject
     public KubernetesEnvironmentProvisionerImpl(
@@ -94,8 +96,9 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
         ServiceAccountProvisioner serviceAccountProvisioner,
         CertificateProvisioner certificateProvisioner,
         VcsSshKeysProvisioner vcsSshKeysProvisioner,
-        GitUserProfileProvisioner gitUserProfileProvisioner,
-        PreviewUrlExposer<KubernetesEnvironment> previewUrlExposer) {
+        GitConfigProvisioner gitConfigProvisioner,
+        PreviewUrlExposer<KubernetesEnvironment> previewUrlExposer,
+        VcsSslCertificateProvisioner vcsSslCertificateProvisioner) {
       this.pvcEnabled = pvcEnabled;
       this.volumesStrategy = volumesStrategy;
       this.uniqueNamesProvisioner = uniqueNamesProvisioner;
@@ -112,7 +115,8 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
       this.serviceAccountProvisioner = serviceAccountProvisioner;
       this.certificateProvisioner = certificateProvisioner;
       this.vcsSshKeysProvisioner = vcsSshKeysProvisioner;
-      this.gitUserProfileProvisioner = gitUserProfileProvisioner;
+      this.vcsSslCertificateProvisioner = vcsSslCertificateProvisioner;
+      this.gitConfigProvisioner = gitConfigProvisioner;
       this.previewUrlExposer = previewUrlExposer;
     }
 
@@ -152,7 +156,8 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
       serviceAccountProvisioner.provision(k8sEnv, identity);
       certificateProvisioner.provision(k8sEnv, identity);
       vcsSshKeysProvisioner.provision(k8sEnv, identity);
-      gitUserProfileProvisioner.provision(k8sEnv, identity);
+      vcsSslCertificateProvisioner.provision(k8sEnv, identity);
+      gitConfigProvisioner.provision(k8sEnv, identity);
       LOG.debug("Provisioning Kubernetes environment done for workspace '{}'", workspaceId);
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSslCertificateProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSslCertificateProvisioner.java
@@ -75,9 +75,9 @@ public class VcsSslCertificateProvisioner
   }
 
   /**
-   * Return given in configuration git server host.
+   * Return given in configuration git server host (e.g. 110.23.0.1:3000).
    *
-   * @return git server host for git config it configured
+   * @return git server host for git config if it configured in che.git.self_signed_cert_host
    */
   public String getGitServerHost() {
     return host;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSslCertificateProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSslCertificateProvisioner.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Collections.singletonMap;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.inject.Inject;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import java.util.Optional;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+
+/**
+ * Mount configured self-signed certificate for git provider as file in each workspace machines if
+ * configured.
+ *
+ * @author Vitalii Parfonov
+ */
+@Singleton
+public class VcsSslCertificateProvisioner
+    implements ConfigurationProvisioner<KubernetesEnvironment> {
+  static final String CHE_GIT_SELF_SIGNED_CERT_CONFIG_MAP_SUFFIX = "-che-git-self-signed-cert";
+  static final String CHE_GIT_SELF_SIGNED_VOLUME = "che-git-self-signed-cert";
+  static final String CERT_MOUNT_PATH = "/etc/che/git/cert/";
+  static final String CA_CERT_FILE = "ca.crt";
+
+  @Inject(optional = true)
+  @Named("che.git.self_signed_cert")
+  private String certificate;
+
+  @Inject(optional = true)
+  @Named("che.git.self_signed_cert_host")
+  private String host;
+
+  public VcsSslCertificateProvisioner() {}
+
+  @VisibleForTesting
+  VcsSslCertificateProvisioner(String certificate, String host) {
+    this.certificate = certificate;
+    this.host = host;
+  }
+
+  /**
+   * @return true only if system configured for using self-signed certificate fot https git
+   *     operation
+   */
+  public boolean isConfigured() {
+    return !isNullOrEmpty(certificate);
+  }
+
+  /** @return path to the certificate file */
+  public String getCertPath() {
+    return CERT_MOUNT_PATH + CA_CERT_FILE;
+  }
+
+  /**
+   * Return given in configuration git server host.
+   *
+   * @return git server host for git config it configured
+   */
+  public String getGitServerHost() {
+    return host;
+  }
+
+  @Override
+  public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+    if (!isConfigured()) {
+      return;
+    }
+    String selfSignedCertConfigMapName =
+        identity.getWorkspaceId() + CHE_GIT_SELF_SIGNED_CERT_CONFIG_MAP_SUFFIX;
+    k8sEnv
+        .getConfigMaps()
+        .put(
+            selfSignedCertConfigMapName,
+            new ConfigMapBuilder()
+                .withNewMetadata()
+                .withName(selfSignedCertConfigMapName)
+                .endMetadata()
+                .withData(singletonMap(CA_CERT_FILE, certificate))
+                .build());
+
+    for (PodData pod : k8sEnv.getPodsData().values()) {
+      Optional<Volume> certVolume =
+          pod.getSpec()
+              .getVolumes()
+              .stream()
+              .filter(v -> v.getName().equals(CHE_GIT_SELF_SIGNED_VOLUME))
+              .findAny();
+
+      if (!certVolume.isPresent()) {
+        pod.getSpec().getVolumes().add(buildCertVolume(selfSignedCertConfigMapName));
+      }
+
+      for (Container container : pod.getSpec().getInitContainers()) {
+        provisionCertVolumeMountIfNeeded(container);
+      }
+      for (Container container : pod.getSpec().getContainers()) {
+        provisionCertVolumeMountIfNeeded(container);
+      }
+    }
+  }
+
+  private void provisionCertVolumeMountIfNeeded(Container container) {
+    Optional<VolumeMount> certVolumeMount =
+        container
+            .getVolumeMounts()
+            .stream()
+            .filter(vm -> vm.getName().equals(CHE_GIT_SELF_SIGNED_VOLUME))
+            .findAny();
+    if (!certVolumeMount.isPresent()) {
+      container.getVolumeMounts().add(buildCertVolumeMount());
+    }
+  }
+
+  private VolumeMount buildCertVolumeMount() {
+    return new VolumeMountBuilder()
+        .withName(CHE_GIT_SELF_SIGNED_VOLUME)
+        .withNewReadOnly(true)
+        .withMountPath(CERT_MOUNT_PATH)
+        .build();
+  }
+
+  private Volume buildCertVolume(String configMapName) {
+    return new VolumeBuilder()
+        .withName(CHE_GIT_SELF_SIGNED_VOLUME)
+        .withConfigMap(new ConfigMapVolumeSourceBuilder().withName(configMapName).build())
+        .build();
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisionerTest.java
@@ -19,7 +19,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironment
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitUserProfileProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ImagePullSecretProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.IngressTlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner;
@@ -29,6 +29,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SecurityCon
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSshKeysProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitRequestProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
@@ -66,8 +67,9 @@ public class KubernetesEnvironmentProvisionerTest {
   @Mock private ServiceAccountProvisioner serviceAccountProvisioner;
   @Mock private CertificateProvisioner certificateProvisioner;
   @Mock private VcsSshKeysProvisioner vcsSshKeysProvisioner;
-  @Mock private GitUserProfileProvisioner gitUserProfileProvisioner;
+  @Mock private GitConfigProvisioner gitConfigProvisioner;
   @Mock private PreviewUrlExposer previewUrlExposer;
+  @Mock private VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
 
   private KubernetesEnvironmentProvisioner<KubernetesEnvironment> k8sInfraProvisioner;
 
@@ -93,8 +95,9 @@ public class KubernetesEnvironmentProvisionerTest {
             serviceAccountProvisioner,
             certificateProvisioner,
             vcsSshKeysProvisioner,
-            gitUserProfileProvisioner,
-            previewUrlExposer);
+            gitConfigProvisioner,
+            previewUrlExposer,
+            vcsSslCertificateProvisioner);
     provisionOrder =
         inOrder(
             logsVolumeMachineProvisioner,
@@ -111,7 +114,7 @@ public class KubernetesEnvironmentProvisionerTest {
             proxySettingsProvisioner,
             serviceAccountProvisioner,
             certificateProvisioner,
-            gitUserProfileProvisioner,
+            gitConfigProvisioner,
             previewUrlExposer);
   }
 
@@ -137,7 +140,7 @@ public class KubernetesEnvironmentProvisionerTest {
     provisionOrder.verify(proxySettingsProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verify(serviceAccountProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verify(certificateProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
-    provisionOrder.verify(gitUserProfileProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
+    provisionOrder.verify(gitConfigProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verifyNoMoreInteractions();
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSslCertificateProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/VcsSslCertificateProvisionerTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner.CA_CERT_FILE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner.CERT_MOUNT_PATH;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner.CHE_GIT_SELF_SIGNED_CERT_CONFIG_MAP_SUFFIX;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner.CHE_GIT_SELF_SIGNED_VOLUME;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSource;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link VcsSslCertificateProvisioner}.
+ *
+ * @author Vitalii Parfonov
+ */
+@Listeners(MockitoTestNGListener.class)
+public class VcsSslCertificateProvisionerTest {
+
+  private static final String WORKSPACE_ID = "workspace123";
+  private static final String EXPECTED_CERT_NAME =
+      WORKSPACE_ID + CHE_GIT_SELF_SIGNED_CERT_CONFIG_MAP_SUFFIX;
+
+  private static final String CERT_CONTENT =
+      "-----BEGIN CERTIFICATE-----\n"
+          + UUID.randomUUID().toString()
+          + "\n-----END CERTIFICATE-----";
+  @Mock private RuntimeIdentity runtimeId;
+
+  private VcsSslCertificateProvisioner provisioner;
+  private KubernetesEnvironment k8sEnv;
+
+  @BeforeMethod
+  public void setUp() {
+    when(runtimeId.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+
+    provisioner = new VcsSslCertificateProvisioner(CERT_CONTENT, "");
+    k8sEnv = KubernetesEnvironment.builder().build();
+  }
+
+  @Test
+  public void shouldReturnFalseIfCertificateIsNotConfigured() {
+    provisioner = new VcsSslCertificateProvisioner();
+    assertFalse(provisioner.isConfigured());
+  }
+
+  @Test
+  public void shouldReturnTrueIfCertificateIsConfigured() {
+    provisioner = new VcsSslCertificateProvisioner(CERT_CONTENT, "localhost");
+    assertTrue(provisioner.isConfigured());
+  }
+
+  @Test
+  public void shouldReturnCertPathFile() {
+    String certPath = provisioner.getCertPath();
+    assertEquals(certPath, "/etc/che/git/cert/ca.crt");
+  }
+
+  @Test
+  public void shouldAddConfigMapWithCertificateIntoEnvironment() throws Exception {
+    provisioner.provision(k8sEnv, runtimeId);
+
+    Map<String, ConfigMap> configMaps = k8sEnv.getConfigMaps();
+    assertEquals(configMaps.size(), 1);
+
+    ConfigMap configMap = configMaps.get(EXPECTED_CERT_NAME);
+    assertNotNull(configMap);
+    assertEquals(configMap.getMetadata().getName(), EXPECTED_CERT_NAME);
+    assertEquals(configMap.getData().get(CA_CERT_FILE), CERT_CONTENT);
+  }
+
+  @Test
+  public void shouldAddVolumeAndVolumeMountsToPodsAndContainersInEnvironment() throws Exception {
+    k8sEnv.addPod(createPod("pod"));
+    k8sEnv.addPod(createPod("pod2"));
+
+    provisioner.provision(k8sEnv, runtimeId);
+
+    for (Pod pod : k8sEnv.getPodsCopy().values()) {
+      verifyVolumeIsPresent(pod);
+
+      for (Container container : pod.getSpec().getInitContainers()) {
+        verifyVolumeMountIsPresent(container);
+      }
+
+      for (Container container : pod.getSpec().getContainers()) {
+        verifyVolumeMountIsPresent(container);
+      }
+    }
+  }
+
+  @Test
+  public void
+      shouldNotAddVolumeAndVolumeMountsToPodsAndContainersInEnvironmentIfCertIsNotConfigured()
+          throws Exception {
+    provisioner = new VcsSslCertificateProvisioner("", "");
+    k8sEnv.addPod(createPod("pod"));
+    k8sEnv.addPod(createPod("pod2"));
+
+    provisioner.provision(k8sEnv, runtimeId);
+
+    for (Pod pod : k8sEnv.getPodsCopy().values()) {
+      assertTrue(pod.getSpec().getVolumes().isEmpty());
+      for (Container container : pod.getSpec().getContainers()) {
+        assertTrue(container.getVolumeMounts().isEmpty());
+      }
+    }
+  }
+
+  private void verifyVolumeIsPresent(Pod pod) {
+    List<Volume> podVolumes = pod.getSpec().getVolumes();
+    assertEquals(podVolumes.size(), 1);
+    Volume certVolume = podVolumes.get(0);
+    assertEquals(certVolume.getName(), CHE_GIT_SELF_SIGNED_VOLUME);
+    ConfigMapVolumeSource volumeConfigMap = certVolume.getConfigMap();
+    assertNotNull(volumeConfigMap);
+    assertEquals(volumeConfigMap.getName(), EXPECTED_CERT_NAME);
+  }
+
+  private void verifyVolumeMountIsPresent(Container container) {
+    List<VolumeMount> volumeMounts = container.getVolumeMounts();
+    assertEquals(volumeMounts.size(), 1);
+    VolumeMount volumeMount = volumeMounts.get(0);
+    assertEquals(volumeMount.getName(), CHE_GIT_SELF_SIGNED_VOLUME);
+    assertTrue(volumeMount.getReadOnly());
+    assertEquals(volumeMount.getMountPath(), CERT_MOUNT_PATH);
+  }
+
+  private Pod createPod(String podName) {
+    return new PodBuilder()
+        .withNewMetadata()
+        .withName(podName)
+        .endMetadata()
+        .withNewSpec()
+        .withInitContainers(new ContainerBuilder().build())
+        .withContainers(new ContainerBuilder().build(), new ContainerBuilder().build())
+        .endSpec()
+        .build();
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -21,7 +21,7 @@ import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironmentProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitUserProfileProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ImagePullSecretProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.PodTerminationGracePeriodProvisioner;
@@ -29,6 +29,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ProxySettin
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSshKeysProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitRequestProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
@@ -69,8 +70,9 @@ public class OpenShiftEnvironmentProvisioner
   private final ServiceAccountProvisioner serviceAccountProvisioner;
   private final CertificateProvisioner certificateProvisioner;
   private final VcsSshKeysProvisioner vcsSshKeysProvisioner;
-  private final GitUserProfileProvisioner gitUserProfileProvisioner;
+  private final GitConfigProvisioner gitConfigProvisioner;
   private final PreviewUrlExposer<OpenShiftEnvironment> previewUrlExposer;
+  private final VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
 
   @Inject
   public OpenShiftEnvironmentProvisioner(
@@ -89,8 +91,9 @@ public class OpenShiftEnvironmentProvisioner
       ServiceAccountProvisioner serviceAccountProvisioner,
       CertificateProvisioner certificateProvisioner,
       VcsSshKeysProvisioner vcsSshKeysProvisioner,
-      GitUserProfileProvisioner gitUserProfileProvisioner,
-      OpenShiftPreviewUrlExposer previewUrlEndpointsProvisioner) {
+      GitConfigProvisioner gitConfigProvisioner,
+      OpenShiftPreviewUrlExposer previewUrlEndpointsProvisioner,
+      VcsSslCertificateProvisioner vcsSslCertificateProvisioner) {
     this.pvcEnabled = pvcEnabled;
     this.volumesStrategy = volumesStrategy;
     this.uniqueNamesProvisioner = uniqueNamesProvisioner;
@@ -106,8 +109,9 @@ public class OpenShiftEnvironmentProvisioner
     this.serviceAccountProvisioner = serviceAccountProvisioner;
     this.certificateProvisioner = certificateProvisioner;
     this.vcsSshKeysProvisioner = vcsSshKeysProvisioner;
-    this.gitUserProfileProvisioner = gitUserProfileProvisioner;
+    this.gitConfigProvisioner = gitConfigProvisioner;
     this.previewUrlExposer = previewUrlEndpointsProvisioner;
+    this.vcsSslCertificateProvisioner = vcsSslCertificateProvisioner;
   }
 
   @Override
@@ -143,7 +147,8 @@ public class OpenShiftEnvironmentProvisioner
     serviceAccountProvisioner.provision(osEnv, identity);
     certificateProvisioner.provision(osEnv, identity);
     vcsSshKeysProvisioner.provision(osEnv, identity);
-    gitUserProfileProvisioner.provision(osEnv, identity);
+    vcsSslCertificateProvisioner.provision(osEnv, identity);
+    gitConfigProvisioner.provision(osEnv, identity);
     LOG.debug(
         "Provisioning OpenShift environment done for workspace '{}'", identity.getWorkspaceId());
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -17,13 +17,14 @@ import static org.mockito.Mockito.inOrder;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitUserProfileProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ImagePullSecretProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.LogsVolumeMachineProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.PodTerminationGracePeriodProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ProxySettingsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSshKeysProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.RamLimitRequestProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
@@ -63,8 +64,9 @@ public class OpenShiftEnvironmentProvisionerTest {
   @Mock private ServiceAccountProvisioner serviceAccountProvisioner;
   @Mock private CertificateProvisioner certificateProvisioner;
   @Mock private VcsSshKeysProvisioner vcsSshKeysProvisioner;
-  @Mock private GitUserProfileProvisioner gitUserProfileProvisioner;
+  @Mock private GitConfigProvisioner gitConfigProvisioner;
   @Mock private OpenShiftPreviewUrlExposer previewUrlEndpointsProvisioner;
+  @Mock private VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
 
   private OpenShiftEnvironmentProvisioner osInfraProvisioner;
 
@@ -89,8 +91,9 @@ public class OpenShiftEnvironmentProvisionerTest {
             serviceAccountProvisioner,
             certificateProvisioner,
             vcsSshKeysProvisioner,
-            gitUserProfileProvisioner,
-            previewUrlEndpointsProvisioner);
+            gitConfigProvisioner,
+            previewUrlEndpointsProvisioner,
+            vcsSslCertificateProvisioner);
     provisionOrder =
         inOrder(
             logsVolumeMachineProvisioner,
@@ -107,7 +110,8 @@ public class OpenShiftEnvironmentProvisionerTest {
             serviceAccountProvisioner,
             certificateProvisioner,
             vcsSshKeysProvisioner,
-            gitUserProfileProvisioner,
+            vcsSslCertificateProvisioner,
+            gitConfigProvisioner,
             previewUrlEndpointsProvisioner);
   }
 
@@ -131,7 +135,8 @@ public class OpenShiftEnvironmentProvisionerTest {
     provisionOrder.verify(serviceAccountProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(certificateProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(vcsSshKeysProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
-    provisionOrder.verify(gitUserProfileProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
+    provisionOrder.verify(vcsSslCertificateProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
+    provisionOrder.verify(gitConfigProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verifyNoMoreInteractions();
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Support git operations for repositories with self-signed SSL certs #14527 


#### How it works:
For testing on my laptop I setup local git server which support cloning my https (e.g. https://gogs.io/) pretty easy for installation.
#### minikube:
After successfully deploy Eclipse on minikube need to execute next command:
`kubectl create configmap che-git-self-signed-cert --from-file=ca.crt --from-literal=githost={host}:{port} -n=che`
where:
 ```
ca.crt - your self-signed certificate 
 {host}:{port} - host and port for HTTPS connection on your git server.  (optional if not set it given certificate will be used for all HTTPS repositories)
```
#### minishift:
After deploy Eclipse Che on minishift
1. start `minishift dasfboard`
2. Go to the "Resources -> Config Map"
3. Create new Config Map:
     `ca.crt` : certificate content
     `githost` :  host and port for HTTPS connection on your git server (optional if not set it given certificate will be used for all HTTPS repositories).

![configmap](https://user-images.githubusercontent.com/1636592/69053665-955fe400-0a12-11ea-850a-f297dd61356e.png)


4. Go to "Applications -> Deployments - > Che" and in Actions menu select "Edit YAML". In `containers` sections add configuration like this:
```
            - name: CHE_GIT_SELF__SIGNED__CERT
              valueFrom:
                configMapKeyRef:
                  key: ca.crt
                  name: che-git-self-signed-cert
                  optional: false
            - name: CHE_GIT_SELF__SIGNED__CERT__HOST
              valueFrom:
                configMapKeyRef:
                  key: githost
                  name: che-git-self-signed-cert
                  optional: true
```
![deployments](https://user-images.githubusercontent.com/1636592/69053691-a4df2d00-0a12-11ea-925b-dfe3d5807a6a.png)

Now you can create and start new workspace.
On each container of your workspace will be mount special volume that contains file with your self-signed certificate and to the `gitconfig` section with information about   git server host and path to the certificate. E.g.
```
[http "https://10.33.177.118:3000"]
        sslCAInfo = /etc/che/git/cert/cert.pem
```

### What issues does this PR fix or reference?
#14527 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

https://github.com/eclipse/che-docs/pull/936
