### PR TITLE
Adding more logging levels to the utils/Logger class

### DIFF
--- a/tests/e2e/utils/Logger.ts
+++ b/tests/e2e/utils/Logger.ts
@@ -16,47 +16,44 @@ export abstract class Logger {
      * Uses for logging of fatal errors.
      * @param text log text
      */
-    public static error(text: string) {
-        console.log(`    [FATAL] ${text} [FATAL]`);
+    public static error(text: string, indentLevel: number = 1) {
+        this.logText(indentLevel, `[ERROR] ${text}`);
     }
 
     /**
      * Uses for logging of recoverable errors and general warnings.
      * @param text log text
      */
-    public static warn(text: string) {
+    public static warn(text: string, indentLevel: number = 1) {
         if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'ERROR') {
             return;
         }
-
-        console.log(`    (⚠) ${text} (⚠)`);
+        this.logText(indentLevel, `[WARN] ${text}`);
     }
 
     /**
      * Uses for logging of the public methods of the pageobjects.
      * @param text log text
      */
-    public static info(text: string) {
+    public static info(text: string, indentLevel: number = 3) {
         if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'ERROR' ||
             TestConstants.TS_SELENIUM_LOG_LEVEL === 'WARN') {
             return;
         }
-
-        console.log(`        • ${text}`);
+        this.logText(indentLevel, `• ${text}`);
     }
 
     /**
      * Uses for logging of the public methods of the pageobjects.
      * @param text log text
      */
-    public static debug(text: string) {
+    public static debug(text: string, indentLevel: number = 5) {
         if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'ERROR' ||
             TestConstants.TS_SELENIUM_LOG_LEVEL === 'WARN' ||
             TestConstants.TS_SELENIUM_LOG_LEVEL === 'INFO') {
             return;
         }
-
-        console.log(`        ▼ ${text}`);
+        this.logText(indentLevel, `▼ ${text}`);
     }
 
     /**
@@ -64,15 +61,27 @@ export abstract class Logger {
      * private methods inside of pageobjects.
      * @param text log text
      */
-    public static trace(text: string) {
+    public static trace(text: string, indentLevel: number = 6) {
         if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'ERROR' ||
             TestConstants.TS_SELENIUM_LOG_LEVEL === 'WARN' ||
             TestConstants.TS_SELENIUM_LOG_LEVEL === 'INFO' ||
             TestConstants.TS_SELENIUM_LOG_LEVEL === 'DEBUG') {
             return;
         }
-
-        console.log(`            ‣ ${text}`);
+        this.logText(indentLevel, `‣ ${text}`);
     }
 
+    private static logText(messageIndentationLevel: number, text: string) {
+        // start group for every level
+        for (let i = 0; i < messageIndentationLevel; i++) {
+            console.group();
+        }
+        // print the trimmed text
+        // if multiline, the message should be properly padded
+        console.log(text);
+        // end group for every level
+        for (let i = 0; i < messageIndentationLevel; i++) {
+            console.groupEnd();
+        }
+    }
 }

--- a/tests/e2e/utils/Logger.ts
+++ b/tests/e2e/utils/Logger.ts
@@ -11,12 +11,48 @@ import { TestConstants } from '../TestConstants';
  **********************************************************************/
 
 export abstract class Logger {
+
+    /**
+     * Uses for logging of fatal errors.
+     * @param text log text
+     */
+    public static error(text: string) {
+        console.log(`    [FATAL] ${text} [FATAL]`);
+    }
+
+    /**
+     * Uses for logging of recoverable errors and general warnings.
+     * @param text log text
+     */
+    public static warn(text: string) {
+        if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'ERROR') {
+            return;
+        }
+
+        console.log(`    (⚠) ${text} (⚠)`);
+    }
+
+    /**
+     * Uses for logging of the public methods of the pageobjects.
+     * @param text log text
+     */
+    public static info(text: string) {
+        if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'ERROR' ||
+            TestConstants.TS_SELENIUM_LOG_LEVEL === 'WARN') {
+            return;
+        }
+
+        console.log(`        • ${text}`);
+    }
+
     /**
      * Uses for logging of the public methods of the pageobjects.
      * @param text log text
      */
     public static debug(text: string) {
-        if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'INFO') {
+        if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'ERROR' ||
+            TestConstants.TS_SELENIUM_LOG_LEVEL === 'WARN' ||
+            TestConstants.TS_SELENIUM_LOG_LEVEL === 'INFO') {
             return;
         }
 
@@ -29,11 +65,10 @@ export abstract class Logger {
      * @param text log text
      */
     public static trace(text: string) {
-        if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'INFO') {
-            return;
-        }
-
-        if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'DEBUG') {
+        if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'ERROR' ||
+            TestConstants.TS_SELENIUM_LOG_LEVEL === 'WARN' ||
+            TestConstants.TS_SELENIUM_LOG_LEVEL === 'INFO' ||
+            TestConstants.TS_SELENIUM_LOG_LEVEL === 'DEBUG') {
             return;
         }
 


### PR DESCRIPTION
### What does this PR do?
This PR adds more options for logging into the utils.Logger.ts class

example output:
```
  Login test
            ‣ DriverHelper.getDriver
  [ERROR] I am an error message.
  I am split to multiple lines.
  [WARN] I am a warning message.
  I'm also split into
  multiple lines.
      • I am an info message.
          ▼ I am a usual debug message
          split into multiple lines.
            ‣ I am a trace message.
    1) Test Logger


  0 passing (170ms)
  1 failing

  1) Login test
       Test Logger:
     Error: I am an exception message.
      at Object.<anonymous> (/home/tdancs/Workspace/che/tests/e2e/tests/login/Login.spec.ts:26:15)
      at Generator.next (<anonymous>)
      at /home/tdancs/Workspace/che/tests/e2e/dist/tests/login/Login.spec.js:16:71
      at new Promise (<anonymous>)
      at __awaiter (/home/tdancs/Workspace/che/tests/e2e/dist/tests/login/Login.spec.js:12:12)
      at Context.<anonymous> (/home/tdancs/Workspace/che/tests/e2e/tests/login/Login.spec.ts:20:36)
      at callFn (/home/tdancs/Workspace/che/tests/e2e/node_modules/mocha/lib/runnable.js:387:21)
      at Test.Runnable.run (/home/tdancs/Workspace/che/tests/e2e/node_modules/mocha/lib/runnable.js:379:7)
      at Runner.runTest (/home/tdancs/Workspace/che/tests/e2e/node_modules/mocha/lib/runner.js:535:10)
      at /home/tdancs/Workspace/che/tests/e2e/node_modules/mocha/lib/runner.js:653:12
      at next (/home/tdancs/Workspace/che/tests/e2e/node_modules/mocha/lib/runner.js:447:14)
      at /home/tdancs/Workspace/che/tests/e2e/node_modules/mocha/lib/runner.js:457:7
      at next (/home/tdancs/Workspace/che/tests/e2e/node_modules/mocha/lib/runner.js:362:14)
      at Immediate.<anonymous> (/home/tdancs/Workspace/che/tests/e2e/node_modules/mocha/lib/runner.js:425:5)
      at processImmediate (internal/timers.js:456:21)
```

### What issues does this PR fix or reference?
none

#### Release Notes
N/A

#### Docs PR
No changes in docs - improvement for selenium typescript tests
