### PR TITLE
Provision environment variables for initContainers of chePlugin/cheEditor

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/EnvVars.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/EnvVars.java
@@ -35,8 +35,8 @@ public class EnvVars {
    * <p>If a container does not have the corresponding env - it will be provisioned, if it has - the
    * value will be overridden.
    *
-   * @param podData pod to apply env
-   * @param env env var to apply
+   * @param podData pod to supply env vars
+   * @param env env vars to apply
    */
   public void apply(PodData podData, List<? extends Env> env) {
     Stream.concat(
@@ -45,7 +45,16 @@ public class EnvVars {
         .forEach(c -> apply(c, env));
   }
 
-  private void apply(Container container, List<? extends Env> toApply) {
+  /**
+   * Applies the specified env vars list to the specified containers.
+   *
+   * <p>If a container does not have the corresponding env - it will be provisioned, if it has - the
+   * value will be overridden.
+   *
+   * @param container pod to supply env vars
+   * @param toApply env vars to apply
+   */
+  public void apply(Container container, List<? extends Env> toApply) {
     List<EnvVar> targetEnv = container.getEnv();
     if (targetEnv == null) {
       targetEnv = new ArrayList<>();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolver.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toMap;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.DEVFILE_COMPONENT_ALIAS_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
@@ -23,10 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.devfile.Component;
-import org.eclipse.che.api.core.model.workspace.devfile.Env;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
@@ -67,7 +66,7 @@ public class MachineResolver {
     InternalMachineConfig machineConfig =
         new InternalMachineConfig(
             toServers(containerEndpoints),
-            component.getEnv().stream().collect(Collectors.toMap(Env::getName, Env::getValue)),
+            emptyMap(),
             resolveMachineAttributes(),
             toWorkspaceVolumes(cheContainer));
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -63,6 +64,7 @@ import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.DevfileImpl;
+import org.eclipse.che.api.workspace.server.model.impl.devfile.EnvImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalEnvironment;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
@@ -79,6 +81,8 @@ import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Warnings;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.EnvVars;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
@@ -108,6 +112,7 @@ public class KubernetesPluginsToolingApplierTest {
   @Mock private RuntimeIdentity runtimeIdentity;
   @Mock private ProjectsRootEnvVariableProvider projectsRootEnvVariableProvider;
   @Mock private ChePluginsVolumeApplier chePluginsVolumeApplier;
+  @Mock private EnvVars envVars;
 
   private KubernetesEnvironment internalEnvironment;
   private KubernetesPluginsToolingApplier applier;
@@ -122,7 +127,8 @@ public class KubernetesPluginsToolingApplierTest {
             MEMORY_LIMIT_MB,
             false,
             projectsRootEnvVariableProvider,
-            chePluginsVolumeApplier);
+            chePluginsVolumeApplier,
+            envVars);
 
     Map<String, InternalMachineConfig> machines = new HashMap<>();
     List<Container> containers = new ArrayList<>();
@@ -166,6 +172,33 @@ public class KubernetesPluginsToolingApplierTest {
     assertEquals(
         envCommand.getAttributes().get(WORKING_DIRECTORY_ATTRIBUTE), pluginCommand.getWorkingDir());
     validateContainerNameName(envCommand.getAttributes().get(MACHINE_NAME_ATTRIBUTE), "container");
+  }
+
+  @Test
+  public void shouldProvisionApplyEnvironmentVariableToContainersAndInitContainersOfPlugin()
+      throws Exception {
+    // given
+    CheContainer container = new CheContainer();
+    container.setName("container");
+    CheContainer initContainer = new CheContainer();
+    initContainer.setName("initContainer");
+
+    ChePlugin chePlugin =
+        createChePlugin(
+            "publisher/id/1.0.0", singletonList(container), singletonList(initContainer));
+    ComponentImpl component = internalEnvironment.getDevfile().getComponents().get(0);
+    component.getEnv().add(new EnvImpl("TEST", "VALUE"));
+    ArgumentCaptor<Container> containerArgumentCaptor = ArgumentCaptor.forClass(Container.class);
+
+    // when
+    applier.apply(runtimeIdentity, internalEnvironment, singletonList(chePlugin));
+
+    // then
+    verify(envVars, times(2)).apply(containerArgumentCaptor.capture(), eq(component.getEnv()));
+    List<Container> containers = containerArgumentCaptor.getAllValues();
+    // containers names are suffixed to provide uniqueness and converted to be k8s API compatible
+    assertTrue(containers.get(0).getName().startsWith("initcontainer"));
+    assertTrue(containers.get(1).getName().startsWith("container"));
   }
 
   @Test(
@@ -758,7 +791,8 @@ public class KubernetesPluginsToolingApplierTest {
             MEMORY_LIMIT_MB,
             true,
             projectsRootEnvVariableProvider,
-            chePluginsVolumeApplier);
+            chePluginsVolumeApplier,
+            envVars);
 
     applier.apply(runtimeIdentity, internalEnvironment, singletonList(createChePlugin()));
 
@@ -774,7 +808,8 @@ public class KubernetesPluginsToolingApplierTest {
             MEMORY_LIMIT_MB,
             true,
             projectsRootEnvVariableProvider,
-            chePluginsVolumeApplier);
+            chePluginsVolumeApplier,
+            envVars);
     internalEnvironment.getAttributes().put(SECURE_EXPOSER_IMPL_PROPERTY, "somethingElse");
 
     applier.apply(runtimeIdentity, internalEnvironment, singletonList(createChePlugin()));
@@ -791,7 +826,8 @@ public class KubernetesPluginsToolingApplierTest {
             MEMORY_LIMIT_MB,
             true,
             projectsRootEnvVariableProvider,
-            chePluginsVolumeApplier);
+            chePluginsVolumeApplier,
+            envVars);
 
     applier.apply(runtimeIdentity, internalEnvironment, singletonList(createChePlugin()));
 
@@ -816,7 +852,8 @@ public class KubernetesPluginsToolingApplierTest {
             MEMORY_LIMIT_MB,
             true,
             projectsRootEnvVariableProvider,
-            chePluginsVolumeApplier);
+            chePluginsVolumeApplier,
+            envVars);
 
     applier.apply(runtimeIdentity, internalEnvironment, singletonList(createChePlugin()));
 
@@ -844,17 +881,26 @@ public class KubernetesPluginsToolingApplierTest {
   }
 
   private ChePlugin createChePlugin(CheContainer... containers) {
-    return createChePlugin("publisher/" + NameGenerator.generate("name", 3) + "/0.0.1", containers);
+    return createChePlugin(
+        "publisher/" + NameGenerator.generate("name", 3) + "/0.0.1",
+        Arrays.asList(containers),
+        emptyList());
   }
 
   private ChePlugin createChePlugin(String id, CheContainer... containers) {
+    return createChePlugin(id, Arrays.asList(containers), emptyList());
+  }
+
+  private ChePlugin createChePlugin(
+      String id, List<CheContainer> containers, List<CheContainer> initContainers) {
     String[] splittedId = id.split("/");
     ChePlugin plugin = new ChePlugin();
     plugin.setPublisher(splittedId[0]);
     plugin.setName(splittedId[1]);
     plugin.setVersion(splittedId[2]);
     plugin.setId(id);
-    plugin.setContainers(Arrays.asList(containers));
+    plugin.setContainers(containers);
+    plugin.setInitContainers(initContainers);
 
     internalEnvironment.getDevfile().getComponents().add(new ComponentImpl("chePlugin", id));
     return plugin;

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/MachineResolverTest.java
@@ -25,7 +25,6 @@ import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.VolumeImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
-import org.eclipse.che.api.workspace.server.model.impl.devfile.EnvImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.wsplugins.model.CheContainer;
@@ -162,18 +161,6 @@ public class MachineResolverTest {
     InternalMachineConfig machineConfig = resolver.resolve();
 
     assertEquals(machineConfig.getAttributes().get(MEMORY_LIMIT_ATTRIBUTE), expectedMemLimit);
-  }
-
-  @Test
-  public void
-      shouldProvisionEnvironmentVarsIntoMachineConfigOfASidecarIfTheyAreSetInTheCorrespondingComponent()
-          throws InfrastructureException {
-    component.getEnv().add(new EnvImpl("test", "value"));
-
-    InternalMachineConfig machineConfig = resolver.resolve();
-
-    assertEquals(machineConfig.getEnv().size(), 1);
-    assertEquals(machineConfig.getEnv().get("test"), "value");
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Provisions environment variables for initContainers of chePlugin/cheEditor.

The only init container we have now for chePlugin/cheEditor - remote-plugin-laucher and I'm not sure if it makes sense to tune it. But I think if we provision additional, unused env vars to init containers - it won't hurt anyone in most cases but potentially can be used if there is need to tune initContainer of chePlugin/cheEditor and we will have consistent behavior for all component types.

### What issues does this PR fix or reference?
If follows up https://github.com/eclipse/che/pull/15435

### How to test this PR 
Che Server image build by Happy Path job: maxura/che-server:15508
<details>

<summary>Devfile</summary>

```yaml
metadata:
  name: env-override-new
components:
  - type: kubernetes
    reference: >-
      https://gist.githubusercontent.com/sleshchenko/86d28a2c4426bdd0cef57bdfe3c7a829/raw/555b20c10ff7d6519b80d0841a30735a2f4f2118/deployment.yaml
    alias: env-test
    env:
      - value: Tom
        name: NAME
  - memoryLimit: 1G
    type: cheEditor
    reference: >-
      https://gist.githubusercontent.com/sleshchenko/5e1118c93a17e6b7d4efc4cd6f88b164/raw/b90a076ab92e3a14101f0275e0573b3ce2eff49d/meta.yaml
    alias: editor
    env:
      - value: Tom
        name: NAME
  - id: ms-vscode/go/latest
    memoryLimit: 256M
    type: chePlugin
    alias: plugin
    env:
      - value: Tom
        name: NAME
apiVersion: 1.0.0
commands:
  - name: test-initContainers
    actions:
      - type: exec
        command: cd /hello && ls
        component: env-test
  - name: test-editor
    actions:
      - type: exec
        command: 'echo Hello ${NAME}'
        component: editor
  - name: test-plugin
    actions:
      - type: exec
        command: 'echo Hello ${NAME}'
        component: plugin
```

</details>
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
N/A

#### Docs PR
A note will be added to che docs if reviewers think it makes sense to provision env vars to initContainers as well.