### PR TITLE
Prevent & log NPE in KubernetesRuntime;

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -814,17 +814,23 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
       String machineName = Names.machineName(toCreateMeta, container);
 
       LOG.debug("Creating machine '{}' in workspace '{}'", machineName, workspaceId);
-      // Sometimes we facing NPE trying to retrieve machine config. Possible names mismatch. Need to get more info on that cases.
-      Optional<InternalMachineConfig> machineConfigOpt = Optional
-          .ofNullable(machineConfigs.get(machineName));
-      if (!machineConfigOpt.isPresent()) {
-        LOG.error(
-            "Workspace '{}' start failed. Machine with name '{}' requested but not found in configs map. Present machines are: {}.",
-            workspaceId, machineName, String.join(",", machineConfigs.keySet()));
-        throw new InfrastructureException(format(
-            "Unable to start workspace '%s' due to internal error. Case will be investigated.",
-            workspaceId)):
-      }
+      // Sometimes we facing NPE trying to retrieve machine config. Possible names mismatch. Need to
+      // get more info on that cases.
+      InternalMachineConfig machineConfig =
+          Optional.ofNullable(machineConfigs.get(machineName))
+              .orElseThrow(
+                  () -> {
+                    LOG.error(
+                        "Workspace '{}' start failed. Machine with name '{}' requested but not found in configs map. Present machines are: {}.",
+                        workspaceId,
+                        machineName,
+                        String.join(",", machineConfigs.keySet()));
+                    return new InfrastructureException(
+                        format(
+                            "Unable to start the workspace '%s' due to an internal inconsistency while composing the workspace runtime."
+                                + "Please report a bug. If possible, include the details from Che devfile and erver log in bug report (your admin can help with that)",
+                            workspaceId));
+                  });
       machines.put(
           getContext().getIdentity(),
           new KubernetesMachineImpl(
@@ -833,7 +839,7 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
               createdPod.getMetadata().getName(),
               container.getName(),
               MachineStatus.STARTING,
-              machineConfigOpt.get().getAttributes(),
+              machineConfig.getAttributes(),
               serverResolver.resolve(machineName)));
       eventPublisher.sendStartingEvent(machineName, getContext().getIdentity());
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -828,7 +828,7 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
                     return new InfrastructureException(
                         format(
                             "Unable to start the workspace '%s' due to an internal inconsistency while composing the workspace runtime."
-                                + "Please report a bug. If possible, include the details from Che devfile and erver log in bug report (your admin can help with that)",
+                                + "Please report a bug. If possible, include the details from Che devfile and server log in bug report (your admin can help with that)",
                             workspaceId));
                   });
       machines.put(


### PR DESCRIPTION
### What does this PR do?
Add more debugging and prevent NPE in case machine can not be found by it's name in configs map.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/15974


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
N/A