### PR TITLE
Adapt automated E2E pre-release tests to verify released Che version

### DIFF
--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -444,16 +444,3 @@ function runDevfileTestSuite() {
   -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
   quay.io/eclipse/che-e2e:nightly || IS_TESTS_FAILED=true
 }
-
-function getReleaseVersion() {
-  echo $(mvn help:evaluate -Dexpression=project.version -q -DforceStdout | cut -d'-' -f1) #cut SNAPSHOT from the version name
-}
-
-function setupReleaseVersionAndTag() {
-  echo "======== Starting Che RC test job $(date) ========"
-  RELEASE_VERSION=$(getReleaseVersion)
-  RELEASE_TAG="rc"
-
-  echo "======== Release version:" ${RELEASE_VERSION}
-  echo "======== Release tag:" ${RELEASE_TAG}
-}

--- a/tests/.infra/centos-ci/rc/cico-rc-multiuser-happy-path-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-multiuser-happy-path-test.sh
@@ -15,11 +15,10 @@ source tests/.infra/centos-ci/rc/rc_function_util.sh
 setupEnvs
 installKVM
 installDependencies
-setupReleaseVersionAndTag
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile false
-installCheCtl
+installReleaseCheCtl
 deployCheIntoCluster  --che-operator-cr-yaml=/tmp/custom-resource.yaml
 createTestUserAndObtainUserToken
 createTestWorkspaceAndRunTest  --devfile=https://raw.githubusercontent.com/eclipse/che/cico-rc-test/tests/e2e/files/happy-path/happy-path-workspace.yaml

--- a/tests/.infra/centos-ci/rc/cico-rc-multiuser-integration-tests.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-multiuser-integration-tests.sh
@@ -12,13 +12,12 @@ source tests/.infra/centos-ci/rc/rc_function_util.sh
 
 setupEnvs
 installDependencies
-setupReleaseVersionAndTag
 installDockerCompose
 installKVM
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile false
-installCheCtl
+installReleaseCheCtl
 deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/custom-resource.yaml
 createIndentityProvider
 seleniumTestsSetup

--- a/tests/.infra/centos-ci/rc/cico-rc-ocp-oauth-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-ocp-oauth-test.sh
@@ -12,13 +12,12 @@ source tests/.infra/centos-ci/rc/rc_function_util.sh
 
 setupEnvs
 installDependencies
-setupReleaseVersionAndTag
 installDockerCompose
 installKVM
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile true
-installCheCtl
+installReleaseCheCtl
 deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/custom-resource.yaml
 seleniumTestsSetup
 

--- a/tests/.infra/centos-ci/rc/cico-rc-rolling-strategy-test.sh
+++ b/tests/.infra/centos-ci/rc/cico-rc-rolling-strategy-test.sh
@@ -12,13 +12,12 @@ source tests/.infra/centos-ci/rc/rc_function_util.sh
 
 setupEnvs
 installDependencies
-setupReleaseVersionAndTag
 installDockerCompose
 installKVM
 installAndStartMinishift
 loginToOpenshiftAndSetDevRole
 prepareCustomResourceFile false
-installCheCtl
+installReleaseCheCtl
 deployCheIntoCluster  --chenamespace=eclipse-che --che-operator-cr-yaml=/tmp/custom-resource.yaml
 seleniumTestsSetup
 

