### PR TITLE
Fix: [InjectOnMemberAndConstructor] Members shouldn't be annotated with @Inject if constructor is already annotated @Inject

### DIFF
--- a/tests/legacy-e2e/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/GitReset.java
+++ b/tests/legacy-e2e/che-selenium-test/src/main/java/org/eclipse/che/selenium/pageobject/git/GitReset.java
@@ -23,7 +23,7 @@ import org.openqa.selenium.support.PageFactory;
 /** @author Andrey Chizhikov */
 @Singleton
 public class GitReset {
-  @Inject SeleniumWebDriverHelper seleniumWebDriverHelper;
+  SeleniumWebDriverHelper seleniumWebDriverHelper;
 
   interface Locators {
     String RESET_TO_COMMIT_FORM = "gwt-debug-git-reset-window";

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
@@ -46,7 +46,7 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
   private GithubSourceStorageBuilder githubSourceStorageBuilder;
 
   /** ProjectDtoMerger */
-  @Inject private ProjectConfigDtoMerger projectConfigDtoMerger;
+  private ProjectConfigDtoMerger projectConfigDtoMerger;
 
   @Inject
   public GithubFactoryParametersResolver(


### PR DESCRIPTION
### What does this PR do?
Fixed error-prone's reported issue.

### What issues does this PR fix or reference?
https://errorprone.info/bugpattern/InjectOnMemberAndConstructor
[InjectOnMemberAndConstructor] Members shouldn't be annotated with @Inject if constructor is already annotated @Inject

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
n/a

#### Docs PR
n/a