### PR TITLE
Test E2E: Delete redundant steps from 'InstallCheByOperatorHub' test

### DIFF
--- a/tests/e2e/pageobjects/openshift/OcpWebConsolePage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpWebConsolePage.ts
@@ -34,7 +34,7 @@ export class OcpWebConsolePage {
     async waitDisappearanceNavpanelOpenShift() {
         Logger.debug('OcpWebConsolePage.waitDisappearanceNavpanelOpenShift');
 
-        await this.driverHelper.waitDisappearance(By.css(OcpWebConsolePage.NAV_PANEL_OPENSHIFT_CSS));
+        await this.driverHelper.waitDisappearanceWithTimeout(By.css(OcpWebConsolePage.NAV_PANEL_OPENSHIFT_CSS));
     }
 
     async openOperatorHubMainPageByUrl(url: string) {

--- a/tests/e2e/tests/e2e_install_che_operatorhub/InstallCheByOperatorHub.spec.ts
+++ b/tests/e2e/tests/e2e_install_che_operatorhub/InstallCheByOperatorHub.spec.ts
@@ -67,11 +67,4 @@ suite('E2E', async () => {
         });
     });
 
-    suite('Logout from web console OpenShift', async () => {
-        test('Logout from temp admin user', async () => {
-            await ocpWebConsole.logoutFromWebConsole();
-            await ocpWebConsole.waitDisappearanceNavpanelOpenShift();
-        });
-    });
-
 });


### PR DESCRIPTION
### What does this PR do?
* Delete redundant steps from E2E test _InstallCheByOperatorHub_
* Replace method in the _OcpWebConsolePage_ pageobject to the method with enough timeout

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16367
