### PR TITLE
[Selenium] Login to Che by Openshift OAuth

### DIFF
--- a/tests/e2e/pageobjects/login/RegularUserOcpCheLoginPage.ts
+++ b/tests/e2e/pageobjects/login/RegularUserOcpCheLoginPage.ts
@@ -26,21 +26,29 @@ export class RegularUserOcpCheLoginPage implements ICheLoginPage {
     async login() {
         Logger.debug('RegularUserOcpCheLoginPage.login');
 
-        await this.ocpLogin.clickOnLoginProviderTitle();
+        if (await this.ocpLogin.isIdentityProviderLinkVisible()) {
+            await this.ocpLogin.clickOnLoginWitnHtpasswd();
+        }
+
         await this.ocpLogin.waitOpenShiftLoginWelcomePage();
         await this.ocpLogin.enterUserNameOpenShift(TestConstants.TS_SELENIUM_OCP_USERNAME);
         await this.ocpLogin.enterPasswordOpenShift(TestConstants.TS_SELENIUM_OCP_PASSWORD);
         await this.ocpLogin.clickOnLoginButton();
         await this.ocpLogin.waitDisappearanceOpenShiftLoginWelcomePage();
-        await this.ocpLogin.waitAuthorizeOpenShiftIdentityProviderPage();
-        await this.ocpLogin.clickOnApproveAuthorizeAccessButton();
 
-        await this.cheLogin.waitFirstBrokerLoginPage();
-        await this.cheLogin.enterEmailFirstBrokerLoginPage(TestConstants.TS_SELENIUM_EMAIL_USER);
-        await this.cheLogin.enterFirstNameBrokerLoginPage(TestConstants.TS_SELENIUM_FIRST_NAME);
-        await this.cheLogin.enterLastNameBrokerLoginPage(TestConstants.TS_SELENIUM_LAST_NAME);
-        await this.cheLogin.clickOnSubmitButton();
-        await this.cheLogin.waitDisappearanceBrokerLoginPage();
+        if (await this.ocpLogin.isAuthorizeOpenShiftIdentityProviderPageVisible()) {
+            await this.ocpLogin.waitAuthorizeOpenShiftIdentityProviderPage();
+            await this.ocpLogin.clickOnApproveAuthorizeAccessButton();
+        }
+
+        if (await this.cheLogin.isFirstBrokerLoginPageVisible()) {
+            await this.cheLogin.waitFirstBrokerLoginPage();
+            await this.cheLogin.enterEmailFirstBrokerLoginPage(TestConstants.TS_SELENIUM_EMAIL_USER);
+            await this.cheLogin.enterFirstNameBrokerLoginPage(TestConstants.TS_SELENIUM_FIRST_NAME);
+            await this.cheLogin.enterLastNameBrokerLoginPage(TestConstants.TS_SELENIUM_LAST_NAME);
+            await this.cheLogin.clickOnSubmitButton();
+            await this.cheLogin.waitDisappearanceBrokerLoginPage();
+        }
     }
 
 }

--- a/tests/e2e/pageobjects/openshift/CheLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/CheLoginPage.ts
@@ -44,6 +44,12 @@ export class CheLoginPage {
         await this.driverHelper.waitAndClick(By.id('kc-login'));
     }
 
+    async isFirstBrokerLoginPageVisible(): Promise<boolean> {
+        Logger.debug('CheLoginPage.waitFirstBrokerLoginPage');
+
+        return await this.driverHelper.isVisible(By.id('kc-update-profile-form'));
+    }
+
     async waitFirstBrokerLoginPage() {
         Logger.debug('CheLoginPage.waitFirstBrokerLoginPage');
 

--- a/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
@@ -32,7 +32,7 @@ export class OcpLoginPage {
     async waitOpenShiftLoginWelcomePage() {
         Logger.debug('OcpLoginPage.waitOpenShiftLoginWelcomePage');
 
-        await this.driverHelper.waitVisibility(By.xpath(OcpLoginPage.LOGIN_PAGE_OPENSHIFT_XPATH));
+        await this.driverHelper.waitVisibility(By.xpath(OcpLoginPage.LOGIN_PAGE_OPENSHIFT_XPATH), 30000);
     }
 
     async clickOnLoginProviderTitle() {
@@ -40,6 +40,27 @@ export class OcpLoginPage {
 
         const loginProviderTitleLocator: By = By.css(`a[title=\'Log in with ${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
         await this.driverHelper.waitAndClick(loginProviderTitleLocator);
+    }
+
+    async isIdentityProviderLinkVisible(): Promise<boolean> {
+        Logger.debug('OcpLoginPage.isIdentityProviderLinkVisible');
+
+        const loginWithHtpaswdLocator: By = By.css('a[title=\'Log in with htpasswd\']');
+        return await this.driverHelper.isVisible(loginWithHtpaswdLocator);
+    }
+
+    async clickOnLoginWitnHtpasswd() {
+        Logger.debug('OcpLoginPage.clickOnLoginWitnHtpasswd');
+
+        const loginWithHtpaswdLocator: By = By.css('a[title=\'Log in with htpasswd\']');
+        await this.driverHelper.waitAndClick(loginWithHtpaswdLocator);
+    }
+
+    async isAuthorizeOpenShiftIdentityProviderPageVisible(): Promise<boolean> {
+        Logger.debug('OcpLoginPage.isAuthorizeOpenShiftIdentityProviderPageVisible');
+
+        const authorizeOpenshiftIdentityProviderPageLocator: By = By.xpath('//h1[text()=\'Authorize Access\']');
+        return await this.driverHelper.isVisible(authorizeOpenshiftIdentityProviderPageLocator);
     }
 
     async waitAuthorizeOpenShiftIdentityProviderPage() {

--- a/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
@@ -32,7 +32,7 @@ export class OcpLoginPage {
     async waitOpenShiftLoginWelcomePage() {
         Logger.debug('OcpLoginPage.waitOpenShiftLoginWelcomePage');
 
-        await this.driverHelper.waitVisibility(By.xpath(OcpLoginPage.LOGIN_PAGE_OPENSHIFT_XPATH), 30000);
+        await this.driverHelper.waitVisibility(By.xpath(OcpLoginPage.LOGIN_PAGE_OPENSHIFT_XPATH));
     }
 
     async clickOnLoginProviderTitle() {
@@ -46,7 +46,7 @@ export class OcpLoginPage {
         Logger.debug('OcpLoginPage.isIdentityProviderLinkVisible');
 
         const loginWithHtpaswdLocator: By = By.css('a[title=\'Log in with htpasswd\']');
-        return await this.driverHelper.isVisible(loginWithHtpaswdLocator);
+        return await this.driverHelper.waitVisibilityBoolean(loginWithHtpaswdLocator, 3, 5000);
     }
 
     async clickOnLoginWitnHtpasswd() {


### PR DESCRIPTION
### What does this PR do?
We need to run E2E typescript selenium tests against Eclipse Che deployed to OCP with Openshift OAuth option enabled.

Test uses next properties for new user creation:
- TS_SELENIUM_EMAIL_USER: process.env.TS_SELENIUM_EMAIL_USER || 'test@test.com'
- TS_SELENIUM_FIRST_NAME: process.env.TS_SELENIUM_FIRST_NAME || 'qa'
- TS_SELENIUM_LAST_NAME: process.env.TS_SELENIUM_LAST_NAME || 'test'

And next property to determine how to login in installed application:
- TS_SELENIUM_VALUE_OPENSHIFT_OAUTH="true"

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15585