### PR TITLE
Fix colliding of parameters between PR check builds

### DIFF
--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                 description: 'Repo of Che server image')
 
         string(name: 'cheImageTag',
-                defaultValue: "$ghprbPullId",
+                defaultValue: "",
                 description: 'Tag of Che server image')
 
         booleanParam(name: 'buildChe',
@@ -48,6 +48,16 @@ pipeline {
     }
 
     stages {
+        stage("Setup environment") {
+            steps {
+                script {
+                    if (cheImageTag == null || cheImageTag == '') {
+                        cheImageTag = ghprbPullId
+                    }
+                }
+            }
+        }
+
         stage("Prepare to start Che on K8S") {
             failFast true
 


### PR DESCRIPTION
### What does this PR do?
It fixes colliding of parameters between the Happy path tests PR check builds, which leads to error:
```
+ docker tag eclipse/che-server:nightly docker.io/maxura/che-server:
Error parsing reference: "docker.io/maxura/che-server:" is not a valid repository/tag: invalid reference format
```

### What issues does this PR fix or reference?
#15397