### PR TITLE
The "PreviewWidget.waitUrl" method has locator not applicable for all stacks

### DIFF
--- a/tests/e2e/pageobjects/ide/PreviewWidget.ts
+++ b/tests/e2e/pageobjects/ide/PreviewWidget.ts
@@ -17,8 +17,7 @@ import { Logger } from '../../utils/Logger';
 
 @injectable()
 export class PreviewWidget {
-    private static readonly WIDGET_TOOLBAR_XPATH: string = '//*[@id=\'theia-right-side-panel\']//div[@class=\'theia-mini-browser-toolbar\']';
-    private static readonly WIDGET_URL_LOCATOR: By = By.xpath(`${PreviewWidget.WIDGET_TOOLBAR_XPATH}//input[@class='theia-input']`);
+    private static readonly WIDGET_URL_LOCATOR: By = By.css('div.theia-mini-browser input');
 
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
         @inject(CLASSES.Ide) private readonly ide: Ide) { }


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Update the "PreviewWidget.waitUrl" locator

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/15717
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
