### PR TITLE
Explicitly marked cascade deletion as Foreground

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesConfigsMaps.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesConfigsMaps.java
@@ -65,6 +65,7 @@ public class KubernetesConfigsMaps {
           .configMaps()
           .inNamespace(namespace)
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
+          .withPropagationPolicy("Foreground")
           .delete();
     } catch (KubernetesClientException e) {
       throw new KubernetesInfrastructureException(e);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -925,7 +925,8 @@ public class KubernetesDeployments {
         toCloseOnException = watch;
       }
 
-      Boolean deleteSucceeded = deploymentResource.delete();
+      Boolean deleteSucceeded =
+          deploymentResource.cascading(true).withPropagationPolicy("Foreground").delete();
 
       if (deleteSucceeded == null || !deleteSucceeded) {
         deleteFuture.complete(null);
@@ -963,7 +964,8 @@ public class KubernetesDeployments {
       final Watch watch = podResource.watch(new DeleteWatcher<Pod>(deleteFuture));
       toCloseOnException = watch;
 
-      Boolean deleteSucceeded = podResource.delete();
+      Boolean deleteSucceeded =
+          podResource.cascading(true).withPropagationPolicy("Foreground").delete();
       if (deleteSucceeded == null || !deleteSucceeded) {
         deleteFuture.complete(null);
       }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -925,8 +925,7 @@ public class KubernetesDeployments {
         toCloseOnException = watch;
       }
 
-      Boolean deleteSucceeded =
-          deploymentResource.cascading(true).withPropagationPolicy("Foreground").delete();
+      Boolean deleteSucceeded = deploymentResource.withPropagationPolicy("Foreground").delete();
 
       if (deleteSucceeded == null || !deleteSucceeded) {
         deleteFuture.complete(null);
@@ -964,8 +963,7 @@ public class KubernetesDeployments {
       final Watch watch = podResource.watch(new DeleteWatcher<Pod>(deleteFuture));
       toCloseOnException = watch;
 
-      Boolean deleteSucceeded =
-          podResource.cascading(true).withPropagationPolicy("Foreground").delete();
+      Boolean deleteSucceeded = podResource.withPropagationPolicy("Foreground").delete();
       if (deleteSucceeded == null || !deleteSucceeded) {
         deleteFuture.complete(null);
       }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesIngresses.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesIngresses.java
@@ -144,6 +144,7 @@ public class KubernetesIngresses {
           .ingresses()
           .inNamespace(namespace)
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
+          .withPropagationPolicy("Foreground")
           .delete();
     } catch (KubernetesClientException e) {
       throw new KubernetesInfrastructureException(e);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -317,7 +317,6 @@ public class KubernetesNamespace {
   private void delete(String namespaceName, KubernetesClient client)
       throws InfrastructureException {
     try {
-      System.out.println(client.namespaces().withName(namespaceName));
       client.namespaces().withName(namespaceName).withPropagationPolicy("Foreground").delete();
     } catch (KubernetesClientException e) {
       if (e.getCode() == 404) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -317,7 +317,12 @@ public class KubernetesNamespace {
   private void delete(String namespaceName, KubernetesClient client)
       throws InfrastructureException {
     try {
-      client.namespaces().withName(namespaceName).delete();
+      client
+          .namespaces()
+          .withName(namespaceName)
+          .cascading(true)
+          .withPropagationPolicy("Foreground")
+          .delete();
     } catch (KubernetesClientException e) {
       if (e.getCode() == 404) {
         LOG.warn(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -317,12 +317,8 @@ public class KubernetesNamespace {
   private void delete(String namespaceName, KubernetesClient client)
       throws InfrastructureException {
     try {
-      client
-          .namespaces()
-          .withName(namespaceName)
-          .cascading(true)
-          .withPropagationPolicy("Foreground")
-          .delete();
+      System.out.println(client.namespaces().withName(namespaceName));
+      client.namespaces().withName(namespaceName).withPropagationPolicy("Foreground").delete();
     } catch (KubernetesClientException e) {
       if (e.getCode() == 404) {
         LOG.warn(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPersistentVolumeClaims.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesPersistentVolumeClaims.java
@@ -151,6 +151,7 @@ public class KubernetesPersistentVolumeClaims {
           .persistentVolumeClaims()
           .inNamespace(namespace)
           .withLabels(labels)
+          .withPropagationPolicy("Foreground")
           .delete();
     } catch (KubernetesClientException e) {
       throw new KubernetesInfrastructureException(e);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecrets.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecrets.java
@@ -19,6 +19,8 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Defines an internal API for managing {@link Secret} instances in {@link
@@ -64,6 +66,7 @@ public class KubernetesSecrets {
           .secrets()
           .inNamespace(namespace)
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
+          .withPropagationPolicy("Foreground")
           .delete();
     } catch (KubernetesClientException e) {
       throw new KubernetesInfrastructureException(e);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecrets.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecrets.java
@@ -19,8 +19,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Defines an internal API for managing {@link Secret} instances in {@link

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesServices.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesServices.java
@@ -87,6 +87,7 @@ public class KubernetesServices {
           .services()
           .inNamespace(namespace)
           .withLabel(CHE_WORKSPACE_ID_LABEL, workspaceId)
+          .withPropagationPolicy("Foreground")
           .delete();
     } catch (KubernetesClientException e) {
       throw new KubernetesInfrastructureException(e);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeploymentsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeploymentsTest.java
@@ -18,6 +18,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.POD_
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.POD_STATUS_PHASE_SUCCEEDED;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
@@ -456,6 +457,7 @@ public class KubernetesDeploymentsTest {
     doReturn(POD_NAME).when(metadata).getName();
 
     doReturn(Boolean.FALSE).when(podResource).delete();
+    doReturn(podResource).when(podResource).withPropagationPolicy(eq("Foreground"));
     Watch watch = mock(Watch.class);
     doReturn(watch).when(podResource).watch(any());
 
@@ -470,7 +472,7 @@ public class KubernetesDeploymentsTest {
   public void testDeletePodThrowingKubernetesClientExceptionShouldCloseWatch() throws Exception {
     final String POD_NAME = "nonExistingPod";
     doReturn(POD_NAME).when(metadata).getName();
-
+    doReturn(podResource).when(podResource).withPropagationPolicy(eq("Foreground"));
     doThrow(KubernetesClientException.class).when(podResource).delete();
     Watch watch = mock(Watch.class);
     doReturn(watch).when(podResource).watch(any());
@@ -491,7 +493,8 @@ public class KubernetesDeploymentsTest {
   public void testDeleteNonExistingDeploymentBeforeWatch() throws Exception {
     final String DEPLOYMENT_NAME = "nonExistingPod";
     doReturn(DEPLOYMENT_NAME).when(deploymentMetadata).getName();
-
+    doReturn(podResource).when(podResource).withPropagationPolicy(eq("Foreground"));
+    doReturn(deploymentResource).when(deploymentResource).withPropagationPolicy(eq("Foreground"));
     doReturn(Boolean.FALSE).when(deploymentResource).delete();
     Watch watch = mock(Watch.class);
     doReturn(watch).when(podResource).watch(any());
@@ -510,6 +513,7 @@ public class KubernetesDeploymentsTest {
     doReturn(DEPLOYMENT_NAME).when(deploymentMetadata).getName();
 
     doThrow(KubernetesClientException.class).when(deploymentResource).delete();
+    doReturn(deploymentResource).when(deploymentResource).withPropagationPolicy(eq("Foreground"));
     Watch watch = mock(Watch.class);
     doReturn(watch).when(podResource).watch(any());
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -365,6 +366,7 @@ public class KubernetesNamespaceTest {
   private Resource prepareNamespaceResource(String namespaceName) {
     Resource namespaceResource = mock(Resource.class);
     doReturn(namespaceResource).when(namespaceOperation).withName(namespaceName);
+    doReturn(namespaceResource).when(namespaceResource).withPropagationPolicy(eq("Foreground"));
     when(namespaceResource.get())
         .thenReturn(
             new NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build());
@@ -375,6 +377,7 @@ public class KubernetesNamespaceTest {
   private Resource prepareManagedNamespaceResource(String namespaceName) {
     Resource namespaceResource = mock(Resource.class);
     doReturn(namespaceResource).when(namespaceOperation).withName(namespaceName);
+    doReturn(namespaceResource).when(namespaceResource).withPropagationPolicy(eq("Foreground"));
     when(namespaceResource.get())
         .thenReturn(
             new NamespaceBuilder()

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecretsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesSecretsTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_WORKSPACE_ID_LABEL;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -73,6 +74,7 @@ public class KubernetesSecretsTest {
     when(client.secrets()).thenReturn(secretsMixedOperation);
     lenient().when(secretsMixedOperation.inNamespace(any())).thenReturn(nonNamespaceOperation);
     lenient().when(nonNamespaceOperation.withLabel(any(), any())).thenReturn(deletableList);
+    lenient().doReturn(deletableList).when(deletableList).withPropagationPolicy(eq("Foreground"));
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
Explicitly marked cascade deletion as Foreground.
My assumption is that reason for https://github.com/eclipse/che/issues/16512 is deleted but not garbage collected objects. 

In this PR https://github.com/fabric8io/kubernetes-client/pull/1742 introduced changes in delete behavior. As you can see here https://github.com/eclipse/che/issues/16512#issuecomment-609676415
Instead of ```{"apiVersion":"v1","kind":"DeleteOptions","orphanDependents":false}``` it sends now  ```{"apiVersion":"v1","kind":"DeleteOptions","orphanDependents":true}```. This issue was reported here  https://github.com/fabric8io/kubernetes-client/issues/1840.

After studying this code  
 - https://github.com/fabric8io/kubernetes-client/blob/555c3790b02b910d62f72e95350dd563c97359a8/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java#L221
 - https://github.com/kubernetes/kubernetes/blob/c1f1b1bceb8e6dfbc0083617a25f17dd8d57340b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go#L478-L494

I think that instead of trying to revert this behavior we should use new semantic with ```propagationPolicy= foreground ``` since we don't expect some leftovers after we call `delete` operation. See more: https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#controlling-how-the-garbage-collector-deletes-dependents. 


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16512

#### Release Notes
n/a

#### Docs PR
n/a