### PR TITLE
Load test - throw error if workspace is not stopped

### DIFF
--- a/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
+++ b/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
@@ -164,6 +164,9 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
                 }
                 await this.driverHelper.wait(TestConstants.TS_SELENIUM_DEFAULT_POLLING);
             }
+            const wsStatus = await this.processRequestHandler.get(stopWorkspaceApiUrl);
+            let waitTime = TestConstants.TS_SELENIUM_PLUGIN_PRECENCE_ATTEMPTS*TestConstants.TS_SELENIUM_DEFAULT_POLLING;
+            throw new error.TimeoutError(`The workspace was not stopped in ${waitTime} ms. Currnet status is: ${wsStatus.data.status}`);
         } catch (err) {
             console.log(`Stopping workspace failed. URL used: ${stopWorkspaceApiUrl}`);
             throw err;


### PR DESCRIPTION
### What does this PR do?
If the workspace is not stopped, it should be visible. Now test fails on a "remove workspace" step when API call returns error code 409. This means, that workspace can not be removed as it's not stopped. 
This PR adds throwing of an error if the stop fails with a better error message. The default timeout for the workspace stop time is 20 seconds.
