### PR TITLE
🚧 Add dashboard-next into che-server

### DIFF
--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -9,11 +9,14 @@
 # Variables in `COPY --from=` is not supported see https://github.com/moby/moby/issues/34482
 # this is workaround to handle that.
 ARG CHE_DASHBOARD_ORGANIZATION=quay.io/eclipse
+ARG CHE_DASHBOARD_NEXT_ORGANIZATION=quay.io/che-incubator
 ARG CHE_DASHBOARD_VERSION=next
+ARG CHE_DASHBOARD_NEXT_VERSION=next
 ARG CHE_WORKSPACE_LOADER_ORGANIZATION=quay.io/eclipse
 ARG CHE_WORKSPACE_LOADER_VERSION=next
 
 FROM ${CHE_DASHBOARD_ORGANIZATION}/che-dashboard:${CHE_DASHBOARD_VERSION} as che_dashboard_base
+FROM ${CHE_DASHBOARD_NEXT_ORGANIZATION}/che-dashboard-next:${CHE_DASHBOARD_NEXT_VERSION} as che_dashboard_next
 FROM ${CHE_WORKSPACE_LOADER_ORGANIZATION}/che-workspace-loader:${CHE_WORKSPACE_LOADER_VERSION} as che_workspace_loader_base
 
 FROM openjdk:8u252-jre-slim
@@ -25,6 +28,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 RUN mkdir /logs /data && \
     chmod 0777 /logs /data
 COPY --from=che_dashboard_base /usr/local/apache2/htdocs/dashboard /home/user/eclipse-che/tomcat/webapps/dashboard
+COPY --from=che_dashboard_next /usr/local/apache2/htdocs/dashboard /home/user/eclipse-che/tomcat/webapps/dashboard/next
 COPY --from=che_workspace_loader_base /usr/local/apache2/htdocs/workspace-loader/ /home/user/eclipse-che/tomcat/webapps/workspace-loader
 ADD eclipse-che /home/user/eclipse-che
 RUN find /home/user -type d -exec chmod 777 {} \;


### PR DESCRIPTION
Signed-off-by: Oleksii Orel <oorel@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Added ability to run dashboard-next along with Che Server. Dashboard-next will be served on  ```<hostname>/dashboard/next``` .

![Screenshot from 2020-05-28 17-29-21](https://user-images.githubusercontent.com/6310786/83156131-b7959580-a10a-11ea-83fa-99fcd7d7fac7.png)
![Screenshot from 2020-05-28 17-30-19](https://user-images.githubusercontent.com/6310786/83156138-b9f7ef80-a10a-11ea-821e-155300326594.png)

### What issues does this PR fix or reference?
It fixes https://github.com/eclipse/che/issues/16688

It has 🚧 because it must not be merged before CQs from  https://github.com/eclipse/che/issues/17024 are created and resolved