### PR TITLE
Disable CORS by default in helm

### DIFF
--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -120,9 +120,6 @@ data:
   CHE_CORS_ENABLED: "false"
   CHE_CORS_ALLOW__CREDENTIALS: "false"
   CHE_CORS_ALLOWED__ORIGINS: "*"
-  CHE_WSAGENT_CORS_ENABLED: "true"
-  CHE_WSAGENT_CORS_ALLOW__CREDENTIALS: "true"
-  CHE_WSAGENT_CORS_ALLOWED__ORIGINS: "NULL"
   CHE_TRACING_ENABLED: {{ .Values.global.tracingEnabled | quote }}
   JAEGER_ENDPOINT: "http://jaeger-collector:14268/api/traces"
   JAEGER_SERVICE_NAME: "che-server"

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -117,7 +117,7 @@ data:
 {{- if .Values.global.cheWorkspaceClusterRole }}
   CHE_INFRA_KUBERNETES_CLUSTER__ROLE__NAME: {{ .Values.global.cheWorkspaceClusterRole }}
 {{- end }}
-  CHE_CORS_ENABLED: "true"
+  CHE_CORS_ENABLED: "false"
   CHE_CORS_ALLOW__CREDENTIALS: "false"
   CHE_CORS_ALLOWED__ORIGINS: "*"
   CHE_WSAGENT_CORS_ENABLED: "true"


### PR DESCRIPTION
### What does this PR do?
Disable CORS by default in helm.
Align helm and che-operator configuration

### What issues does this PR fix or reference?
We have a lot of complaints about security vulnerabilities related to cors. 
That is why it's disabled by default in che-operator. This PR sync helm with che-operator


#### Release Notes
n/a

#### Docs PR
n/a