### PR TITLE
Add a possibility to set product version from the product.json

### DIFF
--- a/dashboard/src/components/branding/branding.constant.ts
+++ b/dashboard/src/components/branding/branding.constant.ts
@@ -14,6 +14,7 @@
 export type IBranding = {
   title: string,
   name: string,
+  productVersion?: string;
   logoFile: string,
   logoTextFile: string,
   favicon: string,

--- a/dashboard/src/components/branding/che-branding.ts
+++ b/dashboard/src/components/branding/che-branding.ts
@@ -63,6 +63,7 @@ export class CheBranding {
     return {
       title: this.getProductName(),
       name: this.getName(),
+      productVersion: this.getProductVersion(),
       logoURL: this.getProductLogo(),
       logoText: this.getProductLogoText(),
       favicon: this.getProductFavicon(),
@@ -92,6 +93,13 @@ export class CheBranding {
    */
   getProductName(): string {
     return this.branding.title;
+  }
+
+  /**
+   * Gets product name.
+   */
+  getProductVersion(): string | undefined {
+    return this.branding.productVersion;
   }
 
   /**

--- a/dashboard/src/index.html
+++ b/dashboard/src/index.html
@@ -59,7 +59,7 @@
       <div id="main-content" role="main" ng-view layout="column" flex ng-show="waitingLoaded && !showIDE"></div>
       <ide-iframe id="ide-iframe-window" ng-show="showIDE && ideIframeLink" flex style="height: 100%"></ide-iframe>
       <che-footer che-logo="{{branding.logoURL}}"
-                  che-version="{{productVersion}}"
+                  che-version="{{branding.productVersion ? branding.productVersion : productVersion}}"
                   che-product-name="{{branding.productName}}"
                   ng-show="waitingLoaded && !showIDE">
         {{branding.footer.content}}


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Add a possibility to set product version from the product.json.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16404

Just add **productVersion** into **product.json** and you will see it as a product version of CHE:
``` 
...
"productVersion": "2.1.0.GA (Eclipse Che 7.9.1)",
...
```
And you will see a custom version
![Screenshot from 2020-03-19 19-21-26](https://user-images.githubusercontent.com/6310786/77095758-ffb38000-6a16-11ea-97af-d934c88a717c.png)

Remove  **productVersion** from the **product.json**  and default product version come back:
![Screenshot from 2020-03-19 19-20-20](https://user-images.githubusercontent.com/6310786/77095683-ead6ec80-6a16-11ea-9e56-ad6024ba815d.png)



