### PR TITLE
Remove selfSignedCertSecretName property

### DIFF
--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -104,9 +104,9 @@ spec:
               optional: false
         {{- end }}
 
-        # If workspaces are created in a separate precreated namespace
+        # If workspaces are created in a separate namespace(s)
         # then configure Che Server to propagate TLS secret to workspaces' namespaces
-        {{- if not (contains "<" .Values.global.cheWorkspacesNamespace) }}
+        {{- if ne .Release.Namespace .Values.global.cheWorkspacesNamespace }}
         - name: "CHE_INFRA_KUBERNETES_TLS__CERT"
           valueFrom:
             secretKeyRef:

--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ca.crt
-              name: {{ .Values.global.tls.selfSignedCertSecretName }}
+              name: {{ .Values.global.tls.secretName }}
               optional: false
         {{- end }}
 
@@ -111,13 +111,13 @@ spec:
           valueFrom:
             secretKeyRef:
               key: tls.crt
-              name: {{ .Values.global.tls.secretName  }}
+              name: {{ .Values.global.tls.secretName }}
               optional: false
         - name: "CHE_INFRA_KUBERNETES_TLS__KEY"
           valueFrom:
             secretKeyRef:
               key: tls.key
-              name: {{ .Values.global.tls.secretName  }}
+              name: {{ .Values.global.tls.secretName }}
               optional: false
         {{- end }}
         {{- end }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -45,10 +45,9 @@ global:
     ## it MUST be pre-created in the configured Che namespace
     secretName: che-tls
 
-    ## If self-signed certificate is enabled
-    ## then certificate from `tls.selfSignedCertSecretName` will be propagated to Che components' trust stores
+    ## If self-signed certificate flag is enabled
+    ## then CA certificate from `tls.secretName` will be propagated to Che components' trust stores
     useSelfSignedCerts: false
-    selfSignedCertSecretName: self-signed-cert
 
 
   ## If using git self-signed certificate is enabled


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Reduces number of tls secrets in Che installation process.
Actually we may use the same certificate, but treat it differently depending on `self-signed` flag.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15810
Should be merged together with https://github.com/che-incubator/chectl/pull/476