### PR TITLE
Switching workspace readyness logic over to preloader

### DIFF
--- a/tests/e2e/pageobjects/ide/Ide.ts
+++ b/tests/e2e/pageobjects/ide/Ide.ts
@@ -159,12 +159,18 @@ export class Ide {
         await this.driverHelper.waitVisibility(By.css(Ide.LEFT_CONTENT_PANEL_CSS));
     }
 
-    async waitPreloaderAbsent(attempts: number = TestConstants.TS_SELENIUM_DEFAULT_ATTEMPTS,
-        polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING) {
-
+    async waitPreloaderAbsent(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+        const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
+        const attempts: number = timeout / polling;
         Logger.debug('Ide.waitPreloaderAbsent');
 
         await this.driverHelper.waitDisappearance(By.css(Ide.PRELOADER_CSS), attempts, polling);
+    }
+
+    async waitPreloaderVisible(timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+        Logger.debug('Ide.waitPreloaderVisible');
+
+        await this.driverHelper.waitVisibility(By.css(Ide.PRELOADER_CSS), timeout);
     }
 
     async waitStatusBarContains(expectedText: string, timeout: number = TestConstants.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT) {

--- a/tests/e2e/testsLibrary/ProjectAndFileTests.ts
+++ b/tests/e2e/testsLibrary/ProjectAndFileTests.ts
@@ -17,7 +17,10 @@ const editor: Editor = e2eContainer.get(CLASSES.Editor);
 
 export function waitWorkspaceReadiness(sampleName : string, folder: string) {
     test('Wait for workspace readiness', async () => {
-        await ide.waitWorkspaceAndIde();
+        await ide.waitAndSwitchToIdeFrame();
+        await ide.waitPreloaderVisible();
+        await ide.waitPreloaderAbsent();
+        await ide.waitIde();
         await projectTree.openProjectTreeContainer();
         await projectTree.waitProjectImported(sampleName, folder);
     });


### PR DESCRIPTION
### What does this PR do?
This PR changes the logic which waits for workspace readiness to use the preloader instead of the waitWorkspaceAndIde method which can behave inconsistently and is ignoring the workspace startup timeout env variable

### What issues does this PR fix or reference?
N/A

#### Release Notes
N/A

#### Docs PR
N/A
