### PR TITLE
Close if condition in the configmap.yaml

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -104,6 +104,7 @@ data:
   CHE_WORKSPACE_PLUGIN__REGISTRY__URL: https://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
   {{- else }}
   CHE_WORKSPACE_PLUGIN__REGISTRY__URL: http://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
+  {{- end }}
 {{- end }}
 {{- if .Values.che.workspace.pluginBroker }}
   {{- if .Values.che.workspace.pluginBroker.waitTimeoutMin }}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Currently syntaxis in the `deploy/kubernetes/helm/che/templates/configmap.yaml` file  is broken. It causes an error when trying to execute `helm upgrade` command:
```
$ helm upgrade che --set global.useGitSelfSignedCerts=true --set global.ingressDomain=$(minikube ip).nip.io .
UPGRADE FAILED
Error: parse error in "che/templates/configmap.yaml": template: che/templates/configmap.yaml:136: unexpected EOF
Error: UPGRADE FAILED: parse error in "che/templates/configmap.yaml": template: che/templates/configmap.yaml:136: unexpected EOF
```
see: https://www.eclipse.org/che/docs/che-7/advanced-configuration-options/#configuring-support-for-self-signed-git-repositories-on-kubernetes

Add missing close statement to fix the error.
### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
