### PR TITLE
Fix "Happy path" tests failed on "Run application" step because test application was unable to access spring-petclinic-2.3.0.BUILD_SNAPSHOT.jar

### DIFF
--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -53,19 +53,19 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: java -jar spring-petclinic-2.3.0.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
+        command: java -jar spring-petclinic-2.3.1.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
         workdir: /projects/petclinic/target
   - name: run-with-changes
     actions:
       - type: exec
         component: maven-container
-        command: java -jar spring-petclinic-2.3.0.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
+        command: java -jar spring-petclinic-2.3.1.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
         workdir: /projects/petclinic/target
   - name: run-debug
     actions:
       - type: exec
         component: maven-container
-        command: java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 spring-petclinic-2.3.0.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
+        command: java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 spring-petclinic-2.3.1.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
         workdir: /projects/petclinic/target
   - name: Debug remote java application
     actions:


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Fix "Happy path" tests failed on "Run application" step because test application was unable to access spring-petclinic-2.3.0.BUILD_SNAPSHOT.jar

### What issues does this PR fix or reference?
issue: https://github.com/eclipse/che/issues/17155
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
