### PR TITLE
Enable to set che.api.internal .

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -18,6 +18,9 @@ che.database=${che.home}/storage
 # API service. Browsers initiate REST communications to Che server with this URL
 che.api=http://${CHE_HOST}:${CHE_PORT}/api
 
+# API service endpoint used by in-cluster pods.
+che.api.internal=http://${CHE_HOST}:${CHE_PORT}/api
+
 # Che websocket major endpoint. Provides basic communication endpoint
 # for major websocket interaction/messaging.
 che.websocket.endpoint=ws://${CHE_HOST}:${CHE_PORT}/api/websocket

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesCheApiInternalEnvVarProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesCheApiInternalEnvVarProvider.java
@@ -28,7 +28,8 @@ public class KubernetesCheApiInternalEnvVarProvider implements CheApiInternalEnv
   private final String cheServerEndpoint;
 
   @Inject
-  public KubernetesCheApiInternalEnvVarProvider(@Named("che.api") String cheServerEndpoint) {
+  public KubernetesCheApiInternalEnvVarProvider(
+      @Named("che.api.internal") String cheServerEndpoint) {
     this.cheServerEndpoint = cheServerEndpoint;
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiEnvVarProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiEnvVarProvider.java
@@ -18,7 +18,7 @@ import org.eclipse.che.commons.lang.Pair;
 
 /**
  * CHE_API endpoint var provided. For all currently supported infrastructures, it reuses {@link
- * CheApiInternalEnvVarProvider} to provide the value.
+ * CheApiExternalEnvVarProvider} to provide the value.
  *
  * @deprecated this class shall soon be removed, as this variable is provided only for backward
  *     compatibility
@@ -31,11 +31,11 @@ public class CheApiEnvVarProvider implements EnvVarProvider {
   /** Che API url */
   public static final String CHE_API_VARIABLE = "CHE_API";
 
-  private final CheApiInternalEnvVarProvider cheApiInternalEnvVarProvider;
+  private final CheApiExternalEnvVarProvider cheApiExternalEnvVarProvider;
 
   @Inject
-  public CheApiEnvVarProvider(CheApiInternalEnvVarProvider cheApiInternalEnvVarProvider) {
-    this.cheApiInternalEnvVarProvider = cheApiInternalEnvVarProvider;
+  public CheApiEnvVarProvider(CheApiExternalEnvVarProvider cheApiExternalEnvVarProvider) {
+    this.cheApiExternalEnvVarProvider = cheApiExternalEnvVarProvider;
   }
 
   /**
@@ -45,6 +45,6 @@ public class CheApiEnvVarProvider implements EnvVarProvider {
    */
   @Override
   public Pair<String, String> get(RuntimeIdentity runtimeIdentity) throws InfrastructureException {
-    return Pair.of(CHE_API_VARIABLE, cheApiInternalEnvVarProvider.get(runtimeIdentity).second);
+    return Pair.of(CHE_API_VARIABLE, cheApiExternalEnvVarProvider.get(runtimeIdentity).second);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiEnvVarProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiEnvVarProvider.java
@@ -20,12 +20,9 @@ import org.eclipse.che.commons.lang.Pair;
  * CHE_API endpoint var provided. For all currently supported infrastructures, it reuses {@link
  * CheApiExternalEnvVarProvider} to provide the value.
  *
- * @deprecated this class shall soon be removed, as this variable is provided only for backward
- *     compatibility
  * @author Sergii Leshchenko
  * @author Mykhailo Kuznietsov
  */
-@Deprecated
 public class CheApiEnvVarProvider implements EnvVarProvider {
 
   /** Che API url */


### PR DESCRIPTION
# What does this PR do?

Enables to set `che.api.internal` that is used by in-container pods.
This property will be passed to pods as the environment variable named `CHE_API_INTERNAL` in pods.
Almost all users don't need to care about this because the default value is set.

`che.api` is bound to the environment variable `CHE_API` and `CHE_API_EXTERNAL`.
It is same as the current implementation.

Note that `che.api.external` have not existed until now. And it won't provided in the future also.

### What issues does this PR fix or reference?

- An alternative of #13774 .
- Will fix #15663 .
