### PR TITLE
Turn off the tests which check refresh

### DIFF
--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
@@ -30,8 +30,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/** @author Andrey chizhikov
- * TODO turn on the test after https://github.com/eclipse/che/issues/15317 resolved
+/**
+ * @author Andrey chizhikov TODO turn on the test after https://github.com/eclipse/che/issues/15317
+ *     resolved
  */
 @Test(groups = UNDER_REPAIR)
 public class ProjectStateAfterRefreshTest {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.workspaces;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
 
 import com.google.inject.Inject;
@@ -29,7 +30,10 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/** @author Andrey chizhikov */
+/** @author Andrey chizhikov
+ * TODO turn on the test after https://github.com/eclipse/che/issues/15317 resolved
+ */
+@Test(groups = UNDER_REPAIR)
 public class ProjectStateAfterRefreshTest {
   private static final String WORKSPACE_NAME =
       generate(ProjectStateAfterRefreshTest.class.getSimpleName(), 5);

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -32,8 +32,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev
- * TODO turn on the test after https://github.com/eclipse/che/issues/15317 resolved
+/**
+ * @author Aleksandr Shmaraev TODO turn on the test after
+ *     https://github.com/eclipse/che/issues/15317 resolved
  */
 @Test(groups = UNDER_REPAIR)
 public class ProjectStateAfterRenameWorkspaceTest {

--- a/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/selenium/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.workspaces;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
 
 import com.google.inject.Inject;
@@ -31,7 +32,10 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/** @author Aleksandr Shmaraev */
+/** @author Aleksandr Shmaraev
+ * TODO turn on the test after https://github.com/eclipse/che/issues/15317 resolved
+ */
+@Test(groups = UNDER_REPAIR)
 public class ProjectStateAfterRenameWorkspaceTest {
   private static final String WORKSPACE_NAME =
       generate(ProjectStateAfterRenameWorkspaceTest.class.getSimpleName(), 5);


### PR DESCRIPTION
### What does this PR do?
Turns off the tests which check restoring IDE tabs after refresh and rename:
- ProjectStateAfterRefreshTest
- ProjectStateAfterRenameWorkspaceTest

### What issues does this PR fix or reference?
#15317