### PR TITLE
Add certificate in the correct configuration for HA use case

### DIFF
--- a/dockerfiles/keycloak/cli/add_openshift_certificate-ha.cli
+++ b/dockerfiles/keycloak/cli/add_openshift_certificate-ha.cli
@@ -1,0 +1,4 @@
+embed-server --server-config=standalone-ha.xml --std-out=echo
+/subsystem=keycloak-server/spi=truststore/:add
+/subsystem=keycloak-server/spi=truststore/provider=file/:add(properties={file => "/scripts/openshift.jks", password => "openshift", disabled => "false" },enabled=true)
+stop-embedded-server

--- a/dockerfiles/keycloak/kc_realm_user.sh
+++ b/dockerfiles/keycloak/kc_realm_user.sh
@@ -37,7 +37,8 @@ if [ "${CHE_SELF__SIGNED__CERT}" != "" ]; then
     echo "${CHE_SELF__SIGNED__CERT}" > /scripts/openshift.cer
     keytool -importcert -alias HOSTDOMAIN -keystore /scripts/openshift.jks -file /scripts/openshift.cer -storepass openshift -noprompt
     keytool -importkeystore -srckeystore $JAVA_HOME/jre/lib/security/cacerts -destkeystore /scripts/openshift.jks -srcstorepass changeit -deststorepass openshift
-    /opt/jboss/keycloak/bin/jboss-cli.sh --file=/scripts/cli/add_openshift_certificate.cli && rm -rf /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
+    /opt/jboss/keycloak/bin/jboss-cli.sh --file=/scripts/cli/add_openshift_certificate.cli && rm -f /opt/jboss/keycloak/standalone/configuration/standalone_xml_history
+    /opt/jboss/keycloak/bin/jboss-cli.sh --file=/scripts/cli/add_openshift_certificate-ha.cli
 fi
 
 # POSTGRES_PORT is assigned by Kubernetes controller


### PR DESCRIPTION
### What does this PR do?
When keycloack start, he use the standalone-ha.xml configuration but in entrypoint the certificate is added in standalone.xml : 
/usr/lib/jvm/java/bin/java -D[Standalone] -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true -Dorg.jboss.boot.log.file=/opt/jboss/keycloak/standalone/log/server.log -Dlogging.configuration=file:/opt/jboss/keycloak/standalone/configuration/logging.properties -jar /opt/jboss/keycloak/jboss-modules.jar -mp /opt/jboss/keycloak/modules org.jboss.as.standalone -Djboss.home.dir=/opt/jboss/keycloak -Djboss.server.base.dir=/opt/jboss/keycloak/standalone -Djboss.bind.address=10.128.5.254 -Djboss.bind.address.private=10.128.5.254 **-c=standalone-ha.xml** -Dkeycloak.migration.action=import -Dkeycloak.migration.provider=dir -Dkeycloak.migration.strategy=IGNORE_EXISTING -Dkeycloak.migration.dir=/scripts/ -Djboss.bind.address=0.0.0.0

### What issues does this PR fix or reference?
Fix issue when you deploy Che on Openshift for multi user use case with self sign certificate for the master nodes.