--- a/tests/.infra/centos-ci/rc/rc_function_util.sh
+++ b/tests/.infra/centos-ci/rc/rc_function_util.sh
@@ -7,19 +7,30 @@
 # http://www.eclipse.org/legal/epl-v10.html
 
 function prepareCustomResourceFile() {
+  RELEASE_VERSION=7.12.1
   echo "======== Patch custom-resource.yaml ========"
   cd /tmp
-  wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
+  wget https://raw.githubusercontent.com/eclipse/che-operator/$RELEASE_VERSION/deploy/crds/org_v1_che_cr.yaml -O custom-resource.yaml
   setOpenShiftoAuth=$1 # sets the value of 'openShiftoAuth' parameter
   sed -i "s@openShiftoAuth: false@openShiftoAuth: $1@g" /tmp/custom-resource.yaml
   sed -i "s@server:@server:\n    customCheProperties:\n      CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'@g" /tmp/custom-resource.yaml
   sed -i "s/customCheProperties:/customCheProperties:\n      CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'/" /tmp/custom-resource.yaml
-  sed -i "s@identityProviderImage: 'quay.io/eclipse/che-keycloak:nightly'@identityProviderImage: 'quay.io/eclipse/che-keycloak:$RELEASE_TAG'@g" /tmp/custom-resource.yaml
+  sed -i "s@identityProviderImage: 'quay.io/eclipse/che-keycloak:nightly'@identityProviderImage: 'quay.io/eclipse/che-keycloak:$RELEASE_VERSION'@g" /tmp/custom-resource.yaml
   sed -i "s@cheImage: ''@cheImage: 'quay.io/eclipse/che-server'@g" /tmp/custom-resource.yaml
-  sed -i "s@cheImageTag: 'nightly'@cheImageTag: '$RELEASE_TAG'@g" /tmp/custom-resource.yaml
+  sed -i "s@cheImageTag: 'nightly'@cheImageTag: '$RELEASE_VERSION'@g" /tmp/custom-resource.yaml
   sed -i "s@devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:nightly'@devfileRegistryImage: 'quay.io/eclipse/che-devfile-registry:$RELEASE_VERSION'@g" /tmp/custom-resource.yaml
   sed -i "s@pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:nightly'@pluginRegistryImage: 'quay.io/eclipse/che-plugin-registry:$RELEASE_VERSION'@g " /tmp/custom-resource.yaml
   sed -i "s@tlsSupport: true@tlsSupport: false@g" /tmp/custom-resource.yaml
   sed -i "s@identityProviderPassword: ''@identityProviderPassword: 'admin'@g" /tmp/custom-resource.yaml
   cat /tmp/custom-resource.yaml
+}
+
+function installReleaseCheCtl() {
+  # 7.12.1 chectl
+  releaseChectlPackageUrl=https://github.com/che-incubator/chectl/releases/download/20200501092240/chectl-linux-x64.tar.gz
+
+  cd /tmp
+  wget ${releaseChectlPackageUrl} -O chectl-linux-x64.tar.gz
+  tar -xzf chectl-linux-x64.tar.gz
+  export PATH=$PATH:/tmp/chectl/bin
 }

--- a/tests/.infra/crw-ci/master/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/master/k8s/Jenkinsfile
@@ -45,14 +45,17 @@ pipeline {
                                         string(name: 'testWorkspaceDevfileUrl',
                                                 value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
 
-                                        text(name: 'customResourceFileContent',
-                                                value: ''),
-
                                         booleanParam(name: 'createTestWorkspace',
                                                 value: true),
 
                                         string(name: 'e2eTestParameters',
-                                                value: '')
+                                                value: ''),
+
+                                        string(name: 'chectlPackageUrl',
+                                                value: ''),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: 'nightly')
                                 ]
                     }
                 }
@@ -82,14 +85,17 @@ pipeline {
                                         string(name: 'testWorkspaceDevfileUrl',
                                                 value: ''),
 
-                                        text(name: 'customResourceFileContent',
-                                                value: ''),
-
                                         booleanParam(name: 'createTestWorkspace',
                                                 value: false),
 
                                         string(name: 'e2eTestParameters',
-                                                value: '')
+                                                value: ''),
+
+                                        string(name: 'chectlPackageUrl',
+                                                value: ''),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: 'nightly')
                                 ]
                     }
                 }
@@ -120,14 +126,17 @@ pipeline {
                                             string(name: 'testWorkspaceDevfileUrl',
                                                     value: ''),
 
-                                            text(name: 'customResourceFileContent',
-                                                    value: ''),
-
                                             booleanParam(name: 'createTestWorkspace',
                                                     value: false),
 
                                             string(name: 'e2eTestParameters',
-                                                    value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0")
+                                                    value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+
+                                            string(name: 'chectlPackageUrl',
+                                                    value: ''),
+
+                                            string(name: 'cheE2eImageTag',
+                                                    value: 'nightly')
                                     ]
                         }
                     }

