### PR TITLE
Adapt automated E2E pre-release tests to check already released Che

### DIFF
--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -438,16 +438,3 @@ function runDevfileTestSuite() {
   -e TS_SELENIUM_WORKSPACE_STATUS_POLLING=20000 \
   quay.io/eclipse/che-e2e:nightly || IS_TESTS_FAILED=true
 }
-
-function getReleaseVersion() {
-  echo $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | cut -d'-' -f1) #cut SNAPSHOT from the version name
-}
-
-function setupReleaseVersionAndTag() {
-  echo "======== Starting Che RC test job $(date) ========"
-  RELEASE_VERSION=$(getReleaseVersion)
-  RELEASE_TAG="rc"
-
-  echo "======== Release version:" ${RELEASE_VERSION}
-  echo "======== Release tag:" ${RELEASE_TAG}
-}

--- a/tests/.infra/centos-ci/rc/cico-rc-multiuser-happy-path-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-multiuser-happy-path-test.sh
@@ -15,7 +15,6 @@ source tests/.infra/centos-ci/rc/rc_function_util.sh
 setupEnvs
 installKVM
 installDependencies
-setupReleaseVersionAndTag
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile false

--- a/tests/.infra/centos-ci/rc/cico-rc-multiuser-happy-path-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-multiuser-happy-path-test.sh
@@ -19,7 +19,7 @@ setupReleaseVersionAndTag
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile false
-installCheCtl
+installReleaseCheCtl
 deployCheIntoCluster  --che-operator-cr-yaml=/tmp/custom-resource.yaml
 createTestUserAndObtainUserToken
 createTestWorkspaceAndRunTest  --devfile=https://raw.githubusercontent.com/eclipse/che/cico-rc-test/tests/e2e/files/happy-path/happy-path-workspace.yaml

--- a/tests/.infra/centos-ci/rc/cico-rc-multiuser-integration-tests.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-multiuser-integration-tests.sh
@@ -12,7 +12,6 @@ source tests/.infra/centos-ci/rc/rc_function_util.sh
 
 setupEnvs
 installDependencies
-setupReleaseVersionAndTag
 installDockerCompose
 installKVM
 installAndStartMinishift

--- a/tests/.infra/centos-ci/rc/cico-rc-multiuser-integration-tests.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-multiuser-integration-tests.sh
@@ -18,7 +18,7 @@ installKVM
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile false
-installCheCtl
+installReleaseCheCtl
 deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/custom-resource.yaml
 createIndentityProvider
 seleniumTestsSetup

--- a/tests/.infra/centos-ci/rc/cico-rc-ocp-oauth-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-ocp-oauth-test.sh
@@ -12,7 +12,6 @@ source tests/.infra/centos-ci/rc/rc_function_util.sh
 
 setupEnvs
 installDependencies
-setupReleaseVersionAndTag
 installDockerCompose
 installKVM
 installAndStartMinishift

--- a/tests/.infra/centos-ci/rc/cico-rc-ocp-oauth-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-ocp-oauth-test.sh
@@ -18,7 +18,7 @@ installKVM
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile true
-installCheCtl
+installReleaseCheCtl
 deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/custom-resource.yaml
 seleniumTestsSetup
 

--- a/tests/.infra/centos-ci/rc/cico-rc-rolling-strategy-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-rolling-strategy-test.sh
@@ -18,7 +18,7 @@ installKVM
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile false
-installCheCtl
+installReleaseCheCtl
 deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/custom-resource.yaml
 seleniumTestsSetup
 

--- a/tests/.infra/centos-ci/rc/cico-rc-rolling-strategy-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-rolling-strategy-test.sh
@@ -12,7 +12,6 @@ source tests/.infra/centos-ci/rc/rc_function_util.sh
 
 setupEnvs
 installDependencies
-setupReleaseVersionAndTag
 installDockerCompose
 installKVM
 installAndStartMinishift

