### PR TITLE
Print build information to the startup logs

### DIFF
--- a/core/che-core-api-core/pom.xml
+++ b/core/che-core-api-core/pom.xml
@@ -258,6 +258,7 @@
                             <excludes>
                                 <exclude>org/eclipse/che/api/core/util/ProcessUtilTest.java</exclude>
                                 <exclude>org/eclipse/che/api/core/util/StandardLinuxShellTest.java</exclude>
+                                <exclude>**/it/*Test.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -277,6 +278,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
+                            <excludes>
+                                <exclude>**/it/*Test.java</exclude>
+                            </excludes>
                             <includes>
                                 <include>org/eclipse/che/api/core/util/ProcessUtilTest.java</include>
                                 <include>org/eclipse/che/api/core/util/StandardLinuxShellTest.java</include>
@@ -286,6 +290,34 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>integration</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <includes>
+                                <include>**/it/*Test.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+
         </profile>
     </profiles>
 </project>

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoProvider.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/ApiInfoProvider.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.core.rest;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 import javax.inject.Inject;
@@ -47,8 +48,14 @@ public class ApiInfoProvider implements Provider<ApiInfo> {
 
   private ApiInfo readApiInfo(String buildInfo) {
     try {
-      try (InputStream manifestInputStream =
-          ApiInfoProvider.class.getResourceAsStream("/META-INF/MANIFEST.MF")) {
+      // calculate path to MANIFEST.MF in the jar with ApiInfo.class
+      Class clazz = ApiInfo.class;
+      String classPath = clazz.getResource(clazz.getSimpleName() + ".class").toString();
+
+      String manifestPath =
+          classPath.substring(0, classPath.lastIndexOf("!") + 1) + "/META-INF/MANIFEST.MF";
+
+      try (InputStream manifestInputStream = new URL(manifestPath).openStream()) {
 
         final Manifest manifest = new Manifest(manifestInputStream);
         final Attributes mainAttributes = manifest.getMainAttributes();

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CoreRestModule.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/rest/CoreRestModule.java
@@ -15,6 +15,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import org.eclipse.che.api.core.rest.shared.dto.ApiInfo;
+import org.eclipse.che.api.core.util.ApiInfoLogInformer;
 
 /** @author andrew00x */
 public class CoreRestModule extends AbstractModule {
@@ -24,6 +25,7 @@ public class CoreRestModule extends AbstractModule {
     bind(ApiExceptionMapper.class);
     bind(RuntimeExceptionMapper.class);
     bind(ApiInfo.class).toProvider(ApiInfoProvider.class);
+    bind(ApiInfoLogInformer.class).asEagerSingleton();
     Multibinder.newSetBinder(binder(), Class.class, Names.named("che.json.ignored_classes"));
     bind(WebApplicationExceptionMapper.class);
   }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/ApiInfoLogInformer.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/util/ApiInfoLogInformer.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.util;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.rest.shared.dto.ApiInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Prints information about Eclipse Che Core implementation, such as: version, scm revision, build
+ * info.
+ */
+public class ApiInfoLogInformer {
+  private static final Logger LOG = LoggerFactory.getLogger(ApiInfoLogInformer.class);
+
+  private final ApiInfo apiInfo;
+
+  @Inject
+  public ApiInfoLogInformer(ApiInfo apiInfo) {
+    this.apiInfo = apiInfo;
+  }
+
+  @PostConstruct
+  public void printApiInfoOnStart() {
+    LOG.info(
+        "Eclipse Che Api Core: Build info '{}' scmRevision '{}' implementationVersion '{}'",
+        apiInfo.getBuildInfo(),
+        apiInfo.getScmRevision(),
+        apiInfo.getImplementationVersion());
+  }
+}

--- a/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/it/ApiInfoProviderTest.java
+++ b/core/che-core-api-core/src/test/java/org/eclipse/che/api/core/rest/it/ApiInfoProviderTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.core.rest.it;
+
+import static org.testng.Assert.*;
+
+import org.eclipse.che.api.core.rest.ApiInfoProvider;
+import org.eclipse.che.api.core.rest.shared.dto.ApiInfo;
+import org.testng.annotations.Test;
+
+public class ApiInfoProviderTest {
+
+  @Test
+  public void testGet() {
+    // given
+    ApiInfoProvider provider = new ApiInfoProvider("my custom build");
+    // when
+    ApiInfo apiInfo = provider.get();
+    // then
+    assertEquals(apiInfo.getBuildInfo(), "my custom build");
+    assertNotNull(apiInfo.getScmRevision());
+    assertNotNull(apiInfo.getSpecificationTitle());
+    assertNotNull(apiInfo.getSpecificationVersion());
+    assertNotNull(apiInfo.getImplementationVendor());
+    assertNotNull(apiInfo.getImplementationVersion());
+    assertEquals(apiInfo.getScmRevision().length(), 40);
+    assertEquals(apiInfo.getSpecificationTitle(), "Che REST API");
+    assertEquals(apiInfo.getSpecificationVersion(), "1.0-beta2");
+    assertEquals(apiInfo.getImplementationVendor(), "Red Hat, Inc.");
+    assertTrue(apiInfo.getImplementationVersion().length() > 4);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Quite an often happens that to be able to respond on some bug request we need to know the precise version of the code that is running on the server-side. This pr prints this information to the logs. The second thing that this pr is doing it fixes `readApiInfo` before this fix it was reading `"/META-INF/MANIFEST.MF"` random jar. From now it will read with the jar that contains `ApiInfo` class. 


![Знімок екрана  о 13 21 54](https://user-images.githubusercontent.com/1614429/69870020-ce1f7900-12ae-11ea-9b8e-aaef5a2f47bb.png)

### What issues does this PR fix or reference?
n/a

#### Release Notes
n/a

#### Docs PR
n/a