### PR TITLE
[Metric] Total workspace count 

### DIFF
--- a/deploy/openshift/templates/monitoring/che-monitoring.yaml
+++ b/deploy/openshift/templates/monitoring/che-monitoring.yaml
@@ -74,7 +74,7 @@ objects:
           deploymentconfig: grafana
       spec:
         containers:
-        - image: grafana/grafana
+        - image: grafana/grafana:6.6.2
           imagePullPolicy: Always
           name: grafana
           ports:

--- a/deploy/openshift/templates/monitoring/grafana-dashboards.yaml
+++ b/deploy/openshift/templates/monitoring/grafana-dashboards.yaml
@@ -3608,7 +3608,7 @@ data:
       "version": 1
     }
   che-workspaces.json: |-
-    {
+      {
       "annotations": {
         "list": [
           {
@@ -3625,7 +3625,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 1,
-      "iteration": 1587034540924,
+      "iteration": 1587125836872,
       "links": [],
       "panels": [
         {
@@ -4717,13 +4717,18 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "che_workspace_total or sum(che_workspace_status)",
+              "expr": "che_workspace_total",
               "format": "time_series",
               "instant": false,
               "interval": "",
               "intervalFactor": 1,
-              "legendFormat": "Number of Workspaces",
+              "legendFormat": "total",
               "refId": "A"
+            },
+            {
+              "expr": "sum(che_workspace_status)",
+              "legendFormat": "status sum",
+              "refId": "B"
             }
           ],
           "thresholds": [],
@@ -5103,6 +5108,7 @@ data:
             "x": 0,
             "y": 37
           },
+          "hiddenSeries": false,
           "id": 105,
           "interval": "",
           "legend": {
@@ -5191,6 +5197,7 @@ data:
             "x": 12,
             "y": 37
           },
+          "hiddenSeries": false,
           "id": 108,
           "interval": "",
           "legend": {
@@ -9691,6 +9698,10 @@ data:
       "templating": {
         "list": [
           {
+            "current": {
+              "text": "che",
+              "value": "che"
+            },
             "hide": 0,
             "includeAll": false,
             "label": null,

--- a/deploy/openshift/templates/monitoring/grafana-dashboards.yaml
+++ b/deploy/openshift/templates/monitoring/grafana-dashboards.yaml
@@ -3625,8 +3625,7 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 1,
-      "id": 2,
-      "iteration": 1574014597638,
+      "iteration": 1587034540924,
       "links": [],
       "panels": [
         {
@@ -3818,98 +3817,6 @@ data:
           "valueName": "current"
         },
         {
-          "aliasColors": {},
-          "bars": false,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${datasource}",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 12,
-            "y": 17
-          },
-          "hiddenSeries": false,
-          "id": 110,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "sum(che_workspace_starting_attempts_total)",
-              "legendFormat": "Workspace start attempts",
-              "refId": "A"
-            },
-            {
-              "expr": "che_workspace_starting_attempts_total{debug='true'}",
-              "legendFormat": "Workspace start attempts in start-debug mode",
-              "refId": "B"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Workspace start attempts",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": 0,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
           "collapsed": false,
           "datasource": "$datasource",
           "gridPos": {
@@ -3938,6 +3845,7 @@ data:
             "x": 0,
             "y": 7
           },
+          "hiddenSeries": false,
           "id": 36,
           "interval": "",
           "legend": {
@@ -4037,6 +3945,7 @@ data:
             "x": 6,
             "y": 7
           },
+          "hiddenSeries": false,
           "id": 48,
           "interval": "",
           "legend": {
@@ -4135,6 +4044,7 @@ data:
             "x": 12,
             "y": 7
           },
+          "hiddenSeries": false,
           "id": 6,
           "legend": {
             "avg": true,
@@ -4225,6 +4135,7 @@ data:
             "x": 18,
             "y": 7
           },
+          "hiddenSeries": false,
           "id": 59,
           "legend": {
             "avg": true,
@@ -4316,6 +4227,7 @@ data:
             "x": 0,
             "y": 12
           },
+          "hiddenSeries": false,
           "id": 44,
           "legend": {
             "avg": true,
@@ -4408,6 +4320,7 @@ data:
             "x": 6,
             "y": 12
           },
+          "hiddenSeries": false,
           "id": 49,
           "legend": {
             "avg": true,
@@ -4500,6 +4413,7 @@ data:
             "x": 12,
             "y": 12
           },
+          "hiddenSeries": false,
           "id": 8,
           "legend": {
             "avg": false,
@@ -4590,6 +4504,7 @@ data:
             "x": 18,
             "y": 12
           },
+          "hiddenSeries": false,
           "id": 10,
           "legend": {
             "avg": true,
@@ -4681,6 +4596,7 @@ data:
             "x": 0,
             "y": 17
           },
+          "hiddenSeries": false,
           "id": 62,
           "legend": {
             "avg": true,
@@ -4773,6 +4689,7 @@ data:
             "x": 6,
             "y": 17
           },
+          "hiddenSeries": false,
           "id": 77,
           "legend": {
             "avg": false,
@@ -4800,9 +4717,10 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(che_workspace_status)",
+              "expr": "che_workspace_total or sum(che_workspace_status)",
               "format": "time_series",
               "instant": false,
+              "interval": "",
               "intervalFactor": 1,
               "legendFormat": "Number of Workspaces",
               "refId": "A"
@@ -4852,6 +4770,98 @@ data:
           }
         },
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${datasource}",
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 6,
+            "x": 12,
+            "y": 17
+          },
+          "hiddenSeries": false,
+          "id": 110,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "sum(che_workspace_starting_attempts_total)",
+              "legendFormat": "Workspace start attempts",
+              "refId": "A"
+            },
+            {
+              "expr": "che_workspace_starting_attempts_total{debug='true'}",
+              "legendFormat": "Workspace start attempts in start-debug mode",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Workspace start attempts",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": 0,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
           "collapsed": false,
           "datasource": "$datasource",
           "gridPos": {
@@ -4881,6 +4891,7 @@ data:
             "x": 0,
             "y": 23
           },
+          "hiddenSeries": false,
           "id": 78,
           "legend": {
             "avg": false,
@@ -4985,6 +4996,7 @@ data:
             "x": 0,
             "y": 29
           },
+          "hiddenSeries": false,
           "id": 16,
           "legend": {
             "avg": false,
@@ -9513,11 +9525,11 @@ data:
               }
             },
             {
-              "datasource": "${datasource}",
               "aliasColors": {},
               "bars": false,
               "dashLength": 10,
               "dashes": false,
+              "datasource": "${datasource}",
               "fill": 1,
               "fillGradient": 0,
               "gridPos": {
@@ -9578,22 +9590,22 @@ data:
               },
               "yaxes": [
                 {
+                  "decimals": 0,
                   "format": "short",
                   "label": null,
                   "logBase": 1,
                   "max": null,
                   "min": 0,
-                  "show": true,
-                  "decimals": 0
+                  "show": true
                 },
                 {
+                  "decimals": 0,
                   "format": "short",
                   "label": null,
                   "logBase": 1,
                   "max": null,
                   "min": 0,
-                  "show": true,
-                  "decimals": 0
+                  "show": true
                 }
               ],
               "yaxis": {
@@ -9673,7 +9685,7 @@ data:
         }
       ],
       "refresh": "15m",
-      "schemaVersion": 19,
+      "schemaVersion": 22,
       "style": "dark",
       "tags": [],
       "templating": {

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaWorkspaceDao.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaWorkspaceDao.java
@@ -237,11 +237,11 @@ public class MultiuserJpaWorkspaceDao implements WorkspaceDao {
 
   @Override
   @Transactional
-  public long getTotalCount() throws ServerException {
+  public long getWorkspacesTotalCount() throws ServerException {
     try {
       return managerProvider
           .get()
-          .createNamedQuery("Workspace.getTotalCount", Long.class)
+          .createNamedQuery("Workspace.getWorkspacesTotalCount", Long.class)
           .getSingleResult();
     } catch (RuntimeException x) {
       throw new ServerException(x.getLocalizedMessage(), x);

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaWorkspaceDao.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaWorkspaceDao.java
@@ -235,6 +235,19 @@ public class MultiuserJpaWorkspaceDao implements WorkspaceDao {
     }
   }
 
+  @Override
+  @Transactional
+  public long getTotalCount() throws ServerException {
+    try {
+      return managerProvider
+          .get()
+          .createNamedQuery("Workspace.getTotalCount", Long.class)
+          .getSingleResult();
+    } catch (RuntimeException x) {
+      throw new ServerException(x.getLocalizedMessage(), x);
+    }
+  }
+
   @Transactional
   protected void doCreate(WorkspaceImpl workspace) {
     if (workspace.getConfig() != null) {

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserJpaWorkspaceDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserJpaWorkspaceDaoTest.java
@@ -129,7 +129,7 @@ public class MultiuserJpaWorkspaceDaoTest {
 
   @Test
   public void shouldGetTotalWorkspaceCount() throws ServerException {
-    assertEquals(dao.getTotalCount(), 3);
+    assertEquals(dao.getWorkspacesTotalCount(), 3);
   }
 
   @AfterClass

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserJpaWorkspaceDaoTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserJpaWorkspaceDaoTest.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import javax.persistence.EntityManager;
 import org.eclipse.che.account.spi.AccountImpl;
+import org.eclipse.che.api.core.ServerException;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
@@ -124,6 +125,11 @@ public class MultiuserJpaWorkspaceDaoTest {
         .getResultList()
         .forEach(manager::remove);
     manager.getTransaction().commit();
+  }
+
+  @Test
+  public void shouldGetTotalWorkspaceCount() throws ServerException {
+    assertEquals(dao.getTotalCount(), 3);
   }
 
   @AfterClass

--- a/wsmaster/che-core-api-metrics/pom.xml
+++ b/wsmaster/che-core-api-metrics/pom.xml
@@ -53,6 +53,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-workspace</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-workspace-activity</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-metrics/src/main/java/org/eclipse/che/api/metrics/WorkspaceMeterBinder.java
+++ b/wsmaster/che-core-api-metrics/src/main/java/org/eclipse/che/api/metrics/WorkspaceMeterBinder.java
@@ -33,7 +33,7 @@ public class WorkspaceMeterBinder implements MeterBinder {
 
   @Override
   public void bindTo(MeterRegistry registry) {
-    Gauge.builder(workspaceMetric(".total"), this::count)
+    Gauge.builder(workspaceMetric("total"), this::count)
         .description("Total number of workspaces")
         .register(registry);
   }

--- a/wsmaster/che-core-api-metrics/src/main/java/org/eclipse/che/api/metrics/WorkspaceMeterBinder.java
+++ b/wsmaster/che-core-api-metrics/src/main/java/org/eclipse/che/api/metrics/WorkspaceMeterBinder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.metrics;
+
+import static org.eclipse.che.api.metrics.WorkspaceBinders.workspaceMetric;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+
+/** Provides metrics of workspace. */
+@Singleton
+public class WorkspaceMeterBinder implements MeterBinder {
+  private final WorkspaceManager workspaceManager;
+
+  @Inject
+  public WorkspaceMeterBinder(WorkspaceManager workspaceManager) {
+    this.workspaceManager = workspaceManager;
+  }
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    Gauge.builder(workspaceMetric(".total"), this::count)
+        .description("Total number of workspaces")
+        .register(registry);
+  }
+
+  private double count() {
+    try {
+      return workspaceManager.getTotalCount();
+    } catch (ServerException e) {
+      return Double.NaN;
+    }
+  }
+}

--- a/wsmaster/che-core-api-metrics/src/main/java/org/eclipse/che/api/metrics/WorkspaceMeterBinder.java
+++ b/wsmaster/che-core-api-metrics/src/main/java/org/eclipse/che/api/metrics/WorkspaceMeterBinder.java
@@ -40,7 +40,7 @@ public class WorkspaceMeterBinder implements MeterBinder {
 
   private double count() {
     try {
-      return workspaceManager.getTotalCount();
+      return workspaceManager.getWorkspacesTotalCount();
     } catch (ServerException e) {
       return Double.NaN;
     }

--- a/wsmaster/che-core-api-metrics/src/main/java/org/eclipse/che/api/metrics/WsMasterMetricsModule.java
+++ b/wsmaster/che-core-api-metrics/src/main/java/org/eclipse/che/api/metrics/WsMasterMetricsModule.java
@@ -35,5 +35,6 @@ public class WsMasterMetricsModule extends AbstractModule {
     meterMultibinder.addBinding().to(WorkspaceStartAttemptsMeterBinder.class);
     meterMultibinder.addBinding().to(UserMeterBinder.class);
     meterMultibinder.addBinding().to(RuntimeLogMeterBinder.class);
+    meterMultibinder.addBinding().to(WorkspaceMeterBinder.class);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -585,6 +585,16 @@ public class WorkspaceManager {
     }
   }
 
+  /**
+   * Gets total count of all workspaces
+   *
+   * @return workspaces count
+   * @throws ServerException when any error occurs
+   */
+  public long getTotalCount() throws ServerException {
+    return workspaceDao.getTotalCount();
+  }
+
   private WorkspaceImpl doCreateWorkspace(
       WorkspaceConfig config, Account account, Map<String, String> attributes, boolean isTemporary)
       throws ConflictException, ServerException {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -591,8 +591,8 @@ public class WorkspaceManager {
    * @return workspaces count
    * @throws ServerException when any error occurs
    */
-  public long getTotalCount() throws ServerException {
-    return workspaceDao.getTotalCount();
+  public long getWorkspacesTotalCount() throws ServerException {
+    return workspaceDao.getWorkspacesTotalCount();
   }
 
   private WorkspaceImpl doCreateWorkspace(

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDao.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDao.java
@@ -262,6 +262,19 @@ public class JpaWorkspaceDao implements WorkspaceDao {
     return merged;
   }
 
+  @Override
+  @Transactional
+  public long getTotalCount() throws ServerException {
+    try {
+      return managerProvider
+          .get()
+          .createNamedQuery("Workspace.getTotalCount", Long.class)
+          .getSingleResult();
+    } catch (RuntimeException x) {
+      throw new ServerException(x.getLocalizedMessage(), x);
+    }
+  }
+
   @Singleton
   public static class RemoveWorkspaceBeforeAccountRemovedEventSubscriber
       extends CascadeEventSubscriber<BeforeAccountRemovedEvent> {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDao.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/jpa/JpaWorkspaceDao.java
@@ -264,11 +264,11 @@ public class JpaWorkspaceDao implements WorkspaceDao {
 
   @Override
   @Transactional
-  public long getTotalCount() throws ServerException {
+  public long getWorkspacesTotalCount() throws ServerException {
     try {
       return managerProvider
           .get()
-          .createNamedQuery("Workspace.getTotalCount", Long.class)
+          .createNamedQuery("Workspace.getWorkspacesTotalCount", Long.class)
           .getSingleResult();
     } catch (RuntimeException x) {
       throw new ServerException(x.getLocalizedMessage(), x);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
@@ -67,6 +67,7 @@ import org.eclipse.persistence.descriptors.DescriptorEventAdapter;
   @NamedQuery(
       name = "Workspace.getByNamespaceCount",
       query = "SELECT COUNT(w) " + "FROM Workspace w " + "WHERE w.account.name = :namespace "),
+  @NamedQuery(name = "Workspace.getTotalCount", query = "SELECT COUNT(w) FROM Workspace w"),
   @NamedQuery(
       name = "Workspace.getByTemporaryCount",
       query = "SELECT COUNT(w) " + "FROM Workspace w " + "WHERE w.isTemporary = :temporary ")

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/WorkspaceImpl.java
@@ -67,7 +67,9 @@ import org.eclipse.persistence.descriptors.DescriptorEventAdapter;
   @NamedQuery(
       name = "Workspace.getByNamespaceCount",
       query = "SELECT COUNT(w) " + "FROM Workspace w " + "WHERE w.account.name = :namespace "),
-  @NamedQuery(name = "Workspace.getTotalCount", query = "SELECT COUNT(w) FROM Workspace w"),
+  @NamedQuery(
+      name = "Workspace.getWorkspacesTotalCount",
+      query = "SELECT COUNT(w) FROM Workspace w"),
   @NamedQuery(
       name = "Workspace.getByTemporaryCount",
       query = "SELECT COUNT(w) " + "FROM Workspace w " + "WHERE w.isTemporary = :temporary ")

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/WorkspaceDao.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/WorkspaceDao.java
@@ -136,10 +136,10 @@ public interface WorkspaceDao {
       throws ServerException;
 
   /**
-   * Get count of all workspaces from persistent layer.
+   * Get the count of all workspaces from the persistent layer.
    *
    * @return workspace count
    * @throws ServerException when any error occurs
    */
-  long getTotalCount() throws ServerException;
+  long getWorkspacesTotalCount() throws ServerException;
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/WorkspaceDao.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/WorkspaceDao.java
@@ -134,4 +134,12 @@ public interface WorkspaceDao {
    */
   Page<WorkspaceImpl> getWorkspaces(boolean isTemporary, int maxItems, long skipCount)
       throws ServerException;
+
+  /**
+   * Get count of all workspaces from persistent layer.
+   *
+   * @return workspace count
+   * @throws ServerException when any error occurs
+   */
+  long getTotalCount() throws ServerException;
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -129,7 +129,7 @@ public class WorkspaceDaoTest {
 
   @Test
   public void shouldBeAbleToCountWorkspaces() throws ServerException {
-    assertEquals(workspaceDao.getTotalCount(), COUNT_OF_WORKSPACES);
+    assertEquals(workspaceDao.getWorkspacesTotalCount(), COUNT_OF_WORKSPACES);
   }
 
   @Test
@@ -139,7 +139,7 @@ public class WorkspaceDaoTest {
     workspaceRepo.createAll(
         ImmutableList.of(createWorkspaceFromDevfile("id222", accounts[0], "name-bbb")));
     // then
-    assertEquals(workspaceDao.getTotalCount(), COUNT_OF_WORKSPACES + 1);
+    assertEquals(workspaceDao.getWorkspacesTotalCount(), COUNT_OF_WORKSPACES + 1);
   }
 
   @Test
@@ -149,7 +149,7 @@ public class WorkspaceDaoTest {
     // when
     workspaceDao.remove(workspaces[1].getId());
     // then
-    assertEquals(workspaceDao.getTotalCount(), COUNT_OF_WORKSPACES - 1);
+    assertEquals(workspaceDao.getWorkspacesTotalCount(), COUNT_OF_WORKSPACES - 1);
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/spi/tck/WorkspaceDaoTest.java
@@ -128,6 +128,31 @@ public class WorkspaceDaoTest {
   }
 
   @Test
+  public void shouldBeAbleToCountWorkspaces() throws ServerException {
+    assertEquals(workspaceDao.getTotalCount(), COUNT_OF_WORKSPACES);
+  }
+
+  @Test
+  public void shouldBeAbleToCountNewWorkspaces() throws ServerException, TckRepositoryException {
+    // given
+    // when
+    workspaceRepo.createAll(
+        ImmutableList.of(createWorkspaceFromDevfile("id222", accounts[0], "name-bbb")));
+    // then
+    assertEquals(workspaceDao.getTotalCount(), COUNT_OF_WORKSPACES + 1);
+  }
+
+  @Test
+  public void shouldBeAbleToSubtractRemovedWorkspaces()
+      throws ServerException, TckRepositoryException {
+    // given
+    // when
+    workspaceDao.remove(workspaces[1].getId());
+    // then
+    assertEquals(workspaceDao.getTotalCount(), COUNT_OF_WORKSPACES - 1);
+  }
+
+  @Test
   public void shouldGetWorkspaceById() throws Exception {
     final WorkspaceImpl workspace = workspaces[0];
 


### PR DESCRIPTION
### What does this PR do?
Changes 
 - add explicit methods to get total number of workspaces to `WorkspaceManager` `WorkspaceDao` `MultiuserJpaWorkspaceDao` `JpaWorkspaceDao`
-  Set grafana image version from upstream.
-  `che_workspace_total or sum(che_workspace_status)` used to display number of workspaces on the dashboard.

<img width="412" alt="Знімок екрана 2020-04-17 о 14 20 31" src="https://user-images.githubusercontent.com/1614429/79568713-a5115080-80b6-11ea-92b8-b281f6cb7f29.png">

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/16465

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a

#### Docs PR
n/a