### PR TITLE
Align JGroups labels property name and add one preventing to connect to unready pods

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/jgroups/che-tcp.xml
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/jgroups/che-tcp.xml
@@ -32,7 +32,7 @@
     port_range="3"
     namespace="${KUBERNETES_NAMESPACE:che}"
     labels="${KUBERNETES_LABELS:app=che,component=che}"
-    useNotReadyAddresses="false"
+    useNotReadyAddresses="${KUBERNETES_USE_NOT_READY_ADDRESSES:false}"
   />
 
   <MERGE3 min_interval="10000"

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/jgroups/che-tcp.xml
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/jgroups/che-tcp.xml
@@ -31,7 +31,8 @@
   <org.jgroups.protocols.kubernetes.KUBE_PING
     port_range="3"
     namespace="${KUBERNETES_NAMESPACE:che}"
-    labels="${KUBERNETES_LABEL:app=che,component=che}"
+    labels="${KUBERNETES_LABELS:app=che,component=che}"
+    useNotReadyAddresses="false"
   />
 
   <MERGE3 min_interval="10000"


### PR DESCRIPTION
### What does this PR do?
Align JGroups labels property name with original one in `KUBE_PING` (see https://github.com/jgroups-extras/jgroups-kubernetes/blob/master/src/main/java/org/jgroups/protocols/kubernetes/KUBE_PING.java#L81) to avoid possible inconsistency and add another preventing to connect to unready pods which will help to reduce number of `ConnectioRefused` warning when trying to connect to not yet fully started pod.

Issue to `KUBE_PING` upstream to align their documentation: https://github.com/jgroups-extras/jgroups-kubernetes/issues/79

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/15176


#### Release Notes
N/A


#### Docs PR
N/A