### PR TITLE
use subPaths for secret mounted as files only on supported k8s versions

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/K8sVersion.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/K8sVersion.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+
+import io.fabric8.kubernetes.client.VersionInfo;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Gets version of k8s cluster from given {@link KubernetesClientFactory#create()} and provides
+ * functions over it.
+ *
+ * <p>In case of issue like infrastructure or parsing failures, this implementation assumes that
+ * we're on newer version.
+ *
+ * <p>Parsing of version strings is very naive, we just strip all non-digit characters and parse as
+ * integer. This should be enough for standard version strings and where it fails, we assume we're
+ * on newer version. These are version formats from various platforms:
+ *
+ * <pre>
+ * minikube v1.11.0 with k8s 1.17.6:
+ * {
+ *  major=1,
+ *  minor=17,
+ *  ...
+ * }
+ *
+ * minishift v1.34.2+83ebaab:
+ * {
+ *   major=1,
+ *   minor=11+,
+ *   ...
+ * }
+ *
+ * crc 1.12.0+6710aff with OpenShift version 4.4.8
+ * {
+ *  major=1,
+ *  minor=17+,
+ *  ...
+ * }
+ * </pre>
+ */
+@Singleton
+public class K8sVersion {
+
+  private static final Logger LOG = LoggerFactory.getLogger(K8sVersion.class);
+
+  private final KubernetesClientFactory clientFactory;
+  private VersionInfo versionInfo;
+  private int major;
+  private int minor;
+
+  @Inject
+  public K8sVersion(KubernetesClientFactory clientFactory) {
+    this.clientFactory = clientFactory;
+  }
+
+  /**
+   * Returns 'true' if given {@code major.minor} is newer or equal than k8s cluster version. 'false'
+   * if given {@code major.minor} is older.
+   *
+   * <p>In case of any issue like infrastructure or parse failures, assume we're on newer version
+   * and return 'true'.
+   *
+   * @param major major version to compare
+   * @param minor minor version to compare
+   * @return true if given {@code major.minor} version is newer or equal version than k8s version
+   */
+  public boolean newerOrEqualThan(int major, int minor) {
+    try {
+      initVersionInfo();
+    } catch (InfrastructureException ie) {
+      LOG.warn("Unable to obtain k8s VersionInfo.", ie);
+      return true;
+    }
+
+    if (major > this.major) {
+      return true;
+    } else if (major == this.major) {
+      return minor >= this.minor;
+    } else {
+      return false;
+    }
+  }
+
+  /**
+   * Returns 'true' if given {@code major.minor} is older than k8s cluster version. 'false' if given
+   * {@code major.minor} is newer or equal.
+   *
+   * <p>In case of any issue like infrastructure or parse failures, assume we're on newer version
+   * and return 'false'.
+   *
+   * @param major major version to compare
+   * @param minor minor version to compare
+   * @return true if given {@code major.minor} version is older than k8s version
+   */
+  public boolean olderThan(int major, int minor) {
+    return !newerOrEqualThan(major, minor);
+  }
+
+  private void initVersionInfo() throws InfrastructureException {
+    if (versionInfo == null) {
+      synchronized (this) {
+        if (versionInfo == null) {
+          versionInfo = clientFactory.create().getVersion();
+          parseVersions();
+        }
+      }
+    }
+  }
+
+  /**
+   * Try parse versions into integers. This naive implementation removes all non-digits and try to
+   * parse what's left into integer.
+   */
+  private void parseVersions() {
+    try {
+      this.major = parseVersionNumber(versionInfo.getMajor());
+      this.minor = parseVersionNumber(versionInfo.getMinor());
+    } catch (NumberFormatException nfe) {
+      this.major = 0;
+      this.minor = 0;
+    }
+  }
+
+  private int parseVersionNumber(String versionString) {
+    versionString = versionString.replaceAll("\\D+", "");
+    return Integer.parseInt(versionString);
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/K8sVersion.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/K8sVersion.java
@@ -70,15 +70,15 @@ public class K8sVersion {
   }
 
   /**
-   * Returns 'true' if given {@code major.minor} is newer or equal than k8s cluster version. 'false'
-   * if given {@code major.minor} is older.
+   * Returns 'true' if k8s version is newer or equal than given {@code major.minor}. 'false' if k8s
+   * version is older.
    *
    * <p>In case of any issue like infrastructure or parse failures, assume we're on newer version
    * and return 'true'.
    *
    * @param major major version to compare
    * @param minor minor version to compare
-   * @return true if given {@code major.minor} version is newer or equal version than k8s version
+   * @return true if k8s version is newer or equal than given {@code major.minor}
    */
   public boolean newerOrEqualThan(int major, int minor) {
     try {
@@ -88,18 +88,18 @@ public class K8sVersion {
       return true;
     }
 
-    if (major > this.major) {
+    if (this.major > major) {
       return true;
-    } else if (major == this.major) {
-      return minor >= this.minor;
+    } else if (this.major == major) {
+      return this.minor >= minor;
     } else {
       return false;
     }
   }
 
   /**
-   * Returns 'true' if given {@code major.minor} is older than k8s cluster version. 'false' if given
-   * {@code major.minor} is newer or equal.
+   * Returns 'true' if k8s version is older than given {@code major.minor}. 'false' if k8s version
+   * is newer or equal.
    *
    * <p>In case of any issue like infrastructure or parse failures, assume we're on newer version
    * and return 'false'.
@@ -138,8 +138,8 @@ public class K8sVersion {
           versionInfo.getMajor(),
           versionInfo.getMinor(),
           nfe);
-      this.major = 0;
-      this.minor = 0;
+      this.major = Integer.MAX_VALUE;
+      this.minor = Integer.MAX_VALUE;
     }
   }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplier.java
@@ -25,6 +25,7 @@ import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import java.nio.file.Paths;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
@@ -131,11 +132,18 @@ public class FileSecretApplier extends KubernetesSecretApplier<KubernetesEnviron
               .getVolumeMounts()
               .removeIf(vm -> Paths.get(vm.getMountPath()).equals(Paths.get(componentMountPath)));
         }
-        for (String secretFile : secret.getData().keySet()) {
-          container
-              .getVolumeMounts()
-              .add(buildVolumeMount(volumeFromSecret, componentMountPath, secretFile));
-        }
+
+        container
+            .getVolumeMounts()
+            .addAll(
+                secret
+                    .getData()
+                    .keySet()
+                    .stream()
+                    .map(
+                        secretFile ->
+                            buildVolumeMount(volumeFromSecret, componentMountPath, secretFile))
+                    .collect(Collectors.toList()));
       }
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplier.java
@@ -125,6 +125,8 @@ public class FileSecretApplier extends KubernetesSecretApplier<KubernetesEnviron
         // it's not possible to mount multiple volumes on same path on k8s older than 1.15, so we
         // remove the existing mount here to replace it with new one.
         if (k8sVersion.olderThan(1, 15)) {
+          LOG.debug(
+              "Unable to mount multiple VolumeMounts on same path on this k8s version. Removing conflicting volumes in favor of secret mounts.");
           container
               .getVolumeMounts()
               .removeIf(vm -> Paths.get(vm.getMountPath()).equals(Paths.get(componentMountPath)));
@@ -149,6 +151,8 @@ public class FileSecretApplier extends KubernetesSecretApplier<KubernetesEnviron
     // subPaths are supported from k8s v1.15
     if (k8sVersion.newerOrEqualThan(1, 15)) {
       volumeMountBuilder.withSubPath(secretFile);
+    } else {
+      LOG.debug("This version of k8s does not support sutPaths for VolumeMounts.");
     }
 
     return volumeMountBuilder.build();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplier.java
@@ -122,6 +122,8 @@ public class FileSecretApplier extends KubernetesSecretApplier<KubernetesEnviron
               getOverridenComponentPath(component.get(), secret.getMetadata().getName());
         }
         final String componentMountPath = overridePathOptional.orElse(secretMountPath);
+        // it's not possible to mount multiple volumes on same path on k8s older than 1.15, so we
+        // remove the existing mount here to replace it with new one.
         if (k8sVersion.olderThan(1, 15)) {
           container
               .getVolumeMounts()

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/K8sVersionTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/K8sVersionTest.java
@@ -63,47 +63,63 @@ public class K8sVersionTest {
   public void testGreaterOrEqualTrueWhenInfrastructureFails() throws InfrastructureException {
     when(kubernetesClientFactory.create()).thenThrow(new InfrastructureException("eh"));
     assertTrue(k8sVersion.newerOrEqualThan(1, 1));
+    assertTrue(k8sVersion.newerOrEqualThan(-1, -1));
     assertTrue(k8sVersion.newerOrEqualThan(0, 1));
     assertTrue(k8sVersion.newerOrEqualThan(0, 0));
+    assertTrue(k8sVersion.newerOrEqualThan(1337, 1337));
+    assertTrue(k8sVersion.newerOrEqualThan(6655321, 6655321));
   }
 
   @Test
   public void testOlderThanWhenInfrastructureFails() throws InfrastructureException {
     when(kubernetesClientFactory.create()).thenThrow(new InfrastructureException("eh"));
     assertFalse(k8sVersion.olderThan(1, 1));
+    assertFalse(k8sVersion.olderThan(-1, -1));
     assertFalse(k8sVersion.olderThan(0, 1));
     assertFalse(k8sVersion.olderThan(0, 0));
+    assertFalse(k8sVersion.olderThan(1337, 1337));
+    assertFalse(k8sVersion.olderThan(6655321, 6655321));
   }
 
   @Test
   public void testGreaterOrEqualWhenParseFailure() throws ParseException {
     when(kubernetesClient.getVersion()).thenReturn(createDummyVersionInfo("abc", "cde"));
     assertTrue(k8sVersion.newerOrEqualThan(1, 1));
+    assertTrue(k8sVersion.newerOrEqualThan(-1, -1));
     assertTrue(k8sVersion.newerOrEqualThan(0, 1));
     assertTrue(k8sVersion.newerOrEqualThan(0, 0));
+    assertTrue(k8sVersion.newerOrEqualThan(1337, 1337));
+    assertTrue(k8sVersion.newerOrEqualThan(6655321, 6655321));
   }
 
   @Test
   public void testOlderThanWhenParseFailure() throws ParseException {
     when(kubernetesClient.getVersion()).thenReturn(createDummyVersionInfo("abc", "cde"));
     assertFalse(k8sVersion.olderThan(1, 1));
+    assertFalse(k8sVersion.olderThan(-1, -1));
     assertFalse(k8sVersion.olderThan(0, 1));
     assertFalse(k8sVersion.olderThan(0, 0));
+    assertFalse(k8sVersion.olderThan(1337, 1337));
+    assertFalse(k8sVersion.olderThan(6655321, 6655321));
   }
 
   @DataProvider
   public Object[][] greaterThanData() throws ParseException {
     VersionInfo versionInfo = createDummyVersionInfo("2", "10");
     return new Object[][] {
-      {versionInfo, 1, 9, false},
-      {versionInfo, 1, 10, false},
-      {versionInfo, 1, 11, false},
-      {versionInfo, 2, 9, false},
+      {versionInfo, 1, 9, true},
+      {versionInfo, 1, 10, true},
+      {versionInfo, 1, 11, true},
+      {versionInfo, 2, 9, true},
       {versionInfo, 2, 10, true},
-      {versionInfo, 2, 11, true},
-      {versionInfo, 3, 9, true},
-      {versionInfo, 3, 10, true},
-      {versionInfo, 3, 11, true},
+      {versionInfo, 2, 11, false},
+      {versionInfo, 3, 9, false},
+      {versionInfo, 3, 10, false},
+      {versionInfo, 3, 11, false},
+      {createDummyVersionInfo("1", "17+"), 1, 17, true},
+      {createDummyVersionInfo("1", "17+"), 1, 18, false},
+      {createDummyVersionInfo("1", "17+"), 1, 16, true},
+      {createDummyVersionInfo("1", "11+"), 1, 17, false},
     };
   }
 
@@ -111,15 +127,18 @@ public class K8sVersionTest {
   public Object[][] olderThanData() throws ParseException {
     VersionInfo versionInfo = createDummyVersionInfo("2", "10");
     return new Object[][] {
-      {versionInfo, 1, 9, true},
-      {versionInfo, 1, 10, true},
-      {versionInfo, 1, 11, true},
-      {versionInfo, 2, 9, true},
+      {versionInfo, 1, 9, false},
+      {versionInfo, 1, 10, false},
+      {versionInfo, 1, 11, false},
+      {versionInfo, 2, 9, false},
       {versionInfo, 2, 10, false},
-      {versionInfo, 2, 11, false},
-      {versionInfo, 3, 9, false},
-      {versionInfo, 3, 10, false},
-      {versionInfo, 3, 11, false},
+      {versionInfo, 2, 11, true},
+      {versionInfo, 3, 9, true},
+      {versionInfo, 3, 10, true},
+      {versionInfo, 3, 11, true},
+      {createDummyVersionInfo("1", "17+"), 1, 17, false},
+      {createDummyVersionInfo("1", "17+"), 1, 11, false},
+      {createDummyVersionInfo("1", "11+"), 1, 17, true},
     };
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/K8sVersionTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/K8sVersionTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.VersionInfo;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class K8sVersionTest {
+
+  private K8sVersion k8sVersion;
+
+  @Mock KubernetesClientFactory kubernetesClientFactory;
+
+  @Mock KubernetesClient kubernetesClient;
+
+  @BeforeMethod
+  public void setUp() throws InfrastructureException {
+    k8sVersion = new K8sVersion(kubernetesClientFactory);
+    when(kubernetesClientFactory.create()).thenReturn(kubernetesClient);
+  }
+
+  @Test(dataProvider = "greaterThanData")
+  public void testGreaterOrEqual(VersionInfo versionInfo, int major, int minor, boolean expected) {
+    when(kubernetesClient.getVersion()).thenReturn(versionInfo);
+    assertEquals(k8sVersion.newerOrEqualThan(major, minor), expected);
+  }
+
+  @Test(dataProvider = "olderThanData")
+  public void testOlderThan(VersionInfo versionInfo, int major, int minor, boolean expected) {
+    when(kubernetesClient.getVersion()).thenReturn(versionInfo);
+    assertEquals(k8sVersion.olderThan(major, minor), expected);
+  }
+
+  @Test
+  public void testGreaterOrEqualTrueWhenInfrastructureFails() throws InfrastructureException {
+    when(kubernetesClientFactory.create()).thenThrow(new InfrastructureException("eh"));
+    assertTrue(k8sVersion.newerOrEqualThan(1, 1));
+    assertTrue(k8sVersion.newerOrEqualThan(0, 1));
+    assertTrue(k8sVersion.newerOrEqualThan(0, 0));
+  }
+
+  @Test
+  public void testOlderThanWhenInfrastructureFails() throws InfrastructureException {
+    when(kubernetesClientFactory.create()).thenThrow(new InfrastructureException("eh"));
+    assertFalse(k8sVersion.olderThan(1, 1));
+    assertFalse(k8sVersion.olderThan(0, 1));
+    assertFalse(k8sVersion.olderThan(0, 0));
+  }
+
+  @Test
+  public void testGreaterOrEqualWhenParseFailure() throws ParseException {
+    when(kubernetesClient.getVersion()).thenReturn(createDummyVersionInfo("abc", "cde"));
+    assertTrue(k8sVersion.newerOrEqualThan(1, 1));
+    assertTrue(k8sVersion.newerOrEqualThan(0, 1));
+    assertTrue(k8sVersion.newerOrEqualThan(0, 0));
+  }
+
+  @Test
+  public void testOlderThanWhenParseFailure() throws ParseException {
+    when(kubernetesClient.getVersion()).thenReturn(createDummyVersionInfo("abc", "cde"));
+    assertFalse(k8sVersion.olderThan(1, 1));
+    assertFalse(k8sVersion.olderThan(0, 1));
+    assertFalse(k8sVersion.olderThan(0, 0));
+  }
+
+  @DataProvider
+  public Object[][] greaterThanData() throws ParseException {
+    VersionInfo versionInfo = createDummyVersionInfo("2", "10");
+    return new Object[][] {
+      {versionInfo, 1, 9, false},
+      {versionInfo, 1, 10, false},
+      {versionInfo, 1, 11, false},
+      {versionInfo, 2, 9, false},
+      {versionInfo, 2, 10, true},
+      {versionInfo, 2, 11, true},
+      {versionInfo, 3, 9, true},
+      {versionInfo, 3, 10, true},
+      {versionInfo, 3, 11, true},
+    };
+  }
+
+  @DataProvider
+  public Object[][] olderThanData() throws ParseException {
+    VersionInfo versionInfo = createDummyVersionInfo("2", "10");
+    return new Object[][] {
+      {versionInfo, 1, 9, true},
+      {versionInfo, 1, 10, true},
+      {versionInfo, 1, 11, true},
+      {versionInfo, 2, 9, true},
+      {versionInfo, 2, 10, false},
+      {versionInfo, 2, 11, false},
+      {versionInfo, 3, 9, false},
+      {versionInfo, 3, 10, false},
+      {versionInfo, 3, 11, false},
+    };
+  }
+
+  private VersionInfo createDummyVersionInfo(String major, String minor) throws ParseException {
+    Map<String, String> versionData = new HashMap<>();
+    versionData.put(
+        VERSION_KEYS.BUILD_DATE,
+        new SimpleDateFormat(VERSION_KEYS.BUILD_DATE_FORMAT).format(new Date()));
+    versionData.put(VERSION_KEYS.GIT_COMMIT, "3f6f40d");
+    versionData.put(VERSION_KEYS.GIT_VERSION, "v1.17.1+3f6f40d");
+    versionData.put(VERSION_KEYS.GIT_TREE_STATE, "clean");
+    versionData.put(VERSION_KEYS.GO_VERSION, "go1.13.4");
+    versionData.put(VERSION_KEYS.PLATFORM, "linux/amd64");
+    versionData.put(VERSION_KEYS.COMPILER, "gc");
+
+    versionData.put(VERSION_KEYS.MAJOR, major);
+    versionData.put(VERSION_KEYS.MINOR, minor);
+    return new VersionInfo(versionData);
+  }
+
+  private final class VERSION_KEYS {
+
+    public static final String BUILD_DATE = "buildDate";
+    public static final String GIT_COMMIT = "gitCommit";
+    public static final String GIT_VERSION = "gitVersion";
+    public static final String MAJOR = "major";
+    public static final String MINOR = "minor";
+    public static final String GIT_TREE_STATE = "gitTreeState";
+    public static final String PLATFORM = "platform";
+    public static final String GO_VERSION = "goVersion";
+    public static final String COMPILER = "compiler";
+    public static final String BUILD_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplierTest.java
@@ -79,8 +79,8 @@ public class FileSecretApplierTest {
 
   @BeforeMethod
   public void setUp() throws Exception {
-    lenient().when(kubernetesVersion.newerOrEqualThan(1, 15)).thenReturn(true);
-    lenient().when(kubernetesVersion.olderThan(1, 15)).thenReturn(false);
+    lenient().when(kubernetesVersion.newerOrEqualThan(1, 13)).thenReturn(true);
+    lenient().when(kubernetesVersion.olderThan(1, 13)).thenReturn(false);
     secretApplier = new FileSecretApplier(kubernetesVersion);
     when(environment.getPodsData()).thenReturn(singletonMap("pod1", podData));
     when(podData.getRole()).thenReturn(PodRole.DEPLOYMENT);
@@ -482,8 +482,8 @@ public class FileSecretApplierTest {
 
   @Test
   public void shouldNotUseSubpathForOlderK8s() throws InfrastructureException {
-    lenient().when(kubernetesVersion.newerOrEqualThan(1, 15)).thenReturn(false);
-    lenient().when(kubernetesVersion.olderThan(1, 15)).thenReturn(true);
+    lenient().when(kubernetesVersion.newerOrEqualThan(1, 13)).thenReturn(false);
+    lenient().when(kubernetesVersion.olderThan(1, 13)).thenReturn(true);
 
     Container container_match1 = new ContainerBuilder().withName("maven").build();
 
@@ -538,7 +538,7 @@ public class FileSecretApplierTest {
             .getVolumeMounts()
             .get(0);
     assertEquals(mount1.getName(), "test_secret");
-    assertEquals(mount1.getMountPath(), "/home/user/.m2/settings.xml");
+    assertEquals(mount1.getMountPath(), "/home/user/.m2");
     assertNull(mount1.getSubPath());
   }
 
@@ -624,8 +624,8 @@ public class FileSecretApplierTest {
 
   @Test
   public void shouldOverrideExistingVolumeMountsOnOlderK8s() throws InfrastructureException {
-    lenient().when(kubernetesVersion.newerOrEqualThan(1, 15)).thenReturn(false);
-    lenient().when(kubernetesVersion.olderThan(1, 15)).thenReturn(true);
+    lenient().when(kubernetesVersion.newerOrEqualThan(1, 13)).thenReturn(false);
+    lenient().when(kubernetesVersion.olderThan(1, 13)).thenReturn(true);
 
     Container container_match1 =
         new ContainerBuilder()
@@ -688,7 +688,7 @@ public class FileSecretApplierTest {
             .getVolumeMounts()
             .get(0);
     assertEquals(secretMount.getName(), "test_secret");
-    assertEquals(secretMount.getMountPath(), "/home/user/.m2/settings.xml");
+    assertEquals(secretMount.getMountPath(), "/home/user/.m2");
     assertNull(secretMount.getSubPath());
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplierTest.java
@@ -49,6 +49,7 @@ import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfi
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodRole;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.K8sVersion;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -69,7 +70,9 @@ public class FileSecretApplierTest {
 
   @Mock private RuntimeIdentity runtimeIdentity;
 
-  FileSecretApplier secretApplier = new FileSecretApplier();
+  @Mock private K8sVersion kubernetesVersion;
+
+  FileSecretApplier secretApplier = new FileSecretApplier(kubernetesVersion);
 
   @BeforeMethod
   public void setUp() throws Exception {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/FileSecretApplierTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secr
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.KubernetesSecretApplier.ANNOTATION_AUTOMOUNT;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.SecretAsContainerResourceProvisioner.ANNOTATION_MOUNT_AS;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -26,6 +27,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -40,6 +42,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.ComponentImpl;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.DevfileImpl;
@@ -72,10 +75,13 @@ public class FileSecretApplierTest {
 
   @Mock private K8sVersion kubernetesVersion;
 
-  FileSecretApplier secretApplier = new FileSecretApplier(kubernetesVersion);
+  FileSecretApplier secretApplier;
 
   @BeforeMethod
   public void setUp() throws Exception {
+    lenient().when(kubernetesVersion.newerOrEqualThan(1, 15)).thenReturn(true);
+    lenient().when(kubernetesVersion.olderThan(1, 15)).thenReturn(false);
+    secretApplier = new FileSecretApplier(kubernetesVersion);
     when(environment.getPodsData()).thenReturn(singletonMap("pod1", podData));
     when(podData.getRole()).thenReturn(PodRole.DEPLOYMENT);
     when(podData.getSpec()).thenReturn(podSpec);
@@ -472,5 +478,217 @@ public class FileSecretApplierTest {
             .build();
     when(secrets.get(any(LabelSelector.class))).thenReturn(singletonList(secret));
     secretApplier.applySecret(environment, runtimeIdentity, secret);
+  }
+
+  @Test
+  public void shouldNotUseSubpathForOlderK8s() throws InfrastructureException {
+    lenient().when(kubernetesVersion.newerOrEqualThan(1, 15)).thenReturn(false);
+    lenient().when(kubernetesVersion.olderThan(1, 15)).thenReturn(true);
+
+    Container container_match1 = new ContainerBuilder().withName("maven").build();
+
+    PodSpec localSpec =
+        new PodSpecBuilder().withContainers(ImmutableList.of(container_match1)).build();
+
+    when(podData.getSpec()).thenReturn(localSpec);
+
+    Secret secret =
+        new SecretBuilder()
+            .withData(ImmutableMap.of("settings.xml", "random"))
+            .withMetadata(
+                new ObjectMetaBuilder()
+                    .withName("test_secret")
+                    .withAnnotations(
+                        ImmutableMap.of(
+                            ANNOTATION_MOUNT_AS,
+                            "file",
+                            ANNOTATION_MOUNT_PATH,
+                            "/home/user/.m2",
+                            ANNOTATION_AUTOMOUNT,
+                            "true"))
+                    .withLabels(emptyMap())
+                    .build())
+            .build();
+
+    secretApplier.applySecret(environment, runtimeIdentity, secret);
+
+    // pod has volume created
+    assertEquals(environment.getPodsData().get("pod1").getSpec().getVolumes().size(), 1);
+    Volume volume = environment.getPodsData().get("pod1").getSpec().getVolumes().get(0);
+    assertEquals(volume.getName(), "test_secret");
+    assertEquals(volume.getSecret().getSecretName(), "test_secret");
+
+    assertEquals(
+        environment
+            .getPodsData()
+            .get("pod1")
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getVolumeMounts()
+            .size(),
+        1);
+    VolumeMount mount1 =
+        environment
+            .getPodsData()
+            .get("pod1")
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getVolumeMounts()
+            .get(0);
+    assertEquals(mount1.getName(), "test_secret");
+    assertEquals(mount1.getMountPath(), "/home/user/.m2/settings.xml");
+    assertNull(mount1.getSubPath());
+  }
+
+  @Test
+  public void shouldNotOverrideExistingVolumeMounts() throws InfrastructureException {
+    Container container_match1 =
+        new ContainerBuilder()
+            .withName("maven")
+            .withVolumeMounts(
+                new VolumeMountBuilder()
+                    .withName("existing-volume")
+                    .withMountPath("/home/user/.m2")
+                    .build())
+            .build();
+
+    PodSpec localSpec =
+        new PodSpecBuilder().withContainers(ImmutableList.of(container_match1)).build();
+
+    when(podData.getSpec()).thenReturn(localSpec);
+
+    Secret secret =
+        new SecretBuilder()
+            .withData(ImmutableMap.of("settings.xml", "random"))
+            .withMetadata(
+                new ObjectMetaBuilder()
+                    .withName("test_secret")
+                    .withAnnotations(
+                        ImmutableMap.of(
+                            ANNOTATION_MOUNT_AS,
+                            "file",
+                            ANNOTATION_MOUNT_PATH,
+                            "/home/user/.m2",
+                            ANNOTATION_AUTOMOUNT,
+                            "true"))
+                    .withLabels(emptyMap())
+                    .build())
+            .build();
+
+    secretApplier.applySecret(environment, runtimeIdentity, secret);
+
+    // pod has volume created
+    assertEquals(environment.getPodsData().get("pod1").getSpec().getVolumes().size(), 1);
+    Volume volume = environment.getPodsData().get("pod1").getSpec().getVolumes().get(0);
+    assertEquals(volume.getName(), "test_secret");
+    assertEquals(volume.getSecret().getSecretName(), "test_secret");
+
+    assertEquals(
+        environment
+            .getPodsData()
+            .get("pod1")
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getVolumeMounts()
+            .size(),
+        2);
+    VolumeMount mount1 =
+        environment
+            .getPodsData()
+            .get("pod1")
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getVolumeMounts()
+            .get(0);
+    assertEquals(mount1.getName(), "existing-volume");
+    assertEquals(mount1.getMountPath(), "/home/user/.m2");
+    assertNull(mount1.getSubPath());
+
+    VolumeMount mount2 =
+        environment
+            .getPodsData()
+            .get("pod1")
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getVolumeMounts()
+            .get(1);
+    assertEquals(mount2.getName(), "test_secret");
+    assertEquals(mount2.getMountPath(), "/home/user/.m2/settings.xml");
+    assertEquals(mount2.getSubPath(), "settings.xml");
+  }
+
+  @Test
+  public void shouldOverrideExistingVolumeMountsOnOlderK8s() throws InfrastructureException {
+    lenient().when(kubernetesVersion.newerOrEqualThan(1, 15)).thenReturn(false);
+    lenient().when(kubernetesVersion.olderThan(1, 15)).thenReturn(true);
+
+    Container container_match1 =
+        new ContainerBuilder()
+            .withName("maven")
+            .withVolumeMounts(
+                new VolumeMountBuilder()
+                    .withName("existing-volume")
+                    .withMountPath("/home/user/.m2")
+                    .build())
+            .build();
+
+    PodSpec localSpec =
+        new PodSpecBuilder().withContainers(ImmutableList.of(container_match1)).build();
+
+    when(podData.getSpec()).thenReturn(localSpec);
+
+    Secret secret =
+        new SecretBuilder()
+            .withData(ImmutableMap.of("settings.xml", "random"))
+            .withMetadata(
+                new ObjectMetaBuilder()
+                    .withName("test_secret")
+                    .withAnnotations(
+                        ImmutableMap.of(
+                            ANNOTATION_MOUNT_AS,
+                            "file",
+                            ANNOTATION_MOUNT_PATH,
+                            "/home/user/.m2",
+                            ANNOTATION_AUTOMOUNT,
+                            "true"))
+                    .withLabels(emptyMap())
+                    .build())
+            .build();
+
+    secretApplier.applySecret(environment, runtimeIdentity, secret);
+
+    // pod has volume created
+    assertEquals(environment.getPodsData().get("pod1").getSpec().getVolumes().size(), 1);
+    Volume volume = environment.getPodsData().get("pod1").getSpec().getVolumes().get(0);
+    assertEquals(volume.getName(), "test_secret");
+    assertEquals(volume.getSecret().getSecretName(), "test_secret");
+
+    assertEquals(
+        environment
+            .getPodsData()
+            .get("pod1")
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getVolumeMounts()
+            .size(),
+        1);
+    VolumeMount secretMount =
+        environment
+            .getPodsData()
+            .get("pod1")
+            .getSpec()
+            .getContainers()
+            .get(0)
+            .getVolumeMounts()
+            .get(0);
+    assertEquals(secretMount.getName(), "test_secret");
+    assertEquals(secretMount.getMountPath(), "/home/user/.m2/settings.xml");
+    assertNull(secretMount.getSubPath());
   }
 }


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Checks used k8s version and decides how to mount secrets as files. On k8s v1.13+, we're using subPath so it's possible to mount secret beside already existing files. On older versions, we don't use it as it is not supported and we override existing volume mounts on same path from the devfile with secret mount.

### What issues does this PR fix or reference?
#17213

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
https://github.com/eclipse/che-docs/pull/1392
