### PR TITLE
Adding VIDEO_RECORDING=false parameter for load test.

### DIFF
--- a/tests/performance/pod.yaml
+++ b/tests/performance/pod.yaml
@@ -37,6 +37,8 @@ spec:
           value: "REPLACE_LOG_LEVEL"
         - name: NODE_TLS_REJECT_UNAUTHORIZED
           value: "0"
+        - name: VIDEO_RECORDING
+          value: "false"
         image: REPLACE_IMAGE 
         imagePullPolicy: Always
         name: load-testing-container


### PR DESCRIPTION
### What does this PR do?
Add the `VIDEO_RECORDING` parameter for a load test and set it to `false`. If this is not disabled, the pods are killed for OOM issues.
