### PR TITLE
[UD] Added ability to disable some menu items and corresponding routes

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -235,7 +235,7 @@ Mocks are also provided for the Che API, allowing to emulate a real backend for 
 
 The `configuration.menu.disabled` field in [product.json](/src/assets/branding/product.json) allows users to list there menu entries they want to hide in left navigation bar. Along with that corresponding routes also will be disabled.
 
-For example:
+Available values are `'administration'`, `'factories'`,  `'getstarted'`, `'organizations'`, `'stacks'`.
 
 ```json
 // product.json

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,10 +1,13 @@
 ## About Eclipse Che
+
 Eclipse Che is a next generation Eclipse IDE and open source alternative to IntelliJ. This repository is licensed under the Eclipse Public License 2.0. Visit [Eclipse Che's Web site](https://eclipse.org/che) for feature information or the main [Che assembly repository](https://github.com/codenvy/che) for a description of all participating repositories.
 
 Che Dashboard
+
 ==============
 
 ## Requirements
+
 - Docker
 
 ## Quick start
@@ -22,54 +25,61 @@ $ mvn -Pnative clean install
 ```
 
 Required tools for native build:
+
 - Python `v2.7.x`(`v3.x.x`currently not supported)
 - Node.js `v8.x.x` or `v9.x.x`
 - yarn `v1.13.0` or higher
 - gulp
 
