### PR TITLE
Refactor plugin brokering process

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -464,8 +464,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.init.image=eclipse/che-init-plugin-broker:v0.24
-che.workspace.plugin_broker.unified.image=eclipse/che-unified-plugin-broker:v0.24
+che.workspace.plugin_broker.metadata.image=quay.io/eclipse/che-plugin-metadata-broker:v3.0.0
+che.workspace.plugin_broker.artifacts.image=quay.io/eclipse/che-plugin-artifacts-broker:v3.0.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesArtifactsBrokerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesArtifactsBrokerApplier.java
@@ -28,22 +28,20 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory;
 
 /**
- * Given a {@link InternalEnvironment} representing a workspace, adds the plugin broker as an init
- * container to the workspace Pod. This is necessary if the workspace is created using emptyDir
- * volumes (to allow the broker to add files to the workspace pod's volumes).
+ * Given a {@link InternalEnvironment} representing a workspace, adds the artifacts plugin broker as
+ * an init container to the workspace Pod in order to ensure that any extensions are downloaded.
  *
  * <p>This API is in <b>Beta</b> and is subject to changes or removal.
  *
  * @author Angel Misevski
  */
 @Beta
-public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironment> {
+public class KubernetesArtifactsBrokerApplier<E extends KubernetesEnvironment> {
 
   private final BrokerEnvironmentFactory<E> brokerEnvironmentFactory;
 
   @Inject
-  public KubernetesBrokerInitContainerApplier(
-      BrokerEnvironmentFactory<E> brokerEnvironmentFactory) {
+  public KubernetesArtifactsBrokerApplier(BrokerEnvironmentFactory<E> brokerEnvironmentFactory) {
     this.brokerEnvironmentFactory = brokerEnvironmentFactory;
   }
 
@@ -55,7 +53,7 @@ public class KubernetesBrokerInitContainerApplier<E extends KubernetesEnvironmen
       E workspaceEnvironment, RuntimeIdentity runtimeID, Collection<PluginFQN> pluginFQNs)
       throws InfrastructureException {
 
-    E brokerEnvironment = brokerEnvironmentFactory.create(pluginFQNs, runtimeID);
+    E brokerEnvironment = brokerEnvironmentFactory.createForArtifactsBroker(pluginFQNs, runtimeID);
 
     Map<String, PodData> workspacePods = workspaceEnvironment.getPodsData();
     if (workspacePods.size() != 1) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/PluginBrokerManager.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/PluginBrokerManager.java
@@ -107,7 +107,7 @@ public class PluginBrokerManager<E extends KubernetesEnvironment> {
     KubernetesNamespace kubernetesNamespace = factory.getOrCreate(identity);
     BrokersResult brokersResult = new BrokersResult();
 
-    E brokerEnvironment = brokerEnvironmentFactory.create(pluginFQNs, identity);
+    E brokerEnvironment = brokerEnvironmentFactory.createForMetadataBroker(pluginFQNs, identity);
     if (isEphemeral) {
       EphemeralWorkspaceUtility.makeEphemeral(brokerEnvironment.getAttributes());
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/SidecarToolingProvisioner.java
@@ -41,18 +41,18 @@ public class SidecarToolingProvisioner<E extends KubernetesEnvironment> {
   private static final Logger LOG = LoggerFactory.getLogger(SidecarToolingProvisioner.class);
 
   private final Map<String, ChePluginsApplier> workspaceNextAppliers;
-  private final KubernetesBrokerInitContainerApplier<E> brokerApplier;
+  private final KubernetesArtifactsBrokerApplier<E> artifactsBrokerApplier;
   private final PluginFQNParser pluginFQNParser;
   private final PluginBrokerManager<E> pluginBrokerManager;
 
   @Inject
   public SidecarToolingProvisioner(
       Map<String, ChePluginsApplier> workspaceNextAppliers,
-      KubernetesBrokerInitContainerApplier<E> brokerApplier,
+      KubernetesArtifactsBrokerApplier<E> artifactsBrokerApplier,
       PluginFQNParser pluginFQNParser,
       PluginBrokerManager<E> pluginBrokerManager) {
     this.workspaceNextAppliers = ImmutableMap.copyOf(workspaceNextAppliers);
-    this.brokerApplier = brokerApplier;
+    this.artifactsBrokerApplier = artifactsBrokerApplier;
     this.pluginFQNParser = pluginFQNParser;
     this.pluginBrokerManager = pluginBrokerManager;
   }
@@ -80,9 +80,7 @@ public class SidecarToolingProvisioner<E extends KubernetesEnvironment> {
         pluginBrokerManager.getTooling(identity, startSynchronizer, pluginFQNs, isEphemeral);
 
     pluginsApplier.apply(identity, environment, chePlugins);
-    if (isEphemeral) {
-      brokerApplier.apply(environment, identity, pluginFQNs);
-    }
+    artifactsBrokerApplier.apply(environment, identity, pluginFQNs);
     LOG.debug("Finished sidecar tooling provisioning workspace '{}'", identity.getWorkspaceId());
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/KubernetesBrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/KubernetesBrokerEnvironmentFactory.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases;
 
-import static java.util.Collections.singletonMap;
-
 import com.google.common.annotations.Beta;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -21,6 +19,7 @@ import org.eclipse.che.api.workspace.server.spi.provision.env.MachineTokenEnvVar
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory.BrokersConfigs;
 
 /**
  * Extends {@link BrokerEnvironmentFactory} to be used in the kubernetes infrastructure.
@@ -39,8 +38,8 @@ public class KubernetesBrokerEnvironmentFactory
       @Named("che.workspace.plugin_broker.pull_policy") String brokerPullPolicy,
       AgentAuthEnableEnvVarProvider authEnableEnvVarProvider,
       MachineTokenEnvVarProvider machineTokenEnvVarProvider,
-      @Named("che.workspace.plugin_broker.init.image") String initBrokerImage,
-      @Named("che.workspace.plugin_broker.unified.image") String unifiedBrokerImage,
+      @Named("che.workspace.plugin_broker.artifacts.image") String artifactsBrokerImage,
+      @Named("che.workspace.plugin_broker.metadata.image") String metadataBrokerImage,
       @Nullable @Named("che.workspace.plugin_registry_url") String pluginRegistryUrl,
       CertificateProvisioner certProvisioner) {
     super(
@@ -48,8 +47,8 @@ public class KubernetesBrokerEnvironmentFactory
         brokerPullPolicy,
         authEnableEnvVarProvider,
         machineTokenEnvVarProvider,
-        unifiedBrokerImage,
-        initBrokerImage,
+        artifactsBrokerImage,
+        metadataBrokerImage,
         pluginRegistryUrl,
         certProvisioner);
   }
@@ -59,7 +58,7 @@ public class KubernetesBrokerEnvironmentFactory
     return KubernetesEnvironment.builder()
         .setConfigMaps(brokersConfigs.configMaps)
         .setMachines(brokersConfigs.machines)
-        .setPods(singletonMap(brokersConfigs.pod.getMetadata().getName(), brokersConfigs.pod))
+        .setPods(brokersConfigs.pods)
         .build();
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesArtifactsBrokerApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesArtifactsBrokerApplierTest.java
@@ -39,7 +39,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.wsplugins.model.PluginFQN;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesBrokerInitContainerApplier;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesArtifactsBrokerApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.brokerphases.BrokerEnvironmentFactory;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -48,12 +48,12 @@ import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 /**
- * Tests {@link KubernetesBrokerInitContainerApplier}.
+ * Tests {@link KubernetesArtifactsBrokerApplier}.
  *
  * @author Angel Misevski
  */
 @Listeners(MockitoTestNGListener.class)
-public class KubernetesBrokerInitContainerApplierTest {
+public class KubernetesArtifactsBrokerApplierTest {
 
   private static final String WORKSPACE_POD_NAME = "workspacePod";
   private static final String WORKSPACE_MACHINE_NAME = "workspaceMachine";
@@ -85,7 +85,7 @@ public class KubernetesBrokerInitContainerApplierTest {
   private KubernetesEnvironment workspaceEnvironment;
   private Pod workspacePod;
 
-  private KubernetesBrokerInitContainerApplier<KubernetesEnvironment> applier;
+  private KubernetesArtifactsBrokerApplier<KubernetesEnvironment> applier;
 
   @BeforeMethod
   public void setUp() throws Exception {
@@ -121,9 +121,11 @@ public class KubernetesBrokerInitContainerApplierTest {
             .setConfigMaps(ImmutableMap.of(BROKER_CONFIGMAP_NAME, brokerConfigMap))
             .setMachines(ImmutableMap.of(BROKER_MACHINE_NAME, brokerMachine))
             .build();
-    doReturn(brokerEnvironment).when(brokerEnvironmentFactory).create(any(), any());
+    doReturn(brokerEnvironment)
+        .when(brokerEnvironmentFactory)
+        .createForArtifactsBroker(any(), any());
 
-    applier = new KubernetesBrokerInitContainerApplier<>(brokerEnvironmentFactory);
+    applier = new KubernetesArtifactsBrokerApplier<>(brokerEnvironmentFactory);
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
@@ -28,7 +28,7 @@ import org.eclipse.che.api.workspace.server.wsplugins.PluginFQNParser;
 import org.eclipse.che.api.workspace.server.wsplugins.model.PluginFQN;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility;
-import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesBrokerInitContainerApplier;
+import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesArtifactsBrokerApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.PluginBrokerManager;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.SidecarToolingProvisioner;
 import org.mockito.Mock;
@@ -49,7 +49,7 @@ public class SidecarToolingProvisionerTest {
   private static final String PLUGIN_FQN_ID = "TestPluginId";
 
   @Mock private StartSynchronizer startSynchronizer;
-  @Mock private KubernetesBrokerInitContainerApplier<KubernetesEnvironment> brokerApplier;
+  @Mock private KubernetesArtifactsBrokerApplier<KubernetesEnvironment> artifactsBrokerApplier;
   @Mock private PluginFQNParser pluginFQNParser;
   @Mock private PluginBrokerManager<KubernetesEnvironment> brokerManager;
   @Mock private KubernetesEnvironment nonEphemeralEnvironment;
@@ -86,22 +86,22 @@ public class SidecarToolingProvisionerTest {
 
     provisioner =
         new SidecarToolingProvisioner<>(
-            workspaceNextAppliers, brokerApplier, pluginFQNParser, brokerManager);
+            workspaceNextAppliers, artifactsBrokerApplier, pluginFQNParser, brokerManager);
   }
 
   @Test
-  public void shouldNotAddInitContainerWhenWorkspaceIsNotEphemeral() throws Exception {
+  public void shouldIncludexArtifactsBrokerWhenWorkspaceIsNotEphemeral() throws Exception {
     provisioner.provision(runtimeId, startSynchronizer, nonEphemeralEnvironment);
 
     verify(chePluginsApplier, times(1)).apply(any(), any(), any());
-    verify(brokerApplier, times(0)).apply(any(), any(), any());
+    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any());
   }
 
   @Test
-  public void shouldIncludeInitContainerWhenWorkspaceIsEphemeral() throws Exception {
+  public void shouldIncludeArtifactsBrokerWhenWorkspaceIsEphemeral() throws Exception {
     provisioner.provision(runtimeId, startSynchronizer, ephemeralEnvironment);
 
     verify(chePluginsApplier, times(1)).apply(any(), any(), any());
-    verify(brokerApplier, times(1)).apply(any(), any(), any());
+    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any());
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.wsplugins.brokerphases;
 
-import static java.util.Collections.singletonMap;
-
 import com.google.common.annotations.Beta;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -41,8 +39,8 @@ public class OpenshiftBrokerEnvironmentFactory
       @Named("che.workspace.plugin_broker.pull_policy") String brokerPullPolicy,
       AgentAuthEnableEnvVarProvider authEnableEnvVarProvider,
       MachineTokenEnvVarProvider machineTokenEnvVarProvider,
-      @Named("che.workspace.plugin_broker.init.image") String initBrokerImage,
-      @Named("che.workspace.plugin_broker.unified.image") String unifiedBrokerImage,
+      @Named("che.workspace.plugin_broker.artifacts.image") String artifactsBrokerImage,
+      @Named("che.workspace.plugin_broker.metadata.image") String metadataBrokerImage,
       @Nullable @Named("che.workspace.plugin_registry_url") String pluginRegistryUrl,
       CertificateProvisioner certProvisioner) {
     super(
@@ -50,8 +48,8 @@ public class OpenshiftBrokerEnvironmentFactory
         brokerPullPolicy,
         authEnableEnvVarProvider,
         machineTokenEnvVarProvider,
-        unifiedBrokerImage,
-        initBrokerImage,
+        artifactsBrokerImage,
+        metadataBrokerImage,
         pluginRegistryUrl,
         certProvisioner);
   }
@@ -61,7 +59,7 @@ public class OpenshiftBrokerEnvironmentFactory
     return OpenShiftEnvironment.builder()
         .setConfigMaps(brokersConfigs.configMaps)
         .setMachines(brokersConfigs.machines)
-        .setPods(singletonMap(brokersConfigs.pod.getMetadata().getName(), brokersConfigs.pod))
+        .setPods(brokersConfigs.pods)
         .build();
   }
 }


### PR DESCRIPTION
### What does this PR do?
Rework plugin brokering process to accomodate changes in https://github.com/eclipse/che-plugin-broker/pull/80.

Run metadata broker to get plugin tooling (similarly to how we're running the unified broker currently). Add the artifacts broker as an init container on the workspace pod to ensure extensions are downloaded.

One benefit with this change is that we do not need to do anything differently when running in ephemeral mode.

Since PR https://github.com/eclipse/che-plugin-broker/pull/80 is not yet merged, to test this PR you can reuse my built broker images:

```
CHE_WORKSPACE_PLUGIN__BROKER_METADATA_IMAGE=amisevsk/che-metadata-plugin-broker:dev
CHE_WORKSPACE_PLUGIN__BROKER_ARTIFACTS_IMAGE=amisevsk/che-artifacts-plugin-broker:dev
```

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14494

#### Release Notes
Improved plugin brokering process for faster workspace startup.

#### Docs PR
N/A

### Additional Info
Depends on https://github.com/eclipse/che-plugin-broker/pull/80