### PR TITLE
Added fallback in case if firstTimestamp and lastTimeStamp both null

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -22,7 +22,6 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.POD_
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabel;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.setSelector;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Strings;
 import io.fabric8.kubernetes.api.model.ContainerStateTerminated;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -527,8 +526,22 @@ public class KubernetesDeployments {
               if (POD_OBJECT_KIND.equals(involvedObject.getKind())
                   || REPLICASET_OBJECT_KIND.equals(involvedObject.getKind())
                   || DEPLOYMENT_OBJECT_KIND.equals(involvedObject.getKind())) {
-
+                LOG.debug("Event {}", event);
                 String podName = involvedObject.getName();
+                String lastTimestamp = event.getLastTimestamp();
+                if (lastTimestamp == null) {
+                  String firstTimestamp = event.getFirstTimestamp();
+                  if (firstTimestamp != null) {
+                    // Done in the same way like it made in
+                    // https://github.com/kubernetes/kubernetes/pull/86557
+                    lastTimestamp = firstTimestamp;
+                  } else {
+                    LOG.warn(
+                        "lastTimestamp and firstTimestamp are undefined. Event: {}.  Fallback to the current time.",
+                        event);
+                    lastTimestamp = PodEvents.convertDateToEventTimestamp(new Date());
+                  }
+                }
 
                 PodEvent podEvent =
                     new PodEvent(
@@ -537,8 +550,7 @@ public class KubernetesDeployments {
                         event.getReason(),
                         event.getMessage(),
                         event.getMetadata().getCreationTimestamp(),
-                        MoreObjects.firstNonNull(
-                            event.getLastTimestamp(), event.getFirstTimestamp()));
+                        lastTimestamp);
 
                 try {
                   if (happenedAfterWatcherInitialization(podEvent)) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -526,7 +526,6 @@ public class KubernetesDeployments {
               if (POD_OBJECT_KIND.equals(involvedObject.getKind())
                   || REPLICASET_OBJECT_KIND.equals(involvedObject.getKind())
                   || DEPLOYMENT_OBJECT_KIND.equals(involvedObject.getKind())) {
-                LOG.debug("Event {}", event);
                 String podName = involvedObject.getName();
                 String lastTimestamp = event.getLastTimestamp();
                 if (lastTimestamp == null) {


### PR DESCRIPTION
### What does this PR do?
Added fallback in case if firstTimestamp and lastTimeStamp both null.
Tested on crc and latest minikube. Observed only on crc. Looks like minikube is not affected.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16349
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a
#### Docs PR
n/a