### PR TITLE
[Selenium] Fix storing selenium tests results to artifacts.ci.centos.org

### DIFF
--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -62,6 +62,6 @@ bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
 echo "=========================== THIS IS POST TEST ACTIONS =============================="
 saveSeleniumTestResult
 getOpenshiftLogs
-archiveArtifacts "che-pullrequests-test-temporary"
+archiveArtifacts "che-pullrequests-java-selenium-tests"
 
 if [[ "$IS_TESTS_FAILED" == "true" ]]; then exit 1; fi

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.workspaces;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
 
 import com.google.inject.Inject;
@@ -29,11 +30,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/**
- * @author Andrey chizhikov TODO turn on the test after https://github.com/eclipse/che/issues/15317
- *     resolved
- */
-@Test
+/** @author Andrey chizhikov */
+@Test(groups = {UNDER_REPAIR})
 public class ProjectStateAfterRefreshTest {
   private static final String WORKSPACE_NAME =
       generate(ProjectStateAfterRefreshTest.class.getSimpleName(), 5);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.selenium.workspaces;
 
 import static org.eclipse.che.commons.lang.NameGenerator.generate;
+import static org.eclipse.che.selenium.core.TestGroup.UNDER_REPAIR;
 import static org.eclipse.che.selenium.pageobject.dashboard.ProjectSourcePage.Template.CONSOLE_JAVA_SIMPLE;
 
 import com.google.inject.Inject;
@@ -31,11 +32,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-/**
- * @author Aleksandr Shmaraev TODO turn on the test after
- *     https://github.com/eclipse/che/issues/15317 resolved
- */
-@Test
+/** @author Aleksandr Shmaraev */
+@Test(groups = {UNDER_REPAIR})
 public class ProjectStateAfterRenameWorkspaceTest {
   private static final String WORKSPACE_NAME =
       generate(ProjectStateAfterRenameWorkspaceTest.class.getSimpleName(), 5);


### PR DESCRIPTION
### What does this PR do?
We need to fix a path for storing selenium tests results in `cico_pr_test.sh` script according to jenkins job renaming.