### PR TITLE
Allow to override attibutes in devfile by factory URL parameters

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/OverridePropertiesApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/OverridePropertiesApplier.java
@@ -31,7 +31,7 @@ import org.eclipse.che.api.workspace.server.devfile.exception.OverrideParameterE
  * be used during object modification:
  *
  * <ul>
- *   <li>Only allowed top-level fields can be altered: apiVersion, metadata, project.
+ *   <li>Only allowed top-level fields can be altered: apiVersion, metadata, project, attributes.
  *   <li>The absent segment will be created as an empty object and next segment will be added as a
  *       field of it
  *   <li>The property identifier cannot ends with an array type reference
@@ -41,13 +41,14 @@ import org.eclipse.che.api.workspace.server.devfile.exception.OverrideParameterE
  */
 public class OverridePropertiesApplier {
 
-  private final List<String> allowedFirstSegments = asList("apiVersion", "metadata", "projects");
+  private final List<String> allowedFirstSegments =
+      asList("apiVersion", "metadata", "projects", "attributes");
 
   public JsonNode applyPropertiesOverride(
       JsonNode devfileNode, Map<String, String> overrideProperties)
       throws OverrideParameterException {
     for (Map.Entry<String, String> entry : overrideProperties.entrySet()) {
-      String[] pathSegments = entry.getKey().split("\\.");
+      String[] pathSegments = parseSegments(entry.getKey());
       if (pathSegments.length < 1) {
         continue;
       }
@@ -88,6 +89,10 @@ public class OverridePropertiesApplier {
       ((ObjectNode) currentNode).put(lastSegment, entry.getValue());
     }
     return devfileNode;
+  }
+
+  private String[] parseSegments(String key) {
+    return key.split("\\.", key.startsWith("attributes.") ? 2 : 0);
   }
 
   private void validateFirstSegment(String[] pathSegments) throws OverrideParameterException {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/OverridePropertiesApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/OverridePropertiesApplier.java
@@ -93,7 +93,7 @@ public class OverridePropertiesApplier {
 
   private String[] parseSegments(String key) {
     return key.startsWith("attributes.")
-        // for attributes we treat anything as a attribute name so just need only 2 parts
+        // for attributes we treat the rest as a attribute name so just need only 2 parts
         ? key.split("\\.", 2)
         : key.split("\\.");
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/OverridePropertiesApplier.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/OverridePropertiesApplier.java
@@ -92,7 +92,10 @@ public class OverridePropertiesApplier {
   }
 
   private String[] parseSegments(String key) {
-    return key.split("\\.", key.startsWith("attributes.") ? 2 : 0);
+    return key.startsWith("attributes.")
+        // for attributes we treat anything as a attribute name so just need only 2 parts
+        ? key.split("\\.", 2)
+        : key.split("\\.");
   }
 
   private void validateFirstSegment(String[] pathSegments) throws OverrideParameterException {

--- a/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
+++ b/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
@@ -749,8 +749,7 @@
       },
       "additionalProperties": {
         "type": "string"
-      },
-      "javaType": "java.util.Map<String, String>"
+      }
     }
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/OverridePropertiesApplierTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/OverridePropertiesApplierTest.java
@@ -55,6 +55,48 @@ public class OverridePropertiesApplierTest {
   }
 
   @Test
+  public void shouldCreateUnExistingAttributesInDevfile() throws Exception {
+    String json = "{" + "\"apiVersion\": \"1.0.0\"" + "}";
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("attributes.persistVolumes", "true");
+    // when
+    JsonNode result = applier.applyPropertiesOverride(jsonMapper.readTree(json), overrides);
+    assertEquals(result.get("attributes").get("persistVolumes").textValue(), "true");
+  }
+
+  @Test
+  public void shouldUpdateExistingAttributesInDevfile() throws Exception {
+    String json =
+        "{"
+            + "\"apiVersion\": \"1.0.0\","
+            + "\"attributes\": {"
+            + "    \"persistVolumes\": \"false\""
+            + "  }"
+            + "}";
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("attributes.persistVolumes", "true");
+    // when
+    JsonNode result = applier.applyPropertiesOverride(jsonMapper.readTree(json), overrides);
+    assertEquals(result.get("attributes").get("persistVolumes").textValue(), "true");
+  }
+
+  @Test
+  public void shouldUpdateExistingAttributesWithDotsInDevfile() throws Exception {
+    String json =
+        "{"
+            + "\"apiVersion\": \"1.0.0\","
+            + "\"attributes\": {"
+            + "    \"che.persistVolumes\": \"false\""
+            + "  }"
+            + "}";
+    Map<String, String> overrides = new HashMap<>();
+    overrides.put("attributes.che.persistVolumes", "true");
+    // when
+    JsonNode result = applier.applyPropertiesOverride(jsonMapper.readTree(json), overrides);
+    assertEquals(result.get("attributes").get("che.persistVolumes").textValue(), "true");
+  }
+
+  @Test
   public void shouldRewriteValueInProjectsArrayElementByName() throws Exception {
     String json =
         "{"
@@ -155,7 +197,7 @@ public class OverridePropertiesApplierTest {
   @Test(
       expectedExceptions = OverrideParameterException.class,
       expectedExceptionsMessageRegExp =
-          "Override path 'commands.run.foo.bar' starts with an unsupported field pointer. Supported fields are \\{\"apiVersion\",\"metadata\",\"projects\"\\}.")
+          "Override path 'commands.run.foo.bar' starts with an unsupported field pointer. Supported fields are \\{\"apiVersion\",\"metadata\",\"projects\"\\,\"attributes\"\\}.")
   public void shouldThrowExceptionIfOverrideReferenceUsesUnsupportedField() throws Exception {
     String json =
         "{"


### PR DESCRIPTION
### What does this PR do?
Allow to override attibutes in devfile by factory URL parameters.
Example query parameter:
`override.attributes.persistVolumes=true`

### What issues does this PR fix or reference?
#15500 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


### Docs PR
https://github.com/eclipse/che-docs/pull/1031