### PR TITLE
Generate broker container names more sensibly

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactory.java
@@ -247,7 +247,25 @@ public abstract class BrokerEnvironmentFactory<E extends KubernetesEnvironment> 
    */
   @VisibleForTesting
   protected String generateContainerNameFromImageRef(String image) {
-    return image.toLowerCase().replaceAll("[^/]*/", "").replaceAll("[^\\d\\w-]", "-");
+    String containerName;
+    if (image.contains("@")) {
+      // Image is tagged with digest; we trim digest to 10 chars and remove "sha256"
+      String[] parts = image.split("@");
+      String imagePart = parts[0];
+      String digest = parts[1];
+      if (digest.contains(":")) {
+        digest = digest.split(":")[1];
+      }
+      if (digest.length() > 10) {
+        digest = digest.substring(0, 10);
+      }
+      image = String.format("%s-%s", imagePart, digest);
+    }
+    containerName = image.toLowerCase().replaceAll("[^/]*/", "").replaceAll("[^\\d\\w-]", "-");
+    if (containerName.length() > 63) {
+      containerName = containerName.substring(0, 63);
+    }
+    return containerName;
   }
 
   public static class BrokersConfigs {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactoryTest.java
@@ -315,7 +315,7 @@ public class BrokerEnvironmentFactoryTest {
     assertEquals(
         actual,
         expected,
-        String.format("Should remove registry and organization from image '%s'.", image));
+        String.format("Should generate name '%s' from image '%s'.", expected, image));
   }
 
   @DataProvider(name = "imageRefs")
@@ -325,7 +325,17 @@ public class BrokerEnvironmentFactoryTest {
       {"very-long-registry-hostname-url.service/eclipse/image:tag", "image-tag"},
       {"eclipse/che-unified-plugin-broker:v0.20", "che-unified-plugin-broker-v0-20"},
       {"very-long-organization.name-eclipse-che/image:tag", "image-tag"},
-      {"very-long-registry-hostname-url.service/very-long-organization/image:tag", "image-tag"}
+      {"very-long-registry-hostname-url.service/very-long-organization/image:tag", "image-tag"},
+      {
+        "image-with-digest@sha256:7b868470f7b63d9da10a788d26abf4c076f90dc4c7de24d1298a8160c9a3dcc9",
+        "image-with-digest-7b868470f7"
+      },
+      {"image-with-short-digest@sha256:abcd", "image-with-short-digest-abcd"},
+      {"no-exception-when-no-colon@sha256abcd", "no-exception-when-no-colon-sha256abcd"},
+      {
+        "image-and-tag-longer-than-63-chars:really-long-tag-for-some-reason",
+        "image-and-tag-longer-than-63-chars-really-long-tag-for-some-rea"
+      }
     };
   }
 }


### PR DESCRIPTION
### What does this PR do?
Fixes an issue where container names for brokers could be longer than 63 characters:

- If a broker image is referenced by tag, trim the digest to 10 chars and use that instead of the full thing
- If the generated name is longer than 63 chars for whatever reason, trim it to allow the workspace to start.

### What issues does this PR fix or reference?
Fixes #16288