### PR TITLE
Fix NPE in devfile schema validator

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceEntityProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceEntityProvider.java
@@ -80,7 +80,7 @@ public class WorkspaceEntityProvider
     try {
       JsonNode wsNode = mapper.readTree(entityStream);
       JsonNode devfileNode = wsNode.path("devfile");
-      if (!devfileNode.isNull()) {
+      if (!devfileNode.isNull() && !devfileNode.isMissingNode()) {
         devfileManager.parseJson(devfileNode.toString());
       }
       return DtoFactory.getInstance().createDtoFromJson(wsNode.toString(), WorkspaceDto.class);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/DevfileManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/DevfileManager.java
@@ -199,6 +199,9 @@ public class DevfileManager {
     DevfileImpl devfile;
     try {
       JsonNode parsed = mapper.readTree(content);
+      if (parsed == null) {
+        throw new DevfileFormatException("Unable to parse Devfile - provided source is empty");
+      }
       parsed = overridePropertiesApplier.applyPropertiesOverride(parsed, overrideProperties);
       schemaValidator.validate(parsed);
       devfile = mapper.treeToValue(parsed, DevfileImpl.class);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/DevfileManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/DevfileManagerTest.java
@@ -122,6 +122,22 @@ public class DevfileManagerTest {
 
   @Test(
       expectedExceptions = DevfileException.class,
+      expectedExceptionsMessageRegExp = "Unable to parse Devfile - provided source is empty")
+  public void shouldThrowDevfileExceptionWhenEmptyObjectProvided() throws Exception {
+    // when
+    devfileManager.parseJson("{}");
+  }
+
+  @Test(
+      expectedExceptions = DevfileException.class,
+      expectedExceptionsMessageRegExp = "Unable to parse Devfile - provided source is empty")
+  public void shouldThrowDevfileExceptionWhenEmptySourceProvided() throws Exception {
+    // when
+    devfileManager.parseJson("");
+  }
+
+  @Test(
+      expectedExceptions = DevfileException.class,
       expectedExceptionsMessageRegExp = "Unable to resolve reference of component: test")
   public void shouldThrowDevfileExceptionWhenReferenceIsNotResolvable() throws Exception {
 
@@ -157,6 +173,7 @@ public class DevfileManagerTest {
     // given
     JsonProcessingException jsonException = mock(JsonProcessingException.class);
     when(jsonException.getMessage()).thenReturn("non valid");
+    when(jsonMapper.readTree(anyString())).thenReturn(devfileJsonNode);
     doThrow(jsonException).when(jsonMapper).treeToValue(any(), any());
 
     // when


### PR DESCRIPTION
### What does this PR do?

Fix NPE in devfile schema validator when provided JSON content of the defile is empty.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15339


#### Release Notes
N/A


#### Docs PR
N/A