### PR TITLE
Add cloud-shell to list servers with liveness probes

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -143,7 +143,7 @@ che.workspace.server.ping_success_threshold=1
 che.workspace.server.ping_interval_milliseconds=3000
 
 # List of servers names which require liveness probes
-che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia,jupyter,dirigible
+che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia,jupyter,dirigible,cloud-shell
 
 ### TEMPLATES
 # Folder that contains JSON files with code templates and samples


### PR DESCRIPTION
### What does this PR do?
Add cloud-shell to list servers with liveness probes. Need to fix first loading application after workspace start.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15434

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>
