### PR TITLE
reset EnvironmentContext between test to avoid influence one test on another

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -54,6 +54,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFacto
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
@@ -93,6 +94,11 @@ public class KubernetesNamespaceFactoryTest {
     lenient()
         .when(userManager.getById(USER_ID))
         .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    EnvironmentContext.reset();
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
reset EnvironmentContext between test to avoid influence one test on another

### What issues does this PR fix or reference?
Failed test when I run it with `mvn clean install`

```
EL Info]: connection: 2020-02-05 11:08:00.52--ServerSession(1495319789)--/file:/Users/skabashn/dev/src/redhat/che/infrastructures/kubernetes/target/test-classes/_test logout successful
[ERROR] Tests run: 593, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 10.449 s <<< FAILURE! - in TestSuite
[ERROR] testEvalNamespaceTreatsWorkspaceRecordedNamespaceLiterally(org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactoryTest)  Time elapsed: 0.007 s  <<< FAILURE!
java.lang.AssertionError: expected [<userid>] but found [che-id]
	at org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactoryTest.testEvalNamespaceTreatsWorkspaceRecordedNamespaceLiterally(KubernetesNamespaceFactoryTest.java:459)

[INFO]
[INFO] Results:
[INFO]
[ERROR] Failures:
[ERROR]   KubernetesNamespaceFactoryTest.testEvalNamespaceTreatsWorkspaceRecordedNamespaceLiterally:459 expected [<userid>] but found [che-id]
[INFO]
[ERROR] Tests run: 593, Failures: 1, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
```
Not reproduced if I run it in other ways.


<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a
#### Docs PR
n/a