### PR TITLE
che #15906 Disabling 'che.workspace.stop.role.enabled' by default

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -159,7 +159,7 @@ che.workspace.startup_debug_log_limit_bytes=10485760
 
 # If true, 'stop-workspace' role with the edit privileges will be granted to the 'che' ServiceAccount.
 # This configuration is mainly required for workspace idling when the OpenShift OAuth is enabled.
-che.workspace.stop.role.enabled=true
+che.workspace.stop.role.enabled=false
 
 ### Templates
 


### PR DESCRIPTION
Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

Hot-fix for https://github.com/eclipse/che/issues/16724

### What does this PR do?
Disabling 'che.workspace.stop.role.enabled' by default
the logic with granting stop-workspace role will not work in all the cases

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16724

