### PR TITLE
Fix indentation that prevents oc apply with an absolute path

### DIFF
--- a/deploy/openshift/templates/monitoring/grafana-dashboards.yaml
+++ b/deploy/openshift/templates/monitoring/grafana-dashboards.yaml
@@ -3608,7 +3608,7 @@ data:
       "version": 1
     }
   che-workspaces.json: |-
-      {
+    {
       "annotations": {
         "list": [
           {


### PR DESCRIPTION
### What does this PR do?
Fix indentation that prevents `oc apply` with an absolute path.

### What issues does this PR fix or reference?
```
error: error parsing /Users/skabashn/dev/src/redhat/che/deploy/openshift/templates/monitoring/grafana-dashboards.yaml: error converting YAML to JSON: yaml: line 9751: did not find expected key
```
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a


#### Docs PR
n/a