### PR TITLE
Add '--insecure-skip-tls-verify' option when login to minishift in ci.centos test scripts

### DIFF
--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -285,9 +285,9 @@ function deployCheIntoCluster() {
 }
 
 function loginToOpenshiftAndSetDevRole() {
-  oc login -u system:admin
+  oc login -u system:admin --insecure-skip-tls-verify
   oc adm policy add-cluster-role-to-user cluster-admin developer
-  oc login -u developer -p pass
+  oc login -u developer -p pass --insecure-skip-tls-verify
 }
 
 function archiveArtifacts() {


### PR DESCRIPTION
### What does this PR do?
Adding '--insecure-skip-tls-verify' option to `oc login` command will allow to install Eclipse Che on _minishift_, which otherwise fails because of error:
```
[user@host bin]$ ./run server:start --platform=minishift
  ✖ Verify Kubernetes API
    → Failed to connect to Kubernetes API. Error: self signed certificate in certificate chain
    👀  Looking for an already existing Eclipse Che instance
 ›   Error: Error: Failed to connect to Kubernetes API. Error: self signed certificate in certificate chain
 ›   Installation failed, check logs in '/tmp/chectl-logs/1581691057034'
```

### What issues does this PR fix or reference?
https://github.com/minishift/minishift/issues/3420