### PR TITLE
Fixed README typo with linked text

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you are interested in fixing issues and contributing directly to the code bas
 - :bug: [Submitting bugs](https://github.com/eclipse/che/issues/new/choose)
 - :page_facing_up: [Contributor license agreement](https://github.com/eclipse/che/wiki/Eclipse-Contributor-Agreement)
 - :checkered_flag: [Development workflows](./CONTRIBUTING.md)
-- :ok_hand: Review [source code changes](https://github.com/eclipse/che/pulls)
+- :ok_hand: [Review source code changes](https://github.com/eclipse/che/pulls)
 - :pencil: [Improve docs](https://github.com/eclipse/che-docs)
 - :building_construction: [Che architecture](https://www.eclipse.org/che/docs/che-7/che-architecture.html)
 - :octocat: [Che repositories](./CONTRIBUTING.md#other-che-repositories)


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
A tiny fix that makes the "review code changes" link the same as the text around it (as in the whole line is a link, before this the word review stood out as it wasn't a link).

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
N/A

#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
