### PR TITLE
Prepare environment for async storage of project sources

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -622,4 +622,4 @@ che.workspace.provision.secret.labels=app.kubernetes.io/part-of=che.eclipse.org,
 che.workspace.devfile.async.storage.plugin=eclipse/che-async-pv-plugin/nightly
 
 # Docker image for the Che async storage
-che.infra.kubernetes.async.storage.image=vparfonov/che-workspace-data-sync-storage:latest
+che.infra.kubernetes.async.storage.image=quay.io/eclipse/che-workspace-data-sync-storage:latest

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -330,7 +330,7 @@ che.infra.kubernetes.pvc.strategy=common
 che.infra.kubernetes.pvc.precreate_subpaths=true
 
 # Defines the settings of PVC name for che workspaces.
-# Each PVC strategy suplies this value differently.
+# Each PVC strategy supplies this value differently.
 # See doc for che.infra.kubernetes.pvc.strategy property
 che.infra.kubernetes.pvc.name=claim-che-workspace
 
@@ -615,3 +615,11 @@ che.workspace.devfile.default_editor.plugins=eclipse/che-machine-exec-plugin/nig
 # which will be mount into workspace containers as a files or env variables.
 # Only secrets that match ALL given labels will be selected.
 che.workspace.provision.secret.labels=app.kubernetes.io/part-of=che.eclipse.org,app.kubernetes.io/component=workspace-secret
