### PR TITLE
Read self-signed certiicate from dedicated secret

### DIFF
--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -100,7 +100,7 @@ spec:
           valueFrom:
             secretKeyRef:
               key: ca.crt
-              name: {{ .Values.global.tls.secretName }}
+              name: {{ .Values.global.tls.selfSignedCertSecretName }}
               optional: false
         {{- end }}
 

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -46,8 +46,9 @@ global:
     secretName: che-tls
 
     ## If self-signed certificate flag is enabled
-    ## then CA certificate from `tls.secretName` will be propagated to Che components' trust stores
-    useSelfSignedCerts: false
+    ## then CA certificate from `tls.selfSignedCertSecretName` will be propagated to Che components' trust stores
+    useSelfSignedCerts: true
+    selfSignedCertSecretName: self-signed-certificate
 
     ## Name of the config-map with public certificates to add to Java trust store of the Che server.
     serverTrustStoreConfigMapName: ""


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Makes `self-signed-certificate` secret the source of Che server CA certificate. This is done to be consistent with other installers. Also such approach make autodetection of self-signed certificate usage easier.

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/16764
Should be merged together with https://github.com/che-incubator/chectl/pull/734