--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -44,14 +44,17 @@ pipeline {
                                         string(name: 'testWorkspaceDevfileUrl',
                                                 value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
 
-                                        text(name: 'customResourceFileContent',
-                                                value: ''),
-
                                         booleanParam(name: 'createTestWorkspace',
                                                 value: true),
 
                                         string(name: 'e2eTestParameters',
-                                                value: '')
+                                                value: ''),
+
+                                        string(name: 'chectlPackageUrl',
+                                                value: ''),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: 'nightly')
                                 ]
                     }
                 }
@@ -81,14 +84,17 @@ pipeline {
                                         string(name: 'testWorkspaceDevfileUrl',
                                                 value: ''),
 
-                                        text(name: 'customResourceFileContent',
-                                                value: ''),
-
                                         booleanParam(name: 'createTestWorkspace',
                                                 value: false),
 
                                         string(name: 'e2eTestParameters',
-                                                value: '')
+                                                value: ''),
+
+                                        string(name: 'chectlPackageUrl',
+                                                value: ''),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: 'nightly')
                                 ]
                     }
                 }
@@ -119,14 +125,17 @@ pipeline {
                                                 string(name: 'testWorkspaceDevfileUrl',
                                                         value: ''),
 
-                                                text(name: 'customResourceFileContent',
-                                                        value: ''),
-
                                                 booleanParam(name: 'createTestWorkspace',
                                                         value: false),
 
                                                 string(name: 'e2eTestParameters',
-                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0")
+                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+
+                                                string(name: 'chectlPackageUrl',
+                                                        value: ''),
+
+                                                string(name: 'cheE2eImageTag',
+                                                        value: 'nightly')
                                         ]
                         }
                     }

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -15,13 +15,14 @@ pipeline {
         JENKINS_BUILD = "true"
 
         DEVFILE_PATH = "${WORKSPACE}/test-workspace-devfile.yaml"
-        CUSTOM_RESOURCE_FILE_PATH = "${WORKSPACE}/custom-resource.yaml"
+        CUSTOM_RESOURCE_PATCH_FILE_PATH = "${WORKSPACE}/custom-resource-patch.yaml"
 
         SUCCESS_THRESHOLD = 5
 
         LOGS_AND_CONFIGS ="${WORKSPACE}/logs-and-configs"
 
         mutableCheImageTag = ""
+        pathToChectl = ""
     }
 
     parameters {
@@ -45,10 +46,6 @@ pipeline {
                 defaultValue: "",
                 description: 'URL of devfile of test workspace')
 
-        text(name: 'customResourceFileContent',
-                defaultValue: "",
-                description: 'Content of custom-resource.yaml')
-
         booleanParam(name: 'createTestWorkspace',
                 defaultValue: true,
                 description: 'Should create test workspace')
@@ -58,6 +55,18 @@ pipeline {
 
         string(name: 'e2eTestParameters',
                 defaultValue: "")
+
+        string(
+                name: "chectlPackageUrl",
+                defaultValue: "",
+                description: "URL address of chectl package"
+        )
+
+        string(
+                name: "cheE2eImageTag",
+                defaultValue: "nightly",
+                description: "Tag of quay.io/eclipse/che-e2e image"
+        )
     }
 
     stages {
@@ -68,16 +77,6 @@ pipeline {
                         mutableCheImageTag = ghprbPullId
                     } else {
                         mutableCheImageTag = cheImageTag
-                    }
-
-                    if (customResourceFileContent == null || customResourceFileContent == '') {
-                        sh """
-                            wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml \\
-                            -O $CUSTOM_RESOURCE_FILE_PATH                                                  
-                        """
-
-                    } else {
-                        writeFile file: CUSTOM_RESOURCE_FILE_PATH, text: customResourceFileContent
                     }
                 }
             }
