### PR TITLE
Remove ls init test

### DIFF
--- a/tests/e2e/tests/devfiles/JavaVertx.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaVertx.spec.ts
@@ -20,7 +20,6 @@ const fileFolderPath: string = `${workspaceSampleName}/${workspaceRootFolderName
 const tabTitle: string = 'HttpApplication.java';
 const codeNavigationClassName: string = 'RouterImpl.class';
 const buildTaskName: string = 'maven build';
-const LSstarting: string = 'Activating Language Support for Java';
 const stack: string = 'Java Vert.x';
 
 suite(`${stack} test`, async () => {
@@ -31,9 +30,8 @@ suite(`${stack} test`, async () => {
 
     suite('Language server validation', async () => {
         projectAndFileTests.openFile(fileFolderPath, tabTitle);
-        commonLsTests.waitLSInitialization(LSstarting, 1_800_000, 360_000);
-        commonLsTests.suggestionInvoking(tabTitle, 19, 31, 'router(Vertx vertx) : Router');
         commonLsTests.errorHighlighting(tabTitle, 'error', 20);
+        commonLsTests.suggestionInvoking(tabTitle, 19, 31, 'router(Vertx vertx) : Router');
         commonLsTests.autocomplete(tabTitle, 19, 7, 'Router - io.vertx.ext.web');
         commonLsTests.codeNavigation(tabTitle, 19, 7, codeNavigationClassName);
     });

--- a/tests/e2e/tests/devfiles/NodeJS.spec.ts
+++ b/tests/e2e/tests/devfiles/NodeJS.spec.ts
@@ -37,7 +37,7 @@ suite(`${workspaceStack} test`, async () => {
         projectManager.openFile(fileFolderPath, fileName);
         commonLsTests.suggestionInvoking(fileName, 15, 20, 'require');
         commonLsTests.autocomplete(fileName, 15, 20, 'require');
-        // commonLsTests.errorHighlighting(fileName, 'error_text;\n', 17); // error highlighting doesn't work in nodejs devfile https://github.com/eclipse/che/issues/16993
+        commonLsTests.errorHighlighting(fileName, 'error text;\n', 17);
         // commonLsTests.codeNavigation(fileName, 19, 10, 'index.d.ts'); // codenavigation is inconsistent https://github.com/eclipse/che/issues/16929
     });
     suite('Run nodejs application', async () => {

--- a/tests/e2e/tests/devfiles/NodeJS.spec.ts
+++ b/tests/e2e/tests/devfiles/NodeJS.spec.ts
@@ -35,9 +35,9 @@ suite(`${workspaceStack} test`, async () => {
     });
     suite(`'Language server validation'`, async () => {
         projectManager.openFile(fileFolderPath, fileName);
+        commonLsTests.errorHighlighting(fileName, 'error text;\n', 17);
         commonLsTests.suggestionInvoking(fileName, 15, 20, 'require');
         commonLsTests.autocomplete(fileName, 15, 20, 'require');
-        commonLsTests.errorHighlighting(fileName, 'error text;\n', 17);
         // commonLsTests.codeNavigation(fileName, 19, 10, 'index.d.ts'); // codenavigation is inconsistent https://github.com/eclipse/che/issues/16929
     });
     suite('Run nodejs application', async () => {

--- a/tests/e2e/tests/devfiles/Quarkus.spec.ts
+++ b/tests/e2e/tests/devfiles/Quarkus.spec.ts
@@ -20,7 +20,6 @@ const workspaceRootFolderName: string = 'getting-started';
 const fileFolderPath: string = `${workspaceSampleName}/${workspaceRootFolderName}/src/main/java/org/acme/getting/started`;
 const fileName: string = `GreetingService.java`;
 
-const lsStarting: string = 'Activating Quarkus';
 const taskPackage: string = 'Package';
 const taskPackageNative: string = 'Package Native';
 const taskStartNative: string = 'Start Native';
@@ -33,21 +32,20 @@ suite(`${workspaceStack} test`, async () => {
     });
     suite(`'Language server validation'`, async () => {
         projectManager.openFile(fileFolderPath, fileName);
-        commonLsTests.waitLSInitialization(lsStarting, 1_800_000, 360_000);
+        commonLsTests.errorHighlighting(fileName, 'error_text;', 7);
         commonLsTests.suggestionInvoking(fileName, 8, 33, 'String');
         commonLsTests.autocomplete(fileName, 8, 33, 'String');
-        commonLsTests.errorHighlighting(fileName, 'error_text;', 7);
         commonLsTests.codeNavigation(fileName, 8, 33, 'String.class');
     });
     suite('Package Quarkus application', async () => {
         codeExecutionHelper.runTask(taskPackage, 180_000);
         codeExecutionHelper.closeTerminal(taskPackage);
     });
-    suite('Package Quarkus Native bundle', async () => {
+    suite.skip('Package Quarkus Native bundle', async () => { // enable again once https://github.com/eclipse/che/issues/17356 is fixed
         codeExecutionHelper.runTask(taskPackageNative, 600_000);
         codeExecutionHelper.closeTerminal(taskPackageNative);
     });
-    suite('Start Quarkus Native application', async () => {
+    suite.skip('Start Quarkus Native application', async () => { // enable again once https://github.com/eclipse/che/issues/17356 is fixed
         codeExecutionHelper.runTaskWithDialogShellAndOpenLink(taskStartNative, taskExpectedDialogText, 90_000);
     });
     suite('Stop and remove workspace', async() => {


### PR DESCRIPTION
### What does this PR do?
Remove checking of LS initialization to prevent flakiness. The next step to stabilize those tests is to replace TS_SELENIUM_DEFAULT_TIMEOUT variable https://github.com/eclipse/che/issues/17362.
As a part of this PR, dislabe Quarkus tests for `Package Native` and `Start Native` as it's not working correctly https://github.com/eclipse/che/issues/17356