### PR TITLE
Added support of env for k8s/os component

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplier.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplier.java
@@ -19,6 +19,7 @@ import javax.inject.Named;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesComponentToWorkspaceApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesEnvironmentProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesRecipeParser;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.EnvVars;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 
 public class OpenshiftComponentToWorkspaceApplier extends KubernetesComponentToWorkspaceApplier {
@@ -26,6 +27,7 @@ public class OpenshiftComponentToWorkspaceApplier extends KubernetesComponentToW
   public OpenshiftComponentToWorkspaceApplier(
       KubernetesRecipeParser objectsParser,
       KubernetesEnvironmentProvisioner k8sEnvProvisioner,
+      EnvVars envVars,
       @Named("che.workspace.projects.storage") String projectFolderPath,
       @Named("che.workspace.projects.storage.default.size") String defaultProjectPVCSize,
       @Named("che.infra.kubernetes.pvc.access_mode") String defaultPVCAccessMode,
@@ -34,6 +36,7 @@ public class OpenshiftComponentToWorkspaceApplier extends KubernetesComponentToW
     super(
         objectsParser,
         k8sEnvProvisioner,
+        envVars,
         OpenShiftEnvironment.TYPE,
         projectFolderPath,
         defaultProjectPVCSize,

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
@@ -25,6 +25,7 @@ import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesComponentToWorkspaceApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.devfile.KubernetesEnvironmentProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesRecipeParser;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.EnvVars;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -42,6 +43,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
   private KubernetesComponentToWorkspaceApplier applier;
   @Mock private KubernetesEnvironmentProvisioner k8sEnvProvisioner;
   @Mock private KubernetesRecipeParser k8sRecipeParser;
+  @Mock private EnvVars envVars;
 
   @BeforeMethod
   public void setUp() {
@@ -51,6 +53,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
         new OpenshiftComponentToWorkspaceApplier(
             k8sRecipeParser,
             k8sEnvProvisioner,
+            envVars,
             "/projects",
             "1Gi",
             "ReadWriteOnce",

--- a/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
+++ b/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
@@ -344,6 +344,7 @@
                   "type": {},
                   "alias": {},
                   "mountSources": {},
+                  "env":  {},
                   "reference": {
                     "description": "Describes absolute or devfile-relative location of Kubernetes list yaml file. Applicable only for 'kubernetes' and 'openshift' type components",
                     "type": "string",
@@ -430,6 +431,7 @@
                   "type": {},
                   "alias": {},
                   "mountSources": {},
+                  "env":  {},
                   "image": {
                     "type": "string",
                     "description": "Specifies the docker image that should be used for component",
@@ -494,30 +496,6 @@
                           "examples": [
                             "/home/user/data"
                           ]
-                        }
-                      }
-                    }
-                  },
-                  "env": {
-                    "type": "array",
-                    "description": "The environment variables list that should be set to docker container",
-                    "items": {
-                      "type": "object",
-                      "description": "Describes environment variable",
-                      "required": [
-                        "name",
-                        "value"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "title": "The Environment Variable Name",
-                          "description": "The environment variable name"
-                        },
-                        "value": {
-                          "type": "string",
-                          "title": "The Environment Variable Value",
-                          "description": "The environment variable value"
                         }
                       }
                     }
@@ -606,6 +584,30 @@
             "type": "boolean",
             "description": "Describes whether projects sources should be mount to the component. `CHE_PROJECTS_ROOT` environment variable should contains a path where projects sources are mount",
             "default": "false"
+          },
+          "env": {
+            "type": "array",
+            "description": "The environment variables list that should be set to docker container",
+            "items": {
+              "type": "object",
+              "description": "Describes environment variable",
+              "required": [
+                "name",
+                "value"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "The Environment Variable Name",
+                  "description": "The environment variable name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "The Environment Variable Value",
+                  "description": "The environment variable value"
+                }
+              }
+            }
           }
         },
         "additionalProperties": true

--- a/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.1-beta/devfile.json
+++ b/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.1-beta/devfile.json
@@ -333,6 +333,7 @@
                   "type": {},
                   "alias": {},
                   "mountSources": {},
