### PR TITLE
Ignore ssl certificate errors in e2e tests

### DIFF
--- a/tests/e2e/driver/ChromeDriver.ts
+++ b/tests/e2e/driver/ChromeDriver.ts
@@ -37,7 +37,8 @@ export class ChromeDriver implements IDriver {
         let options: Options = new Options()
             .addArguments('--no-sandbox')
             .addArguments('--disable-web-security')
-            .addArguments('--allow-running-insecure-content');
+            .addArguments('--allow-running-insecure-content')
+            .addArguments('--ignore-certificate-errors');
         // if 'true' run in 'headless' mode
         if (TestConstants.TS_SELENIUM_HEADLESS) {
             options = options.addArguments('headless');


### PR DESCRIPTION
### What does this PR do?
It allows to run typescript tests against Che /CRW with SSL support based on self-signed certificate:
https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/crw-typescript-tests/1288/artifact/test-repo/report/Login_test_Login/screenshot-Login.png
![screenshot-Login](https://user-images.githubusercontent.com/1197777/74475108-75c04680-4eaf-11ea-8389-e9566d3c296f.png)

### What issues does this PR fix or reference?
#15585