-Installation instructions for Node.js can be found on the following [link](https://docs.npmjs.com/getting-started/installing-node). 
+Installation instructions for Node.js can be found on the following [link](https://docs.npmjs.com/getting-started/installing-node).
 
 ## Running
+
 In order to run the project, the serve command is used
+
 ```sh
 $ gulp serve
 ```
+
 It will launch the server and then the project can be tested on http://localhost:3000
 
 By default it will use http://localhost:8080 as a remote server, so make sure that Che is running locally. More details about how to do that can be found on the following [link](https://github.com/eclipse/che/wiki/Development-Workflow#build-and-run---tomcat)  
 
 The argument `--server <url>` may allow to use another server. (url is for example http://my-server.com)
 
-
 ```sh
 $ gulp serve:dist
 ```
+
 This command will provide the 'minified/optimised' version of the application
 
 This is a good check for testing if the final rendering is OK
 
-
 ## Tests
+
 The application contains both unit tests and e2e tests (end-to-end)
 
 Unit tests
+
 ```sh
 $ gulp test
 ```
 
 e2e tests
+
 ```sh
 $ gulp protractor
 ```
 
 Both tests
+
 ```sh
 $ gulp alltests
 ```
 
 Note: before pushing contribution, these tests should always work
 
-#Architecture design
+# Architecture design
 
 ## Ecmascript 2015/es6
 
@@ -80,54 +90,60 @@ So application is written with the new language but the resulting build is Javas
 Among new features, Class, arrow functions, etc
 
 ## Styling/css
+
 [Stylus](https://github.com/LearnBoost/stylus) is used for produced the final CSS.
 
 Variables, simple syntax, etc is then provided
 
-
 ## Code convention
 
 ### indent
+
 There is a .editorconfig file that is indicating the current identation which is
+
 ```
 indent_style = space
 indent_size = 2
 ```
 
 ### syntax
+
 The syntax is checked by jshint (through .jshintrc file)
 
 Also when launching gulp serve command, there is a report on each file that may have invalid data
 
-For example use single quote 'hello', no "double quote", use === and !=== and not == or !=
-
+For example use single quote `'hello'`, no `"double quote"`, use `===` and `!===` and not `==` or `!=`
 
 ### name of the files
-Controllers are in files named <name>.controller.js
 
-Directives: <name>.directive.js
+Controllers are in files named `[name].controller.ts`
 
-Templates: <name>.html
+Directives: `[name].directive.ts`
 
-Factories: <name>.factory.js
+Templates: `[name].html`
 
-Unit test: <name>.spec.js (for my-example.factory.js will be named my-example.spec.js)
+Factories: `[name].factory.ts`
+
+Unit test: `[name].spec.ts` (for `my-example.factory.ts` will be named `my-example.spec.ts`)
 
 #### About e2e tests
+
 If a 'project' page needs to be tested:
 
-project.po.js will contain the Page Object pattern (all methods allowing to get HTML elements on the page)
+`project.po.ts` will contain the Page Object pattern (all methods allowing to get HTML elements on the page)
 
-project.spec.js will have the e2e test
+`project.spec.ts` will have the e2e test
 
-project.mock.js will provide some mock for the test
+`project.mock.ts` will provide some mock for the test
 
 ## source tree
+
 Each 'page' needs to have its own folder which include:
 
 controller, directive, template, style for the page
 
 for a 'list-projects' page, the folder tree will have
+
 ```
 list-projects
   - list-projects.controller.js
@@ -135,15 +151,16 @@ list-projects
   - list-projects.styl
 ```
 
-## AngularJS recommandation
+## AngularJS recommendation
+
 As classes are available, the controller will be designed as es6 classes.
 
-All injection required will be done through the constructor by adding also the  static $inject = ['$toBeInjected']; line.
-
+All injection required will be done through the constructor by adding also the  static `$inject = ['$toBeInjected'];` line.
 
 Also properties are bound with this. scope (so avoid to use $scope in injection as this will be more aligned with AngularJS 2.0 where scope will disappear)
 
 example
+
 ```js
 /**
  * Defines a controller
@@ -173,8 +190,8 @@ export default CheToggleCtrl;
 
 So, no need to add specific arrays for injection.
 
-
 By using the this syntax, the controllerAs needs to be used when adding the router view
+
 ```js
     .when('/myURL', {
       templateUrl: 'mytemplate.html',
@@ -183,11 +200,12 @@ By using the this syntax, the controllerAs needs to be used when adding the rout
     })
 ```
 
-And then, when there is a need to interact with code of a controller, the controllerAs value is used.
+And then, when there is a need to interact with code of a controller, the `controllerAs` value is used.
 
 ```html
  <div>Selected book is {{myCtrl.selectedBook}}</div>
 ```
+
 Note that as if scope was using, the values are always prefixed
 
 ## Directives
@@ -196,23 +214,38 @@ The whole idea is to be able to reuse some 'widgets' when designing HTML pages
 
 So instead that each page make the design/css for all buttons, inputs, it should be defined in some widget components.
 
-The components are located in the src/components/widget folder
+The components are located in the `src/components/widget` folder
 
-It includes toggle buttons, selecter, etc.
+It includes toggle buttons, selector, etc.
 
 A demo page is also provided to browse them: localhost:5000/#/demo-components
-
 
 ## API of Che
 
 Each call to the Che API shouldn't be made directly from the controller of the page.
-For that, it has to use Che API fatories which are handling the job (with promises operations)
+For that, it has to use Che API factories which are handling the job (with promises operations)
 
 By injecting 'cheAPI' inside a controller, all operations can be called.
 
-for example cheAPI.getWorkspace().getWorkspaces() for getting the array of the current workspaces of the user
+for example `cheAPI.getWorkspace().getWorkspaces()` for getting the array of the current workspaces of the user
 
 Mocks are also provided for the Che API, allowing to emulate a real backend for unit tests or e2e tests
 
+## Configurability
 
+The `configuration.menu.disabled` field in [product.json](/src/assets/branding/product.json) allows users to list there menu entries they want to hide in left navigation bar. Along with that corresponding routes also will be disabled.
 
+For example:
+
+```json
+// product.json
+{
+  // disables the `Organizations` menu item and prevents opening views 
+  // with list of available organizations or an organization details
+  "configuration": {
+    "menu": {
+      "disabled": ["organizations"]
+    }
+  }
+}
+```

--- a/dashboard/src/app/administration/administration-config.service.ts
+++ b/dashboard/src/app/administration/administration-config.service.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
+
+export class AdministrationConfigService {
+
+  static $inject = [
+    'cheDashboardConfigurationService'
+  ];
+
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
+
+  constructor(
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
+  ) {
+    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
+  }
+
+  allowAdministrationRoutes(): ng.IPromise<void> {
+    return this.cheDashboardConfigurationService.allowRoutes('administration');
+  }
+
+}

--- a/dashboard/src/app/administration/administration-config.ts
+++ b/dashboard/src/app/administration/administration-config.ts
@@ -11,11 +11,10 @@
  */
 'use strict';
 
-
 import {DockerRegistryList} from './docker-registry/docker-registry-list/docker-registry-list.directive';
 import {DockerRegistryListController} from './docker-registry/docker-registry-list/docker-registry-list.controller';
 import {EditRegistryController} from './docker-registry/docker-registry-list/edit-registry/edit-registry.controller';
-
+import { AdministrationConfigService } from './administration-config.service';
 
 export class AdministrationConfig {
 
@@ -25,11 +24,20 @@ export class AdministrationConfig {
 
     register.controller('EditRegistryController', EditRegistryController);
 
+    register.service('administrationConfigService', AdministrationConfigService);
+
     // config routes
     register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
       $routeProvider.accessWhen('/administration', {
         title: 'Administration',
-        templateUrl: 'app/administration/administration.html'
+        templateUrl: 'app/administration/administration.html',
+        resolve: {
+          init: [
+            'administrationConfigService',
+            (svc: AdministrationConfigService) => {
+              return svc.allowAdministrationRoutes();
+            }]
+        }
       });
     }]);
 

--- a/dashboard/src/app/dashboard/dashboard-config.ts
+++ b/dashboard/src/app/dashboard/dashboard-config.ts
@@ -38,7 +38,7 @@ export class DashboardConfig {
             const defer = $q.defer();
             cheWorkspace.fetchWorkspaces().then(() => {
               if (cheWorkspace.getWorkspaces().length === 0) {
-                $window.open(MENU_ITEM.getStarted, '_self');
+                $window.open(MENU_ITEM.getstarted, '_self');
                 defer.reject();
               } else {
                 defer.resolve();

--- a/dashboard/src/app/factories/factories-config.ts
+++ b/dashboard/src/app/factories/factories-config.ts
@@ -11,7 +11,6 @@
  */
 'use strict';
 
-
 import {FactoryDetailsConfig} from './factory-details/factory-details-config';
 import {CreateFactoryConfig} from './create-factory/create-factory-config';
 import {LastFactoriesConfig} from './last-factories/last-factories-config';
@@ -20,6 +19,7 @@ import {FactoryItemController} from './list-factories/factory-item/factory-item.
 import {CheFactoryItem} from './list-factories/factory-item/factory-item.directive';
 import {LoadFactoryController} from './load-factory/load-factory.controller';
 import {LoadFactoryService} from './load-factory/load-factory.service';
+import { FactoryConfigService } from './factory-config.service';
 
 export class FactoryConfig {
 
@@ -32,27 +32,44 @@ export class FactoryConfig {
     register.controller('LoadFactoryController', LoadFactoryController);
     register.service('loadFactoryService', LoadFactoryService);
 
+    register.service('factoryConfigService', FactoryConfigService);
+
     // config routes
     register.app.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) => {
-      $routeProvider.accessWhen('/factories', {
-        title: 'Factories',
-        templateUrl: 'app/factories/list-factories/list-factories.html',
-        controller: 'ListFactoriesController',
-        controllerAs: 'listFactoriesCtrl'
-      })
+      $routeProvider
+        .accessWhen('/factories', {
+          title: 'Factories',
+          templateUrl: 'app/factories/list-factories/list-factories.html',
+          controller: 'ListFactoriesController',
+          controllerAs: 'listFactoriesCtrl',
+          resolve: {
+            initData: ['factoryConfigService', (svc: FactoryConfigService) => {
+              return svc.allowFactoriesRoutes();
+            }]
+          }
+        })
         .accessWhen('/load-factory', {
           title: 'Load Factory',
           templateUrl: 'app/factories/load-factory/load-factory.html',
           controller: 'LoadFactoryController',
-          controllerAs: 'loadFactoryController'
+          controllerAs: 'loadFactoryController',
+          resolve: {
+            initData: ['factoryConfigService', (svc: FactoryConfigService) => {
+              return svc.allowFactoriesRoutes();
+            }]
+          }
         })
-      .accessWhen('/load-factory/:id', {
-        title: 'Load Factory',
-        templateUrl: 'app/factories/load-factory/load-factory.html',
-        controller: 'LoadFactoryController',
-        controllerAs: 'loadFactoryController'
-      });
-
+        .accessWhen('/load-factory/:id', {
+          title: 'Load Factory',
+          templateUrl: 'app/factories/load-factory/load-factory.html',
+          controller: 'LoadFactoryController',
+          controllerAs: 'loadFactoryController',
+          resolve: {
+            initData: ['factoryConfigService', (svc: FactoryConfigService) => {
+              return svc.allowFactoriesRoutes();
+            }]
+          }
+        });
     }]);
 
     // config files
@@ -63,4 +80,3 @@ export class FactoryConfig {
     /* tslint:enable */
   }
 }
-

--- a/dashboard/src/app/factories/factory-config.service.ts
+++ b/dashboard/src/app/factories/factory-config.service.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
+
+export class FactoryConfigService {
+
+  static $inject = [
+    'cheDashboardConfigurationService'
+  ];
+
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
+
+  constructor(
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
+  ) {
+    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
+  }
+
+  allowFactoriesRoutes(): ng.IPromise<void> {
+    return this.cheDashboardConfigurationService.allowRoutes('factories');
+  }
+
+}

--- a/dashboard/src/app/factories/factory-details/factory-details-config.ts
+++ b/dashboard/src/app/factories/factory-details/factory-details-config.ts
@@ -13,7 +13,7 @@
 
 import {FactoryDetailsController} from '../factory-details/factory-details.controller';
 import {InformationTabConfig} from './information-tab/information-tab-config';
-
+import { FactoryConfigService } from '../factory-config.service';
 
 export class FactoryDetailsConfig {
 
@@ -26,7 +26,12 @@ export class FactoryDetailsConfig {
         title: 'Factory',
         templateUrl: 'app/factories/factory-details/factory-details.html',
         controller: 'FactoryDetailsController',
-        controllerAs: 'factoryDetailsController'
+        controllerAs: 'factoryDetailsController',
+        resolve: {
+          initData: ['factoryConfigService', (svc: FactoryConfigService) => {
+            return svc.allowFactoriesRoutes();
+          }]
+        }
       };
 
       $routeProvider.accessWhen('/factory/:id', locationProvider)

--- a/dashboard/src/app/get-started/get-started-config.service.ts
+++ b/dashboard/src/app/get-started/get-started-config.service.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
+
+export class GetStartedConfigService {
+
+  static $inject = [
+    'cheDashboardConfigurationService'
+  ];
+
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
+
+  constructor(
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
+  ) {
+    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
+  }
+
+  allowGetStartedRoutes(): ng.IPromise<void> {
+    return this.cheDashboardConfigurationService.allowRoutes('getstarted');
+  }
+
+}

--- a/dashboard/src/app/get-started/get-started-config.ts
+++ b/dashboard/src/app/get-started/get-started-config.ts
@@ -13,9 +13,10 @@
 
 import {TemplateListController} from './template-list/template-list.controller';
 import {Template} from './template/template.directive';
+import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
+import { GetStartedConfigService } from './get-started-config.service';
 
 /**
- * @ngdoc controller
  * @name getStarted:GetStartedConfig
  * @description This class is used for configuring all get started devfiles.
  * @author Oleksii Orel
@@ -27,13 +28,20 @@ export class GetStartedConfig {
 
     register.controller('TemplateListController', TemplateListController);
 
+    register.service('getStartedConfigService', GetStartedConfigService);
+
     // config routes
     register.app.config(['$routeProvider', ($routeProvider: any) => {
       $routeProvider.accessWhen('/getstarted', {
         title: 'Get Started',
         templateUrl: 'app/get-started/template-list/template-list.html',
         controller: 'TemplateListController',
-        controllerAs: 'templateListController'
+        controllerAs: 'templateListController',
+        resolve: {
+          initData: ['getStartedConfigService', (svc: GetStartedConfigService) => {
+            return svc.allowGetStartedRoutes();
+          }]
+        }
       });
     }]);
   }

--- a/dashboard/src/app/navbar/navbar.controller.ts
+++ b/dashboard/src/app/navbar/navbar.controller.ts
@@ -13,30 +13,36 @@
 import {CheAPI} from '../../components/api/che-api.factory';
 import {CheKeycloak} from '../../components/api/che-keycloak.factory';
 import {CheService} from '../../components/api/che-service.factory';
+import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
 
-export const MENU_ITEM = {
-  dashboard: '#/',
-  getStarted: '#/getstarted',
-  workspaces: '#/workspaces',
-  stacks: '#/stacks',
-  factories: '#/factories',
+type ConfigurableMenu = { [key in che.ConfigurableMenuItem ]: string };
+
+const CONFIGURABLE_MENU: ConfigurableMenu = {
   administration: '#/administration',
-  usermanagement: '#/admin/usermanagement',
+  factories: '#/factories',
+  getstarted: '#/getstarted',
   organizations: '#/organizations',
-  account: '#/account'
+  stacks: '#/stacks',
 };
+
+export const MENU_ITEM = angular.extend({
+  account: '#/account',
+  dashboard: '#/',
+  usermanagement: '#/admin/usermanagement',
+  workspaces: '#/workspaces',
+}, CONFIGURABLE_MENU);
 
 export class CheNavBarController {
 
-  static $inject = ['$mdSidenav',
-    '$scope',
+  static $inject = [
     '$location',
-    '$route',
+    '$scope',
     'cheAPI',
-    '$window',
-    'chePermissions',
+    'cheDashboardConfigurationService',
     'cheKeycloak',
-    'cheService'];
+    'chePermissions',
+    'cheService',
+  ];
 
   menuItemUrl = MENU_ITEM;
 
@@ -55,42 +61,39 @@ export class CheNavBarController {
     }
   ];
 
-  private $mdSidenav: ng.material.ISidenavService;
-  private $scope: ng.IScope;
-  private $window: ng.IWindowService;
   private $location: ng.ILocationService;
-  private $route: ng.route.IRouteService;
+  private $scope: ng.IScope;
   private cheAPI: CheAPI;
-  private profile: che.IProfile;
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
+  private cheKeycloak: CheKeycloak;
   private chePermissions: che.api.IChePermissions;
+  private cheService: CheService;
+
+  private profile: che.IProfile;
   private userServices: che.IUserServices;
   private hasPersonalAccount: boolean;
   private organizations: Array<che.IOrganization>;
-  private cheKeycloak: CheKeycloak;
-  private cheService: CheService;
   private isPermissionServiceAvailable: boolean;
   private isKeycloackPresent: boolean;
 
   /**
    * Default constructor
    */
-  constructor($mdSidenav: ng.material.ISidenavService,
-              $scope: ng.IScope,
-              $location: ng.ILocationService,
-              $route: ng.route.IRouteService,
-              cheAPI: CheAPI,
-              $window: ng.IWindowService,
-              chePermissions: che.api.IChePermissions,
-              cheKeycloak: CheKeycloak,
-              cheService: CheService) {
-    this.$mdSidenav = $mdSidenav;
-    this.$scope = $scope;
+  constructor(
+    $location: ng.ILocationService,
+    $scope: ng.IScope,
+    cheAPI: CheAPI,
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
+    cheKeycloak: CheKeycloak,
+    chePermissions: che.api.IChePermissions,
+    cheService: CheService,
+  ) {
     this.$location = $location;
-    this.$route = $route;
+    this.$scope = $scope;
     this.cheAPI = cheAPI;
-    this.$window = $window;
-    this.chePermissions = chePermissions;
+    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
     this.cheKeycloak = cheKeycloak;
+    this.chePermissions = chePermissions;
     this.cheService = cheService;
   }
 
@@ -210,6 +213,10 @@ export class CheNavBarController {
     return rootOrganizations.length;
   }
 
+  showMenuItem(menuItem: che.ConfigurableMenuItem | string): boolean {
+    return this.cheDashboardConfigurationService.allowedMenuItem(menuItem);
+  }
+
   /**
    * Opens user profile in new browser page.
    */
@@ -223,4 +230,5 @@ export class CheNavBarController {
   private logout(): void {
     this.cheKeycloak.logout();
   }
+
 }

--- a/dashboard/src/app/navbar/navbar.html
+++ b/dashboard/src/app/navbar/navbar.html
@@ -29,7 +29,9 @@
       <div class="admin-navbar-menu">
         <section class="left-sidebar-menu" layout="column" layout-align="center center">
           <md-list layout="column">
-            <md-list-item flex class="navbar-subsection-item">
+            <!-- Dashboard -->
+            <md-list-item ng-if="navbarController.showMenuItem('dashboard')"
+              flex class="navbar-subsection-item">
               <md-button nav-bar-selected flex che-reload-href href="{{navbarController.menuItemUrl.dashboard}}"
                          layout-align="left"
                          target="_self">
@@ -39,8 +41,10 @@
                 </div>
               </md-button>
             </md-list-item>
-            <md-list-item flex class="navbar-subsection-item">
-              <md-button nav-bar-selected flex che-reload-href href="{{navbarController.menuItemUrl.getStarted}}"
+            <!-- Get Started -->
+            <md-list-item ng-if="navbarController.showMenuItem('getstarted')"
+              flex class="navbar-subsection-item">
+              <md-button nav-bar-selected flex che-reload-href href="{{navbarController.menuItemUrl.getstarted}}"
                          layout-align="left"
                          target="_self">
                 <div class="navbar-item" layout="row" layout-align="start center">
@@ -49,7 +53,9 @@
                 </div>
               </md-button>
             </md-list-item>
-            <md-list-item flex class="navbar-subsection-item">
+            <!-- Workspaces -->
+            <md-list-item ng-if="navbarController.showMenuItem('workspaces')"
+              flex class="navbar-subsection-item">
               <md-button nav-bar-selected flex che-reload-href href="{{navbarController.menuItemUrl.workspaces}}"
                          layout-align="left">
                 <div class="navbar-item" layout="row" layout-align="start center" id="workspaces-item">
@@ -61,7 +67,9 @@
                 </div>
               </md-button>
             </md-list-item>
-            <md-list-item flex class="navbar-subsection-item">
+            <!-- Stacks -->
+            <md-list-item ng-if="navbarController.showMenuItem('stacks')"
+              flex class="navbar-subsection-item">
               <md-button nav-bar-selected flex che-reload-href
                          href="{{navbarController.menuItemUrl.stacks}}" layout-align="left">
                 <div class="navbar-item" layout="row" layout-align="start center" id="stacks-item">
@@ -70,7 +78,9 @@
                 </div>
               </md-button>
             </md-list-item>
-            <md-list-item flex class="navbar-subsection-item">
+            <!-- Factories -->
+            <md-list-item ng-if="navbarController.showMenuItem('factories')"
+              flex class="navbar-subsection-item">
               <md-button nav-bar-selected flex che-reload-href
                          href="{{navbarController.menuItemUrl.factories}}" layout-align="left">
                 <div class="navbar-item" layout="row" layout-align="start center" id="factories-item">
@@ -82,7 +92,9 @@
                 </div>
               </md-button>
             </md-list-item>
-            <md-list-item flex class="navbar-subsection-item">
+            <!-- Administration -->
+            <md-list-item ng-if="navbarController.showMenuItem('administration')"
+              flex class="navbar-subsection-item">
               <md-button nav-bar-selected flex che-reload-href
                          href="{{navbarController.menuItemUrl.administration}}" layout-align="left">
                 <div class="navbar-item" layout="row" layout-align="start center" id="administration-item">
@@ -91,8 +103,12 @@
                 </div>
               </md-button>
             </md-list-item>
+            <!-- Organizations -->
             <md-list-item flex class="navbar-subsection-item"
-                          ng-if="navbarController.isPermissionServiceAvailable && !navbarController.userServices.hasInstallationManagerService && !navbarController.hasPersonalAccount">
+                          ng-if="navbarController.showMenuItem('organizations') &&
+                          navbarController.isPermissionServiceAvailable &&
+                          !navbarController.userServices.hasInstallationManagerService &&
+                          !navbarController.hasPersonalAccount">
               <md-button nav-bar-selected flex che-reload-href
                          href="{{navbarController.menuItemUrl.organizations}}" layout-align="left">
                 <div class="navbar-item" layout="row" layout-align="start center">

--- a/dashboard/src/app/organizations/organizations-config.service.spec.ts
+++ b/dashboard/src/app/organizations/organizations-config.service.spec.ts
@@ -84,7 +84,6 @@ describe('OrganizationsConfig >', () => {
       spyOn(callbacks, 'testReject');
 
       $location.path('/admin/create-organization');
-      $rootScope.$digest();
 
       const service = $injector.invoke(resolveBlock);
 
@@ -92,6 +91,7 @@ describe('OrganizationsConfig >', () => {
         .then(callbacks.testResolve)
         .catch(callbacks.testReject);
 
+      $rootScope.$digest();
       $httpBackend.flush();
 
       expect(callbacks.testResolve).toHaveBeenCalledWith({
@@ -137,7 +137,6 @@ describe('OrganizationsConfig >', () => {
       spyOn(callbacks, 'testReject');
 
       $location.path(`/admin/create-organization/${parentOrg.qualifiedName}`);
-      $rootScope.$digest();
 
       const service = $injector.invoke(resolveBlock);
 
@@ -145,6 +144,7 @@ describe('OrganizationsConfig >', () => {
         .then(callbacks.testResolve)
         .catch(callbacks.testReject);
 
+      $rootScope.$digest();
       $httpBackend.flush();
 
       expect(callbacks.testResolve).toHaveBeenCalled();
@@ -169,7 +169,6 @@ describe('OrganizationsConfig >', () => {
       spyOn(callbacks, 'testReject');
 
       $location.path(`/admin/create-organization/${parentOrg.qualifiedName}`);
-      $rootScope.$digest();
 
       // make response for organizations list fail
       $httpBackend.expect('GET', /\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
@@ -180,6 +179,7 @@ describe('OrganizationsConfig >', () => {
         .then(callbacks.testResolve)
         .catch(callbacks.testReject);
 
+      $rootScope.$digest();
       $httpBackend.flush();
 
       expect(callbacks.testResolve).toHaveBeenCalledWith({
@@ -253,7 +253,6 @@ describe('OrganizationsConfig >', () => {
       spyOn(callbacks, 'testReject');
 
       $location.path(`/organization/${parentOrg.qualifiedName}`);
-      $rootScope.$digest();
 
       const service = $injector.invoke(resolveBlock);
 
@@ -261,6 +260,7 @@ describe('OrganizationsConfig >', () => {
         .then(callbacks.testResolve)
         .catch(callbacks.testReject);
 
+      $rootScope.$digest();
       $httpBackend.flush();
 
       expect(callbacks.testResolve).toHaveBeenCalled();
@@ -288,7 +288,6 @@ describe('OrganizationsConfig >', () => {
       spyOn(callbacks, 'testReject');
 
       $location.path(`/organization/${parentOrg.qualifiedName}`);
-      $rootScope.$digest();
 
       // make response for organizations list fail
       $httpBackend.expect('GET', /\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
@@ -299,6 +298,7 @@ describe('OrganizationsConfig >', () => {
         .then(callbacks.testResolve)
         .catch(callbacks.testReject);
 
+      $rootScope.$digest();
       $httpBackend.flush();
 
       expect(callbacks.testResolve).toHaveBeenCalled();
@@ -345,7 +345,6 @@ describe('OrganizationsConfig >', () => {
       spyOn(callbacks, 'testReject');
 
       $location.path(`/organization/${subOrg.qualifiedName}`);
-      $rootScope.$digest();
 
       const service = $injector.invoke(resolveBlock);
 
@@ -353,6 +352,7 @@ describe('OrganizationsConfig >', () => {
         .then(callbacks.testResolve)
         .catch(callbacks.testReject);
 
+      $rootScope.$digest();
       $httpBackend.flush();
 
       expect(callbacks.testResolve).toHaveBeenCalled();
@@ -380,7 +380,6 @@ describe('OrganizationsConfig >', () => {
       spyOn(callbacks, 'testReject');
 
       $location.path(`/organization/${subOrg.qualifiedName}`);
-      $rootScope.$digest();
 
       // make response for organizations list fail
       $httpBackend.expect('GET', /\/api\/organization(\?.*$)?/).respond(500, [], {message: 'response failed'});
@@ -391,6 +390,7 @@ describe('OrganizationsConfig >', () => {
         .then(callbacks.testResolve)
         .catch(callbacks.testReject);
 
+      $rootScope.$digest();
       $httpBackend.flush();
 
       expect(callbacks.testResolve).toHaveBeenCalled();

--- a/dashboard/src/app/organizations/organizations-config.service.ts
+++ b/dashboard/src/app/organizations/organizations-config.service.ts
@@ -11,9 +11,20 @@
  */
 'use strict';
 
+import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
+
 export class OrganizationsConfigService {
 
-  static $inject = ['$log', '$q', '$route', 'cheOrganization', 'chePermissions', 'cheResourcesDistribution', 'cheUser'];
+  static $inject = [
+    '$log',
+    '$q',
+    '$route',
+    'cheDashboardConfigurationService',
+    'cheOrganization',
+    'chePermissions',
+    'cheResourcesDistribution',
+    'cheUser'
+  ];
 
   /**
    * Log service.
@@ -43,19 +54,28 @@ export class OrganizationsConfigService {
    * User profile API interaction.
    */
   private cheUser: any;
-
-  /** Default constructor that is using resource injection
+  /**
+   * Dashboard configuration service.
    */
-  constructor($log: ng.ILogService,
-              $q: ng.IQService,
-              $route: ng.route.IRouteService,
-              cheOrganization: che.api.ICheOrganization,
-              chePermissions: che.api.IChePermissions,
-              cheResourcesDistribution: che.api.ICheResourcesDistribution,
-              cheUser: any) {
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
+
+  /**
+   * Default constructor that is using resource injection
+   */
+  constructor(
+    $log: ng.ILogService,
+    $q: ng.IQService,
+    $route: ng.route.IRouteService,
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
+    cheOrganization: che.api.ICheOrganization,
+    chePermissions: che.api.IChePermissions,
+    cheResourcesDistribution: che.api.ICheResourcesDistribution,
+    cheUser: any
+  ) {
     this.$log = $log;
     this.$q = $q;
     this.$route = $route;
+    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
     this.cheOrganization = cheOrganization;
     this.chePermissions = chePermissions;
     this.cheResourcesDistribution = cheResourcesDistribution;
@@ -229,6 +249,10 @@ export class OrganizationsConfigService {
     }
 
     return this.$q.all(userPromises);
+  }
+
+  allowOrganizationsRoutes(): ng.IPromise<void> {
+    return this.cheDashboardConfigurationService.allowRoutes('organizations');
   }
 
   /**

--- a/dashboard/src/app/organizations/organizations-config.ts
+++ b/dashboard/src/app/organizations/organizations-config.ts
@@ -79,7 +79,9 @@ export class OrganizationsConfig {
       controllerAs: 'organizationDetailsController',
       resolve: {
         initData: ['organizationsConfigService', (organizationConfigService: OrganizationsConfigService) => {
-          return organizationConfigService.resolveOrganizationDetailsRoute();
+          return organizationConfigService.allowOrganizationsRoutes().then(() => {
+            return organizationConfigService.resolveOrganizationDetailsRoute();
+          });
         }]
       }
     };
@@ -91,7 +93,9 @@ export class OrganizationsConfig {
       controllerAs: 'createOrganizationController',
       resolve: {
         initData: ['organizationsConfigService', (organizationsConfigService: OrganizationsConfigService) => {
-          return organizationsConfigService.resolveCreateOrganizationRoute();
+          return organizationsConfigService.allowOrganizationsRoutes().then(() => {
+            return organizationsConfigService.resolveCreateOrganizationRoute();
+          });
         }]
       }
     };
@@ -102,7 +106,12 @@ export class OrganizationsConfig {
         title: 'organizations',
         templateUrl: 'app/organizations/organizations.html',
         controller: 'OrganizationsController',
-        controllerAs: 'organizationsController'
+        controllerAs: 'organizationsController',
+        resolve: {
+          initData: ['organizationsConfigService', (organizationsConfigService: OrganizationsConfigService) => {
+            return organizationsConfigService.allowOrganizationsRoutes();
+          }]
+        }
       })
         .accessWhen('/admin/create-organization', createOrganizationLocationProvider)
         .accessWhen('/admin/create-organization/:parentQualifiedName*', createOrganizationLocationProvider)

--- a/dashboard/src/app/stacks/stacks-config.service.ts
+++ b/dashboard/src/app/stacks/stacks-config.service.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+
+import { CheDashboardConfigurationService } from '../../components/branding/che-dashboard-configuration.service';
+
+export class StacksConfigService {
+
+  static $inject = [
+    'cheDashboardConfigurationService'
+  ];
+
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
+
+  constructor(
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
+  ) {
+    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
+  }
+
+  allowStacksRoutes(): ng.IPromise<void> {
+    return this.cheDashboardConfigurationService.allowRoutes('stacks');
+  }
+
+}

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
@@ -235,9 +235,16 @@ describe(`WorkspaceDetailsController >`, () => {
         return {
           getDocs: () => {
             const converting = 'converting-a-che-6-workspace-to-a-che-7-devfile';
-            return {converting};
+            return { converting };
+          },
+          getConfiguration: () => {
+            return {
+              menu: {
+                disabled: []
+              }
+            };
           }
-        }
+        };
       })
       // terminal directives which prevent to execute an original ones
       .directive('mdTab', function () {

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
@@ -19,7 +19,6 @@ import {CheService} from '../../../components/api/che-service.factory';
 import {PluginRegistry} from '../../../components/api/plugin-registry.factory';
 import {WorkspaceDataManager} from '../../../components/api/workspace/workspace-data-manager';
 import { ConfirmDialogService } from '../../../components/service/confirm-dialog/confirm-dialog.service';
-import { CheDashboardConfigurationService } from '../../../components/branding/che-dashboard-configuration.service';
 
 interface IPage {
   title: string;
@@ -85,15 +84,14 @@ export class WorkspaceDetailsService {
   static $inject = [
     '$log',
     '$q',
-    'cheDashboardConfigurationService',
-    'cheNotification',
-    'chePermissions',
-    'cheService',
     'cheWorkspace',
-    'confirmDialogService',
+    'cheNotification',
     'ideSvc',
-    'pluginRegistry',
     'workspaceDetailsProjectsService',
+    'cheService',
+    'chePermissions',
+    'confirmDialogService',
+    'pluginRegistry'
   ];
 
   /**
@@ -151,7 +149,6 @@ export class WorkspaceDetailsService {
    * Workspace data manager.
    */
   private workspaceDataManager: WorkspaceDataManager;
-  private cheDashboardConfigurationService: CheDashboardConfigurationService;
 
   /**
    * Default constructor that is using resource
@@ -159,15 +156,14 @@ export class WorkspaceDetailsService {
   constructor (
     $log: ng.ILogService,
     $q: ng.IQService,
-    cheDashboardConfigurationService: CheDashboardConfigurationService,
-    cheNotification: CheNotification,
-    chePermissions: che.api.IChePermissions,
-    cheService: CheService,
     cheWorkspace: CheWorkspace,
-    confirmDialogService: ConfirmDialogService,
+    cheNotification: CheNotification,
     ideSvc: IdeSvc,
-    pluginRegistry: PluginRegistry,
     workspaceDetailsProjectsService: WorkspaceDetailsProjectsService,
+    cheService: CheService,
+    chePermissions: che.api.IChePermissions,
+    confirmDialogService: ConfirmDialogService,
+    pluginRegistry: PluginRegistry
   ) {
     this.$log = $log;
     this.$q = $q;
@@ -177,7 +173,6 @@ export class WorkspaceDetailsService {
     this.pluginRegistry = pluginRegistry;
     this.workspaceDetailsProjectsService = workspaceDetailsProjectsService;
     this.confirmDialogService = confirmDialogService;
-    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
 
     this.observable =  new Observable<any>();
 
@@ -186,9 +181,7 @@ export class WorkspaceDetailsService {
     this.observable = new Observable();
 
     cheService.fetchServices().finally(() => {
-      const organizationsAllowed = cheDashboardConfigurationService.allowedMenuItem('organizations');
-      const permissionServiceAvailable = cheService.isServiceAvailable(chePermissions.getPermissionsServicePath());
-      if (organizationsAllowed && permissionServiceAvailable) {
+      if (cheService.isServiceAvailable(chePermissions.getPermissionsServicePath())) {
         this.addPage('Share', '<share-workspace></share-workspace>', 'icon-ic_folder_shared_24px');
       }
     });

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.service.ts
@@ -19,6 +19,7 @@ import {CheService} from '../../../components/api/che-service.factory';
 import {PluginRegistry} from '../../../components/api/plugin-registry.factory';
 import {WorkspaceDataManager} from '../../../components/api/workspace/workspace-data-manager';
 import { ConfirmDialogService } from '../../../components/service/confirm-dialog/confirm-dialog.service';
+import { CheDashboardConfigurationService } from '../../../components/branding/che-dashboard-configuration.service';
 
 interface IPage {
   title: string;
@@ -84,14 +85,15 @@ export class WorkspaceDetailsService {
   static $inject = [
     '$log',
     '$q',
-    'cheWorkspace',
+    'cheDashboardConfigurationService',
     'cheNotification',
-    'ideSvc',
-    'workspaceDetailsProjectsService',
-    'cheService',
     'chePermissions',
+    'cheService',
+    'cheWorkspace',
     'confirmDialogService',
-    'pluginRegistry'
+    'ideSvc',
+    'pluginRegistry',
+    'workspaceDetailsProjectsService',
   ];
 
   /**
@@ -149,6 +151,7 @@ export class WorkspaceDetailsService {
    * Workspace data manager.
    */
   private workspaceDataManager: WorkspaceDataManager;
+  private cheDashboardConfigurationService: CheDashboardConfigurationService;
 
   /**
    * Default constructor that is using resource
@@ -156,14 +159,15 @@ export class WorkspaceDetailsService {
   constructor (
     $log: ng.ILogService,
     $q: ng.IQService,
-    cheWorkspace: CheWorkspace,
+    cheDashboardConfigurationService: CheDashboardConfigurationService,
     cheNotification: CheNotification,
-    ideSvc: IdeSvc,
-    workspaceDetailsProjectsService: WorkspaceDetailsProjectsService,
-    cheService: CheService,
     chePermissions: che.api.IChePermissions,
+    cheService: CheService,
+    cheWorkspace: CheWorkspace,
     confirmDialogService: ConfirmDialogService,
-    pluginRegistry: PluginRegistry
+    ideSvc: IdeSvc,
+    pluginRegistry: PluginRegistry,
+    workspaceDetailsProjectsService: WorkspaceDetailsProjectsService,
   ) {
     this.$log = $log;
     this.$q = $q;
@@ -173,6 +177,7 @@ export class WorkspaceDetailsService {
     this.pluginRegistry = pluginRegistry;
     this.workspaceDetailsProjectsService = workspaceDetailsProjectsService;
     this.confirmDialogService = confirmDialogService;
+    this.cheDashboardConfigurationService = cheDashboardConfigurationService;
 
     this.observable =  new Observable<any>();
 
@@ -181,7 +186,9 @@ export class WorkspaceDetailsService {
     this.observable = new Observable();
 
     cheService.fetchServices().finally(() => {
-      if (cheService.isServiceAvailable(chePermissions.getPermissionsServicePath())) {
+      const organizationsAllowed = cheDashboardConfigurationService.allowedMenuItem('organizations');
+      const permissionServiceAvailable = cheService.isServiceAvailable(chePermissions.getPermissionsServicePath());
+      if (organizationsAllowed && permissionServiceAvailable) {
         this.addPage('Share', '<share-workspace></share-workspace>', 'icon-ic_folder_shared_24px');
       }
     });

--- a/dashboard/src/components/branding/che-branding-config.ts
+++ b/dashboard/src/components/branding/che-branding-config.ts
@@ -12,12 +12,14 @@
 'use strict';
 
 import {CheBranding} from './che-branding.factory';
+import { CheDashboardConfigurationService } from './che-dashboard-configuration.service';
 
 export class CheBrandingConfig {
 
   constructor(register: che.IRegisterService) {
     // register this factory
     register.factory('cheBranding', CheBranding);
+    register.service('cheDashboardConfigurationService', CheDashboardConfigurationService);
 
   }
 }

--- a/dashboard/src/components/branding/che-dashboard-configuration.service.ts
+++ b/dashboard/src/components/branding/che-dashboard-configuration.service.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import { CheBranding } from './che-branding.factory';
+
+/**
+ * This class handles configuration data of Dashboard.
+ * @author Oleksii Kurinnyi
+ */
+export class CheDashboardConfigurationService {
+
+  static $inject = [
+    '$q',
+    'cheBranding',
+  ];
+
+  $q: ng.IQService;
+  cheBranding: CheBranding;
+
+  constructor(
+    $q: ng.IQService,
+    cheBranding: CheBranding,
+  ) {
+    this.$q = $q;
+    this.cheBranding = cheBranding;
+  }
+
+  allowedMenuItem(menuItem: che.ConfigurableMenuItem | string): boolean {
+    const disabledItems = this.cheBranding.getConfiguration().menu.disabled;
+    return (disabledItems as string[]).indexOf(menuItem) === -1;
+  }
+
+  allowRoutes(menuItem: che.ConfigurableMenuItem): ng.IPromise<void> {
+    return this.cheBranding.ready.then(() => {
+      if (this.allowedMenuItem(menuItem) === false) {
+        return this.$q.reject();
+      }
+    });
+  }
+
+}

--- a/dashboard/src/components/typings/che.d.ts
+++ b/dashboard/src/components/typings/che.d.ts
@@ -15,6 +15,8 @@ declare module 'che' {
 
 declare namespace che {
 
+  export type ConfigurableMenuItem = 'administration' | 'factories' | 'getstarted' | 'organizations' | 'stacks';
+
   export interface IRootScopeService extends ng.IRootScopeService {
     hideLoader: boolean;
     showIDE: boolean;


### PR DESCRIPTION
Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR introduces ability to configure the User Dashboard. Now it's possible to disable some of menu entries in sidebar by providing configuration in `product.json`, for example, following configuration disables the `Organizations` menu item and prevents opening views with list of available organizations or an organization details.

```json
// product.json
{
  "configuration": {
    "menu": {
      "disabled": ["organizations"]
    }
  }
}
```

### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/15462 (hide Organizations tab)