--- a/tests/.infra/centos-ci/rc/rc_function_util.sh
+++ b/tests/.infra/centos-ci/rc/rc_function_util.sh
@@ -7,18 +7,29 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 function prepareCustomResourceFile() {
+  RELEASE_VERSION=7.12.1
   echo "======== Patch custom-resource.yaml ========"
   cd /tmp
-  wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
+  wget https://raw.githubusercontent.com/eclipse/che-operator/$RELEASE_VERSION/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   setOpenShiftoAuth=$1 # sets the value of 'openShiftoAuth' parameter
   sed -i "s@openShiftoAuth: false@openShiftoAuth: $1@g" /tmp/custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
   sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
-  sed -i "s@identityProviderImage: 'quay.io/eclipse/che-keycloak:nightly'@identityProviderImage: 'quay.io/eclipse/che-keycloak:$RELEASE_TAG'@g" /tmp/custom-resource.yaml
+  sed -i "s@identityProviderImage: 'quay.io/eclipse/che-keycloak:nightly'@identityProviderImage: 'quay.io/eclipse/che-keycloak:$RELEASE_VERSION'@g" /tmp/custom-resource.yaml
   sed -i "s@cheImage: ''@cheImage: 'quay.io/eclipse/che-server'@g" /tmp/custom-resource.yaml
-  sed -i "s@cheImageTag: 'nightly'@cheImageTag: '$RELEASE_TAG'@g" /tmp/custom-resource.yaml
+  sed -i "s@cheImageTag: 'nightly'@cheImageTag: '$RELEASE_VERSION'@g" /tmp/custom-resource.yaml
   sed -i "s@devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:nightly'@devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:$RELEASE_VERSION'@g" /tmp/custom-resource.yaml
   sed -i "s@pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:nightly'@pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:$RELEASE_VERSION'@g " /tmp/custom-resource.yaml
   sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
+}
+
+function installReleaseCheCtl() {
+  # 7.12.1 chectl
+  releaseChectlPackageUrl=https://github.com/che-incubator/chectl/releases/download/20200501092240/chectl-linux-x64.tar.gz
+
+  cd /tmp
+  wget ${releaseChectlPackageUrl} -O chectl-linux-x64.tar.gz
+  tar -xzf chectl-linux-x64.tar.gz
+  export PATH=$PATH:/tmp/chectl/bin
 }

--- a/tests/.infra/crw-ci/master/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/master/k8s/Jenkinsfile
@@ -52,7 +52,13 @@ pipeline {
                                                 value: true),
 
                                         string(name: 'e2eTestParameters',
-                                                value: '')
+                                                value: ''),
+
+                                        string(name: 'chectlPackageUrl',
+                                                value: ''),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: 'nightly')
                                 ]
                     }
                 }
@@ -89,7 +95,13 @@ pipeline {
                                                 value: false),
 
                                         string(name: 'e2eTestParameters',
-                                                value: '')
+                                                value: ''),
+
+                                        string(name: 'chectlPackageUrl',
+                                                value: ''),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: 'nightly')
                                 ]
                     }
                 }
@@ -127,7 +139,13 @@ pipeline {
                                                     value: false),
 
                                             string(name: 'e2eTestParameters',
-                                                    value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0")
+                                                    value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+
+                                            string(name: 'chectlPackageUrl',
+                                                    value: ''),
+
+                                            string(name: 'cheE2eImageTag',
+                                                    value: 'nightly')
                                     ]
                         }
                     }

--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -51,7 +51,13 @@ pipeline {
                                                 value: true),
 
                                         string(name: 'e2eTestParameters',
-                                                value: '')
+                                                value: ''),
+
+                                        string(name: 'chectlPackageUrl',
+                                                value: ''),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: 'nightly')
                                 ]
                     }
                 }
@@ -88,7 +94,13 @@ pipeline {
                                                 value: false),
 
                                         string(name: 'e2eTestParameters',
-                                                value: '')
+                                                value: ''),
+
+                                        string(name: 'chectlPackageUrl',
+                                                value: ''),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: 'nightly')
                                 ]
                     }
                 }
@@ -126,7 +138,13 @@ pipeline {
                                                         value: false),
 
                                                 string(name: 'e2eTestParameters',
-                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0")
+                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+
+                                                string(name: 'chectlPackageUrl',
+                                                        value: ''),
+
+                                                string(name: 'cheE2eImageTag',
+                                                        value: 'nightly')
                                         ]
                         }
                     }

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
         LOGS_AND_CONFIGS ="${WORKSPACE}/logs-and-configs"
 
         mutableCheImageTag = ""
