### PR TITLE
Do not create internal servers for public endpoints

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposer.java
@@ -188,7 +188,10 @@ public class KubernetesServerExposer<T extends KubernetesEnvironment> {
 
     Service service = createService(internalServers, externalServers, unsecuredPorts, securedPorts);
 
-    exposeNonSecureServers(service.getMetadata().getName(), externalServers, unsecuredPorts);
+    String serviceName = service.getMetadata().getName();
+    k8sEnv.getServices().put(serviceName, service);
+
+    exposeNonSecureServers(serviceName, externalServers, unsecuredPorts);
 
     exposeSecureServers(secureServers, securedPorts);
   }
@@ -298,8 +301,6 @@ public class KubernetesServerExposer<T extends KubernetesEnvironment> {
             .withServers(allInternalServers)
             .build();
 
-    String serviceName = service.getMetadata().getName();
-    k8sEnv.getServices().put(serviceName, service);
     return service;
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposerTest.java
@@ -513,8 +513,12 @@ public class KubernetesServerExposerTest {
         Annotations.newDeserializer(service.getMetadata().getAnnotations());
     assertEquals(serviceAnnotations.machineName(), machineName);
     // check that we did not create servers for public endpoints
-    assertFalse(serviceAnnotations.servers().keySet().stream()
-        .anyMatch(key -> expectedServers.containsKey(key)));
+    assertFalse(
+        serviceAnnotations
+            .servers()
+            .keySet()
+            .stream()
+            .anyMatch(key -> expectedServers.containsKey(key)));
 
     verify(externalServerExposer)
         .expose(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/KubernetesServerExposerTest.java
@@ -512,6 +512,9 @@ public class KubernetesServerExposerTest {
     Annotations.Deserializer serviceAnnotations =
         Annotations.newDeserializer(service.getMetadata().getAnnotations());
     assertEquals(serviceAnnotations.machineName(), machineName);
+    // check that we did not create servers for public endpoints
+    assertFalse(serviceAnnotations.servers().keySet().stream()
+        .anyMatch(key -> expectedServers.containsKey(key)));
 
     verify(externalServerExposer)
         .expose(


### PR DESCRIPTION
### What does this PR do?
Some kind of inconsistence was introduced earlies, causing than public endpoinds having both 
intenal server and external ingress/route (see att), so clients get confused. Thix fix disallows creation of internal servers for public endpoints.
![2-servers-8080](https://user-images.githubusercontent.com/1651062/80386797-8f6b0a80-88b0-11ea-90db-eca7ea77bfd4.png)



### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16381


#### Release Notes
N/A


#### Docs PR
N/A