### PR TITLE
Resolve relative links to icons on Create Workspace page

### DIFF
--- a/dashboard/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.controller.ts
+++ b/dashboard/src/app/workspaces/create-workspace/ready-to-go-stacks/devfile-selector/devfile-selector.controller.ts
@@ -50,7 +50,12 @@ export class DevfileSelectorController {
   loadDevfiles(): void {
     let location = this.cheWorkspace.getWorkspaceSettings().cheWorkspaceDevfileRegistryUrl;
     this.devfileRegistry.fetchDevfiles(location).then((data: Array<IDevfileMetaData>) => {
-      this.devfiles = data;
+      this.devfiles = data.map(devfile => {
+        if (!devfile.icon.startsWith('http')) {
+          devfile.icon = location + devfile.icon;
+        }
+        return devfile;
+      });
 
       if (this.devfiles && this.devfiles.length > 0) {
         this.devfileOnClick(this.devfiles[0]);


### PR DESCRIPTION
### What does this PR do?
Resolves relative icons links on Create Workspace page:
![Screenshot_20200127_125625](https://user-images.githubusercontent.com/5887312/73169374-9db85780-4104-11ea-82bb-47b1d59e1d8b.png)


### What issues does this PR fix or reference?
Part of https://github.com/eclipse/che/issues/15581
