### PR TITLE
[UD] view and change target kubernetes namespace when creating a new workspace

### DIFF
--- a/dashboard/src/app/factories/load-factory/load-factory.controller.ts
+++ b/dashboard/src/app/factories/load-factory/load-factory.controller.ts
@@ -354,7 +354,7 @@ export class LoadFactoryController {
       }
 
       const attrs = {factoryurl: `${url}${params}`};
-      this.cheAPI.getWorkspace().createWorkspaceFromDevfile(null, devfile, attrs)
+      this.cheAPI.getWorkspace().createWorkspaceFromDevfile(undefined, undefined, devfile, attrs)
         .then((workspace: che.IWorkspace) => defer.resolve(workspace));
     }
     defer.promise.then((workspace: che.IWorkspace) => {

--- a/dashboard/src/app/get-started/template-list/template-list.controller.ts
+++ b/dashboard/src/app/get-started/template-list/template-list.controller.ts
@@ -132,7 +132,7 @@ export class TemplateListController {
     return this.devfileRegistry.fetchDevfile(this.devfileRegistryUrl, selfLink).then(() => {
       const devfile = this.devfileRegistry.getDevfile(this.devfileRegistryUrl, selfLink);
       const attributes = {stackName: this.selectedDevfile.displayName};
-      return this.createWorkspaceSvc.createWorkspaceFromDevfile(devfile, attributes, true);
+      return this.createWorkspaceSvc.createWorkspaceFromDevfile(undefined, devfile, attributes, true);
     });
   }
 

--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.controller.ts
@@ -12,6 +12,7 @@
 'use strict';
 
 import { CreateWorkspaceSvc } from './create-workspace.service';
+import { DevfileChangeEventData } from './devfile-change-event-data';
 import {
   ICheButtonDropdownMainAction,
   ICheButtonDropdownOtherAction
@@ -24,14 +25,6 @@ enum TABS {
   READY_TO_GO,
   IMPORT_DEVFILE
 }
-
-/**
- *
- */
-type DevfileChangeEventData = {
-  devfile: che.IWorkspaceDevfile,
-  attrs?: { [key: string]: string }
-};
 
 /**
  * This class is handling the controller for workspace creation.
@@ -192,10 +185,9 @@ export class CreateWorkspaceController {
    * Creates workspace.
    */
   createWorkspace(): ng.IPromise<che.IWorkspace> {
-    const { devfile, attrs } = this.devfiles.get(this.selectedTab);
-    return this.createWorkspaceSvc.createWorkspaceFromDevfile(devfile, attrs, this.selectedTab === TABS.IMPORT_DEVFILE);
+    const { devfile, attrs, infrastructureNamespaceId } = this.devfiles.get(this.selectedTab);
+    return this.createWorkspaceSvc.createWorkspaceFromDevfile(infrastructureNamespaceId, devfile, attrs, this.selectedTab === TABS.IMPORT_DEVFILE);
   }
-
 
   /**
    * Creates a workspace and redirects to the IDE.
@@ -206,8 +198,8 @@ export class CreateWorkspaceController {
     });
   }
 
-  onDevfileChange(tab: number, devfile: che.IWorkspaceDevfile, attrs: { [key: string]: string }): void {
-    this.devfiles.set(tab, { devfile, attrs });
+  onDevfileChange(tab: number, eventData: DevfileChangeEventData): void {
+    this.devfiles.set(tab, eventData);
   }
 
 }

--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.html
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.html
@@ -13,6 +13,7 @@
              md-selected="createWorkspaceController.selectedTab"
              class="create-workspace-content"
              md-no-ink-bar>
+
       <!-- READY-TO-GO STACK -->
       <md-tab md-on-select="createWorkspaceController.onSelectTab(createWorkspaceController.tabs.READY_TO_GO)">
         <md-tab-label>
@@ -22,7 +23,7 @@
           <ng-form name="createWorkspaceReadyToGoForm" id="create-workspace-ready-to-go-form">
             <ready-to-go-stacks
               ng-init="createWorkspaceController.registerForm(createWorkspaceController.tabs.READY_TO_GO, createWorkspaceReadyToGoForm)"
-              on-change="createWorkspaceController.onDevfileChange(createWorkspaceController.tabs.READY_TO_GO, devfile, attrs)">
+              on-change="createWorkspaceController.onDevfileChange(createWorkspaceController.tabs.READY_TO_GO, {devfile, attrs, infrastructureNamespaceId})">
               <che-button-save-flat id="create-workspace-ready-to-go-button" name="saveButton"
                                     che-button-title="Create & Open"
                                     ng-click="createWorkspaceController.createWorkspaceAndOpenIDE()"
@@ -32,6 +33,7 @@
           </ng-form>
         </md-tab-body>
       </md-tab>
+
       <!-- IMPORT CUSTOM STACK -->
       <md-tab
         md-on-select="createWorkspaceController.onSelectTab(createWorkspaceController.tabs.IMPORT_DEVFILE)">
@@ -42,7 +44,7 @@
           <ng-form name="createWorkspaceImportStackForm" id="create-workspace-import-stack-form">
             <import-stack
               ng-init="createWorkspaceController.registerForm(createWorkspaceController.tabs.IMPORT_DEVFILE, createWorkspaceImportStackForm)"
-              on-change="createWorkspaceController.onDevfileChange(createWorkspaceController.tabs.IMPORT_DEVFILE, devfile, attrs)">
+              on-change="createWorkspaceController.onDevfileChange(createWorkspaceController.tabs.IMPORT_DEVFILE, {devfile, attrs, infrastructureNamespaceId})">
               <che-button-save-flat id="create-workspace-import-stack-form-button" name="saveButton"
                                     che-button-title="Create & Open"
                                     ng-click="createWorkspaceController.createWorkspaceAndOpenIDE()"
@@ -52,6 +54,7 @@
           </ng-form>
         </md-tab-body>
       </md-tab>
+
     </md-tabs>
   </md-content>
 </div>

--- a/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
+++ b/dashboard/src/app/workspaces/create-workspace/create-workspace.service.ts
@@ -150,7 +150,7 @@ export class CreateWorkspaceSvc {
     return defer.promise;
   }
 
-  createWorkspaceFromDevfile(sourceDevfile: che.IWorkspaceDevfile, attributes: any, skipProjectTemplates?: boolean): ng.IPromise<che.IWorkspace> {
+  createWorkspaceFromDevfile(infrastructureNamespaceId: string, sourceDevfile: che.IWorkspaceDevfile, attributes: any, skipProjectTemplates: boolean): ng.IPromise<che.IWorkspace> {
     const namespaceId = this.namespaceSelectorSvc.getNamespaceId(),
           noProjectsFromDevfile = !sourceDevfile.projects || !sourceDevfile.projects.length,
           projectsTemplates = this.projectSourceSelectorService.getProjectTemplates();
@@ -158,12 +158,12 @@ export class CreateWorkspaceSvc {
     return this.checkEditingProgress().then(() => {
       if (!skipProjectTemplates) {
         sourceDevfile.projects = projectsTemplates;
-        // If no projects defined in devfile were added - remove the commands from devfile as well:
+        // if no projects defined in devfile were added - remove the commands from devfile as well:
         if (noProjectsFromDevfile) {
           sourceDevfile.commands = [];
         }
       }
-      return this.cheWorkspace.createWorkspaceFromDevfile(namespaceId, sourceDevfile, attributes).then((workspace: che.IWorkspace) => {
+      return this.cheWorkspace.createWorkspaceFromDevfile(namespaceId, infrastructureNamespaceId, sourceDevfile, attributes).then((workspace: che.IWorkspace) => {
         return this.cheWorkspace.fetchWorkspaces().then(() => this.cheWorkspace.getWorkspaceById(workspace.id));
       })
       .then((workspace: che.IWorkspace) => {

--- a/dashboard/src/app/workspaces/create-workspace/devfile-change-event-data.ts
+++ b/dashboard/src/app/workspaces/create-workspace/devfile-change-event-data.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+export type DevfileChangeEventData = {
+  devfile: che.IWorkspaceDevfile,
+  attrs: { [key: string]: string } | undefined,
+  infrastructureNamespaceId: string,
+};

--- a/dashboard/src/app/workspaces/create-workspace/import-custom-stack/import-custom-stack.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/import-custom-stack/import-custom-stack.directive.ts
@@ -11,8 +11,13 @@
  */
 'use strict';
 
+import { DevfileChangeEventData } from '../devfile-change-event-data';
+
 export interface IImportStackScopeBindings {
-  onChange: (eventData: { devfile: che.IWorkspaceDevfile, attrs?: { [key: string]: any } }) => void;
+  onChange: IImportStackScopeOnChange;
+}
+export interface IImportStackScopeOnChange {
+  (eventData: DevfileChangeEventData): void;
 }
 
 /**

--- a/dashboard/src/app/workspaces/create-workspace/import-custom-stack/import-custom-stack.html
+++ b/dashboard/src/app/workspaces/create-workspace/import-custom-stack/import-custom-stack.html
@@ -6,18 +6,25 @@
       selected-source="importStackController.selectedSource"
       on-change="importStackController.onSourceChange(source)"></devfile-source-selector>
   </che-label-container>
+
+  <!-- Kubernetes namespace selector -->
+  <che-label-container che-label-name="Kubernetes Namespace" che-label-description="{{importStackController.infrastructureNamespaceHint}}">
+    <kubernetes-namespace-selector on-change="importStackController.onInfrastructureNamespaceChange(namespaceId)"></kubernetes-namespace-selector>
+  </che-label-container>
+
   <!-- Import stack  -->
   <che-label-container che-label-name="{{importStackController.selectedSource}}">
     <!-- URL -->
     <devfile-by-url ng-if="importStackController.isUrlSelected() === true"
                     workspace-devfile-location="importStackController.devfileLocation"
-                    workspace-devfile-on-change="importStackController.updateDevfile(devfile, attributes)"></devfile-by-url>
+                    workspace-devfile-on-change="importStackController.updateDevfileFromRemote(devfile, attributes)"></devfile-by-url>
     <!-- YAML -->
     <workspace-devfile-editor ng-if="importStackController.isYamlSelected() === true"
                               is-active="true"
-                              workspace-devfile="importStackController.devfile"
-                              workspace-devfile-on-change="importStackController.updateDevfile(devfile)"></workspace-devfile-editor>
+                              workspace-devfile="importStackController.devfileYaml"
+                              workspace-devfile-on-change="importStackController.updateDevfileFromYaml(devfile)"></workspace-devfile-editor>
   </che-label-container>
+
   <!-- Create Workspace Button -->
   <che-label-container>
     <ng-transclude></ng-transclude>

--- a/dashboard/src/app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.controller.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import { IKubernetesNamespaceScopeBindings, IKubernetesNamespaceOnChange } from './kubernetes-namespace-selector.directive';
+
+/**
+ * This class handles infrastructure namespace for new workspaces.
+ *
+ * @author Oleksii Kurinnyi
+ */
+export class KubernetesNamespaceSelectorController implements IKubernetesNamespaceScopeBindings {
+
+  static $inject = [
+    'cheKubernetesNamespace',
+  ];
+
+  /**
+   * Directive scope bindings.
+   */
+  onChange: IKubernetesNamespaceOnChange;
+
+  selectedName: string;
+  namespaces: string[] = [];
+  namespaceById: { [name: string]: che.IKubernetesNamespace };
+
+  private cheKubernetesNamespace: che.api.ICheKubernetesNamespace;
+
+  /**
+   * Default constructor that is using resource injection
+   */
+  constructor(
+    cheKubernetesNamespace: che.api.ICheKubernetesNamespace
+  ) {
+    this.cheKubernetesNamespace = cheKubernetesNamespace;
+  }
+
+  $onInit(): void {
+    this.cheKubernetesNamespace.fetchKubernetesNamespace().then((namespaces: che.IKubernetesNamespace[]) => this.updateNamespacesList(namespaces));
+  }
+
+  updateNamespacesList(kubernetesNamespaces: che.IKubernetesNamespace[]): void {
+    this.namespaces.length = 0;
+    this.namespaceById = {};
+    this.selectedName = undefined;
+
+    kubernetesNamespaces.forEach(namespace => {
+      const displayName = this.getDisplayName(namespace);
+      this.namespaceById[displayName] = namespace;
+      this.namespaces.push(displayName);
+      if (this.selectedName === undefined || namespace.attributes.default) {
+        this.selectedName = displayName;
+      }
+    });
+    this.namespaces.sort();
+
+    this.onChangeNamespace(this.selectedName);
+  }
+
+  onChangeNamespace(displayName: string): void {
+    const namespace = this.namespaceById[displayName];
+
+    // we don't need to propagate the namespace placeholder as namespace ID
+    if (this.cheKubernetesNamespace.isPlaceholder(namespace)) {
+      this.onChange({ namespaceId: undefined });
+      return;
+    }
+
+    const namespaceId = namespace.name || displayName;
+    this.onChange({ namespaceId });
+  }
+
+  getDisplayName(namespace: che.IKubernetesNamespace): string {
+    return namespace.attributes.displayName || namespace.name;
+  }
+
+}

--- a/dashboard/src/app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.directive.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+export interface IKubernetesNamespaceScopeBindings {
+  onChange: IKubernetesNamespaceOnChange;
+}
+export interface IKubernetesNamespaceOnChange {
+  (eventData: { namespaceId: string }): void;
+}
+
+export class KubernetesNamespaceSelectorDirective implements ng.IDirective {
+
+  restrict: string = 'E';
+  templateUrl: string = 'app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.html';
+  controller: string = 'KubernetesNamespaceSelectorController';
+  controllerAs: string = 'ctrl';
+  bindToController: boolean = true;
+
+  transclude: boolean = true;
+
+  scope: {
+    onChange: string;
+  };
+
+  constructor() {
+    this.scope = {
+      onChange: '&onChange',
+    };
+  }
+
+}

--- a/dashboard/src/app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.html
+++ b/dashboard/src/app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.html
@@ -1,0 +1,8 @@
+<div class="kubernetes-namespace">
+  <div ng-if="ctrl.namespaces.length === 1">
+    <che-input-box che-name="kubernetes-namespace" aria-label="Kubernetes Namespace" che-place-holder="Kubernetes Namespace" ng-model="ctrl.selectedName" che-readonly="true"></che-input-box>
+  </div>
+  <div ng-if="ctrl.namespaces.length > 1" layout="row" layout-align="start center">
+    <che-filter-selector che-values="ctrl.namespaces" ng-model="ctrl.selectedName" che-width="200px" che-on-change="ctrl.onChangeNamespace(value)"></che-filter-selector>
+  </div>
+</div>

--- a/dashboard/src/app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.styl
+++ b/dashboard/src/app/workspaces/create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.styl
@@ -1,0 +1,11 @@
+.kubernetes-namespace
+
+  .che-input-box
+    margin-top -1px
+
+    input
+      width auto !important
+
+  .che-filter-selector-button
+    background-color $white-color !important
+

--- a/dashboard/src/app/workspaces/create-workspace/ready-to-go-stacks/ready-to-go-stacks.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/ready-to-go-stacks/ready-to-go-stacks.controller.ts
@@ -14,8 +14,9 @@
 import { CreateWorkspaceSvc } from '../create-workspace.service';
 import { NamespaceSelectorSvc } from './namespace-selector/namespace-selector.service';
 import { RandomSvc } from '../../../../components/utils/random.service';
-import { IReadyToGoStacksScopeBindings } from './ready-to-go-stacks.directive';
+import { IReadyToGoStacksScopeBindings, IReadyToGoStacksScopeOnChange } from './ready-to-go-stacks.directive';
 import { ProjectSourceSelectorService } from './project-source-selector/project-source-selector.service';
+import { CheKubernetesNamespace } from '../../../../components/api/che-kubernetes-namespace.factory';
 
 /**
  * This class is handling the controller for predefined stacks.
@@ -25,7 +26,7 @@ import { ProjectSourceSelectorService } from './project-source-selector/project-
 export class ReadyToGoStacksController implements IReadyToGoStacksScopeBindings {
 
   static $inject = [
-    '$timeout',
+    'cheKubernetesNamespace',
     'createWorkspaceSvc',
     'namespaceSelectorSvc',
     'projectSourceSelectorService',
@@ -35,7 +36,7 @@ export class ReadyToGoStacksController implements IReadyToGoStacksScopeBindings 
   /**
    * Directive scope bindings.
    */
-  onChange: (eventData: { devfile: che.IWorkspaceDevfile, attrs: { [key: string]: any } }) => void;
+  onChange: IReadyToGoStacksScopeOnChange;
   /**
    * The selected devfile.
    */
@@ -48,20 +49,33 @@ export class ReadyToGoStacksController implements IReadyToGoStacksScopeBindings 
    * Form name
    */
   WORKSPACE_NAME_FORM = 'workspaceName';
+  infrastructureNamespaceHint: string = '';
 
   /**
    * Injected dependencies.
    */
-  private $timeout: ng.ITimeoutService;
+  private cheKubernetesNamespace: CheKubernetesNamespace;
   private createWorkspaceSvc: CreateWorkspaceSvc;
   private namespaceSelectorSvc: NamespaceSelectorSvc;
   private projectSourceSelectorService: ProjectSourceSelectorService;
   private randomSvc: RandomSvc;
 
   /**
-   * The selected namespace ID.
+   * The workspace devfile.
    */
-  private namespaceId: string;
+  private devfile: che.IWorkspaceDevfile;
+  /**
+   * The workspace attributes.
+   */
+  private attrs: { [key: string]: any } = {};
+  /**
+   * The selected Che namespace ID.
+   */
+  private cheNamespaceId: string;
+  /**
+   * The selected Kubernetes namespace ID.
+   */
+  private infrastructureNamespaceId: string;
   /**
    * The map of forms.
    */
@@ -83,13 +97,13 @@ export class ReadyToGoStacksController implements IReadyToGoStacksScopeBindings 
    * Default constructor that is using resource injection
    */
   constructor(
-    $timeout: ng.ITimeoutService,
+    cheKubernetesNamespace: CheKubernetesNamespace,
     createWorkspaceSvc: CreateWorkspaceSvc,
     namespaceSelectorSvc: NamespaceSelectorSvc,
     projectSourceSelectorService: ProjectSourceSelectorService,
     randomSvc: RandomSvc
   ) {
-    this.$timeout = $timeout;
+    this.cheKubernetesNamespace = cheKubernetesNamespace;
     this.createWorkspaceSvc = createWorkspaceSvc;
     this.namespaceSelectorSvc = namespaceSelectorSvc;
     this.projectSourceSelectorService = projectSourceSelectorService;
@@ -100,13 +114,14 @@ export class ReadyToGoStacksController implements IReadyToGoStacksScopeBindings 
   }
 
   $onInit(): void {
-    this.namespaceId = this.namespaceSelectorSvc.getNamespaceId();
-    this.createWorkspaceSvc.buildListOfUsedNames(this.namespaceId).then((namesList: string[]) => {
+    this.cheNamespaceId = this.namespaceSelectorSvc.getNamespaceId();
+    this.createWorkspaceSvc.buildListOfUsedNames(this.cheNamespaceId).then((namesList: string[]) => {
       this.usedNamesList = namesList;
       this.workspaceName = this.randomSvc.getRandString({ prefix: 'wksp-', list: this.usedNamesList });
       this.providedWorkspaceName = this.workspaceName;
       this.reValidateName();
     });
+    this.cheKubernetesNamespace.fetchKubernetesNamespace().then(() => this.updateInfrastructureNamespaceHint());
   }
 
   /**
@@ -121,7 +136,8 @@ export class ReadyToGoStacksController implements IReadyToGoStacksScopeBindings 
 
   onDevfileNameChange(newName: string): void {
     this.providedWorkspaceName = newName;
-    this.onDevfileChange();
+    this.updateDevfileMetadataName();
+    this.propagateChanges();
   }
 
   /**
@@ -162,60 +178,37 @@ export class ReadyToGoStacksController implements IReadyToGoStacksScopeBindings 
    */
   onDevfileSelected(devfile: che.IWorkspaceDevfile): void {
     this.selectedDevfile = devfile;
-    this.onDevfileChange();
+    this.updateDevfile();
+    this.propagateChanges();
   }
 
   /**
    * Callback which is called when a project template is added, updated or removed.
    */
   onProjectSelectorChange(): void {
-    this.onDevfileChange();
-  }
-
-  onDevfileChange(): void {
-    const devfile = angular.copy(this.selectedDevfile);
-
-    this.updateDevfileProjects(devfile);
-    devfile.metadata.name = this.providedWorkspaceName;
-
-    this.onChange({
-      devfile: devfile,
-      attrs: { stackName: this.stackName }
-    });
+    this.updateDevfileProjects();
+    this.propagateChanges();
   }
 
   /**
-   * Populates a devfile with chosen projects
+   * Callback which is called when Che namespace is selected.
    */
-  updateDevfileProjects(devfile: che.IWorkspaceDevfile): che.IWorkspaceDevfile {
-    // projects to add to current devfile
-    const projectTemplates = this.projectSourceSelectorService.getProjectTemplates();
-
-    devfile.projects = projectTemplates;
-
-    // check if some of added projects are defined in initial devfile
-    const projectDefinedInDevfile = projectTemplates.some((template: che.IProjectTemplate) =>
-      devfile.projects.some((devfileProject: any) => devfileProject.name === template.name)
-    );
-
-    // if no projects defined in devfile were added - remove the commands from devfile as well:
-    if (projectDefinedInDevfile === false) {
-      devfile.commands = [];
-    }
-
-    return devfile;
-  }
-
-  /**
-   * Callback which is called when namespace is selected.
-   */
-  onNamespaceChanged(namespaceId: string) {
-    this.namespaceId = namespaceId;
+  onCheNamespaceChanged(namespaceId: string) {
+    this.cheNamespaceId = namespaceId;
 
     this.createWorkspaceSvc.buildListOfUsedNames(namespaceId).then((namesList: string[]) => {
       this.usedNamesList = namesList;
       this.reValidateName();
     });
+  }
+
+  onInfrastructureNamespaceChanged(namespaceId: string): void {
+    this.infrastructureNamespaceId = namespaceId;
+    this.propagateChanges();
+  }
+
+  private updateInfrastructureNamespaceHint(): void {
+    this.infrastructureNamespaceHint = this.cheKubernetesNamespace.getHintDescription();
   }
 
   /**
@@ -233,6 +226,46 @@ export class ReadyToGoStacksController implements IReadyToGoStacksScopeBindings 
       if (model) {
         model.$validate();
       }
+    });
+  }
+
+  private updateDevfile(): void {
+    this.devfile = angular.copy(this.selectedDevfile);
+    this.updateDevfileProjects();
+    this.updateDevfileMetadataName();
+  }
+
+  private updateDevfileMetadataName(): void {
+    this.devfile.metadata.name = this.providedWorkspaceName;
+  }
+
+  /**
+   * Populates a devfile with chosen projects
+   */
+  private updateDevfileProjects() {
+    // projects to add to current devfile
+    const projectTemplates = this.projectSourceSelectorService.getProjectTemplates();
+
+    this.devfile.projects = projectTemplates;
+
+    // check if some of added projects are defined in initial devfile
+    const projectDefinedInDevfile = projectTemplates.some((template: che.IProjectTemplate) =>
+      this.devfile.projects.some((devfileProject: any) => devfileProject.name === template.name)
+    );
+
+    // if no projects defined in devfile were added - remove the commands from devfile as well:
+    if (projectDefinedInDevfile === false) {
+      this.devfile.commands = [];
+    }
+  }
+
+  private propagateChanges(): void {
+    this.onChange({
+      devfile: this.devfile,
+      attrs: {
+        stackName: this.stackName,
+      },
+      infrastructureNamespaceId: this.infrastructureNamespaceId,
     });
   }
 

--- a/dashboard/src/app/workspaces/create-workspace/ready-to-go-stacks/ready-to-go-stacks.directive.ts
+++ b/dashboard/src/app/workspaces/create-workspace/ready-to-go-stacks/ready-to-go-stacks.directive.ts
@@ -11,8 +11,13 @@
  */
 'use strict';
 
+import { DevfileChangeEventData } from '../devfile-change-event-data';
+
 export interface IReadyToGoStacksScopeBindings {
-  onChange: (eventData: { devfile: che.IWorkspaceDevfile, attrs?: { [key: string]: any} }) => void;
+  onChange: IReadyToGoStacksScopeOnChange;
+}
+export interface IReadyToGoStacksScopeOnChange {
+  (eventData: DevfileChangeEventData): void;
 }
 
 export class ReadyToGoStacks implements ng.IDirective {

--- a/dashboard/src/app/workspaces/create-workspace/ready-to-go-stacks/ready-to-go-stacks.html
+++ b/dashboard/src/app/workspaces/create-workspace/ready-to-go-stacks/ready-to-go-stacks.html
@@ -28,11 +28,16 @@
   </ng-form>
 </che-label-container>
 
-<!-- Namespace selector -->
+<!-- Kubernetes namespace selector -->
+<che-label-container che-label-name="Kubernetes Namespace" che-label-description="{{readyToGoStacksController.infrastructureNamespaceHint}}">
+  <kubernetes-namespace-selector on-change="readyToGoStacksController.onInfrastructureNamespaceChanged(namespaceId)"></kubernetes-namespace-selector>
+</che-label-container>
+
+<!-- Che namespace selector -->
 <che-label-container che-label-name="{{ readyToGoStacksController.getNamespaceCaption() }}"
   ng-if="readyToGoStacksController.getNamespaces().length > 0 || readyToGoStacksController.getNamespaceEmptyMessage()">
   <namespace-selector
-  on-namespace-change="readyToGoStacksController.onNamespaceChanged(namespaceId)">
+  on-namespace-change="readyToGoStacksController.onCheNamespaceChanged(namespaceId)">
   </namespace-selector>
 </che-label-container>
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
@@ -67,7 +67,7 @@ describe(`WorkspaceDetailsController >`, () => {
         'ide': 'http://localhost:8080/che/wksp-98cs'
       },
       'id': 'workspacezbkov1e8qcm00dli',
-      'attributes': {'created': 1516282666658, 'stackId': 'blank-default'}
+      'attributes': {'created': 1516282666658, 'stackId': 'blank-default', 'infrastructureNamespace': 'che'}
     };
   }
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.html
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.html
@@ -1,7 +1,7 @@
 <md-progress-linear ng-show="workspaceDetailsOverviewController.isLoading" md-mode="indeterminate"></md-progress-linear>
 <div class="workspace-overview-tab-content" ng-hide="workspaceDetailsOverviewController.isLoading">
   <!-- Name -->
-  <che-label-container che-label-name="Workspace name">
+  <che-label-container che-label-name="Workspace name" class="workspace-name-input-container">
     <che-input-box
       che-form="workspaceDetailsOverviewController.overviewForm"
       che-name="name"
@@ -27,6 +27,17 @@
   <che-label-container ng-repeat="section in workspaceDetailsOverviewController.getSections()"
                        che-label-name="{{section.title}}" che-label-description="{{section.description}}">
     <div che-compile="section.content"></div>
+  </che-label-container>
+  <!-- Infrastructure Namespace -->
+  <che-label-container class="infrastructure-namespace-input-container"
+    che-label-name="Kubernetes Namespace"
+    ng-if="workspaceDetailsOverviewController.infrastructureNamespace">
+    <che-input
+      che-name="kubernetes-namespace"
+      che-place-holder="Kubernetes Namespace"
+      aria-label="Kubernetes Namespace"
+      che-readonly="true"
+      ng-model="workspaceDetailsOverviewController.infrastructureNamespace"></che-input>
   </che-label-container>
   <!-- Namespace -->
   <che-label-container che-label-name="{{workspaceDetailsOverviewController.getNamespaceCaption()}}"

--- a/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.styl
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-overview/workspace-details-overview.styl
@@ -1,10 +1,23 @@
 .workspace-overview-tab-content
   margin-top 30px
-  .che-label-container:not(:first-child)
+  .che-label-container
     padding 10px 0
-  .che-label-container:first-child
-    height 55px
-    padding 0
+
+    &.workspace-name-input-container,
+    &.infrastructure-namespace-input-container
+      height 56px
+
+    &.workspace-name-input-container .che-input-box
+      margin-top -1px
+
+    &.infrastructure-namespace-input-container
+
+      .che-input
+        margin-top 3px
+
+        .che-input-desktop-value-column
+          flex auto
+
   div.che-label-container
     border-bottom none
 

--- a/dashboard/src/app/workspaces/workspaces-config.ts
+++ b/dashboard/src/app/workspaces/workspaces-config.ts
@@ -78,6 +78,8 @@ import {DevfileByUrl} from './create-workspace/import-custom-stack/devfile-by-ur
 import {DevfileByUrlController} from './create-workspace/import-custom-stack/devfile-by-url/devfile-by-url.controller';
 import {ImportStackController} from './create-workspace/import-custom-stack/import-custom-stack.controller';
 import {ImportStack} from './create-workspace/import-custom-stack/import-custom-stack.directive';
+import {KubernetesNamespaceSelectorController} from './create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.controller';
+import {KubernetesNamespaceSelectorDirective} from './create-workspace/kubernetes-namespace-selector/kubernetes-namespace-selector.directive';
 
 /**
  * @ngdoc controller
@@ -159,6 +161,8 @@ export class WorkspacesConfig {
     register.controller('DevfileByUrlController', DevfileByUrlController);
     register.controller('ImportStackController', ImportStackController);
     register.directive('importStack', ImportStack);
+    register.controller('KubernetesNamespaceSelectorController', KubernetesNamespaceSelectorController);
+    register.directive('kubernetesNamespaceSelector', KubernetesNamespaceSelectorDirective);
 
     // config routes
     register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {

--- a/dashboard/src/components/api/che-api-config.ts
+++ b/dashboard/src/components/api/che-api-config.ts
@@ -39,7 +39,8 @@ import {CheInvite} from './che-invite.factory';
 import {NpmRegistry} from './npm-registry.factory';
 import {PluginRegistry} from './plugin-registry.factory';
 import {DevfileRegistry} from './devfile-registry.factory';
-import { CheDevfile } from './che-devfile.factory';
+import {CheDevfile} from './che-devfile.factory';
+import {CheKubernetesNamespace} from './che-kubernetes-namespace.factory';
 
 export class ApiConfig {
 
@@ -73,5 +74,6 @@ export class ApiConfig {
     register.factory('pluginRegistry', PluginRegistry);
     register.factory('devfileRegistry', DevfileRegistry);
     register.factory('cheDevfile', CheDevfile);
+    register.factory('cheKubernetesNamespace', CheKubernetesNamespace);
   }
 }

--- a/dashboard/src/components/api/che-api.factory.ts
+++ b/dashboard/src/components/api/che-api.factory.ts
@@ -19,8 +19,8 @@ import {ChePreferences} from './che-preferences.factory';
 import {CheService} from './che-service.factory';
 import {CheOAuthProvider} from './che-o-auth-provider.factory';
 import {CheUser} from './che-user.factory';
-import { CheDevfile } from './che-devfile.factory';
-
+import {CheDevfile} from './che-devfile.factory';
+import {CheKubernetesNamespace} from './che-kubernetes-namespace.factory';
 
 /**
  * This class is providing the entry point for accessing to Che API
@@ -29,42 +29,67 @@ import { CheDevfile } from './che-devfile.factory';
  */
 export class CheAPI {
 
-  static $inject = ['cheWorkspace', 'cheFactory', 'cheFactoryTemplate',
-               'cheProfile', 'chePreferences', 'cheService', 'cheOAuthProvider',
-            'cheSsh', 'cheUser', 'chePermissions', 'cheOrganization', 'cheDevfile'];
+  static $inject = [
+    'cheDevfile',
+    'cheFactory',
+    'cheFactoryTemplate',
+    'cheKubernetesNamespace',
+    'cheOAuthProvider',
+    'cheOrganization',
+    'chePermissions',
+    'chePreferences',
+    'cheProfile',
+    'cheService',
+    'cheSsh',
+    'cheUser',
+    'cheWorkspace',
+  ];
 
-  private cheWorkspace: CheWorkspace;
-  private cheProfile: CheProfile;
-  private chePreferences: ChePreferences;
+  private cheDevfile: CheDevfile;
   private cheFactory: CheFactory;
   private cheFactoryTemplate: CheFactoryTemplate;
-  private cheService: CheService;
+  private cheKubernetesNamespace: che.api.ICheKubernetesNamespace;
   private cheOAuthProvider: CheOAuthProvider;
+  private cheOrganization: che.api.ICheOrganization;
+  private chePermissions: che.api.IChePermissions;
+  private chePreferences: ChePreferences;
+  private cheProfile: CheProfile;
+  private cheService: CheService;
   private cheSsh: CheSsh;
   private cheUser: CheUser;
-  private chePermissions: che.api.IChePermissions;
-  private cheOrganization: che.api.ICheOrganization;
-  private cheDevfile: CheDevfile;
+  private cheWorkspace: CheWorkspace;
 
   /**
    * Default constructor that is using resource
    */
-  constructor(cheWorkspace: CheWorkspace, cheFactory: CheFactory, cheFactoryTemplate: CheFactoryTemplate,
-              cheProfile: CheProfile, chePreferences: ChePreferences, cheService: CheService, cheOAuthProvider: CheOAuthProvider,
-              cheSsh: CheSsh, cheUser: CheUser, chePermissions: che.api.IChePermissions, cheOrganization: che.api.ICheOrganization,
-              cheDevfile: CheDevfile) {
-    this.cheWorkspace = cheWorkspace;
-    this.cheProfile = cheProfile;
+  constructor(
+    cheDevfile: CheDevfile,
+    cheFactory: CheFactory,
+    cheFactoryTemplate: CheFactoryTemplate,
+    cheKubernetesNamespace: CheKubernetesNamespace,
+    cheOAuthProvider: CheOAuthProvider,
+    cheOrganization: che.api.ICheOrganization,
+    chePermissions: che.api.IChePermissions,
+    chePreferences: ChePreferences,
+    cheProfile: CheProfile,
+    cheService: CheService,
+    cheSsh: CheSsh,
+    cheUser: CheUser,
+    cheWorkspace: CheWorkspace,
+  ) {
+    this.cheDevfile = cheDevfile;
     this.cheFactory = cheFactory;
     this.cheFactoryTemplate = cheFactoryTemplate;
-    this.chePreferences = chePreferences;
-    this.cheService = cheService;
+    this.cheKubernetesNamespace = cheKubernetesNamespace;
     this.cheOAuthProvider = cheOAuthProvider;
+    this.cheOrganization = cheOrganization;
+    this.chePermissions = chePermissions;
+    this.chePreferences = chePreferences;
+    this.cheProfile = cheProfile;
+    this.cheService = cheService;
     this.cheSsh = cheSsh;
     this.cheUser = cheUser;
-    this.chePermissions = chePermissions;
-    this.cheOrganization = cheOrganization;
-    this.cheDevfile = cheDevfile;
+    this.cheWorkspace = cheWorkspace;
   }
 
   /**
@@ -162,5 +187,12 @@ export class CheAPI {
    */
   getDevfile(): che.api.ICheDevfile {
     return this.cheDevfile;
+  }
+
+  /**
+   * The Che Kubernetes Namespace API
+   */
+  getKubernetesNamespace(): che.api.ICheKubernetesNamespace {
+    return this.cheKubernetesNamespace;
   }
 }

--- a/dashboard/src/components/api/che-kubernetes-namespace.factory.ts
+++ b/dashboard/src/components/api/che-kubernetes-namespace.factory.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+const MAIN_URL = '/api/kubernetes/namespace';
+
+/**
+ * This class is handling the interactions with Kubernetes Namespace API.
+ *
+ * @author Oleksii Kurinnyi
+ */
+export class CheKubernetesNamespace implements che.api.ICheKubernetesNamespace {
+
+  static $inject = [
+    '$http',
+  ];
+
+  private $http: ng.IHttpService;
+  private fetchKubernetesNamespacePromise: ng.IPromise<Array<che.IKubernetesNamespace>>;
+  private namespaces: Array<che.IKubernetesNamespace> = [];
+
+  /**
+   * Default constructor that is using resource
+   */
+  constructor(
+    $http: ng.IHttpService,
+  ) {
+    this.$http = $http;
+  }
+
+  fetchKubernetesNamespace(): ng.IPromise<che.IKubernetesNamespace[]> {
+    if (this.fetchKubernetesNamespacePromise) {
+      return this.fetchKubernetesNamespacePromise;
+    }
+
+    this.fetchKubernetesNamespacePromise = this.$http.get<che.IKubernetesNamespace[]>(MAIN_URL).then(response => {
+      this.namespaces.length = 0;
+
+      response.data.forEach((namespace: che.IKubernetesNamespace) => {
+        this.namespaces.push(namespace);
+      });
+
+      return this.namespaces;
+    });
+
+    return this.fetchKubernetesNamespacePromise;
+  }
+
+  /**
+   * Returns `true` if provided namespace is the placeholder namespace, i.e. "<workspaceId>".
+   * @param namespace infrastructure namespace
+   */
+  isPlaceholder(namespace: che.IKubernetesNamespace): boolean {
+    return /^</.test(namespace.name);
+  }
+
+  /**
+   * Returns `true` if at least one of kubernetes namespaces is the placeholder namespace (i.e. "<workspaceId>").
+   */
+  containsPlaceholder(): boolean {
+    return this.namespaces.some(this.isPlaceholder);
+  }
+
+  getHintDescription(): string {
+    if (this.containsPlaceholder()) {
+      return 'The infrastructure namespace where the workspace will be created. If the placeholder (i.e. &lt;workspaceId&gt;) is chosen then new kubernetes namespace named as workspace ID will be created.';
+    }
+    return 'The infrastructure namespace where the workspace will be created.';
+  }
+
+}

--- a/dashboard/src/components/api/workspace/che-workspace.factory.ts
+++ b/dashboard/src/components/api/workspace/che-workspace.factory.ts
@@ -23,7 +23,6 @@ const WS_AGENT_WS_LINK: string = 'wsagent/ws';
 
 interface ICHELicenseResource<T> extends ng.resource.IResourceClass<T> {
   createDevfile: any;
-  createDevfileWithNamespace: any;
   deleteWorkspace: any;
   updateWorkspace: any;
   addProject: any;
@@ -127,9 +126,7 @@ export class CheWorkspace {
 
     // remote call
     this.remoteWorkspaceAPI = <ICHELicenseResource<any>>this.$resource('/api/workspace', {}, {
-        // having 2 methods for creation to ensure namespace parameter won't be send at all if value is null or undefined
         createDevfile: {method: 'POST', url: '/api/workspace/devfile'},
-        createDevfileWithNamespace: {method: 'POST', url: '/api/workspace/devfile?namespace=:namespace'},
         deleteWorkspace: {method: 'DELETE', url: '/api/workspace/:workspaceId'},
         updateWorkspace: {method: 'PUT', url: '/api/workspace/:workspaceId'},
         addProject: {method: 'POST', url: '/api/workspace/:workspaceId/project'},
@@ -377,15 +374,15 @@ export class CheWorkspace {
     return this.remoteWorkspaceAPI.deleteProject({workspaceId: workspaceId, path: path}).$promise;
   }
 
-  createWorkspaceFromDevfile(namespace: string, devfile: che.IWorkspaceDevfile, attributes: any): ng.IPromise<che.IWorkspace> {
+  createWorkspaceFromDevfile(cheNamespaceId: string, infrastructureNamespaceId: string, devfile: che.IWorkspaceDevfile, attributes: any): ng.IPromise<che.IWorkspace> {
     let attrs = this.lodash.map(this.lodash.pairs(attributes || {}), (item: any) => {
       return item[0] + ':' + item[1];
     });
-    return namespace ? this.remoteWorkspaceAPI.createDevfileWithNamespace({
-      namespace: namespace,
-      attribute: attrs
-    }, devfile).$promise :
-      this.remoteWorkspaceAPI.createDevfile({attribute: attrs}, devfile).$promise;
+    return this.remoteWorkspaceAPI.createDevfile({
+      attribute: attrs,
+      namespace: cheNamespaceId,
+      'infrastructure-namespace': infrastructureNamespaceId,
+    }, devfile).$promise;
   }
 
   /**

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -131,6 +131,13 @@ declare namespace che {
       fetchDevfileSchema(): ng.IPromise<any>;
     }
 
+    export interface ICheKubernetesNamespace {
+      fetchKubernetesNamespace(): ng.IPromise<IKubernetesNamespace[]>;
+      isPlaceholder(namespace: che.IKubernetesNamespace): boolean;
+      containsPlaceholder(): boolean;
+      getHintDescription(): string;
+    }
+
   }
 
   export namespace resource {
@@ -311,6 +318,7 @@ declare namespace che {
     factoryId?: string;
     factoryurl?: string;
     errorMessage?: string;
+    infrastructureNamespace: string;
     [propName: string]: string | number;
   }
 
@@ -338,7 +346,8 @@ declare namespace che {
     commands?: Array <any>;
     attributes?: che.IWorkspaceConfigAttributes;
     metadata: {
-      name: string
+      name?: string;
+      generateName?: string;
     }
   }
 
@@ -545,4 +554,14 @@ declare namespace che {
     name?: string;
     isPending?: boolean;
   }
+
+  export interface IKubernetesNamespace {
+    name: string;
+    attributes: {
+      default?: boolean;
+      displayName?: string;
+      phase: string;
+    };
+  }
+
 }

--- a/dashboard/src/components/widget/filter-selector/che-filter-selector.controller.ts
+++ b/dashboard/src/components/widget/filter-selector/che-filter-selector.controller.ts
@@ -19,6 +19,7 @@
 export class CheFilterSelectorController {
 
   private valueModel: string;
+  private values: string[];
   private width: string;
   private onChange: Function;
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR introduces ability to view and change the kubernetes namespace where the workspace will be created.

#### Screenshots

![Screenshot 2020-01-15 at 12 58 47](https://user-images.githubusercontent.com/16220722/72428821-27783480-3797-11ea-9faf-653c374bf81a.png)

*several kubernetes namespaces*
![Screenshot 2020-01-15 at 11 07 22](https://user-images.githubusercontent.com/16220722/72428835-2cd57f00-3797-11ea-9b78-c5c2b4ed4124.png)

*one kubernetes namespace*
![Screenshot 2020-01-15 at 13 15 36](https://user-images.githubusercontent.com/16220722/72429679-35c75000-3799-11ea-957b-aeca638bc3c2.png)

![Screenshot 2020-01-15 at 12 59 09](https://user-images.githubusercontent.com/16220722/72428842-3232c980-3797-11ea-87bd-d543b0f3a47c.png)


### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/14389

