### PR TITLE
Add parts for running Openshift plugin test nightly

### DIFF
--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -446,7 +446,7 @@ function runDevfileTestSuite() {
   -e TS_SELENIUM_LOAD_PAGE_TIMEOUT=240000 \
   -e TS_SELENIUM_WORKSPACE_STATUS_POLLING=20000 \
   -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
-  quay.io/eclipse/che-e2e:nightly || IS_TESTS_FAILED=true
+  maxura/e2e-tests:CHE-16927 || IS_TESTS_FAILED=true
 }
 
 function setupSelfSignedCertificate() {

--- a/tests/.infra/centos-ci/nightly/cico-openshift-connector-test.sh
+++ b/tests/.infra/centos-ci/nightly/cico-openshift-connector-test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright (c) 2018 Red Hat, Inc.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+set -x
+
+echo "========Starting nigtly test job $(date)========"
+
+source tests/.infra/centos-ci/functional_tests_utils.sh
+
+function runOpenshiftConnectorTest(){
+    
+    ### Create directory for report
+    cd /root/payload
+    mkdir report
+    REPORT_FOLDER=$(pwd)/report
+    ### Run tests
+    docker run --net=host  --ipc=host -v $REPORT_FOLDER:/tmp/e2e/report:Z -p 5920:5920 \
+    -e TS_SELENIUM_HEADLESS=true \
+    -e TS_SELENIUM_LOAD_PAGE_TIMEOUT=420000 \
+    -e TS_SELENIUM_WORKSPACE_STATUS_POLLING=20000 \
+    -e TS_SELENIUM_BASE_URL="https://$CHE_ROUTE" \
+    -e TS_SELENIUM_LOG_LEVEL=DEBUG \
+    -e TS_SELENIUM_USERNAME=${TEST_USERNAME} \
+    -e TS_SELENIUM_PASSWORD=${TEST_USERNAME} \
+    -e TS_TEST_OPENSHIFT_PLUGIN_USERNAME=developer \
+    -e TS_TEST_OPENSHIFT_PLUGIN_PASSWORD=pass \
+    -e TS_TEST_OPENSHIFT_PLUGIN_PROJECT=default \
+    -e TS_SELENIUM_MULTIUSER=true \
+    -e DELETE_WORKSPACE_ON_FAILED_TEST=true \
+    -e TEST_SUITE=test-openshift-connector \
+    -e NODE_TLS_REJECT_UNAUTHORIZED=0 \
+     quay.io/eclipse/che-e2e:nightly || IS_TESTS_FAILED=true
+    
+}
+
+
+function prepareCustomResourcePatchFile() {
+  cat > /tmp/custom-resource-patch.yaml <<EOL
+spec:
+  auth:
+    updateAdminPassword: false
+EOL
+    
+    cat /tmp/custom-resource-patch.yaml
+}
+
+setupEnvs
+installKVM
+installDependencies
+prepareCustomResourcePatchFile
+installCheCtl
+installAndStartMinishift
+deployCheIntoCluster --che-operator-cr-patch-yaml=/tmp/custom-resource-patch.yaml
+defineCheRoute
+createTestUserAndObtainUserToken
+runOpenshiftConnectorTest
+echo "=========================== THIS IS POST TEST ACTIONS =============================="
+getOpenshiftLogs
+archiveArtifacts "che-nightly-openshift-connector"
+if [[ "$IS_TESTS_FAILED" == "true" ]]; then exit 1; fi

--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -238,12 +238,12 @@ export const TestConstants = {
     /**
      * Login for a user whom has been created in the test Openshift cluster. Need for Openshift connector test
      */
-    TS_TEST_OPENSHIFT_PLUGIN_USERNAME: process.env.TS_LOGIN_NAME_OF_OPENSHIFT_REGULAR_USER || '',
+    TS_TEST_OPENSHIFT_PLUGIN_USERNAME: process.env.TS_TEST_OPENSHIFT_PLUGIN_USERNAME || '',
 
     /**
      * Password for a user whom has been created in the test Openshift cluster. Need for Openshift connector test
      */
-    TS_TEST_OPENSHIFT_PLUGIN_PASSWORD: process.env.TS_PASSWORD_OF_OPENSHIFT_REGULAR_USER || '',
+    TS_TEST_OPENSHIFT_PLUGIN_PASSWORD: process.env.TS_TEST_OPENSHIFT_PLUGIN_PASSWORD || '',
 
     /**
      * The name of project in the Openshidt plugin tree

--- a/tests/e2e/pageobjects/ide/OpenshiftPlugin.ts
+++ b/tests/e2e/pageobjects/ide/OpenshiftPlugin.ts
@@ -20,7 +20,7 @@ export enum OpenshiftAppExplorerToolbar {
     ReportExtensionIssueOnGitHub = 'Report Extension Issue on GitHub',
     RefreshView = 'Refresh View',
     SwitchContexts = 'Switch Contexts',
-    LogIntoCluster = 'Log in to cluster'
+    LogIntoCluster = 'Login into Cluster'
 }
 
 export enum OpenshiftContextMenuItems {

--- a/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
+++ b/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
@@ -88,8 +88,9 @@ suite('Openshift connector user story', async () => {
     await quickOpenContainer.clickOnContainerItem('Credentials');
     await quickOpenContainer.clickOnContainerItem(`https://${openshiftIP}`);
     await quickOpenContainer.clickOnContainerItem('$(plus) Add new user...');
-    await quickOpenContainer.typeAndSelectSuggestion(TestConstants.TS_TEST_OPENSHIFT_PLUGIN_USERNAME, `Provide Username ${provideAuthenticationSuffix}`);
-    await quickOpenContainer.typeAndSelectSuggestion(TestConstants.TS_TEST_OPENSHIFT_PLUGIN_PASSWORD, `Provide Password ${provideAuthenticationSuffix}`);
+    await quickOpenContainer.typeAndSelectSuggestion(TestConstants.TS_LOGIN_NAME_OF_OPENSHIFT_REGULAR_USER, `Provide Username ${provideAuthenticationSuffix}`);
+    await quickOpenContainer.typeAndSelectSuggestion(TestConstants.TS_PASSWORD_OF_OPENSHIFT_REGULAR_USER, `Provide Password ${provideAuthenticationSuffix}`);
+    await openshiftPlugin.waitItemInTree(TestConstants.TS_TEST_OPENSHIFT_PLUGIN_PROJECT);
   });
 
   test('Create new component with application', async () => {
@@ -116,7 +117,7 @@ suite('Openshift connector user story', async () => {
     await quickOpenContainer.clickOnContainerItem(TestConstants.TS_TEST_OPENSHIFT_PLUGIN_PROJECT);
     await quickOpenContainer.clickOnContainerItem('node-js-app');
     await quickOpenContainer.clickOnContainerItem('component-node-js');
-    await terminal.waitText('OpenShift', 'Changes successfully pushed to component', TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+    await terminal.selectTabByPrefixAndWaitText('OpenShift: Push', 'Changes successfully pushed to component', TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
   });
 
 });

--- a/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
+++ b/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
@@ -88,8 +88,8 @@ suite('Openshift connector user story', async () => {
     await quickOpenContainer.clickOnContainerItem('Credentials');
     await quickOpenContainer.clickOnContainerItem(`https://${openshiftIP}`);
     await quickOpenContainer.clickOnContainerItem('$(plus) Add new user...');
-    await quickOpenContainer.typeAndSelectSuggestion(TestConstants.TS_LOGIN_NAME_OF_OPENSHIFT_REGULAR_USER, `Provide Username ${provideAuthenticationSuffix}`);
-    await quickOpenContainer.typeAndSelectSuggestion(TestConstants.TS_PASSWORD_OF_OPENSHIFT_REGULAR_USER, `Provide Password ${provideAuthenticationSuffix}`);
+    await quickOpenContainer.typeAndSelectSuggestion(TestConstants.TS_TEST_OPENSHIFT_PLUGIN_USERNAME, `Provide Username ${provideAuthenticationSuffix}`);
+    await quickOpenContainer.typeAndSelectSuggestion(TestConstants.TS_TEST_OPENSHIFT_PLUGIN_PASSWORD, `Provide Password ${provideAuthenticationSuffix}`);
     await openshiftPlugin.waitItemInTree(TestConstants.TS_TEST_OPENSHIFT_PLUGIN_PROJECT);
   });
 


### PR DESCRIPTION
### What does this PR do?
* Adapt test to latest changes in UI of the plugin
* Add script for launching nightly on centos-ci
* Add method for selecting and getting text in terminal tabs with long names by prefix


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16927
