### PR TITLE
Update plugin brokers to v3.1.2

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -416,7 +416,7 @@ che.infra.kubernetes.pod.termination_grace_period_sec=0
 # (http requests or ongoing  web socket calls)
 # supported in the underlying shared http client
 # of the `KubernetesClient` instances.
-# Default values are 64, and 5 per-host, which 
+# Default values are 64, and 5 per-host, which
 # doesn't seem correct for multi-user scenarios
 # knowing that Che keeps a number of connections
 # opened (e.g. for command or ws-agent logs)
@@ -492,8 +492,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.metadata.image=quay.io/eclipse/che-plugin-metadata-broker:v3.1.1
-che.workspace.plugin_broker.artifacts.image=quay.io/eclipse/che-plugin-artifacts-broker:v3.1.1
+che.workspace.plugin_broker.metadata.image=quay.io/eclipse/che-plugin-metadata-broker:v3.1.2
+che.workspace.plugin_broker.artifacts.image=quay.io/eclipse/che-plugin-artifacts-broker:v3.1.2
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
### What does this PR do?
The plugin brokers [v3.1.2](https://github.com/eclipse/che-plugin-broker/releases/tag/v3.1.2) contains fix which prevents them
to crash when userID contains colon

v3.1.2 images could be checked in:
https://quay.io/repository/eclipse/che-plugin-metadata-broker?tab=tags
https://quay.io/repository/eclipse/che-plugin-artifacts-broker?tab=tags

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/15013

#### Release Notes
N/A

#### Docs PR
N/A