### PR TITLE
Propagate plugin/editor component environment variables

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/WorkspaceConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/WorkspaceConfig.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.Command;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.core.model.workspace.config.ProjectConfig;
+import org.eclipse.che.api.core.model.workspace.devfile.Devfile;
 import org.eclipse.che.commons.annotation.Nullable;
 
 /**
@@ -64,4 +65,7 @@ public interface WorkspaceConfig {
    * values.
    */
   Map<String, String> getAttributes();
+
+  /** Returns devfile that was to generating workspace config, null otherwise. */
+  Devfile getDevfile();
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
@@ -41,7 +41,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
-import org.eclipse.che.api.core.model.workspace.devfile.Component;
 import org.eclipse.che.api.core.model.workspace.devfile.Endpoint;
 import org.eclipse.che.api.workspace.server.devfile.Constants;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
@@ -51,6 +50,7 @@ import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.Containers;
@@ -103,7 +103,7 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
   @Override
   public void apply(
       WorkspaceConfigImpl workspaceConfig,
-      Component dockerimageComponent,
+      ComponentImpl dockerimageComponent,
       FileContentProvider contentProvider)
       throws DevfileException {
     checkArgument(workspaceConfig != null, "Workspace config must not be null");

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
@@ -51,6 +51,7 @@ import org.eclipse.che.api.workspace.server.devfile.convert.component.ComponentT
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.server.model.impl.MachineConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
@@ -134,7 +135,7 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
   @Override
   public void apply(
       WorkspaceConfigImpl workspaceConfig,
-      Component k8sComponent,
+      ComponentImpl k8sComponent,
       FileContentProvider contentProvider)
       throws DevfileException {
     checkArgument(workspaceConfig != null, "Workspace config must not be null");

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
@@ -272,7 +272,7 @@ public class JwtProxyProvisioner {
   }
 
   private InternalMachineConfig createJwtProxyMachine() {
-    return new InternalMachineConfig(null, emptyMap(), emptyMap(), attributes, null);
+    return new InternalMachineConfig(emptyMap(), emptyMap(), attributes, null);
   }
 
   private Pod createJwtProxyPod() {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolver.java
@@ -13,26 +13,20 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
-import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.DEVFILE_COMPONENT_ALIAS_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
-import static org.eclipse.che.api.workspace.server.devfile.Constants.EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE;
-import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.PROJECTS_VOLUME_NAME;
-import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE;
-import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE;
 
 import io.fabric8.kubernetes.api.model.Container;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.stream.Collectors;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.core.model.workspace.devfile.Component;
+import org.eclipse.che.api.core.model.workspace.devfile.Env;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
@@ -47,95 +41,49 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSize;
 /** @author Oleksandr Garagatyi */
 public class MachineResolver {
 
-  private final String pluginPublisherAndName;
-  private final String pluginId;
   private final Container container;
   private final CheContainer cheContainer;
   private final String defaultSidecarMemoryLimitBytes;
   private final List<ChePluginEndpoint> containerEndpoints;
-  private Map<String, String> wsAttributes;
   private final Pair<String, String> projectsRootPathEnvVar;
+  private final Component component;
 
   public MachineResolver(
-      String pluginPublisher,
-      String pluginName,
-      String pluginId,
       Pair<String, String> projectsRootPathEnvVar,
       Container container,
       CheContainer cheContainer,
       String defaultSidecarMemoryLimitBytes,
       List<ChePluginEndpoint> containerEndpoints,
-      Map<String, String> wsAttributes) {
-    this.pluginPublisherAndName = pluginPublisher + "/" + pluginName;
-    this.pluginId = pluginId;
+      Component component) {
     this.container = container;
     this.cheContainer = cheContainer;
     this.defaultSidecarMemoryLimitBytes = defaultSidecarMemoryLimitBytes;
     this.containerEndpoints = containerEndpoints;
-    this.wsAttributes = wsAttributes != null ? wsAttributes : Collections.emptyMap();
     this.projectsRootPathEnvVar = projectsRootPathEnvVar;
+    this.component = component;
   }
 
   public InternalMachineConfig resolve() throws InfrastructureException {
     InternalMachineConfig machineConfig =
         new InternalMachineConfig(
-            null,
             toServers(containerEndpoints),
-            toEnvVariables(wsAttributes),
-            toMachineAttributes(pluginId, wsAttributes),
+            component.getEnv().stream().collect(Collectors.toMap(Env::getName, Env::getValue)),
+            resolveMachineAttributes(),
             toWorkspaceVolumes(cheContainer));
 
     normalizeMemory(container, machineConfig);
     return machineConfig;
   }
 
-  private Map<String,String> toEnvVariables(Map<String,String> wsAttributes) {
-    String envVars = wsAttributes
-        .get(format(SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE, pluginPublisherAndName));
-    if (isNullOrEmpty(envVars)) {
-      return null;
-    }
-    return Stream.of(envVars.split(","))
-        // only splitting by 1'st '=' since env value may also contain it
-        .map(value -> value.split("=", 2))
-        .collect(toMap(arr -> arr[0], arr -> arr[1]));
-  }
-
-  private Map<String, String> toMachineAttributes(
-      String pluginId, Map<String, String> wsAttributes) {
+  private Map<String, String> resolveMachineAttributes() {
     Map<String, String> attributes = new HashMap<>();
 
-    Optional<String> pluginAlias = findPluginAlias(pluginId, wsAttributes);
-    pluginAlias.ifPresent(s -> attributes.put(DEVFILE_COMPONENT_ALIAS_ATTRIBUTE, s));
+    String alias = component.getAlias();
+    if (alias != null) {
+      attributes.put(DEVFILE_COMPONENT_ALIAS_ATTRIBUTE, alias);
+    }
 
     return attributes;
-  }
-
-  private Optional<String> findPluginAlias(String pluginId, Map<String, String> wsAttributes) {
-
-    List<String> aliases = new ArrayList<>();
-
-    String pluginComponentAliases =
-        wsAttributes.get(PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE);
-    if (!isNullOrEmpty(pluginComponentAliases)) {
-      aliases.addAll(asList(pluginComponentAliases.split(",")));
-    }
-
-    String editorComponentAlias = wsAttributes.get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE);
-    if (!isNullOrEmpty(editorComponentAlias)) {
-      aliases.add(editorComponentAlias);
-    }
-
-    if (aliases.isEmpty()) {
-      return Optional.empty();
-    }
-
-    return aliases
-        .stream()
-        .map(value -> value.split("="))
-        .filter(arr -> arr[0].equals(pluginId))
-        .map(arr -> arr[1])
-        .findAny();
   }
 
   private void normalizeMemory(Container container, InternalMachineConfig machineConfig) {
@@ -143,9 +91,7 @@ public class MachineResolver {
     if (ramLimit == 0) {
       machineConfig.getAttributes().put(MEMORY_LIMIT_ATTRIBUTE, defaultSidecarMemoryLimitBytes);
     }
-    // Use plugin_publisher/plugin_name to find overriding of memory limit.
-    String overriddenSidecarMemLimit =
-        wsAttributes.get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, pluginPublisherAndName));
+    String overriddenSidecarMemLimit = component.getMemoryLimit();
     if (!isNullOrEmpty(overriddenSidecarMemLimit)) {
       machineConfig
           .getAttributes()
@@ -174,7 +120,7 @@ public class MachineResolver {
                     + " the mountSources attribute to true instead and remove the manual volume"
                     + " mount in the plugin. After that the mount path of the sources will be"
                     + " available automatically in the '%s' environment variable.",
-                pluginPublisherAndName,
+                component.getId(),
                 PROJECTS_VOLUME_NAME,
                 container.getName(),
                 volume.getMountPath(),

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverBuilder.java
@@ -13,7 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 
 import io.fabric8.kubernetes.api.model.Container;
 import java.util.List;
-import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.devfile.Component;
 import org.eclipse.che.api.workspace.server.wsplugins.model.CheContainer;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ChePluginEndpoint;
 import org.eclipse.che.commons.lang.Pair;
@@ -25,35 +25,25 @@ public class MachineResolverBuilder {
   private CheContainer cheContainer;
   private String defaultSidecarMemorySizeAttribute;
   private List<ChePluginEndpoint> containerEndpoints;
-  private Map<String, String> wsAttributes;
   private Pair<String, String> projectsRootPathEnvVar;
-  private String pluginPublisher;
-  private String pluginName;
-  private String pluginId;
+  private Component component;
 
   public MachineResolver build() {
     if (container == null
         || cheContainer == null
         || defaultSidecarMemorySizeAttribute == null
-        || wsAttributes == null
         || containerEndpoints == null
-        || projectsRootPathEnvVar == null
-        || pluginPublisher == null
-        || pluginName == null
-        || pluginId == null) {
+        || projectsRootPathEnvVar == null) {
       throw new IllegalStateException();
     }
 
     return new MachineResolver(
-        pluginPublisher,
-        pluginName,
-        pluginId,
         projectsRootPathEnvVar,
         container,
         cheContainer,
         defaultSidecarMemorySizeAttribute,
         containerEndpoints,
-        wsAttributes);
+        component);
   }
 
   public MachineResolverBuilder setContainer(Container container) {
@@ -77,29 +67,14 @@ public class MachineResolverBuilder {
     return this;
   }
 
-  public MachineResolverBuilder setAttributes(Map<String, String> wsConfigAttributes) {
-    this.wsAttributes = wsConfigAttributes;
-    return this;
-  }
-
   public MachineResolverBuilder setProjectsRootPathEnvVar(
       Pair<String, String> projectsRootPathEnvVar) {
     this.projectsRootPathEnvVar = projectsRootPathEnvVar;
     return this;
   }
 
-  public MachineResolverBuilder setPluginPublisher(String pluginPublisher) {
-    this.pluginPublisher = pluginPublisher;
-    return this;
-  }
-
-  public MachineResolverBuilder setPluginName(String pluginName) {
-    this.pluginName = pluginName;
-    return this;
-  }
-
-  public MachineResolverBuilder setPluginId(String pluginId) {
-    this.pluginId = pluginId;
+  public MachineResolverBuilder setComponent(Component component) {
+    this.component = component;
     return this;
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/TestObjects.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/TestObjects.java
@@ -127,8 +127,7 @@ public class TestObjects {
     }
 
     public InternalMachineConfig build() {
-      return new InternalMachineConfig(
-          new ArrayList<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(), volumes);
+      return new InternalMachineConfig(new HashMap<>(), new HashMap<>(), new HashMap<>(), volumes);
     }
   }
 }

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -114,16 +114,6 @@ public final class Constants {
   public static final String WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE = "plugins";
 
   /**
-   * Template for workspace attribute key that sets sidecar limit in a plugin. %s should be replaced
-   * with pluginPublisher/pluginName. When plugin provides several sidecars this property sets the
-   * same limit for each sidecar, so is not that useful in such a case. Value format see {@link
-   * KubernetesSize}
-   */
-  public static final String SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE = "sidecar.%s.memory_limit";
-
-  public static final String SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE = "sidecar.%s.environment_variables";
-
-  /**
    * Describes workspace runtimes which perform start/stop of this workspace. Should be set/read
    * from {@link Workspace#getAttributes}
    */

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -121,6 +121,8 @@ public final class Constants {
    */
   public static final String SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE = "sidecar.%s.memory_limit";
 
+  public static final String SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE = "sidecar.%s.environment_variables";
+
   /**
    * Describes workspace runtimes which perform start/stop of this workspace. Should be set/read
    * from {@link Workspace#getAttributes}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/Constants.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/Constants.java
@@ -40,22 +40,6 @@ public class Constants {
   /** Action type that should be used for commands execution. */
   public static final String EXEC_ACTION_TYPE = "exec";
 
-  /**
-   * Workspace config attribute which contains comma-separated list of mappings of chePlugin
-   * component id to its name.
-   *
-   * <p>Example value:
-   *
-   * <pre>
-   * eclipse/maven-jdk8/1.0.0=mvn-stack,eclipse/theia-jdtls/0.0.3=jdt.ls
-   * </pre>
-   */
-  public static final String PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE =
-      "pluginComponentsAliases";
-
-  /** Workspace config attribute which contains cheEditor component name. */
-  public static final String EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE = "editorComponentAlias";
-
   /** Workspace command attributes that indicates with which component it is associated. */
   public static final String COMPONENT_ALIAS_COMMAND_ATTRIBUTE = "componentAlias";
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/ComponentToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/ComponentToWorkspaceApplier.java
@@ -11,10 +11,10 @@
  */
 package org.eclipse.che.api.workspace.server.devfile.convert.component;
 
-import org.eclipse.che.api.core.model.workspace.devfile.Component;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 
 /**
  * Applies changes on workspace config according to the specified component. Different
@@ -37,6 +37,8 @@ public interface ComponentToWorkspaceApplier {
    * @throws DevfileException if any exception occurs during content retrieving
    */
   void apply(
-      WorkspaceConfigImpl workspaceConfig, Component component, FileContentProvider contentProvider)
+      WorkspaceConfigImpl workspaceConfig,
+      ComponentImpl component,
+      FileContentProvider contentProvider)
       throws DevfileException;
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/editor/EditorComponentToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/editor/EditorComponentToWorkspaceApplier.java
@@ -14,15 +14,19 @@ package org.eclipse.che.api.workspace.server.devfile.convert.component.editor;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.api.core.model.workspace.config.Command.PLUGIN_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.EDITOR_COMPONENT_TYPE;
+import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE;
 import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_EDITOR_ATTRIBUTE;
 
+import java.util.List;
 import javax.inject.Inject;
 import org.eclipse.che.api.core.model.workspace.devfile.Component;
+import org.eclipse.che.api.core.model.workspace.devfile.Env;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.convert.component.ComponentFQNParser;
 import org.eclipse.che.api.workspace.server.devfile.convert.component.ComponentToWorkspaceApplier;
@@ -70,6 +74,7 @@ public class EditorComponentToWorkspaceApplier implements ComponentToWorkspaceAp
     final String editorId = editorComponent.getId();
     final String registryUrl = editorComponent.getRegistryUrl();
     final String memoryLimit = editorComponent.getMemoryLimit();
+    final List<? extends Env> env = editorComponent.getEnv();
 
     final ExtendedPluginFQN fqn = componentFQNParser.evaluateFQN(editorComponent, contentProvider);
     if (editorComponentAlias != null) {
@@ -106,5 +111,14 @@ public class EditorComponentToWorkspaceApplier implements ComponentToWorkspaceAp
                     && editorComponentAlias.equals(
                         c.getAttributes().get(COMPONENT_ALIAS_COMMAND_ATTRIBUTE)))
         .forEach(c -> c.getAttributes().put(PLUGIN_ATTRIBUTE, fqn.getId()));
+
+    if (!env.isEmpty()) {
+      workspaceConfig.getAttributes()
+          .put(format(SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE, fqn.getPublisherAndName()),
+              String.join(",", env.stream().map(
+                  (java.util.function.Function<Env, String>) e -> e.getName() + "=" + e.getValue())
+                  .collect(toList())));
+    }
   }
+
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/plugin/PluginComponentToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/plugin/PluginComponentToWorkspaceApplier.java
@@ -14,25 +14,19 @@ package org.eclipse.che.api.workspace.server.devfile.convert.component.plugin;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
-import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.api.core.model.workspace.config.Command.PLUGIN_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
-import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGIN_COMPONENT_TYPE;
-import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE;
-import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE;
 
-import java.util.List;
 import javax.inject.Inject;
-import org.eclipse.che.api.core.model.workspace.devfile.Component;
-import org.eclipse.che.api.core.model.workspace.devfile.Env;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.convert.component.ComponentFQNParser;
 import org.eclipse.che.api.workspace.server.devfile.convert.component.ComponentToWorkspaceApplier;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ExtendedPluginFQN;
 import org.eclipse.che.commons.annotation.Nullable;
 
@@ -63,7 +57,7 @@ public class PluginComponentToWorkspaceApplier implements ComponentToWorkspaceAp
   @Override
   public void apply(
       WorkspaceConfigImpl workspaceConfig,
-      Component pluginComponent,
+      ComponentImpl pluginComponent,
       @Nullable FileContentProvider contentProvider)
       throws DevfileException {
     checkArgument(workspaceConfig != null, "Workspace config must not be null");
@@ -94,12 +88,6 @@ public class PluginComponentToWorkspaceApplier implements ComponentToWorkspaceAp
                   workspacePluginsAttribute,
                   componentFQNParser.getCompositeId(registryUrl, pluginId)));
     }
-    String memoryLimit = pluginComponent.getMemoryLimit();
-    if (memoryLimit != null) {
-      workspaceConfig
-          .getAttributes()
-          .put(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, fqn.getPublisherAndName()), memoryLimit);
-    }
 
     for (CommandImpl command : workspaceConfig.getCommands()) {
       String commandComponent = command.getAttributes().get(COMPONENT_ALIAS_COMMAND_ATTRIBUTE);
@@ -116,30 +104,9 @@ public class PluginComponentToWorkspaceApplier implements ComponentToWorkspaceAp
       command.getAttributes().put(PLUGIN_ATTRIBUTE, fqn.getId());
     }
 
-    String pluginsAliases =
-        workspaceConfig.getAttributes().get(PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE);
-    if (pluginComponent.getAlias() != null) {
-      workspaceConfig
-          .getAttributes()
-          .put(
-              PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE,
-              append(
-                  pluginsAliases,
-                  componentFQNParser.getCompositeId(
-                          fqn.getRegistry() != null ? fqn.getRegistry().toString() : null,
-                          fqn.getId())
-                      + "="
-                      + pluginComponent.getAlias()));
-    }
-
-    final List<? extends Env> env = pluginComponent.getEnv();
-    if (!env.isEmpty()) {
-      workspaceConfig.getAttributes()
-          .put(format(SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE, fqn.getPublisherAndName()),
-              String.join(",", env.stream().map(
-                  (java.util.function.Function<Env, String>) e -> e.getName() + "=" + e.getValue())
-                  .collect(toList())));
-    }
+    // make sure id is set to be able to match component with plugin broker result
+    // when referenceContent is used
+    pluginComponent.setId(fqn.getId());
   }
 
   private String append(String source, String toAppend) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/plugin/PluginComponentToWorkspaceApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/component/plugin/PluginComponentToWorkspaceApplier.java
@@ -14,15 +14,19 @@ package org.eclipse.che.api.workspace.server.devfile.convert.component.plugin;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.api.core.model.workspace.config.Command.PLUGIN_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGIN_COMPONENT_TYPE;
+import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE;
 import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE;
 
+import java.util.List;
 import javax.inject.Inject;
 import org.eclipse.che.api.core.model.workspace.devfile.Component;
+import org.eclipse.che.api.core.model.workspace.devfile.Env;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.convert.component.ComponentFQNParser;
 import org.eclipse.che.api.workspace.server.devfile.convert.component.ComponentToWorkspaceApplier;
@@ -126,6 +130,15 @@ public class PluginComponentToWorkspaceApplier implements ComponentToWorkspaceAp
                           fqn.getId())
                       + "="
                       + pluginComponent.getAlias()));
