### PR TITLE
Allow configuring ImagePullPolicy for some workspace components

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -334,7 +334,7 @@ che.infra.kubernetes.pvc.quantity=10Gi
 # Pod that is launched when performing persistent volume claim maintenance jobs on OpenShift
 che.infra.kubernetes.pvc.jobs.image=centos:centos7
 
-# Image pull police of container that used for the maintenance jobs on OpenShift
+# Image pull policy of container that used for the maintenance jobs on Kubernetes/OpenShift cluster
 che.infra.kubernetes.pvc.jobs.image.pull_policy=IfNotPresent
 
 # Defines pod memory limit for persistent volume claim maintenance jobs

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -334,6 +334,9 @@ che.infra.kubernetes.pvc.quantity=10Gi
 # Pod that is launched when performing persistent volume claim maintenance jobs on OpenShift
 che.infra.kubernetes.pvc.jobs.image=centos:centos7
 
+# Image pull police of container that used for the maintenance jobs on OpenShift
+che.infra.kubernetes.pvc.jobs.image.pull_policy=IfNotPresent
+
 # Defines pod memory limit for persistent volume claim maintenance jobs
 che.infra.kubernetes.pvc.jobs.memorylimit=250Mi
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
@@ -71,13 +71,16 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
   static final String CHE_COMPONENT_NAME_LABEL = "che.component.name";
 
   private final String projectFolderPath;
+  private final String imagePullPolicy;
   private final KubernetesEnvironmentProvisioner k8sEnvProvisioner;
 
   @Inject
   public DockerimageComponentToWorkspaceApplier(
       @Named("che.workspace.projects.storage") String projectFolderPath,
+      @Named("che.workspace.sidecar.image_pull_policy") String imagePullPolicy,
       KubernetesEnvironmentProvisioner k8sEnvProvisioner) {
     this.projectFolderPath = projectFolderPath;
+    this.imagePullPolicy = imagePullPolicy;
     this.k8sEnvProvisioner = k8sEnvProvisioner;
   }
 
@@ -187,6 +190,7 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
     Container container =
         new ContainerBuilder()
             .withImage(image)
+            .withImagePullPolicy(imagePullPolicy)
             .withName(name)
             .withEnv(env)
             .withCommand(command)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
@@ -70,6 +70,7 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
   private final String environmentType;
   private final String projectFolderPath;
   private final String defaultProjectPVCSize;
+  private final String imagePullPolicy;
   private final Set<String> kubernetesBasedComponentTypes;
   private final String defaultPVCAccessMode;
   private final String pvcStorageClassName;
@@ -84,6 +85,7 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
       @Named("che.workspace.projects.storage.default.size") String defaultProjectPVCSize,
       @Named("che.infra.kubernetes.pvc.access_mode") String defaultPVCAccessMode,
       @Named("che.infra.kubernetes.pvc.storage_class_name") String pvcStorageClassName,
+      @Named("che.workspace.sidecar.image_pull_policy") String imagePullPolicy,
       @Named(KUBERNETES_BASED_COMPONENTS_KEY_NAME) Set<String> kubernetesBasedComponentTypes) {
     this(
         objectsParser,
@@ -94,6 +96,7 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
         defaultProjectPVCSize,
         defaultPVCAccessMode,
         pvcStorageClassName,
+        imagePullPolicy,
         kubernetesBasedComponentTypes);
   }
 
@@ -106,6 +109,7 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
       String defaultProjectPVCSize,
       String defaultPVCAccessMode,
       String pvcStorageClassName,
+      String imagePullPolicy,
       Set<String> kubernetesBasedComponentTypes) {
     this.objectsParser = objectsParser;
     this.k8sEnvProvisioner = k8sEnvProvisioner;
@@ -114,6 +118,7 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
     this.defaultProjectPVCSize = defaultProjectPVCSize;
     this.defaultPVCAccessMode = defaultPVCAccessMode;
     this.pvcStorageClassName = pvcStorageClassName;
+    this.imagePullPolicy = imagePullPolicy;
     this.kubernetesBasedComponentTypes = kubernetesBasedComponentTypes;
     this.envVars = envVars;
   }
@@ -154,6 +159,11 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
     }
 
     List<PodData> podsData = getPodDatas(componentObjects);
