### PR TITLE
Used version docker-maven-plugin:0.22.1 that is defined in parent-pom

### DIFF
--- a/multiuser/integration-tests/che-multiuser-postgresql-tck/pom.xml
+++ b/multiuser/integration-tests/che-multiuser-postgresql-tck/pom.xml
@@ -219,7 +219,6 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.15.16</version>
                         <!-- Connect start/stop to pre- and
                  post-integration-test phase, respectively if you want to start
                  your docker containers during integration tests -->


### PR DESCRIPTION
### What does this PR do?
Used version docker-maven-plugin:0.22.1 that is defined in parent-pom and fixed an issue with auth in some cases

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16879
