### PR TITLE
Bug/ multiple plugin endpoints on the same port

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/DefaultHostExternalServiceExposureStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/DefaultHostExternalServiceExposureStrategy.java
@@ -11,8 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
-import io.fabric8.kubernetes.api.model.ServicePort;
-
 /**
  * Provides a path-based strategy for exposing service ports outside the cluster using Ingress
  * Ingresses will be created without an explicit host (defaulting to *).
@@ -45,12 +43,12 @@ public class DefaultHostExternalServiceExposureStrategy implements ExternalServi
   public static final String DEFAULT_HOST_STRATEGY = "default-host";
 
   @Override
-  public String getExternalHost(String serviceName, ServicePort servicePort) {
+  public String getExternalHost(String serviceName, String serverName) {
     return null;
   }
 
   @Override
-  public String getExternalPath(String serviceName, ServicePort servicePort) {
-    return "/" + serviceName + "/" + servicePort.getName();
+  public String getExternalPath(String serviceName, String serverName) {
+    return "/" + serviceName + "/" + serverName;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServiceExposureStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServiceExposureStrategy.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
-import io.fabric8.kubernetes.api.model.ServicePort;
 import org.eclipse.che.commons.annotation.Nullable;
 
 /**
@@ -22,8 +21,8 @@ public interface ExternalServiceExposureStrategy {
 
   /** Returns a host that should be used to expose the service */
   @Nullable
-  String getExternalHost(String serviceName, ServicePort servicePort);
+  String getExternalHost(String serviceName, String serverName);
 
   /** Returns the path on which the service should be exposed */
-  String getExternalPath(String serviceName, ServicePort servicePort);
+  String getExternalPath(String serviceName, String serverName);
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/MultiHostExternalServiceExposureStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/MultiHostExternalServiceExposureStrategy.java
@@ -15,7 +15,6 @@ import static java.lang.String.format;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.IngressServiceExposureStrategyProvider.STRATEGY_PROPERTY;
 
 import com.google.common.base.Strings;
-import io.fabric8.kubernetes.api.model.ServicePort;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.inject.ConfigurationException;
@@ -65,12 +64,12 @@ public class MultiHostExternalServiceExposureStrategy implements ExternalService
   }
 
   @Override
