### PR TITLE
Switch java selenium tests and typscript tests to test Che with TLS support

### DIFF
--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -5,8 +5,7 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-set -e
-set +x
+set -ex
 
 source tests/.infra/centos-ci/functional_tests_utils.sh
 

--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -53,7 +53,8 @@ createIndentityProvider
 bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
   --threads=3 \
   --host=${CHE_ROUTE} \
-  --port=80 \
+  --https \
+  --port=443 \
   --multiuser \
   --fail-script-on-failed-tests \
   || IS_TESTS_FAILED=true

--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -22,6 +22,7 @@ function prepareCustomResourceFile() {
   sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
   sed -i "s@cheImage: ''@cheImage: 'quay.io/eclipse/che-server'@g" /tmp/custom-resource.yaml
   sed -i "s@cheImageTag: 'nightly'@cheImageTag: '${TAG}'@g" /tmp/custom-resource.yaml
+  sed -i "s@selfSignedCert: false@selfSignedCert: true@" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 

--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -268,7 +268,6 @@ function deployCheIntoCluster() {
   if chectl server:start \
       -a operator \
       -p openshift \
-      --self-signed-cert \
       --k8spodreadytimeout=360000 $1 $2; then
     echo "Started succesfully"
     oc get checluster -o yaml

--- a/tests/.infra/centos-ci/nightly/cico-devfiles-test.sh
+++ b/tests/.infra/centos-ci/nightly/cico-devfiles-test.sh
@@ -10,7 +10,7 @@ installCheCtl
 installJQ
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
-deployCheIntoCluster
+deployCheIntoCluster --self-signed-cert
 createTestUserAndObtainUserToken
 runDevfileTestSuite 
 echo "=========================== THIS IS POST TEST ACTIONS =============================="

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-all-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-all-tests.sh
@@ -35,7 +35,8 @@ createIndentityProvider
 bash tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
   --threads=3 \
   --host=${CHE_ROUTE} \
-  --port=80 \
+  --https \
+  --port=443 \
   --multiuser \
   --fail-script-on-failed-tests \
   --include-tests-under-repair \

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-all-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-all-tests.sh
@@ -16,6 +16,7 @@ function prepareCustomResourceFile() {
   wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
   sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
+  sed -i "s@selfSignedCert: false@selfSignedCert: true@" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-hot-update-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-hot-update-tests.sh
@@ -21,8 +21,9 @@ deployCheIntoCluster
 seleniumTestsSetup
 
 bash tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
---host=${CHE_ROUTE} \
- --port=80 \
+ --host=${CHE_ROUTE} \
+ --https \
+ --port=443 \
  --multiuser \
  --threads=1 \
  --fail-script-on-failed-tests \

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-hot-update-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-hot-update-tests.sh
@@ -17,7 +17,7 @@ installDockerCompose
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 installCheCtl
-deployCheIntoCluster
+deployCheIntoCluster --self-signed-cert
 seleniumTestsSetup
 
 bash tests/legacy-e2e/che-selenium-test/selenium-tests.sh \

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-stable-selenium-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-stable-selenium-tests.sh
@@ -15,6 +15,7 @@ function prepareCustomResourceFile() {
   wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
   sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
+  sed -i "s@selfSignedCert: false@selfSignedCert: true@" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 setupEnvs

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-stable-selenium-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-stable-selenium-tests.sh
@@ -32,7 +32,8 @@ createIndentityProvider
 bash tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
   --threads=3 \
   --host=${CHE_ROUTE} \
-  --port=80 \
+  --https \
+  --port=443 \
   --multiuser \
   --fail-script-on-failed-tests \
   || IS_TESTS_FAILED=true

--- a/tests/.infra/centos-ci/nightly/nightly-happypath-test.sh
+++ b/tests/.infra/centos-ci/nightly/nightly-happypath-test.sh
@@ -17,7 +17,7 @@ installDependencies
 installCheCtl
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
-deployCheIntoCluster
+deployCheIntoCluster --self-signed-cert
 createTestUserAndObtainUserToken
 createTestWorkspaceAndRunTest
 echo "=========================== THIS IS POST TEST ACTIONS =============================="

--- a/tests/.infra/centos-ci/nightly/ocp-oauth-test.sh
+++ b/tests/.infra/centos-ci/nightly/ocp-oauth-test.sh
@@ -13,6 +13,7 @@ function prepareCustomResourceFile() {
   wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   sed -i "s@openShiftoAuth: false@openShiftoAuth: true@g" /tmp/custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
+  sed -i "s@selfSignedCert: false@selfSignedCert: true@" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 setupEnvs

--- a/tests/.infra/centos-ci/nightly/ocp-oauth-test.sh
+++ b/tests/.infra/centos-ci/nightly/ocp-oauth-test.sh
@@ -29,7 +29,8 @@ seleniumTestsSetup
 bash tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
   --threads=1 \
   --host=${CHE_ROUTE} \
-  --port=80 \
+  --https \
+  --port=443 \
   --multiuser \
   --fail-script-on-failed-tests \
   --test=org.eclipse.che.selenium.site.ocpoauth.** \

--- a/tests/.infra/centos-ci/rc/cico-rc-multiuser-integration-tests.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-multiuser-integration-tests.sh
@@ -26,7 +26,8 @@ seleniumTestsSetup
 bash /root/payload/tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
    --threads=3 \
    --host=${CHE_ROUTE} \
-   --port=80 \
+   --https \
+   --port=443 \
    --multiuser \
    --fail-script-on-failed-tests \
    || IS_TESTS_FAILED=true

--- a/tests/.infra/centos-ci/rc/cico-rc-ocp-oauth-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-ocp-oauth-test.sh
@@ -25,7 +25,8 @@ seleniumTestsSetup
 bash tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
     --threads=1 \
     --host=${CHE_ROUTE} \
-    --port=80 \
+    --https \
+    --port=443 \
     --multiuser \
     --test=org.eclipse.che.selenium.site.ocpoauth.** \
     --fail-script-on-failed-tests \

--- a/tests/.infra/centos-ci/rc/cico-rc-rolling-strategy-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-rolling-strategy-test.sh
@@ -25,7 +25,8 @@ seleniumTestsSetup
 bash tests/legacy-e2e/che-selenium-test/selenium-tests.sh \
     --threads=1 \
     --host=${CHE_ROUTE} \
-    --port=80 \
+    --https \
+    --port=443 \
     --multiuser \
     --test=org.eclipse.che.selenium.hotupdate.rolling.** \
     --fail-script-on-failed-tests \

--- a/tests/.infra/centos-ci/rc/rc_function_util.sh
+++ b/tests/.infra/centos-ci/rc/rc_function_util.sh
@@ -19,5 +19,6 @@ function prepareCustomResourceFile() {
   sed -i "s@cheImageTag: 'nightly'@cheImageTag: '$RELEASE_TAG'@g" /tmp/custom-resource.yaml
   sed -i "s@devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:nightly'@devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:$RELEASE_VERSION'@g" /tmp/custom-resource.yaml
   sed -i "s@pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:nightly'@pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:$RELEASE_VERSION'@g " /tmp/custom-resource.yaml
+  sed -i "s@selfSignedCert: false@selfSignedCert: true@" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }


### PR DESCRIPTION
### What does this PR do?
After recent changes in che-operator Eclipse Che Operator installs Che with TLS support by default.
So we need to fix E2E _java selenium tests_ and _typescript selenium tests_ on ci.centos.org to be run against Eclipse Che with TLS support.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16299