### PR TITLE
Update postgresql to multi-arch to support s390x

### DIFF
--- a/dockerfiles/postgres/Dockerfile
+++ b/dockerfiles/postgres/Dockerfile
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-FROM centos/postgresql-96-centos7
+FROM registry.access.redhat.com/rhscl/postgresql-10-rhel7
 ADD init-che-user-and-run.sh.erb init-che-user.sh.erb /var/lib/pgsql/
 RUN cat /var/lib/pgsql/init-che-user.sh.erb | \
     sed -e "/exit 0/d" > /var/lib/pgsql/init-che-user-and-run.sh && \


### PR DESCRIPTION
Signed-off-by: Shahid Shaikh <shahid@us.ibm.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Update the base image to `postgresql-10-rhel7` which supports multi-arch. Thus providing support to variety of architectures including s390x.

### What issues does this PR fix or reference?
This PR is part of [this](https://github.com/eclipse/che/issues/16655) initiative. 
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
