### PR TITLE
Increase time for IDE loading

### DIFF
--- a/tests/.infra/crw-ci/master/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/master/k8s/Jenkinsfile
@@ -79,6 +79,9 @@ pipeline {
                                         string(name: 'testWorkspaceDevfileUrl',
                                                 value: ''),
 
+                                        string(name: 'e2eTestParameters',
+                                                value: '-e "TS_SELENIUM_LOAD_PAGE_TIMEOUT=180000""')
+
                                         text(name: 'customResourceFileContent',
                                                 value: ''),
 


### PR DESCRIPTION
### What does this PR do?
Increasing timeout for loading page `TS_SELENIUM_LOAD_PAGE_TIMEOUT` - should prevent intermittent failures with IDE not loading in 2 minutes from starting a workspace. The default timeout is 120000 seconds and was increased to 180000 seconds.

### What issues does this PR fix or reference?
The related issue is logged for Hosted Che. This will fix only nightly runs of tests of Che. 
Hosted Che issue can be found here: https://github.com/redhat-developer/rh-che/issues/1604
