### PR TITLE
fix race-condition sensitive logwatcher test

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/log/ContainerLogWatchTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/log/ContainerLogWatchTest.java
@@ -126,17 +126,18 @@ public class ContainerLogWatchTest {
   public void testCloseFromOutside() throws IOException, InterruptedException {
     PipedInputStream inputStream = new PipedInputStream();
     PipedOutputStream outputStream = new PipedOutputStream(inputStream);
-    outputStream.write("message\na\na\na\na\na".getBytes());
+    outputStream.write("message\n".getBytes());
     logWatch.setInputStream(inputStream);
 
     CountDownLatch latch = new CountDownLatch(1);
     doAnswer(
             (a) -> {
+              outputStream.write("nextMessage\n".getBytes());
               latch.countDown();
               return null;
             })
         .when(podLogHandler)
-        .handle("message", container);
+        .handle(any(), any());
 
     ContainerLogWatch clw =
         new ContainerLogWatch(


### PR DESCRIPTION
### What does this PR do?
Fix ContainerLogWatch test that was sensitive to race-condition and was failing randomly.

### What issues does this PR fix or reference?
n/a

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
