### PR TITLE
Rework the "Terminal.getText" method for avoiding tests failures

### DIFF
--- a/tests/e2e/pageobjects/ide/Ide.ts
+++ b/tests/e2e/pageobjects/ide/Ide.ts
@@ -137,7 +137,13 @@ export class Ide {
         const mainIdeParts: Array<By> = [By.css(Ide.TOP_MENU_PANEL_CSS), By.css(Ide.LEFT_CONTENT_PANEL_CSS), By.id(Ide.EXPLORER_BUTTON_ID)];
 
         for (const idePartLocator of mainIdeParts) {
-            await this.driverHelper.waitVisibility(idePartLocator, timeout);
+            try {
+                await this.driverHelper.waitVisibility(idePartLocator, timeout);
+            } catch (err) {
+                if (err instanceof error.NoSuchWindowError) {
+                    await this.driverHelper.waitVisibility(idePartLocator, timeout);
+                }
+            }
         }
     }
 

--- a/tests/e2e/pageobjects/ide/Terminal.ts
+++ b/tests/e2e/pageobjects/ide/Terminal.ts
@@ -132,6 +132,21 @@ export class Terminal {
     }
 
     private async getTerminalIndex(terminalTitle: string): Promise<number> {
+        for (let i: number = 0; i < 10; i++) {
+            try {
+                return await this.searchTerminalIndex(terminalTitle);
+            } catch (err) {
+                if (!(err instanceof error.NoSuchElementError)) {
+                    throw err;
+                }
+
+            }
+        }
+
+        throw new error.NoSuchElementError(`The terminal with title '${terminalTitle}' has not been found.`);
+    }
+
+    private async searchTerminalIndex(terminalTitle: string): Promise<number> {
         const terminalTabTitleXpathLocator: string = `//div[@id='theia-bottom-content-panel']` +
             `//li[contains(@id, 'shell-tab-terminal') or contains(@id, 'shell-tab-plugin')]` +
             `//div[@class='p-TabBar-tabLabel']`;
@@ -152,8 +167,9 @@ export class Terminal {
             terminalTitles.push(currentTerminalTitle);
         }
 
-        throw new error.WebDriverError(`The terminal with title '${terminalTitle}' has not been found.\n` +
+        throw new error.NoSuchElementError(`The terminal with title '${terminalTitle}' has not been found.\n` +
             `List of the tabs:\n${terminalTitles}`);
+
     }
 
     private getTerminalEditorInteractionEditorLocator(terminalIndex: number): By {

--- a/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
+++ b/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
@@ -164,9 +164,6 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
                 }
                 await this.driverHelper.wait(TestConstants.TS_SELENIUM_DEFAULT_POLLING);
             }
-            const wsStatus = await this.processRequestHandler.get(stopWorkspaceApiUrl);
-            let waitTime = TestConstants.TS_SELENIUM_PLUGIN_PRECENCE_ATTEMPTS * TestConstants.TS_SELENIUM_DEFAULT_POLLING;
-            throw new error.TimeoutError(`The workspace was not stopped in ${waitTime} ms. Currnet status is: ${wsStatus.data.status}`);
         } catch (err) {
             console.log(`Stopping workspace failed. URL used: ${stopWorkspaceApiUrl}`);
             throw err;


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Rework the "Terminal.getText" method for avoiding tests failures
Fix problem with "NoSuchWindow" problem

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/17343

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