+        pathToChectl = ""
     }
 
     parameters {
@@ -58,6 +59,18 @@ pipeline {
 
         string(name: 'e2eTestParameters',
                 defaultValue: "")
+
+        string(
+                name: "chectlPackageUrl",
+                defaultValue: "https://github.com/che-incubator/chectl/releases/download/20200424063811/chectl-linux-x64.tar.gz",
+                description: "URL address of chectl package"
+        )
+
+        string(
+                name: "cheE2eImageTag",
+                defaultValue: "nightly",
+                description: "Tag of quay.io/eclipse/che-e2e image"
+        )
     }
 
     stages {
@@ -91,14 +104,24 @@ pipeline {
                     steps {
                         script {
                             retry(2) {
-                                // TO-DO use option "--install-path" https://github.com/eclipse/che/pull/14182
-                                sh """
-                                curl -sL https://www.eclipse.org/che/chectl/ > install_chectl.sh
-                                chmod +x install_chectl.sh
-                                sudo PATH=$PATH ./install_chectl.sh --channel=next
-                                sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
-                                sudo chmod +x ${WORKSPACE}/chectl
-                                """
+                                if (chectlPackageUrl != "") {
+                                    sh """
+                                        wget ${chectlPackageUrl} -O chectl-linux-x64.tar.gz
+                                        tar -xzf chectl-linux-x64.tar.gz
+                                    """
+                                    pathToChectl = "${WORKSPACE}/chectl/bin/chectl"
+
+                                } else {
+                                    echo "Install chectl using https://www.eclipse.org/che/chectl/ --channel=next"
+                                    sh """
+                                        curl -sL https://www.eclipse.org/che/chectl/ > install_chectl.sh
+                                        chmod +x install_chectl.sh
+                                        sudo PATH=$PATH ./install_chectl.sh --channel=next
+                                        sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
+                                        sudo chmod +x ${WORKSPACE}/chectl
+                                    """
+                                    pathToChectl = "${WORKSPACE}/chectl"
+                                }
                             }
                         }
                     }
@@ -177,7 +200,7 @@ pipeline {
                         script {
                             retry(2) {
                                 sh """
-                                    docker pull quay.io/eclipse/che-e2e:nightly
+                                    docker pull quay.io/eclipse/che-e2e:$cheE2eImageTag
                                     docker pull quay.io/eclipse/happy-path:nightly
                                 """
                             }
@@ -214,16 +237,13 @@ pipeline {
                         sed -i "s|cheLogLevel: INFO|cheLogLevel: DEBUG|" $CUSTOM_RESOURCE_FILE_PATH
                         sed -i "s|ingressDomain: '192.168.99.101.nip.io'|ingressDomain: '\$(minikube ip).nip.io'|" $CUSTOM_RESOURCE_FILE_PATH
 
-                        # temporary workaround to https://github.com/eclipse/che/issues/16292
-                        sed -i "s/tlsSupport: true/tlsSupport: false/" $CUSTOM_RESOURCE_FILE_PATH  
-
                         # TODO: "selfSignedCert: true" so as TLS support is enebled by default 
-                        # sed -i "s/selfSignedCert: false/selfSignedCert: true/" $CUSTOM_RESOURCE_FILE_PATH    
+                        sed -i "s/selfSignedCert: false/selfSignedCert: true/" $CUSTOM_RESOURCE_FILE_PATH    
                     """
 
                     echo "Install Che"
                     sh """
-                        ${WORKSPACE}/chectl server:start \\
+                        ${pathToChectl} server:start \\
                         --k8spodreadytimeout=180000 \\
                         --installer=operator \\
                         --listr-renderer=verbose \\
@@ -291,7 +311,7 @@ pipeline {
                            -d "grant_type=password" \\
                            -d "client_id=che-public" | jq -r .access_token)
     
-                        ${WORKSPACE}/chectl workspace:create --start \\
+                        ${pathToChectl} workspace:create --start \\
                            --devfile=${DEVFILE_PATH} \\
                            --access-token "\$USER_ACCESS_TOKEN"
                     """
@@ -316,7 +336,7 @@ pipeline {
                        -e TEST_SUITE="${e2eTestToRun}" ${e2eTestParameters} \\
                        -e NODE_TLS_REJECT_UNAUTHORIZED=0 \\
                        -v ${WORKSPACE}/tests/e2e:/tmp/e2e:Z \\
-                       quay.io/eclipse/che-e2e:nightly
+                       quay.io/eclipse/che-e2e:${cheE2eImageTag}
                 """
             }
         }
@@ -359,7 +379,7 @@ pipeline {
                 docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
 
                 env > $LOGS_AND_CONFIGS/env.output.txt || true
-                ${WORKSPACE}/chectl --help > $LOGS_AND_CONFIGS/chectl.version.txt || true
+                ${pathToChectl} --help > $LOGS_AND_CONFIGS/chectl.version.txt || true
 
                 cp -r /tmp/chectl-logs $LOGS_AND_CONFIGS || true
             """

--- a/tests/.infra/crw-ci/pre-release-testing/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pre-release-testing/k8s/Jenkinsfile
@@ -11,9 +11,6 @@ pipeline {
     environment {
         YQ_TOOL_URL='https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64'
 
-        CHE_THEIA_META_YAML_URL='https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/eclipse/che-theia/next/meta.yaml'
-        VSCODE_YAML_META_YAML_DIR_URL='https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/redhat/vscode-yaml/'
-        JAVA8_META_YAML_DIR_URL='https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/redhat/java8/'
         DEVFILE_URL="${WORKSPACE}/happy-path-workspace.yaml"
 
         String customResourceFileContent = ""
@@ -21,12 +18,16 @@ pipeline {
 
     parameters {
         string(name: 'RELEASE_BRANCH',
-                defaultValue: "7.5.x",
+                defaultValue: "7.12.x",
                 description: 'Branch with pre-release version to take E2E Happy path test.')
 
         string(name: 'RELEASE_VERSION',
-                defaultValue: "7.5.0",
+                defaultValue: "7.12.1",
                 description: 'Version of Che-theia')
+
+        string(name: 'CHECTL_PACKAGE_URL',
+                defaultValue: "https://github.com/che-incubator/chectl/releases/download/20200501092240/chectl-linux-x64.tar.gz",
+                description: 'URL address of chectl package tar ball')
     }
 
     stages {
@@ -34,6 +35,8 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'GITHUB_TOKEN')]) {
                     sh """
+                      CHE_THEIA_META_YAML_URL='https://raw.githubusercontent.com/eclipse/che-plugin-registry/$RELEASE_BRANCH/v3/plugins/eclipse/che-theia/next/meta.yaml'
+
                       wget https://raw.githubusercontent.com/eclipse/che/$RELEASE_BRANCH/tests/e2e/files/happy-path/happy-path-workspace.yaml --no-check-certificate -O $DEVFILE_URL
                     
                       PR_CHECK_FILES_DIR=${WORKSPACE}/pr-check-files/che/$RELEASE_VERSION
@@ -45,7 +48,7 @@ pipeline {
                       wget $YQ_TOOL_URL
                       sudo chmod +x yq_linux_amd64
                     
-                      wget $CHE_THEIA_META_YAML_URL -O \$PR_CHECK_FILES_DIR/che_theia_meta.yaml
+                      wget \$CHE_THEIA_META_YAML_URL -O \$PR_CHECK_FILES_DIR/che_theia_meta.yaml
                       ./yq_linux_amd64 w -i \$PR_CHECK_FILES_DIR/che_theia_meta.yaml spec.containers[0].image quay.io/eclipse/che-theia:$RELEASE_VERSION
                       ./yq_linux_amd64 w -i \$PR_CHECK_FILES_DIR/che_theia_meta.yaml spec.initContainers[0].image quay.io/eclipse/che-theia-endpoint-runtime-binary:$RELEASE_VERSION
                     
@@ -70,7 +73,7 @@ pipeline {
                     String customResourceFilePath = "${WORKSPACE}/custom-resource.yaml"
 
                     sh """
-                        wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml \\
+                        wget https://raw.githubusercontent.com/eclipse/che-operator/$RELEASE_VERSION/deploy/crds/org_v1_che_cr.yaml \\
                           -O $customResourceFilePath
 
                         # TODO: "selfSignedCert: true" so as TLS support is enebled by default 
@@ -82,7 +85,7 @@ pipeline {
                     """
 
                     customResourceFileContent = readFile customResourceFilePath
-                    customResourceFileContent = customResourceFileContent.replace("eclipse/che-keycloak:nightly", "eclipse/che-keycloak:rc")
+                    customResourceFileContent = customResourceFileContent.replace("eclipse/che-keycloak:nightly", "eclipse/che-keycloak:$RELEASE_VERSION")
                     customResourceFileContent = customResourceFileContent.replace("quay.io/eclipse/che-devfile-registry:nightly", "quay.io/eclipse/che-devfile-registry:$RELEASE_VERSION")
                     customResourceFileContent = customResourceFileContent.replace("quay.io/eclipse/che-plugin-registry:nightly", "quay.io/eclipse/che-plugin-registry:$RELEASE_VERSION")
                 }
@@ -102,13 +105,13 @@ pipeline {
                                                     value: 'quay.io/eclipse/che-server'),
 
                                             string(name: 'cheImageTag',
-                                                    value: 'rc'),
+                                                    value: RELEASE_VERSION),
 
                                             booleanParam(name: 'buildChe',
                                                     value: false),
 
                                             string(name: 'ghprbSourceBranch',
-                                                    value: "$RELEASE_BRANCH"),
+                                                    value: RELEASE_BRANCH),
 
                                             string(name: 'ghprbPullId',
                                                     value: ''),
@@ -126,7 +129,13 @@ pipeline {
                                                     value: true),
 
                                             string(name: 'e2eTestParameters',
-                                                    value: '')
+                                                    value: ''),
+
+                                            string(name: 'chectlPackageUrl',
+                                                    value: CHECTL_PACKAGE_URL),
+
+                                            string(name: 'cheE2eImageTag',
+                                                    value: RELEASE_VERSION)
                                     ]
                         }
                     }
