### PR TITLE
Prevent session already invalidated error when re-logging in with different user

### DIFF
--- a/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/filter/MultiUserEnvironmentInitializationFilter.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/filter/MultiUserEnvironmentInitializationFilter.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.multiuser.api.authentication.commons.filter;
 
-import static java.lang.String.format;
 import static org.eclipse.che.multiuser.api.authentication.commons.Constants.CHE_SUBJECT_ATTRIBUTE;
 
 import java.io.IOException;
@@ -126,9 +125,9 @@ public abstract class MultiUserEnvironmentInitializationFilter implements Filter
       session.setAttribute(CHE_SUBJECT_ATTRIBUTE, sessionSubject);
     } else if (!sessionSubject.getUserId().equals(userId)) {
       LOG.debug(
-          format(
-              "Invalidating session with mismatched user IDs: old was %s, new is %s.",
-              sessionSubject.getUserId(), userId));
+          "Invalidating session with mismatched user IDs: old was '{}', new is '{}'.",
+          sessionSubject.getUserId(),
+          userId);
       session.invalidate();
       HttpSession new_session = httpRequest.getSession(true);
       sessionSubject = extractSubject(token);

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/filter/MultiUserEnvironmentInitializationFilter.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/filter/MultiUserEnvironmentInitializationFilter.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.multiuser.api.authentication.commons.filter;
 
+import static java.lang.String.format;
 import static org.eclipse.che.multiuser.api.authentication.commons.Constants.CHE_SUBJECT_ATTRIBUTE;
 
 import java.io.IOException;
@@ -28,6 +29,8 @@ import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.multiuser.api.authentication.commons.SessionStore;
 import org.eclipse.che.multiuser.api.authentication.commons.SubjectHttpRequestWrapper;
 import org.eclipse.che.multiuser.api.authentication.commons.token.RequestTokenExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Performs basic environment initialization actions as follows:
@@ -43,6 +46,9 @@ import org.eclipse.che.multiuser.api.authentication.commons.token.RequestTokenEx
  * @author Max Shaposhnyk (mshaposh@redhat.com)
  */
 public abstract class MultiUserEnvironmentInitializationFilter implements Filter {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(MultiUserEnvironmentInitializationFilter.class);
 
   private final SessionStore sessionStore;
   private final RequestTokenExtractor tokenExtractor;
@@ -119,6 +125,10 @@ public abstract class MultiUserEnvironmentInitializationFilter implements Filter
       sessionSubject = extractSubject(token);
       session.setAttribute(CHE_SUBJECT_ATTRIBUTE, sessionSubject);
     } else if (!sessionSubject.getUserId().equals(userId)) {
+      LOG.debug(
+          format(
+              "Invalidating session with mismatched user IDs: old was %s, new is %s.",
+              sessionSubject.getUserId(), userId));
       session.invalidate();
       HttpSession new_session = httpRequest.getSession(true);
       sessionSubject = extractSubject(token);

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/filter/MultiUserEnvironmentInitializationFilter.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/filter/MultiUserEnvironmentInitializationFilter.java
@@ -115,7 +115,15 @@ public abstract class MultiUserEnvironmentInitializationFilter implements Filter
     HttpSession session = httpRequest.getSession(true);
     // retrieve and check / create new subject
     sessionSubject = (Subject) session.getAttribute(CHE_SUBJECT_ATTRIBUTE);
-    if (sessionSubject == null || !sessionSubject.getToken().equals(token)) {
+    if (sessionSubject == null) {
+      sessionSubject = extractSubject(token);
+      session.setAttribute(CHE_SUBJECT_ATTRIBUTE, sessionSubject);
+    } else if (!sessionSubject.getUserId().equals(userId)) {
+      session.invalidate();
+      HttpSession new_session = httpRequest.getSession(true);
+      sessionSubject = extractSubject(token);
+      new_session.setAttribute(CHE_SUBJECT_ATTRIBUTE, sessionSubject);
+    } else if (!sessionSubject.getToken().equals(token)) {
       sessionSubject = extractSubject(token);
       session.setAttribute(CHE_SUBJECT_ATTRIBUTE, sessionSubject);
     }

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/test/java/org/eclipse/che/multiuser/api/authentication/commons/filter/MultiUserEnvironmentInitializationFilterTest.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/test/java/org/eclipse/che/multiuser/api/authentication/commons/filter/MultiUserEnvironmentInitializationFilterTest.java
@@ -102,6 +102,19 @@ public class MultiUserEnvironmentInitializationFilterTest {
 
   @Test
   public void shouldReCreateSubjectIfTokensDidNotMatch() throws Exception {
+    Subject otherSubject =
+        new SubjectImpl(subject.getUserId(), subject.getUserName(), "token111", false);
+    when(tokenExtractor.getToken(any(HttpServletRequest.class))).thenReturn(token);
+    when(sessionStore.getSession(eq(userId), any())).thenReturn(session);
+    when(session.getAttribute(eq(CHE_SUBJECT_ATTRIBUTE))).thenReturn(otherSubject);
+    // when
+    filter.doFilter(request, response, chain);
+    // then
+    verify(filter).extractSubject(eq(token));
+  }
+
+  @Test
+  public void shouldInvalidateSessionIfUserChanged() throws Exception {
     Subject otherSubject = new SubjectImpl("another_user", "user987", "token111", false);
     when(tokenExtractor.getToken(any(HttpServletRequest.class))).thenReturn(token);
     when(sessionStore.getSession(eq(userId), any())).thenReturn(session);
@@ -109,6 +122,7 @@ public class MultiUserEnvironmentInitializationFilterTest {
     // when
     filter.doFilter(request, response, chain);
     // then
+    verify(session).invalidate();
     verify(filter).extractSubject(eq(token));
   }
 


### PR DESCRIPTION
### What does this PR do?
Prevent session already invalidated error when logging in with different users simultaneously.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15798


#### Release Notes
N/A


#### Docs PR
N/A