### PR TITLE
Fix workspace deletion in typescript tests

### DIFF
--- a/tests/e2e/pageobjects/dashboard/Workspaces.ts
+++ b/tests/e2e/pageobjects/dashboard/Workspaces.ts
@@ -95,10 +95,25 @@ export class Workspaces {
     async confirmWorkspaceDeletion(timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
         Logger.debug('Workspaces.confirmWorkspaceDeletion');
 
-        const checkbox: By = By.xpath(`//che-popup//input[contains(@type, 'checkbox')]`);
-        await this.driverHelper.waitAndClick(checkbox, 10000);
-
+        const checkbox: By = By.xpath(`//che-popup//input[@id='enable-button' and contains(@class, 'ng-empty')]`);
+        const checkbox_checked: By = By.xpath(`//che-popup//input[@id='enable-button' and contains(@class, 'ng-not-empty')]`);
         const deleteButton: By = By.xpath('//che-popup//che-button-danger');
+
+        await this.driverHelper.waitAndClick(checkbox, 5000);
+        try {
+            await this.driverHelper.waitVisibility(checkbox_checked, 3000);
+        } catch (err) {
+            Logger.info('The checkbox is not checked. Trying again.');
+            await this.driverHelper.waitAndClick(checkbox, 5000);
+
+            try {
+                await this.driverHelper.waitVisibility(checkbox_checked, 3000);
+            } catch (err) {
+                Logger.error('Test was not able to select the checkbox during a workspace deletion.');
+                throw err;
+            }
+        }
+
         await this.driverHelper.waitAndClick(deleteButton, 10000);
     }
 


### PR DESCRIPTION
### What does this PR do?
Checkbox for workspace deletion is sometimes visible but not clickable. Adding try/check to verify that checkbox was selected and if needed - retry to select the checkbox.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16592
