### PR TITLE
Remove unnecessary import

### DIFF
--- a/tests/e2e/tests/e2e/GitSsh.spec.ts
+++ b/tests/e2e/tests/e2e/GitSsh.spec.ts
@@ -9,7 +9,6 @@
  **********************************************************************/
 
 import { assert } from 'chai';
-import { test } from 'mocha';
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES, TYPES } from '../../inversify.types';
 import { Editor } from '../../pageobjects/ide/Editor';


### PR DESCRIPTION
Remove of unnecessary import from the test. This import influences on the downstream dependency and does not affect on the test.