### PR TITLE
Remove the beta status from the che.infra.kubernetes.namespace.allow_user_defined

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -245,11 +245,8 @@ che.infra.kubernetes.namespace=
 # Is used by OpenShift infra as well to specify Project
 che.infra.kubernetes.namespace.default=<username>-che
 
-# Defines if a user is able to specify Kubernetes namespace different from default.
-# It's NOT RECOMMENDED to configured true without OAuth configured.
-# Is used by OpenShift infra as well to allows users choose Project
-#
-# BETA This is not currently supported and setting it to true doesn't have any effect.
+# Defines if a user is able to specify Kubernetes namespace (or OpenShift project) different from the default.
+# It's NOT RECOMMENDED to configured true without OAuth configured. This property is also used by the OpenShift infra.
 che.infra.kubernetes.namespace.allow_user_defined=false
 
 # Defines Kubernetes Service Account name which should be specified to be bound to all workspaces pods.


### PR DESCRIPTION
### What does this PR do?
Removes the beta status from the `che.infra.kubernetes.namespace.allow_user_defined` property and slightly rewords its description.