### PR TITLE
Move cert-manager related templates into Che repository

### DIFF
--- a/deploy/cert-manager/ca-cert-generator-role-binding.yml
+++ b/deploy/cert-manager/ca-cert-generator-role-binding.yml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ca-cert-generator-role-binding
+  namespace: cert-manager
+subjects:
+- kind: ServiceAccount
+  name: ca-cert-generator
+  apiGroup: ''
+roleRef:
+  kind: Role
+  name: ca-cert-generator-role
+  apiGroup: ''

--- a/deploy/cert-manager/ca-cert-generator-role.yml
+++ b/deploy/cert-manager/ca-cert-generator-role.yml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ca-cert-generator-role
+  namespace: cert-manager
+rules:
+- apiGroups:
+    - ''
+  resources:
+    - secrets
+  verbs:
+    - create

--- a/deploy/cert-manager/che-certificate.yml
+++ b/deploy/cert-manager/che-certificate.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: che-certificate
+  namespace: che
+spec:
+  secretName: che-tls
+  issuerRef:
+    name: che-cluster-issuer
+    kind: ClusterIssuer
+  # This is a template and it will be set from --domain parameter
+  # For example: '*.192.168.99.100.nip.io'
+  commonName: '*.<domain>'
+  dnsNames:
+    - '*.<domain>'

--- a/deploy/cert-manager/che-cluster-issuer.yml
+++ b/deploy/cert-manager/che-cluster-issuer.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: che-cluster-issuer
+  namespace: cert-manager
+spec:
+  ca:
+    secretName: ca


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Moves templates related to Cert Manager deployment from CheCtl repository into Che repository.
This is done for consistence as we have helm charts in Che repository as well.