### PR TITLE
Deprecate CHE_API_EXTERNAL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,5 +199,5 @@ subjects:
 EOF
 ```
 
-Also `CHE_API_INTERNAL`, `CHE_API_EXTERNAL` and `CHE_API` should be set in runner container and point to new Che server API.
+Also `CHE_API_INTERNAL` and `CHE_API` should be set in runner container and point to new Che server API.
 If one uses provided devfile, they are already set to: `http://che-dev:8080/api`, which should be changed in case of https protocol.

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiEnvVarProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiEnvVarProvider.java
@@ -18,7 +18,7 @@ import org.eclipse.che.commons.lang.Pair;
 
 /**
  * CHE_API endpoint var provided. For all currently supported infrastructures, it reuses {@link
- * CheApiInternalEnvVarProvider} to provide the value.
+ * CheApiExternalEnvVarProvider} to provide the value.
  *
  * @deprecated this class shall soon be removed, as this variable is provided only for backward
  *     compatibility
@@ -31,11 +31,11 @@ public class CheApiEnvVarProvider implements EnvVarProvider {
   /** Che API url */
   public static final String CHE_API_VARIABLE = "CHE_API";
 
-  private final CheApiInternalEnvVarProvider cheApiInternalEnvVarProvider;
+  private final CheApiExternalEnvVarProvider cheApiExternalEnvVarProvider;
 
   @Inject
-  public CheApiEnvVarProvider(CheApiInternalEnvVarProvider cheApiInternalEnvVarProvider) {
-    this.cheApiInternalEnvVarProvider = cheApiInternalEnvVarProvider;
+  public CheApiEnvVarProvider(CheApiExternalEnvVarProvider cheApiExternalEnvVarProvider) {
+    this.cheApiExternalEnvVarProvider = cheApiExternalEnvVarProvider;
   }
 
   /**
@@ -45,6 +45,6 @@ public class CheApiEnvVarProvider implements EnvVarProvider {
    */
   @Override
   public Pair<String, String> get(RuntimeIdentity runtimeIdentity) throws InfrastructureException {
-    return Pair.of(CHE_API_VARIABLE, cheApiInternalEnvVarProvider.get(runtimeIdentity).second);
+    return Pair.of(CHE_API_VARIABLE, cheApiExternalEnvVarProvider.get(runtimeIdentity).second);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiEnvVarProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiEnvVarProvider.java
@@ -20,12 +20,9 @@ import org.eclipse.che.commons.lang.Pair;
  * CHE_API endpoint var provided. For all currently supported infrastructures, it reuses {@link
  * CheApiExternalEnvVarProvider} to provide the value.
  *
- * @deprecated this class shall soon be removed, as this variable is provided only for backward
- *     compatibility
  * @author Sergii Leshchenko
  * @author Mykhailo Kuznietsov
  */
-@Deprecated
 public class CheApiEnvVarProvider implements EnvVarProvider {
 
   /** Che API url */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiExternalEnvVarProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/provision/env/CheApiExternalEnvVarProvider.java
@@ -15,7 +15,12 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.lang.Pair;
 
-/** @author Mykhailo Kuznietsov */
+/**
+ * @deprecated this class shall soon be removed, as this variable is provided only for backward
+ *     compatibility. Use `CHE_API` instead of `CHE_API_EXTERNAL`.
+ * @author Mykhailo Kuznietsov
+ */
+@Deprecated
 public interface CheApiExternalEnvVarProvider extends EnvVarProvider {
 
   /** Env variable for machine that contains url of Che API */


### PR DESCRIPTION
### What does this PR do?

Moves `deprecated` flags from `CHE_API` to `CHE_API_EXTERNAL`.
This is a first step of removing `CHE_API_EXTERNAL`.

### What issues does this PR fix or reference?

- spin off of #15682. Referring to the discussion,  there is no room to deprecate/remove `CHE_API_EXTERNAL`. 
- An alternative of #13774 .