### PR TITLE
Fallback to firstTimestamp if lastTimestamp is not set when handling event

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -22,6 +22,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.POD_
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.setSelector;
 
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -535,7 +536,8 @@ public class KubernetesDeployments {
                         event.getReason(),
                         event.getMessage(),
                         event.getMetadata().getCreationTimestamp(),
-                        event.getLastTimestamp());
+                        MoreObjects.firstNonNull(
+                            event.getLastTimestamp(), event.getFirstTimestamp()));
 
                 try {
                   if (happenedAfterWatcherInitialization(podEvent)) {


### PR DESCRIPTION
# What does this PR do?
Fallback to firstTimestamp if lastTimestamp is not set when handling event.
Related to  https://github.com/kubernetes/kubernetes/pull/86557

### What issues does this PR fix or reference?

Fixes https://github.com/eclipse/che/issues/15395

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a


#### Docs PR
n/a