### PR TITLE
Prevent ArrayIndexOutOfBoundsException in HeaderRequestTokenExtractor 

### DIFF
--- a/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractor.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractor.java
@@ -12,17 +12,25 @@
 package org.eclipse.che.multiuser.api.authentication.commons.token;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.HttpHeaders;
 
 /** Extract sso token from request headers. */
 public class HeaderRequestTokenExtractor implements RequestTokenExtractor {
+
   @Override
   public String getToken(HttpServletRequest req) {
     if (req.getHeader(HttpHeaders.AUTHORIZATION) == null) {
       return null;
     }
-    return req.getHeader(HttpHeaders.AUTHORIZATION).toLowerCase().startsWith("bearer")
-        ? req.getHeader(HttpHeaders.AUTHORIZATION).split(" ")[1]
-        : req.getHeader(HttpHeaders.AUTHORIZATION);
+    if (req.getHeader(HttpHeaders.AUTHORIZATION).toLowerCase().startsWith("bearer")) {
+      String[] parts = req.getHeader(HttpHeaders.AUTHORIZATION).split(" ");
+      if (parts.length != 2) {
+        throw new BadRequestException("Invalid authorization header format.");
+      }
+      return parts[1];
+    } else {
+      return req.getHeader(HttpHeaders.AUTHORIZATION);
+    }
   }
 }

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractor.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractor.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.che.multiuser.api.authentication.commons.token;
 
-import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.HttpHeaders;
@@ -19,15 +18,13 @@ import javax.ws.rs.core.HttpHeaders;
 /** Extract sso token from request headers. */
 public class HeaderRequestTokenExtractor implements RequestTokenExtractor {
 
-  private static final Pattern splitPattern = Pattern.compile("\\s+");
-
   @Override
   public String getToken(HttpServletRequest req) {
     if (req.getHeader(HttpHeaders.AUTHORIZATION) == null) {
       return null;
     }
     if (req.getHeader(HttpHeaders.AUTHORIZATION).toLowerCase().startsWith("bearer")) {
-      String[] parts = splitPattern.split(req.getHeader(HttpHeaders.AUTHORIZATION));
+      String[] parts = req.getHeader(HttpHeaders.AUTHORIZATION).split(" ");
       if (parts.length != 2) {
         throw new BadRequestException("Invalid authorization header format.");
       }

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractor.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractor.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.multiuser.api.authentication.commons.token;
 
+import java.util.regex.Pattern;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.HttpHeaders;
@@ -18,13 +19,15 @@ import javax.ws.rs.core.HttpHeaders;
 /** Extract sso token from request headers. */
 public class HeaderRequestTokenExtractor implements RequestTokenExtractor {
 
+  private static final Pattern splitPattern = Pattern.compile("\\s+");
+
   @Override
   public String getToken(HttpServletRequest req) {
     if (req.getHeader(HttpHeaders.AUTHORIZATION) == null) {
       return null;
     }
     if (req.getHeader(HttpHeaders.AUTHORIZATION).toLowerCase().startsWith("bearer")) {
-      String[] parts = req.getHeader(HttpHeaders.AUTHORIZATION).split("\\s+");
+      String[] parts = splitPattern.split(req.getHeader(HttpHeaders.AUTHORIZATION));
       if (parts.length != 2) {
         throw new BadRequestException("Invalid authorization header format.");
       }

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractor.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/main/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractor.java
@@ -24,7 +24,7 @@ public class HeaderRequestTokenExtractor implements RequestTokenExtractor {
       return null;
     }
     if (req.getHeader(HttpHeaders.AUTHORIZATION).toLowerCase().startsWith("bearer")) {
-      String[] parts = req.getHeader(HttpHeaders.AUTHORIZATION).split(" ");
+      String[] parts = req.getHeader(HttpHeaders.AUTHORIZATION).split("\\s+");
       if (parts.length != 2) {
         throw new BadRequestException("Invalid authorization header format.");
       }

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/test/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractorTest.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/test/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractorTest.java
@@ -59,7 +59,7 @@ public class HeaderRequestTokenExtractorTest {
     return new Object[][] {
       {"token123", "token123"},
       {"bearer token123", "token123"},
-      {"bearer       token123", "token123"},
+      {"Bearer token123", "token123"},
     };
   }
 }

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/test/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractorTest.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/test/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractorTest.java
@@ -44,11 +44,12 @@ public class HeaderRequestTokenExtractorTest {
   }
 
   @Test(
+      dataProvider = "invalidHeadersProvider",
       expectedExceptions = BadRequestException.class,
       expectedExceptionsMessageRegExp = "Invalid authorization header format.")
-  public void shouldThrowExceptionOnInvalidToken() {
+  public void shouldThrowExceptionOnInvalidToken(String headerValue) {
 
-    when(servletRequest.getHeader(eq(AUTHORIZATION))).thenReturn("bearertoken123");
+    when(servletRequest.getHeader(eq(AUTHORIZATION))).thenReturn(headerValue);
 
     // when
     tokenExtractor.getToken(servletRequest);
@@ -61,5 +62,10 @@ public class HeaderRequestTokenExtractorTest {
       {"bearer token123", "token123"},
       {"Bearer token123", "token123"},
     };
+  }
+
+  @DataProvider
+  private Object[][] invalidHeadersProvider() {
+    return new Object[][] {{"bearertoken123"}, {"bearer   token123"}, {"bearer token 123"}};
   }
 }

--- a/multiuser/api/che-multiuser-api-authentication-commons/src/test/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractorTest.java
+++ b/multiuser/api/che-multiuser-api-authentication-commons/src/test/java/org/eclipse/che/multiuser/api/authentication/commons/token/HeaderRequestTokenExtractorTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.api.authentication.commons.token;
+
+import static javax.ws.rs.core.HttpHeaders.AUTHORIZATION;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.BadRequestException;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class HeaderRequestTokenExtractorTest {
+
+  private HeaderRequestTokenExtractor tokenExtractor = new HeaderRequestTokenExtractor();
+
+  @Mock HttpServletRequest servletRequest;
+
+  @Test(dataProvider = "validHeadersProvider")
+  public void shouldExtractTokensFromValidHeaders(String headerValue, String expectedToken) {
+
+    when(servletRequest.getHeader(eq(AUTHORIZATION))).thenReturn(headerValue);
+
+    // when
+    String token = tokenExtractor.getToken(servletRequest);
+
+    // then
+    assertEquals(token, expectedToken);
+  }
+
+  @Test(
+      expectedExceptions = BadRequestException.class,
+      expectedExceptionsMessageRegExp = "Invalid authorization header format.")
+  public void shouldThrowExceptionOnInvalidToken() {
+
+    when(servletRequest.getHeader(eq(AUTHORIZATION))).thenReturn("bearertoken123");
+
+    // when
+    tokenExtractor.getToken(servletRequest);
+  }
+
+  @DataProvider
+  private Object[][] validHeadersProvider() {
+    return new Object[][] {
+      {"token123", "token123"},
+      {"bearer token123", "token123"},
+      {"bearer       token123", "token123"},
+    };
+  }
+}


### PR DESCRIPTION

### What does this PR do?
Prevent ArrayIndexOutOfBoundsException in HeaderRequestTokenExtractor if token header value is incorrect

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16318


#### Release Notes
N/A

#### Docs PR
N/A