### PR TITLE
[TS_SELENIUM] Fix the logical mistake in the "Editor.ts" pageobject leads to "StaleElementReference" error

### DIFF
--- a/tests/e2e/pageobjects/ide/Editor.ts
+++ b/tests/e2e/pageobjects/ide/Editor.ts
@@ -12,7 +12,7 @@ import { injectable, inject } from 'inversify';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { CLASSES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
-import { By, Key, error, ActionSequence, Button, WebElement } from 'selenium-webdriver';
+import { By, Key, error, ActionSequence, Button } from 'selenium-webdriver';
 import { Ide } from './Ide';
 import { Logger } from '../../utils/Logger';
 
@@ -337,18 +337,18 @@ export class Editor {
     async waitStoppedDebugBreakpoint(tabTitle: string, lineNumber: number, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
         Logger.debug(`Editor.waitStoppedDebugBreakpoint title: "${tabTitle}" line: "${lineNumber}"`);
 
-        await this.driverHelper.waitUntilTrue(() => this.isBreakpointPresent(lineNumber, true), timeout);
+        await this.driverHelper.waitUntilTrue(() => this.isBreakpointPresent(tabTitle, lineNumber, true), timeout);
     }
 
     async waitBreakpoint(tabTitle: string, lineNumber: number, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
         Logger.debug(`Editor.waitBreakpoint title: "${tabTitle}" line: "${lineNumber}"`);
 
-        await this.driverHelper.waitUntilTrue(() => this.isBreakpointPresent(lineNumber), timeout);
+        await this.driverHelper.waitUntilTrue(() => this.isBreakpointPresent(tabTitle, lineNumber), timeout);
     }
 
     async waitBreakpointAbsence(tabTitle: string, lineNumber: number, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
         Logger.debug(`Editor.waitBreakpointAbsence title: "${tabTitle}" line: "${lineNumber}"`);
-        await this.driverHelper.waitUntilTrue(() => !this.isBreakpointPresent(lineNumber), timeout);
+        await this.driverHelper.waitUntilTrue(() => !this.isBreakpointPresent(tabTitle, lineNumber), timeout);
     }
 
     async activateBreakpoint(tabTitle: string, lineNumber: number) {
@@ -547,33 +547,24 @@ export class Editor {
      * @param triggered Whether this breakpoint is triggered or not. Default false.
      */
 
-    private async isBreakpointPresent(lineNumber: number, triggered: boolean = false): Promise<boolean> {
+    private async isBreakpointPresent(tabTitle: string, lineNumber: number, triggered: boolean = false): Promise<boolean> {
+        Logger.debug('Editor.isBreakpointPresent');
 
-        // get current editor element
-        const currentEditorLocator: By = By.xpath(`//div[contains(@id, 'code-editor-opener') and not(contains(@class, 'p-mod-hidden'))]`);
-        const currentEditor: WebElement = await this.driverHelper.waitVisibility(currentEditorLocator);
+        const linesBarXpathLocator: string = `//div[contains(@id, '${tabTitle}')]//div[@class='margin']`;
+        const triggeredBreakpointXpathLocator: string = `//div[contains(@class, 'theia-debug-breakpoint') and contains(@class, 'theia-debug-top-stack-frame')]`;
+        const regularBreakpointXpathLocator: string = `//div[contains(@class, 'theia-debug-breakpoint')]`;
+        const lineNumberRelativeXpathLocator: string = `/parent::div/div[contains(@class, 'line-numbers') and text()=${lineNumber}]`;
 
-        // get line number element
-        const lineNumberLocator: By = By.xpath(`.//div[contains(@class, 'line-numbers') and text()='${lineNumber}']` +
-            `//parent::div[contains(@style, 'position')]`);
-        const lineElement: WebElement = await currentEditor.findElement(lineNumberLocator);
+        const breakpointLocator: string = (triggered ? triggeredBreakpointXpathLocator : regularBreakpointXpathLocator);
+        const breakpointLineNumberXpathLocator = linesBarXpathLocator + breakpointLocator + lineNumberRelativeXpathLocator;
 
-        // get breakpoint locator
-        let breakpointLocator: By;
-        if (triggered) {
-            breakpointLocator = By.xpath(`.//div[contains(@class, 'theia-debug-breakpoint') and contains(@class, 'theia-debug-top-stack-frame')]`);
-        } else {
-            breakpointLocator = By.xpath(`.//div[contains(@class, 'theia-debug-breakpoint')]`);
-        }
-
-        // look for breakpoint
-        const elements: WebElement[] = await lineElement.findElements(breakpointLocator);
-        if (elements.length < 1) {
-            Logger.debug('Editor.isBreakpointPresent - Breakpoint is NOT present.');
-            return false;
-        } else {
-            Logger.debug('Editor.isBreakpointPresent - Breakpoint is present.');
+        if (await this.driverHelper.isVisible(By.xpath(breakpointLineNumberXpathLocator))) {
+            Logger.trace('Editor.isBreakpointPresent - Breakpoint is present.');
             return true;
         }
+
+        Logger.trace('Editor.isBreakpointPresent - Breakpoint is NOT present.');
+        return false;
     }
+
 }

--- a/tests/e2e/pageobjects/ide/Editor.ts
+++ b/tests/e2e/pageobjects/ide/Editor.ts
@@ -558,13 +558,7 @@ export class Editor {
         const breakpointLocator: string = (triggered ? triggeredBreakpointXpathLocator : regularBreakpointXpathLocator);
         const breakpointLineNumberXpathLocator = linesBarXpathLocator + breakpointLocator + lineNumberRelativeXpathLocator;
 
-        if (await this.driverHelper.isVisible(By.xpath(breakpointLineNumberXpathLocator))) {
-            Logger.trace('Editor.isBreakpointPresent - Breakpoint is present.');
-            return true;
-        }
-
-        Logger.trace('Editor.isBreakpointPresent - Breakpoint is NOT present.');
-        return false;
+        return await this.driverHelper.isVisible(By.xpath(breakpointLineNumberXpathLocator));
     }
 
 }


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix the logical mistake in the "Editor.ts" pageobject leads to "StaleElementReference" error

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/15940

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
