### PR TITLE
Tests E2E: Update ''OcpLoginPage' to provide login both OCP and OSD

### DIFF
--- a/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
@@ -38,14 +38,14 @@ export class OcpLoginPage {
     async clickOnLoginProviderTitle() {
         Logger.debug('OcpLoginPage.clickOnLoginProviderTitle');
 
-        const loginProviderTitleLocator: By = By.css(`a[title=\'Log in with ${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
+        const loginProviderTitleLocator: By = By.xpath(`//a[text()=\'${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
         await this.driverHelper.waitAndClick(loginProviderTitleLocator);
     }
 
     async isIdentityProviderLinkVisible(): Promise<boolean> {
         Logger.debug('OcpLoginPage.isIdentityProviderLinkVisible');
 
-        const loginWithHtpaswdLocator: By = By.css(`a[title=\'Log in with ${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
+        const loginWithHtpaswdLocator: By = By.xpath(`//a[text()=\'${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
         return await this.driverHelper.waitVisibilityBoolean(loginWithHtpaswdLocator, 3, 5000);
     }
 


### PR DESCRIPTION
#16455 # What does this PR do?
* Update locator in the methods of _OcpLoginPage_ to provide login of E2E tests to both OCP and OSD clusters when is configured _HTPasswd_ identity provider

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16710
