### PR TITLE
Add workspace maximum time

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
@@ -40,6 +40,10 @@ che.limits.workspace.env.ram=16gb
 # counts toward idleness.
 che.limits.workspace.idle.timeout=1800000
 
+# The length of time that a workspace will run, regardless of activity, before
+# the system will suspend it.
+che.limits.workspace.run.timeout=0
+
 ### Users workspace limits
 
 # The total amount of RAM that a single user is allowed to allocate to running

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
@@ -40,7 +40,7 @@ che.limits.workspace.env.ram=16gb
 # counts toward idleness.
 che.limits.workspace.idle.timeout=1800000
 
-# The length of time that a workspace will run, regardless of activity, before
+# The length of time in milliseconds that a workspace will run, regardless of activity, before
 # the system will suspend it.  Set this property if you want to automatically stop
 # workspaces after a period of time.  The default is zero, meaning that there is no
 # run timeout.

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
@@ -41,7 +41,9 @@ che.limits.workspace.env.ram=16gb
 che.limits.workspace.idle.timeout=1800000
 
 # The length of time that a workspace will run, regardless of activity, before
-# the system will suspend it.
+# the system will suspend it.  Set this property if you want to automatically stop
+# workspaces after a period of time.  The default is zero, meaning that there is no
+# run timeout.
 che.limits.workspace.run.timeout=0
 
 ### Users workspace limits

--- a/multiuser/api/che-multiuser-api-workspace-activity/src/main/java/org/eclipse/che/multiuser/api/workspace/activity/MultiUserWorkspaceActivityManager.java
+++ b/multiuser/api/che-multiuser-api-workspace-activity/src/main/java/org/eclipse/che/multiuser/api/workspace/activity/MultiUserWorkspaceActivityManager.java
@@ -46,6 +46,7 @@ public class MultiUserWorkspaceActivityManager extends WorkspaceActivityManager 
   private final AccountManager accountManager;
   private final ResourceManager resourceManager;
   private final long defaultTimeout;
+  private final long runTimeout;
 
   @Inject
   public MultiUserWorkspaceActivityManager(
@@ -54,11 +55,13 @@ public class MultiUserWorkspaceActivityManager extends WorkspaceActivityManager 
       EventService eventService,
       AccountManager accountManager,
       ResourceManager resourceManager,
-      @Named("che.limits.workspace.idle.timeout") long defaultTimeout) {
-    super(workspaceManager, activityDao, eventService, defaultTimeout);
+      @Named("che.limits.workspace.idle.timeout") long defaultTimeout,
+      @Named("che.limits.workspace.run.timeout") long runTimeout) {
+    super(workspaceManager, activityDao, eventService, defaultTimeout, runTimeout);
     this.accountManager = accountManager;
     this.resourceManager = resourceManager;
     this.defaultTimeout = defaultTimeout;
+    this.runTimeout = runTimeout;
   }
 
   @Override

--- a/multiuser/api/che-multiuser-api-workspace-activity/src/test/java/org/eclipse/che/multiuser/api/workspace/activity/MultiUserWorkspaceActivityManagerTest.java
+++ b/multiuser/api/che-multiuser-api-workspace-activity/src/test/java/org/eclipse/che/multiuser/api/workspace/activity/MultiUserWorkspaceActivityManagerTest.java
@@ -35,6 +35,7 @@ import org.testng.annotations.Test;
 public class MultiUserWorkspaceActivityManagerTest {
   private static final long DEFAULT_TIMEOUT = 60_000L; // 1 minute
   private static final long USER_LIMIT_TIMEOUT = 120_000L; // 2 minutes
+  private static final long DEFAULT_HARD_EXPIRATION_TIMEOUT = 60000 * 60 * 3; // 3 hours
 
   @Mock private AccountManager accountManager;
   @Mock private ResourceManager resourceManager;
@@ -58,7 +59,8 @@ public class MultiUserWorkspaceActivityManagerTest {
             eventService,
             accountManager,
             resourceManager,
-            DEFAULT_TIMEOUT);
+            DEFAULT_TIMEOUT,
+            DEFAULT_HARD_EXPIRATION_TIMEOUT);
 
     when(account.getId()).thenReturn("account123");
     when(accountManager.getByName(anyString())).thenReturn(account);

