### PR TITLE
Restart workspaces in debug mode after startup failure

### DIFF
--- a/dashboard/src/app/ide/ide.controller.ts
+++ b/dashboard/src/app/ide/ide.controller.ts
@@ -35,6 +35,8 @@ class IdeCtrl {
   selectedWorkspaceExists: boolean = true;
   selectedWorkspaceName: string = null;
 
+  isDebugMode: boolean;
+
   /**
    * Default constructor that is using resource
    */
@@ -51,6 +53,8 @@ class IdeCtrl {
     this.$rootScope.wantTokeepLoader = true;
 
     this.selectedWorkspaceExists = true;
+
+    this.isDebugMode = $location.search().debug;
 
     // search the selected workspace
     let namespace = this.$routeParams.namespace;
@@ -158,7 +162,7 @@ class IdeCtrl {
       return;
     }
 
-    this.ideSvc.openIde(this.selectedWorkspace.id);
+    this.ideSvc.openIde(this.selectedWorkspace.id, this.isDebugMode);
   }
 }
 

--- a/dashboard/src/app/ide/ide.service.ts
+++ b/dashboard/src/app/ide/ide.service.ts
@@ -131,8 +131,7 @@ class IdeSvc {
   }
 
   startWorkspace(data: any): ng.IPromise<any> {
-    let startWorkspacePromise = this.cheAPI.getWorkspace().startWorkspace(data.id, data.config ? data.config.defaultEnv: null);
-    return startWorkspacePromise;
+    return this.cheAPI.getWorkspace().startWorkspace(data.id);
   }
 
   setLoadingParameter(paramName: string, paramValue: string): void {
@@ -143,14 +142,14 @@ class IdeSvc {
     this.ideAction = ideAction;
   }
 
-  openIde(workspaceId: string): void {
+  openIde(workspaceId: string, isDebugMode?: boolean): void {
     (this.$rootScope as any).hideNavbar = false;
 
     this.updateRecentWorkspace(workspaceId);
 
     let inDevMode = this.userDashboardConfig.developmentMode;
     let randVal = Math.floor((Math.random() * 1000000) + 1);
-    let appendUrl = '?uid=' + randVal;
+    let appendUrl = `?uid=${randVal}${isDebugMode ? '&debug=true' : ''}`;
     let workspace = this.cheWorkspace.getWorkspaceById(workspaceId);
     this.openedWorkspace = workspace;
 

--- a/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
+++ b/dashboard/src/app/navbar/recent-workspaces/recent-workspaces.controller.ts
@@ -165,6 +165,14 @@ export class NavbarRecentWorkspacesController {
           this.runRecentWorkspace(workspaceId);
         }
       },
+      {
+        name: 'Run in debug mode',
+        scope: 'STOPPED',
+        icon: 'fa fa-play',
+        _onclick: (workspaceId: string) => {
+          this.runRecentWorkspace(workspaceId, true);
+        }
+      },
       // not supported
       {
         name: 'Not supported',
@@ -359,9 +367,10 @@ export class NavbarRecentWorkspacesController {
 
   /**
    * Starts specified workspace
-   * @param workspaceId {String} workspace id
+   * @param workspaceId workspace id
+   * @param isDebugMode debug mode
    */
-  runRecentWorkspace(workspaceId: string): void {
+  runRecentWorkspace(workspaceId: string, isDebugMode?: boolean): void {
     if (this.checkUnsavedChanges(workspaceId)) {
       this.workspaceDetailsService.notifyUnsavedChangesDialog();
       return;
@@ -371,7 +380,7 @@ export class NavbarRecentWorkspacesController {
 
     this.updateRecentWorkspace(workspaceId);
 
-    this.cheWorkspace.startWorkspace(workspace.id).catch((error: any) => {
+    this.cheWorkspace.startWorkspace(workspace.id, isDebugMode).catch((error: any) => {
       this.$log.error(error);
       this.cheNotification.showError('Run workspace error.', error);
     });


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Added restarting workspaces in debug mode after startup failure.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16050

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
In progress.

You can tested it with  the next che-server image:  olexii4dockerid/che-server:nightly

![Screenshot from 2020-03-19 13-19-46](https://user-images.githubusercontent.com/6310786/77066544-0973be00-69ec-11ea-9ba3-e6085205cf6f.png)