+
+
+# Plugin is added in case async storage feature will be enabled in workspace config
+# and supported by environment
+che.workspace.devfile.async.storage.plugin=eclipse/che-async-pv-plugin/nightly
+
+# Docker image for the Che async storage
+che.infra.kubernetes.async.storage.image=vparfonov/che-workspace-data-sync-storage:latest

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Constants.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Constants.java
@@ -31,6 +31,9 @@ public final class Constants {
   /** The label that contains a value with workspace id to which object belongs to. */
   public static final String CHE_WORKSPACE_ID_LABEL = "che.workspace_id";
 
+  /** The label that contains a value with user id to which object belongs to. */
+  public static final String CHE_USER_ID_LABEL = "che.user_id";
+
   /** The label that contains name of deployment responsible for Pod. */
   public static final String CHE_DEPLOYMENT_NAME_LABEL = "che.deployment_name";
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java
@@ -43,7 +43,7 @@ public class PodTerminationGracePeriodProvisioner implements ConfigurationProvis
    * on amount of files, size of files and network ability. This is some empirical number of seconds
    * which should be enough for most projects.
    */
-  private final long graceTerminationPeriodAsyncPvc = 60;
+  private static final long GRACE_TERMINATION_PERIOD_ASYNC_STORAGE_WS_SEC = 60;
 
   @Inject
   public PodTerminationGracePeriodProvisioner(
@@ -77,7 +77,7 @@ public class PodTerminationGracePeriodProvisioner implements ConfigurationProvis
   private long getGraceTerminationPeriodSec(KubernetesEnvironment k8sEnv) {
     Map<String, String> attributes = k8sEnv.getAttributes();
     if (isEphemeral(attributes) && parseBoolean(attributes.get(ASYNC_PERSIST_ATTRIBUTE))) {
-      return graceTerminationPeriodAsyncPvc;
+      return GRACE_TERMINATION_PERIOD_ASYNC_STORAGE_WS_SEC;
     }
     return graceTerminationPeriodSec;
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/PodTerminationGracePeriodProvisioner.java
@@ -15,6 +15,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRI
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
 
 import io.fabric8.kubernetes.api.model.PodSpec;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -66,8 +67,8 @@ public class PodTerminationGracePeriodProvisioner implements ConfigurationProvis
   }
 
   private long getGraceTerminationPeriodSec(KubernetesEnvironment k8sEnv) {
-    if (isEphemeral(k8sEnv.getAttributes())
-        && "true".equals(k8sEnv.getAttributes().get(ASYNC_PERSIST_ATTRIBUTE))) {
+    Map<String, String> attributes = k8sEnv.getAttributes();
+    if (isEphemeral(attributes) && "true".equals(attributes.get(ASYNC_PERSIST_ATTRIBUTE))) {
       return graceTerminationPeriodAsyncPvc;
     }
     return graceTerminationPeriodSec;

--- a/infrastructures/openshift/pom.xml
+++ b/infrastructures/openshift/pom.xml
@@ -72,6 +72,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-api-ssh-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-api-system</artifactId>
         </dependency>
         <dependency>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidator.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidator.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRI
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.COMMON_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
 
+import com.google.common.base.Strings;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -38,10 +39,10 @@ import org.slf4j.LoggerFactory;
  * </ul>
  *
  * <p>If set only {@link org.eclipse.che.api.workspace.shared.Constants#ASYNC_PERSIST_ATTRIBUTE} =
- * 'true' {@link ValidationException} thrown.
+ * 'true', {@link ValidationException} is thrown.
  *
- * <p>If system configure with other value of properties than below {@link ValidationException}
- * thrown.
+ * <p>If system is configured with other value of properties than below {@link ValidationException},
+ * is thrown.
  *
  * <ul>
  *   <li>che.infra.kubernetes.namespace.default=<username>-che
@@ -61,13 +62,13 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
 
   @Inject
   public AsyncStorageModeValidator(
-      @Named("che.infra.kubernetes.pvc.strategy") String strategy,
+      @Named("che.infra.kubernetes.pvc.strategy") String pvcStrategy,
       @Named("che.infra.kubernetes.namespace.allow_user_defined")
           boolean allowUserDefinedNamespaces,
       @Nullable @Named("che.infra.kubernetes.namespace.default") String defaultNamespaceName,
       @Named("che.limits.user.workspaces.run.count") int runtimesPerUser) {
 
-    pvcStrategy = strategy;
+    this.pvcStrategy = pvcStrategy;
     this.allowUserDefinedNamespaces = allowUserDefinedNamespaces;
     this.defaultNamespaceName = defaultNamespaceName;
     this.runtimesPerUser = runtimesPerUser;
@@ -95,8 +96,7 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
         runtimesPerUserValidation();
       } else {
         String message =
-            format(
-                "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage");
+            "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage";
         LOG.warn(message);
         throw new ValidationException(message);
       }
@@ -107,8 +107,7 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
       throws ValidationException {
     if (!isEphemeral(attributes)) {
       String message =
-          format(
-              "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage");
+          "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage";
       LOG.warn(message);
       throw new ValidationException(message);
     }
@@ -126,10 +125,10 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
   }
 
   private void nameSpaceStrategyValidation() throws ValidationException {
-    if (!"<username>-che".equals(defaultNamespaceName)) {
+    if (Strings.isNullOrEmpty(defaultNamespaceName)
+        || !defaultNamespaceName.contains("<username>")) {
       String message =
-          format(
-              "Workspace configuration not valid: Asynchronous storage available only for 'per-user' namespace strategy");
+          "Workspace configuration not valid: Asynchronous storage available only for 'per-user' namespace strategy";
       LOG.warn(message);
       throw new ValidationException(message);
     }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidator.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidator.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift;
+
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.String.format;
+import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.COMMON_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
+
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.workspace.server.WorkspaceAttributeValidator;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates the workspace attributes before workspace creation and updating if async storage
+ * configure.
+ *
+ * <p>To be valid for async storage workspace MUST have attributes:
+ *
+ * <ul>
+ *   <li>{@link org.eclipse.che.api.workspace.shared.Constants#ASYNC_PERSIST_ATTRIBUTE} = 'true'
+ *   <li>{@link org.eclipse.che.api.workspace.shared.Constants#PERSIST_VOLUMES_ATTRIBUTE} = 'false'
+ * </ul>
+ *
+ * <p>If set only {@link org.eclipse.che.api.workspace.shared.Constants#ASYNC_PERSIST_ATTRIBUTE} =
+ * 'true' {@link ValidationException} thrown.
+ *
+ * <p>If system configure with other value of properties than below {@link ValidationException}
+ * thrown.
+ *
+ * <ul>
+ *   <li>che.infra.kubernetes.namespace.default=<username>-che
+ *   <li>che.infra.kubernetes.namespace.allow_user_defined=false
+ *   <li>che.infra.kubernetes.pvc.strategy=common
+ *   <li>che.limits.user.workspaces.run.count=1
+ * </ul>
+ */
+public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncStorageModeValidator.class);
+
+  private final String pvcStrategy;
+  private final boolean allowUserDefinedNamespaces;
+  private final String defaultNamespaceName;
+  private final int runtimesPerUser;
+
+  @Inject
+  public AsyncStorageModeValidator(
+      @Named("che.infra.kubernetes.pvc.strategy") String strategy,
+      @Named("che.infra.kubernetes.namespace.allow_user_defined")
+          boolean allowUserDefinedNamespaces,
+      @Nullable @Named("che.infra.kubernetes.namespace.default") String defaultNamespaceName,
+      @Named("che.limits.user.workspaces.run.count") int runtimesPerUser) {
+
+    pvcStrategy = strategy;
+    this.allowUserDefinedNamespaces = allowUserDefinedNamespaces;
+    this.defaultNamespaceName = defaultNamespaceName;
+    this.runtimesPerUser = runtimesPerUser;
+  }
+
+  @Override
+  public void validate(Map<String, String> attributes) throws ValidationException {
+    if (parseBoolean(attributes.get(ASYNC_PERSIST_ATTRIBUTE))) {
+      isEphemeralAttributeValidation(attributes);
+      pvcStrategyValidation();
+      alowUserDefinedNamespaceValidation();
+      nameSpaceStrategyValidation();
+      runtimesPerUserValidation();
+    }
+  }
+
+  @Override
+  public void validateUpdate(Map<String, String> existing, Map<String, String> update)
+      throws ValidationException {
+    if (parseBoolean(update.get(ASYNC_PERSIST_ATTRIBUTE))) {
+      if (isEphemeral(existing) || isEphemeral(update)) {
+        pvcStrategyValidation();
+        alowUserDefinedNamespaceValidation();
+        nameSpaceStrategyValidation();
+        runtimesPerUserValidation();
+      } else {
+        String message =
+            format(
+                "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage");
+        LOG.warn(message);
+        throw new ValidationException(message);
+      }
+    }
+  }
+
+  private void isEphemeralAttributeValidation(Map<String, String> attributes)
+      throws ValidationException {
+    if (!isEphemeral(attributes)) {
+      String message =
+          format(
+              "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage");
+      LOG.warn(message);
+      throw new ValidationException(message);
+    }
+  }
+
+  private void runtimesPerUserValidation() throws ValidationException {
+    if (runtimesPerUser > 1) {
+      String message =
+          format(
+              "Workspace configuration not valid: Asynchronous storage available only if 'che.limits.user.workspaces.run.count' set to 1, but got %s",
+              runtimesPerUser);
+      LOG.warn(message);
+      throw new ValidationException(message);
+    }
+  }
+
+  private void nameSpaceStrategyValidation() throws ValidationException {
+    if (!"<username>-che".equals(defaultNamespaceName)) {
+      String message =
+          format(
+              "Workspace configuration not valid: Asynchronous storage available only for 'per-user' namespace strategy");
+      LOG.warn(message);
+      throw new ValidationException(message);
+    }
+  }
+
+  private void alowUserDefinedNamespaceValidation() throws ValidationException {
+    if (allowUserDefinedNamespaces) {
+      String message =
+          format(
+              "Workspace configuration not valid: Asynchronous storage available only if 'che.infra.kubernetes.namespace.allow_user_defined' set to 'false', but got '%s'",
+              allowUserDefinedNamespaces);
+      LOG.warn(message);
+      throw new ValidationException(message);
+    }
+  }
+
+  private void pvcStrategyValidation() throws ValidationException {
+    if (!COMMON_STRATEGY.equals(pvcStrategy)) {
+      String message =
+          format(
+              "Workspace configuration not valid: Asynchronous storage available only for 'common' PVC strategy, but got %s",
+              pvcStrategy);
+      LOG.warn(message);
+      throw new ValidationException(message);
+    }
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -36,6 +36,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpoli
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.ServersConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.PreviewUrlExposer;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStoragePodInterceptor;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftUniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.RouteTlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftPreviewUrlExposer;
@@ -67,7 +69,9 @@ public class OpenShiftEnvironmentProvisioner
   private final PodTerminationGracePeriodProvisioner podTerminationGracePeriodProvisioner;
   private final ImagePullSecretProvisioner imagePullSecretProvisioner;
   private final ProxySettingsProvisioner proxySettingsProvisioner;
+  private final AsyncStoragePodInterceptor asyncStoragePodObserver;
   private final ServiceAccountProvisioner serviceAccountProvisioner;
+  private final AsyncStorageProvisioner asyncStorageProvisioner;
   private final CertificateProvisioner certificateProvisioner;
   private final SshKeysProvisioner sshKeysProvisioner;
   private final GitConfigProvisioner gitConfigProvisioner;
@@ -88,6 +92,8 @@ public class OpenShiftEnvironmentProvisioner
       PodTerminationGracePeriodProvisioner podTerminationGracePeriodProvisioner,
       ImagePullSecretProvisioner imagePullSecretProvisioner,
       ProxySettingsProvisioner proxySettingsProvisioner,
+      AsyncStorageProvisioner asyncStorageProvisioner,
+      AsyncStoragePodInterceptor asyncStoragePodObserver,
       ServiceAccountProvisioner serviceAccountProvisioner,
       CertificateProvisioner certificateProvisioner,
       SshKeysProvisioner sshKeysProvisioner,
@@ -106,6 +112,8 @@ public class OpenShiftEnvironmentProvisioner
     this.podTerminationGracePeriodProvisioner = podTerminationGracePeriodProvisioner;
     this.imagePullSecretProvisioner = imagePullSecretProvisioner;
     this.proxySettingsProvisioner = proxySettingsProvisioner;
+    this.asyncStorageProvisioner = asyncStorageProvisioner;
+    this.asyncStoragePodObserver = asyncStoragePodObserver;
     this.serviceAccountProvisioner = serviceAccountProvisioner;
     this.certificateProvisioner = certificateProvisioner;
     this.sshKeysProvisioner = sshKeysProvisioner;
@@ -124,6 +132,7 @@ public class OpenShiftEnvironmentProvisioner
         "Start provisioning OpenShift environment for workspace '{}'", identity.getWorkspaceId());
     // 1 stage - update environment according Infrastructure specific
     if (pvcEnabled) {
+      asyncStoragePodObserver.intercept(osEnv, identity);
       logsVolumeMachineProvisioner.provision(osEnv, identity);
     }
 
@@ -144,6 +153,7 @@ public class OpenShiftEnvironmentProvisioner
     imagePullSecretProvisioner.provision(osEnv, identity);
     proxySettingsProvisioner.provision(osEnv, identity);
     serviceAccountProvisioner.provision(osEnv, identity);
+    asyncStorageProvisioner.provision(osEnv, identity);
     certificateProvisioner.provision(osEnv, identity);
     sshKeysProvisioner.provision(osEnv, identity);
     vcsSslCertificateProvisioner.provision(osEnv, identity);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -82,6 +82,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftE
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironmentFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.project.OpenShiftProjectFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.project.RemoveProjectOnWorkspaceRemove;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftPreviewUrlCommandProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftCookiePathStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftExternalServerExposer;
@@ -222,5 +223,6 @@ public class OpenShiftInfraModule extends AbstractModule {
     bind(ExternalServiceExposureStrategy.class).to(OpenShiftServerExposureStrategy.class);
     bind(CookiePathStrategy.class).to(OpenShiftCookiePathStrategy.class);
     bind(NonTlsDistributedClusterModeNotifier.class);
+    bind(AsyncStorageProvisioner.class);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -94,9 +94,10 @@ import org.eclipse.che.workspace.infrastructure.openshift.wsplugins.brokerphases
 public class OpenShiftInfraModule extends AbstractModule {
   @Override
   protected void configure() {
-    Multibinder.newSetBinder(binder(), WorkspaceAttributeValidator.class)
-        .addBinding()
-        .to(K8sInfraNamespaceWsAttributeValidator.class);
+    Multibinder<WorkspaceAttributeValidator> workspaceAttributeValidators =
+        Multibinder.newSetBinder(binder(), WorkspaceAttributeValidator.class);
+    workspaceAttributeValidators.addBinding().to(K8sInfraNamespaceWsAttributeValidator.class);
+    workspaceAttributeValidators.addBinding().to(AsyncStorageModeValidator.class);
 
     bind(KubernetesNamespaceService.class);
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
@@ -47,19 +47,19 @@ public class AsyncStoragePodInterceptor {
   private static final int DELETE_POD_TIMEOUT_IN_MIN = 5;
 
   private final OpenShiftClientFactory clientFactory;
-  private final String strategy;
+  private final String pvcStrategy;
 
   @Inject
   public AsyncStoragePodInterceptor(
-      @Named("che.infra.kubernetes.pvc.strategy") String strategy,
+      @Named("che.infra.kubernetes.pvc.strategy") String pvcStrategy,
       OpenShiftClientFactory openShiftClientFactory) {
-    this.strategy = strategy;
+    this.pvcStrategy = pvcStrategy;
     this.clientFactory = openShiftClientFactory;
   }
 
   public void intercept(OpenShiftEnvironment osEnv, RuntimeIdentity identity)
       throws InfrastructureException {
-    if (!COMMON_STRATEGY.equals(strategy) || isEphemeral(osEnv.getAttributes())) {
+    if (!COMMON_STRATEGY.equals(pvcStrategy) || isEphemeral(osEnv.getAttributes())) {
       return;
     }
 
@@ -80,15 +80,17 @@ public class AsyncStoragePodInterceptor {
       Thread.currentThread().interrupt();
       throw new InfrastructureException(
           format(
-              "Interrupted while waiting for pod '%s' removal. " + ex.getMessage(), ASYNC_STORAGE));
+              "Interrupted while waiting for pod '%s' removal. " + ex.getMessage(), ASYNC_STORAGE),
+          ex);
     } catch (ExecutionException ex) {
       throw new InfrastructureException(
           format(
               "Error occurred while waiting for pod '%s' removal. " + ex.getMessage(),
-              ASYNC_STORAGE));
+              ASYNC_STORAGE),
+          ex);
     } catch (TimeoutException ex) {
       throw new InfrastructureException(
-          format("Pod '%s' removal timeout reached " + ex.getMessage(), ASYNC_STORAGE));
+          format("Pod '%s' removal timeout reached " + ex.getMessage(), ASYNC_STORAGE), ex);
     }
   }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.openshift.provision;
 
 import static java.util.Objects.isNull;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.COMMON_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
 import static org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner.ASYNC_STORAGE;
 
@@ -58,7 +59,7 @@ public class AsyncStoragePodInterceptor {
 
   public void intercept(OpenShiftEnvironment osEnv, RuntimeIdentity identity)
       throws InfrastructureException {
-    if (!"common".equals(strategy)) {
+    if (!COMMON_STRATEGY.equals(strategy)) {
       return;
     }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import static java.lang.String.format;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
+import static org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner.ASYNC_STORAGE;
+
+import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Checking if starting workspace configured to persisted storage and async storage pod is running.
+ * To prevent 'Multi-Attach error for volume' async storage pod will be shutdown. After deleting
+ * asynchronous storage pod procedure of starting workspace will be continued.
+ */
+public class AsyncStoragePodInterceptor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncStoragePodInterceptor.class);
+
+  private final OpenShiftClientFactory clientFactory;
+  private final String strategy;
+
+  @Inject
+  public AsyncStoragePodInterceptor(
+      @Named("che.infra.kubernetes.pvc.strategy") String strategy,
+      OpenShiftClientFactory openShiftClientFactory) {
+    this.strategy = strategy;
+    this.clientFactory = openShiftClientFactory;
+  }
+
+  public void intercept(OpenShiftEnvironment osEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+    if (!"common".equals(strategy)) {
+      return;
+    }
+
+    if (isEphemeral(osEnv.getAttributes())) {
+      return;
+    }
+
+    String namespace = identity.getInfrastructureNamespace();
+    PodResource<Pod, DoneablePod> podResource =
+        clientFactory
+            .create(identity.getWorkspaceId())
+            .pods()
+            .inNamespace(namespace)
+            .withName(ASYNC_STORAGE);
+    if (podResource.get() == null) {
+      return;
+    }
+    try {
+      doDeletePod(identity.getWorkspaceId(), namespace).get(5, TimeUnit.MINUTES);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new InfrastructureException(
+          "Interrupted while waiting for pod removal. " + ex.getMessage());
+    } catch (ExecutionException ex) {
+      throw new InfrastructureException(
+          "Error occurred while waiting for pod removal. " + ex.getMessage());
+    } catch (TimeoutException ex) {
+      throw new InfrastructureException("Pod removal timeout reached " + ex.getMessage());
+    }
+  }
+
+  protected CompletableFuture<Void> doDeletePod(String workspaceId, String namespace)
+      throws InfrastructureException {
+    Watch toCloseOnException = null;
+    try {
+      PodResource<Pod, DoneablePod> podResource =
+          clientFactory.create(workspaceId).pods().inNamespace(namespace).withName(ASYNC_STORAGE);
+      if (podResource.get() == null) {
+        throw new InfrastructureException(
+            format("No pod found to delete for name %s", ASYNC_STORAGE));
+      }
+
+      final CompletableFuture<Void> deleteFuture = new CompletableFuture<>();
+      final Watch watch = podResource.watch(new DeleteWatcher<>(deleteFuture));
+      toCloseOnException = watch;
+
+      Boolean deleteSucceeded = podResource.withPropagationPolicy("Background").delete();
+      if (deleteSucceeded == null || !deleteSucceeded) {
+        deleteFuture.complete(null);
+      }
+      return deleteFuture.whenComplete(
+          (v, e) -> {
+            if (e != null) {
+              LOG.warn("Failed to remove pod {} cause {}", ASYNC_STORAGE, e.getMessage());
+            }
+            watch.close();
+          });
+    } catch (KubernetesClientException e) {
+      if (toCloseOnException != null) {
+        toCloseOnException.close();
+      }
+      throw new KubernetesInfrastructureException(e);
+    } catch (Exception e) {
+      if (toCloseOnException != null) {
+        toCloseOnException.close();
+      }
+      throw e;
+    }
+  }
+
+  private static class DeleteWatcher<T> implements Watcher<T> {
+
+    private final CompletableFuture<Void> future;
+
+    private DeleteWatcher(CompletableFuture<Void> future) {
+      this.future = future;
+    }
+
+    @Override
+    public void eventReceived(Action action, T hasMetadata) {
+      if (action == Action.DELETED) {
+        future.complete(null);
+      }
+    }
+
+    @Override
+    public void onClose(KubernetesClientException e) {
+      // if event about removing is received then this completion has no effect
+      future.completeExceptionally(
+          new RuntimeException(
+              "Websocket connection is closed. But event about removing is not received.", e));
+    }
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.workspace.infrastructure.openshift.provision;
 
 import static java.lang.String.format;
-import static java.util.Objects.isNull;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.COMMON_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
 import static org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner.ASYNC_STORAGE;
@@ -38,9 +37,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Checking if starting workspace configured to persisted storage and async storage pod is running.
- * To prevent 'Multi-Attach error for volume' async storage pod will be shutdown. After deleting
- * asynchronous storage pod procedure of starting workspace will be continued.
+ * This interceptor checks whether the starting workspace is configured with persistent storage and
+ * makes sure to stop the async storage pod (if any is running) to prevent "Multi-Attach error for
+ * volume". After the async storage pod is stopped and deleted, the workspace start is resumed.
  */
 public class AsyncStoragePodInterceptor {
 
@@ -70,7 +69,7 @@ public class AsyncStoragePodInterceptor {
     PodResource<Pod, DoneablePod> asyncStoragePodResource =
         getAsyncStoragePodResource(namespace, workspaceId);
 
-    if (isNull(asyncStoragePodResource.get())) { // pod doesn't exist
+    if (asyncStoragePodResource.get() == null) { // pod doesn't exist
       return;
     }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.provision;
 
+import static java.lang.String.format;
 import static java.util.Objects.isNull;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.COMMON_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
@@ -59,11 +60,7 @@ public class AsyncStoragePodInterceptor {
 
   public void intercept(OpenShiftEnvironment osEnv, RuntimeIdentity identity)
       throws InfrastructureException {
-    if (!COMMON_STRATEGY.equals(strategy)) {
-      return;
-    }
-
-    if (isEphemeral(osEnv.getAttributes())) {
+    if (!COMMON_STRATEGY.equals(strategy) || isEphemeral(osEnv.getAttributes())) {
       return;
     }
 
@@ -83,12 +80,16 @@ public class AsyncStoragePodInterceptor {
     } catch (InterruptedException ex) {
       Thread.currentThread().interrupt();
       throw new InfrastructureException(
-          "Interrupted while waiting for pod removal. " + ex.getMessage());
+          format(
+              "Interrupted while waiting for pod '%s' removal. " + ex.getMessage(), ASYNC_STORAGE));
     } catch (ExecutionException ex) {
       throw new InfrastructureException(
-          "Error occurred while waiting for pod removal. " + ex.getMessage());
+          format(
+              "Error occurred while waiting for pod '%s' removal. " + ex.getMessage(),
+              ASYNC_STORAGE));
     } catch (TimeoutException ex) {
-      throw new InfrastructureException("Pod removal timeout reached " + ex.getMessage());
+      throw new InfrastructureException(
+          format("Pod '%s' removal timeout reached " + ex.getMessage(), ASYNC_STORAGE));
     }
   }
 
@@ -149,7 +150,7 @@ public class AsyncStoragePodInterceptor {
       // if event about removing is received then this completion has no effect
       future.completeExceptionally(
           new RuntimeException(
-              "Websocket connection is closed. But event about removing is not received.", e));
+              "WebSocket connection is closed. But event about removing is not received.", e));
     }
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptor.java
@@ -93,7 +93,7 @@ public class AsyncStoragePodInterceptor {
   }
 
   private PodResource<Pod, DoneablePod> getAsyncStoragePodResource(
-      String workspaceId, String namespace) throws InfrastructureException {
+      String namespace, String workspaceId) throws InfrastructureException {
     return clientFactory.create(workspaceId).pods().inNamespace(namespace).withName(ASYNC_STORAGE);
   }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisioner.java
@@ -139,7 +139,7 @@ public class AsyncStorageProvisioner {
     if ("true".equals(osEnv.getAttributes().get(ASYNC_PERSIST_ATTRIBUTE))
         && !isEphemeral(osEnv.getAttributes())) {
       String message =
-          "Workspace configuration not valid: Asynchronous storage available only if attribute 'persistVolumes' set to false";
+          format("Workspace configuration not valid: Asynchronous storage available only if '%s' attribute set to false", ASYNC_PERSIST_ATTRIBUTE );
       LOG.warn(message);
       osEnv.addWarning(new WarningImpl(4200, message));
       throw new InfrastructureException(message);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisioner.java
@@ -147,7 +147,9 @@ public class AsyncStorageProvisioner {
     if (parseBoolean(osEnv.getAttributes().get(ASYNC_PERSIST_ATTRIBUTE))
         && !isEphemeral(osEnv.getAttributes())) {
       String message =
-          format("Workspace configuration not valid: Asynchronous storage available only if '%s' attribute set to false", ASYNC_PERSIST_ATTRIBUTE );
+          format(
+              "Workspace configuration not valid: Asynchronous storage available only if '%s' attribute set to false",
+              ASYNC_PERSIST_ATTRIBUTE);
       LOG.warn(message);
       osEnv.addWarning(new WarningImpl(4200, message));
       throw new InfrastructureException(message);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisioner.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import static java.lang.String.format;
+import static java.lang.String.valueOf;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_SSH_KEYS;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_SSH_KEYS_MESSAGE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import io.fabric8.kubernetes.api.model.ConfigMapVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.IntOrStringBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSourceBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.ServiceSpec;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.ssh.server.SshManager;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.ssh.shared.model.SshPair;
+import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Configure environment for Async Storage feature (details described in issue
+ * https://github.com/eclipse/che/issues/15384) This environment will allow backup on workspace stop
+ * event and restore on restart created earlier. <br>
+ * Will apply only in case workspace has attributes: asyncPersist: true - persistVolumes:
+ * false.</br> In case workspace has attributes: asyncPersist: true - persistVolumes: true will
+ * throw exception.</br> Feature enabled only for 'common' PVC strategy, in other cases will throw
+ * exception.</br> During provision will be created: - storage Pod - service for rsync connection
+ * via SSH - configmap, with public part of SSH key - PVC for storing backups;
+ */
+public class AsyncStorageProvisioner {
+
+  private static final int SERVICE_PORT = 2222;
+  private static final String AUTHORIZED_KEYS = "authorized_keys";
+  static final String ASYNC_STORAGE = "async-storage";
+  static final String ASYNC_STORAGE_CONFIG = "async-storage-config";
+  private static final String ASYNC_STORAGE_DATA_PATH = "/" + ASYNC_STORAGE;
+  private static final String SSH_KEY_PATH = "/.ssh/" + AUTHORIZED_KEYS;
+  static final String SSH_KEY_NAME = "rsync-via-ssh";
+  private static final String CONFIG_MAP_VOLUME_NAME = "async-storage-configvolume";
+  private static final String STORAGE_VOLUME = "async-storage-data";
+
+  private static final Logger LOG = LoggerFactory.getLogger(AsyncStorageProvisioner.class);
+
+  private final String pvcQuantity;
+  private final String storageImage;
+  private final String accessMode;
+  private final String strategy;
+  private final String configuredPVCName;
+  private final String pvcStorageClassName;
+  private final SshManager sshManager;
+  private final OpenShiftClientFactory clientFactory;
+
+  @Inject
+  public AsyncStorageProvisioner(
+      @Named("che.infra.kubernetes.pvc.quantity") String pvcQuantity,
+      @Named("che.infra.kubernetes.async.storage.image") String image,
+      @Named("che.infra.kubernetes.pvc.access_mode") String accessMode,
+      @Named("che.infra.kubernetes.pvc.strategy") String strategy,
+      @Named("che.infra.kubernetes.pvc.name") String configuredPVCName,
+      @Named("che.infra.kubernetes.pvc.storage_class_name") String pvcStorageClassName,
+      SshManager sshManager,
+      OpenShiftClientFactory openShiftClientFactory) {
+    this.pvcQuantity = pvcQuantity;
+    this.storageImage = image;
+    this.accessMode = accessMode;
+    this.strategy = strategy;
+    this.configuredPVCName = configuredPVCName;
+    this.pvcStorageClassName = pvcStorageClassName;
+    this.sshManager = sshManager;
+    this.clientFactory = openShiftClientFactory;
+  }
+
+  public void provision(OpenShiftEnvironment osEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+    if (!"true".equals(osEnv.getAttributes().get(ASYNC_PERSIST_ATTRIBUTE))) {
+      return;
+    }
+
+    if ("true".equals(osEnv.getAttributes().get(ASYNC_PERSIST_ATTRIBUTE))
+        && !"common".equals(strategy)) {
+      String message =
+          format(
+              "Workspace configuration not valid: Asynchronous storage available only for 'common' PVC strategy, but got %s",
+              strategy);
+      LOG.warn(message);
+      osEnv.addWarning(new WarningImpl(4200, message));
+      throw new InfrastructureException(message);
+    }
+
+    if ("true".equals(osEnv.getAttributes().get(ASYNC_PERSIST_ATTRIBUTE))
+        && !isEphemeral(osEnv.getAttributes())) {
+      String message =
+          "Workspace configuration not valid: Asynchronous storage available only if attribute 'persistVolumes' set to false";
+      LOG.warn(message);
+      osEnv.addWarning(new WarningImpl(4200, message));
+      throw new InfrastructureException(message);
+    }
+
+    String namespace = identity.getInfrastructureNamespace();
+    KubernetesClient oc = clientFactory.create(identity.getWorkspaceId());
+
+    boolean isPvcExist =
+        oc.persistentVolumeClaims()
+            .inNamespace(namespace)
+            .list()
+            .getItems()
+            .stream()
+            .anyMatch(
+                (Predicate<PersistentVolumeClaim>)
+                    pvc -> pvc.getMetadata().getName().equals(configuredPVCName));
+
+    if (!isPvcExist) {
+      PersistentVolumeClaim pvc =
+          KubernetesObjectUtil.newPVC(
+              configuredPVCName, accessMode, pvcQuantity, pvcStorageClassName);
+      oc.persistentVolumeClaims().inNamespace(namespace).create(pvc);
+    }
+
+    String configMapName = namespace + ASYNC_STORAGE_CONFIG;
+    boolean isMapExist =
+        oc.configMaps()
+            .inNamespace(namespace)
+            .list()
+            .getItems()
+            .stream()
+            .anyMatch(
+                (Predicate<ConfigMap>)
+                    configMap -> configMap.getMetadata().getName().equals(configMapName));
+
+    if (!isMapExist) {
+      ConfigMap configMap = createConfigMap(namespace, configMapName, identity, osEnv);
+      oc.configMaps().inNamespace(namespace).create(configMap);
+    }
+
+    boolean isPodExist =
+        oc.pods()
+            .inNamespace(namespace)
+            .list()
+            .getItems()
+            .stream()
+            .anyMatch((Predicate<Pod>) pod -> pod.getMetadata().getName().equals(ASYNC_STORAGE));
+
+    if (!isPodExist) {
+      Pod pod = createStoragePod(namespace, configMapName);
+      oc.pods().inNamespace(namespace).create(pod);
+    }
+
+    boolean isServiceExist =
+        oc.services()
+            .inNamespace(namespace)
+            .list()
+            .getItems()
+            .stream()
+            .anyMatch(
+                (Predicate<Service>)
+                    service -> service.getMetadata().getName().equals(ASYNC_STORAGE));
+
+    if (!isServiceExist) {
+      Service service = createStorageService(namespace);
+      oc.services().inNamespace(namespace).create(service);
+    }
+  }
+
+  /** Get or create new pair of SSH keys, this is need for securing rsync connection */
+  private List<SshPairImpl> getOrCreateSshPairs(
+      RuntimeIdentity identity, OpenShiftEnvironment osEnv) throws InfrastructureException {
+    List<SshPairImpl> sshPairs;
+    try {
+      sshPairs = sshManager.getPairs(identity.getOwnerId(), "internal");
+    } catch (ServerException e) {
+      String message = format("Unable to get SSH Keys. Cause: %s", e.getMessage());
+      LOG.warn(message);
+      osEnv.addWarning(
+          new WarningImpl(
+              NOT_ABLE_TO_PROVISION_SSH_KEYS,
+              format(NOT_ABLE_TO_PROVISION_SSH_KEYS_MESSAGE, message)));
+      throw new InfrastructureException(e);
+    }
+    if (sshPairs.isEmpty()) {
+      try {
+        sshPairs =
+            singletonList(sshManager.generatePair(identity.getOwnerId(), "internal", SSH_KEY_NAME));
+      } catch (ServerException | ConflictException e) {
+        String message =
+            format(
+                "Unable to generate the SSH key for async storage service. Cause: %S",
+                e.getMessage());
+        LOG.warn(message);
+        osEnv.addWarning(
+            new WarningImpl(
+                NOT_ABLE_TO_PROVISION_SSH_KEYS,
+                format(NOT_ABLE_TO_PROVISION_SSH_KEYS_MESSAGE, message)));
+        throw new InfrastructureException(e);
+      }
+    }
+    return sshPairs;
+  }
+
+  /** Create configmap with public part of SSH key */
+  private ConfigMap createConfigMap(
+      String namespace, String configMapName, RuntimeIdentity identity, OpenShiftEnvironment osEnv)
+      throws InfrastructureException {
+    List<SshPairImpl> sshPairs = getOrCreateSshPairs(identity, osEnv);
+    if (sshPairs == null) {
+      return null;
+    }
+    SshPair sshPair = sshPairs.get(0);
+    Map<String, String> sshConfigData =
+        ImmutableMap.of(AUTHORIZED_KEYS, sshPair.getPublicKey() + "\n");
+    return new ConfigMapBuilder()
+        .withNewMetadata()
+        .withName(configMapName)
+        .withNamespace(namespace)
+        .endMetadata()
+        .withData(sshConfigData)
+        .build();
+  }
+
+  /**
+   * Create storage Pod with container with mounted volume for storing project source backups, SSH
+   * key and exposed port for rsync connection
+   */
+  private Pod createStoragePod(String namespace, String configMap) {
+    String containerName = Names.generateName(ASYNC_STORAGE);
+
+    Volume storageVolume =
+        new VolumeBuilder()
+            .withName(STORAGE_VOLUME)
+            .withPersistentVolumeClaim(
+                new PersistentVolumeClaimVolumeSourceBuilder()
+                    .withClaimName(configuredPVCName)
+                    .withReadOnly(false)
+                    .build())
+            .build();
+
+    Volume sshKeyVolume =
+        new VolumeBuilder()
+            .withName(CONFIG_MAP_VOLUME_NAME)
+            .withConfigMap(
+                new ConfigMapVolumeSourceBuilder()
+                    .withName(configMap)
+                    .withDefaultMode(0600)
+                    .build())
+            .build();
+
+    VolumeMount storageVolumeMount =
+        new VolumeMountBuilder()
+            .withMountPath(ASYNC_STORAGE_DATA_PATH)
+            .withName(STORAGE_VOLUME)
+            .withReadOnly(false)
+            .build();
+
+    VolumeMount sshVolumeMount =
+        new VolumeMountBuilder()
+            .withMountPath(SSH_KEY_PATH)
+            .withSubPath(AUTHORIZED_KEYS)
+            .withName(CONFIG_MAP_VOLUME_NAME)
+            .withReadOnly(true)
+            .build();
+
+    Container container =
+        new ContainerBuilder()
+            .withName(containerName)
+            .withImage(storageImage)
+            .withNewResources()
+            .addToLimits("memory", new Quantity("512Mi"))
+            .addToRequests("memory", new Quantity("256Mi"))
+            .endResources()
+            .withPorts(
+                new ContainerPortBuilder()
+                    .withContainerPort(SERVICE_PORT)
+                    .withProtocol("TCP")
+                    .build())
+            .withVolumeMounts(storageVolumeMount, sshVolumeMount)
+            .build();
+
+    PodSpecBuilder podSpecBuilder = new PodSpecBuilder();
+    PodSpec podSpec =
+        podSpecBuilder.withContainers(container).withVolumes(storageVolume, sshKeyVolume).build();
+
+    return new PodBuilder()
+        .withApiVersion("v1")
+        .withKind("Pod")
+        .withNewMetadata()
+        .withName(ASYNC_STORAGE)
+        .withNamespace(namespace)
+        .withLabels(singletonMap("app", ASYNC_STORAGE))
+        .endMetadata()
+        .withSpec(podSpec)
+        .build();
+  }
+
+  /** Create service for serving rsync connection */
+  private Service createStorageService(String namespace) {
+    ObjectMeta meta = new ObjectMeta();
+    meta.setName(ASYNC_STORAGE);
+    meta.setNamespace(namespace);
+
+    IntOrString targetPort =
+        new IntOrStringBuilder().withIntVal(SERVICE_PORT).withStrVal(valueOf(SERVICE_PORT)).build();
+
+    ServicePort port =
+        new ServicePortBuilder()
+            .withName("rsync-port")
+            .withProtocol("TCP")
+            .withPort(SERVICE_PORT)
+            .withTargetPort(targetPort)
+            .build();
+    ServiceSpec spec = new ServiceSpec();
+    spec.setPorts(singletonList(port));
+    spec.setSelector(singletonMap("app", ASYNC_STORAGE));
+
+    Service service = new Service();
+    service.setApiVersion("v1");
+    service.setKind("Service");
+    service.setMetadata(meta);
+    service.setSpec(spec);
+
+    return service;
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidatorTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidatorTest.java
@@ -44,6 +44,16 @@ public class AsyncStorageModeValidatorTest {
   @Test(
       expectedExceptions = ValidationException.class,
       expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for 'per-user' namespace strategy")
+  public void shouldThrowExceptionWithNullNamespaceStrategy() throws ValidationException {
+    AsyncStorageModeValidator validator = new AsyncStorageModeValidator("common", false, null, 1);
+
+    validator.validate(of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
           "Workspace configuration not valid: Asynchronous storage available only if 'che.infra.kubernetes.namespace.allow_user_defined' set to 'false', but got 'true'")
   public void shouldThrowExceptionIfUserDefineNamespaceAllowed() throws ValidationException {
     AsyncStorageModeValidator validator =

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidatorTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidatorTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
+
+import org.eclipse.che.api.core.ValidationException;
+import org.testng.annotations.Test;
+
+public class AsyncStorageModeValidatorTest {
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for 'common' PVC strategy, but got not-common")
+  public void shouldThrowExceptionIfNotCommonStrategy() throws ValidationException {
+    AsyncStorageModeValidator validator = new AsyncStorageModeValidator("not-common", false, "", 1);
+
+    validator.validate(of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for 'per-user' namespace strategy")
+  public void shouldThrowExceptionIfNotPerUserNamespaceStrategy() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "my-name", 1);
+
+    validator.validate(of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only if 'che.infra.kubernetes.namespace.allow_user_defined' set to 'false', but got 'true'")
+  public void shouldThrowExceptionIfUserDefineNamespaceAllowed() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", true, "<username>-che", 1);
+
+    validator.validate(of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only if 'che.limits.user.workspaces.run.count' set to 1, but got 2")
+  public void shouldThrowExceptionIfMoreThanOneRuntimeEnabled() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 2);
+
+    validator.validate(of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test
+  public void shouldBeFineForEphemeralMode() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validate(of(PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test
+  public void shouldBeFineForPersistentMode() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validate(of(PERSIST_VOLUMES_ATTRIBUTE, "true"));
+  }
+
+  @Test
+  public void shouldBeFineForEmptyAttribute() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validate(of());
+  }
+
+  @Test
+  public void shouldBeFineForAsyncMode() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validate(of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage")
+  public void shouldThrowExceptionIfAsyncAttributeForNotEphemeral() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validate(of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "true"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for 'common' PVC strategy, but got not-common")
+  public void shouldThrowExceptionIfNotCommonStrategyUpdate() throws ValidationException {
+    AsyncStorageModeValidator validator = new AsyncStorageModeValidator("not-common", false, "", 1);
+
+    validator.validateUpdate(
+        of(), of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for 'per-user' namespace strategy")
+  public void shouldThrowExceptionIfNotPerUserNamespaceStrategyUpdate() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "my-name", 1);
+
+    validator.validateUpdate(
+        of(), of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only if 'che.infra.kubernetes.namespace.allow_user_defined' set to 'false', but got 'true'")
+  public void shouldThrowExceptionIfUserDefineNamespaceAllowedUpdate() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", true, "<username>-che", 1);
+
+    validator.validateUpdate(
+        of(), of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only if 'che.limits.user.workspaces.run.count' set to 1, but got 2")
+  public void shouldThrowExceptionIfMoreThanOneRuntimeEnabledUpdate() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 2);
+
+    validator.validateUpdate(
+        of(), of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test
+  public void shouldBeFineForEphemeralModeUpdate() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validateUpdate(of(), of(PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test
+  public void shouldBeFineForPersistentModeUpdate() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validateUpdate(of(), of(PERSIST_VOLUMES_ATTRIBUTE, "true"));
+  }
+
+  @Test
+  public void shouldBeFineForEmptyAttributeUpdate() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validateUpdate(of(), of());
+  }
+
+  @Test
+  public void shouldBeFineForAsyncModeUpdate() throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validateUpdate(
+        of(), of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "false"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage")
+  public void shouldThrowExceptionIfAsyncAttributeForNotEphemeralUpdate()
+      throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validateUpdate(
+        of(), of(ASYNC_PERSIST_ATTRIBUTE, "true", PERSIST_VOLUMES_ATTRIBUTE, "true"));
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for NOT persistent storage")
+  public void shouldThrowExceptionIfAsyncAttributeForNotEphemeralUpdate2()
+      throws ValidationException {
+    AsyncStorageModeValidator validator =
+        new AsyncStorageModeValidator("common", false, "<username>-che", 1);
+
+    validator.validateUpdate(
+        of(PERSIST_VOLUMES_ATTRIBUTE, "true"), of(ASYNC_PERSIST_ATTRIBUTE, "true"));
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -30,6 +30,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.restartpolicy.RestartPolicyRewriter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.ServersConverter;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStoragePodInterceptor;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftUniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.provision.RouteTlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftPreviewUrlExposer;
@@ -62,6 +64,8 @@ public class OpenShiftEnvironmentProvisionerTest {
   @Mock private ImagePullSecretProvisioner imagePullSecretProvisioner;
   @Mock private ProxySettingsProvisioner proxySettingsProvisioner;
   @Mock private ServiceAccountProvisioner serviceAccountProvisioner;
+  @Mock private AsyncStorageProvisioner asyncStorageProvisioner;
+  @Mock private AsyncStoragePodInterceptor asyncStoragePodObserver;
   @Mock private CertificateProvisioner certificateProvisioner;
   @Mock private SshKeysProvisioner sshKeysProvisioner;
   @Mock private GitConfigProvisioner gitConfigProvisioner;
@@ -88,6 +92,8 @@ public class OpenShiftEnvironmentProvisionerTest {
             podTerminationGracePeriodProvisioner,
             imagePullSecretProvisioner,
             proxySettingsProvisioner,
+            asyncStorageProvisioner,
+            asyncStoragePodObserver,
             serviceAccountProvisioner,
             certificateProvisioner,
             sshKeysProvisioner,

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptorTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStoragePodInterceptorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static java.util.Collections.emptyMap;
+import static java.util.UUID.randomUUID;
+import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner.ASYNC_STORAGE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.DoneablePod;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.openshift.client.OpenShiftClient;
+import java.util.UUID;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class AsyncStoragePodInterceptorTest {
+
+  private static final String WORKSPACE_ID = UUID.randomUUID().toString();
+  private static final String NAMESPACE = UUID.randomUUID().toString();
+
+  @Mock private OpenShiftEnvironment openShiftEnvironment;
+  @Mock private RuntimeIdentity identity;
+  @Mock private OpenShiftClientFactory clientFactory;
+  @Mock private OpenShiftClient osClient;
+  @Mock private PodResource<Pod, DoneablePod> podResource;
+  @Mock private MixedOperation mixedOperationPod;
+  @Mock private NonNamespaceOperation namespacePodOperation;
+  @Mock private FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> deletable;
+
+  private AsyncStoragePodInterceptor asyncStoragePodInterceptor;
+
+  @BeforeMethod
+  public void setUp() {
+    asyncStoragePodInterceptor = new AsyncStoragePodInterceptor("common", clientFactory);
+  }
+
+  @Test
+  public void shouldDoNothingIfNotCommonStrategy() throws Exception {
+    AsyncStoragePodInterceptor asyncStoragePodInterceptor =
+        new AsyncStoragePodInterceptor(randomUUID().toString(), clientFactory);
+    asyncStoragePodInterceptor.intercept(openShiftEnvironment, identity);
+    verifyNoMoreInteractions(clientFactory);
+    verifyNoMoreInteractions(identity);
+  }
+
+  @Test
+  public void shouldDoNothingIfEphemeralWorkspace() throws Exception {
+    when(openShiftEnvironment.getAttributes()).thenReturn(of(PERSIST_VOLUMES_ATTRIBUTE, "false"));
+    asyncStoragePodInterceptor.intercept(openShiftEnvironment, identity);
+    verifyNoMoreInteractions(clientFactory);
+    verifyNoMoreInteractions(identity);
+  }
+
+  @Test
+  public void shouldDoNothingIfWorkspaceConfiguredWithAsyncStorage() throws Exception {
+    when(openShiftEnvironment.getAttributes())
+        .thenReturn(of(PERSIST_VOLUMES_ATTRIBUTE, "false", ASYNC_PERSIST_ATTRIBUTE, "true"));
+    asyncStoragePodInterceptor.intercept(openShiftEnvironment, identity);
+    verifyNoMoreInteractions(clientFactory);
+    verifyNoMoreInteractions(identity);
+  }
+
+  @Test
+  public void shouldDoNothingIfPodDoesNotExist() throws InfrastructureException {
+    when(identity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+    when(identity.getInfrastructureNamespace()).thenReturn(NAMESPACE);
+
+    when(clientFactory.create(WORKSPACE_ID)).thenReturn(osClient);
+    when(openShiftEnvironment.getAttributes()).thenReturn(emptyMap());
+
+    when(osClient.pods()).thenReturn(mixedOperationPod);
+    when(mixedOperationPod.inNamespace(NAMESPACE)).thenReturn(namespacePodOperation);
+    when(namespacePodOperation.withName(ASYNC_STORAGE)).thenReturn(podResource);
+    when(podResource.get()).thenReturn(null);
+
+    asyncStoragePodInterceptor.intercept(openShiftEnvironment, identity);
+    verifyNoMoreInteractions(clientFactory);
+    verifyNoMoreInteractions(identity);
+    verifyNoMoreInteractions(osClient);
+  }
+
+  @Test
+  public void shouldDoDeletePodIfWorkspaceWithEmptyAttributes() throws InfrastructureException {
+    when(identity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+    when(identity.getInfrastructureNamespace()).thenReturn(NAMESPACE);
+
+    when(clientFactory.create(WORKSPACE_ID)).thenReturn(osClient);
+    when(openShiftEnvironment.getAttributes()).thenReturn(emptyMap());
+
+    when(osClient.pods()).thenReturn(mixedOperationPod);
+    when(mixedOperationPod.inNamespace(NAMESPACE)).thenReturn(namespacePodOperation);
+    when(namespacePodOperation.withName(ASYNC_STORAGE)).thenReturn(podResource);
+
+    ObjectMeta meta = new ObjectMeta();
+    meta.setName(ASYNC_STORAGE);
+    Pod pod = new Pod();
+    pod.setMetadata(meta);
+
+    when(podResource.get()).thenReturn(pod);
+    when(podResource.withPropagationPolicy("Background")).thenReturn(deletable);
+
+    Watch watch = mock(Watch.class);
+    when(podResource.watch(any())).thenReturn(watch);
+
+    asyncStoragePodInterceptor.intercept(openShiftEnvironment, identity);
+    verify(deletable).delete();
+    verify(watch).close();
+  }
+
+  @Test
+  public void shouldDoDeletePodIfWorkspaceConfigureToPersistentStorage()
+      throws InfrastructureException {
+    when(identity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
+    when(identity.getInfrastructureNamespace()).thenReturn(NAMESPACE);
+
+    when(clientFactory.create(WORKSPACE_ID)).thenReturn(osClient);
+    when(openShiftEnvironment.getAttributes())
+        .thenReturn(ImmutableMap.of(PERSIST_VOLUMES_ATTRIBUTE, "true"));
+
+    when(osClient.pods()).thenReturn(mixedOperationPod);
+    when(mixedOperationPod.inNamespace(NAMESPACE)).thenReturn(namespacePodOperation);
+    when(namespacePodOperation.withName(ASYNC_STORAGE)).thenReturn(podResource);
+
+    ObjectMeta meta = new ObjectMeta();
+    meta.setName(ASYNC_STORAGE);
+    Pod pod = new Pod();
+    pod.setMetadata(meta);
+
+    when(podResource.get()).thenReturn(pod);
+    when(podResource.withPropagationPolicy("Background")).thenReturn(deletable);
+
+    Watch watch = mock(Watch.class);
+    when(podResource.watch(any())).thenReturn(watch);
+
+    asyncStoragePodInterceptor.intercept(openShiftEnvironment, identity);
+    verify(deletable).delete();
+    verify(watch).close();
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisionerTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.provision;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static java.util.UUID.randomUUID;
+import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner.ASYNC_STORAGE;
+import static org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner.ASYNC_STORAGE_CONFIG;
+import static org.eclipse.che.workspace.infrastructure.openshift.provision.AsyncStorageProvisioner.SSH_KEY_NAME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapList;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaimList;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServiceList;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.openshift.client.OpenShiftClient;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.ssh.server.SshManager;
+import org.eclipse.che.api.ssh.server.model.impl.SshPairImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class AsyncStorageProvisionerTest {
+
+  @Mock private OpenShiftEnvironment openShiftEnvironment;
+  @Mock private RuntimeIdentity identity;
+  @Mock private OpenShiftClientFactory clientFactory;
+  @Mock private OpenShiftClient osClient;
+  @Mock private SshManager sshManager;
+  @Mock private PersistentVolumeClaimList pvcs;
+  @Mock private ConfigMapList configMaps;
+  @Mock private PodList pods;
+  @Mock private ServiceList services;
+  @Mock private MixedOperation mixedOperationPvc;
+  @Mock private MixedOperation mixedOperationConfigMap;
+  @Mock private NonNamespaceOperation namespacePvcOperation;
+  @Mock private NonNamespaceOperation namespaceConfigMapOperation;
+  @Mock private MixedOperation mixedOperationPod;
+  @Mock private MixedOperation mixedOperationService;
+  @Mock private NonNamespaceOperation namespacePodOperation;
+  @Mock private NonNamespaceOperation namespaceServiceOperation;
+
+  private Map<String, String> attributes;
+  private AsyncStorageProvisioner asyncStorageProvisioner;
+  private SshPairImpl sshPair;
+
+  @BeforeMethod
+  public void setUp() {
+    asyncStorageProvisioner =
+        new AsyncStorageProvisioner(
+            "10Gi",
+            "org/image:tag",
+            "ReadWriteOnce",
+            "common",
+            "name",
+            "storage",
+            sshManager,
+            clientFactory);
+    attributes = new HashMap<>(2);
+    attributes.put(ASYNC_PERSIST_ATTRIBUTE, "true");
+    attributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");
+    sshPair = new SshPairImpl("user", "internal", SSH_KEY_NAME, "", "");
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void shouldThrowExceptionIfNotCommonStrategy() throws Exception {
+    AsyncStorageProvisioner asyncStorageProvisioner =
+        new AsyncStorageProvisioner(
+            "10Gi",
+            "org/image:tag",
+            "ReadWriteOnce",
+            randomUUID().toString(),
+            "pvcName",
+            "storageClass",
+            sshManager,
+            clientFactory);
+    when(openShiftEnvironment.getAttributes()).thenReturn(attributes);
+    asyncStorageProvisioner.provision(openShiftEnvironment, identity);
+    verifyNoMoreInteractions(sshManager);
+    verifyNoMoreInteractions(clientFactory);
+    verifyNoMoreInteractions(identity);
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void shouldThrowExceptionIfAsyncStorageForNotEphemeralWorkspace() throws Exception {
+    Map attributes = new HashMap<>(2);
+    attributes.put(ASYNC_PERSIST_ATTRIBUTE, "true");
+    attributes.put(PERSIST_VOLUMES_ATTRIBUTE, "true");
+    when(openShiftEnvironment.getAttributes()).thenReturn(attributes);
+    asyncStorageProvisioner.provision(openShiftEnvironment, identity);
+    verifyNoMoreInteractions(sshManager);
+    verifyNoMoreInteractions(clientFactory);
+    verifyNoMoreInteractions(identity);
+  }
+
+  @Test
+  public void shouldDoNothingIfNotSetAttribute() throws InfrastructureException {
+    when(openShiftEnvironment.getAttributes()).thenReturn(emptyMap());
+    asyncStorageProvisioner.provision(openShiftEnvironment, identity);
+    verifyNoMoreInteractions(sshManager);
+    verifyNoMoreInteractions(clientFactory);
+    verifyNoMoreInteractions(identity);
+  }
+
+  @Test
+  public void shouldDoNothingIfAttributesAsyncPersistOnly() throws InfrastructureException {
+    when(openShiftEnvironment.getAttributes())
+        .thenReturn(singletonMap(PERSIST_VOLUMES_ATTRIBUTE, "false"));
+    asyncStorageProvisioner.provision(openShiftEnvironment, identity);
+    verifyNoMoreInteractions(sshManager);
+    verifyNoMoreInteractions(clientFactory);
+    verifyNoMoreInteractions(identity);
+  }
+
+  @Test
+  public void shouldCreateAll() throws InfrastructureException, ServerException, ConflictException {
+    when(openShiftEnvironment.getAttributes()).thenReturn(attributes);
+    when(clientFactory.create(anyString())).thenReturn(osClient);
+    when(identity.getWorkspaceId()).thenReturn("wsid");
+    when(identity.getInfrastructureNamespace()).thenReturn("wsid");
+    when(identity.getOwnerId()).thenReturn("user");
+    when(sshManager.getPairs("user", "internal")).thenReturn(singletonList(sshPair));
+
+    when(osClient.persistentVolumeClaims()).thenReturn(mixedOperationPvc);
+    when(mixedOperationPvc.inNamespace(anyString())).thenReturn(namespacePvcOperation);
+    when(namespacePvcOperation.list()).thenReturn(pvcs);
+    when(pvcs.getItems()).thenReturn(emptyList());
+
+    when(osClient.configMaps()).thenReturn(mixedOperationConfigMap);
+    when(mixedOperationConfigMap.inNamespace(anyString())).thenReturn(namespaceConfigMapOperation);
+    when(namespaceConfigMapOperation.list()).thenReturn(configMaps);
+    when(configMaps.getItems()).thenReturn(emptyList());
+
+    when(osClient.pods()).thenReturn(mixedOperationPod);
+    when(mixedOperationPod.inNamespace(anyString())).thenReturn(namespacePodOperation);
+    when(namespacePodOperation.list()).thenReturn(pods);
+    when(pods.getItems()).thenReturn(emptyList());
+
+    when(osClient.services()).thenReturn(mixedOperationService);
+    when(mixedOperationService.inNamespace(anyString())).thenReturn(namespaceServiceOperation);
+    when(namespaceServiceOperation.list()).thenReturn(services);
+    when(services.getItems()).thenReturn(emptyList());
+
+    asyncStorageProvisioner.provision(openShiftEnvironment, identity);
+    verify(identity, times(1)).getInfrastructureNamespace();
+    verify(identity, times(1)).getOwnerId();
+    verify(sshManager, times(1)).getPairs("user", "internal");
+    verify(sshManager, never()).generatePair("user", "internal", SSH_KEY_NAME);
+    verify(osClient.services().inNamespace(anyString()), times(1)).create(any(Service.class));
+    verify(osClient.configMaps().inNamespace(anyString()), times(1)).create(any(ConfigMap.class));
+    verify(osClient.pods().inNamespace(anyString()), times(1)).create(any(Pod.class));
+    verify(osClient.persistentVolumeClaims().inNamespace(anyString()), times(1))
+        .create(any(PersistentVolumeClaim.class));
+  }
+
+  @Test
+  public void shouldNotCreateConfigMap()
+      throws InfrastructureException, ServerException, ConflictException {
+    when(openShiftEnvironment.getAttributes()).thenReturn(attributes);
+    when(clientFactory.create(anyString())).thenReturn(osClient);
+    when(identity.getWorkspaceId()).thenReturn("wsid");
+    when(identity.getInfrastructureNamespace()).thenReturn("wsid");
+    when(osClient.persistentVolumeClaims()).thenReturn(mixedOperationPvc);
+    when(mixedOperationPvc.inNamespace(anyString())).thenReturn(namespacePvcOperation);
+    when(namespacePvcOperation.list()).thenReturn(pvcs);
+    when(pvcs.getItems()).thenReturn(emptyList());
+
+    when(osClient.configMaps()).thenReturn(mixedOperationConfigMap);
+    when(mixedOperationConfigMap.inNamespace(anyString())).thenReturn(namespaceConfigMapOperation);
+    when(namespaceConfigMapOperation.list()).thenReturn(configMaps);
+    ObjectMeta meta = new ObjectMeta();
+    meta.setName("wsid" + ASYNC_STORAGE_CONFIG);
+    ConfigMap configMap = new ConfigMap();
+    configMap.setMetadata(meta);
+    when(configMaps.getItems()).thenReturn(singletonList(configMap));
+
+    when(osClient.pods()).thenReturn(mixedOperationPod);
+    when(mixedOperationPod.inNamespace(anyString())).thenReturn(namespacePodOperation);
+    when(namespacePodOperation.list()).thenReturn(pods);
+    when(pods.getItems()).thenReturn(emptyList());
+
+    when(osClient.services()).thenReturn(mixedOperationService);
+    when(mixedOperationService.inNamespace(anyString())).thenReturn(namespaceServiceOperation);
+    when(namespaceServiceOperation.list()).thenReturn(services);
+    when(services.getItems()).thenReturn(emptyList());
+
+    asyncStorageProvisioner.provision(openShiftEnvironment, identity);
+    verify(identity, times(1)).getInfrastructureNamespace();
+    verify(identity, never()).getOwnerId();
+    verify(identity, times(1)).getWorkspaceId();
+    verify(sshManager, never()).getPairs("user", "internal");
+    verify(sshManager, never()).generatePair("user", "internal", SSH_KEY_NAME);
+    verify(osClient.services().inNamespace(anyString()), times(1)).create(any(Service.class));
+    verify(osClient.configMaps().inNamespace(anyString()), never()).create(any(ConfigMap.class));
+    verify(osClient.pods().inNamespace(anyString()), times(1)).create(any(Pod.class));
+    verify(osClient.persistentVolumeClaims().inNamespace(anyString()), times(1))
+        .create(any(PersistentVolumeClaim.class));
+  }
+
+  @Test
+  public void shouldNotCreatePod()
+      throws InfrastructureException, ServerException, ConflictException {
+    when(openShiftEnvironment.getAttributes()).thenReturn(attributes);
+    when(clientFactory.create(anyString())).thenReturn(osClient);
+    when(identity.getWorkspaceId()).thenReturn("wsid");
+    when(identity.getInfrastructureNamespace()).thenReturn("wsid");
+    when(identity.getOwnerId()).thenReturn("user");
+    when(sshManager.getPairs("user", "internal")).thenReturn(singletonList(sshPair));
+
+    when(osClient.persistentVolumeClaims()).thenReturn(mixedOperationPvc);
+    when(mixedOperationPvc.inNamespace(anyString())).thenReturn(namespacePvcOperation);
+    when(namespacePvcOperation.list()).thenReturn(pvcs);
+    when(pvcs.getItems()).thenReturn(emptyList());
+
+    when(osClient.configMaps()).thenReturn(mixedOperationConfigMap);
+    when(mixedOperationConfigMap.inNamespace(anyString())).thenReturn(namespaceConfigMapOperation);
+    when(namespaceConfigMapOperation.list()).thenReturn(configMaps);
+    when(configMaps.getItems()).thenReturn(emptyList());
+
+    when(osClient.pods()).thenReturn(mixedOperationPod);
+    when(mixedOperationPod.inNamespace(anyString())).thenReturn(namespacePodOperation);
+    when(namespacePodOperation.list()).thenReturn(pods);
+    ObjectMeta meta = new ObjectMeta();
+    meta.setName(ASYNC_STORAGE);
+    Pod pod = new Pod();
+    pod.setMetadata(meta);
+    when(pods.getItems()).thenReturn(singletonList(pod));
+
+    when(osClient.services()).thenReturn(mixedOperationService);
+    when(mixedOperationService.inNamespace(anyString())).thenReturn(namespaceServiceOperation);
+    when(namespaceServiceOperation.list()).thenReturn(services);
+    when(services.getItems()).thenReturn(emptyList());
+
+    asyncStorageProvisioner.provision(openShiftEnvironment, identity);
+    verify(identity, times(1)).getInfrastructureNamespace();
+    verify(identity, times(1)).getOwnerId();
+    verify(sshManager, times(1)).getPairs("user", "internal");
+    verify(sshManager, never()).generatePair("user", "internal", SSH_KEY_NAME);
+    verify(osClient.services().inNamespace(anyString()), times(1)).create(any(Service.class));
+    verify(osClient.configMaps().inNamespace(anyString()), times(1)).create(any(ConfigMap.class));
+    verify(osClient.pods().inNamespace(anyString()), never()).create(any(Pod.class));
+    verify(osClient.persistentVolumeClaims().inNamespace(anyString()), times(1))
+        .create(any(PersistentVolumeClaim.class));
+  }
+
+  @Test
+  public void shouldNotCreateService()
+      throws InfrastructureException, ServerException, ConflictException {
+    when(openShiftEnvironment.getAttributes()).thenReturn(attributes);
+    when(clientFactory.create(anyString())).thenReturn(osClient);
+    when(identity.getWorkspaceId()).thenReturn("wsid");
+    when(identity.getInfrastructureNamespace()).thenReturn("wsid");
+    when(identity.getOwnerId()).thenReturn("user");
+    when(sshManager.getPairs("user", "internal")).thenReturn(singletonList(sshPair));
+
+    when(osClient.persistentVolumeClaims()).thenReturn(mixedOperationPvc);
+    when(mixedOperationPvc.inNamespace(anyString())).thenReturn(namespacePvcOperation);
+    when(namespacePvcOperation.list()).thenReturn(pvcs);
+    when(pvcs.getItems()).thenReturn(emptyList());
+
+    when(osClient.configMaps()).thenReturn(mixedOperationConfigMap);
+    when(mixedOperationConfigMap.inNamespace(anyString())).thenReturn(namespaceConfigMapOperation);
+    when(namespaceConfigMapOperation.list()).thenReturn(configMaps);
+    when(configMaps.getItems()).thenReturn(emptyList());
+
+    when(osClient.pods()).thenReturn(mixedOperationPod);
+    when(mixedOperationPod.inNamespace(anyString())).thenReturn(namespacePodOperation);
+    when(namespacePodOperation.list()).thenReturn(pods);
+    when(pods.getItems()).thenReturn(emptyList());
+
+    when(osClient.services()).thenReturn(mixedOperationService);
+    when(mixedOperationService.inNamespace(anyString())).thenReturn(namespaceServiceOperation);
+    when(namespaceServiceOperation.list()).thenReturn(services);
+    ObjectMeta meta = new ObjectMeta();
+    meta.setName(ASYNC_STORAGE);
+    Service service = new Service();
+    service.setMetadata(meta);
+    when(services.getItems()).thenReturn(singletonList(service));
+
+    asyncStorageProvisioner.provision(openShiftEnvironment, identity);
+    verify(identity, times(1)).getInfrastructureNamespace();
+    verify(identity, times(1)).getOwnerId();
+    verify(sshManager, times(1)).getPairs("user", "internal");
+    verify(sshManager, never()).generatePair("user", "internal", SSH_KEY_NAME);
+    verify(osClient.services().inNamespace(anyString()), never()).create(any(Service.class));
+    verify(osClient.configMaps().inNamespace(anyString()), times(1)).create(any(ConfigMap.class));
+    verify(osClient.pods().inNamespace(anyString()), times(1)).create(any(Pod.class));
+    verify(osClient.persistentVolumeClaims().inNamespace(anyString()), times(1))
+        .create(any(PersistentVolumeClaim.class));
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisionerTest.java
@@ -95,6 +95,7 @@ public class AsyncStorageProvisionerTest {
   public void setUp() {
     asyncStorageProvisioner =
         new AsyncStorageProvisioner(
+            "Always",
             "10Gi",
             "org/image:tag",
             "ReadWriteOnce",
@@ -113,6 +114,7 @@ public class AsyncStorageProvisionerTest {
   public void shouldThrowExceptionIfNotCommonStrategy() throws Exception {
     AsyncStorageProvisioner asyncStorageProvisioner =
         new AsyncStorageProvisioner(
+            "Always",
             "10Gi",
             "org/image:tag",
             "ReadWriteOnce",

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisionerTest.java
@@ -67,6 +67,7 @@ public class AsyncStorageProvisionerTest {
   private static final String NAMESPACE = UUID.randomUUID().toString();
   private static final String CONFIGMAP_NAME = NAMESPACE + ASYNC_STORAGE_CONFIG;
   private static final String VPC_NAME = UUID.randomUUID().toString();
+  private static final String USER = "user";
 
   @Mock private OpenShiftEnvironment openShiftEnvironment;
   @Mock private RuntimeIdentity identity;
@@ -105,7 +106,7 @@ public class AsyncStorageProvisionerTest {
     attributes = new HashMap<>(2);
     attributes.put(ASYNC_PERSIST_ATTRIBUTE, "true");
     attributes.put(PERSIST_VOLUMES_ATTRIBUTE, "false");
-    sshPair = new SshPairImpl("user", "internal", SSH_KEY_NAME, "", "");
+    sshPair = new SshPairImpl(USER, "internal", SSH_KEY_NAME, "", "");
   }
 
   @Test(expectedExceptions = InfrastructureException.class)
@@ -164,8 +165,8 @@ public class AsyncStorageProvisionerTest {
     when(clientFactory.create(anyString())).thenReturn(osClient);
     when(identity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
     when(identity.getInfrastructureNamespace()).thenReturn(NAMESPACE);
-    when(identity.getOwnerId()).thenReturn("user");
-    when(sshManager.getPairs("user", "internal")).thenReturn(singletonList(sshPair));
+    when(identity.getOwnerId()).thenReturn(USER);
+    when(sshManager.getPairs(USER, "internal")).thenReturn(singletonList(sshPair));
 
     when(osClient.persistentVolumeClaims()).thenReturn(mixedOperationPvc);
     when(mixedOperationPvc.inNamespace(NAMESPACE)).thenReturn(namespacePvcOperation);
@@ -190,8 +191,8 @@ public class AsyncStorageProvisionerTest {
     asyncStorageProvisioner.provision(openShiftEnvironment, identity);
     verify(identity, times(1)).getInfrastructureNamespace();
     verify(identity, times(1)).getOwnerId();
-    verify(sshManager, times(1)).getPairs("user", "internal");
-    verify(sshManager, never()).generatePair("user", "internal", SSH_KEY_NAME);
+    verify(sshManager, times(1)).getPairs(USER, "internal");
+    verify(sshManager, never()).generatePair(USER, "internal", SSH_KEY_NAME);
     verify(osClient.services().inNamespace(NAMESPACE), times(1)).create(any(Service.class));
     verify(osClient.configMaps().inNamespace(NAMESPACE), times(1)).create(any(ConfigMap.class));
     verify(osClient.pods().inNamespace(NAMESPACE), times(1)).create(any(Pod.class));
@@ -206,6 +207,7 @@ public class AsyncStorageProvisionerTest {
     when(clientFactory.create(anyString())).thenReturn(osClient);
     when(identity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
     when(identity.getInfrastructureNamespace()).thenReturn(NAMESPACE);
+    when(identity.getOwnerId()).thenReturn(USER);
 
     when(osClient.persistentVolumeClaims()).thenReturn(mixedOperationPvc);
     when(mixedOperationPvc.inNamespace(NAMESPACE)).thenReturn(namespacePvcOperation);
@@ -233,10 +235,10 @@ public class AsyncStorageProvisionerTest {
 
     asyncStorageProvisioner.provision(openShiftEnvironment, identity);
     verify(identity, times(1)).getInfrastructureNamespace();
-    verify(identity, never()).getOwnerId();
+    verify(identity, times(1)).getOwnerId();
     verify(identity, times(1)).getWorkspaceId();
-    verify(sshManager, never()).getPairs("user", "internal");
-    verify(sshManager, never()).generatePair("user", "internal", SSH_KEY_NAME);
+    verify(sshManager, never()).getPairs(USER, "internal");
+    verify(sshManager, never()).generatePair(USER, "internal", SSH_KEY_NAME);
     verify(osClient.services().inNamespace(NAMESPACE), times(1)).create(any(Service.class));
     verify(osClient.configMaps().inNamespace(NAMESPACE), never()).create(any(ConfigMap.class));
     verify(osClient.pods().inNamespace(NAMESPACE), times(1)).create(any(Pod.class));
@@ -251,8 +253,8 @@ public class AsyncStorageProvisionerTest {
     when(clientFactory.create(anyString())).thenReturn(osClient);
     when(identity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
     when(identity.getInfrastructureNamespace()).thenReturn(NAMESPACE);
-    when(identity.getOwnerId()).thenReturn("user");
-    when(sshManager.getPairs("user", "internal")).thenReturn(singletonList(sshPair));
+    when(identity.getOwnerId()).thenReturn(USER);
+    when(sshManager.getPairs(USER, "internal")).thenReturn(singletonList(sshPair));
 
     when(osClient.persistentVolumeClaims()).thenReturn(mixedOperationPvc);
     when(mixedOperationPvc.inNamespace(NAMESPACE)).thenReturn(namespacePvcOperation);
@@ -281,8 +283,8 @@ public class AsyncStorageProvisionerTest {
     asyncStorageProvisioner.provision(openShiftEnvironment, identity);
     verify(identity, times(1)).getInfrastructureNamespace();
     verify(identity, times(1)).getOwnerId();
-    verify(sshManager, times(1)).getPairs("user", "internal");
-    verify(sshManager, never()).generatePair("user", "internal", SSH_KEY_NAME);
+    verify(sshManager, times(1)).getPairs(USER, "internal");
+    verify(sshManager, never()).generatePair(USER, "internal", SSH_KEY_NAME);
     verify(osClient.services().inNamespace(NAMESPACE), times(1)).create(any(Service.class));
     verify(osClient.configMaps().inNamespace(NAMESPACE), times(1)).create(any(ConfigMap.class));
     verify(osClient.pods().inNamespace(NAMESPACE), never()).create(any(Pod.class));
@@ -297,8 +299,8 @@ public class AsyncStorageProvisionerTest {
     when(clientFactory.create(anyString())).thenReturn(osClient);
     when(identity.getWorkspaceId()).thenReturn(WORKSPACE_ID);
     when(identity.getInfrastructureNamespace()).thenReturn(NAMESPACE);
-    when(identity.getOwnerId()).thenReturn("user");
-    when(sshManager.getPairs("user", "internal")).thenReturn(singletonList(sshPair));
+    when(identity.getOwnerId()).thenReturn(USER);
+    when(sshManager.getPairs(USER, "internal")).thenReturn(singletonList(sshPair));
 
     when(osClient.persistentVolumeClaims()).thenReturn(mixedOperationPvc);
     when(mixedOperationPvc.inNamespace(NAMESPACE)).thenReturn(namespacePvcOperation);
@@ -327,8 +329,8 @@ public class AsyncStorageProvisionerTest {
     asyncStorageProvisioner.provision(openShiftEnvironment, identity);
     verify(identity, times(1)).getInfrastructureNamespace();
     verify(identity, times(1)).getOwnerId();
-    verify(sshManager, times(1)).getPairs("user", "internal");
-    verify(sshManager, never()).generatePair("user", "internal", SSH_KEY_NAME);
+    verify(sshManager, times(1)).getPairs(USER, "internal");
+    verify(sshManager, never()).generatePair(USER, "internal", SSH_KEY_NAME);
     verify(osClient.services().inNamespace(NAMESPACE), never()).create(any(Service.class));
     verify(osClient.configMaps().inNamespace(NAMESPACE), times(1)).create(any(ConfigMap.class));
     verify(osClient.pods().inNamespace(NAMESPACE), times(1)).create(any(Pod.class));

--- a/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
+++ b/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
@@ -288,6 +288,9 @@ public class JpaEntitiesCascadeRemovalTest {
                 bind(String[].class)
                     .annotatedWith(Names.named("che.workspace.devfile.default_editor.plugins"))
                     .toInstance(new String[] {"default/plugin/0.0.1"});
+                bind(String.class)
+                    .annotatedWith(Names.named("che.workspace.devfile.async.storage.plugin"))
+                    .toInstance("");
               }
             });
 

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -122,6 +122,20 @@ public final class Constants {
   public static final String PERSIST_VOLUMES_ATTRIBUTE = "persistVolumes";
 
   /**
+   * The attribute allows to configure workspace with async storage support this configuration. Make
+   * sense only in case org.eclipse.che.api.workspace.shared.Constants#PERSIST_VOLUMES_ATTRIBUTE set
+   * to 'false'.
+   *
+   * <p>Should be set/read from {@link WorkspaceConfig#getAttributes}.
+   *
+   * <p>Value is expected to be boolean, and if set to 'true' special plugin will be added to
+   * workspace. It will provide ability to backup/restore project source to the async storage.
+   * Workspace volumes still would be created as `emptyDir`. During stopping workspace project
+   * source will be sent to the storage Pod and restore from it on next restarts.
+   */
+  public static final String ASYNC_PERSIST_ATTRIBUTE = "asyncPersist";
+
+  /**
    * Contains a list of workspace tooling plugins that should be used in a workspace. Should be
    * set/read from {@link WorkspaceConfig#getAttributes}.
    *

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/DefaultEditorProvisionerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/DefaultEditorProvisionerTest.java
@@ -17,16 +17,19 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.PLUGIN_COMP
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.convert.component.ComponentFQNParser;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.DevfileImpl;
 import org.eclipse.che.api.workspace.server.wsplugins.PluginFQNParser;
+import org.eclipse.che.api.workspace.shared.Constants;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.Listeners;
@@ -50,6 +53,7 @@ public class DefaultEditorProvisionerTest {
 
   private static final String TERMINAL_PLUGIN_NAME = "theia-terminal";
   private static final String TERMINAL_PLUGIN_VERSION = "0.0.4";
+  private static final String ASYNC_STORAGE_PLUGIN_REF = "eclipse/che-async-pv-plugin/nightly";
   private static final String TERMINAL_PLUGIN_REF =
       EDITOR_PUBLISHER + "/" + TERMINAL_PLUGIN_NAME + "/" + TERMINAL_PLUGIN_VERSION;
 
@@ -65,7 +69,9 @@ public class DefaultEditorProvisionerTest {
   @Test
   public void shouldNotProvisionDefaultEditorIfItIsNotConfigured() throws Exception {
     // given
-    provisioner = new DefaultEditorProvisioner(null, new String[] {}, fqnParser, pluginFQNParser);
+    provisioner =
+        new DefaultEditorProvisioner(
+            null, new String[] {}, ASYNC_STORAGE_PLUGIN_REF, fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
 
     // when
@@ -82,6 +88,7 @@ public class DefaultEditorProvisionerTest {
         new DefaultEditorProvisioner(
             EDITOR_REF,
             new String[] {TERMINAL_PLUGIN_REF, COMMAND_PLUGIN_REF},
+            "",
             fqnParser,
             pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
@@ -103,7 +110,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, fqnParser, pluginFQNParser);
+            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl defaultEditorWithDifferentVersion =
@@ -129,7 +136,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, fqnParser, pluginFQNParser);
+            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl defaultEditorWithDifferentVersion =
@@ -156,7 +163,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, fqnParser, pluginFQNParser);
+            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl editorWithNameSimilarToDefault =
@@ -180,7 +187,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, fqnParser, pluginFQNParser);
+            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     devfile.getAttributes().put(EDITOR_FREE_DEVFILE_ATTRIBUTE, "true");
@@ -200,7 +207,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, fqnParser, pluginFQNParser);
+            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl pluginWithNameSimilarToDefault =
@@ -224,7 +231,7 @@ public class DefaultEditorProvisionerTest {
       throws Exception {
     // given
     provisioner =
-        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, fqnParser, pluginFQNParser);
+        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl nonDefaultEditor =
         new ComponentImpl(EDITOR_COMPONENT_TYPE, "anypublisher/anyname/v" + EDITOR_VERSION);
@@ -244,7 +251,7 @@ public class DefaultEditorProvisionerTest {
       throws Exception {
     // given
     provisioner =
-        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, fqnParser, pluginFQNParser);
+        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl myTheiaEditor =
         new ComponentImpl(
@@ -265,7 +272,7 @@ public class DefaultEditorProvisionerTest {
       throws Exception {
     // given
     provisioner =
-        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, fqnParser, pluginFQNParser);
+        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl myTheiaEditor =
         new ComponentImpl(
@@ -300,7 +307,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, fqnParser, pluginFQNParser);
+            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl myTerminal =
         new ComponentImpl(
@@ -323,7 +330,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, fqnParser, pluginFQNParser);
+            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     String meta =
         "apiVersion: v2\n"
@@ -360,6 +367,7 @@ public class DefaultEditorProvisionerTest {
         new DefaultEditorProvisioner(
             EDITOR_REF,
             new String[] {EDITOR_PUBLISHER + "/" + "my-plugin/v2.0"},
+            "",
             fqnParser,
             pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
@@ -389,6 +397,7 @@ public class DefaultEditorProvisionerTest {
         new DefaultEditorProvisioner(
             EDITOR_REF,
             new String[] {EDITOR_PUBLISHER + "/" + "my-plugin/v2.0", referencePluginRef},
+            "",
             fqnParser,
             pluginFQNParser);
     String meta =
@@ -414,6 +423,59 @@ public class DefaultEditorProvisionerTest {
     List<ComponentImpl> components = devfile.getComponents();
     assertEquals(components.size(), 3);
     assertTrue(components.contains(myPlugin));
+  }
+
+  @Test
+  public void shouldProvisionAsyncStoragePluginsIfWorkspaceHasOnlyOneAttribute() throws Exception {
+    // given
+    provisioner =
+        new DefaultEditorProvisioner(
+            EDITOR_REF,
+            new String[] {TERMINAL_PLUGIN_REF},
+            ASYNC_STORAGE_PLUGIN_REF,
+            fqnParser,
+            pluginFQNParser);
+
+    DevfileImpl devfile = new DevfileImpl();
+    devfile.setAttributes(ImmutableMap.of(Constants.ASYNC_PERSIST_ATTRIBUTE, "true"));
+    // when
+    provisioner.apply(devfile, fileContentProvider);
+
+    // then
+    List<ComponentImpl> components = devfile.getComponents();
+    assertEquals(components.size(), 2);
+
+    assertFalse(
+        components.contains(new ComponentImpl(PLUGIN_COMPONENT_TYPE, ASYNC_STORAGE_PLUGIN_REF)));
+  }
+
+  @Test
+  public void shouldProvisionAsyncStoragePluginsIfWorkspaceHasBothAttributes() throws Exception {
+    // given
+    provisioner =
+        new DefaultEditorProvisioner(
+            EDITOR_REF,
+            new String[] {TERMINAL_PLUGIN_REF},
+            ASYNC_STORAGE_PLUGIN_REF,
+            fqnParser,
+            pluginFQNParser);
+
+    DevfileImpl devfile = new DevfileImpl();
+    devfile.setAttributes(
+        ImmutableMap.of(
+            Constants.ASYNC_PERSIST_ATTRIBUTE,
+            "true",
+            Constants.PERSIST_VOLUMES_ATTRIBUTE,
+            "false"));
+    // when
+    provisioner.apply(devfile, fileContentProvider);
+
+    // then
+    List<ComponentImpl> components = devfile.getComponents();
+    assertEquals(components.size(), 3);
+
+    assertTrue(
+        components.contains(new ComponentImpl(PLUGIN_COMPONENT_TYPE, ASYNC_STORAGE_PLUGIN_REF)));
   }
 
   private ComponentImpl findById(List<ComponentImpl> components, String id) {


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

This PR will introduce a new **_experimental_** feature which should provide fast I/O and give ability to persist your changes. In other words this is new kind of storage with fast I/O like in **Ephemeral Mode** but with saving changes like in traditional **Persistent Mode.** 

For  this we introduce special plugin which will be automatically added to workspace configuration in case user select this type of storage. Plugin will initiate restore command on workspace startup and backup all sources on workspace stop, also changes will be periodically backup during workspace is running (e.g. each 5 or 10 minutes). 

During restore procedure events with information about restore process sent via WebScoket connection and client (like Che Theia) can show this information in UI. 

For backup/restore procedure used rsync (https://rsync.samba.org/) via SSH connection. 

The special pod will start in OpenShift environment in user namespace, it will respond for storing files. In other words plugin it’s rsync client, storage pod - rsync server.

Here initial for plugin and storage: [Initial contribution for workspace sync feature #2 ](https://github.com/che-incubator/workspace-data-sync/pull/2)

For establishing secure connection special pair of SSH keys will be generated if they don't exist and mount to the plugin container (private part) and to the storage pod (public part). 

#### IMPORTANT: This feature at the moment will work only with [**_common_** PVC strategy.](https://github.com/eclipse/che/blob/master/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/pvc/CommonPVCStrategy.java#L40) 

If other (or current workspace) configured to the to use the traditional persistent mode,
to prevent getting 'Multi-Attach error for volume' asynchronous storage pod will be shutdown. After deleting asynchronous storage pod procedure of starting workspace will be continued as usual.

To try this PR you can use this devfile:
```
metadata:
  name: jerry-second-ws
attributes:
  persistVolumes: 'false'
  asyncPersist: 'true'
components:
  - id: che-incubator/typescript/latest
    type: chePlugin
  - mountSources: true
    endpoints:
      - name: angular
        port: 4200
    memoryLimit: 1Gi
    type: dockerimage
    alias: nodejs
    image: 'quay.io/eclipse/che-nodejs10-community:7.12.1'
apiVersion: 1.0.0
```

Ready to use images:
che-server: `vparfonov/che-server:0708`
che-plugin-registry: `vparfonov/che-plugin-registry:0708`

 


### What issues does this PR fix or reference?

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
