### PR TITLE
Change redirect of output of maven build-to-file command

### DIFF
--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -48,7 +48,7 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: cd /projects/petclinic && mvn package >> build-output.txt && tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build-output.txt
+        command: cd /projects/petclinic && mvn package | tee build-output.txt && tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build-output.txt
   - name: run
     actions:
       - type: exec


### PR DESCRIPTION
### What does this PR do?
Change redirect of the output of maven build-to-file command to tee. This way, the output will be written in build-output.txt and also into a terminal, so it will be more visible in which state the build is. 