+                  "env":  {},
                   "reference": {
                     "description": "Describes absolute or devfile-relative location of Kubernetes list yaml file. Applicable only for 'kubernetes' and 'openshift' type components",
                     "type": "string",
@@ -419,6 +420,7 @@
                   "type": {},
                   "alias": {},
                   "mountSources": {},
+                  "env":  {},
                   "image": {
                     "type": "string",
                     "description": "Specifies the docker image that should be used for component",
@@ -483,30 +485,6 @@
                           "examples": [
                             "/home/user/data"
                           ]
-                        }
-                      }
-                    }
-                  },
-                  "env": {
-                    "type": "array",
-                    "description": "The environment variables list that should be set to docker container",
-                    "items": {
-                      "type": "object",
-                      "description": "Describes environment variable",
-                      "required": [
-                        "name",
-                        "value"
-                      ],
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "title": "The Environment Variable Name",
-                          "description": "The environment variable name"
-                        },
-                        "value": {
-                          "type": "string",
-                          "title": "The Environment Variable Value",
-                          "description": "The environment variable value"
                         }
                       }
                     }
@@ -595,6 +573,30 @@
             "type": "boolean",
             "description": "Describes whether projects sources should be mount to the component. `CHE_PROJECTS_ROOT` environment variable should contains a path where projects sources are mount",
             "default": "false"
+          },
+          "env": {
+            "type": "array",
+            "description": "The environment variables list that should be set to docker container",
+            "items": {
+              "type": "object",
+              "description": "Describes environment variable",
+              "required": [
+                "name",
+                "value"
+              ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "The Environment Variable Name",
+                  "description": "The environment variable name"
+                },
+                "value": {
+                  "type": "string",
+                  "title": "The Environment Variable Value",
+                  "description": "The environment variable value"
+                }
+              }
+            }
           }
         },
         "additionalProperties": true

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
@@ -57,6 +57,7 @@ public class DevfileSchemaValidatorTest {
       {
         "kubernetes_openshift_component/devfile_openshift_component_reference_and_content_as_block.yaml"
       },
+      {"kubernetes_openshift_component/devfile_k8s_openshift_component_with_env.yaml"},
       {"kubernetes_openshift_component/devfile_openshift_component_content_without_reference.yaml"},
       {
         "kubernetes_openshift_component/devfile_kubernetes_component_content_without_reference.yaml"

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/kubernetes_openshift_component/devfile_k8s_openshift_component_with_env.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/kubernetes_openshift_component/devfile_k8s_openshift_component_with_env.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+---
+apiVersion: 1.0.0
+metadata:
+  name: petclinic-dev-environment
+components:
+  - alias: mysql
+    type: openshift
+    reference: petclinic.yaml
+    env:
+      - name: TEST_ENV
+        value: any
+  - alias: web-app
+    type: kubernetes
+    reference: petclinic.yaml
+    env:
+      - name: TEST_ENV
+        value: any


### PR DESCRIPTION
### What does this PR do?
Adds support of env for k8s/os component.

<details>
<summary>Devfile to test</summary>

```yaml
metadata:
  name: env-override
components:
  - referenceContent: |
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: empty-env
      spec:
        selector:
          matchLabels:
            app.kubernetes.io/name: empty-env
        template:
          metadata:
            labels:
              app.kubernetes.io/name: empty-env
            name: empty-env
          spec:
            containers:
            - name: empty-env
              image: alpine
              env: []
    type: kubernetes
    entrypoints:
      - command:
          - tail
          - '-f'
          - /dev/null
    alias: empty-env
    env:
      - value: Hello!
        name: TEST
  - referenceContent: |
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: no-env
      spec:
        selector:
          matchLabels:
            app.kubernetes.io/name: no-env
        template:
          metadata:
            labels:
              app.kubernetes.io/name: no-env
            name: no-env
          spec:
            containers:
            - name: no-env
              image: alpine
    type: kubernetes
    entrypoints:
      - command:
          - tail
          - '-f'
          - /dev/null
    alias: no-env
    env:
      - value: Hello!
        name: TEST
  - referenceContent: |
      apiVersion: apps/v1
      kind: Deployment
      metadata:
        name: env-override
      spec:
        selector:
          matchLabels:
            app.kubernetes.io/name: env-override
        template:
          metadata:
            labels:
              app.kubernetes.io/name: env-override
            name: env-override
          spec:
            containers:
            - name: env-override
              image: alpine
              env:
                - name: TEST
                  value: Bye!
    type: kubernetes
    entrypoints:
      - command:
          - tail
          - '-f'
          - /dev/null
    alias: env-override
    env:
      - value: Hello!
        name: TEST
apiVersion: 1.0.0
commands:
  - name: hello from no-env
    actions:
      - type: exec
        command: 'echo ${TEST}'
        component: no-env
  - name: hello from empty-env
    actions:
      - type: exec
        command: 'echo ${TEST}'
        component: empty-env
  - name: hello from env-override
    actions:
      - type: exec
        command: 'echo ${TEST}'
        component: env-override
```
</details>

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15121

#### Release Notes
Added support of env for k8s/os component

#### Docs PR
https://github.com/eclipse/che-docs/pull/935