-  public String getExternalHost(String serviceName, ServicePort servicePort) {
-    return serviceName + "-" + servicePort.getName() + "." + domain;
+  public String getExternalHost(String serviceName, String serverName) {
+    return serviceName + "-" + serverName + "." + domain;
   }
 
   @Override
-  public String getExternalPath(String serviceName, ServicePort servicePort) {
+  public String getExternalPath(String serviceName, String serverName) {
     return "/";
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/SingleHostExternalServiceExposureStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/SingleHostExternalServiceExposureStrategy.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
-import io.fabric8.kubernetes.api.model.ServicePort;
 import javax.inject.Inject;
 import javax.inject.Named;
 
@@ -53,12 +52,12 @@ public class SingleHostExternalServiceExposureStrategy implements ExternalServic
   }
 
   @Override
-  public String getExternalHost(String serviceName, ServicePort servicePort) {
+  public String getExternalHost(String serviceName, String serverName) {
     return cheHost;
   }
 
   @Override
-  public String getExternalPath(String serviceName, ServicePort servicePort) {
-    return "/" + serviceName + "/" + servicePort.getName();
+  public String getExternalPath(String serviceName, String serverName) {
+    return "/" + serviceName + "/" + serverName;
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisionerTest.java
@@ -129,8 +129,7 @@ public class JwtProxyProvisionerTest {
     port.setTargetPort(new IntOrString(4401));
 
     // when
-    jwtProxyProvisioner.expose(
-        k8sEnv, "terminal", port, "TCP", ImmutableMap.of("server", secureServer));
+    jwtProxyProvisioner.expose(k8sEnv, "terminal", port, "TCP", "server", secureServer);
 
     // then
     InternalMachineConfig jwtProxyMachine =
@@ -179,12 +178,7 @@ public class JwtProxyProvisionerTest {
     port.setTargetPort(new IntOrString(4401));
 
     // when
-    jwtProxyProvisioner.expose(
-        k8sEnv,
-        "terminal",
-        port,
-        "TCP",
-        ImmutableMap.of("server1", server1, "server2", server2, "server3", server3));
+    jwtProxyProvisioner.expose(k8sEnv, "terminal", port, "TCP", "server1", server1);
   }
 
   @Test
@@ -220,8 +214,7 @@ public class JwtProxyProvisionerTest {
     port.setTargetPort(new IntOrString(4401));
 
     // when
-    jwtProxyProvisioner.expose(
-        k8sEnv, "terminal", port, "TCP", ImmutableMap.of("server1", server1, "server2", server2));
+    jwtProxyProvisioner.expose(k8sEnv, "terminal", port, "TCP", "server1", server1);
 
     // then
     verify(configBuilder).addVerifierProxy(any(), any(), any(), eq(true), any(), any());
@@ -250,8 +243,7 @@ public class JwtProxyProvisionerTest {
     port.setTargetPort(new IntOrString(4401));
 
     // when
-    jwtProxyProvisioner.expose(
-        k8sEnv, "terminal", port, "TCP", ImmutableMap.of("server1", server1));
+    jwtProxyProvisioner.expose(k8sEnv, "terminal", port, "TCP", "server1", server1);
 
     // then
     verify(configBuilder).addVerifierProxy(any(), any(), any(), eq(false), any(), any());

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxySecureServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxySecureServerExposerTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -73,7 +72,7 @@ public class JwtProxySecureServerExposerTest {
     ServicePort jwtProxyServicePort = new ServicePort();
     doReturn(jwtProxyServicePort)
         .when(jwtProxyProvisioner)
-        .expose(any(), anyString(), any(), anyString(), anyMap());
+        .expose(any(), anyString(), any(), anyString(), any(), any());
 
     when(jwtProxyProvisioner.getServiceName()).thenReturn(JWT_PROXY_SERVICE_NAME);
 
@@ -84,7 +83,7 @@ public class JwtProxySecureServerExposerTest {
     // then
     verify(jwtProxyProvisioner)
         .expose(
-            eq(k8sEnv), eq(MACHINE_SERVICE_NAME), eq(machineServicePort), eq("TCP"), eq(servers));
+            eq(k8sEnv), eq(MACHINE_SERVICE_NAME), eq(machineServicePort), eq("TCP"), any(), any());
     verify(externalServerExposer)
         .expose(
             eq(k8sEnv),

--- a/infrastructures/openshift/pom.xml
+++ b/infrastructures/openshift/pom.xml
@@ -97,6 +97,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-tracing</artifactId>
         </dependency>
         <dependency>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftExternalServerExposer.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftExternalServerExposer.java
@@ -19,8 +19,8 @@ import io.fabric8.openshift.api.model.Route;
 import java.util.Collections;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
-import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposer;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 
@@ -105,7 +105,12 @@ public class OpenShiftExternalServerExposer extends ExternalServerExposer<OpenSh
     for (Map.Entry<String, ServerConfig> e : externalServers.entrySet()) {
       Route route =
           new RouteBuilder()
-              .withName(Names.generateName("route"))
+              .withName(
+                  NameGenerator.generate("route", 3)
+                      + "-"
+                      + makeValidDnsName(machineName)
+                      + "-"
+                      + makeValidDnsName(e.getKey()))
               .withMachineName(machineName)
               .withTargetPort(servicePort.getName())
               .withServer(makeValidDnsName(e.getKey()), e.getValue())
@@ -165,7 +170,7 @@ public class OpenShiftExternalServerExposer extends ExternalServerExposer<OpenSh
           .endMetadata()
           .withNewSpec()
           .withNewTo()
-          .withName(serviceName + "-" + serverName)
+          .withName(serviceName)
           .endTo()
           .withNewPort()
           .withTargetPort(targetPort)

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerExposureStrategy.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerExposureStrategy.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.server;
 
-import io.fabric8.kubernetes.api.model.ServicePort;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServiceExposureStrategy;
 
 /**
@@ -21,12 +20,12 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.Exter
  */
 public class OpenShiftServerExposureStrategy implements ExternalServiceExposureStrategy {
   @Override
-  public String getExternalHost(String serviceName, ServicePort servicePort) {
+  public String getExternalHost(String serviceName, String serverName) {
     return null;
   }
 
   @Override
-  public String getExternalPath(String serviceName, ServicePort servicePort) {
+  public String getExternalPath(String serviceName, String serverName) {
     return "/";
   }
 }


### PR DESCRIPTION
### What does this PR do?

Changes the way we create ingresses/routes, so that there is 1:1 mapping between an ingress/route and a plugin endpoint.

More than anything else, this enables 1 service to be reached from multiple URLs which hopefully helps enabling webview.

### What issues does this PR fix or reference?
#15283

### Additional Notes

This PR is a draft, because we've not gone through the design phase with this and I've not added any tests and most possibly broke others. Comments both on the possible better approach to this as well as the code itself are more than welcome.