### PR TITLE
Ensure cascade removal is working correctly in JpaKubernetesMachineCache and JpaKubernetesRuntimeStateCache

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/jpa/JpaKubernetesRuntimeStateCache.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/jpa/JpaKubernetesRuntimeStateCache.java
@@ -179,10 +179,9 @@ public class JpaKubernetesRuntimeStateCache implements KubernetesRuntimeStateCac
     }
   }
 
-  @Transactional
+  @Transactional(rollbackOn = {RuntimeException.class, ServerException.class})
   protected void doRemove(RuntimeIdentity runtimeIdentity) throws ServerException {
     EntityManager em = managerProvider.get();
-
     KubernetesRuntimeState runtime =
         em.find(KubernetesRuntimeState.class, runtimeIdentity.getWorkspaceId());
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/jpa/JpaKubernetesRuntimeStateCache.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/jpa/JpaKubernetesRuntimeStateCache.java
@@ -182,6 +182,7 @@ public class JpaKubernetesRuntimeStateCache implements KubernetesRuntimeStateCac
   @Transactional(rollbackOn = {RuntimeException.class, ServerException.class})
   protected void doRemove(RuntimeIdentity runtimeIdentity) throws ServerException {
     EntityManager em = managerProvider.get();
+
     KubernetesRuntimeState runtime =
         em.find(KubernetesRuntimeState.class, runtimeIdentity.getWorkspaceId());
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesMachinesCacheTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesMachinesCacheTest.java
@@ -278,6 +278,16 @@ public class KubernetesMachinesCacheTest {
     assertEquals(machineCache.getMachines(runtimeId).size(), 0);
   }
 
+  // This test ensure that if during cascade removal of machine from cache (initiated during removal
+  // of runtime
+  // from cache) will happen an exception then transaction in runtime cache will rollback removal of
+  // machine cache.
+  // see
+  // @Transactional(rollbackOn = {RuntimeException.class, ServerException.class})
+  // protected void doRemove(RuntimeIdentity runtimeIdentity) throws ServerException
+  // Note that any checked exception that happened during RemoveEvent(extends CascadeEvent) would be
+  // transformed to
+  // ServerException. See RemoveEvent.propagateException.
   @Test
   public void shouldRollbackTransactionOnFailedCascadeMachine() throws Exception {
     // given

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesMachinesCacheTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesMachinesCacheTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.cache.tck.Test
 import static org.eclipse.che.workspace.infrastructure.kubernetes.cache.tck.TestObjects.createWorkspace;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
@@ -28,12 +29,16 @@ import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.core.model.workspace.runtime.MachineStatus;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
+import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.test.tck.TckListener;
 import org.eclipse.che.commons.test.tck.repository.TckRepository;
 import org.eclipse.che.commons.test.tck.repository.TckRepositoryException;
+import org.eclipse.che.core.db.cascade.CascadeEventSubscriber;
+import org.eclipse.che.workspace.infrastructure.kubernetes.cache.BeforeKubernetesRuntimeStateRemovedEvent;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
+import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesRuntimeStateCache;
 import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesMachineImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesRuntimeState;
 import org.eclipse.che.workspace.infrastructure.kubernetes.model.KubernetesServerImpl;
@@ -60,6 +65,10 @@ public class KubernetesMachinesCacheTest {
   @Inject private TckRepository<KubernetesMachineImpl> machineRepository;
 
   @Inject private KubernetesMachineCache machineCache;
+
+  @Inject private KubernetesRuntimeStateCache runtimesStatesCache;
+
+  @Inject private EventService eventService;
 
   private WorkspaceImpl[] workspaces;
   private KubernetesRuntimeState[] runtimeStates;
@@ -267,5 +276,34 @@ public class KubernetesMachinesCacheTest {
 
     // then
     assertEquals(machineCache.getMachines(runtimeId).size(), 0);
+  }
+
+  @Test
+  public void shouldRollbackTransactionOnFailedCascadeMachine() throws Exception {
+    // given
+    assertTrue(machineCache.getMachines(runtimeStates[0].getRuntimeId()).size() > 0);
+    CascadeEventSubscriber subscriber =
+        new CascadeEventSubscriber<BeforeKubernetesRuntimeStateRemovedEvent>() {
+          @Override
+          public void onCascadeEvent(BeforeKubernetesRuntimeStateRemovedEvent event)
+              throws Exception {
+            machineCache.remove(event.getRuntimeState().getRuntimeId());
+            throw new InfrastructureException("exception");
+          }
+        };
+    eventService.subscribe(subscriber, BeforeKubernetesRuntimeStateRemovedEvent.class);
+    // when
+    try {
+      runtimesStatesCache.remove(runtimeStates[0].getRuntimeId());
+      fail("Should fail with InfrastructureException");
+    } catch (InfrastructureException exc) {
+      // ok
+      exc.printStackTrace();
+    } finally {
+      eventService.unsubscribe(subscriber, BeforeKubernetesRuntimeStateRemovedEvent.class);
+    }
+
+    // then
+    assertTrue(machineCache.getMachines(runtimeStates[0].getRuntimeId()).size() > 0);
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesMachinesCacheTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesMachinesCacheTest.java
@@ -308,7 +308,6 @@ public class KubernetesMachinesCacheTest {
       fail("Should fail with InfrastructureException");
     } catch (InfrastructureException exc) {
       // ok
-      exc.printStackTrace();
     } finally {
       eventService.unsubscribe(subscriber, BeforeKubernetesRuntimeStateRemovedEvent.class);
     }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesRuntimeStateCacheTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesRuntimeStateCacheTest.java
@@ -144,6 +144,12 @@ public class KubernetesRuntimeStateCacheTest {
     assertEquals(new CommandImpl(updatedCommands.get(0)), newCommand);
   }
 
+  // Ensure that we are not affected https://bugs.eclipse.org/bugs/show_bug.cgi?id=474203 Orphan
+  // Removal not working
+  // when, object is added to collection and then same object is removed from collection in same
+  // transaction.
+  //
+  // Probable reason - two different transactions was used.
   @Test(dependsOnMethods = "shouldReturnCommands")
   public void shouldUpdateCommandsAndDeleteRuntime() throws Exception {
     // given
@@ -155,7 +161,6 @@ public class KubernetesRuntimeStateCacheTest {
     runtimesStatesCache.updateCommands(runtimesStates[0].getRuntimeId(), newCommands);
     runtimesStatesCache.remove(runtimesStates[0].getRuntimeId());
     // then
-
     // ok
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesRuntimeStateCacheTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesRuntimeStateCacheTest.java
@@ -19,6 +19,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -151,17 +152,21 @@ public class KubernetesRuntimeStateCacheTest {
   //
   // Probable reason - two different transactions was used.
   @Test(dependsOnMethods = "shouldReturnCommands")
-  public void shouldUpdateCommandsAndDeleteRuntime() throws Exception {
+  public void shouldUpdateCommandsAndDeleteRuntime() {
     // given
     List<CommandImpl> newCommands = new ArrayList<>();
     CommandImpl newCommand = new CommandImpl("new", "build", "custom");
     newCommands.add(newCommand);
 
     // when
-    runtimesStatesCache.updateCommands(runtimesStates[0].getRuntimeId(), newCommands);
-    runtimesStatesCache.remove(runtimesStates[0].getRuntimeId());
+    try {
+      runtimesStatesCache.updateCommands(runtimesStates[0].getRuntimeId(), newCommands);
+      runtimesStatesCache.remove(runtimesStates[0].getRuntimeId());
+    } catch (InfrastructureException e) {
+      fail("No exception expected here, got " + e.getLocalizedMessage());
+    }
     // then
-    // ok
+    // if no exception happened during remove operation that means test passed correctly.
   }
 
   @Test(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesRuntimeStateCacheTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/cache/tck/KubernetesRuntimeStateCacheTest.java
@@ -29,6 +29,7 @@ import org.eclipse.che.account.spi.AccountImpl;
 import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 import org.eclipse.che.api.core.model.workspace.config.Command;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.core.notification.EventService;
 import org.eclipse.che.api.workspace.server.model.impl.CommandImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
@@ -59,6 +60,8 @@ public class KubernetesRuntimeStateCacheTest {
   @Inject private TckRepository<KubernetesRuntimeState> runtimesRepository;
 
   @Inject private KubernetesRuntimeStateCache runtimesStatesCache;
+
+  @Inject private EventService eventService;
 
   private WorkspaceImpl[] workspaces;
   private KubernetesRuntimeState[] runtimesStates;
@@ -139,6 +142,21 @@ public class KubernetesRuntimeStateCacheTest {
         runtimesStatesCache.getCommands(runtimesStates[0].getRuntimeId());
     assertEquals(updatedCommands.size(), 1);
     assertEquals(new CommandImpl(updatedCommands.get(0)), newCommand);
+  }
+
+  @Test(dependsOnMethods = "shouldReturnCommands")
+  public void shouldUpdateCommandsAndDeleteRuntime() throws Exception {
+    // given
+    List<CommandImpl> newCommands = new ArrayList<>();
+    CommandImpl newCommand = new CommandImpl("new", "build", "custom");
+    newCommands.add(newCommand);
+
+    // when
+    runtimesStatesCache.updateCommands(runtimesStates[0].getRuntimeId(), newCommands);
+    runtimesStatesCache.remove(runtimesStates[0].getRuntimeId());
+    // then
+
+    // ok
   }
 
   @Test(


### PR DESCRIPTION
### What does this PR do?

Ensure cascade removal is working correctly in JpaKubernetesMachineCache and JpaKubernetesRuntimeStateCache

### What issues does this PR fix or reference?

During the investigation of issue https://github.com/eclipse/che/issues/15800 I met report https://bugs.eclipse.org/bugs/show_bug.cgi?id=474203 that is states that `Orphan Removal not working when, object is added to collection and then same object is removed from collection in same transaction`
this cause was not confirmed in our case see shouldUpdateCommandsAndDeleteRuntime test. 

Although I did not find the true cause of the https://github.com/eclipse/che/issues/15800 problem with the help of @sleshchenko I was able to find inconsistency in work with transactions in method `doRemove` which potentially may be a reason of inconsistencies.


#### Release Notes
n/a

#### Docs PR
n/a
