### PR TITLE
Fix: The termination grace period is set to maximum explicitly defined values, otherwise, it is set to null.

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
@@ -115,11 +115,17 @@ public class PodMerger {
           baseSpec.getImagePullSecrets().add(pullSecret);
         }
       }
-
-      baseSpec.setTerminationGracePeriodSeconds(
-          mergeTerminationGracePeriodSeconds(
-              baseSpec.getTerminationGracePeriodSeconds(),
-              podData.getSpec().getTerminationGracePeriodSeconds()));
+      if (podData.getSpec().getTerminationGracePeriodSeconds() != null) {
+        if (baseSpec.getTerminationGracePeriodSeconds() != null) {
+          baseSpec.setTerminationGracePeriodSeconds(
+              Long.max(
+                  baseSpec.getTerminationGracePeriodSeconds(),
+                  podData.getSpec().getTerminationGracePeriodSeconds()));
+        } else {
+          baseSpec.setTerminationGracePeriodSeconds(
+              podData.getSpec().getTerminationGracePeriodSeconds());
+        }
+      }
 
       baseSpec.setSecurityContext(
           mergeSecurityContexts(
@@ -173,14 +179,6 @@ public class PodMerger {
   private String mergeServiceAccountName(@Nullable String a, @Nullable String b)
       throws ValidationException {
     return nonNullOrEqual(a, b, "Cannot merge pods with different service account names: %s, %s");
-  }
-
-  private Long mergeTerminationGracePeriodSeconds(@Nullable Long a, @Nullable Long b)
-      throws ValidationException {
-    return nonNullOrEqual(
-        a,
-        b,
-        "Cannot merge pods with a different configuration of the termination grace period: %d, %d");
   }
 
   @Nullable

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
@@ -116,6 +116,11 @@ public class PodMerger {
         }
       }
 
+      baseSpec.setTerminationGracePeriodSeconds(
+          mergeTerminationGracePeriodSeconds(
+              baseSpec.getTerminationGracePeriodSeconds(),
+              podData.getSpec().getTerminationGracePeriodSeconds()));
+
       baseSpec.setSecurityContext(
           mergeSecurityContexts(
               baseSpec.getSecurityContext(), podData.getSpec().getSecurityContext()));
@@ -168,6 +173,14 @@ public class PodMerger {
   private String mergeServiceAccountName(@Nullable String a, @Nullable String b)
       throws ValidationException {
     return nonNullOrEqual(a, b, "Cannot merge pods with different service account names: %s, %s");
+  }
+
+  private Long mergeTerminationGracePeriodSeconds(@Nullable Long a, @Nullable Long b)
+      throws ValidationException {
+    return nonNullOrEqual(
+        a,
+        b,
+        "Cannot merge pods with a different configuration of the termination grace period: %d, %d");
   }
 
   @Nullable

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
@@ -238,6 +238,57 @@ public class PodMergerTest {
   }
 
   @Test
+  public void shouldMergeTerminationGracePeriodSharedByPods() throws Exception {
+    // given
+    PodSpec podSpec1 = new PodSpecBuilder().withTerminationGracePeriodSeconds(24L).build();
+    PodData podData1 = new PodData(podSpec1, new ObjectMetaBuilder().build());
+    PodSpec podSpec2 = new PodSpecBuilder().withTerminationGracePeriodSeconds(24L).build();
+    PodData podData2 = new PodData(podSpec2, new ObjectMetaBuilder().build());
+
+    // when
+    Deployment merged = podMerger.merge(Arrays.asList(podData1, podData2));
+
+    // then
+    PodTemplateSpec podTemplate = merged.getSpec().getTemplate();
+    assertEquals(podTemplate.getSpec().getTerminationGracePeriodSeconds(), (Long) 24L);
+  }
+
+  @Test
+  public void shouldMergeTerminationGracePeriodSharedByPodsIfOneIsNull() throws Exception {
+    // given
+    PodSpec podSpec1 = new PodSpecBuilder().withTerminationGracePeriodSeconds(null).build();
+    PodData podData1 = new PodData(podSpec1, new ObjectMetaBuilder().build());
+    PodSpec podSpec2 = new PodSpecBuilder().withTerminationGracePeriodSeconds(24L).build();
+    PodData podData2 = new PodData(podSpec2, new ObjectMetaBuilder().build());
+
+    // when
+    Deployment merged = podMerger.merge(Arrays.asList(podData1, podData2));
+
+    // then
+    PodTemplateSpec podTemplate = merged.getSpec().getTemplate();
+    assertEquals(podTemplate.getSpec().getTerminationGracePeriodSeconds(), (Long) 24L);
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Cannot merge pods with a different configuration of the termination grace period: 24, 25")
+  public void shouldFailIfTerminationGracePeriodSharedBDiffersInPods() throws Exception {
+    // given
+    PodSpec podSpec1 = new PodSpecBuilder().withTerminationGracePeriodSeconds(24L).build();
+    PodData podData1 = new PodData(podSpec1, new ObjectMetaBuilder().build());
+    PodSpec podSpec2 = new PodSpecBuilder().withTerminationGracePeriodSeconds(25L).build();
+    PodData podData2 = new PodData(podSpec2, new ObjectMetaBuilder().build());
+
+    // when
+    Deployment merged = podMerger.merge(Arrays.asList(podData1, podData2));
+
+    // then
+    PodTemplateSpec podTemplate = merged.getSpec().getTemplate();
+    assertEquals(podTemplate.getSpec().getTerminationGracePeriodSeconds(), (Long) 42L);
+  }
+
+  @Test
   public void shouldAssignSecurityContextSharedByPods() throws Exception {
     // given
     PodSpec podSpec1 =

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -271,28 +270,6 @@ public class PodMergerTest {
       {Arrays.asList(27L, 27L), 27L},
       {Arrays.asList(27L, null), 27L}
     };
-  }
-
-  @Test
-  public void shouldLeftUnsetIfTerminationGracePeriodIsNotSet() throws Exception {
-    // given
-    List<PodData> podData =
-        Arrays.asList(
-            new PodData(
-                new PodSpecBuilder().withTerminationGracePeriodSeconds(null).build(),
-                new ObjectMetaBuilder().build()),
-            new PodData(
-                new PodSpecBuilder().withTerminationGracePeriodSeconds(null).build(),
-                new ObjectMetaBuilder().build()),
-            new PodData(
-                new PodSpecBuilder().withTerminationGracePeriodSeconds(null).build(),
-                new ObjectMetaBuilder().build()));
-    // when
-    Deployment merged = podMerger.merge(podData);
-
-    // then
-    PodTemplateSpec podTemplate = merged.getSpec().getTemplate();
-    assertNull(podTemplate.getSpec().getTerminationGracePeriodSeconds());
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
The termination grace period is set to maximum explicitly defined values, otherwise, it is set to null.
Note, that this is related to the loop that is happened inside of PodMerger. Before it, there is another loop other all pods that set https://github.com/eclipse/che/blob/master/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java#L51
Basically what is happening in the bubble sort inside    https://github.com/eclipse/che/blob/master/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java#L72 this loop. I believe that because of PodTerminationGracePeriodProvisioner at the end erminationGracePeriod should never be null. 


### What issues does this PR fix or reference?
Fixes: https://github.com/eclipse/che/issues/16200

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a

#### Docs PR
n/a