### PR TITLE
create ingress only for matching services of secure servers

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposer.java
@@ -319,13 +319,7 @@ public class KubernetesServerExposer<T extends KubernetesEnvironment> {
             matchedSecureServers,
             (serverId, srvrs) -> {
               secureServerExposer.expose(
-                  k8sEnv,
-                  pod,
-                  machineName,
-                  secureServiceName,
-                  serverId,
-                  servicePort,
-                  srvrs);
+                  k8sEnv, pod, machineName, secureServiceName, serverId, servicePort, srvrs);
             });
       }
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposer.java
@@ -325,7 +325,7 @@ public class KubernetesServerExposer<T extends KubernetesEnvironment> {
                   secureServiceName,
                   serverId,
                   servicePort,
-                  matchedSecureServers);
+                  srvrs);
             });
       }
     }


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
issue was that we put annotations of both servers to the ingress. Instead, we should pass there filtered map of servers so we add just annotations for servers we really need.

It's ok for unsecure servers.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16330

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
