### PR TITLE
Do not provision the stop workspace role if there is no OS OAuth identitty provider

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -55,6 +55,8 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
   private final OpenShiftClientFactory clientFactory;
   private final OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner;
 
+  private final String oAuthIdentityProvider;
+
   @Inject
   public OpenShiftProjectFactory(
       @Nullable @Named("che.infra.openshift.project") String projectName,
@@ -67,7 +69,9 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
       OpenShiftClientConfigFactory clientConfigFactory,
       OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner,
       UserManager userManager,
-      KubernetesSharedPool sharedPool) {
+      KubernetesSharedPool sharedPool,
+      @Nullable @Named("che.infra.openshift.oauth_identity_provider")
+          String oAuthIdentityProvider) {
     super(
         projectName,
         serviceAccountName,
@@ -85,6 +89,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
     }
     this.clientFactory = clientFactory;
     this.stopWorkspaceRoleProvisioner = stopWorkspaceRoleProvisioner;
+    this.oAuthIdentityProvider = oAuthIdentityProvider;
   }
 
   public OpenShiftProject getOrCreate(RuntimeIdentity identity) throws InfrastructureException {
@@ -97,7 +102,10 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
           doCreateServiceAccount(osProject.getWorkspaceId(), osProject.getName());
       osWorkspaceServiceAccount.prepare();
     }
-    stopWorkspaceRoleProvisioner.provision(osProject.getName());
+
+    if (!isNullOrEmpty(oAuthIdentityProvider)) {
+      stopWorkspaceRoleProvisioner.provision(osProject.getName());
+    }
     return osProject;
   }
 


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Do not provision the stop workspace role if there is no OS OAuth identitty provider configured.

Signed-off-by: Tom George <tgeorge@redhat.com>


### What issues does this PR fix or reference?

This is a more long-term fix for https://github.com/eclipse/che/issues/16724

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
