### PR TITLE
Forces to use sources compatible with java8 and runtime java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,8 @@
     </scm>
     <properties>
         <?SORTPOM IGNORE?>
+        <java.target.version>8</java.target.version>
+        <jdk.min.version>11</jdk.min.version>
         <build.info>${project.version}</build.info>
         <che.dashboard.version>7.15.0-SNAPSHOT</che.dashboard.version>
         <che.version>7.15.0-SNAPSHOT</che.version>


### PR DESCRIPTION
### What does this PR do?
Forces to use sources compatible with java8 and runtime java 11.

In case of java 8 runtime
```
[INFO]
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (enforce-java-version) @ che-parent ---
[WARNING] Rule 0: org.apache.maven.plugins.enforcer.RequireJavaVersion failed with message:
To build this project JDK 11 (or upper) is required. Please install it.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Che Parent 7.15.0-SNAPSHOT:
```

In case java 11 code

```

INFO] Changes detected - recompiling the module!
[INFO] Compiling 36 source files to /Users/skabashn/dev/src/redhat/che/core/commons/che-core-commons-lang/target/classes
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/skabashn/dev/src/redhat/che/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/IoUtil.java:[73,34] cannot find symbol
  symbol:   method isBlank()
  location: variable name of type java.lang.String
[ERROR] /Users/skabashn/dev/src/redhat/che/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/IoUtil.java:[74,26] cannot find symbol
  symbol:   method repeat(int)
  location: class java.lang.String
[ERROR] /Users/skabashn/dev/src/redhat/che/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/IoUtil.java:[89,27] cannot find symbol
  symbol:   method isBlank()
  location: class java.lang.String
[ERROR] /Users/skabashn/dev/src/redhat/che/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/IoUtil.java:[89,46] cannot find symbol
  symbol:   method repeat(int)
  location: class java.lang.String
[INFO] 4 errors
[INFO] -------------------------------------------------------------
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Che Parent 7.15.0-SNAPSHOT:
[INFO]
[INFO] Che Parent ......................................... SUCCESS [  2.719 s]
[INFO] Che Core Parent .................................... SUCCESS [  0.091 s]
[INFO] Che Core :: Commons :: Parent ...................... SUCCESS [  0.078 s]
[INFO] Che Core :: Commons :: Annotations ................. SUCCESS [  3.074 s]
[INFO] Che Core :: Commons :: Java API extension classes .. FAILURE [  1.557 s]
[INFO] Che Core :: Commons :: Utilities for tests ......... SKIPPED
```


### What issues does this PR fix or reference?
Since we might need to backport some feature for old branches it would be nice to keep source code in master java 8 compatible for some time
