### PR TITLE
Fix authentication error when non-root path requested

### DIFF
--- a/assembly/assembly-root-war/src/main/webapp/_app/loader.js
+++ b/assembly/assembly-root-war/src/main/webapp/_app/loader.js
@@ -232,11 +232,12 @@ class Loader {
     }
 
     /**
-     * Returns `true` if any machine in workspace contains a server which matches with `redirectUrl`
+     * Finds and returns appropriate server which user request belongs to, or throw error
+     * if none is found.
      * @param {*} workspace a workspace
      * @param {string} redirectUrl a redirect URL
      */
-    asyncCheckServiceLink(workspace, redirectUrl) {
+    asyncGetMatchedServer(workspace, redirectUrl) {
         return new Promise((resolve, reject) => {
             if (!workspace.runtime) {
                 reject(new Error("Can't check service link: Workspace isn't RUNNING at the moment."));
@@ -274,6 +275,7 @@ class Loader {
     }
 
     /**
+     * Calls auth endpoint in order to accept authentication cookie.
      * @param {string} redirectUrl a redirect URL
      * @param {string} token
      */
@@ -336,7 +338,7 @@ class Loader {
 
         await new KeycloakLoader().loadKeycloakSettings();
         const workspace = await loader.asyncGetWorkspace(workspaceId);
-        const server = await loader.asyncCheckServiceLink(workspace, redirectUrl);
+        const server = await loader.asyncGetMatchedServer(workspace, redirectUrl);
         const token = await loader.asyncGetWsToken(workspace);
         await loader.asyncAuthenticate(server.url, token);
 

--- a/assembly/assembly-root-war/src/main/webapp/_app/loader.js
+++ b/assembly/assembly-root-war/src/main/webapp/_app/loader.js
@@ -336,9 +336,9 @@ class Loader {
 
         await new KeycloakLoader().loadKeycloakSettings();
         const workspace = await loader.asyncGetWorkspace(workspaceId);
-        await loader.asyncCheckServiceLink(workspace, redirectUrl);
+        const server = await loader.asyncCheckServiceLink(workspace, redirectUrl);
         const token = await loader.asyncGetWsToken(workspace);
-        await loader.asyncAuthenticate(redirectUrl, token);
+        await loader.asyncAuthenticate(server.url, token);
 
         window.location.replace(redirectUrl);
     } catch (errorMessage) {


### PR DESCRIPTION
### What does this PR do?
When secure enpoint requested first time, IDE loader makes request to an endpoint to obtain cookies by appending `jwt/auth` part, like: 
`http://routed1h37d2q-admin-che.192.168.99.114.nip.io/jwt/auth`
If non-root resource requested, URL becames invalid like 
`http://routed1h37d2q-admin-che.192.168.99.114.nip.io/vs/editor/editor.main.cssjwt/auth`

Since we cannot remove the `path` part of URL due to single-host mode which uses path to differentiate servers, we need to do auth requests not using full initial redirect URL but the base URL which is set in approppriate server.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15430



#### Release Notes
N/A


#### Docs PR
None