### PR TITLE
Added the reason of problem to clean up preferences for owner of the workspace

### DIFF
--- a/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/AppStatesPreferenceCleaner.java
+++ b/wsmaster/che-core-api-user/src/main/java/org/eclipse/che/api/user/server/AppStatesPreferenceCleaner.java
@@ -83,9 +83,10 @@ public class AppStatesPreferenceCleaner implements EventSubscriber<WorkspaceRemo
     } catch (NotFoundException | ServerException e) {
       Workspace workspace = workspaceRemovedEvent.getWorkspace();
       LOG.error(
-          "Unable to clean up preferences for owner of the workspace {} with namespace {}",
+          "Unable to clean up preferences for owner of the workspace {} with namespace {} because of '{}'",
           workspace.getId(),
-          workspace.getNamespace());
+          workspace.getNamespace(),
+          e.getMessage());
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?
The message `Unable to clean up preferences for the owner of the workspace workspacebXXX with namespace YY` doesn't tell anything about the problem.  This pr add more information to the log.

### What issues does this PR fix or reference?
n/a


#### Release Notes
n/a

#### Docs PR
n/a