### PR TITLE
Propagate default value for persistVolumes for clients

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -482,6 +482,14 @@ che.workspace.plugin_registry_url=https://che-plugin-registry.prod-preview.opens
 # In case Che plugins tooling is not needed value 'NULL' should be used
 che.workspace.devfile_registry_url=https://che-devfile-registry.prod-preview.openshift.io/
 
+# Defines a default value for persist volumes that clients like Dashboard
+# should propose for users during workspace creation.
+# Possible values: true or false
+# In case of true - PersistentVolumeClaims are used by declared volumes by user and plugins. `true`
+# value is supposed not to be set explicitly in Devfile attributes since it's default fixed behaviour.
+# In case of false - emptyDir is used instead of PVCs. Note that data will be lost after workspace restart.
+che.workspace.persist_volumes.default=true
+
 # Configures in which way secure servers will be protected with authentication.
 # Suitable values:
 #   - 'default': no additionally authentication system will be enabled.

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -37,6 +37,23 @@ public final class Constants {
 
   public static final String CHE_WORKSPACE_AUTO_START = "che.workspace.auto_start";
 
+  /**
+   * The configuration property that defines a default value for persist volumes that clients like
+   * Dashboard should propose for users during workspace creation.
+   *
+   * <p>Possible values: true or false
+   *
+   * <ul>
+   *   <li>In case of true - PersistentVolumeClaims are used by declared volumes by user and
+   *       plugins. `true` value is supposed not to be set explicitly in Devfile attributes since
+   *       it's default fixed behaviour.
+   *   <li>In case of false - emptyDir is used instead of PVCs. Note that data will be lost after
+   *       workspace restart.
+   * </ul>
+   */
+  public static final String CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY =
+      "che.workspace.persist_volumes.default";
+
   /** Property name for Che plugin registry url. */
   public static final String CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY =
       "che.workspace.plugin_registry_url";

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -21,6 +21,7 @@ import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
 import static org.eclipse.che.api.workspace.server.WorkspaceKeyValidator.validateKey;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_DEVFILE_REGISTRY_URL_PROPERTY;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
 
@@ -107,6 +108,7 @@ public class WorkspaceService extends Service {
   private final String apiEndpoint;
   private final boolean cheWorkspaceAutoStart;
   private final FileContentProvider devfileContentProvider;
+  private final boolean defaultPersistVolumes;
 
   @Inject
   public WorkspaceService(
@@ -117,6 +119,7 @@ public class WorkspaceService extends Service {
       WorkspaceLinksGenerator linksGenerator,
       @Named(CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY) @Nullable String pluginRegistryUrl,
       @Named(CHE_WORKSPACE_DEVFILE_REGISTRY_URL_PROPERTY) @Nullable String devfileRegistryUrl,
+      @Named(CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY) boolean defaultPersistVolumes,
       URLFetcher urlFetcher) {
     this.apiEndpoint = apiEndpoint;
     this.cheWorkspaceAutoStart = cheWorkspaceAutoStart;
@@ -126,6 +129,7 @@ public class WorkspaceService extends Service {
     this.pluginRegistryUrl = pluginRegistryUrl;
     this.devfileRegistryUrl = devfileRegistryUrl;
     this.devfileContentProvider = new URLFileContentProvider(null, urlFetcher);
+    this.defaultPersistVolumes = defaultPersistVolumes;
   }
 
   @POST
@@ -828,6 +832,8 @@ public class WorkspaceService extends Service {
     if (devfileRegistryUrl != null) {
       settings.put("cheWorkspaceDevfileRegistryUrl", devfileRegistryUrl);
     }
+
+    settings.put(CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY, Boolean.toString(defaultPersistVolumes));
 
     return settings.build();
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -23,6 +23,7 @@ import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.RUNNING;
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
@@ -123,6 +124,8 @@ public class WorkspaceServiceTest {
   private static final String CHE_WORKSPACE_PLUGIN_REGISTRY_ULR = "http://localhost:9898/plugins/";
   private static final String CHE_WORKSPACE_DEVFILE_REGISTRY_ULR =
       "http://localhost:9898/devfiles/";
+  private static final boolean CHE_WORKSPACES_DEFAULT_PERSIST_VOLUMES = false;
+
   private static final Account TEST_ACCOUNT = new AccountImpl("anyId", NAMESPACE, "test");
 
   @SuppressWarnings("unused")
@@ -149,6 +152,7 @@ public class WorkspaceServiceTest {
             linksGenerator,
             CHE_WORKSPACE_PLUGIN_REGISTRY_ULR,
             CHE_WORKSPACE_DEVFILE_REGISTRY_ULR,
+            CHE_WORKSPACES_DEFAULT_PERSIST_VOLUMES,
             urlFetcher);
   }
 
@@ -1327,7 +1331,9 @@ public class WorkspaceServiceTest {
             "cheWorkspacePluginRegistryUrl",
             CHE_WORKSPACE_PLUGIN_REGISTRY_ULR,
             "cheWorkspaceDevfileRegistryUrl",
-            CHE_WORKSPACE_DEVFILE_REGISTRY_ULR));
+            CHE_WORKSPACE_DEVFILE_REGISTRY_ULR,
+            CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY,
+            Boolean.toString(CHE_WORKSPACES_DEFAULT_PERSIST_VOLUMES)));
   }
 
   private static String unwrapError(Response response) {


### PR DESCRIPTION
### What does this PR do?
Propagate default value for persistVolumes for clients.

It's a lighter version of changes made in https://github.com/eclipse/che/pull/15713 that does not change the current Che Server behavior and at the same time allows us to configure Dashboard behavior via Che Server configuration.
More see https://github.com/eclipse/che/pull/15713#discussion_r369055733

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15462

#### Release Notes
N/A

#### Docs PR
The documentation will be generated from the description of the new property in `che.properties`