### PR TITLE
Set current GitHub repository URL and branch into devfile projects if they're missing or didn't match

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -115,8 +116,13 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
                 .withPath("/".concat(githubUrl.getRepository()));
           });
     } else if (factory.getDevfile() == null) {
-      // initialize default devfile and github project
+      // initialize default devfile
       factory.setDevfile(urlFactoryBuilder.buildDefaultDevfile(githubUrl.getRepository()));
+    }
+
+    List<ProjectDto> projects = factory.getDevfile().getProjects();
+    // if no projects set, set the default one from GitHub url
+    if (projects.isEmpty()) {
       factory
           .getDevfile()
           .setProjects(
@@ -124,6 +130,14 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
                   newDto(ProjectDto.class)
                       .withSource(githubSourceStorageBuilder.buildDevfileSource(githubUrl))
                       .withName(githubUrl.getRepository())));
+    } else {
+      // update existing project with same repository, set current branch if needed
+      projects.forEach(
+          project -> {
+            if (project.getSource().getLocation().equals(githubUrl.repositoryLocation() + ".git")) {
+              project.getSource().setBranch(githubUrl.getBranch());
+            }
+          });
     }
     return factory;
   }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
@@ -134,7 +134,9 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
       // update existing project with same repository, set current branch if needed
       projects.forEach(
           project -> {
-            if (project.getSource().getLocation().equals(githubUrl.repositoryLocation() + ".git")) {
+            final String location = project.getSource().getLocation();
+            if (location.equals(githubUrl.repositoryLocation())
+                || location.equals(githubUrl.repositoryLocation() + ".git")) {
               project.getSource().setBranch(githubUrl.getBranch());
             }
           });

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubSourceStorageBuilder.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubSourceStorageBuilder.java
@@ -57,7 +57,7 @@ public class GithubSourceStorageBuilder {
    */
   public SourceDto buildDevfileSource(GithubUrl githubUrl) {
     return newDto(SourceDto.class)
-        .withLocation(githubUrl.repositoryLocation())
+        .withLocation(githubUrl.repositoryLocation() + ".git")
         .withType("github")
         .withBranch(githubUrl.getBranch())
         .withSparseCheckoutDir(githubUrl.getSubfolder());

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
@@ -129,7 +129,7 @@ public class GithubFactoryParametersResolverTest {
     verify(urlFactoryBuilder).buildDefaultDevfile(eq("che"));
     assertEquals(factory, computedFactory);
     SourceDto source = factory.getDevfile().getProjects().get(0).getSource();
-    assertEquals(source.getLocation(), githubUrl);
+    assertEquals(source.getLocation(), githubUrl + ".git");
     assertEquals(source.getBranch(), "master");
   }
 
@@ -164,7 +164,7 @@ public class GithubFactoryParametersResolverTest {
   @Test
   public void shouldSetDefaultProjectIntoDevfileIfNotSpecified() throws Exception {
 
-    String githubUrl = "https://github.com/eclipse/che";
+    String githubUrl = "https://github.com/eclipse/che/tree/foobar";
 
     FactoryDto computedFactory = generateDevfileFactory();
 
@@ -177,8 +177,8 @@ public class GithubFactoryParametersResolverTest {
     // then
     assertNotNull(factory.getDevfile());
     SourceDto source = factory.getDevfile().getProjects().get(0).getSource();
-    assertEquals(source.getLocation(), githubUrl);
-    assertEquals(source.getBranch(), "master");
+    assertEquals(source.getLocation(), "https://github.com/eclipse/che.git");
+    assertEquals(source.getBranch(), "foobar");
   }
 
   @Test

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
@@ -39,6 +39,8 @@ import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.DevfileDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.MetadataDto;
+import org.eclipse.che.api.workspace.shared.dto.devfile.ProjectDto;
+import org.eclipse.che.api.workspace.shared.dto.devfile.SourceDto;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -126,6 +128,9 @@ public class GithubFactoryParametersResolverTest {
     // then
     verify(urlFactoryBuilder).buildDefaultDevfile(eq("che"));
     assertEquals(factory, computedFactory);
+    SourceDto source = factory.getDevfile().getProjects().get(0).getSource();
+    assertEquals(source.getLocation(), githubUrl);
+    assertEquals(source.getBranch(), "master");
   }
 
   @Test
@@ -154,6 +159,52 @@ public class GithubFactoryParametersResolverTest {
         "https://raw.githubusercontent.com/eclipse/che/master/devfile.yaml");
 
     assertEquals(factoryUrlArgumentCaptor.getValue().getDevfileFilename(), "devfile.yaml");
+  }
+
+  @Test
+  public void shouldSetDefaultProjectIntoDevfileIfNotSpecified() throws Exception {
+
+    String githubUrl = "https://github.com/eclipse/che";
+
+    FactoryDto computedFactory = generateDevfileFactory();
+
+    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+        .thenReturn(Optional.of(computedFactory));
+
+    Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, githubUrl);
+    // when
+    FactoryDto factory = githubFactoryParametersResolver.createFactory(params);
+    // then
+    assertNotNull(factory.getDevfile());
+    SourceDto source = factory.getDevfile().getProjects().get(0).getSource();
+    assertEquals(source.getLocation(), githubUrl);
+    assertEquals(source.getBranch(), "master");
+  }
+
+  @Test
+  public void shouldSetBranchIntoDevfileIfNotMatchesCurrent() throws Exception {
+
+    String githubUrl = "https://github.com/eclipse/che/tree/foobranch";
+
+    FactoryDto computedFactory = generateDevfileFactory();
+    computedFactory
+        .getDevfile()
+        .getProjects()
+        .add(
+            newDto(ProjectDto.class)
+                .withSource(
+                    newDto(SourceDto.class).withLocation("https://github.com/eclipse/che.git")));
+
+    when(urlFactoryBuilder.createFactoryFromDevfile(any(RemoteFactoryUrl.class), any(), anyMap()))
+        .thenReturn(Optional.of(computedFactory));
+
+    Map<String, String> params = ImmutableMap.of(URL_PARAMETER_NAME, githubUrl);
+    // when
+    FactoryDto factory = githubFactoryParametersResolver.createFactory(params);
+    // then
+    assertNotNull(factory.getDevfile());
+    SourceDto source = factory.getDevfile().getProjects().get(0).getSource();
+    assertEquals(source.getBranch(), "foobranch");
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
When creating a factory within an repository with devfile, the same repository must be specified in the devfile project source element. This devfile allows to omit projects part in devfile, and default
project source with given repository URL and/or branch will be applied.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/14547



#### Release Notes
N/A


#### Docs PR
https://github.com/eclipse/che-docs/pull/1051