### PR TITLE
Don't use the label to designate managed namespaces.

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
 import static java.lang.String.format;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.isLabeled;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -114,14 +113,12 @@ public class KubernetesNamespace {
    *
    * <p>Preparing includes creating if needed and waiting for default service account.
    *
-   * @param markManaged mark the namespace as managed by Che. Also applies for already existing
-   *     namespaces.
    * @param canCreate defines what to do when the namespace is not found. The namespace is created
    *     when {@code true}, otherwise an exception is thrown.
    * @throws InfrastructureException if any exception occurs during namespace preparation or if the
    *     namespace doesn't exist and {@code canCreate} is {@code false}.
    */
-  void prepare(boolean markManaged, boolean canCreate) throws InfrastructureException {
+  void prepare(boolean canCreate) throws InfrastructureException {
     KubernetesClient client = clientFactory.create(workspaceId);
     Namespace namespace = get(name, client);
 
@@ -130,33 +127,18 @@ public class KubernetesNamespace {
         throw new InfrastructureException(
             format("Creating the namespace '%s' is not allowed, yet it was not found.", name));
       }
-      namespace = create(name, client);
-    }
-
-    if (markManaged && !isLabeled(namespace, MANAGED_NAMESPACE_LABEL, "true")) {
-      // provision managed label is marking is requested but label is missing
-      KubernetesObjectUtil.putLabel(namespace, MANAGED_NAMESPACE_LABEL, "true");
-      update(namespace, client);
+      create(name, client);
     }
   }
 
   /**
    * Deletes the namespace. Deleting a non-existent namespace is not an error as is not an attempt
-   * to delete a namespace that is already being deleted. If the namespace is not marked as managed,
-   * it is silently not deleted.
+   * to delete a namespace that is already being deleted.
    *
    * @throws InfrastructureException if any unexpected exception occurs during namespace deletion
    */
-  void deleteIfManaged() throws InfrastructureException {
+  void delete() throws InfrastructureException {
     KubernetesClient client = clientFactory.create(workspaceId);
-
-    if (!isNamespaceManaged(client)) {
-      LOG.info(
-          "Namespace {} for workspace {} is not marked as managed. Ignoring the delete request.",
-          name,
-          workspaceId);
-      return;
-    }
 
     try {
       delete(name, client);
@@ -170,34 +152,6 @@ public class KubernetesNamespace {
       }
 
       throw new KubernetesInfrastructureException(e);
-    }
-  }
-
-  private boolean isNamespaceManaged(KubernetesClient client) throws InfrastructureException {
-    try {
-      Namespace namespace = client.namespaces().withName(name).get();
-      return namespace.getMetadata().getLabels() != null
-          && "true".equals(namespace.getMetadata().getLabels().get(MANAGED_NAMESPACE_LABEL));
-    } catch (KubernetesClientException e) {
-      if (e.getCode() == 403) {
-        throw new InfrastructureException(
-            format(
-                "Could not access the namespace %s when trying to determine if it is managed "
-                    + "for workspace %s",
-                name, workspaceId),
-            e);
-      } else if (e.getCode() == 404) {
-        // we don't want to block whatever work the caller is doing on the namespace. The caller
-        // will fail anyway if the namespace doesn't exist.
-        return true;
-      }
-
-      throw new InternalInfrastructureException(
-          format(
-              "Failed to determine whether the namespace"
-                  + " %s is managed. Kubernetes client said: %s",
-              getName(), e.getMessage()),
-          e);
     }
   }
 
@@ -277,37 +231,21 @@ public class KubernetesNamespace {
     }
   }
 
-  private Namespace create(String namespaceName, KubernetesClient client)
+  private void create(String namespaceName, KubernetesClient client)
       throws InfrastructureException {
     try {
-      Namespace ns =
-          client
-              .namespaces()
-              .createNew()
-              .withNewMetadata()
-              .withName(namespaceName)
-              .endMetadata()
-              .done();
+      client
+          .namespaces()
+          .createNew()
+          .withNewMetadata()
+          .withName(namespaceName)
+          .endMetadata()
+          .done();
       waitDefaultServiceAccount(namespaceName, client);
-
-      return ns;
     } catch (KubernetesClientException e) {
       if (e.getCode() == 403) {
         LOG.error(
             "Unable to create new Kubernetes project due to lack of permissions."
-                + "When using workspace namespace placeholders, service account with lenient permissions (cluster-admin) must be used.");
-      }
-      throw new KubernetesInfrastructureException(e);
-    }
-  }
-
-  private void update(Namespace namespace, KubernetesClient client) throws InfrastructureException {
-    try {
-      client.namespaces().createOrReplace(namespace);
-    } catch (KubernetesClientException e) {
-      if (e.getCode() == 403) {
-        LOG.error(
-            "Unable to update new Kubernetes namespace due to lack of permissions."
                 + "When using workspace namespace placeholders, service account with lenient permissions (cluster-admin) must be used.");
       }
       throw new KubernetesInfrastructureException(e);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -317,24 +317,23 @@ public class KubernetesNamespaceFactory {
   }
 
   /**
-   * Tells the caller whether the namespace that is being prepared, should be marked as managed or
-   * not.
+   * A managed namespace of a workspace is a namespace that is fully controlled by Che. Such
+   * namespaces are deleted when the workspace is deleted.
    *
-   * @param identity the runtime identity of the workspace
-   * @return true if the workspace namespace should be marked managed, false otherwise
+   * @param namespaceName the name of the namespace the workspace is stored in
+   * @param workspace the workspace
+   * @throws InfrastructureException in case of legacy workspaces that don't store their namespace
+   *     in the attributes, this method might fail
    */
-  protected boolean shouldMarkNamespaceManaged(RuntimeIdentity identity) {
-    // when infra namespace contains workspaceId that is generated
-    // it mean that Che Server provides unique namespace for each workspace
-    // and nothing else except workspace should be run there
-    // Che Server also removes such namespace after workspace is removed
-    return identity.getInfrastructureNamespace().contains(identity.getWorkspaceId());
+  protected boolean isWorkspaceNamespaceManaged(String namespaceName, Workspace workspace)
+      throws InfrastructureException {
+    return namespaceName != null && namespaceName.contains(workspace.getId());
   }
 
   public KubernetesNamespace getOrCreate(RuntimeIdentity identity) throws InfrastructureException {
     KubernetesNamespace namespace = get(identity);
 
-    namespace.prepare(shouldMarkNamespaceManaged(identity), canCreateNamespace(identity));
+    namespace.prepare(canCreateNamespace(identity));
 
     if (!isNullOrEmpty(serviceAccountName)) {
       KubernetesWorkspaceServiceAccount workspaceServiceAccount =
@@ -454,7 +453,9 @@ public class KubernetesNamespaceFactory {
 
   public void deleteIfManaged(Workspace workspace) throws InfrastructureException {
     KubernetesNamespace namespace = get(workspace);
-    namespace.deleteIfManaged();
+    if (isWorkspaceNamespaceManaged(namespace.getName(), workspace)) {
+      namespace.delete();
+    }
   }
 
   private String resolveLegacyNamespaceName(NamespaceResolutionContext resolutionCtx) {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -270,27 +270,6 @@ public class KubernetesNamespaceFactoryTest {
   }
 
   @Test
-  public void shouldMarkNamespaceManagedIfWorkspaceIdIsUsedInItsName() throws Exception {
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "", "", "", "<workspaceid>", false, clientFactory, userManager, pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
-
-    // then
-    assertEquals(toReturnNamespace, namespace);
-    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnNamespace).prepare(eq(true), eq(true));
-  }
-
-  @Test
   public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
       throws Exception {
     // There is only one scenario where this can happen. The workspace was created and started in
@@ -315,34 +294,7 @@ public class KubernetesNamespaceFactoryTest {
     // then
     assertEquals(toReturnNamespace, namespace);
     verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnNamespace).prepare(eq(false), eq(false));
-  }
-
-  @Test
-  public void
-      shouldHandleUpgradeOfManagedFlagAndRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
-          throws Exception {
-    // This is a variation of the above test that checks the same scenario, but additionally checks
-    // that we correctly set the managed flag on the namespace if the namespace name contains
-    // the workspace id (and thus will be automatically deleted after workspace stop).
-
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "", "", "", "che", false, clientFactory, userManager, pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "che-ws-workspace123");
-    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
-
-    // then
-    assertEquals(toReturnNamespace, namespace);
-    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnNamespace).prepare(eq(true), eq(false));
+    verify(toReturnNamespace).prepare(eq(false));
   }
 
   @Test

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -86,7 +86,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
   public OpenShiftProject getOrCreate(RuntimeIdentity identity) throws InfrastructureException {
     OpenShiftProject osProject = get(identity);
 
-    osProject.prepare(shouldMarkNamespaceManaged(identity), canCreateNamespace(identity));
+    osProject.prepare(canCreateNamespace(identity));
 
     if (!isNullOrEmpty(getServiceAccountName())) {
       OpenShiftWorkspaceServiceAccount osWorkspaceServiceAccount =
@@ -109,7 +109,9 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
   @Override
   public void deleteIfManaged(Workspace workspace) throws InfrastructureException {
     OpenShiftProject osProject = get(workspace);
-    osProject.deleteIfManaged();
+    if (isWorkspaceNamespaceManaged(osProject.getName(), workspace)) {
+      osProject.delete();
+    }
   }
 
   @Override

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -54,7 +54,6 @@ import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
@@ -332,35 +331,6 @@ public class OpenShiftProjectFactoryTest {
   }
 
   @Test
-  public void shouldMarkNamespaceManagedIfWorkspaceIdIsUsedInItsName() throws Exception {
-    // given
-    projectFactory =
-        spy(
-            new OpenShiftProjectFactory(
-                "",
-                "",
-                "",
-                "<workspaceid>",
-                false,
-                clientFactory,
-                configFactory,
-                userManager,
-                pool));
-    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    OpenShiftProject project = projectFactory.getOrCreate(identity);
-
-    // then
-    assertEquals(toReturnProject, project);
-    verify(projectFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnProject).prepare(eq(true), eq(true));
-  }
-
-  @Test
   public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
       throws Exception {
     // There is only one scenario where this can happen. The workspace was created and started in
@@ -393,34 +363,7 @@ public class OpenShiftProjectFactoryTest {
     // then
     assertEquals(toReturnProject, project);
     verify(projectFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnProject).prepare(eq(false), eq(false));
-  }
-
-  @Test
-  public void
-      shouldHandleUpgradeOfManagedFlagAndRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
-          throws Exception {
-    // This is a variation of the above test that checks the same scenario, but additionally checks
-    // that we correctly set the managed flag on the namespace if the namespace name contains
-    // the workspace id (and thus will be automatically deleted after workspace stop).
-
-    // given
-    projectFactory =
-        spy(
-            new OpenShiftProjectFactory(
-                "", "", "", "che", false, clientFactory, configFactory, userManager, pool));
-    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "che-ws-workspace123");
-    KubernetesNamespace namespace = projectFactory.getOrCreate(identity);
-
-    // then
-    assertEquals(toReturnProject, namespace);
-    verify(projectFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnProject).prepare(eq(true), eq(false));
+    verify(toReturnProject).prepare(eq(false));
   }
 
   @Test

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -23,7 +23,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
@@ -36,7 +35,6 @@ import io.fabric8.openshift.api.model.ProjectBuilder;
 import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
 import io.fabric8.openshift.client.OpenShiftClient;
 import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
@@ -116,7 +114,7 @@ public class OpenShiftProjectTest {
         new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
 
     // when
-    project.prepare(false, true);
+    project.prepare(true);
 
     // then
     verify(projectMeta, never()).withName(PROJECT_NAME);
@@ -133,7 +131,7 @@ public class OpenShiftProjectTest {
         new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
 
     // when
-    openShiftProject.prepare(false, true);
+    openShiftProject.prepare(true);
 
     // then
     verify(projectMetadata).withName(PROJECT_NAME);
@@ -148,56 +146,10 @@ public class OpenShiftProjectTest {
         new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
 
     // when
-    project.prepare(false, false);
+    project.prepare(false);
 
     // then
     // exception is thrown
-  }
-
-  @Test
-  public void testMarksNamespaceManaged() throws Exception {
-    // given
-    MetadataNested projectMeta = prepareProjectRequest();
-
-    Project projectResource = prepareProject(PROJECT_NAME);
-    ObjectMeta metadata = mock(ObjectMeta.class);
-    @SuppressWarnings("unchecked")
-    Map<String, String> labels = mock(Map.class);
-    when(projectResource.getMetadata()).thenReturn(metadata);
-    when(metadata.getLabels()).thenReturn(labels);
-
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-
-    // when
-    project.prepare(true, false);
-
-    // then
-    verify(projectMeta, never()).withName(PROJECT_NAME);
-    verify(labels).put("che-managed", "true");
-  }
-
-  @Test
-  public void testDoesntMarkNamespaceManaged() throws Exception {
-    // given
-    MetadataNested projectMeta = prepareProjectRequest();
-
-    Project projectResource = prepareProject(PROJECT_NAME);
-    ObjectMeta metadata = mock(ObjectMeta.class);
-    @SuppressWarnings("unchecked")
-    Map<String, String> labels = mock(Map.class);
-    when(projectResource.getMetadata()).thenReturn(metadata);
-    when(metadata.getLabels()).thenReturn(labels);
-
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-
-    // when
-    project.prepare(false, false);
-
-    // then
-    verify(projectMeta, never()).withName(PROJECT_NAME);
-    verify(labels, never()).put(anyString(), anyString());
   }
 
   @Test
@@ -234,31 +186,17 @@ public class OpenShiftProjectTest {
   }
 
   @Test
-  public void testDeletesExistingManagedProject() throws Exception {
-    // given
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-    Resource resource = prepareManagedProjectResource(PROJECT_NAME);
-
-    // when
-    project.deleteIfManaged();
-
-    // then
-    verify(resource).delete();
-  }
-
-  @Test
-  public void testDoesntDeleteExistingNonManagedNamespace() throws Exception {
+  public void testDeletesExistingProject() throws Exception {
     // given
     OpenShiftProject project =
         new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
     Resource resource = prepareProjectResource(PROJECT_NAME);
 
     // when
-    project.deleteIfManaged();
+    project.delete();
 
     // then
-    verify(resource, never()).delete();
+    verify(resource).delete();
   }
 
   @Test
@@ -266,12 +204,12 @@ public class OpenShiftProjectTest {
     // given
     OpenShiftProject project =
         new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-    Resource resource = prepareManagedProjectResource(PROJECT_NAME);
+    Resource resource = prepareProjectResource(PROJECT_NAME);
     when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
     when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
 
     // when
-    project.deleteIfManaged();
+    project.delete();
 
     // then
     verify(resource).delete();
@@ -283,11 +221,11 @@ public class OpenShiftProjectTest {
     // given
     OpenShiftProject project =
         new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-    Resource resource = prepareManagedProjectResource(PROJECT_NAME);
+    Resource resource = prepareProjectResource(PROJECT_NAME);
     when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
 
     // when
-    project.deleteIfManaged();
+    project.delete();
 
     // then
     verify(resource).delete();
@@ -317,26 +255,6 @@ public class OpenShiftProjectTest {
     when(projectResource.get())
         .thenReturn(
             new ProjectBuilder().withNewMetadata().withName(projectName).endMetadata().build());
-
-    openShiftClient.projects().withName(projectName).get();
-    return projectResource;
-  }
-
-  private Resource prepareManagedProjectResource(String projectName) {
-    Resource projectResource = mock(Resource.class);
-
-    NonNamespaceOperation projectOperation = mock(NonNamespaceOperation.class);
-    doReturn(projectResource).when(projectOperation).withName(projectName);
-    doReturn(projectOperation).when(openShiftClient).projects();
-
-    when(projectResource.get())
-        .thenReturn(
-            new ProjectBuilder()
-                .withNewMetadata()
-                .withName(projectName)
-                .addToLabels("che-managed", "true")
-                .endMetadata()
-                .build());
 
     openShiftClient.projects().withName(projectName).get();
     return projectResource;


### PR DESCRIPTION
# What does this PR do?
Don't use the label to designate managed namespaces. Instead rely solely on the heuristics.

This is a "proper" fix for https://github.com/eclipse/che/pull/16612. Unlike https://github.com/eclipse/che/pull/16617 which provides the minimal changes to unblock us in the 7.9.x branch, this fix (applied to master) gets rid of the need to even have the labels put on the namespaces/projects and thus circumvents the issue completely.

The same logic that we used to use to decide whether a namespace should be managed is now used to determine whether the namespace should be deleted or not (which is the only place where we used the label).

### What issues does this PR fix or reference?

#16612
