### PR TITLE
cleanup before workspace start

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -186,6 +186,8 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
       startSynchronizer.setStartThread();
       startSynchronizer.start();
 
+      namespace.cleanUp();
+
       // Tooling side car provisioner should be applied before other provisioners
       // because new machines may be provisioned there
       toolingProvisioner.provision(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -410,6 +410,7 @@ public class KubernetesInternalRuntimeTest {
     verify(services).create(any());
     verify(secrets).create(any());
     verify(configMaps).create(any());
+    verify(namespace).cleanUp();
     verify(namespace.deployments(), times(1)).watchEvents(any());
     verify(eventService, times(4)).publish(any());
     verifyOrderedEventsChains(
@@ -617,7 +618,7 @@ public class KubernetesInternalRuntimeTest {
     try {
       internalRuntime.start(emptyMap());
     } catch (Exception rethrow) {
-      verify(namespace).cleanUp();
+      verify(namespace, times(2)).cleanUp();
       verify(namespace, never()).services();
       verify(namespace, never()).ingresses();
       throw rethrow;
@@ -663,7 +664,7 @@ public class KubernetesInternalRuntimeTest {
     try {
       internalRuntime.start(emptyMap());
     } catch (Exception rethrow) {
-      verify(namespace).cleanUp();
+      verify(namespace, times(2)).cleanUp();
       verify(namespace).services();
       verify(namespace, never()).ingresses();
       throw rethrow;

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -142,7 +142,9 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.SidecarTool
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
 import org.testng.annotations.BeforeMethod;
@@ -420,6 +422,19 @@ public class KubernetesInternalRuntimeTest {
     verify(serverCheckerFactory).create(IDENTITY, M2_NAME, emptyMap());
     verify(serversChecker, times(2)).startAsync(any());
     verify(namespace.deployments(), times(1)).stopWatch();
+  }
+
+  @Test
+  public void testCleanupHappensFirst() throws InfrastructureException {
+    internalRuntime.start(emptyMap());
+
+    InOrder cleanupInOrderExecutionVerification =
+        Mockito.inOrder(namespace, deployments, toolingProvisioner);
+    cleanupInOrderExecutionVerification.verify(namespace).cleanUp();
+    cleanupInOrderExecutionVerification
+        .verify(toolingProvisioner)
+        .provision(any(), any(), any(), any());
+    cleanupInOrderExecutionVerification.verify(deployments).deploy(any(Pod.class));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Cleanup workspace objects before start to avoid failures when creating.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16418

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
