### PR TITLE
fixes #16976 - fix ContainerLogWatch flaky test

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/log/ContainerLogWatchTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/log/ContainerLogWatchTest.java
@@ -199,7 +199,7 @@ public class ContainerLogWatchTest {
 
     // verify events were properly fired
     verify(eventsPublisher, times(1)).sendWatchLogStartedEvent(any(String.class));
-    verify(eventsPublisher, times(1)).sendWatchLogStoppedEvent(any(String.class));
+    verify(eventsPublisher, timeout(1000).times(1)).sendWatchLogStoppedEvent(any(String.class));
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
`ContainerLogWatchTest#testCloseOfOutputStream` was failing ramdomly. On my local environment circa 20 failures for 10k runs.

It was caused by test race condition, that assume that method is called before the call check. 1s timeout fix the issue

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16976

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
n/a


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
n/a