### PR TITLE
Add "build" PR check.

### DIFF
--- a/.ci/cico_build_pullrequest.sh
+++ b/.ci/cico_build_pullrequest.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Copyright (c) 2017 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+
+# Just a script to get and build eclipse-che locally
+# please send PRs to github.com/kbsingh/build-run-che
+
+# update machine, get required deps in place
+# this script assumes its being run on CentOS Linux 7/x86_64
+
+#include common scripts
+. ./.ci/cico_common.sh
+
+load_jenkins_vars
+load_mvn_settings_gpg_key
+install_deps
+
+DO_NOT_IGNORE_TESTS="true"
+mvn_build

--- a/.ci/cico_common.sh
+++ b/.ci/cico_common.sh
@@ -72,7 +72,11 @@ install_deps(){
 
 mvn_build() {
     set -x
-    scl enable rh-maven33 'mvn clean install -U -Pintegration'
+    if [[ $DO_NOT_IGNORE_TESTS == "true" ]]; then
+        scl enable rh-maven33 'mvn clean install -U -Pintegration -Dmaven.test.failure.ignore=false'
+    else
+        scl enable rh-maven33 'mvn clean install -U -Pintegration'
+    fi
     if [[ $? -eq 0 ]]; then
         echo 'Build Success!'
     else


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
Adds script which will be run as a PR check on PR's to eclipse/che repo.
This should be direct successor of https://ci.codenvycorp.com/view/pr-builds/job/che-pullrequests-build/, which is set as mandatory PR check fro eclipse/che repository.


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
