### PR TITLE
poststart container commands to link mounted secrets

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/ContainerCommandQueue.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/ContainerCommandQueue.java
@@ -1,0 +1,6 @@
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+public interface ContainerCommandQueue {
+  void add(String pod, String container, String command);
+  void execute();
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/ContainerCommandQueueImpl.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/ContainerCommandQueueImpl.java
@@ -1,0 +1,54 @@
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ContainerCommandQueueImpl implements ContainerCommandQueue {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ContainerCommandQueueImpl.class);
+
+  private final Queue<ContainerCommand> commands = new LinkedList<>();
+  private final KubernetesNamespace namespace;
+
+  public ContainerCommandQueueImpl(
+      KubernetesNamespace namespace) {
+    this.namespace = namespace;
+  }
+
+  @Override
+  public void add(String pod, String container, String command) {
+    LOG.info("should execute '{}' on '{} : {}'", command, pod, container);
+    commands.add(new ContainerCommand(pod, container, command));
+  }
+
+  @Override
+  public void execute() {
+    ContainerCommand command;
+    while ((command = commands.poll()) != null) {
+      try {
+        LOG.info("execute '{}' on '{} : {}'", command.command, command.pod, command.container);
+        namespace.deployments().exec(command.pod, command.container, 10,
+            command.command.split(" "), (s, s2) -> LOG.info("[{}] {}", s, s2));
+      } catch (InfrastructureException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  private static final class ContainerCommand {
+
+    private final String pod;
+    private final String container;
+    private final String command;
+
+    private ContainerCommand(String pod, String container, String command) {
+      this.pod = pod;
+      this.container = container;
+      this.command = command;
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesDeployments.java
@@ -739,7 +739,7 @@ public class KubernetesDeployments {
             .inContainer(containerName)
             .writingError(errStream)
             .usingListener(watchdog)
-            .exec(encode(command))) {
+            .exec(command)) {
       try {
         watchdog.wait(timeoutMin, TimeUnit.MINUTES);
         final byte[] error = errStream.toByteArray();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SecretAsContainerResourceProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SecretAsContainerResourceProvisionerTest.java
@@ -42,7 +42,12 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.ContainerCommandQueue;
+import org.eclipse.che.workspace.infrastructure.kubernetes.ContainerCommandQueueImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodRole;
@@ -69,6 +74,7 @@ public class SecretAsContainerResourceProvisionerTest {
   @Mock private PodData podData;
 
   @Mock private PodSpec podSpec;
+  private ContainerCommandQueue postStartCommands = new ContainerCommandQueueImpl(namespace);
 
   @BeforeMethod
   public void setUp() throws Exception {
@@ -105,7 +111,7 @@ public class SecretAsContainerResourceProvisionerTest {
             .build();
 
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
 
     // nothing to do with unmatched container
     verify(container_unmatch).getName();
@@ -147,7 +153,7 @@ public class SecretAsContainerResourceProvisionerTest {
             .build();
 
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
 
     // nothing to do with unmatched container
     verify(container_unmatch).getName();
@@ -186,7 +192,7 @@ public class SecretAsContainerResourceProvisionerTest {
             .build();
 
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
 
     // both containers has env set
     assertEquals(container_match1.getEnv().size(), 1);
@@ -233,7 +239,7 @@ public class SecretAsContainerResourceProvisionerTest {
             .build();
 
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
 
     // pod has volume created
     assertEquals(environment.getPodsData().get("pod1").getSpec().getVolumes().size(), 1);
@@ -300,7 +306,7 @@ public class SecretAsContainerResourceProvisionerTest {
                     .build())
             .build();
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
   }
 
   @Test(
@@ -319,7 +325,7 @@ public class SecretAsContainerResourceProvisionerTest {
                     .build())
             .build();
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
   }
 
   @Test(
@@ -343,7 +349,7 @@ public class SecretAsContainerResourceProvisionerTest {
             .build();
 
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
   }
 
   @Test(
@@ -367,7 +373,7 @@ public class SecretAsContainerResourceProvisionerTest {
             .build();
 
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
   }
 
   @Test(
@@ -407,6 +413,6 @@ public class SecretAsContainerResourceProvisionerTest {
             .build();
 
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
-    provisioner.provision(environment, namespace);
+    provisioner.provision(environment, namespace, postStartCommands);
   }
 }


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
First implementation with mounting secrets into `/tmp` and linking them into final places after container startup.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17113

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->

TODO
