### PR TITLE
Make several attempts to reach desired values in multi-thread dependent tests

### DIFF
--- a/core/commons/che-core-commons-observability/pom.xml
+++ b/core/commons/che-core-commons-observability/pom.xml
@@ -68,6 +68,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/core/commons/che-core-commons-observability/src/test/java/io/micrometer/core/instrument/internal/TimedCronExecutorServiceTest.java
+++ b/core/commons/che-core-commons-observability/src/test/java/io/micrometer/core/instrument/internal/TimedCronExecutorServiceTest.java
@@ -11,7 +11,7 @@
  */
 package io.micrometer.core.instrument.internal;
 
-import static org.testng.Assert.assertEquals;
+import static org.eclipse.che.commons.test.AssertRetry.assertWithRetry;
 
 import io.micrometer.core.instrument.MockClock;
 import io.micrometer.core.instrument.Tag;
@@ -56,21 +56,28 @@ public class TimedCronExecutorServiceTest {
 
     lock.await();
     // then
-    assertEquals(
-        registry
-            .get("executor.scheduled.cron")
-            .tags(userTags)
-            .tag("name", TimedCronExecutorServiceTest.class.getName())
-            .counter()
-            .count(),
-        1.0);
-    assertEquals(
-        registry
-            .get("executor")
-            .tags(userTags)
-            .tag("name", TimedCronExecutorServiceTest.class.getName())
-            .timer()
-            .count(),
-        1L);
+    assertWithRetry(
+        () ->
+            registry
+                .get("executor.scheduled.cron")
+                .tags(userTags)
+                .tag("name", TimedCronExecutorServiceTest.class.getName())
+                .counter()
+                .count(),
+        1.0,
+        10,
+        50);
+
+    assertWithRetry(
+        () ->
+            registry
+                .get("executor")
+                .tags(userTags)
+                .tag("name", TimedCronExecutorServiceTest.class.getName())
+                .timer()
+                .count(),
+        1L,
+        10,
+        50);
   }
 }

--- a/core/commons/che-core-commons-observability/src/test/java/org/eclipse/che/commons/observability/MeteredExecutorServiceWrapperTest.java
+++ b/core/commons/che-core-commons-observability/src/test/java/org/eclipse/che/commons/observability/MeteredExecutorServiceWrapperTest.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.commons.observability;
 
+import static org.eclipse.che.commons.test.AssertRetry.assertWithRetry;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -29,11 +30,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
 import org.eclipse.che.commons.schedule.executor.CronExecutorService;
 import org.eclipse.che.commons.schedule.executor.CronExpression;
 import org.eclipse.che.commons.schedule.executor.CronThreadPoolExecutor;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -431,18 +430,5 @@ public class MeteredExecutorServiceWrapperTest {
             .counter()
             .count(),
         1.0);
-  }
-
-  <V> void assertWithRetry(Supplier<V> predicate, V expected, int times, int pause_millis)
-      throws InterruptedException {
-    for (int i = 0; i <= times; i++) {
-      V actual = predicate.get();
-      if (expected.equals(actual)) {
-        return;
-      } else if (i + 1 <= times) {
-        Thread.sleep(pause_millis);
-      }
-    }
-    Assert.fail("Not able to get expected value " + expected + " with " + times + " retries");
   }
 }

--- a/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/AssertRetry.java
+++ b/core/commons/che-core-commons-test/src/main/java/org/eclipse/che/commons/test/AssertRetry.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.commons.test;
+
+import java.util.function.Supplier;
+import org.testng.Assert;
+
+public class AssertRetry {
+  /**
+   * Assert that is making several attempts with pauses to match expected value with the value
+   * provided by Supplier.
+   */
+  public static <V> void assertWithRetry(
+      Supplier<V> predicate, V expected, int times, int pause_millis) throws InterruptedException {
+    for (int i = 0; i <= times; i++) {
+      V actual = predicate.get();
+      if (expected.equals(actual)) {
+        return;
+      } else if (i + 1 <= times) {
+        Thread.sleep(pause_millis);
+      }
+    }
+    Assert.fail("Not able to get expected value " + expected + " with " + times + " retries");
+  }
+}

--- a/core/commons/che-core-commons-test/src/test/java/org/eclipse/che/commons/test/AssertRetryTest.java
+++ b/core/commons/che-core-commons-test/src/test/java/org/eclipse/che/commons/test/AssertRetryTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.commons.test;
+
+import static org.testng.Assert.*;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.testng.annotations.Test;
+
+public class AssertRetryTest {
+
+  @Test
+  public void testAssertWithRetry() throws InterruptedException {
+    // Given
+    AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+    // When
+    new Thread(
+            () -> {
+              try {
+                Thread.sleep(100);
+                atomicBoolean.getAndSet(true);
+              } catch (InterruptedException e) {
+              }
+            })
+        .start();
+    // then
+    AssertRetry.assertWithRetry(() -> atomicBoolean.get(), Boolean.TRUE, 100, 10);
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void testAssertFailWithRetry() throws InterruptedException {
+    // Given
+    AtomicBoolean atomicBoolean = new AtomicBoolean(false);
+    // When
+    new Thread(
+            () -> {
+              try {
+                Thread.sleep(100);
+                atomicBoolean.getAndSet(true);
+              } catch (InterruptedException e) {
+              }
+            })
+        .start();
+    // then
+    AssertRetry.assertWithRetry(() -> atomicBoolean.get(), Boolean.TRUE, 2, 10);
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Make several attempts to reach desired values in multi-thread dependent tests

### What issues does this PR fix or reference?
@metlos met this error on CI.
```
15:47:30 [INFO] --- che-core-api-dto-maven-plugin:7.9.0-SNAPSHOT:generate (default) @ che-core-api-core ---
15:47:30 [ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 2.528 s <<< FAILURE! - in TestSuite
15:47:30 [ERROR] executor(io.micrometer.core.instrument.internal.TimedCronExecutorServiceTest)  Time elapsed: 0.41 s  <<< FAILURE!
15:47:30 java.lang.AssertionError: expected [1] but found [0]
15:47:30 	at io.micrometer.core.instrument.internal.TimedCronExecutorServiceTest.executor(TimedCronExecutorServiceTest.java:67)
15:47:30 
15:47:30 [INFO] 
15:47:30 [INFO] Results:
15:47:30 [INFO] 
15:47:30 [ERROR] Failures: 
15:47:30 [ERROR]   TimedCronExecutorServiceTest.executor:67 expected [1] but found [0]
15:47:30 [INFO] 
15:47:30 [ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0
```



<!-- #### Changelog -->
n/a

#### Release Notes
n/a

#### Docs PR
n/a