@@ -141,13 +150,13 @@ pipeline {
                                                     value: 'quay.io/eclipse/che-server'),
 
                                             string(name: 'cheImageTag',
-                                                    value: 'rc'),
+                                                    value: RELEASE_VERSION),
 
                                             booleanParam(name: 'buildChe',
                                                     value: false),
 
                                             string(name: 'ghprbSourceBranch',
-                                                    value: "$RELEASE_BRANCH"),
+                                                    value: RELEASE_BRANCH),
 
                                             string(name: 'ghprbPullId',
                                                     value: ''),
@@ -159,13 +168,19 @@ pipeline {
                                                     value: ""),
 
                                             text(name: 'customResourceFileContent',
-                                                    value: "$customResourceFileContent"),
+                                                    value: customResourceFileContent),
 
                                             booleanParam(name: 'createTestWorkspace',
                                                     value: false),
 
                                             string(name: 'e2eTestParameters',
-                                                    value: '')
+                                                    value: ''),
+
+                                            string(name: 'chectlPackageUrl',
+                                                    value: CHECTL_PACKAGE_URL),
+
+                                            string(name: 'cheE2eImageTag',
+                                                    value: RELEASE_VERSION)
                                     ]
                         }
                     }
@@ -180,13 +195,13 @@ pipeline {
                                                         value: 'quay.io/eclipse/che-server'),
 
                                                 string(name: 'cheImageTag',
-                                                        value: 'nightly'),
+                                                        value: RELEASE_VERSION),
 
                                                 booleanParam(name: 'buildChe',
                                                         value: false),
 
                                                 string(name: 'ghprbSourceBranch',
-                                                        value: "$RELEASE_BRANCH"),
+                                                        value: RELEASE_BRANCH),
 
                                                 string(name: 'ghprbPullId',
                                                         value: ''),
