### PR TITLE
fix workspace count metric

### DIFF
--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -58,6 +58,7 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
     activity.setCreated(createdTimestamp);
     if (activity.getStatus() == null) {
       activity.setStatus(WorkspaceStatus.STOPPED);
+      activity.setLastStopped(createdTimestamp);
     }
   }
 

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -58,7 +58,6 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
     activity.setCreated(createdTimestamp);
     if (activity.getStatus() == null) {
       activity.setStatus(WorkspaceStatus.STOPPED);
-      activity.setLastStopped(createdTimestamp);
     }
   }
 

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -101,6 +101,7 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
           // accordingly already.
           if (a.getStatus() == null) {
             a.setStatus(WorkspaceStatus.STOPPED);
+            a.setLastStopped(createdTimestamp);
           }
         });
   }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -101,7 +101,6 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
           // accordingly already.
           if (a.getStatus() == null) {
             a.setStatus(WorkspaceStatus.STOPPED);
-            a.setLastStopped(createdTimestamp);
           }
         });
   }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -39,7 +39,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
       query =
           "SELECT COUNT(a) FROM WorkspaceActivity a"
               + " WHERE a.status = org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED"
-              + " AND (a.lastStopped <= :time OR a.lastStopped IS NULL)"),
+              + " AND a.lastStopped <= :time"),
   @NamedQuery(
       name = "WorkspaceActivity.getStoppingSince",
       query =

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -39,7 +39,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
       query =
           "SELECT COUNT(a) FROM WorkspaceActivity a"
               + " WHERE a.status = org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED"
-              + " AND a.lastStopped <= :time"),
+              + " AND (a.lastStopped <= :time OR a.lastStopped IS NULL)"),
   @NamedQuery(
       name = "WorkspaceActivity.getStoppingSince",
       query =

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/7.11.0/1__update_inconsistent_stopped_workspace_activities.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/7.11.0/1__update_inconsistent_stopped_workspace_activities.sql
@@ -1,0 +1,15 @@
+--
+-- Copyright (c) 2012-2020 Red Hat, Inc.
+-- This program and the accompanying materials are made
+-- available under the terms of the Eclipse Public License 2.0
+-- which is available at https://www.eclipse.org/legal/epl-2.0/
+--
+-- SPDX-License-Identifier: EPL-2.0
+--
+-- Contributors:
+--   Red Hat, Inc. - initial API and implementation
+--
+
+UPDATE che_workspace_activity
+    SET last_stopped = 0
+    WHERE status = 'STOPPED' AND last_stopped IS NULL;

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/7.11.0/1__update_inconsistent_stopped_workspace_activities.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/7.11.0/1__update_inconsistent_stopped_workspace_activities.sql
@@ -13,5 +13,3 @@
 UPDATE che_workspace_activity
     SET last_stopped = 0
     WHERE status = 'STOPPED' AND last_stopped IS NULL;
-
-ALTER TABLE che_workspace_activity ALTER COLUMN last_stopped SET NOT NULL;

--- a/wsmaster/che-core-sql-schema/src/main/resources/che-schema/7.11.0/1__update_inconsistent_stopped_workspace_activities.sql
+++ b/wsmaster/che-core-sql-schema/src/main/resources/che-schema/7.11.0/1__update_inconsistent_stopped_workspace_activities.sql
@@ -13,3 +13,5 @@
 UPDATE che_workspace_activity
     SET last_stopped = 0
     WHERE status = 'STOPPED' AND last_stopped IS NULL;
+
+ALTER TABLE che_workspace_activity ALTER COLUMN last_stopped SET NOT NULL;


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fixes the workspace count metrics that didn't count created and not-yet started workspaces.

The cause of this issue is that when we create new workspace, we set it's status activity as STOPPED but `lastStopped` remains null. Then this query https://github.com/eclipse/che/blob/master/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java#L38 which is counting the workspaces in stopped state does not pass the second condition and these workspaces are not counted.

:warning: This patch fixes the issue for newly created workspaces, because it fixes the creation process. The workspaces that are already created and never started will remain uncounted. Is that an issue?

Alternative fix might be to update the query to `AND (a.lastStopped <= :time OR a.lastStopped == NULL)`

Another alternative fix of grafana dashboard number would be to create new method, probably in `WorkspaceDao`, to provide simple workspace count. Currently we're doing 4 queries for each status and displaying sum of them on Grafana dashboard. Even if we decide do to it with new method, this patch is still valid IMO.

WDYT?


### What issue does this PR fix
https://github.com/eclipse/che/issues/13226