--- a/multiuser/api/che-multiuser-api-workspace-activity/src/test/java/org/eclipse/che/multiuser/api/workspace/activity/MultiUserWorkspaceActivityManagerTest.java
+++ b/multiuser/api/che-multiuser-api-workspace-activity/src/test/java/org/eclipse/che/multiuser/api/workspace/activity/MultiUserWorkspaceActivityManagerTest.java
@@ -35,7 +35,7 @@ import org.testng.annotations.Test;
 public class MultiUserWorkspaceActivityManagerTest {
   private static final long DEFAULT_TIMEOUT = 60_000L; // 1 minute
   private static final long USER_LIMIT_TIMEOUT = 120_000L; // 2 minutes
-  private static final long DEFAULT_HARD_EXPIRATION_TIMEOUT = 60000 * 60 * 3; // 3 hours
+  private static final long DEFAULT_RUN_TIMEOUT = 0; // No default run timeout
 
   @Mock private AccountManager accountManager;
   @Mock private ResourceManager resourceManager;
@@ -60,7 +60,7 @@ public class MultiUserWorkspaceActivityManagerTest {
             accountManager,
             resourceManager,
             DEFAULT_TIMEOUT,
-            DEFAULT_HARD_EXPIRATION_TIMEOUT);
+            DEFAULT_RUN_TIMEOUT);
 
     when(account.getId()).thenReturn("account123");
     when(accountManager.getByName(anyString())).thenReturn(account);

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -43,11 +43,14 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
   }
 
   @Override
-  public List<String> findExpired(long timestamp) {
+  public List<String> findExpired(long timestamp, long runTimeout) {
     return workspaceActivities
         .values()
         .stream()
-        .filter(a -> a.getExpiration() != null && a.getExpiration() < timestamp)
+        .filter(
+            a ->
+                (a.getExpiration() != null && a.getExpiration() < timestamp)
+                    || (runTimeout > 0 && a.getLastRunning() - a.getLastStarting() > runTimeout))
         .map(WorkspaceActivity::getWorkspaceId)
         .collect(toList());
   }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -53,7 +53,7 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
    * @return
    */
   @Override
-  public List<String> findExpired(long timestamp, long runTimeout) {
+  public List<String> findExpiredRunTimeout(long timestamp, long runTimeout) {
     return workspaceActivities
         .values()
         .stream()
@@ -63,6 +63,16 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
                     || (runTimeout > 0
                         && a.getStatus() == WorkspaceStatus.RUNNING
                         && timestamp - a.getLastRunning() > runTimeout))
+        .map(WorkspaceActivity::getWorkspaceId)
+        .collect(toList());
+  }
+
+  @Override
+  public List<String> findExpiredIdle(long timestamp) {
+    return workspaceActivities
+        .values()
+        .stream()
+        .filter(a -> a.getExpiration() != null && a.getExpiration() < timestamp)
         .map(WorkspaceActivity::getWorkspaceId)
         .collect(toList());
   }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -42,6 +42,16 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
     findActivity(workspaceId).setExpiration(null);
   }
 
+  /**
+   * Finds any workspaces that have expired.
+   *
+   * <p>A workspace is expired when the expiration value is less than the current time or when the
+   * difference between the current time and the last running time is greater than the run timeout
+   *
+   * @param timestamp expiration time
+   * @param runTimeout time after which the workspace will be stopped regardless of activity
+   * @return
+   */
   @Override
   public List<String> findExpired(long timestamp, long runTimeout) {
     return workspaceActivities
@@ -50,7 +60,9 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
         .filter(
             a ->
                 (a.getExpiration() != null && a.getExpiration() < timestamp)
-                    || (runTimeout > 0 && timestamp - a.getLastRunning() > runTimeout))
+                    || (runTimeout > 0
+                        && a.getStatus() == WorkspaceStatus.RUNNING
+                        && timestamp - a.getLastRunning() > runTimeout))
         .map(WorkspaceActivity::getWorkspaceId)
         .collect(toList());
   }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/InmemoryWorkspaceActivityDao.java
