### PR TITLE
Tests E2E: Get rid of temporal admin in test which checks installation by OperatorHub

### DIFF
--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -151,9 +151,9 @@ export const TestConstants = {
     TS_SELENIUM_PASSWORD: process.env.TS_SELENIUM_PASSWORD || '',
 
     /**
-     * Log into OCP if configured an HTPasswd identity provider, "false" by default.
+     * Log into OCP by using appropriate provider title.
      */
-    TS_OCP_LOGIN_PAGE_HTPASW: process.env.TS_OCP_LOGIN_PAGE_HTPASW === 'true',
+    TS_OCP_LOGIN_PAGE_PROVIDER_TITLE: process.env.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE || '',
 
     /**
      * Log into CHE in MultiUser mode, "false" by default.
@@ -161,19 +161,9 @@ export const TestConstants = {
     TS_SELENIUM_MULTIUSER: process.env.TS_SELENIUM_MULTIUSER === 'true',
 
     /**
-     * Temp admin username used to log in OCP.
-     */
-    TS_SELENIUM_OCP_TEMP_ADMIN_USERNAME: process.env.TS_SELENIUM_OCP_TEMP_ADMIN_USERNAME || 'kubeadmin',
-
-    /**
      * Path to folder with load tests execution report.
      */
     TS_SELENIUM_LOAD_TEST_REPORT_FOLDER: process.env.TS_SELENIUM_LOAD_TEST_REPORT_FOLDER || './load-test-folder',
-
-    /**
-     * Enable or disable storing of execution screencast, "true" by default.
-     */
-    TS_SELENIUM_OCP_TEMP_ADMIN_PASSWORD: process.env.TS_SELENIUM_OCP_TEMP_ADMIN_PASSWORD || '',
 
     /**
      * Regular username used to login in OCP.

--- a/tests/e2e/index.ts
+++ b/tests/e2e/index.ts
@@ -41,7 +41,7 @@ export * from './pageobjects/ide/TopMenu';
 export * from './pageobjects/login/ICheLoginPage';
 export * from './pageobjects/login/IOcpLoginPage';
 export * from './pageobjects/login/MultiUserLoginPage';
-export * from './pageobjects/login/OcpLoginByTempAdmin';
+export * from './pageobjects/login/OcpUserLoginPage';
 export * from './pageobjects/login/RegularUserOcpCheLoginPage';
 export * from './pageobjects/login/SingleUserLoginPage';
 export * from './pageobjects/openshift/CheLoginPage';

--- a/tests/e2e/inversify.config.ts
+++ b/tests/e2e/inversify.config.ts
@@ -15,7 +15,7 @@ import { TYPES, CLASSES } from './inversify.types';
 import { ITestWorkspaceUtil } from './utils/workspace/ITestWorkspaceUtil';
 import { TestWorkspaceUtil } from './utils/workspace/TestWorkspaceUtil';
 import { IOcpLoginPage } from './pageobjects/login/IOcpLoginPage';
-import { OcpLoginByTempAdmin } from './pageobjects/login/OcpLoginByTempAdmin';
+import { OcpUserLoginPage } from './pageobjects/login/OcpUserLoginPage';
 import { TestConstants } from './TestConstants';
 import { ICheLoginPage } from './pageobjects/login/ICheLoginPage';
 import { RegularUserOcpCheLoginPage } from './pageobjects/login/RegularUserOcpCheLoginPage';
@@ -59,7 +59,7 @@ const e2eContainer: Container = new Container();
 
 e2eContainer.bind<IDriver>(TYPES.Driver).to(ChromeDriver).inSingletonScope();
 e2eContainer.bind<ITestWorkspaceUtil>(TYPES.WorkspaceUtil).to(TestWorkspaceUtil).inSingletonScope();
-e2eContainer.bind<IOcpLoginPage>(TYPES.OcpLogin).to(OcpLoginByTempAdmin).inSingletonScope();
+e2eContainer.bind<IOcpLoginPage>(TYPES.OcpLogin).to(OcpUserLoginPage).inSingletonScope();
 
 if (TestConstants.TS_SELENIUM_MULTIUSER) {
     e2eContainer.bind<IAuthorizationHeaderHandler>(TYPES.IAuthorizationHeaderHandler).to(CheMultiuserAuthorizationHeaderHandler).inSingletonScope();

--- a/tests/e2e/pageobjects/login/OcpUserLoginPage.ts
+++ b/tests/e2e/pageobjects/login/OcpUserLoginPage.ts
@@ -16,21 +16,21 @@ import { TestConstants } from '../../TestConstants';
 import { Logger } from '../../utils/Logger';
 
 @injectable()
-export class OcpLoginByTempAdmin implements IOcpLoginPage {
+export class OcpUserLoginPage implements IOcpLoginPage {
 
     constructor(
         @inject(CLASSES.OcpLoginPage) private readonly ocpLogin: OcpLoginPage) { }
 
     async login() {
-        Logger.debug('OcpLoginByTempAdmin.login');
+        Logger.debug('OcpUserLoginPage.login');
 
-        if (TestConstants.TS_OCP_LOGIN_PAGE_HTPASW) {
-            await this.ocpLogin.clickOnLoginWitnKubeAdmin();
+        if (TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE !== '') {
+            await this.ocpLogin.clickOnLoginProviderTitle();
             await this.ocpLogin.waitOpenShiftLoginPage();
         }
 
-        await this.ocpLogin.enterUserNameOpenShift(TestConstants.TS_SELENIUM_OCP_TEMP_ADMIN_USERNAME);
-        await this.ocpLogin.enterPasswordOpenShift(TestConstants.TS_SELENIUM_OCP_TEMP_ADMIN_PASSWORD);
+        await this.ocpLogin.enterUserNameOpenShift(TestConstants.TS_SELENIUM_OCP_USERNAME);
+        await this.ocpLogin.enterPasswordOpenShift(TestConstants.TS_SELENIUM_OCP_PASSWORD);
         await this.ocpLogin.clickOnLoginButton();
         await this.ocpLogin.waitDisappearanceOpenShiftLoginPage();
     }

--- a/tests/e2e/pageobjects/login/RegularUserOcpCheLoginPage.ts
+++ b/tests/e2e/pageobjects/login/RegularUserOcpCheLoginPage.ts
@@ -27,7 +27,7 @@ export class RegularUserOcpCheLoginPage implements ICheLoginPage {
         Logger.debug('RegularUserOcpCheLoginPage.login');
 
         await this.ocpLogin.waitOpenShiftLoginPage();
-        await this.ocpLogin.clickOnLoginWitnHtpasswd();
+        await this.ocpLogin.clickOnLoginProviderTitle();
         await this.ocpLogin.waitOpenShiftLoginPage();
         await this.ocpLogin.enterUserNameOpenShift(TestConstants.TS_SELENIUM_OCP_USERNAME);
         await this.ocpLogin.enterPasswordOpenShift(TestConstants.TS_SELENIUM_OCP_PASSWORD);

--- a/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
@@ -13,6 +13,7 @@ import { DriverHelper } from '../../utils/DriverHelper';
 import { CLASSES } from '../../inversify.types';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TestConstants } from '../../TestConstants';
 
 @injectable()
 export class OcpLoginPage {
@@ -34,18 +35,11 @@ export class OcpLoginPage {
         await this.driverHelper.waitVisibility(By.css(OcpLoginPage.LOGIN_PAGE_OPENSHIFT));
     }
 
-    async clickOnLoginWitnKubeAdmin() {
-        Logger.debug('OcpLoginPage.clickOnLoginWitnKubeAdmin');
+    async clickOnLoginProviderTitle() {
+        Logger.debug('OcpLoginPage.clickOnLoginProviderTitle');
 
-        const loginWithKubeAdminLocator: By = By.css('a[title=\'Log in with kube:admin\']');
-        await this.driverHelper.waitAndClick(loginWithKubeAdminLocator);
-    }
-
-    async clickOnLoginWitnHtpasswd() {
-        Logger.debug('OcpLoginPage.clickOnLoginWitnHtpasswd');
-
-        const loginWithHtpaswdLocator: By = By.css('a[title=\'Log in with htpasswd\']');
-        await this.driverHelper.waitAndClick(loginWithHtpaswdLocator);
+        const loginProviderTitleLocator: By = By.css(`a[title=\'Log in with ${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
+        await this.driverHelper.waitAndClick(loginProviderTitleLocator);
     }
 
     async waitAuthorizeOpenShiftIdentityProviderPage() {


### PR DESCRIPTION
### What does this PR do?
* Modified 'TestConstants' file
* Renamed 'OcpLoginByTempAdmin' to 'OcpUserLoginPage' file
* Modified pageobjects related to changes

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-656