### PR TITLE
[TS_SELENIUM] Move "@eclipse-che/api" from "devDependencies" to "dependencies" in the "e2e" project

### DIFF
--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -7,8 +7,7 @@
     "@eclipse-che/api": {
       "version": "7.5.0-SNAPSHOT",
       "resolved": "https://registry.npmjs.org/@eclipse-che/api/-/api-7.5.0-SNAPSHOT.tgz",
-      "integrity": "sha512-4CgKEGCBOIOBGBNoH0dhN8TkP1Sj39fG4LGCXYw3JB7nQucVooJyq7AhIV+w7L4iZ+ln+y2KEfZugCmOIuzIeQ==",
-      "dev": true
+      "integrity": "sha512-4CgKEGCBOIOBGBNoH0dhN8TkP1Sj39fG4LGCXYw3JB7nQucVooJyq7AhIV+w7L4iZ+ln+y2KEfZugCmOIuzIeQ=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -36,10 +36,10 @@
     "ts-node": "^8.0.3",
     "tslint": "5.10.0",
     "typed-rest-client": "^1.2.0",
-    "typescript": "^3.4.3",
-    "@eclipse-che/api": "^7.5.0-SNAPSHOT"
+    "typescript": "^3.4.3"
   },
   "dependencies": {
+    "@eclipse-che/api": "^7.5.0-SNAPSHOT",
     "inversify": "^5.0.1",
     "reflect-metadata": "^0.1.13"
   }


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Move "@eclipse-che/api" from "devDependencies" to "dependencies" in the "e2e" project

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/16172
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
