### PR TITLE
che #15906 setting 'che.workspace.stop.role.enabled' to true

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -157,9 +157,9 @@ che.workspace.server.liveness_probes=wsagent/http,exec-agent/http,terminal,theia
 # default 10MB=10485760
 che.workspace.startup_debug_log_limit_bytes=10485760
 
-# If true, 'stop-workspace' role with the edit privileges will be granted to the 'che' ServiceAccount.
+# If true, 'stop-workspace' role with the edit privileges will be granted to the 'che' ServiceAccount if OpenShift OAuth is enabled.
 # This configuration is mainly required for workspace idling when the OpenShift OAuth is enabled.
-che.workspace.stop.role.enabled=false
+che.workspace.stop.role.enabled=true
 
 ### Templates
 


### PR DESCRIPTION
### What does this PR do?
setting 'che.workspace.stop.role.enabled' to true

After https://github.com/eclipse/che/pull/16735 we should be good to set the property to `true` by default

### What issues does this PR fix or reference?
fixup https://github.com/eclipse/che/issues/15906


#### Release Notes
N/A

#### Docs PR
N/A
