### PR TITLE
Fix release scripts to update endpoint-watcher tag

### DIFF
--- a/.ci/set_tag_version_images_linux.sh
+++ b/.ci/set_tag_version_images_linux.sh
@@ -21,4 +21,5 @@ sed -i "s/che-postgres:nightly/che-postgres:$1/g" ../deploy/kubernetes/helm/che/
 sed -i "s/che-keycloak:nightly/che-keycloak:$1/g" ../deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
 sed -i "s/eclipse\/che-server:nightly/eclipse\/che-server:$1/g" ../deploy/kubernetes/helm/che/values.yaml
 
-
+sed -i "s/che-endpoint-watcher:nightly/che-endpoint-watcher:$1/g" ../deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+sed -i "s/che-endpoint-watcher:nightly/che-endpoint-watcher:$1/g" ../deploy/kubernetes/helm/che/templates/deployment.yaml


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix setting a tagged version of che-endpoint-watcher during the release