### PR TITLE
[Happy Path] Check application readiness before opening the link by the "DialogWindow.waitDialogAndOpenLink" method

### DIFF
--- a/tests/e2e/pageobjects/ide/DialogWindow.ts
+++ b/tests/e2e/pageobjects/ide/DialogWindow.ts
@@ -87,8 +87,7 @@ export class DialogWindow {
     }
 
     async getApplicationUrlFromDialog(dialogWindowText: string) {
-        const dialogBodyXpathLocator: string = '//div[@id=\'theia-dialog-shell\']//div[@class=\'dialogBlock\']';
-        const notificationTextLocator: By = By.xpath(`${dialogBodyXpathLocator}//span[contains(text(), '${dialogWindowText}')]`);
+        const notificationTextLocator: By = By.xpath(`${DialogWindow.DIALOG_BODY_XPATH_LOCATOR}//span[contains(text(), '${dialogWindowText}')]`);
 
         let dialogWindow = await this.driverHelper.waitAndGetText(notificationTextLocator);
         let regexp: RegExp = new RegExp('^.*(https?://.*)$');

--- a/tests/e2e/pageobjects/ide/DialogWindow.ts
+++ b/tests/e2e/pageobjects/ide/DialogWindow.ts
@@ -13,13 +13,15 @@ import { DriverHelper } from '../../utils/DriverHelper';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
 import { TestConstants } from '../../TestConstants';
+import { Ide } from './Ide';
 
 @injectable()
 export class DialogWindow {
     private static readonly DIALOG_BODY_XPATH_LOCATOR: string = '//div[@id=\'theia-dialog-shell\']//div[@class=\'dialogBlock\']';
     private static readonly CLOSE_BUTTON_XPATH_LOCATOR: string = `${DialogWindow.DIALOG_BODY_XPATH_LOCATOR}//button[text()='close']`;
 
-    constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
+    constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
+        @inject(CLASSES.Ide) private readonly ide: Ide) { }
 
     async dialogDisplayes(): Promise<boolean> {
         Logger.debug('DialogWindow.dialogDisplayes');
@@ -73,6 +75,7 @@ export class DialogWindow {
         Logger.debug('DialogWindow.waitDialogAndOpenLink');
 
         await this.waitDialog(timeout, dialogText);
+        await this.ide.waitApllicationIsReady(await this.getApplicationUrlFromDialog(dialogText));
         await this.clickToOpenLinkButton();
         await this.waitDialogDissappearance();
     }
@@ -81,6 +84,20 @@ export class DialogWindow {
         Logger.debug('DialogWindow.waitDialogDissappearance');
 
         await this.driverHelper.waitDisappearanceWithTimeout(By.xpath(DialogWindow.CLOSE_BUTTON_XPATH_LOCATOR));
+    }
+
+    async getApplicationUrlFromDialog(dialogWindowText: string) {
+        const dialogBodyXpathLocator: string = '//div[@id=\'theia-dialog-shell\']//div[@class=\'dialogBlock\']';
+        const notificationTextLocator: By = By.xpath(`${dialogBodyXpathLocator}//span[contains(text(), '${dialogWindowText}')]`);
+
+        let dialogWindow = await this.driverHelper.waitAndGetText(notificationTextLocator);
+        let regexp: RegExp = new RegExp('^.*(https?://.*)$');
+
+        if (!regexp.test(dialogWindow)) {
+            throw new Error('Cannot obtaine url from notification message');
+        }
+
+        return dialogWindow.split(regexp)[1];
     }
 
 }


### PR DESCRIPTION


<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Check application readiness before opening the link by the "DialogWindow.waitDialogAndOpenLink" method

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/15551
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
