### PR TITLE
Stabilising LS tests.

### DIFF
--- a/tests/e2e/tests/devfiles/JavaMaven.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaMaven.spec.ts
@@ -28,13 +28,17 @@ suite(`${stack} test`, async () => {
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
+    suite('Test opening file', async () => {
+        // opening file that soon should give time for LS to initialize
+        projectAndFileTests.openFile(fileFolderPath, tabTitle);
+    });
+
     suite('Validation of workspace build and run', async () => {
         codeExecutionTests.runTask(taskName, 120_000);
         codeExecutionTests.closeTerminal(taskName);
     });
 
     suite('Language server validation', async () => {
-        projectAndFileTests.openFile(fileFolderPath, tabTitle);
         commonLsTests.suggestionInvoking(tabTitle, 10, 20, 'append(char c) : PrintStream');
         commonLsTests.errorHighlighting(tabTitle, 'error', 11);
         commonLsTests.autocomplete(tabTitle, 10, 11, 'System - java.lang');

--- a/tests/e2e/tests/devfiles/Quarkus.spec.ts
+++ b/tests/e2e/tests/devfiles/Quarkus.spec.ts
@@ -30,17 +30,17 @@ suite(`${workspaceStack} test`, async () => {
         workspaceHandler.createAndOpenWorkspace(workspaceStack);
         projectManager.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
-    suite(`'Language server validation'`, async () => {
+
+    suite(`Test opening the file`, async () => {
+        // opening file that soon should give time for LS to initialize
         projectManager.openFile(fileFolderPath, fileName);
-        commonLsTests.errorHighlighting(fileName, 'error_text;', 7);
-        commonLsTests.suggestionInvoking(fileName, 8, 33, 'String');
-        commonLsTests.autocomplete(fileName, 8, 33, 'String');
-        commonLsTests.codeNavigation(fileName, 8, 33, 'String.class');
     });
+
     suite('Package Quarkus application', async () => {
         codeExecutionHelper.runTask(taskPackage, 180_000);
         codeExecutionHelper.closeTerminal(taskPackage);
     });
+
     suite.skip('Package Quarkus Native bundle', async () => { // enable again once https://github.com/eclipse/che/issues/17356 is fixed
         codeExecutionHelper.runTask(taskPackageNative, 600_000);
         codeExecutionHelper.closeTerminal(taskPackageNative);
@@ -48,6 +48,14 @@ suite(`${workspaceStack} test`, async () => {
     suite.skip('Start Quarkus Native application', async () => { // enable again once https://github.com/eclipse/che/issues/17356 is fixed
         codeExecutionHelper.runTaskWithDialogShellAndOpenLink(taskStartNative, taskExpectedDialogText, 90_000);
     });
+
+    suite(`'Language server validation'`, async () => {
+        commonLsTests.errorHighlighting(fileName, 'error_text;', 7);
+        commonLsTests.suggestionInvoking(fileName, 8, 33, 'String');
+        commonLsTests.autocomplete(fileName, 8, 33, 'String');
+        commonLsTests.codeNavigation(fileName, 8, 33, 'String.class');
+    });
+
     suite('Stop and remove workspace', async() => {
         let workspaceName = 'not defined';
         suiteSetup( async () => {

--- a/tests/e2e/testsLibrary/LsTests.ts
+++ b/tests/e2e/testsLibrary/LsTests.ts
@@ -68,6 +68,7 @@ const ide: Ide = e2eContainer.get(CLASSES.Ide);
 
  export function codeNavigation(openedFile: string, line: number, char: number, codeNavigationClassName: string) {
     test('Codenavigation', async () => {
+        // adding retry to fix https://github.com/eclipse/che/issues/17411
         try {
             await editor.moveCursorToLineAndChar(openedFile, line, char);
             await editor.performKeyCombination(openedFile, Key.chord(Key.CONTROL, Key.F12));

--- a/tests/e2e/testsLibrary/LsTests.ts
+++ b/tests/e2e/testsLibrary/LsTests.ts
@@ -68,8 +68,20 @@ const ide: Ide = e2eContainer.get(CLASSES.Ide);
 
  export function codeNavigation(openedFile: string, line: number, char: number, codeNavigationClassName: string) {
     test('Codenavigation', async () => {
-        await editor.moveCursorToLineAndChar(openedFile, line, char);
-        await editor.performKeyCombination(openedFile, Key.chord(Key.CONTROL, Key.F12));
-        await editor.waitEditorAvailable(codeNavigationClassName);
+        try {
+            await editor.moveCursorToLineAndChar(openedFile, line, char);
+            await editor.performKeyCombination(openedFile, Key.chord(Key.CONTROL, Key.F12));
+            await editor.waitEditorAvailable(codeNavigationClassName);
+        } catch (err) {
+            if (err instanceof error.TimeoutError) {
+                Logger.warn('Code navigatino didn\'t work. Trying again.');
+                await editor.moveCursorToLineAndChar(openedFile, line, char);
+                await editor.performKeyCombination(openedFile, Key.chord(Key.CONTROL, Key.F12));
+                await editor.waitEditorAvailable(codeNavigationClassName);
+            } else {
+                Logger.error('Code navigation didn\'t work even after retrying.');
+                throw err;
+            }
+        }
     });
  }

--- a/tests/e2e/testsLibrary/LsTests.ts
+++ b/tests/e2e/testsLibrary/LsTests.ts
@@ -74,7 +74,7 @@ const ide: Ide = e2eContainer.get(CLASSES.Ide);
             await editor.waitEditorAvailable(codeNavigationClassName);
         } catch (err) {
             if (err instanceof error.TimeoutError) {
-                Logger.warn('Code navigatino didn\'t work. Trying again.');
+                Logger.warn('Code navigation didn\'t work. Trying again.');
                 await editor.moveCursorToLineAndChar(openedFile, line, char);
                 await editor.performKeyCombination(openedFile, Key.chord(Key.CONTROL, Key.F12));
                 await editor.waitEditorAvailable(codeNavigationClassName);


### PR DESCRIPTION
### What does this PR do?
Stabilizing LS tests.
 - opening file at the beginning of tests, so LS has enough time to initialize
 - add retry for code navigation to prevent false negatives

### What issues does this PR fix or reference?
There is obvious instability for LS test of code navigation - we see the failures in nightly upstream tests and in periodic Hosted Che tests.

Issue https://github.com/eclipse/che/issues/17411