### PR TITLE
moved some jsonrpc and websocket logging to TRACE level

### DIFF
--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiver.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/JsonRpcMessageReceiver.java
@@ -62,7 +62,7 @@ public class JsonRpcMessageReceiver implements WebSocketMessageReceiver {
     checkNotNull(message, "Message must not be null");
     checkArgument(!message.isEmpty(), "Message must not be empty");
 
-    LOGGER.debug("Receiving message: {}, from endpoint: {}", message, combinedEndpointId);
+    LOGGER.trace("Receiving message: {}, from endpoint: {}", message, combinedEndpointId);
     if (!jsonRpcQualifier.isValidJson(message)) {
       String error = "An error occurred on the server while parsing the JSON text";
       errorTransmitter.transmit(combinedEndpointId, new JsonRpcException(-32700, error));

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestDispatcher.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/commons/RequestDispatcher.java
@@ -39,19 +39,19 @@ public class RequestDispatcher {
     checkArgument(!endpointId.isEmpty(), "Endpoint ID must not be empty");
     checkNotNull(request, "Request must not be null");
 
-    LOGGER.debug("Dispatching request: " + request + ", endpoint: " + endpointId);
+    LOGGER.trace("Dispatching request: " + request + ", endpoint: " + endpointId);
 
     String method = request.getMethod();
 
     JsonRpcParams params = request.getParams();
 
     if (request.hasId()) {
-      LOGGER.debug("Request has ID");
+      LOGGER.trace("Request has ID");
       String requestId = request.getId();
       checkRequestHandlerRegistration(method, requestId);
       requestHandlerManager.handle(endpointId, requestId, method, params);
     } else {
-      LOGGER.debug("Request has no ID -> it is a notification");
+      LOGGER.trace("Request has no ID -> it is a notification");
       checkNotificationHandlerRegistration(method);
       requestHandlerManager.handle(endpointId, method, params);
     }

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/GsonJsonRpcQualifier.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/jsonrpc/impl/GsonJsonRpcQualifier.java
@@ -41,15 +41,15 @@ public class GsonJsonRpcQualifier implements JsonRpcQualifier {
     checkNotNull(message, "Message must not be null");
     checkArgument(!message.isEmpty(), "Message must not be empty");
 
-    LOGGER.debug("Validating message: {}", message);
+    LOGGER.trace("Validating message: {}", message);
 
     try {
       jsonParser.parse(message);
 
-      LOGGER.debug("Validation successful");
+      LOGGER.trace("Validation successful");
       return true;
     } catch (JsonParseException e) {
-      LOGGER.debug("Validation failed: {}", e.getMessage(), e);
+      LOGGER.warn("Validation failed: {}", e.getMessage(), e);
       return false;
     }
   }
@@ -58,18 +58,18 @@ public class GsonJsonRpcQualifier implements JsonRpcQualifier {
   public boolean isJsonRpcRequest(String message) {
     checkNotNull(message, "Message must not be null");
     checkArgument(!message.isEmpty(), "Message must not be empty");
-    LOGGER.debug("Qualifying message: " + message);
+    LOGGER.trace("Qualifying message: " + message);
 
     JsonObject jsonObject = jsonParser.parse(message).getAsJsonObject();
-    LOGGER.debug(
+    LOGGER.trace(
         "Json keys: "
             + jsonObject.entrySet().stream().map(Map.Entry::getKey).collect(Collectors.toSet()));
 
     if (jsonObject.has("method")) {
-      LOGGER.debug("Qualified to request");
+      LOGGER.trace("Qualified to request");
       return true;
     } else {
-      LOGGER.debug("Qualified to response");
+      LOGGER.trace("Qualified to response");
       return false;
     }
   }
@@ -78,15 +78,15 @@ public class GsonJsonRpcQualifier implements JsonRpcQualifier {
   public boolean isJsonRpcResponse(String message) {
     checkNotNull(message, "Message must not be null");
     checkArgument(!message.isEmpty(), "Message must not be empty");
-    LOGGER.debug("Qualifying message: " + message);
+    LOGGER.trace("Qualifying message: " + message);
 
     JsonObject jsonObject = jsonParser.parse(message).getAsJsonObject();
-    LOGGER.debug(
+    LOGGER.trace(
         "Json keys: "
             + jsonObject.entrySet().stream().map(Map.Entry::getKey).collect(Collectors.toSet()));
 
     if (jsonObject.has("error") != jsonObject.has("result")) {
-      LOGGER.debug("Qualified to response");
+      LOGGER.trace("Qualified to response");
       return true;
     }
     return false;

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketEndpoint.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketEndpoint.java
@@ -99,9 +99,9 @@ public abstract class BasicWebSocketEndpoint {
     if (endpointIdOptional.isPresent()) {
       combinedEndpointId = endpointIdOptional.get();
 
-      LOG.debug("Receiving a web socket message.");
-      LOG.debug("Endpoint: {}", combinedEndpointId);
-      LOG.debug("Message: {}", message);
+      LOG.trace("Receiving a web socket message.");
+      LOG.trace("Endpoint: {}", combinedEndpointId);
+      LOG.trace("Message: {}", message);
 
     } else {
       combinedEndpointId = getOrGenerateCombinedEndpointId(session);
@@ -134,18 +134,14 @@ public abstract class BasicWebSocketEndpoint {
   public void onError(Throwable t, Session session) {
     Optional<String> endpointIdOptional = registry.get(session);
 
-    String combinedEndpointId;
     if (endpointIdOptional.isPresent()) {
-      combinedEndpointId = endpointIdOptional.get();
-
       LOG.debug("Web socket session error");
-      LOG.debug("Endpoint: {}", combinedEndpointId);
-      LOG.debug("Error: {}", t);
+      LOG.debug("Endpoint: {}", endpointIdOptional.get());
     } else {
       LOG.warn("Web socket session error");
       LOG.debug("Unidentified session");
-      LOG.debug("Error: {}", t);
     }
+    LOG.debug("Error: ", t);
   }
 
   protected abstract String getEndpointId();

--- a/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketMessageTransmitter.java
+++ b/core/che-core-api-core/src/main/java/org/eclipse/che/api/core/websocket/impl/BasicWebSocketMessageTransmitter.java
@@ -51,11 +51,11 @@ public class BasicWebSocketMessageTransmitter implements WebSocketMessageTransmi
     }
 
     if (!sessionOptional.isPresent() || !sessionOptional.get().isOpen()) {
-      LOG.debug("Session is not registered or closed, adding message to pending");
+      LOG.trace("Session is not registered or closed, adding message to pending");
 
       reSender.add(endpointId, message);
     } else {
-      LOG.debug("Session registered and open, sending message");
+      LOG.trace("Session registered and open, sending message");
 
       try {
         sessionOptional.get().getBasicRemote().sendText(message);


### PR DESCRIPTION
### What does this PR do?
DEBUG logs of che-server are polluted with jsonrpc and websocket logs logging every received/sent message. This PR is moving these messages into TRACE level.

### What issues does this PR fix or reference?
n/a
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