@@ -50,7 +50,7 @@ public class InmemoryWorkspaceActivityDao implements WorkspaceActivityDao {
         .filter(
             a ->
                 (a.getExpiration() != null && a.getExpiration() < timestamp)
-                    || (runTimeout > 0 && a.getLastRunning() - a.getLastStarting() > runTimeout))
+                    || (runTimeout > 0 && timestamp - a.getLastRunning() > runTimeout))
         .map(WorkspaceActivity::getWorkspaceId)
         .collect(toList());
   }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -50,6 +50,16 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
     doUpdateOptionally(workspaceId, a -> a.setExpiration(null));
   }
 
+  /**
+   * Finds any workspaces that have expired.
+   *
+   * <p>A workspace is expired when the expiration value is less than the current time or when the
+   * difference between the current time and the last running time is greater than the run timeout
+   *
+   * @param timestamp expiration time
+   * @param runTimeout time after which the workspace will be stopped regardless of activity
+   * @return
+   */
   @Override
   @Transactional(rollbackOn = ServerException.class)
   public List<String> findExpired(long timestamp, long runTimeout) throws ServerException {

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -62,13 +62,31 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
    */
   @Override
   @Transactional(rollbackOn = ServerException.class)
-  public List<String> findExpired(long timestamp, long runTimeout) throws ServerException {
+  public List<String> findExpiredRunTimeout(long timestamp, long runTimeout)
+      throws ServerException {
     try {
       return managerProvider
           .get()
-          .createNamedQuery("WorkspaceActivity.getExpired", WorkspaceActivity.class)
-          .setParameter("expiration", timestamp)
+          .createNamedQuery("WorkspaceActivity.getExpiredRunTimeout", WorkspaceActivity.class)
+          .setParameter("timestamp", timestamp)
           .setParameter("runTimeout", runTimeout)
+          .getResultList()
+          .stream()
+          .map(WorkspaceActivity::getWorkspaceId)
+          .collect(Collectors.toList());
+    } catch (RuntimeException x) {
+      throw new ServerException(x.getLocalizedMessage(), x);
+    }
+  }
+
+  @Override
+  @Transactional(rollbackOn = ServerException.class)
+  public List<String> findExpiredIdle(long timestamp) throws ServerException {
+    try {
+      return managerProvider
+          .get()
+          .createNamedQuery("WorkspaceActivity.getExpiredIdle", WorkspaceActivity.class)
+          .setParameter("expiration", timestamp)
           .getResultList()
           .stream()
           .map(WorkspaceActivity::getWorkspaceId)

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -67,12 +67,10 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
     try {
       return managerProvider
           .get()
-          .createNamedQuery("WorkspaceActivity.getExpiredRunTimeout", WorkspaceActivity.class)
-          .setParameter("timestamp", timestamp)
-          .setParameter("runTimeout", runTimeout)
+          .createNamedQuery("WorkspaceActivity.getExpiredRunTimeout", String.class)
+          .setParameter("timeDifference", timestamp - runTimeout)
           .getResultList()
           .stream()
-          .map(WorkspaceActivity::getWorkspaceId)
           .collect(Collectors.toList());
     } catch (RuntimeException x) {
       throw new ServerException(x.getLocalizedMessage(), x);
@@ -85,11 +83,10 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
     try {
       return managerProvider
           .get()
-          .createNamedQuery("WorkspaceActivity.getExpiredIdle", WorkspaceActivity.class)
+          .createNamedQuery("WorkspaceActivity.getExpiredIdle", String.class)
           .setParameter("expiration", timestamp)
           .getResultList()
           .stream()
-          .map(WorkspaceActivity::getWorkspaceId)
           .collect(Collectors.toList());
     } catch (RuntimeException x) {
       throw new ServerException(x.getLocalizedMessage(), x);

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/JpaWorkspaceActivityDao.java
@@ -52,12 +52,13 @@ public class JpaWorkspaceActivityDao implements WorkspaceActivityDao {
 
   @Override
   @Transactional(rollbackOn = ServerException.class)
-  public List<String> findExpired(long timestamp) throws ServerException {
+  public List<String> findExpired(long timestamp, long runTimeout) throws ServerException {
     try {
       return managerProvider
           .get()
           .createNamedQuery("WorkspaceActivity.getExpired", WorkspaceActivity.class)
           .setParameter("expiration", timestamp)
+          .setParameter("runTimeout", runTimeout)
           .getResultList()
           .stream()
           .map(WorkspaceActivity::getWorkspaceId)

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -27,13 +27,13 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 @NamedQueries({
   @NamedQuery(
       name = "WorkspaceActivity.getExpiredIdle",
-      query = "SELECT a FROM WorkspaceActivity a WHERE a.expiration < :expiration"),
+      query = "SELECT a.workspaceId FROM WorkspaceActivity a WHERE a.expiration < :expiration"),
   @NamedQuery(
       name = "WorkspaceActivity.getExpiredRunTimeout",
       query =
-          "SELECT a FROM WorkspaceActivity a WHERE "
+          "SELECT a.workspaceId FROM WorkspaceActivity a WHERE "
               + "(a.status = org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING AND "
-              + "a.lastRunning < :timestamp - :runTimeout)"),
+              + "a.lastRunning < :timeDifference)"),
   @NamedQuery(
       name = "WorkspaceActivity.getStoppedSince",
       query =

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -33,8 +33,7 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
       query =
           "SELECT a FROM WorkspaceActivity a WHERE "
               + "(a.status = org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING AND "
-              + ":runTimeout > 0 AND "
-              + ":timestamp - :runTimeout > a.lastRunning)"),
+              + "a.lastRunning < :timestamp - :runTimeout)"),
   @NamedQuery(
       name = "WorkspaceActivity.getStoppedSince",
       query =

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -169,10 +169,6 @@ public class WorkspaceActivity {
     this.expiration = expiration;
   }
 
-  public Long getRunTimeout() {
-    return this.lastRunning - this.lastStarting;
-  }
-
   public WorkspaceStatus getStatus() {
     return status;
   }
@@ -189,7 +185,6 @@ public class WorkspaceActivity {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     WorkspaceActivity activity = (WorkspaceActivity) o;
     return Objects.equals(workspaceId, activity.workspaceId)
         && Objects.equals(created, activity.created)

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -26,12 +26,15 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 @Table(name = "che_workspace_activity")
 @NamedQueries({
   @NamedQuery(
-      name = "WorkspaceActivity.getExpired",
+      name = "WorkspaceActivity.getExpiredIdle",
+      query = "SELECT a FROM WorkspaceActivity a WHERE a.expiration < :expiration"),
+  @NamedQuery(
+      name = "WorkspaceActivity.getExpiredRunTimeout",
       query =
-          "SELECT a FROM WorkspaceActivity a WHERE a.expiration < :expiration OR "
+          "SELECT a FROM WorkspaceActivity a WHERE "
               + "(a.status = org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING AND "
               + ":runTimeout > 0 AND "
-              + ":expiration - a.lastRunning > :runTimeout)"),
+              + ":timestamp - :runTimeout > a.lastRunning)"),
   @NamedQuery(
       name = "WorkspaceActivity.getStoppedSince",
       query =

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivity.java
@@ -27,7 +27,11 @@ import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
 @NamedQueries({
   @NamedQuery(
       name = "WorkspaceActivity.getExpired",
-      query = "SELECT a FROM WorkspaceActivity a WHERE a.expiration < :expiration"),
+      query =
+          "SELECT a FROM WorkspaceActivity a WHERE a.expiration < :expiration OR "
+              + "(a.status = org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING AND "
+              + ":runTimeout > 0 AND "
+              + ":expiration - a.lastRunning > :runTimeout)"),
   @NamedQuery(
       name = "WorkspaceActivity.getStoppedSince",
       query =
@@ -165,6 +169,10 @@ public class WorkspaceActivity {
     this.expiration = expiration;
   }
 
+  public Long getRunTimeout() {
+    return this.lastRunning - this.lastStarting;
+  }
+
   public WorkspaceStatus getStatus() {
     return status;
   }
@@ -181,6 +189,7 @@ public class WorkspaceActivity {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
+
     WorkspaceActivity activity = (WorkspaceActivity) o;
     return Objects.equals(workspaceId, activity.workspaceId)
         && Objects.equals(created, activity.created)

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
@@ -110,7 +110,11 @@ public class WorkspaceActivityChecker {
       if (workspaceActivityManager.getRunTimeout() > 0) {
         activityDao
             .findExpiredRunTimeout(clock.millis(), workspaceActivityManager.getRunTimeout())
-            .forEach(wsId -> stopExpiredQuietly(wsId, WORKSPACE_RUN_TIMEOUT_EXCEEDED));
+            .forEach(
+                wsId -> {
+                  LOG.info("{} for workspace {}", WORKSPACE_RUN_TIMEOUT_EXCEEDED, wsId);
+                  stopExpiredQuietly(wsId, WORKSPACE_RUN_TIMEOUT_EXCEEDED);
+                });
       }
     } catch (ServerException e) {
       LOG.error("Failed to list all expired to perform stop. Cause: {}", e.getMessage(), e);

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityChecker.java
@@ -101,7 +101,9 @@ public class WorkspaceActivityChecker {
 
   private void stopAllExpired() {
     try {
-      activityDao.findExpired(clock.millis()).forEach(this::stopExpiredQuietly);
+      activityDao
+          .findExpired(clock.millis(), workspaceActivityManager.getRunTimeout())
+          .forEach(this::stopExpiredQuietly);
     } catch (ServerException e) {
       LOG.error("Failed to list all expired to perform stop. Cause: {}", e.getMessage(), e);
     }

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityDao.java
@@ -43,14 +43,22 @@ public interface WorkspaceActivityDao {
   void removeExpiration(String workspaceId) throws ServerException;
 
   /**
-   * Finds workspaces which are passed given expiration time and must be stopped.
+   * Finds workspaces which are passed given run timeout and must be stopped.
    *
-   * @param timestamp expiration time
    * @param runTimeout time after which the workspace will be stopped regardless of activity
    * @return list of workspaces which expiration time is older than given timestamp
    * @throws ServerException when operation failed
    */
-  List<String> findExpired(long timestamp, long runTimeout) throws ServerException;
+  List<String> findExpiredRunTimeout(long timestamp, long runTimeout) throws ServerException;
+
+  /**
+   * Finds workspaces which are passed given expiration time and must be stopped.
+   *
+   * @param timestamp expiration time
+   * @return list of workspaces which expiration time is older than given timestamp
+   * @throws ServerException when operation failed
+   */
+  List<String> findExpiredIdle(long timestamp) throws ServerException;
 
   /**
    * Removes the activity record of the provided workspace.

--- a/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityDao.java
+++ b/wsmaster/che-core-api-workspace-activity/src/main/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityDao.java
@@ -46,10 +46,11 @@ public interface WorkspaceActivityDao {
    * Finds workspaces which are passed given expiration time and must be stopped.
    *
    * @param timestamp expiration time
+   * @param runTimeout time after which the workspace will be stopped regardless of activity
    * @return list of workspaces which expiration time is older than given timestamp
    * @throws ServerException when operation failed
    */
-  List<String> findExpired(long timestamp) throws ServerException;
+  List<String> findExpired(long timestamp, long runTimeout) throws ServerException;
 
   /**
    * Removes the activity record of the provided workspace.

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
@@ -55,6 +55,8 @@ import org.testng.annotations.Test;
 @Listeners(value = MockitoTestNGListener.class)
 public class WorkspaceActivityCheckerTest {
   private static final long DEFAULT_TIMEOUT = 60_000L; // 1 minute
+  private static final long DEFAULT_RUN_TIMEOUT = 0; // No default run timeout
+  private static final long ACTIVE_RUN_TIMEOUT = 60000 * 60 * 3; // 3 hours
 
   private ManualClock clock;
   private WorkspaceActivityChecker checker;
@@ -69,7 +71,12 @@ public class WorkspaceActivityCheckerTest {
 
     WorkspaceActivityManager activityManager =
         new WorkspaceActivityManager(
-            workspaceManager, workspaceActivityDao, eventService, DEFAULT_TIMEOUT, clock);
+            workspaceManager,
+            workspaceActivityDao,
+            eventService,
+            DEFAULT_TIMEOUT,
+            DEFAULT_RUN_TIMEOUT,
+            clock);
 
     lenient()
         .when(workspaceActivityDao.getAll(anyInt(), anyLong()))
@@ -88,7 +95,7 @@ public class WorkspaceActivityCheckerTest {
 
   @Test
   public void shouldStopAllExpiredWorkspaces() throws Exception {
-    when(workspaceActivityDao.findExpired(anyLong())).thenReturn(asList("1", "2", "3"));
+    when(workspaceActivityDao.findExpired(anyLong(), anyLong())).thenReturn(asList("1", "2", "3"));
 
     checker.expire();
 

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
@@ -94,7 +94,7 @@ public class WorkspaceActivityCheckerTest {
 
   @Test
   public void shouldStopAllExpiredWorkspaces() throws Exception {
-    when(workspaceActivityDao.findExpired(anyLong(), anyLong())).thenReturn(asList("1", "2", "3"));
+    when(workspaceActivityDao.findExpiredIdle(anyLong())).thenReturn(asList("1", "2", "3"));
 
     checker.expire();
 

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityCheckerTest.java
@@ -56,7 +56,6 @@ import org.testng.annotations.Test;
 public class WorkspaceActivityCheckerTest {
   private static final long DEFAULT_TIMEOUT = 60_000L; // 1 minute
   private static final long DEFAULT_RUN_TIMEOUT = 0; // No default run timeout
-  private static final long ACTIVE_RUN_TIMEOUT = 60000 * 60 * 3; // 3 hours
 
   private ManualClock clock;
   private WorkspaceActivityChecker checker;

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManagerTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/WorkspaceActivityManagerTest.java
@@ -50,7 +50,6 @@ public class WorkspaceActivityManagerTest {
 
   private static final long DEFAULT_TIMEOUT = 60_000L; // 1 minute
   private static final long DEFAULT_RUN_TIMEOUT = 0; // No run timeout
-  private static final long ACTIVE_RUN_TIMEOUT = 60000 * 60 * 3; // 3 hours
 
   @Mock private WorkspaceManager workspaceManager;
 
@@ -106,19 +105,6 @@ public class WorkspaceActivityManagerTest {
     ArgumentCaptor<String> wsIdCaptor = ArgumentCaptor.forClass(String.class);
     verify(workspaceActivityDao, times(1)).setExpirationTime(wsIdCaptor.capture(), any(long.class));
     assertEquals(wsIdCaptor.getValue(), wsId);
-  }
-
-  @Test
-  public void shouldRemoveRunTimeoutWhenWorkspaceStopped() throws Exception {
-    final String wsId = "testWsId";
-    final EventSubscriber<WorkspaceStatusEvent> subscriber = subscribeAndGetStatusEventSubscriber();
-
-    subscriber.onEvent(
-        DtoFactory.newDto(WorkspaceStatusEvent.class)
-            .withStatus(WorkspaceStatus.STOPPED)
-            .withWorkspaceId(wsId));
-    ArgumentCaptor<String> wsIdCaptor = ArgumentCaptor.forClass(String.class);
-    verify(workspaceActivityDao, times(1)).removeExpiration(wsIdCaptor.capture());
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/spi/tck/WorkspaceActivityDaoTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/spi/tck/WorkspaceActivityDaoTest.java
@@ -113,7 +113,7 @@ public class WorkspaceActivityDaoTest {
   @Test
   public void shouldFindExpirationsByTimestamp() throws Exception {
     List<String> expected = asList(activities[0].getWorkspaceId(), activities[1].getWorkspaceId());
-    List<String> found = workspaceActivityDao.findExpired(2_500_000, DEFAULT_RUN_TIMEOUT);
+    List<String> found = workspaceActivityDao.findExpiredIdle(2_500_000);
 
     assertEquals(found, expected);
   }
@@ -124,7 +124,7 @@ public class WorkspaceActivityDaoTest {
 
     workspaceActivityDao.removeExpiration(activities[0].getWorkspaceId());
 
-    List<String> found = workspaceActivityDao.findExpired(2_500_000, DEFAULT_RUN_TIMEOUT);
+    List<String> found = workspaceActivityDao.findExpiredIdle(2_500_000);
     assertEquals(found, expected);
   }
 
@@ -139,7 +139,7 @@ public class WorkspaceActivityDaoTest {
 
     activityTckRepository.createAll(createWorkspaceActivitiesWithStatuses());
 
-    List<String> found = workspaceActivityDao.findExpired(8_000_000, 1_000_000);
+    List<String> found = workspaceActivityDao.findExpiredIdle(8_000_000);
     assertEquals(found, expected);
   }
 
@@ -153,7 +153,7 @@ public class WorkspaceActivityDaoTest {
 
     workspaceActivityDao.setExpirationTime(activities[2].getWorkspaceId(), 1_750_000);
 
-    List<String> found = workspaceActivityDao.findExpired(2_500_000, DEFAULT_RUN_TIMEOUT);
+    List<String> found = workspaceActivityDao.findExpiredIdle(2_500_000);
     assertEquals(found, expected);
   }
 
@@ -176,7 +176,7 @@ public class WorkspaceActivityDaoTest {
     // create new again
     workspaceActivityDao.setExpirationTime(activities[1].getWorkspaceId(), 1_250_000);
 
-    List<String> found = workspaceActivityDao.findExpired(1_500_000, DEFAULT_RUN_TIMEOUT);
+    List<String> found = workspaceActivityDao.findExpiredIdle(1_500_000);
     assertEquals(found, expected);
   }
 

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/spi/tck/WorkspaceActivityDaoTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/spi/tck/WorkspaceActivityDaoTest.java
@@ -96,7 +96,6 @@ public class WorkspaceActivityDaoTest {
       a.setExpiration(base * 1_000_000);
 
       activities[i] = a;
-      System.out.println("activity is " + a);
     }
 
     accountTckRepository.createAll(asList(accounts));

--- a/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/spi/tck/WorkspaceActivityDaoTest.java
+++ b/wsmaster/che-core-api-workspace-activity/src/test/java/org/eclipse/che/api/workspace/activity/spi/tck/WorkspaceActivityDaoTest.java
@@ -12,7 +12,8 @@
 package org.eclipse.che.api.workspace.activity.spi.tck;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.*;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 import static org.testng.Assert.assertEquals;

--- a/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
+++ b/wsmaster/integration-tests/cascade-removal/src/test/java/org/eclipse/che/core/db/jpa/CascadeRemovalTest.java
@@ -239,6 +239,11 @@ public class CascadeRemovalTest {
                 bind(Long.class)
                     .annotatedWith(Names.named("che.limits.workspace.idle.timeout"))
                     .toInstance(100000L);
+
+                bind(Long.class)
+                    .annotatedWith(Names.named("che.limits.workspace.run.timeout"))
+                    .toInstance(0L);
+
                 bind(UserManager.class);
                 bind(AccountManager.class);
 


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?

Adds the property `che.workspace.limits.run.timeout` to set the maximum amount of time a workspace can run before it is stopped by the activity manager, regardless of activity

### What issues does this PR fix or reference?

#17231 

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
