### PR TITLE
Disable Eclipse Che TLS mode in E2E tests on ci.centos

### DIFF
--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -5,8 +5,7 @@
 # which accompanies this distribution, and is available at
 # http://www.eclipse.org/legal/epl-v10.html
 
-set -e
-set +x
+set -ex
 
 source tests/.infra/centos-ci/functional_tests_utils.sh
 
@@ -22,6 +21,7 @@ function prepareCustomResourceFile() {
   sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
   sed -i "s@cheImage: ''@cheImage: 'quay.io/eclipse/che-server'@g" /tmp/custom-resource.yaml
   sed -i "s@cheImageTag: 'nightly'@cheImageTag: '${TAG}'@g" /tmp/custom-resource.yaml
+  sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-all-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-all-tests.sh
@@ -16,6 +16,7 @@ function prepareCustomResourceFile() {
   wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
   sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
+  sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-hot-update-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-hot-update-tests.sh
@@ -10,6 +10,13 @@ echo "========Starting nigtly test job $(date)========"
 
 source tests/.infra/centos-ci/functional_tests_utils.sh
 
+function prepareCustomResourceFile() {
+  cd /tmp
+  wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
+  sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
+  cat /tmp/custom-resource.yaml
+}
+
 setupEnvs
 installKVM
 installDependencies
@@ -17,7 +24,8 @@ installDockerCompose
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 installCheCtl
-deployCheIntoCluster
+prepareCustomResourceFile
+deployCheIntoCluster --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/custom-resource.yaml
 seleniumTestsSetup
 
 bash tests/legacy-e2e/che-selenium-test/selenium-tests.sh \

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-stable-selenium-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-stable-selenium-tests.sh
@@ -15,6 +15,7 @@ function prepareCustomResourceFile() {
   wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
   sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
+  sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
 setupEnvs

--- a/tests/.infra/centos-ci/nightly/nightly-happypath-test.sh
+++ b/tests/.infra/centos-ci/nightly/nightly-happypath-test.sh
@@ -11,13 +11,21 @@ echo "========Starting nigtly test job $(date)========"
 source tests/.infra/centos-ci/functional_tests_utils.sh
 source .ci/cico_common.sh
 
+function prepareCustomResourceFile() {
+  cd /tmp
+  wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
+  sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
+  cat /tmp/custom-resource.yaml
+}
+
 setupEnvs
 installKVM
 installDependencies
 installCheCtl
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
-deployCheIntoCluster
+prepareCustomResourceFile
+deployCheIntoCluster --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/custom-resource.yaml
 createTestUserAndObtainUserToken
 createTestWorkspaceAndRunTest
 echo "=========================== THIS IS POST TEST ACTIONS =============================="

--- a/tests/.infra/centos-ci/nightly/ocp-oauth-test.sh
+++ b/tests/.infra/centos-ci/nightly/ocp-oauth-test.sh
@@ -13,8 +13,10 @@ function prepareCustomResourceFile() {
   wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   sed -i "s@openShiftoAuth: false@openShiftoAuth: true@g" /tmp/custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
+  sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }
+
 setupEnvs
 installKVM
 installDependencies

--- a/tests/.infra/centos-ci/rc/rc_function_util.sh
+++ b/tests/.infra/centos-ci/rc/rc_function_util.sh
@@ -19,5 +19,6 @@ function prepareCustomResourceFile() {
   sed -i "s@cheImageTag: 'nightly'@cheImageTag: '$RELEASE_TAG'@g" /tmp/custom-resource.yaml
   sed -i "s@devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:nightly'@devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:$RELEASE_VERSION'@g" /tmp/custom-resource.yaml
   sed -i "s@pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:nightly'@pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:$RELEASE_VERSION'@g " /tmp/custom-resource.yaml
+  sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
 }

--- a/tests/.infra/crw-ci/master/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/master/k8s/Jenkinsfile
@@ -100,13 +100,13 @@ pipeline {
                             build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                     parameters: [
                                             string(name: 'cheImageRepo',
-                                                    value: 'quay.io/eclipse/che-server'),
+                                                    value: 'maxura/che-server'),
 
                                             string(name: 'cheImageTag',
                                                     value: 'master'),
 
                                             booleanParam(name: 'buildChe',
-                                                    value: false),
+                                                    value: true),
 
                                             string(name: 'ghprbSourceBranch',
                                                     value: 'master'),

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -221,50 +221,48 @@ pipeline {
                         # sed -i "s/selfSignedCert: false/selfSignedCert: true/" $CUSTOM_RESOURCE_FILE_PATH    
                     """
 
-                    retry(2) {
-                        echo "Install Che"
-                        sh """
-                            ${WORKSPACE}/chectl server:start \\
-                            --k8spodreadytimeout=180000 \\
-                            --installer=operator \\
-                            --listr-renderer=verbose \\
-                            --platform=minikube \\
-                            --che-operator-cr-yaml=$CUSTOM_RESOURCE_FILE_PATH
-                        """
+                    echo "Install Che"
+                    sh """
+                        ${WORKSPACE}/chectl server:start \\
+                        --k8spodreadytimeout=180000 \\
+                        --installer=operator \\
+                        --listr-renderer=verbose \\
+                        --platform=minikube \\
+                        --che-operator-cr-yaml=$CUSTOM_RESOURCE_FILE_PATH
+                    """
 
-                        cheHost = sh(
-                                script: "kubectl get ingress che -n=che -o=jsonpath={'.spec.rules[0].host'}",
-                                returnStdout: true
-                        ).trim()
+                    cheHost = sh(
+                            script: "kubectl get ingress che -n=che -o=jsonpath={'.spec.rules[0].host'}",
+                            returnStdout: true
+                    ).trim()
 
-                        echo "Wait che-server to be available"
-                        sh """
-                             COUNTER=0;
-                             SUCCESS_RATE_COUNTER=0;
-                             while true; do
-                              if [ \$COUNTER -gt 180 ]; then
-                              echo "Unable to get stable route. Exiting"
-                                exit 1
-                              fi
-                              
-                              ((COUNTER+=1))
-                              
-                              
-                              STATUS_CODE=\$(curl -k -sL -w "%{http_code}" -I http://${cheHost} -o /dev/null; true) || true
-                              
-                              echo "Try \${COUNTER}. Status code: \${STATUS_CODE}"
-                              if [ "\$STATUS_CODE" == "200" ]; then 
-                                ((SUCCESS_RATE_COUNTER+=1))
-                              fi
-                              sleep 1;
+                    echo "Wait che-server to be available"
+                    sh """
+                            COUNTER=0;
+                            SUCCESS_RATE_COUNTER=0;
+                            while true; do
+                            if [ \$COUNTER -gt 180 ]; then
+                            echo "Unable to get stable route. Exiting"
+                            exit 1
+                            fi
                             
-                              if [ \$SUCCESS_RATE_COUNTER == \$SUCCESS_THRESHOLD ]; then 
-                                echo "Route is stable enough. Continuing running tests"
-                                break
-                              fi
-                             done
-                        """
-                    }
+                            ((COUNTER+=1))
+                            
+                            
+                            STATUS_CODE=\$(curl -k -sL -w "%{http_code}" -I http://${cheHost} -o /dev/null; true) || true
+                            
+                            echo "Try \${COUNTER}. Status code: \${STATUS_CODE}"
+                            if [ "\$STATUS_CODE" == "200" ]; then 
+                            ((SUCCESS_RATE_COUNTER+=1))
+                            fi
+                            sleep 1;
+                        
+                            if [ \$SUCCESS_RATE_COUNTER == \$SUCCESS_THRESHOLD ]; then 
+                            echo "Route is stable enough. Continuing running tests"
+                            break
+                            fi
+                            done
+                    """
                 }
             }
         }
@@ -378,6 +376,8 @@ pipeline {
 
                 env > $LOGS_AND_CONFIGS/env.output.txt || true
                 ${WORKSPACE}/chectl --help > $LOGS_AND_CONFIGS/chectl.version.txt || true
+
+                cp -r /tmp/chectl-logs $LOGS_AND_CONFIGS || true
             """
 
             archiveArtifacts allowEmptyArchive: true, artifacts: "tests/e2e/report/**, logs-and-configs/**"

--- a/tests/.infra/crw-ci/pre-release-testing/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pre-release-testing/k8s/Jenkinsfile
@@ -74,11 +74,11 @@ pipeline {
                           -O $customResourceFilePath
 
                         # TODO: "selfSignedCert: true" so as TLS support is enebled by default 
-                        # sed -i "s/selfSignedCert: false/selfSignedCert: true/" $CUSTOM_RESOURCE_FILE_PATH
+                        # sed -i "s/selfSignedCert: false/selfSignedCert: true/" $customResourceFilePath
 
 
                         # temporary workaround to https://github.com/eclipse/che/issues/16292
-                        sed -i "s/tlsSupport: true/tlsSupport: false/" $CUSTOM_RESOURCE_FILE_PATH      
+                        sed -i "s/tlsSupport: true/tlsSupport: false/" $customResourceFilePath      
                     """
 
                     customResourceFileContent = readFile customResourceFilePath


### PR DESCRIPTION
### What does this PR do?
It disables TLS mode when installing Eclipse Che in E2E testing jobs on Centos CI.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16323