### PR TITLE
Removing waiting for LS initialization to stabilize the tests.

### DIFF
--- a/tests/e2e/tests/devfiles/JavaMaven.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaMaven.spec.ts
@@ -34,7 +34,6 @@ suite(`${stack} test`, async () => {
 
     suite('Language server validation', async () => {
         projectAndFileTests.openFile(fileFolderPath, tabTitle);
-        commonLsTests.waitLSInitialization('Activating Language Support for Java', 1_800_000, 360_000);
         commonLsTests.suggestionInvoking(tabTitle, 10, 20, 'append(char c) : PrintStream');
         commonLsTests.errorHighlighting(tabTitle, 'error', 11);
         commonLsTests.autocomplete(tabTitle, 10, 11, 'System - java.lang');


### PR DESCRIPTION
### What does this PR do?
Remove waiting for an LS initialization and directly go to checking an LS functionality.
It was already tested on Hosted Che and increased stability of the tests.