### PR TITLE
Add warning notifier for non-TLS installation mode

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -74,6 +74,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtprox
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyConfigBuilderFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxyProvisionerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxySecureServerExposerFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.NonTlsDistributedClusterModeNotifier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesPluginsToolingApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.PluginBrokerManager;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.SidecarToolingProvisioner;
@@ -228,5 +229,7 @@ public class KubernetesInfraModule extends AbstractModule {
     // to kubernetes, we just call this in a way that initializes the binding with an empty map.
     KubernetesDevfileBindings.addAllowedEnvironmentTypeUpgradeBindings(
         binder(), KubernetesEnvironment.TYPE);
+
+    bind(NonTlsDistributedClusterModeNotifier.class);
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/NonTlsDistributedClusterModeNotifier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/NonTlsDistributedClusterModeNotifier.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.util;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.util.ApiInfoLogInformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Singleton
+public class NonTlsDistributedClusterModeNotifier {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ApiInfoLogInformer.class);
+
+  private final boolean isTlsEnabled;
+
+  @Inject
+  public NonTlsDistributedClusterModeNotifier(
+      @Named("che.infra.kubernetes.tls_enabled") boolean isTlsEnabled) {
+    this.isTlsEnabled = isTlsEnabled;
+  }
+
+  @PostConstruct
+  public void printWarnOnStartup() {
+    if (!isTlsEnabled) {
+      LOG.warn(
+          "Eclipse Che deployed on non-TLS mode. This may cause client-side problems opening workspaces on multi-cluster installations."
+              + " See https://eclipse.org/che/docs/che-7/introduction-to-eclipse-che/#problems-opening-workspace-in-newest-chrome-versions-on-non-tls-installations-on-distributed-clusters for details.");
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/NonTlsDistributedClusterModeNotifier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/NonTlsDistributedClusterModeNotifier.java
@@ -19,9 +19,7 @@ import org.eclipse.che.api.core.util.ApiInfoLogInformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Prints warning into logs on startup when Che is running in non-TLS mode.
- */
+/** Prints warning into logs on startup when Che is running in non-TLS mode. */
 @Singleton
 public class NonTlsDistributedClusterModeNotifier {
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/NonTlsDistributedClusterModeNotifier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/NonTlsDistributedClusterModeNotifier.java
@@ -19,6 +19,9 @@ import org.eclipse.che.api.core.util.ApiInfoLogInformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Prints warning into logs on startup when Che is running in non-TLS mode.
+ */
 @Singleton
 public class NonTlsDistributedClusterModeNotifier {
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -71,6 +71,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtprox
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyConfigBuilderFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxyProvisionerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxySecureServerExposerFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.NonTlsDistributedClusterModeNotifier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesPluginsToolingApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.PluginBrokerManager;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.SidecarToolingProvisioner;
@@ -220,5 +221,6 @@ public class OpenShiftInfraModule extends AbstractModule {
 
     bind(ExternalServiceExposureStrategy.class).to(OpenShiftServerExposureStrategy.class);
     bind(CookiePathStrategy.class).to(OpenShiftCookiePathStrategy.class);
+    bind(NonTlsDistributedClusterModeNotifier.class);
   }
 }


### PR DESCRIPTION
# What does this PR do?
Add notifier which print warning on startup when Che deployed in non-TLS mode.
See https://github.com/eclipse/che/issues/16384 for detail.

### What issues does this PR fix or reference?
#16384 

