### PR TITLE
Minimal quick fix for the CRW-811 critical bug

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -15,7 +15,6 @@ import static java.lang.String.format;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.isLabeled;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -209,7 +208,8 @@ public class OpenShiftProject extends KubernetesNamespace {
     }
   }
 
-  private Namespace getNamespace(String projectName, OpenShiftClient client) throws InfrastructureException {
+  private Namespace getNamespace(String projectName, OpenShiftClient client)
+      throws InfrastructureException {
     try {
       return client.namespaces().withName(projectName).get();
     } catch (KubernetesClientException e) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -15,6 +15,7 @@ import static java.lang.String.format;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.isLabeled;
 
 import com.google.common.annotations.VisibleForTesting;
+
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -208,8 +209,7 @@ public class OpenShiftProject extends KubernetesNamespace {
     }
   }
 
-  private Namespace getNamespace(String projectName, OpenShiftClient client)
-      throws InfrastructureException {
+  private Namespace getNamespace(String projectName, OpenShiftClient client) throws InfrastructureException {
     try {
       return client.namespaces().withName(projectName).get();
     } catch (KubernetesClientException e) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -117,7 +117,12 @@ public class OpenShiftProject extends KubernetesNamespace {
     if (markManaged && !isLabeled(project, MANAGED_NAMESPACE_LABEL, "true")) {
       // provision managed label is marking is requested but label is missing
       KubernetesObjectUtil.putLabel(project, MANAGED_NAMESPACE_LABEL, "true");
-      update(project, osClient);
+      try {
+        update(project, osClient);
+      } catch (KubernetesInfrastructureException e) {
+        LOG.error(
+            "Unable to mark the workspace project as managed. So it will not be removed automatically when workspace is deleted.");
+      }
     }
   }
 

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -48,6 +48,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -104,6 +105,7 @@ public class OpenShiftProjectTest {
             configsMaps);
   }
 
+  @Ignore
   @Test
   public void testOpenShiftProjectPreparingWhenProjectExists() throws Exception {
     // given
@@ -149,6 +151,7 @@ public class OpenShiftProjectTest {
     // exception is thrown
   }
 
+  @Ignore
   @Test
   public void testMarksNamespaceManaged() throws Exception {
     // given
@@ -171,6 +174,7 @@ public class OpenShiftProjectTest {
     verify(labels).put("che-managed", "true");
   }
 
+  @Ignore
   @Test
   public void testDoesntMarkNamespaceManaged() throws Exception {
     // given
@@ -227,6 +231,7 @@ public class OpenShiftProjectTest {
   }
 
   @Test
+  @Ignore
   public void testDeletesExistingManagedProject() throws Exception {
     // given
     OpenShiftProject project = new OpenShiftProject(clientFactory, PROJECT_NAME, WORKSPACE_ID);
@@ -239,6 +244,7 @@ public class OpenShiftProjectTest {
     verify(resource).delete();
   }
 
+  @Ignore
   @Test
   public void testDoesntDeleteExistingNonManagedNamespace() throws Exception {
     // given
@@ -252,6 +258,7 @@ public class OpenShiftProjectTest {
     verify(resource, never()).delete();
   }
 
+  @Ignore
   @Test
   public void testDoesntFailIfDeletedProjectDoesntExist() throws Exception {
     // given
@@ -268,6 +275,7 @@ public class OpenShiftProjectTest {
     // and no exception is thrown
   }
 
+  @Ignore
   @Test
   public void testDoesntFailIfDeletedProjectIsBeingDeleted() throws Exception {
     // given

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -48,7 +48,6 @@ import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Ignore;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -105,7 +104,6 @@ public class OpenShiftProjectTest {
             configsMaps);
   }
 
-  @Ignore
   @Test
   public void testOpenShiftProjectPreparingWhenProjectExists() throws Exception {
     // given
@@ -151,7 +149,6 @@ public class OpenShiftProjectTest {
     // exception is thrown
   }
 
-  @Ignore
   @Test
   public void testMarksNamespaceManaged() throws Exception {
     // given
@@ -174,7 +171,6 @@ public class OpenShiftProjectTest {
     verify(labels).put("che-managed", "true");
   }
 
-  @Ignore
   @Test
   public void testDoesntMarkNamespaceManaged() throws Exception {
     // given
@@ -231,7 +227,6 @@ public class OpenShiftProjectTest {
   }
 
   @Test
-  @Ignore
   public void testDeletesExistingManagedProject() throws Exception {
     // given
     OpenShiftProject project = new OpenShiftProject(clientFactory, PROJECT_NAME, WORKSPACE_ID);
@@ -244,7 +239,6 @@ public class OpenShiftProjectTest {
     verify(resource).delete();
   }
 
-  @Ignore
   @Test
   public void testDoesntDeleteExistingNonManagedNamespace() throws Exception {
     // given
@@ -258,7 +252,6 @@ public class OpenShiftProjectTest {
     verify(resource, never()).delete();
   }
 
-  @Ignore
   @Test
   public void testDoesntFailIfDeletedProjectDoesntExist() throws Exception {
     // given
@@ -275,7 +268,6 @@ public class OpenShiftProjectTest {
     // and no exception is thrown
   }
 
-  @Ignore
   @Test
   public void testDoesntFailIfDeletedProjectIsBeingDeleted() throws Exception {
     // given


### PR DESCRIPTION
# What does this PR do?

This PR provide a quick and minimal fix to unblock the failing update of workspaces from `CRW 2.0.0` to `CRW 2.1.0` 

To summarize :
- We just log an error to the Che server when the workspace-specific OpenShift project cannot be marked as managed by Che
- And **we do not prevent the workspace to start** anymore
- The **only impact** is that when deleting the workspace, the related OpenShift project will not be deleted automatically.
- But afaict it was already the case in 2.0.0. So I'm not sure this is even a regression
- And this impact is very minor since the default for all new workspaces created after 2.1.0 update will be to use a common user-related OpenShift project.

DISCLAIMER: this is not the final complete fix for the underlying upstream issue https://github.com/eclipse/che/issues/16612

Just a CRW hot-fix to fix CRW `2.1.0` asap.

### What issues does this PR fix or reference?

https://issues.redhat.com/browse/CRW-811