+    }
+
+    final List<? extends Env> env = pluginComponent.getEnv();
+    if (!env.isEmpty()) {
+      workspaceConfig.getAttributes()
+          .put(format(SIDECAR_ENV_VARIABLES_ATTR_TEMPLATE, fqn.getPublisherAndName()),
+              String.join(",", env.stream().map(
+                  (java.util.function.Function<Env, String>) e -> e.getName() + "=" + e.getValue())
+                  .collect(toList())));
     }
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/devfile/ComponentImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/devfile/ComponentImpl.java
@@ -500,7 +500,7 @@ public class ComponentImpl implements Component {
         + "id='"
         + componentId
         + '\''
-        + "alias='"
+        + ", alias='"
         + alias
         + '\''
         + ", type='"

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironment.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironment.java
@@ -23,6 +23,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
 import org.eclipse.che.api.core.model.workspace.config.Command;
 import org.eclipse.che.api.core.model.workspace.config.Environment;
 import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.DevfileImpl;
 import org.eclipse.che.api.workspace.server.spi.RuntimeInfrastructure;
 import org.eclipse.che.commons.annotation.Nullable;
 
@@ -44,6 +45,7 @@ public abstract class InternalEnvironment {
   private final List<Warning> warnings;
   private Map<String, String> attributes;
   private List<CommandImpl> commands;
+  private DevfileImpl devfile;
 
   protected InternalEnvironment() {
     this.warnings = new CopyOnWriteArrayList<>();
@@ -67,6 +69,7 @@ public abstract class InternalEnvironment {
     this.warnings = new CopyOnWriteArrayList<>(internalEnvironment.getWarnings());
     this.attributes = internalEnvironment.getAttributes();
     this.commands = internalEnvironment.getCommands();
+    this.devfile = internalEnvironment.getDevfile();
   }
 
   /**
@@ -179,5 +182,14 @@ public abstract class InternalEnvironment {
       this.commands = commands.stream().map(CommandImpl::new).collect(Collectors.toList());
     }
     return this;
+  }
+
+  /** Return the devfile that was used for the environment constructing. */
+  public DevfileImpl getDevfile() {
+    return devfile;
+  }
+
+  public void setDevfile(DevfileImpl devfile) {
+    this.devfile = devfile;
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalEnvironmentFactory.java
@@ -96,7 +96,6 @@ public abstract class InternalEnvironmentFactory<T extends InternalEnvironment> 
         machines.put(
             machineEntry.getKey(),
             new InternalMachineConfig(
-                installers,
                 normalizeServers(machineConfig.getServers()),
                 machineConfig.getEnv(),
                 machineConfig.getAttributes(),

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalMachineConfig.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/environment/InternalMachineConfig.java
@@ -11,13 +11,10 @@
  */
 package org.eclipse.che.api.workspace.server.spi.environment;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.config.Volume;
-import org.eclipse.che.api.installer.shared.model.Installer;
 
 /**
  * Machine Config to use inside infrastructure.
@@ -32,7 +29,6 @@ import org.eclipse.che.api.installer.shared.model.Installer;
  * @author gazarenkov
  */
 public class InternalMachineConfig {
-  private final List<Installer> installers;
   private final Map<String, ServerConfig> servers;
   private final Map<String, String> env;
   private final Map<String, String> attributes;
@@ -40,14 +36,12 @@ public class InternalMachineConfig {
 
   public InternalMachineConfig() {
     this.servers = new HashMap<>();
-    this.installers = new ArrayList<>();
     this.env = new HashMap<>();
     this.attributes = new HashMap<>();
     this.volumes = new HashMap<>();
   }
 
   public InternalMachineConfig(
-      List<Installer> installers,
       Map<String, ? extends ServerConfig> servers,
       Map<String, String> env,
       Map<String, String> attributes,
@@ -65,11 +59,6 @@ public class InternalMachineConfig {
     if (volumes != null) {
       this.volumes.putAll(volumes);
     }
-  }
-
-  /** Returns modifiable ordered list of installers configs of the machine. */
-  public List<Installer> getInstallers() {
-    return installers;
   }
 
   /** Returns modifiable map of servers configured in the machine. */

--- a/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
+++ b/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
@@ -271,6 +271,7 @@
                   "type": {},
                   "alias": {},
                   "id": {},
+                  "env": {},
                   "reference": {},
                   "registryUrl": {},
                   "memoryLimit": {}
@@ -293,6 +294,7 @@
                   "type": {},
                   "alias": {},
                   "id": {},
+                  "env": {},
                   "memoryLimit": {},
                   "reference": {},
                   "registryUrl": {},
@@ -344,7 +346,7 @@
                   "type": {},
                   "alias": {},
                   "mountSources": {},
-                  "env":  {},
+                  "env": {},
                   "reference": {
                     "description": "Describes absolute or devfile-relative location of Kubernetes list yaml file. Applicable only for 'kubernetes' and 'openshift' type components",
                     "type": "string",
@@ -431,7 +433,7 @@
                   "type": {},
                   "alias": {},
                   "mountSources": {},
-                  "env":  {},
+                  "env": {},
                   "image": {
                     "type": "string",
                     "description": "Specifies the docker image that should be used for component",

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -549,7 +549,7 @@ public class WorkspaceManagerTest {
 
     EnvironmentImpl environment = new EnvironmentImpl(null, emptyMap());
     Command command = new CommandImpl("cmd", "echo hello", "custom");
-    WorkspaceConfig convertedConfig =
+    WorkspaceConfigImpl convertedConfig =
         new WorkspaceConfigImpl(
             "any",
             "",
@@ -575,7 +575,7 @@ public class WorkspaceManagerTest {
 
     EnvironmentImpl environment = new EnvironmentImpl(null, emptyMap());
     Command command = new CommandImpl("cmd", "echo hello", "custom");
-    WorkspaceConfig convertedConfig =
+    WorkspaceConfigImpl convertedConfig =
         new WorkspaceConfigImpl(
             "any",
             "",
@@ -615,7 +615,7 @@ public class WorkspaceManagerTest {
 
     EnvironmentImpl environment = new EnvironmentImpl(null, emptyMap());
     Command command = new CommandImpl("cmd", "echo hello", "custom");
-    WorkspaceConfig convertedConfig =
+    WorkspaceConfigImpl convertedConfig =
         new WorkspaceConfigImpl(
             "any",
             "",

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimesTest.java
@@ -216,7 +216,7 @@ public class WorkspaceRuntimesTest {
     when(noEnvFactory.create(eq(null))).thenReturn(expectedEnvironment);
 
     InternalEnvironment actualEnvironment =
-        runtimes.createInternalEnvironment(null, emptyMap(), emptyList());
+        runtimes.createInternalEnvironment(null, emptyMap(), emptyList(), null);
 
     assertEquals(actualEnvironment, expectedEnvironment);
   }
@@ -229,7 +229,7 @@ public class WorkspaceRuntimesTest {
       throws Exception {
     EnvironmentImpl environment = new EnvironmentImpl();
     environment.setRecipe(new RecipeImpl("not-supported-type", "", "", null));
-    runtimes.createInternalEnvironment(environment, emptyMap(), emptyList());
+    runtimes.createInternalEnvironment(environment, emptyMap(), emptyList(), null);
   }
 
   @Test(
@@ -241,7 +241,7 @@ public class WorkspaceRuntimesTest {
   public void
       internalEnvironmentShouldThrowExceptionWhenNoEnvironmentFactoryFoundForNoEnvironmentWorkspaceCase()
           throws Exception {
-    runtimes.createInternalEnvironment(null, emptyMap(), emptyList());
+    runtimes.createInternalEnvironment(null, emptyMap(), emptyList(), null);
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/component/editor/EditorComponentToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/component/editor/EditorComponentToWorkspaceApplierTest.java
@@ -11,12 +11,9 @@
  */
 package org.eclipse.che.api.workspace.server.devfile.convert.component.editor;
 
-import static java.lang.String.format;
 import static org.eclipse.che.api.core.model.workspace.config.Command.PLUGIN_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
-import static org.eclipse.che.api.workspace.server.devfile.Constants.EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.EDITOR_COMPONENT_TYPE;
-import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_EDITOR_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -66,14 +63,6 @@ public class EditorComponentToWorkspaceApplierTest {
 
     // then
     assertEquals(workspaceConfig.getAttributes().get(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE), editorId);
-    assertEquals(
-        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE),
-        editorId + "=" + editorComponent.getAlias());
-    assertEquals(
-        workspaceConfig
-            .getAttributes()
-            .get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, "eclipse/super-editor")),
-        "12345M");
   }
 
   @Test
@@ -98,18 +87,6 @@ public class EditorComponentToWorkspaceApplierTest {
     assertEquals(
         workspaceConfig.getAttributes().get(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE),
         registryUrl + "#" + editorId);
-    assertEquals(
-        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE),
-        registryUrl.substring(0, registryUrl.length() - 1)
-            + "#"
-            + editorId
-            + "="
-            + editorComponent.getAlias());
-    assertEquals(
-        workspaceConfig
-            .getAttributes()
-            .get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, "eclipse/super-editor")),
-        "12345M");
   }
 
   @Test
@@ -137,14 +114,7 @@ public class EditorComponentToWorkspaceApplierTest {
     // then
     assertEquals(
         workspaceConfig.getAttributes().get(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE), reference);
-    assertEquals(
-        workspaceConfig.getAttributes().get(EDITOR_COMPONENT_ALIAS_WORKSPACE_ATTRIBUTE),
-        "eclipse/super-editor/0.0.1" + "=" + editorComponent.getAlias());
-    assertEquals(
-        workspaceConfig
-            .getAttributes()
-            .get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, "eclipse/super-editor")),
-        "12345M");
+    assertEquals(editorComponent.getId(), "eclipse/super-editor/0.0.1");
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/component/plugin/PluginComponentToWorkspaceApplierTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/component/plugin/PluginComponentToWorkspaceApplierTest.java
@@ -11,12 +11,9 @@
  */
 package org.eclipse.che.api.workspace.server.devfile.convert.component.plugin;
 
-import static java.lang.String.format;
 import static org.eclipse.che.api.core.model.workspace.config.Command.PLUGIN_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
-import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGIN_COMPONENT_TYPE;
-import static org.eclipse.che.api.workspace.shared.Constants.SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -80,16 +77,6 @@ public class PluginComponentToWorkspaceApplierTest {
     assertTrue(workspaceTooling.matches("(.+/.+/.+),(.+/.+/.+)"));
     assertTrue(workspaceTooling.contains(superPluginId));
     assertTrue(workspaceTooling.contains("publisher1/custom-plugin/v1"));
-    String toolingAliases =
-        workspaceConfig.getAttributes().get(PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE);
-    assertTrue(toolingAliases.matches("(.+/.+/.+=.+),(.+/.+/.+=.+)"));
-    assertTrue(toolingAliases.contains(superPluginId + "=super-plugin"));
-    assertTrue(toolingAliases.contains("publisher1/custom-plugin/v1=custom"));
-    assertEquals(
-        workspaceConfig
-            .getAttributes()
-            .get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, "eclipse/super-plugin")),
-        "1234M");
   }
 
   @Test
@@ -124,16 +111,6 @@ public class PluginComponentToWorkspaceApplierTest {
     assertTrue(workspaceTooling.matches("(.+/.+/.+),(.+/.+/.+)"));
     assertTrue(workspaceTooling.contains(superPluginId));
     assertTrue(workspaceTooling.contains(registryUrl + "#" + "publisher1/custom-plugin/v1"));
-    String toolingAliases =
-        workspaceConfig.getAttributes().get(PLUGINS_COMPONENTS_ALIASES_WORKSPACE_ATTRIBUTE);
-    assertTrue(toolingAliases.matches("(.+/.+/.+=.+),(.+/.+/.+=.+)"));
-    assertTrue(toolingAliases.contains(superPluginId + "=super-plugin"));
-    assertTrue(toolingAliases.contains("publisher1/custom-plugin/v1=custom"));
-    assertEquals(
-        workspaceConfig
-            .getAttributes()
-            .get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, "eclipse/super-plugin")),
-        "1234M");
   }
 
   @Test
@@ -174,11 +151,7 @@ public class PluginComponentToWorkspaceApplierTest {
     assertTrue(workspaceTooling.matches("(.+/.+/.+),(https://.+/.+/.+)"));
     assertTrue(workspaceTooling.contains(superPluginId));
     assertTrue(workspaceTooling.contains(reference));
-    assertEquals(
-        workspaceConfig
-            .getAttributes()
-            .get(format(SIDECAR_MEMORY_LIMIT_ATTR_TEMPLATE, "eclipse/super-plugin")),
-        "1234M");
+    assertEquals(customPluginComponent.getId(), "eclipse/super-plugin/0.0.1");
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/MachineConfigsValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/environment/MachineConfigsValidatorTest.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.api.workspace.server.spi.environment;
 
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
@@ -212,7 +211,6 @@ public class MachineConfigsValidatorTest {
   private static InternalMachineConfig machineMock() {
     InternalMachineConfig machineConfig = mock(InternalMachineConfig.class);
     when(machineConfig.getServers()).thenReturn(emptyMap());
-    when(machineConfig.getInstallers()).thenReturn(emptyList());
     return machineConfig;
   }
 

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/editor_plugin_component/devfile_editor_plugins.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/editor_plugin_component/devfile_editor_plugins.yaml
@@ -22,11 +22,17 @@ projects:
 components:
   - type: cheEditor
     id: eclipse/chetheia/0.0.3
+    env:
+      - name: ENV_VAR
+        value: value
   - alias: mvn-stack
     type: chePlugin
     id: eclipse/chemaven-jdk8/1.0.0
   - type: chePlugin
     id: eclipse/chetheia-jdtls/0.0.3
+    env:
+      - name: ENV_VAR
+        value: value
 commands:
   - name: build
     actions:


### PR DESCRIPTION
### What does this PR do?
It introduces a new feature: propagating plugin/editor component environment variables.

This is archived by the following architecture change:
Now we propagate the whole Devfile along with WorkspaceConfig and InternalEnvironment and it makes it possible to access components configuration and apply it on plugin brokering phase.

What can be done better maybe in scope of separate PRs:
1. Now `EditorComponentToWorkspaceConfigApplier`/`PluginComponentToWorkspaceConfigApplier` modifies components that was originally passed. It's needed to make it possible to match component (configured with reference) with ChePlugin provided by plugin broker. As an improvement, we can get rid of it but Plugin Broker should provide additional information where it downloaded ChePlugin configuration. More see https://github.com/eclipse/che/pull/15435#discussion_r356049993
2. The whole Devfile is passed to WorkspaceConfig/InternalEnvironment and by the time being only Plugins/Editors components are used. As an alternative way we could propagate only used parts and there is no clear and easy way to do it smoothly. See more https://github.com/eclipse/che/pull/15435#discussion_r355943668

### How to test this PR
0. Build this branch or use the following image: `sleshchenko/che-server:env-vars`
1. Create a workspace with the following Devfile
<details>

<summary>Devfile</summary>

```yaml
metadata:
  name: env-override
components:
  - type: kubernetes
    reference: >-
      https://gist.githubusercontent.com/sleshchenko/86d28a2c4426bdd0cef57bdfe3c7a829/raw/555b20c10ff7d6519b80d0841a30735a2f4f2118/deployment.yaml
    alias: env-test
    env:
      - value: Serhii
        name: NAME
  - reference: https://gist.githubusercontent.com/sleshchenko/5e1118c93a17e6b7d4efc4cd6f88b164/raw/471553b59cf72510289b497e0f7a6f1c86e48450/meta.yaml
    memoryLimit: 1G
    type: cheEditor
    alias: editor
    env:
      - value: Hello My Dear Friend
        name: TEST
  - id: ms-vscode/go/latest
    type: chePlugin
    alias: plugin
    memoryLimit: 256M
    env:
      - value: Hello My Dear Friend
        name: TEST
apiVersion: 1.0.0
commands:
  - name: testk8s
    actions:
      - type: exec
        command: cd /hello && ls
        component: env-test
  - name: test-editor
    actions:
      - type: exec
        command: 'echo ${TEST}'
        component: editor
  - name: test-plugin
    actions:
      - type: exec
        command: 'echo ${TEST}'
        component: plugin
```

</details>
2. Run every command and make sure that output has values provided with env vars.
3. Check workspace pod deployment (kubectl or K8s/OS Dashboard) and make sure that memoryLimit is right.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14343

#### Release Notes
N/A


#### Docs PR
https://github.com/eclipse/che-docs/pull/966