### PR TITLE
Enable infrastructure request logging

### DIFF
--- a/infrastructures/kubernetes/pom.xml
+++ b/infrastructures/kubernetes/pom.xml
@@ -67,6 +67,10 @@
         </dependency>
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,11 @@
             </dependency>
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
+                <artifactId>logging-interceptor</artifactId>
+                <version>${com.squareup.okhttp3.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp</artifactId>
                 <version>${com.squareup.okhttp3.version}</version>
             </dependency>


### PR DESCRIPTION
# What does this PR do?

Adds `che.infra.request-logging` logger that logs the traffic between the che server and the underlying infrastructure when set to the `TRACE` level.

This can help us debug problems by looking at the traffic between the che server and the kubernetes API.
