### PR TITLE
[Selenium] Use TS_OCP_LOGIN_PAGE_PROVIDER_TITLE constant for identity provider name

### DIFF
--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -148,7 +148,7 @@ export const TestConstants = {
     /**
      * Log into OCP by using appropriate provider title.
      */
-    TS_OCP_LOGIN_PAGE_PROVIDER_TITLE: process.env.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE || 'htpasswd',
+    TS_OCP_LOGIN_PAGE_PROVIDER_TITLE: process.env.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE || '',
 
     /**
      * Log into CHE in MultiUser mode, "false" by default.

--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -148,7 +148,7 @@ export const TestConstants = {
     /**
      * Log into OCP by using appropriate provider title.
      */
-    TS_OCP_LOGIN_PAGE_PROVIDER_TITLE: process.env.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE || '',
+    TS_OCP_LOGIN_PAGE_PROVIDER_TITLE: process.env.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE || 'htpasswd',
 
     /**
      * Log into CHE in MultiUser mode, "false" by default.

--- a/tests/e2e/pageobjects/login/RegularUserOcpCheLoginPage.ts
+++ b/tests/e2e/pageobjects/login/RegularUserOcpCheLoginPage.ts
@@ -27,7 +27,7 @@ export class RegularUserOcpCheLoginPage implements ICheLoginPage {
         Logger.debug('RegularUserOcpCheLoginPage.login');
 
         if (await this.ocpLogin.isIdentityProviderLinkVisible()) {
-            await this.ocpLogin.clickOnLoginWitnHtpasswd();
+            await this.ocpLogin.clickOnLoginProviderTitle();
         }
 
         await this.ocpLogin.waitOpenShiftLoginWelcomePage();

--- a/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
@@ -45,15 +45,8 @@ export class OcpLoginPage {
     async isIdentityProviderLinkVisible(): Promise<boolean> {
         Logger.debug('OcpLoginPage.isIdentityProviderLinkVisible');
 
-        const loginWithHtpaswdLocator: By = By.css('a[title=\'Log in with htpasswd\']');
+        const loginWithHtpaswdLocator: By = By.css(`a[title=\'Log in with ${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
         return await this.driverHelper.waitVisibilityBoolean(loginWithHtpaswdLocator, 3, 5000);
-    }
-
-    async clickOnLoginWitnHtpasswd() {
-        Logger.debug('OcpLoginPage.clickOnLoginWitnHtpasswd');
-
-        const loginWithHtpaswdLocator: By = By.css('a[title=\'Log in with htpasswd\']');
-        await this.driverHelper.waitAndClick(loginWithHtpaswdLocator);
     }
 
     async isAuthorizeOpenShiftIdentityProviderPageVisible(): Promise<boolean> {


### PR DESCRIPTION
### What does this PR do?
Use ```TS_OCP_LOGIN_PAGE_PROVIDER_TITLE```  constant for Openshift identity provider name
 in typescript selenium tests.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15585
