### PR TITLE
set read timeout to URLFetcher so it does not hang

### DIFF
--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/URLFetcher.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/URLFetcher.java
@@ -82,13 +82,15 @@ public class URLFetcher {
    * Fetches the url provided and return its content.
    *
    * @param url the URL to fetch
-   * @param timeout read connection timeout
+   * @param timeout read and connection timeout (see {@link URLConnection#setConnectTimeout(int)}
+   *     and {@link URLConnection#setReadTimeout(int)}
    * @return content of the requested URL
    * @throws IOException if fetch error occurs
    */
   String fetch(@NotNull final String url, int timeout) throws IOException {
     requireNonNull(url, "url parameter can't be null");
     URLConnection connection = new URL(sanitized(url)).openConnection();
+    connection.setConnectTimeout(timeout);
     connection.setReadTimeout(timeout);
     return fetch(connection);
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/URLFetcher.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/URLFetcher.java
@@ -44,6 +44,9 @@ public class URLFetcher {
   /** Maximum size of allowed data. (80KB) */
   protected static final long MAXIMUM_READ_BYTES = 80 * 1024;
 
+  /** timeout when reading */
+  private static final int CONNECTION_READ_TIMEOUT = 10 * 1000; // 10s
+
   /** The Compiled REGEX PATTERN that can be used for http|https git urls */
   final Pattern GIT_HTTP_URL_PATTERN = Pattern.compile("(?<sanitized>^http[s]?://.*)\\.git$");
 
@@ -85,6 +88,7 @@ public class URLFetcher {
    */
   public String fetch(@NotNull URLConnection urlConnection) throws IOException {
     requireNonNull(urlConnection, "urlConnection parameter can't be null");
+    urlConnection.setReadTimeout(CONNECTION_READ_TIMEOUT);
     final String value;
     try (InputStream inputStream = urlConnection.getInputStream();
         BufferedReader reader =

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/URLFetcherTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/URLFetcherTest.java
@@ -42,12 +42,12 @@ import org.testng.annotations.Test;
 public class URLFetcherTest {
 
   /** Instance to test. */
-  @InjectMocks private URLFetcher URLFetcher;
+  @InjectMocks private URLFetcher urlFetcher;
 
   /** Check that when url is null, NPE is thrown */
   @Test(expectedExceptions = NullPointerException.class)
   public void checkNullURL() {
-    URLFetcher.fetchSafely(null);
+    urlFetcher.fetchSafely(null);
   }
 
   /** Check that when url exists the content is retrieved */
@@ -58,14 +58,14 @@ public class URLFetcherTest {
     URL urlJson = getClass().getClassLoader().getResource("devfile/url_fetcher_test_resource.json");
     Assert.assertNotNull(urlJson);
 
-    String content = URLFetcher.fetchSafely(urlJson.toString());
+    String content = urlFetcher.fetchSafely(urlJson.toString());
     assertEquals(content, "Hello");
   }
 
   /** Check when url is invalid */
   @Test
   public void checkUrlFileIsInvalid() {
-    String result = URLFetcher.fetchSafely("hello world");
+    String result = urlFetcher.fetchSafely("hello world");
     assertNull(result);
   }
 
@@ -74,17 +74,17 @@ public class URLFetcherTest {
       expectedExceptions = IOException.class,
       expectedExceptionsMessageRegExp = "no protocol: hello_world")
   public void checkUnsafeGetUrlFileIsInvalid() throws Exception {
-    String result = URLFetcher.fetch("hello_world");
+    String result = urlFetcher.fetch("hello_world");
     assertNull(result);
   }
 
   /** Check Sanitizing of Git URL works */
   @Test
   public void checkDotGitRemovedFromURL() {
-    String result = URLFetcher.sanitized("https://github.com/acme/demo.git");
+    String result = urlFetcher.sanitized("https://github.com/acme/demo.git");
     assertEquals("https://github.com/acme/demo", result);
 
-    result = URLFetcher.sanitized("http://github.com/acme/demo.git");
+    result = urlFetcher.sanitized("http://github.com/acme/demo.git");
     assertEquals("http://github.com/acme/demo", result);
   }
 
@@ -97,7 +97,7 @@ public class URLFetcherTest {
     Assert.assertNotNull(urlJson);
 
     // add extra path to make url not found
-    String content = URLFetcher.fetchSafely(urlJson.toString() + "-invalid");
+    String content = urlFetcher.fetchSafely(urlJson.toString() + "-invalid");
     assertNull(content);
   }
 
@@ -113,7 +113,7 @@ public class URLFetcherTest {
     Assert.assertNotNull(urlJson);
 
     // add extra path to make url not found
-    String content = URLFetcher.fetch(urlJson.toString() + "-invalid");
+    String content = urlFetcher.fetch(urlJson.toString() + "-invalid");
     assertNull(content);
   }
 
@@ -135,14 +135,14 @@ public class URLFetcherTest {
     String extraContent = originalContent + "----";
     when(urlConnection.getInputStream())
         .thenReturn(new ByteArrayInputStream(extraContent.getBytes(UTF_8)));
-    String readcontent = URLFetcher.fetch(urlConnection);
+    String readcontent = urlFetcher.fetch(urlConnection);
     // check extra content has been removed as we keep only first values
     assertEquals(readcontent, originalContent);
   }
 
   @Test
   public void testDefaultFetchTimeoutIsSet() throws IOException {
-    org.eclipse.che.api.workspace.server.devfile.URLFetcher fetcher =
+    URLFetcher fetcher =
         new TimeoutCheckURLFetcher(
             timeout -> assertEquals(timeout.intValue(), CONNECTION_READ_TIMEOUT));
 
@@ -151,7 +151,7 @@ public class URLFetcherTest {
 
   @Test
   public void testFetchTimeoutIsSet() throws IOException {
-    org.eclipse.che.api.workspace.server.devfile.URLFetcher fetcher =
+    URLFetcher fetcher =
         new TimeoutCheckURLFetcher(timeout -> assertEquals(timeout.intValue(), 123));
 
     fetcher.fetch("http://eclipse.org/che", 123);
@@ -159,7 +159,7 @@ public class URLFetcherTest {
 
   @Test(expectedExceptions = IOException.class)
   public void testExceptionIsThrownOnTimeout() throws IOException {
-    org.eclipse.che.api.workspace.server.devfile.URLFetcher fetcher = new URLFetcher();
+    URLFetcher fetcher = new URLFetcher();
     URLConnection connection =
         new URLConnection(new URL("http://eclipse.org/che")) {
           @Override

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/URLFetcherTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/URLFetcherTest.java
@@ -195,6 +195,7 @@ public class URLFetcherTest {
     @Override
     String fetch(URLConnection urlConnection) {
       assertion.accept(urlConnection.getReadTimeout());
+      assertion.accept(urlConnection.getConnectTimeout());
       return "NOOP";
     }
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/URLFetcherTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/URLFetcherTest.java
@@ -178,7 +178,6 @@ public class URLFetcherTest {
 
   /** Limit to only one Byte. */
   static class OneByteURLFetcher extends URLFetcher {
-
     /** Override the limit */
     @Override
     protected long getLimit() {
@@ -187,7 +186,6 @@ public class URLFetcherTest {
   }
 
   private static class TimeoutCheckURLFetcher extends URLFetcher {
-
     private final Consumer<Integer> assertion;
 
     public TimeoutCheckURLFetcher(Consumer<Integer> assertion) {


### PR DESCRIPTION
### What does this PR do?
Fixes hanging URLFetcher by setting read timeout

TODO:
- [x] write test

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17176

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
