### PR TITLE
Improved handling of exceptions in workspace activities related operations

### DIFF
--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -100,11 +100,8 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
                 a -> {
                   switch (status) {
                     case STOPPED:
-                      return isGreater(a.getLastStopped(), timestamp);
                     case STOPPING:
-                      return isGreater(a.getLastStopped(), timestamp);
                     case RUNNING:
-                      return isGreater(a.getLastStopped(), timestamp);
                     case STARTING:
                       return isGreater(a.getLastStopped(), timestamp);
                     default:

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -95,19 +95,7 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
         workspaceActivities
             .values()
             .stream()
-            .filter(a -> a.getStatus() == status)
-            .filter(
-                a -> {
-                  switch (status) {
-                    case STOPPED:
-                    case STOPPING:
-                    case RUNNING:
-                    case STARTING:
-                      return isGreater(a.getLastStopped(), timestamp);
-                    default:
-                      return false;
-                  }
-                })
+            .filter(a -> a.getStatus() == status && isGreater(a.getLastStopped(), timestamp))
             .map(WorkspaceActivity::getWorkspaceId)
             .collect(toList());
 


### PR DESCRIPTION
### What does this PR do?
Improves handling exception in workspace activities related operations. This PR contains two separate commits which do:
1. Correctly catch errors that occur during transaction committing.
2. Process every activity record if an exception occurred during processing one.
The fixed placed are covered with the corresponding tests.

I found the described issue inspiring the following stack trace:
```
org.eclipse.che.api.core.ServerException:
Internal Exception: org.postgresql.util.PSQLException: ERROR: insert or update on table "che_workspace_activity" violates foreign key constraint "ws_activity_workspace_id"
Detail: Key (workspace_id)=(workspaceXXXX) is not present in table "workspace".
    Error Code: 0
Call: INSERT INTO che_workspace_activity (workspace_id, created, expiration, last_running, last_starting, last_stopped, last_stopping, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
bind => [8 parameters bound]
Query: InsertObjectQuery(WorkspaceActivity{workspaceId='workspaceXXXX', created=null, lastStarting=null, lastRunning=null, lastStopping=null, lastStopped=XXXX, expiration=null, status=STOPPED})
at org.eclipse.che.api.workspace.activity.JpaWorkspaceActivityDao.doUpdate(JpaWorkspaceActivityDao.java:279)
at org.eclipse.che.api.workspace.activity.JpaWorkspaceActivityDao.doUpdate(JpaWorkspaceActivityDao.java:247)
at com.google.inject.persist.jpa.JpaLocalTxnInterceptor.invoke(JpaLocalTxnInterceptor.java:64)
at org.eclipse.che.api.workspace.activity.JpaWorkspaceActivityDao.setStatusChangeTime(JpaWorkspaceActivityDao.java:147)
at org.eclipse.che.api.workspace.activity.WorkspaceActivityManager$UpdateStatusChangedTimestampSubscriber.onEvent(WorkspaceActivityManager.java:183)
at org.eclipse.che.api.workspace.activity.WorkspaceActivityManager$UpdateStatusChangedTimestampSubscriber.onEvent(WorkspaceActivityManager.java:173)
at org.eclipse.che.api.core.notification.EventService.publish(EventService.java:108)
at org.eclipse.che.api.workspace.server.WorkspaceRuntimes.publishWorkspaceStatusEvent(WorkspaceRuntimes.java:722)
at org.eclipse.che.api.workspace.server.WorkspaceRuntimes.access$700(WorkspaceRuntimes.java:102)
at org.eclipse.che.api.workspace.server.WorkspaceRuntimes$StartRuntimeTask.run(WorkspaceRuntimes.java:866)
at org.eclipse.che.commons.lang.concurrent.CopyThreadLocalRunnable.run(CopyThreadLocalRunnable.java:38)
at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1626)
```
But this PR does not prevent the same exception to be logged later (slightly different ServerException with the friendly message).
Some work still should be done to investigate how it's even possible that status is changing for removed workspace and what we can do to prevent appears such error.
Probably it may happen when there is two active Che Server (Rolling Update) and it's an error from different Che instance than performs workspace deletion. It's just assumption and may be wrong.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15248

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A


#### Docs PR
N/A