### PR TITLE
Update prometheus and grafana version in requirement.yaml file to be compatible with k8s v1.16

### DIFF
--- a/deploy/kubernetes/helm/che/requirements.yaml
+++ b/deploy/kubernetes/helm/che/requirements.yaml
@@ -30,9 +30,9 @@ dependencies:
     condition: global.tracingEnabled
   - name: prometheus
     repository: https://kubernetes-charts.storage.googleapis.com/
-    version: ^7.4.5
+    version: ^9.3.1
     condition: global.metricsEnabled
   - name: grafana
     repository: https://kubernetes-charts.storage.googleapis.com/
-    version: ^1.19.0
+    version: ^4.0.3
     condition: global.metricsEnabled


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
This PR allows that prometheus and grafana are properly installed when using the helm on k8s v1.16. 
If you do not change the version of prometheus and grafana in the requirement.yaml file, you will get an apiVersion error.

### What issues does this PR fix or reference?
#15168
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
