### PR TITLE
fix NPE in KubernetesSecretApplier when looping through component's aliases

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/KubernetesSecretApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/KubernetesSecretApplier.java
@@ -59,7 +59,7 @@ public abstract class KubernetesSecretApplier<E extends KubernetesEnvironment> {
         return env.getDevfile()
             .getComponents()
             .stream()
-            .filter(c -> c.getAlias().equals(componentName))
+            .filter(c -> componentName.equals(c.getAlias()))
             .findFirst();
       }
     }


### PR DESCRIPTION
### What does this PR do?
Fix NPE caused by looping through component aliases, that are not guaranteed to be non-null.

### What issues does this PR fix or reference?
n/a

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
