### PR TITLE
Use che-bot GitHub token when starting minishift to prevent GitHub AP…

### DIFF
--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -232,8 +232,16 @@ function installAndStartMinishift() {
   then
     echo "\$CHE_BOT_GITHUB_TOKEN is empty. Minishift start might fail with GitGub API rate limit reached."
   else
-    echo "\$CHE_BOT_GITHUB_TOKEN is set, using it for Minishift."
-    export MINISHIFT_GITHUB_API_TOKEN=$CHE_BOT_GITHUB_TOKEN
+    echo "\$CHE_BOT_GITHUB_TOKEN is set, checking limits."
+    GITHUB_RATE_REMAINING=$(curl -slL "https://api.github.com/rate_limit?access_token=$CHE_BOT_GITHUB_TOKEN" | jq .rate.remaining)
+    if [ "$GITHUB_RATE_REMAINING" -gt 1000 ]
+    then
+      echo "Github rate greater than 1000. Using che-bot token for minishift startup."
+      export MINISHIFT_GITHUB_API_TOKEN=$CHE_BOT_GITHUB_TOKEN
+    else
+      echo "Github rate is lower than 1000. *Not* using che-bot for minishift startup."
+      echo "If minishift startup fails, please try again later."
+    fi
   fi
 
   minishift version

--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -227,6 +227,15 @@ function installAndStartMinishift() {
   chmod +x ./minishift
   mv ./minishift /usr/local/bin/minishift
 
+  #Setup GitHub token for minishift
+  if [ -z "$CHE_BOT_GITHUB_TOKEN" ]
+  then
+    echo "\$CHE_BOT_GITHUB_TOKEN is empty. Minishift start might fail with GitGub API rate limit reached."
+  else
+    echo "\$CHE_BOT_GITHUB_TOKEN is set, using it for Minishift."
+    export MINISHIFT_GITHUB_API_TOKEN=$CHE_BOT_GITHUB_TOKEN
+  fi
+
   minishift version
   minishift config set memory 14GB
   minishift config set cpus 4


### PR DESCRIPTION
…I rate limit errors

Signed-off-by: Radim Hopp <rhopp@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
In our testing jobs we are facing with `API rate limit exceeded` when starting minishift.
This PR should solve this (according to this: https://github.com/minishift/minishift/blob/master/docs/source/troubleshooting/troubleshooting-getting-started.adoc#github-api-rate-limit-exceeded)

Before merging this PR it would be great to have job config change merged first (https://gitlab.cee.redhat.com/service/app-interface/merge_requests/3088)

### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
