### PR TITLE
Handle numeric versions for referenced plugins

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/PluginFQNParser.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/wsplugins/PluginFQNParser.java
@@ -197,8 +197,14 @@ public class PluginFQNParser {
     if (version.isMissingNode()) {
       throw new InfrastructureException(formatMessage(reference, "version"));
     }
+    if (!version.isValueNode()) {
+      throw new InfrastructureException(
+          format(
+              "Plugin specified by reference URL '%s' has version field that cannot be parsed to string",
+              reference));
+    }
     return new ExtendedPluginFQN(
-        reference, publisher.textValue(), name.textValue(), version.textValue());
+        reference, publisher.textValue(), name.textValue(), version.asText());
   }
 
   private String formatMessage(String reference, String field) {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/wsplugins/PluginFQNParserTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/wsplugins/PluginFQNParserTest.java
@@ -383,6 +383,16 @@ public class PluginFQNParserTest {
             "publisher",
             "plugin123",
             "0.0.5")
+      },
+      {
+        "https://pastebin.com/raw/EBmz0YMS",
+        "apiVersion: v2\n"
+            + "publisher: publisher\n"
+            + "name: numericVersion\n"
+            + "version: 1.1\n"
+            + "type: Che Plugin",
+        new ExtendedPluginFQN(
+            "https://pastebin.com/raw/EBmz0YMS", "publisher", "numericVersion", "1.1")
       }
     };
   }


### PR DESCRIPTION
### What does this PR do?
For plugins defined by a reference, we have to download a remote meta.yaml and parse the plugin FQN from it; this will break if the version in the meta.yaml is specified in a way that can be interpreted
as a number.

This commit uses the text value of the version field instead of assuming that is in a string format.

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/16340
