### PR TITLE
Adapt rolling update tests according to deploy CHE with operator

### DIFF
--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -50,8 +50,18 @@ deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/cus
 seleniumTestsSetup
 createIndentityProvider
 
-bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh --threads=3 --host=${CHE_ROUTE} --port=80 --multiuser
+bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
+   --threads=3 \
+   --host=${CHE_ROUTE} \
+   --port=80 \
+   --multiuser \
+   --fail-script-on-failed-tests \
+   || IS_TESTS_FAILED=true
 
+
+echo "=========================== THIS IS POST TEST ACTIONS =============================="
 saveSeleniumTestResult
 getOpenshiftLogs
 archiveArtifacts "che-pullrequests-test-temporary"
+
+[[ $IS_TESTS_FAILED == true ]] && exit 1

--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -19,9 +19,9 @@ function prepareCustomResourceFile() {
   cd /tmp
   wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
-#  sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
-#  sed -i "s@cheImage: ''@cheImage: 'quay.io/eclipse/che-server'@g" /tmp/custom-resource.yaml
-#  sed -i "s@cheImageTag: 'nightly'@cheImageTag: '${TAG}'@g" /tmp/custom-resource.yaml
+  sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
+  sed -i "s@cheImage: ''@cheImage: 'quay.io/eclipse/che-server'@g" /tmp/custom-resource.yaml
+  sed -i "s@cheImageTag: 'nightly'@cheImageTag: '${TAG}'@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 
@@ -38,8 +38,8 @@ function pushImageToRegistry() {
 setupEnvs
 installDependencies
 installDockerCompose
-#buidCheServer
-#pushImageToRegistry
+buidCheServer
+pushImageToRegistry
 installKVM
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
@@ -50,7 +50,7 @@ deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/cus
 seleniumTestsSetup
 createIndentityProvider
 
-bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh --threads=1 --host=${CHE_ROUTE} --port=80 --multiuser --test=org.eclipse.che.selenium.hotupdate.rolling.**
+bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh --threads=3 --host=${CHE_ROUTE} --port=80 --multiuser
 
 saveSeleniumTestResult
 getOpenshiftLogs

--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -19,9 +19,9 @@ function prepareCustomResourceFile() {
   cd /tmp
   wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
-  sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
-  sed -i "s@cheImage: ''@cheImage: 'quay.io/eclipse/che-server'@g" /tmp/custom-resource.yaml
-  sed -i "s@cheImageTag: 'nightly'@cheImageTag: '${TAG}'@g" /tmp/custom-resource.yaml
+#  sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
+#  sed -i "s@cheImage: ''@cheImage: 'quay.io/eclipse/che-server'@g" /tmp/custom-resource.yaml
+#  sed -i "s@cheImageTag: 'nightly'@cheImageTag: '${TAG}'@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 
@@ -38,8 +38,8 @@ function pushImageToRegistry() {
 setupEnvs
 installDependencies
 installDockerCompose
-buidCheServer
-pushImageToRegistry
+#buidCheServer
+#pushImageToRegistry
 installKVM
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
@@ -50,7 +50,7 @@ deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/cus
 seleniumTestsSetup
 createIndentityProvider
 
-bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh --threads=3 --host=${CHE_ROUTE} --port=80 --multiuser
+bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh --threads=1 --host=${CHE_ROUTE} --port=80 --multiuser --test=org.eclipse.che.selenium.hotupdate.rolling.**
 
 saveSeleniumTestResult
 getOpenshiftLogs

--- a/tests/legacy-e2e/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/constant/TestTimeoutsConstants.java
+++ b/tests/legacy-e2e/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/constant/TestTimeoutsConstants.java
@@ -15,7 +15,7 @@ package org.eclipse.che.selenium.core.constant;
 public final class TestTimeoutsConstants {
   public static final int MULTIPLE = 1;
   public static final int APPLICATION_START_TIMEOUT_SEC = 300 * MULTIPLE;
-  public static final int PREPARING_WS_TIMEOUT_SEC = 240 * MULTIPLE;
+  public static final int PREPARING_WS_TIMEOUT_SEC = 30 * MULTIPLE;
   public static final int UPDATING_PROJECT_TIMEOUT_SEC = 180 * MULTIPLE;
   public static final int EXPECTED_MESS_IN_CONSOLE_SEC = 120 * MULTIPLE;
   public static final int LOADER_TIMEOUT_SEC = 60 * MULTIPLE;

--- a/tests/legacy-e2e/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/constant/TestTimeoutsConstants.java
+++ b/tests/legacy-e2e/che-selenium-core/src/main/java/org/eclipse/che/selenium/core/constant/TestTimeoutsConstants.java
@@ -15,7 +15,7 @@ package org.eclipse.che.selenium.core.constant;
 public final class TestTimeoutsConstants {
   public static final int MULTIPLE = 1;
   public static final int APPLICATION_START_TIMEOUT_SEC = 300 * MULTIPLE;
-  public static final int PREPARING_WS_TIMEOUT_SEC = 30 * MULTIPLE;
+  public static final int PREPARING_WS_TIMEOUT_SEC = 240 * MULTIPLE;
   public static final int UPDATING_PROJECT_TIMEOUT_SEC = 180 * MULTIPLE;
   public static final int EXPECTED_MESS_IN_CONSOLE_SEC = 120 * MULTIPLE;
   public static final int LOADER_TIMEOUT_SEC = 60 * MULTIPLE;

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
@@ -24,7 +24,6 @@ import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
-import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -83,7 +82,7 @@ public class RollingUpdateStrategyWithEditorTest {
     // check that che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    WaitUtils.sleepQuietly(60);
+    assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
     // check that workspace is successfully migrated to the new master
     assertTrue(testWorkspaceServiceClient.exists(WORKSPACE_NAME, defaultTestUser.getName()));
 

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
@@ -82,7 +82,8 @@ public class RollingUpdateStrategyWithEditorTest {
     // check that che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
+    cheTestSystemClient.waitWorkspaceMasterStatus(60, 1, SystemStatus.RUNNING);
+
     // check that workspace is successfully migrated to the new master
     assertTrue(testWorkspaceServiceClient.exists(WORKSPACE_NAME, defaultTestUser.getName()));
 

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
@@ -24,6 +24,7 @@ import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -82,7 +83,7 @@ public class RollingUpdateStrategyWithEditorTest {
     // check that che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    cheTestSystemClient.waitWorkspaceMasterStatus(60, 1, SystemStatus.RUNNING);
+    WaitUtils.sleepQuietly(60);
 
     // check that workspace is successfully migrated to the new master
     assertTrue(testWorkspaceServiceClient.exists(WORKSPACE_NAME, defaultTestUser.getName()));

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
@@ -24,6 +24,7 @@ import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -82,6 +83,7 @@ public class RollingUpdateStrategyWithEditorTest {
     // check that che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
+    WaitUtils.sleepQuietly(60);
     // check that workspace is successfully migrated to the new master
     assertTrue(testWorkspaceServiceClient.exists(WORKSPACE_NAME, defaultTestUser.getName()));
 

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
@@ -23,7 +23,6 @@ import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
-import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -97,7 +96,7 @@ public class RollingUpdateStrategyWithStartedWorkspaceTest {
     // check that Che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    WaitUtils.sleepQuietly(60);
+    assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
 
     assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
     workspaces.waitWorkspaceIsPresent(WORKSPACE_NAME);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.selenium.hotupdate.rolling;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import java.util.Collections;
@@ -72,7 +73,6 @@ public class RollingUpdateStrategyWithStartedWorkspaceTest {
 
   @Test
   public void startStopWorkspaceFunctionsShouldBeAvailableDuringRollingUpdate() throws Exception {
-    int currentRevision = hotUpdateUtil.getMasterPodRevision();
     theiaIde.waitOpenedWorkspaceIsReadyToUse();
 
     theiaProjectTree.waitFilesTab();
@@ -94,8 +94,8 @@ public class RollingUpdateStrategyWithStartedWorkspaceTest {
     hotUpdateUtil.executeMasterPodUpdateCommand();
 
     // check that Che is updated
-    hotUpdateUtil.waitMasterPodRevision(currentRevision + 1);
-    hotUpdateUtil.waitFullMasterPodUpdate(currentRevision);
+    assertTrue(
+        hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
 
     assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
     workspaces.waitWorkspaceIsPresent(WORKSPACE_NAME);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
@@ -17,11 +17,11 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import java.util.Collections;
-import org.eclipse.che.api.system.shared.SystemStatus;
 import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -95,7 +95,7 @@ public class RollingUpdateStrategyWithStartedWorkspaceTest {
     // check that Che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    cheTestSystemClient.waitWorkspaceMasterStatus(60, 1, SystemStatus.RUNNING);
+    WaitUtils.sleepQuietly(60);
 
     workspaces.waitWorkspaceIsPresent(WORKSPACE_NAME);
     workspaces.waitWorkspaceStatus(WORKSPACE_NAME, Workspaces.Status.RUNNING);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
@@ -23,6 +23,7 @@ import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -96,6 +97,7 @@ public class RollingUpdateStrategyWithStartedWorkspaceTest {
     // check that Che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
+    WaitUtils.sleepQuietly(60);
 
     assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
     workspaces.waitWorkspaceIsPresent(WORKSPACE_NAME);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.selenium.hotupdate.rolling;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
@@ -96,9 +95,8 @@ public class RollingUpdateStrategyWithStartedWorkspaceTest {
     // check that Che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
+    cheTestSystemClient.waitWorkspaceMasterStatus(60, 1, SystemStatus.RUNNING);
 
-    assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
     workspaces.waitWorkspaceIsPresent(WORKSPACE_NAME);
     workspaces.waitWorkspaceStatus(WORKSPACE_NAME, Workspaces.Status.RUNNING);
   }

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
@@ -98,10 +98,8 @@ public class RollingUpdateStrategyWithWorkspacesStartStopTest {
     // execute stop-start commands for existing workspaces
     assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
     workspaces.clickOnWorkspaceStopStartButton(STOPPED_WORKSPACE_NAME);
-    workspaces.clickOnWorkspaceStopStartButton(STARTED_WORKSPACE_NAME);
-
-    // wait successful results of the stop-start requests
     workspaces.waitWorkspaceStatus(STOPPED_WORKSPACE_NAME, Workspaces.Status.STOPPED);
+    workspaces.clickOnWorkspaceStopStartButton(STARTED_WORKSPACE_NAME);
     workspaces.waitWorkspaceStatus(STARTED_WORKSPACE_NAME, Workspaces.Status.RUNNING);
   }
 }

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
@@ -23,6 +23,7 @@ import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -89,6 +90,10 @@ public class RollingUpdateStrategyWithWorkspacesStartStopTest {
     workspaces.waitWorkspaceStatus(STARTED_WORKSPACE_NAME, Workspaces.Status.STOPPED);
 
     hotUpdateUtil.executeMasterPodUpdateCommand();
+    // check that che is updated
+    assertTrue(
+        hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
+    WaitUtils.sleepQuietly(60);
 
     // execute stop-start commands for existing workspaces
     assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
@@ -98,9 +103,5 @@ public class RollingUpdateStrategyWithWorkspacesStartStopTest {
     // wait successful results of the stop-start requests
     workspaces.waitWorkspaceStatus(STOPPED_WORKSPACE_NAME, Workspaces.Status.STOPPED);
     workspaces.waitWorkspaceStatus(STARTED_WORKSPACE_NAME, Workspaces.Status.RUNNING);
-
-    // check that che is updated
-    assertTrue(
-        hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
   }
 }

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.selenium.hotupdate.rolling;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
@@ -92,10 +91,9 @@ public class RollingUpdateStrategyWithWorkspacesStartStopTest {
     // check that che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
+    cheTestSystemClient.waitWorkspaceMasterStatus(60, 1, SystemStatus.RUNNING);
 
     // execute stop-start commands for existing workspaces
-    assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
     workspaces.clickOnWorkspaceStopStartButton(STOPPED_WORKSPACE_NAME);
     workspaces.waitWorkspaceStatus(STOPPED_WORKSPACE_NAME, Workspaces.Status.STOPPED);
     workspaces.clickOnWorkspaceStopStartButton(STARTED_WORKSPACE_NAME);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
@@ -23,7 +23,6 @@ import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
-import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -93,7 +92,7 @@ public class RollingUpdateStrategyWithWorkspacesStartStopTest {
     // check that che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    WaitUtils.sleepQuietly(60);
+    assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);
 
     // execute stop-start commands for existing workspaces
     assertEquals(cheTestSystemClient.getStatus(), SystemStatus.RUNNING);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
@@ -14,6 +14,7 @@ package org.eclipse.che.selenium.hotupdate.rolling;
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import java.util.Collections;
@@ -68,7 +69,6 @@ public class RollingUpdateStrategyWithWorkspacesStartStopTest {
 
   @Test
   public void startStopWorkspaceFunctionsShouldBeAvailableDuringRollingUpdate() throws Exception {
-    int currentRevision = hotUpdateUtil.getMasterPodRevision();
     theiaIde.waitOpenedWorkspaceIsReadyToUse();
 
     theiaProjectTree.waitFilesTab();
@@ -100,7 +100,7 @@ public class RollingUpdateStrategyWithWorkspacesStartStopTest {
     workspaces.waitWorkspaceStatus(STARTED_WORKSPACE_NAME, Workspaces.Status.RUNNING);
 
     // check that che is updated
-    hotUpdateUtil.waitMasterPodRevision(currentRevision + 1);
-    hotUpdateUtil.waitFullMasterPodUpdate(currentRevision);
+    assertTrue(
+        hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
   }
 }

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithWorkspacesStartStopTest.java
@@ -17,11 +17,11 @@ import static org.testng.Assert.assertTrue;
 
 import com.google.inject.Inject;
 import java.util.Collections;
-import org.eclipse.che.api.system.shared.SystemStatus;
 import org.eclipse.che.selenium.core.client.CheTestSystemClient;
 import org.eclipse.che.selenium.core.client.TestWorkspaceServiceClient;
 import org.eclipse.che.selenium.core.executor.hotupdate.HotUpdateUtil;
 import org.eclipse.che.selenium.core.user.DefaultTestUser;
+import org.eclipse.che.selenium.core.utils.WaitUtils;
 import org.eclipse.che.selenium.pageobject.dashboard.CreateWorkspaceHelper;
 import org.eclipse.che.selenium.pageobject.dashboard.Dashboard;
 import org.eclipse.che.selenium.pageobject.dashboard.NewWorkspace.Devfile;
@@ -91,7 +91,7 @@ public class RollingUpdateStrategyWithWorkspacesStartStopTest {
     // check that che is updated
     assertTrue(
         hotUpdateUtil.getRolloutStatus().contains("deployment \"che\" successfully rolled out"));
-    cheTestSystemClient.waitWorkspaceMasterStatus(60, 1, SystemStatus.RUNNING);
+    WaitUtils.sleepQuietly(60);
 
     // execute stop-start commands for existing workspaces
     workspaces.clickOnWorkspaceStopStartButton(STOPPED_WORKSPACE_NAME);


### PR DESCRIPTION
### What does this PR do?
On this moment deploy CHE with ocp.sh and oc 3.9 is deprecated. We change deploy workflow with oc client  3.11 and operator.
According to this changes we should adapt  tests for checking CHE RollingUpdate

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15517