### PR TITLE
Fix nightly build on CentOS CI

### DIFF
--- a/.ci/cico_common.sh
+++ b/.ci/cico_common.sh
@@ -153,7 +153,7 @@ publishImagesOnQuay() {
                rm -r "${LOCAL_ASSEMBLY_DIR}"
            fi
            cp -r "${BUILD_ASSEMBLY_DIR}" "${LOCAL_ASSEMBLY_DIR}"
-           docker build -t ${ORGANIZATION}/che-server:${TAG}-centos -f $(pwd)/${image_dir}/Dockerfile.centos $(pwd)/${image_dir}/
+           docker build -t ${REGISTRY}/${ORGANIZATION}/che-server:${TAG}-centos -f $(pwd)/${image_dir}/Dockerfile.centos $(pwd)/${image_dir}/
          fi
          if [[ $? -ne 0 ]]; then
            echo "ERROR:"
@@ -165,7 +165,6 @@ publishImagesOnQuay() {
     #PUSH IMAGES
     for image in ${IMAGES_LIST[@]}
      do
-         docker tag "${image}:${TAG}" "${REGISTRY}/${image}:${TAG}"
          echo y | docker push "${REGISTRY}/${image}:${TAG}"
          if [[ $2 == "pushLatest" ]]; then
             docker tag "${image}:${TAG}" "${REGISTRY}/${image}:latest"
@@ -173,10 +172,10 @@ publishImagesOnQuay() {
          fi
 
          if [[ ${image} == "${ORGANIZATION}/che-server" ]]; then
-           docker tag "${image}:${TAG}" "${REGISTRY}/${image}:${TAG}-centos"
+           docker tag "${REGISTRY}/${image}:${TAG}" "${REGISTRY}/${image}:${TAG}-centos"
            echo y | docker push "${REGISTRY}/${ORGANIZATION}/che-server:${TAG}-centos"
            if [[ $2 == "pushLatest" ]]; then
-               docker tag "${image}:${TAG}" "${REGISTRY}/${image}:latest-centos"
+               docker tag "${REGISTRY}/${image}:${TAG}" "${REGISTRY}/${image}:latest-centos"
                echo y | docker push "${REGISTRY}/${ORGANIZATION}/che-server:latest-centos"
            fi
          fi


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix build and push images on quay.io step.
After this PR https://github.com/eclipse/che/pull/15768 does not need additional tag operation because image already have registry prefix in the names


### What issues does this PR fix or reference?
#15812 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
