### PR TITLE
Referencing to che-dev@eclipse.org in the CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -35,7 +35,7 @@ This Code of Conduct applies both within project spaces and in public spaces
 when an individual is representing the project or its community.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting a project maintainer at info@codenvy.com. All
+reported by contacting a project maintainer at che-dev@eclipse.org. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. Maintainers are
 obligated to maintain confidentiality with regard to the reporter of an


### PR DESCRIPTION
### What does this PR do?
Referencing to che-dev@eclipse.org in the CODE_OF_CONDUCT.md

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/11238


#### Release Notes
N/A

#### Docs PR
N/A
