### PR TITLE
[UD] Fixed ability to start a workspace after changing its name.

### DIFF
--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -47,6 +47,7 @@ export class NavbarRecentWorkspacesController {
   recentWorkspaces: Array<che.IWorkspace>;
   workspaceUpdated: Map<string, number>;
   veryRecentWorkspaceId: string;
+  workspaceNameById: Map<string, string> = new Map();
   ideSvc: IdeSvc;
   $scope: ng.IScope;
   $log: ng.ILogService;
@@ -179,6 +180,8 @@ export class NavbarRecentWorkspacesController {
    * Update recent workspaces
    */
   updateRecentWorkspaces(): void {
+    this.workspaceNameById.clear();
+
     if (!this.workspaces || this.workspaces.length === 0) {
       this.recentWorkspaces = [];
       return;
@@ -221,6 +224,10 @@ export class NavbarRecentWorkspacesController {
       }
     }
     this.recentWorkspaces = recentWorkspaces.slice(0, MAX_RECENT_WORKSPACES_ITEMS);
+
+    recentWorkspaces.forEach((workspace: che.IWorkspace) =>
+      this.workspaceNameById.set(workspace.id, this.cheWorkspace.getWorkspaceDataManager().getName(workspace))
+    );
   }
 
   /**
@@ -247,8 +254,7 @@ export class NavbarRecentWorkspacesController {
    * @returns {String}
    */
   getWorkspaceName(workspaceId: string): string {
-    let workspace = this.cheWorkspace.getWorkspaceById(workspaceId);
-    return workspace ? this.cheWorkspace.getWorkspaceDataManager().getName(workspace) : 'unknown';
+    return this.workspaceNameById.get(workspaceId) || 'unknown';
   }
 
   /**
@@ -384,7 +390,7 @@ export class NavbarRecentWorkspacesController {
    * Returns `true` if workspace configuration has unsaved changes.
    * @param id a workspace ID
    */
-  checkUnsavedChanges(id: string): ng.IPromise<any> | any {
+  checkUnsavedChanges(id: string): boolean {
     return this.workspaceDetailsService.isWorkspaceConfigSaved(id) === false;
   }
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.controller.ts
@@ -137,8 +137,12 @@ export class WorkspaceDetailsController {
 
       this.initialWorkspaceDetails = angular.copy(newWorkspaceDetails);
       if (this.workspaceDetailsService.isWorkspaceModified(this.workspaceId)) {
+        const newName = this.workspaceDataManager.getName(newWorkspaceDetails);
+        if (this.workspaceName !== newName) {
+          this.$location.path(`workspace/${this.workspaceDetails.namespace}/${newName}`);
+          return;
+        }
         this.workspaceDetails = angular.copy(newWorkspaceDetails);
-        this.workspaceName = this.workspaceDataManager.getName(this.workspaceDetails);
       }
       this.checkEditMode();
       this.updateDeprecatedInfo();

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
@@ -419,7 +419,6 @@ describe(`WorkspaceDetailsController >`, () => {
 
               getSaveButton().click();
               $scope.$digest();
-              $timeout.flush();
             });
 
             it('should not prevent to leave page', () => {
@@ -488,7 +487,6 @@ describe(`WorkspaceDetailsController >`, () => {
               newWorkspace = angular.copy((controller as any).workspaceDetails);
               getSaveButton().click();
               $scope.$digest();
-              $timeout.flush();
             });
 
             it('should not prevent to leave page', () => {
@@ -600,7 +598,6 @@ describe(`WorkspaceDetailsController >`, () => {
 
               getSaveButton().click();
               $scope.$digest();
-              $timeout.flush();
             });
 
             it('should not prevent to leave page', () => {
@@ -668,7 +665,6 @@ describe(`WorkspaceDetailsController >`, () => {
 
               getSaveButton().click();
               $scope.$digest();
-              $timeout.flush();
             });
 
             it('should not prevent to leave page', () => {


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR fixes bug which doesn't allow to start or open a workspace immediately after its name was changed. Changing a workspace name triggers updating related views so all links that contains the workspace name became correct.

### What issues does this PR fix or reference?

fixes https://github.com/eclipse/che/issues/14762
