### PR TITLE
Disable http2 by default for java8

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -113,8 +113,7 @@ public class WsMasterModule extends AbstractModule {
     // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
     // OkHttp wrongly detects JDK8u251 and higher as JDK9 which enables Http2 unsupported for JDK8.
     // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
-    if (System.getProperty("java.version", "").startsWith("1.8")
-        && System.getenv("HTTP2_DISABLE") == null) {
+    if (System.getProperty("java.version", "").startsWith("1.8")) {
       System.setProperty("http2.disable", "true");
     }
 

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -110,6 +110,14 @@ public class WsMasterModule extends AbstractModule {
 
   @Override
   protected void configure() {
+    // Workaround for https://github.com/fabric8io/kubernetes-client/issues/2212
+    // OkHttp wrongly detects JDK8u251 and higher as JDK9 which enables Http2 unsupported for JDK8.
+    // Can be removed after upgrade to Fabric8 4.10.2 or higher or to Java 11
+    if (System.getProperty("java.version", "").startsWith("1.8")
+        && System.getenv("HTTP2_DISABLE") == null) {
+      System.setProperty("http2.disable", "true");
+    }
+
     // db related components modules
     install(new org.eclipse.che.account.api.AccountModule());
     install(new org.eclipse.che.api.ssh.server.jpa.SshJpaModule());


### PR DESCRIPTION
### What does this PR do?
Disable http2 by default for java8. OkHttp wrongly detects JDK8u251 and higher as JDK9 which enables Http2 unsupported for JDK8.

### What issues does this PR fix or reference?
Workaround for https://github.com/eclipse/che/issues/16944