### PR TITLE
Recover runtimes in multi-thread friendly manner

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -847,7 +847,7 @@ public class WorkspaceRuntimes {
         try {
           // Recover runtime in multi-thread friendly manner
           // 1. acquire write lock
-          // 2. check if runtime already restored by other thread.
+          // 2. check if runtime already restored by other threads.
           // 3. If needed restore runtime.
           getInternalRuntime(identity.getWorkspaceId());
         } catch (Exception e) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -855,7 +855,8 @@ public class WorkspaceRuntimes {
               "An error occurred while attempting to recover runtime '{}' using infrastructure '{}'. Reason: '{}'",
               identity.getWorkspaceId(),
               infrastructure.getName(),
-              e.getMessage());
+              e.getMessage(),
+              e);
         }
       }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceRuntimes.java
@@ -843,10 +843,13 @@ public class WorkspaceRuntimes {
     public void run() {
       long startTime = System.currentTimeMillis();
       LOG.info("Recovering of runtimes is started.");
-
       for (RuntimeIdentity identity : identities) {
         try {
-          recoverOne(infrastructure, identity);
+          // Recover runtime in multi-thread friendly manner
+          // 1. acquire write lock
+          // 2. check if runtime already restored by other thread.
+          // 3. If needed restore runtime.
+          getInternalRuntime(identity.getWorkspaceId());
         } catch (Exception e) {
           LOG.error(
               "An error occurred while attempting to recover runtime '{}' using infrastructure '{}'. Reason: '{}'",


### PR DESCRIPTION
### What does this PR do?
The issue caused by `RecoverRuntimesTask ` that iterates over the list of workspace runtimes and trying to recover it without checking if they are already recovered. At the same time, multiple threads can recover runtime from `injectRuntime` methods. 
To mitigate this problem I've revorked RecoverRuntimesTask. It makes such a sequence of actions.

1. acquire write lock
2. check if runtime already restored by other threads.
3. If needed restore runtime.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15801


<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a

#### Docs PR
n/a