@@ -198,13 +213,19 @@ pipeline {
                                                         value: ''),
 
                                                 text(name: 'customResourceFileContent',
-                                                        value: ''),
+                                                        value: customResourceFileContent),
 
                                                 booleanParam(name: 'createTestWorkspace',
                                                         value: false),
 
                                                 string(name: 'e2eTestParameters',
-                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0")
+                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+
+                                                string(name: 'chectlPackageUrl',
+                                                        value: CHECTL_PACKAGE_URL),
+
+                                                string(name: 'cheE2eImageTag',
+                                                        value: RELEASE_VERSION)
                                         ]
                         }
                     }    


### PR DESCRIPTION
### What does this PR do?
It adapts release-candidate E2E tests to check already release version of Eclipse Che 7.12.1 on ci.centos CI and CRW CCI:
- download custom resource yaml from https://github.com/eclipse/che-operator/blob/7.12.1/deploy/crds/org_v1_che_cr.yaml;
- replace nightly tag with **7.12.1** tag instead of **rc**
- use [Chectl **7.12.1** tar balls](https://github.com/che-incubator/chectl/releases/download/20200501092240/chectl-linux-x64.tar.gz) to install Eclipse Che;
- use to run [quay.io/eclipse/che-e2e:**7.12.1**](https://quay.io/eclipse/che-e2e:7.12.1) to run E2E typescript selenium tests;
- remove failing `getReleaseVersion()` method from ci.centos job script.

Test results could be found [here](https://github.com/eclipse/che/issues/16743#issuecomment-623221961).

### What issues does this PR fix or reference?
#16565, #16743

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
