### PR TITLE
Clean up timeouts in typescript jobs

### DIFF
--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -311,9 +311,6 @@ EOL"""
                      CHE_URL=https://${cheHost}
                      docker run --shm-size=1g --net=host --ipc=host \\
                        -p 5920:5920 \\
-                       -e TS_SELENIUM_DEFAULT_TIMEOUT=300000 \\
-                       -e TS_SELENIUM_LOAD_PAGE_TIMEOUT=420000 \\
-                       -e TS_SELENIUM_WORKSPACE_STATUS_POLLING=20000 \\
                        -e TS_SELENIUM_BASE_URL=\${CHE_URL} \\
                        -e TS_SELENIUM_LOG_LEVEL='DEBUG' \\
                        -e TS_SELENIUM_MULTIUSER="true" \\

--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -52,7 +52,7 @@ export const TestConstants = {
     /**
      * Timeout in milliseconds waiting for page load, "120 000" by default.
      */
-    TS_SELENIUM_LOAD_PAGE_TIMEOUT: Number(process.env.TS_SELENIUM_LOAD_PAGE_TIMEOUT) || 120000,
+    TS_SELENIUM_LOAD_PAGE_TIMEOUT: Number(process.env.TS_SELENIUM_LOAD_PAGE_TIMEOUT) || 180000,
 
     /**
      * Timeout in milliseconds waiting for language server initialization, "180 000" by default.
@@ -62,7 +62,7 @@ export const TestConstants = {
     /**
      * Default timeout for most of the waitings, "20 000" by default.
      */
-    TS_SELENIUM_DEFAULT_TIMEOUT: Number(process.env.TS_SELENIUM_DEFAULT_TIMEOUT) || 20000,
+    TS_SELENIUM_DEFAULT_TIMEOUT: Number(process.env.TS_SELENIUM_DEFAULT_TIMEOUT) || 60000,
 
     /**
      * Default ammount of tries, "5" by default.

--- a/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
+++ b/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
@@ -165,7 +165,7 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
                 await this.driverHelper.wait(TestConstants.TS_SELENIUM_DEFAULT_POLLING);
             }
             const wsStatus = await this.processRequestHandler.get(stopWorkspaceApiUrl);
-            let waitTime = TestConstants.TS_SELENIUM_PLUGIN_PRECENCE_ATTEMPTS*TestConstants.TS_SELENIUM_DEFAULT_POLLING;
+            let waitTime = TestConstants.TS_SELENIUM_PLUGIN_PRECENCE_ATTEMPTS * TestConstants.TS_SELENIUM_DEFAULT_POLLING;
             throw new error.TimeoutError(`The workspace was not stopped in ${waitTime} ms. Currnet status is: ${wsStatus.data.status}`);
         } catch (err) {
             console.log(`Stopping workspace failed. URL used: ${stopWorkspaceApiUrl}`);


### PR DESCRIPTION
### What does this PR do?
Remove the high timeouts that served as a workaround when there were infra problems.
Increase some default timeouts - times are gotten by experience from Hosted Che.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17189

