### PR TITLE
Set default organization to 'quay.io/eclipse' instead of 'eclipse'

### DIFF
--- a/dockerfiles/build.include
+++ b/dockerfiles/build.include
@@ -39,7 +39,7 @@ init() {
   BOLD='\033[1m'
   UNDERLINE='\033[4m'
 
-  ORGANIZATION="eclipse"
+  ORGANIZATION="quay.io/eclipse"
   PREFIX="che"
   TAG="nightly"
   SKIP_TESTS=false

--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
                         build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                 parameters: [
                                         string(name: 'cheImageRepo',
-                                                value: 'eclipse/che-server'),
+                                                value: 'quay.io/eclipse/che-server'),
 
                                         string(name: 'cheImageTag',
                                                 value: 'nightly'),
@@ -58,7 +58,7 @@ pipeline {
                         build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                 parameters: [
                                         string(name: 'cheImageRepo',
-                                                value: 'eclipse/che-server'),
+                                                value: 'quay.io/eclipse/che-server'),
 
                                         string(name: 'cheImageTag',
                                                 value: 'nightly'),

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -171,8 +171,8 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
                     sh """
-                        ${WORKSPACE}/dockerfiles/che/build.sh --dockerfile:Dockerfile
-                        docker tag quay.io/eclipse/che-server:nightly docker.io/${cheImageRepo}:${mutableCheImageTag}
+                        ${WORKSPACE}/dockerfiles/che/build.sh --organization:eclipseche --tag:${mutableCheImageTag} --dockerfile:Dockerfile
+                        docker tag eclipseche/che-server:${mutableCheImageTag} docker.io/${cheImageRepo}:${mutableCheImageTag}
                         docker login -u maxura -p ${maxura_docker_password}
                         docker push docker.io/${cheImageRepo}:${mutableCheImageTag}
                     """

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -172,7 +172,7 @@ pipeline {
                 withCredentials([string(credentialsId: 'ed71c034-60bc-4fb1-bfdf-9570209076b5', variable: 'maxura_docker_password')]) {
                     sh """
                         ${WORKSPACE}/dockerfiles/che/build.sh --dockerfile:Dockerfile
-                        docker tag eclipse/che-server:nightly docker.io/${cheImageRepo}:${mutableCheImageTag}
+                        docker tag quay.io/eclipse/che-server:nightly docker.io/${cheImageRepo}:${mutableCheImageTag}
                         docker login -u maxura -p ${maxura_docker_password}
                         docker push docker.io/${cheImageRepo}:${mutableCheImageTag}
                     """

--- a/tests/.infra/crw-ci/pre-release-testing/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pre-release-testing/k8s/Jenkinsfile
@@ -92,7 +92,7 @@ pipeline {
                             build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                     parameters: [
                                             string(name: 'cheImageRepo',
-                                                    value: 'eclipse/che-server'),
+                                                    value: 'quay.io/eclipse/che-server'),
 
                                             string(name: 'cheImageTag',
                                                     value: 'rc'),
@@ -128,7 +128,7 @@ pipeline {
                             build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                     parameters: [
                                             string(name: 'cheImageRepo',
-                                                    value: 'eclipse/che-server'),
+                                                    value: 'quay.io/eclipse/che-server'),
 
                                             string(name: 'cheImageTag',
                                                     value: 'rc'),

--- a/tests/legacy-e2e/che-selenium-test/src/test/resources/projects/nodejs-with-yaml/deployment.yaml
+++ b/tests/legacy-e2e/che-selenium-test/src/test/resources/projects/nodejs-with-yaml/deployment.yaml
@@ -49,7 +49,7 @@ spec:
             - name: CHE_CONF
               value: /home/user/che-conf
             - name: CHE_IMAGE_REPO
-              value: eclipse/che-server
+              value: quay.io/eclipse/che-server
             - name: CHE_IMAGE_TAG
               value: nightly
             - name: CHE_INFRASTRUCTURE
@@ -133,7 +133,7 @@ spec:
                   optional: true
             - name: CHE_WORKSPACE_PLUGIN__REGISTRY__URL
               value: 'NULL'
-          image: 'eclipse/che-server:latest'
+          image: 'quay.io/eclipse/che-server:latest'
           imagePullPolicy: Always
           livenessProbe:
             failureThreshold: 3


### PR DESCRIPTION
…

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Set default organization to 'quay.io/eclipse' instead of 'eclipse'

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