@@ -91,14 +90,24 @@ pipeline {
                     steps {
                         script {
                             retry(2) {
-                                // TO-DO use option "--install-path" https://github.com/eclipse/che/pull/14182
-                                sh """
-                                curl -sL https://www.eclipse.org/che/chectl/ > install_chectl.sh
-                                chmod +x install_chectl.sh
-                                sudo PATH=$PATH ./install_chectl.sh --channel=next
-                                sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
-                                sudo chmod +x ${WORKSPACE}/chectl
-                                """
+                                if (chectlPackageUrl != "") {
+                                    sh """
+                                        wget ${chectlPackageUrl} -O chectl-linux-x64.tar.gz
+                                        tar -xzf chectl-linux-x64.tar.gz
+                                    """
+                                    pathToChectl = "${WORKSPACE}/chectl/bin/chectl"
+
+                                } else {
+                                    echo "Install chectl using https://www.eclipse.org/che/chectl/ --channel=next"
+                                    sh """
+                                        curl -sL https://www.eclipse.org/che/chectl/ > install_chectl.sh
+                                        chmod +x install_chectl.sh
+                                        sudo PATH=$PATH ./install_chectl.sh --channel=next
+                                        sudo mv /usr/local/bin/chectl ${WORKSPACE}/chectl
+                                        sudo chmod +x ${WORKSPACE}/chectl
+                                    """
+                                    pathToChectl = "${WORKSPACE}/chectl"
+                                }
                             }
                         }
                     }
@@ -177,7 +186,7 @@ pipeline {
                         script {
                             retry(2) {
                                 sh """
-                                    docker pull quay.io/eclipse/che-e2e:nightly
+                                    docker pull quay.io/eclipse/che-e2e:$cheE2eImageTag
                                     docker pull quay.io/eclipse/happy-path:nightly
                                 """
                             }
@@ -207,28 +216,26 @@ pipeline {
         stage("Start Che") {
             steps {
                 script {
-                    echo "Patch Che custom-resource.yaml"
-                    sh """
-                        sed -i "s|cheImage: ''|cheImage: '${cheImageRepo}'|" $CUSTOM_RESOURCE_FILE_PATH
-                        sed -i "s|cheImageTag: 'nightly'|cheImageTag: '${mutableCheImageTag}'|" $CUSTOM_RESOURCE_FILE_PATH
-                        sed -i "s|cheLogLevel: INFO|cheLogLevel: DEBUG|" $CUSTOM_RESOURCE_FILE_PATH
-                        sed -i "s|ingressDomain: '192.168.99.101.nip.io'|ingressDomain: '\$(minikube ip).nip.io'|" $CUSTOM_RESOURCE_FILE_PATH
-
-                        # temporary workaround to https://github.com/eclipse/che/issues/16292
-                        sed -i "s/tlsSupport: true/tlsSupport: false/" $CUSTOM_RESOURCE_FILE_PATH  
-
-                        # TODO: "selfSignedCert: true" so as TLS support is enebled by default 
-                        # sed -i "s/selfSignedCert: false/selfSignedCert: true/" $CUSTOM_RESOURCE_FILE_PATH    
-                    """
+                    echo "Create custom-resource patch file"
+                    sh """cat > $CUSTOM_RESOURCE_PATCH_FILE_PATH <<EOL
+spec:
+  server:
+    cheImage: '${cheImageRepo}'
+    cheImageTag: '${mutableCheImageTag}'
+    selfSignedCert: true
+  auth:
+    updateAdminPassword: false
+  k8s:
+    ingressDomain: '\$(minikube ip).nip.io'
+EOL"""
 
                     echo "Install Che"
                     sh """
-                        ${WORKSPACE}/chectl server:start \\
+                        ${pathToChectl} server:start \\
                         --k8spodreadytimeout=180000 \\
-                        --installer=operator \\
                         --listr-renderer=verbose \\
                         --platform=minikube \\
-                        --che-operator-cr-yaml=$CUSTOM_RESOURCE_FILE_PATH
+                        --che-operator-cr-patch-yaml=$CUSTOM_RESOURCE_PATCH_FILE_PATH
                     """
 
                     cheHost = sh(
@@ -282,16 +289,16 @@ pipeline {
                     }
 
                     sh """   
-                        KEYCLOAK_BASE_URL="http://\$(kubectl get ingress/keycloak -n che -o jsonpath='{.spec.rules[0].host}')/auth"
+                        KEYCLOAK_BASE_URL="https://\$(kubectl get ingress/keycloak -n che -o jsonpath='{.spec.rules[0].host}')/auth"
     
-                        USER_ACCESS_TOKEN=\$(curl -X POST \$KEYCLOAK_BASE_URL/realms/che/protocol/openid-connect/token \\
+                        USER_ACCESS_TOKEN=\$(curl -k -X POST \$KEYCLOAK_BASE_URL/realms/che/protocol/openid-connect/token \\
                            -H "Content-Type: application/x-www-form-urlencoded" \\
                            -d "username=admin" \\
                            -d "password=admin" \\
                            -d "grant_type=password" \\
                            -d "client_id=che-public" | jq -r .access_token)
     
-                        ${WORKSPACE}/chectl workspace:create --start \\
+                        ${pathToChectl} workspace:create --start \\
                            --devfile=${DEVFILE_PATH} \\
                            --access-token "\$USER_ACCESS_TOKEN"
                     """
@@ -302,7 +309,7 @@ pipeline {
         stage("Run E2E Happy path tests") {
             steps {
                 sh """
-                     CHE_URL=http://${cheHost}
+                     CHE_URL=https://${cheHost}
                      docker run --shm-size=1g --net=host --ipc=host \\
                        -p 5920:5920 \\
                        -e TS_SELENIUM_DEFAULT_TIMEOUT=300000 \\
@@ -316,7 +323,7 @@ pipeline {
                        -e TEST_SUITE="${e2eTestToRun}" ${e2eTestParameters} \\
                        -e NODE_TLS_REJECT_UNAUTHORIZED=0 \\
                        -v ${WORKSPACE}/tests/e2e:/tmp/e2e:Z \\
-                       quay.io/eclipse/che-e2e:nightly
+                       quay.io/eclipse/che-e2e:${cheE2eImageTag}
                 """
             }
         }
@@ -333,7 +340,7 @@ pipeline {
 
                 cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
                 cp ${DEVFILE_PATH} $LOGS_AND_CONFIGS || true
-                cp ${CUSTOM_RESOURCE_FILE_PATH} $LOGS_AND_CONFIGS || true
+                cp ${CUSTOM_RESOURCE_PATCH_FILE_PATH} $LOGS_AND_CONFIGS || true
 
                 kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml || true
                 kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true
@@ -359,7 +366,7 @@ pipeline {
                 docker ps -a > $LOGS_AND_CONFIGS/docker/containers.txt || true
 
                 env > $LOGS_AND_CONFIGS/env.output.txt || true
-                ${WORKSPACE}/chectl --help > $LOGS_AND_CONFIGS/chectl.version.txt || true
+                ${pathToChectl} --help > $LOGS_AND_CONFIGS/chectl.version.txt || true
 
                 cp -r /tmp/chectl-logs $LOGS_AND_CONFIGS || true
             """

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         JENKINS_BUILD = "true"
 
         DEVFILE_PATH = "${WORKSPACE}/test-workspace-devfile.yaml"
-        CUSTOM_RESOURCE_PATCH_FILE_PATH = "${WORKSPACE}/custom-resource-patch.yaml"
+        CUSTOM_RESOURCE_PATCH_FILE = "${WORKSPACE}/custom-resource-patch.yaml"
 
         SUCCESS_THRESHOLD = 5
 
@@ -217,7 +217,7 @@ pipeline {
             steps {
                 script {
                     echo "Create custom-resource patch file"
-                    sh """cat > $CUSTOM_RESOURCE_PATCH_FILE_PATH <<EOL
+                    sh """cat > $CUSTOM_RESOURCE_PATCH_FILE <<EOL
 spec:
   server:
     cheImage: '${cheImageRepo}'
@@ -235,7 +235,7 @@ EOL"""
                         --k8spodreadytimeout=180000 \\
                         --listr-renderer=verbose \\
                         --platform=minikube \\
-                        --che-operator-cr-patch-yaml=$CUSTOM_RESOURCE_PATCH_FILE_PATH
+                        --che-operator-cr-patch-yaml=$CUSTOM_RESOURCE_PATCH_FILE
                     """
 
                     cheHost = sh(
@@ -340,7 +340,7 @@ EOL"""
 
                 cp ${WORKSPACE}/org_v1_che_cr.yaml $LOGS_AND_CONFIGS/che-config || true
                 cp ${DEVFILE_PATH} $LOGS_AND_CONFIGS || true
-                cp ${CUSTOM_RESOURCE_PATCH_FILE_PATH} $LOGS_AND_CONFIGS || true
+                cp ${CUSTOM_RESOURCE_PATCH_FILE} $LOGS_AND_CONFIGS || true
 
                 kubectl get checluster --namespace=che -o yaml > $LOGS_AND_CONFIGS/che-config/checluster.yaml || true
                 kubectl get configmaps --namespace=che che -o yaml > $LOGS_AND_CONFIGS/che-config/configmap.yaml || true

--- a/tests/.infra/crw-ci/pre-release-testing/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pre-release-testing/k8s/Jenkinsfile
@@ -11,22 +11,21 @@ pipeline {
     environment {
         YQ_TOOL_URL='https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64'
 
-        CHE_THEIA_META_YAML_URL='https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/eclipse/che-theia/next/meta.yaml'
-        VSCODE_YAML_META_YAML_DIR_URL='https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/redhat/vscode-yaml/'
-        JAVA8_META_YAML_DIR_URL='https://raw.githubusercontent.com/eclipse/che-plugin-registry/master/v3/plugins/redhat/java8/'
         DEVFILE_URL="${WORKSPACE}/happy-path-workspace.yaml"
-
-        String customResourceFileContent = ""
     }
 
     parameters {
         string(name: 'RELEASE_BRANCH',
-                defaultValue: "7.5.x",
+                defaultValue: "7.12.x",
                 description: 'Branch with pre-release version to take E2E Happy path test.')
 
         string(name: 'RELEASE_VERSION',
-                defaultValue: "7.5.0",
+                defaultValue: "7.12.1",
                 description: 'Version of Che-theia')
+
+        string(name: 'CHECTL_PACKAGE_URL',
+                defaultValue: "https://github.com/che-incubator/chectl/releases/download/20200501092240/chectl-linux-x64.tar.gz",
+                description: 'URL address of chectl package tar ball')
     }
 
     stages {
@@ -34,6 +33,8 @@ pipeline {
             steps {
                 withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'GITHUB_TOKEN')]) {
                     sh """
+                      CHE_THEIA_META_YAML_URL='https://raw.githubusercontent.com/eclipse/che-plugin-registry/$RELEASE_BRANCH/v3/plugins/eclipse/che-theia/next/meta.yaml'
+
                       wget https://raw.githubusercontent.com/eclipse/che/$RELEASE_BRANCH/tests/e2e/files/happy-path/happy-path-workspace.yaml --no-check-certificate -O $DEVFILE_URL
                     
                       PR_CHECK_FILES_DIR=${WORKSPACE}/pr-check-files/che/$RELEASE_VERSION
@@ -45,7 +46,7 @@ pipeline {
                       wget $YQ_TOOL_URL
                       sudo chmod +x yq_linux_amd64
                     
-                      wget $CHE_THEIA_META_YAML_URL -O \$PR_CHECK_FILES_DIR/che_theia_meta.yaml
+                      wget \$CHE_THEIA_META_YAML_URL -O \$PR_CHECK_FILES_DIR/che_theia_meta.yaml
                       ./yq_linux_amd64 w -i \$PR_CHECK_FILES_DIR/che_theia_meta.yaml spec.containers[0].image quay.io/eclipse/che-theia:$RELEASE_VERSION
                       ./yq_linux_amd64 w -i \$PR_CHECK_FILES_DIR/che_theia_meta.yaml spec.initContainers[0].image quay.io/eclipse/che-theia-endpoint-runtime-binary:$RELEASE_VERSION
                     
@@ -64,110 +65,85 @@ pipeline {
             }
         }
 
-        stage('Patch custom-resource.yaml') {
-            steps {
-                script {
-                    String customResourceFilePath = "${WORKSPACE}/custom-resource.yaml"
-
-                    sh """
-                        wget https://raw.githubusercontent.com/eclipse/che-operator/master/deploy/crds/org_v1_che_cr.yaml \\
-                          -O $customResourceFilePath
-
-                        # TODO: "selfSignedCert: true" so as TLS support is enebled by default 
-                        # sed -i "s/selfSignedCert: false/selfSignedCert: true/" $customResourceFilePath
-
-
-                        # temporary workaround to https://github.com/eclipse/che/issues/16292
-                        sed -i "s/tlsSupport: true/tlsSupport: false/" $customResourceFilePath      
-                    """
-
-                    customResourceFileContent = readFile customResourceFilePath
-                    customResourceFileContent = customResourceFileContent.replace("eclipse/che-keycloak:nightly", "eclipse/che-keycloak:rc")
-                    customResourceFileContent = customResourceFileContent.replace("quay.io/eclipse/che-devfile-registry:nightly", "quay.io/eclipse/che-devfile-registry:$RELEASE_VERSION")
-                    customResourceFileContent = customResourceFileContent.replace("quay.io/eclipse/che-plugin-registry:nightly", "quay.io/eclipse/che-plugin-registry:$RELEASE_VERSION")
-                }
-            }
-        }
-
         stage("Run E2E tests") {
             parallel {
                 stage('Run Happy path tests against Eclipse Che release candidate') {
                     steps {
-                        script {
-                            echo "$customResourceFileContent"
+                        build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                parameters: [
+                                        string(name: 'cheImageRepo',
+                                                value: 'quay.io/eclipse/che-server'),
 
-                            build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                    parameters: [
-                                            string(name: 'cheImageRepo',
-                                                    value: 'quay.io/eclipse/che-server'),
+                                        string(name: 'cheImageTag',
+                                                value: RELEASE_VERSION),
 
-                                            string(name: 'cheImageTag',
-                                                    value: 'rc'),
+                                        booleanParam(name: 'buildChe',
+                                                value: false),
 
-                                            booleanParam(name: 'buildChe',
-                                                    value: false),
+                                        string(name: 'ghprbSourceBranch',
+                                                value: RELEASE_BRANCH),
 
-                                            string(name: 'ghprbSourceBranch',
-                                                    value: "$RELEASE_BRANCH"),
+                                        string(name: 'ghprbPullId',
+                                                value: ''),
 
-                                            string(name: 'ghprbPullId',
-                                                    value: ''),
+                                        string(name: 'e2eTestToRun',
+                                                value: 'test-happy-path'),
 
-                                            string(name: 'e2eTestToRun',
-                                                    value: 'test-happy-path'),
+                                        string(name: 'testWorkspaceDevfileUrl',
+                                                value: "https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che/$RELEASE_VERSION/happy-path-workspace.yaml"),
 
-                                            string(name: 'testWorkspaceDevfileUrl',
-                                                    value: "https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che/$RELEASE_VERSION/happy-path-workspace.yaml"),
+                                        booleanParam(name: 'createTestWorkspace',
+                                                value: true),
 
-                                            text(name: 'customResourceFileContent',
-                                                    value: "$customResourceFileContent"),
+                                        string(name: 'e2eTestParameters',
+                                                value: ''),
 
-                                            booleanParam(name: 'createTestWorkspace',
-                                                    value: true),
+                                        string(name: 'chectlPackageUrl',
+                                                value: CHECTL_PACKAGE_URL),
 
-                                            string(name: 'e2eTestParameters',
-                                                    value: '')
-                                    ]
-                        }
+                                        string(name: 'cheE2eImageTag',
+                                                value: RELEASE_VERSION)
+                                ]
                     }
                 }
 
                 stage('Run devfile tests against Eclipse Che release candidate') {
                     steps {
-                        script {
-                            build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                    parameters: [
-                                            string(name: 'cheImageRepo',
-                                                    value: 'quay.io/eclipse/che-server'),
+                        build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                parameters: [
+                                        string(name: 'cheImageRepo',
+                                                value: 'quay.io/eclipse/che-server'),
 
-                                            string(name: 'cheImageTag',
-                                                    value: 'rc'),
+                                        string(name: 'cheImageTag',
+                                                value: RELEASE_VERSION),
 
-                                            booleanParam(name: 'buildChe',
-                                                    value: false),
+                                        booleanParam(name: 'buildChe',
+                                                value: false),
 
-                                            string(name: 'ghprbSourceBranch',
-                                                    value: "$RELEASE_BRANCH"),
+                                        string(name: 'ghprbSourceBranch',
+                                                value: RELEASE_BRANCH),
 
-                                            string(name: 'ghprbPullId',
-                                                    value: ''),
+                                        string(name: 'ghprbPullId',
+                                                value: ''),
 
-                                            string(name: 'e2eTestToRun',
-                                                    value: 'test-all-devfiles'),
+                                        string(name: 'e2eTestToRun',
+                                                value: 'test-all-devfiles'),
 
-                                            string(name: 'testWorkspaceDevfileUrl',
-                                                    value: ""),
+                                        string(name: 'testWorkspaceDevfileUrl',
+                                                value: ""),
 
-                                            text(name: 'customResourceFileContent',
-                                                    value: "$customResourceFileContent"),
+                                        booleanParam(name: 'createTestWorkspace',
+                                                value: false),
 
-                                            booleanParam(name: 'createTestWorkspace',
-                                                    value: false),
+                                        string(name: 'e2eTestParameters',
+                                                value: ''),
 
-                                            string(name: 'e2eTestParameters',
-                                                    value: '')
-                                    ]
-                        }
+                                        string(name: 'chectlPackageUrl',
+                                                value: CHECTL_PACKAGE_URL),
+
+                                        string(name: 'cheE2eImageTag',
+                                                value: RELEASE_VERSION)
+                                ]
                     }
                 }
 
@@ -180,13 +156,13 @@ pipeline {
                                                         value: 'quay.io/eclipse/che-server'),
 
                                                 string(name: 'cheImageTag',
-                                                        value: 'nightly'),
+                                                        value: RELEASE_VERSION),
 
                                                 booleanParam(name: 'buildChe',
                                                         value: false),
 
                                                 string(name: 'ghprbSourceBranch',
-                                                        value: "$RELEASE_BRANCH"),
+                                                        value: RELEASE_BRANCH),
 
                                                 string(name: 'ghprbPullId',
                                                         value: ''),
@@ -197,14 +173,17 @@ pipeline {
                                                 string(name: 'testWorkspaceDevfileUrl',
                                                         value: ''),
 
-                                                text(name: 'customResourceFileContent',
-                                                        value: ''),
-
                                                 booleanParam(name: 'createTestWorkspace',
                                                         value: false),
 
                                                 string(name: 'e2eTestParameters',
-                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0")
+                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+
+                                                string(name: 'chectlPackageUrl',
+                                                        value: CHECTL_PACKAGE_URL),
+
+                                                string(name: 'cheE2eImageTag',
+                                                        value: RELEASE_VERSION)
                                         ]
                         }
                     }    


### PR DESCRIPTION
### What does this PR do?
1) Fix centos-ci Jenkins RC test job to check already release version of Che;

2) Fix CRW Jenkins job:
- add parameter to set chectl package URL
- add E2E image tag parameter
- install Eclipse Che with TLS support
- use short custom-resource patch file instead of whole custom-resource.yaml content
- remove outdated code

### What issues does this PR fix or reference?
#16565, #16905  