### PR TITLE
allow multiple devfile registries to be specified as a space separated list (rebase PR14059 onto master & update)

### DIFF
--- a/dashboard/src/components/api/devfile-registry.factory.ts
+++ b/dashboard/src/components/api/devfile-registry.factory.ts
@@ -20,6 +20,7 @@ export interface IDevfileMetaData {
   icon: string;
   links: any;
   tags: Array<string>;
+  location: string;
 }
 
 enum MemoryUnit { 'B', 'Ki', 'Mi', 'Gi' }


### PR DESCRIPTION
Signed-off-by: Toby Corbin <corbint@uk.ibm.com>

**What does this PR do?**
This PR allows multiple devfile registries to be specified as a space separated list, for example in values.yml we can have:

```
che: 
  workspace: 
    devfileRegistryUrl: "https://che-devfile-registry.openshift.io/ https://raw.githubusercontent.com/kabanero-io/codewind-templates/master/"
```
The registry location is then stored so that the devfile can be read from the correct location.

**What issues does this PR fix or reference?**
Fixes #13961

**Release Notes**

**Docs PR**