### PR TITLE
[UD] Add Temporary Storage toggle button to Get Started page

### DIFF
--- a/dashboard/src/app/get-started/template-list/template-list.controller.ts
+++ b/dashboard/src/app/get-started/template-list/template-list.controller.ts
@@ -37,6 +37,8 @@ export class TemplateListController {
     '$log',
     'cheNotification'];
 
+  ephemeralMode: boolean;
+
   private $q: ng.IQService;
   private $log: ng.ILogService;
   private $filter: ng.IFilterService;
@@ -104,6 +106,7 @@ export class TemplateListController {
     cheWorkspace.fetchWorkspaceSettings().then(() => {
       const workspaceSettings = cheWorkspace.getWorkspaceSettings();
       this.devfileRegistryUrl = workspaceSettings && workspaceSettings.cheWorkspaceDevfileRegistryUrl;
+      this.ephemeralMode = workspaceSettings['che.workspace.persist_volumes.default'] === 'false';
       this.init();
     });
   }
@@ -140,6 +143,12 @@ export class TemplateListController {
     const selfLink = this.selectedDevfile.links.self;
     return this.devfileRegistry.fetchDevfile(this.devfileRegistryUrl, selfLink).then(() => {
       const devfile = this.devfileRegistry.getDevfile(this.devfileRegistryUrl, selfLink);
+      if (this.ephemeralMode) {
+        if (!devfile.attributes) {
+          devfile.attributes = {};
+        }
+        devfile.attributes.persistVolumes = 'false';
+      }
       const attributes = {stackName: this.selectedDevfile.displayName};
       return this.createWorkspaceSvc.createWorkspaceFromDevfile(undefined, devfile, attributes, true);
     });

--- a/dashboard/src/app/get-started/template-list/template-list.html
+++ b/dashboard/src/app/get-started/template-list/template-list.html
@@ -30,6 +30,20 @@
         <div class="header-title">Select a Sample</div>
         <div class="header-description">Use a sample to create your first workspace.</div>
       </div>
+      <div class="temporary-storage" layout="row" layout-align="start center">
+        <div class="temporary-storage-label">Temporary Storage</div>
+        <span class="temporary-storage-tooltip"
+          uib-tooltip-html="'Temporary Storage allows for faster I/O but may have limited storage and is not persistent.'"
+          tooltip-trigger="mouseenter"
+          tabindex="-1"
+          tooltip-append-to-body="true">
+          <i class="fa fa-question-circle" aria-hidden="true"></i>
+        </span>
+        <md-switch ng-model="templateListController.ephemeralMode"
+          ng-change="templateListController.onEphemeralModeChange()"
+          aria-label="Enables Temporary Storage.">
+        </md-switch>
+      </div>
       <div flex class="template-search">
         <div flex="100" layout="row">
           <div flex="15" class="search-icon" ng-hide="templateListController.searchValue"><i class="fa fa-search"></i>

--- a/dashboard/src/app/get-started/template-list/template-list.styl
+++ b/dashboard/src/app/get-started/template-list/template-list.styl
@@ -88,6 +88,16 @@ md-content.getting-started
           line-height 34px
           font-size 16px
 
+      .temporary-storage
+        margin 0 20px 0 0
+
+        & > *
+          margin 0 6px
+        & > .temporary-storage-label
+          margin-right 3px
+        & > .temporary-storage-tooltip
+          margin-left 3px
+
       .template-info
         text-align end
         font-weight bold


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR adds the toggle button for Temporary Storage on Get Started page.

![Screenshot 2020-02-13 at 10 29 02](https://user-images.githubusercontent.com/16220722/74415268-b5554700-4e4b-11ea-9712-85044742b4a0.png)


### What issues does this PR fix or reference?

resolves https://github.com/eclipse/che/issues/15855

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->



Signed-off-by: Oleksii Kurinnyi <okurinny@redhat.com>

