### PR TITLE
Fix mount target of test report in e2e docker image readme.

### DIFF
--- a/dockerfiles/e2e/README.md
+++ b/dockerfiles/e2e/README.md
@@ -29,7 +29,7 @@ docker run --shm-size=256m -e TS_SELENIUM_BASE_URL=$URL eclipse/che-e2e:nightly
 If you want to gather screenshots of fallen tests, you have to mount a volume to the docker file. Create a folder, when you want to have the screenshots saved. Then run a command:
 
 ```
-docker run --shm-size=256m -v /full/path/to/your/folder:/root/e2e/report:Z -e TS_SELENIUM_BASE_URL=$URL eclipse/che-e2e:nightly
+docker run --shm-size=256m -v /full/path/to/your/folder:/tmp/e2e/report:Z -e TS_SELENIUM_BASE_URL=$URL eclipse/che-e2e:nightly
 ```
 
 Happy Path test suite will be run by default when executing a docker run command. If you want to run another test suite, you can specify that via variable ` TEST_SUITE `. Available tests are e.g. ` test-happy-path `, ` test-operatorhub-installation ` and ` test-wkspc-creation-and-ls `.


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes readme.
`/root/e2e` was a path with bundled tests until [this commit](https://github.com/eclipse/che/commit/e8efb8283a402c34510f61e400c7eb71d574870c) changed that to `/tmp/e2e`

### What issues does this PR fix or reference?
