### PR TITLE
Remove access tokens and refresh tokens from response logging

### DIFF
--- a/tests/e2e/utils/requestHandlers/CheApiRequestHandler.ts
+++ b/tests/e2e/utils/requestHandlers/CheApiRequestHandler.ts
@@ -48,6 +48,12 @@ export class CheApiRequestHandler {
                         }
                     }));
                     response_censored.config.headers['Authorization'] = 'CENSORED';
+                    if (response_censored.data['access_token'] != null) {
+                        response_censored.data['access_token'] = 'CENSORED';
+                    }
+                    if (response_censored.data['refresh_token'] != null) {
+                        response_censored.data['refresh_token'] = 'CENSORED';
+                    }
                     console.log(`RequestHandler response:\n`, response_censored);
                 } catch (err) {
                     console.log(`RequestHandler response: Failed to deep clone AxiosResponse:`, err);


### PR DESCRIPTION
### What does this PR do?
* Removes access_token and refresh_token from response objects in CheApiRequestHandler.ts

### What issues does this PR fix or reference?
hotfix

#### Release Notes
N/A

#### Docs PR
N/A