### PR TITLE
[UD] Added ability to pre-fetch resources defined in configuration

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -233,9 +233,13 @@ Mocks are also provided for the Che API, allowing to emulate a real backend for 
 
 ## Configurability
 
-The `configuration.menu.disabled` field in [product.json](/src/assets/branding/product.json) allows users to list there menu entries they want to hide in left navigation bar. Along with that corresponding routes also will be disabled.
+Configurations for User Dashboard could be applied in [product.json](/src/assets/branding/product.json) in `"configuration"` section.
 
-Available values are `'administration'`, `'factories'`,  `'getstarted'`, `'organizations'`, `'stacks'`.
+Adding the `"configuration.menu.disabled"` field allows users to list there menu entries they want to hide in left navigation bar. Along with that corresponding routes also will be disabled.
+
+Available values are `"administration"`, `"factories"`,  `"getstarted"`, `"organizations"`, `"stacks"`.
+
+For example,
 
 ```json
 // product.json
@@ -249,3 +253,24 @@ Available values are `'administration'`, `'factories'`,  `'getstarted'`, `'organ
   }
 }
 ```
+
+The `"configuration.prefetch"` section allows to define resources that UD should pre-fetch. This section consists of following optional fields:
+
+- `"resources"` is an array of urls to resources to pre-fetch;
+- `"cheCDN"` which is Che specific and points to API endpoint that gives resources to pre-fetch,
+  e.g. response from `"/api/cdn-support/paths"` on `che.openshift.io` has following structure and each of these entries will be pre-fetched:
+
+  ```json
+  [
+    {
+      "chunk": "che.12debab20b181e07ac86.js",
+      "cdn": "https://static.developers.redhat.com/che/theia_artifacts/che.12debab20b181e07ac86.js"
+    },
+    ...
+    {
+      "external": "vs/editor/editor.main.css",
+      "cdn": "https://cdn.jsdelivr.net/npm/@typefox/monaco-editor-core@0.18.0-next.1/min/vs/editor/editor.main.css"
+    },
+    ...
+  ]
+  ```

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -235,7 +235,7 @@ Mocks are also provided for the Che API, allowing to emulate a real backend for 
 
 Configurations for User Dashboard could be applied in [product.json](/src/assets/branding/product.json) in `"configuration"` section.
 
-Adding the `"configuration.menu.disabled"` field allows users to list there menu entries they want to hide in left navigation bar. Along with that corresponding routes also will be disabled.
+Adding the `"configuration.menu.disabled"` field allows Che Admins to list menu entries they want to hide in the left navigation bar, along with the corresponding routes which will be disabled.
 
 Available values are `"administration"`, `"factories"`,  `"getstarted"`, `"organizations"`, `"stacks"`.
 

--- a/dashboard/src/app/index.module.ts
+++ b/dashboard/src/app/index.module.ts
@@ -35,6 +35,7 @@ import {CheUIElementsInjectorService} from '../components/service/injector/che-u
 import {OrganizationsConfig} from './organizations/organizations-config';
 import {TeamsConfig} from './teams/teams-config';
 import {ProfileConfig} from './profile/profile-config';
+import {ResourceFetcherService} from '../components/service/resource-fetcher/resource-fetcher.service';
 
 // init module
 const initModule = angular.module('userDashboard', ['ngAnimate', 'ngCookies', 'ngTouch', 'ngSanitize', 'ngResource', 'ngRoute',
@@ -257,16 +258,27 @@ initModule.config(['$routeProvider', ($routeProvider: che.route.IRouteProvider) 
 /**
  * Setup route redirect module
  */
-initModule.run(['$rootScope', '$location', '$routeParams', 'routingRedirect', '$timeout', '$mdSidenav', 'routeHistory', 'cheUIElementsInjectorService', 'workspaceDetailsService',
+initModule.run([
+  '$location',
+  '$mdSidenav',
+  '$rootScope',
+  '$routeParams',
+  '$timeout',
+  'cheUIElementsInjectorService',
+  'resourceFetcherService',
+  'routeHistory',
+  'routingRedirect',
+  'workspaceDetailsService',
   (
-    $rootScope: che.IRootScopeService,
     $location: ng.ILocationService,
-    $routeParams: ng.route.IRouteParamsService,
-    routingRedirect: RoutingRedirect,
-    $timeout: ng.ITimeoutService,
     $mdSidenav: ng.material.ISidenavService,
+    $rootScope: che.IRootScopeService,
+    $routeParams: ng.route.IRouteParamsService,
+    $timeout: ng.ITimeoutService,
+    cheUIElementsInjectorService: CheUIElementsInjectorService,
+    resourceFetcherService: ResourceFetcherService,
     routeHistory: RouteHistory,
-    cheUIElementsInjectorService: CheUIElementsInjectorService
+    routingRedirect: RoutingRedirect,
   ) => {
 
     $rootScope.hideLoader = false;
@@ -276,6 +288,7 @@ initModule.run(['$rootScope', '$location', '$routeParams', 'routingRedirect', '$
 
     // here only to create instances of these components
     /* tslint:disable */
+    resourceFetcherService;
     routeHistory;
     /* tslint:enable */
 

--- a/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
+++ b/dashboard/src/app/workspaces/workspace-details/workspace-details.directive.spec.ts
@@ -237,11 +237,16 @@ describe(`WorkspaceDetailsController >`, () => {
             const converting = 'converting-a-che-6-workspace-to-a-che-7-devfile';
             return { converting };
           },
+          registerCallback: (callbackId: string, callback: Function): void => {
+            callback();
+          },
+          unregisterCallback: (callbackId: string): void => {},
           getConfiguration: () => {
             return {
               menu: {
                 disabled: []
-              }
+              },
+              prefetch: {}
             };
           }
         };

--- a/dashboard/src/components/branding/che-branding.factory.ts
+++ b/dashboard/src/components/branding/che-branding.factory.ts
@@ -56,8 +56,9 @@ interface IBrandingConfiguration {
   menu: {
     disabled: che.ConfigurableMenuItem[];
   };
-  misc: {
-    idePrefetch?: string[];
+  prefetch: {
+    cheCDN: string;
+    resources: string[];
   };
 }
 
@@ -347,11 +348,17 @@ export class CheBranding {
             ? this.branding.configuration.menu.disabled
             : []
       },
-      misc: {
-        idePrefetch:
+      prefetch: {
+        cheCDN: this.branding.configuration &&
+          this.branding.configuration.prefetch &&
+          this.branding.configuration.prefetch.cheCDN
+          ? this.branding.configuration.prefetch.cheCDN
+          : undefined,
+        resources:
           this.branding.configuration &&
-          this.branding.configuration.misc && this.branding.configuration.misc.idePrefetch
-            ? this.branding.configuration.misc.idePrefetch
+            this.branding.configuration.prefetch &&
+            this.branding.configuration.prefetch.resources
+            ? this.branding.configuration.prefetch.resources
             : []
       }
     };

--- a/dashboard/src/components/service/resource-fetcher/resource-fetcher.service.ts
+++ b/dashboard/src/components/service/resource-fetcher/resource-fetcher.service.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016-2018 Red Hat, Inc.
+ * Copyright (c) 2015-2018 Red Hat, Inc.
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
  * which is available at https://www.eclipse.org/legal/epl-2.0/

--- a/dashboard/src/components/service/resource-fetcher/resource-fetcher.service.ts
+++ b/dashboard/src/components/service/resource-fetcher/resource-fetcher.service.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2016-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+'use strict';
+
+import { CheBranding } from '../../branding/che-branding.factory';
+
+const IDE_FETCHER_CALLBACK_ID = 'cheIdeFetcherCallback';
+
+/**
+ * Provides a way to download IDE .js and then cache it before trying to load the IDE
+ * @author Florent Benoit
+ * @author Oleksii Orel
+ * @author David Festal
+ */
+export class ResourceFetcherService {
+
+  static $inject = [
+    '$log',
+    '$http',
+    'cheBranding'
+  ];
+
+  private $log: ng.ILogService;
+  private $http: ng.IHttpService;
+  private cheBranding: CheBranding;
+
+  /**
+   * Default constructor that is using resource injection
+   */
+  constructor(
+    $log: ng.ILogService,
+    $http: ng.IHttpService,
+    cheBranding: CheBranding
+  ) {
+    this.$log = $log;
+    this.$http = $http;
+    this.cheBranding = cheBranding;
+
+    const callback = () => {
+      const prefetch = this.cheBranding.getConfiguration().prefetch;
+      this.prefetchCheCDNResources(prefetch.cheCDN);
+      this.prefetchResources(prefetch.resources);
+      this.cheBranding.unregisterCallback(IDE_FETCHER_CALLBACK_ID);
+    };
+    this.cheBranding.registerCallback(IDE_FETCHER_CALLBACK_ID, callback.bind(this));
+  }
+
+  /**
+   * Prefetch Che specific resources.
+   */
+  private prefetchCheCDNResources(url: string): void {
+    type resourceEntry = {
+      chunk: string;
+      cdn: string;
+    };
+    this.$http.get(url, { cache: false }).then((response: ng.IHttpResponse<Array<resourceEntry>>) => {
+      if (!response || !response.data) {
+        return;
+      }
+      response.data.forEach(entry => {
+        // load the url
+        if (angular.isDefined(entry.cdn)) {
+          this.appendLink(entry.cdn);
+        } else {
+          this.$log.error('Unable to find the Theia resource file to cache');
+        }
+      });
+    }, (error: any) => {
+      this.$log.log(`Unable to find Theia CDN resources to cache`, error);
+    });
+  }
+
+  /**
+   * Prefetch other resources
+   */
+  private prefetchResources(resources: string[]): void {
+    resources.forEach(resource => {
+      this.appendLink(resource);
+    });
+  }
+
+  /**
+   * Appends the `link` node linked to a resource
+   */
+  private appendLink(url: string): void {
+    this.$log.log('Preloading resource', url);
+    const link = document.createElement('link');
+    link.rel = 'prefetch';
+    link.href = url;
+    document.head.appendChild(link);
+  }
+
+}

--- a/dashboard/src/components/service/resource-fetcher/resource-fetcher.service.ts
+++ b/dashboard/src/components/service/resource-fetcher/resource-fetcher.service.ts
@@ -58,6 +58,9 @@ export class ResourceFetcherService {
    * Prefetch Che specific resources.
    */
   private prefetchCheCDNResources(url: string): void {
+    if (!url) {
+      return;
+    }
     type resourceEntry = {
       chunk: string;
       cdn: string;
@@ -83,6 +86,9 @@ export class ResourceFetcherService {
    * Prefetch other resources
    */
   private prefetchResources(resources: string[]): void {
+    if (!resources || resources.length === 0) {
+      return;
+    }
     resources.forEach(resource => {
       this.appendLink(resource);
     });

--- a/dashboard/src/components/service/service-config.ts
+++ b/dashboard/src/components/service/service-config.ts
@@ -15,7 +15,7 @@ import {CheConfirmDialogController} from './confirm-dialog/che-confirm-dialog.co
 import {ConfirmDialogService} from './confirm-dialog/confirm-dialog.service';
 import {CheUIElementsInjectorService} from './injector/che-ui-elements-injector.service';
 import {ResourcesService} from './resources-service/resources-service';
-
+import { ResourceFetcherService } from './resource-fetcher/resource-fetcher.service';
 
 export class ServiceConfig {
 
@@ -25,5 +25,6 @@ export class ServiceConfig {
 
     register.service('cheUIElementsInjectorService', CheUIElementsInjectorService);
     register.service('resourcesService', ResourcesService);
+    register.service('resourceFetcherService', ResourceFetcherService)
   }
 }


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds the ability to configure the UD to pre-fetch resources either Che specific from `che.openshift.io` CDN or any other.
In `product.json` one can add `configuration.prefetch` section:

```
{
  "configuration": {
    "prefetch": {
       ...
    }
  }
```

which can have following fields:

- `"resources"` is an array of urls to resources to pre-fetch;
- `"cheCDN"` which is Che specific and points to API endpoint that gives resources to pre-fetch,
  e.g. response from `"/api/cdn-support/paths"` on `che.openshift.io` has following structure and each of these entries will be pre-fetched:

  ```json
  [
    {
      "chunk": "che.12debab20b181e07ac86.js",
      "cdn": "https://static.developers.redhat.com/che/theia_artifacts/che.12debab20b181e07ac86.js"
    },
    ...
    {
      "external": "vs/editor/editor.main.css",
      "cdn": "https://cdn.jsdelivr.net/npm/@typefox/monaco-editor-core@0.18.0-next.1/min/vs/editor/editor.main.css"
    },
    ...
  ]
  ``` 


### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/15462 (Pre-fetching of the default editor CDN resources)

Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>
