### PR TITLE
Store events in JSON format to get more info.

### DIFF
--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -339,7 +339,8 @@ pipeline {
         cleanup {
             sh """                   
                 mkdir -p $LOGS_AND_CONFIGS/kubectl
-                kubectl --namespace=che get events -o json > $LOGS_AND_CONFIGS/kubectl/events.txt || true
+                kubectl --namespace=che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
+                kubectl --namespace=che get events -o json > $LOGS_AND_CONFIGS/kubectl/events.json || true
 
                 mkdir -p $LOGS_AND_CONFIGS/che-config
 

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -339,7 +339,7 @@ pipeline {
         cleanup {
             sh """                   
                 mkdir -p $LOGS_AND_CONFIGS/kubectl
-                kubectl --namespace=che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
+                kubectl --namespace=che get events -o json > $LOGS_AND_CONFIGS/kubectl/events.txt || true
 
                 mkdir -p $LOGS_AND_CONFIGS/che-config
 


### PR DESCRIPTION
Signed-off-by: Radim Hopp <rhopp@redhat.com>

### What does this PR do?
When tests finishes, logs are stored as artifacts of the job. One of the artifacts are events from the namespace, where Che under test was deployed.
Until now, these events were stored as output of `kubect get events`, which doesn't contain much info.
Storing events in `json` format allows us access to much more info (as first appearance timestamp, etc.).


### What issues does this PR fix or reference?
No issue was created for this very small change.

