### PR TITLE
Use proxy authenticator on Keycloak Settings retrieval;

### DIFF
--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakSettings.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakSettings.java
@@ -44,6 +44,7 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.commons.proxy.ProxyAuthenticator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +94,7 @@ public class KeycloakSettings {
     URL url;
     Map<String, Object> openIdConfiguration;
     try {
+      ProxyAuthenticator.initAuthenticator(wellKnownEndpoint);
       url = new URL(wellKnownEndpoint);
       final InputStream inputStream = url.openStream();
       final JsonFactory factory = new JsonFactory();
@@ -103,6 +105,8 @@ public class KeycloakSettings {
     } catch (IOException e) {
       throw new RuntimeException(
           "Exception while retrieving OpenId configuration from endpoint: " + wellKnownEndpoint, e);
+    } finally {
+      ProxyAuthenticator.resetAuthenticator();
     }
 
     LOG.info("openid configuration = {}", openIdConfiguration);

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakSettings.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakSettings.java
@@ -93,10 +93,8 @@ public class KeycloakSettings {
 
     URL url;
     Map<String, Object> openIdConfiguration;
-    try {
-      ProxyAuthenticator.initAuthenticator(wellKnownEndpoint);
-      url = new URL(wellKnownEndpoint);
-      final InputStream inputStream = url.openStream();
+    ProxyAuthenticator.initAuthenticator(wellKnownEndpoint);
+    try (InputStream inputStream = new URL(wellKnownEndpoint).openStream()) {
       final JsonFactory factory = new JsonFactory();
       final JsonParser parser = factory.createParser(inputStream);
       final TypeReference<Map<String, Object>> typeReference =

--- a/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakSettings.java
+++ b/multiuser/keycloak/che-multiuser-keycloak-server/src/main/java/org/eclipse/che/multiuser/keycloak/server/KeycloakSettings.java
@@ -91,7 +91,6 @@ public class KeycloakSettings {
 
     LOG.info("Retrieving OpenId configuration from endpoint: {}", wellKnownEndpoint);
 
-    URL url;
     Map<String, Object> openIdConfiguration;
     ProxyAuthenticator.initAuthenticator(wellKnownEndpoint);
     try (InputStream inputStream = new URL(wellKnownEndpoint).openStream()) {


### PR DESCRIPTION
### What does this PR do?
Force using authentiactor when making keycloak settings request via authenticated proxy.


### What issues does this PR fix or reference?
#17348 (partially)

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
