### PR TITLE
Enable to overwrite the organization of che-dashboard and che-workspace-loader.

### DIFF
--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -8,11 +8,13 @@
 
 # Variables in `COPY --from=` is not supported see https://github.com/moby/moby/issues/34482
 # this is workaround to handle that.
+ARG CHE_DASHBOARD_ORGANIZATION=quay.io/eclipse
 ARG CHE_DASHBOARD_VERSION=next
+ARG CHE_WORKSPACE_LOADER_ORGANIZATION=quay.io/eclipse
 ARG CHE_WORKSPACE_LOADER_VERSION=next
 
-FROM quay.io/eclipse/che-dashboard:${CHE_DASHBOARD_VERSION} as che_dashboard_base
-FROM quay.io/eclipse/che-workspace-loader:${CHE_WORKSPACE_LOADER_VERSION} as che_workspace_loader_base
+FROM ${CHE_DASHBOARD_ORGANIZATION}/che-dashboard:${CHE_DASHBOARD_VERSION} as che_dashboard_base
+FROM ${CHE_WORKSPACE_LOADER_ORGANIZATION}/che-workspace-loader:${CHE_WORKSPACE_LOADER_VERSION} as che_workspace_loader_base
 
 FROM openjdk:8u252-jre-slim
 ENV LANG=C.UTF-8


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>

### What does this PR do?

Enables to use customized images for che-dashboard and che-workspace-loader.
Some people (including me) will want to customize brandings (icon and link) in che-dashboard.
And some third-party developer may use che-workspace-loader in their docker repository.

### What issues does this PR fix or reference?

None.

#### Release Notes

I suppose this is not required as this is less effect to marketers.

#### Docs PR

None. AFAIK, there is no paragraph related on `build.sh`.