+
+    podsData
+        .stream()
+        .flatMap(e -> e.getSpec().getContainers().stream())
+        .forEach(c -> c.setImagePullPolicy(imagePullPolicy));
 
     if (Boolean.TRUE.equals(k8sComponent.getMountSources())) {
       applyProjectsVolumes(podsData, componentObjects);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelper.java
@@ -75,7 +75,6 @@ public class PVCSubPathHelper {
   static final String[] RM_COMMAND_BASE = new String[] {"rm", "-rf"};
   static final String[] MKDIR_COMMAND_BASE = new String[] {"mkdir", "-m", "777", "-p"};
 
-  static final String IMAGE_PULL_POLICY = "IfNotPresent";
   static final String POD_RESTART_POLICY = "Never";
   static final String POD_PHASE_SUCCEEDED = "Succeeded";
   static final String POD_PHASE_FAILED = "Failed";
@@ -83,6 +82,7 @@ public class PVCSubPathHelper {
 
   private final String jobImage;
   private final String jobMemoryLimit;
+  private final String imagePullPolicy;
   private final KubernetesNamespaceFactory factory;
   private final ExecutorService executor;
   private final RuntimeEventsPublisher eventsPublisher;
@@ -93,12 +93,14 @@ public class PVCSubPathHelper {
   PVCSubPathHelper(
       @Named("che.infra.kubernetes.pvc.jobs.memorylimit") String jobMemoryLimit,
       @Named("che.infra.kubernetes.pvc.jobs.image") String jobImage,
+      @Named("che.infra.kubernetes.pvc.jobs.image.pull_policy") String imagePullPolicy,
       KubernetesNamespaceFactory factory,
       SecurityContextProvisioner securityContextProvisioner,
       ExecutorServiceWrapper executorServiceWrapper,
       RuntimeEventsPublisher eventPublisher) {
     this.jobMemoryLimit = jobMemoryLimit;
     this.jobImage = jobImage;
+    this.imagePullPolicy = imagePullPolicy;
     this.factory = factory;
     this.securityContextProvisioner = securityContextProvisioner;
     this.eventsPublisher = eventPublisher;
@@ -294,7 +296,7 @@ public class PVCSubPathHelper {
         new ContainerBuilder()
             .withName(podName)
             .withImage(jobImage)
-            .withImagePullPolicy(IMAGE_PULL_POLICY)
+            .withImagePullPolicy(imagePullPolicy)
             .withCommand(command)
             .withVolumeMounts(newVolumeMount(pvcName, JOB_MOUNT_PATH, null))
             .withNewResources()

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
@@ -83,7 +83,8 @@ public class DockerimageComponentToWorkspaceApplierTest {
   @BeforeMethod
   public void setUp() throws Exception {
     dockerimageComponentApplier =
-        new DockerimageComponentToWorkspaceApplier(PROJECTS_MOUNT_PATH, k8sEnvProvisioner);
+        new DockerimageComponentToWorkspaceApplier(
+            PROJECTS_MOUNT_PATH, "Always", k8sEnvProvisioner);
     workspaceConfig = new WorkspaceConfigImpl();
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
@@ -127,8 +127,48 @@ public class DockerimageComponentToWorkspaceApplierTest {
     Container container = podTemplate.getSpec().getContainers().get(0);
     assertEquals(container.getName(), "jdk");
     assertEquals(container.getImage(), "eclipse/ubuntu_jdk8:latest");
+    assertEquals(container.getImagePullPolicy(), "Always");
 
     assertEquals(Names.machineName(podMeta, container), "jdk");
+  }
+
+  @Test
+  public void shouldBeAbleToSetupSpecificImagePullPolicy() throws DevfileException {
+    ComponentImpl dockerimageComponent = new ComponentImpl();
+    dockerimageComponent.setType(DOCKERIMAGE_COMPONENT_TYPE);
+    dockerimageComponent.setImage("eclipse/ubuntu_jdk8:latest");
+    dockerimageComponent.setMemoryLimit("1G");
+    dockerimageComponentApplier =
+        new DockerimageComponentToWorkspaceApplier(PROJECTS_MOUNT_PATH, "Never", k8sEnvProvisioner);
+
+    // when
+    dockerimageComponentApplier.apply(workspaceConfig, dockerimageComponent, null);
+
+    // then
+    verify(k8sEnvProvisioner)
+        .provision(
+            any(),
+            eq(KubernetesEnvironment.TYPE),
+            objectsCaptor.capture(),
+            machinesCaptor.capture());
+    MachineConfigImpl machineConfig = machinesCaptor.getValue().get("eclipse-ubuntu_jdk8-latest");
+    assertNotNull(machineConfig);
+
+    List<HasMetadata> objects = objectsCaptor.getValue();
+    assertEquals(objects.size(), 1);
+    assertTrue(objects.get(0) instanceof Deployment);
+    Deployment deployment = (Deployment) objects.get(0);
+    PodTemplateSpec podTemplate = deployment.getSpec().getTemplate();
+    ObjectMeta podMeta = podTemplate.getMetadata();
+    assertEquals(podMeta.getName(), "eclipse-ubuntu_jdk8-latest");
+
+    Map<String, String> deploymentSelector = deployment.getSpec().getSelector().getMatchLabels();
+    assertFalse(deploymentSelector.isEmpty());
+    assertTrue(podMeta.getLabels().entrySet().containsAll(deploymentSelector.entrySet()));
+
+    Container container = podTemplate.getSpec().getContainers().get(0);
+    assertEquals(container.getName(), "eclipse-ubuntu_jdk8-latest");
+    assertEquals(container.getImagePullPolicy(), "Never");
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
@@ -97,6 +97,7 @@ public class KubernetesComponentToWorkspaceApplierTest {
             "1Gi",
             "ReadWriteOnce",
             "",
+            "Always",
             k8sBasedComponents);
 
     workspaceConfig = new WorkspaceConfigImpl();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
@@ -83,9 +83,11 @@ public class KubernetesComponentToWorkspaceApplierTest {
 
   @Captor private ArgumentCaptor<List<HasMetadata>> objectsCaptor;
 
+  private Set<String> k8sBasedComponents;
+
   @BeforeMethod
   public void setUp() {
-    Set<String> k8sBasedComponents = new HashSet<>();
+    k8sBasedComponents = new HashSet<>();
     k8sBasedComponents.add(KUBERNETES_COMPONENT_TYPE);
     k8sBasedComponents.add("openshift"); // so that we can work with the petclinic.yaml
     applier =
@@ -181,12 +183,11 @@ public class KubernetesComponentToWorkspaceApplierTest {
     applier.apply(workspaceConfig, component, s -> yamlRecipeContent);
 
     // then
+    KubernetesList list = toK8SList(yamlRecipeContent);
+    replaceImagePullPolicy(list, "Always");
     verify(k8sEnvProvisioner)
         .provision(
-            eq(workspaceConfig),
-            eq(KubernetesEnvironment.TYPE),
-            eq(toK8SList(yamlRecipeContent).getItems()),
-            anyMap());
+            eq(workspaceConfig), eq(KubernetesEnvironment.TYPE), eq(list.getItems()), anyMap());
   }
 
   @Test
@@ -201,12 +202,12 @@ public class KubernetesComponentToWorkspaceApplierTest {
 
     applier.apply(workspaceConfig, component, new URLFileContentProvider(null, null));
 
+    KubernetesList list = toK8SList(yamlRecipeContent);
+    replaceImagePullPolicy(list, "Always");
+
     verify(k8sEnvProvisioner)
         .provision(
-            eq(workspaceConfig),
-            eq(KubernetesEnvironment.TYPE),
-            eq(toK8SList(yamlRecipeContent).getItems()),
-            anyMap());
+            eq(workspaceConfig), eq(KubernetesEnvironment.TYPE), eq(list.getItems()), anyMap());
   }
 
   @Test
@@ -255,6 +256,7 @@ public class KubernetesComponentToWorkspaceApplierTest {
                                 .getClaimName()
                                 .equals(PROJECTS_VOLUME_NAME)));
         for (Container c : p.getSpec().getContainers()) {
+          assertEquals(c.getImagePullPolicy(), "Always");
           assertTrue(
               c.getVolumeMounts()
                   .stream()
@@ -456,8 +458,61 @@ public class KubernetesComponentToWorkspaceApplierTest {
     }
   }
 
+  @Test
+  public void shouldBeAbleToOverrideImagePullPolicy() throws Exception {
+    // given
+    applier =
+        new KubernetesComponentToWorkspaceApplier(
+            k8sRecipeParser,
+            k8sEnvProvisioner,
+            envVars,
+            PROJECT_MOUNT_PATH,
+            "1Gi",
+            "ReadWriteOnce",
+            "",
+            "Never",
+            k8sBasedComponents);
+    String yamlRecipeContent = getResource("devfile/petclinic.yaml");
+    doReturn(toK8SList(yamlRecipeContent).getItems()).when(k8sRecipeParser).parse(anyString());
+    List<String> command = asList("teh", "command");
+    ComponentImpl component = new ComponentImpl();
+    component.setType(KUBERNETES_COMPONENT_TYPE);
+    component.setReference(REFERENCE_FILENAME);
+    component.setAlias(COMPONENT_NAME);
+
+    // when
+    applier.apply(workspaceConfig, component, s -> yamlRecipeContent);
+
+    // then
+    verify(k8sEnvProvisioner).provision(any(), any(), objectsCaptor.capture(), any());
+    List<HasMetadata> list = objectsCaptor.getValue();
+    for (HasMetadata o : list) {
+      if (o instanceof Pod) {
+        Pod p = (Pod) o;
+
+        // ignore pods that don't have containers
+        if (p.getSpec() == null) {
+          continue;
+        }
+        for (Container con : p.getSpec().getContainers()) {
+          assertEquals(con.getImagePullPolicy(), "Never");
+        }
+      }
+    }
+  }
+
   private KubernetesList toK8SList(String content) {
     return unmarshal(content, KubernetesList.class);
+  }
+
+  private void replaceImagePullPolicy(KubernetesList list, String imagePullPolicy) {
+    list.getItems()
+        .stream()
+        .filter(item -> item instanceof Pod)
+        .map(item -> (Pod) item)
+        .filter(pod -> pod.getSpec() != null)
+        .flatMap(pod -> pod.getSpec().getContainers().stream())
+        .forEach(c -> c.setImagePullPolicy(imagePullPolicy));
   }
 
   private String getResource(String resourceName) throws IOException {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
@@ -34,6 +34,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodStatus;
 import io.fabric8.kubernetes.api.model.Quantity;
@@ -129,6 +130,10 @@ public class PVCSubPathHelperTest {
 
     verify(osDeployments).create(podCaptor.capture());
     final List<String> actual = podCaptor.getValue().getSpec().getContainers().get(0).getCommand();
+
+    for (Container container : podCaptor.getValue().getSpec().getContainers()) {
+      assertEquals(container.getImagePullPolicy(), "IfNotPresent");
+    }
     final List<String> expected =
         Stream.concat(
                 Arrays.stream(MKDIR_COMMAND_BASE),
@@ -231,5 +236,28 @@ public class PVCSubPathHelperTest {
     verify(osDeployments).wait(anyString(), anyInt(), any());
     verify(podStatus).getPhase();
     verify(osDeployments).delete(anyString());
+  }
+
+  @Test
+  public void shouldBeAbleToConfigureImagePullPolicy() throws InfrastructureException {
+    // given
+    pvcSubPathHelper =
+        new PVCSubPathHelper(
+            jobMemoryLimit,
+            jobImage,
+            "ToBeOrNotIfPresent",
+            k8sNamespaceFactory,
+            securityContextProvisioner,
+            new NoopExecutorServiceWrapper(),
+            eventsPublisher);
+    // when
+    pvcSubPathHelper.execute(
+        WORKSPACE_ID, NAMESPACE, PVC_NAME, MKDIR_COMMAND_BASE, WORKSPACE_ID + PROJECTS_PATH);
+
+    // then
+    verify(osDeployments).create(podCaptor.capture());
+    for (Container container : podCaptor.getValue().getSpec().getContainers()) {
+      assertEquals(container.getImagePullPolicy(), "ToBeOrNotIfPresent");
+    }
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/PVCSubPathHelperTest.java
@@ -93,6 +93,7 @@ public class PVCSubPathHelperTest {
         new PVCSubPathHelper(
             jobMemoryLimit,
             jobImage,
+            "IfNotPresent",
             k8sNamespaceFactory,
             securityContextProvisioner,
             new NoopExecutorServiceWrapper(),

--- a/infrastructures/kubernetes/src/test/resources/devfile/petclinic.yaml
+++ b/infrastructures/kubernetes/src/test/resources/devfile/petclinic.yaml
@@ -66,6 +66,7 @@ items:
   spec:
       containers:
       - name: server
+        imagePullPolicy: Always
         image: test/petclinic
         ports:
         - containerPort: 8080

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplier.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplier.java
@@ -32,6 +32,7 @@ public class OpenshiftComponentToWorkspaceApplier extends KubernetesComponentToW
       @Named("che.workspace.projects.storage.default.size") String defaultProjectPVCSize,
       @Named("che.infra.kubernetes.pvc.access_mode") String defaultPVCAccessMode,
       @Named("che.infra.kubernetes.pvc.storage_class_name") String pvcStorageClassName,
+      @Named("che.workspace.sidecar.image_pull_policy") String imagePullPolicy,
       @Named(KUBERNETES_BASED_COMPONENTS_KEY_NAME) Set<String> kubernetesBasedComponentTypes) {
     super(
         objectsParser,
@@ -42,6 +43,7 @@ public class OpenshiftComponentToWorkspaceApplier extends KubernetesComponentToW
         defaultProjectPVCSize,
         defaultPVCAccessMode,
         pvcStorageClassName,
+        imagePullPolicy,
         kubernetesBasedComponentTypes);
   }
 }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/devfile/OpenshiftComponentToWorkspaceApplierTest.java
@@ -58,6 +58,7 @@ public class OpenshiftComponentToWorkspaceApplierTest {
             "1Gi",
             "ReadWriteOnce",
             "",
+            "Always",
             k8sBasedComponents);
 
     workspaceConfig = new WorkspaceConfigImpl();


### PR DESCRIPTION
### What does this PR do?
Allow configuring ImagePullPolicy for some workspace components

- Added  new property `che.infra.kubernetes.pvc.jobs.image.pull_policy=IfNotPresent` to configure Image pull policy of container that used for the maintenance jobs on Kubernetes/OpenShift cluster
- `che.workspace.sidecar.image_pull_policy` is used for container of 'dockerImage` and `k8` components.

### What issues does this PR fix or reference?
#16448 

#### Release Notes
n/a

#### Docs PR
n/a