### PR TITLE
Add properties that defines available values for storage types and default type

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -524,13 +524,21 @@ che.workspace.plugin_registry_url=https://che-plugin-registry.prod-preview.opens
 # In case Che plugins tooling is not needed value 'NULL' should be used
 che.workspace.devfile_registry_url=https://che-devfile-registry.prod-preview.openshift.io/
 
-# Defines a default value for persist volumes that clients like Dashboard
-# should propose for users during workspace creation.
-# Possible values: true or false
-# In case of true - PersistentVolumeClaims are used by declared volumes by user and plugins. `true`
-# value is supposed not to be set explicitly in Devfile attributes since it's default fixed behaviour.
-# In case of false - emptyDir is used instead of PVCs. Note that data will be lost after workspace restart.
-che.workspace.persist_volumes.default=true
+# The configuration property that defines available values for storage types that clients like
+# Dashboard should propose for users during workspace creation/update.
+# Available values:
+#   - 'persistent': Persistent Storage slow I/O but persistent.
+#   - 'ephemeral': Ephemeral Storage allows for faster I/O but may have limited storage
+#       and is not persistent.
+#   - 'async': Experimental feature: Asynchronous storage is combination of Ephemeral
+#       and Persistent storage. Allows for faster I/O and keep your changes, will backup on stop
+#       and restore on start workspace.
+che.workspace.storage.available_types=persistent,ephemeral,async
+
+# The configuration property that defines a default value for storage type that clients like
+# Dashboard should propose for users during workspace creation/update.
+# The 'async' value not recommended as default type since it's experimental
+che.workspace.storage.default_type=persistent
 
 # Configures in which way secure servers will be protected with authentication.
 # Suitable values:

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -538,7 +538,7 @@ che.workspace.storage.available_types=persistent,ephemeral,async
 # The configuration property that defines a default value for storage type that clients like
 # Dashboard should propose for users during workspace creation/update.
 # The 'async' value not recommended as default type since it's experimental
-che.workspace.storage.default_type=persistent
+che.workspace.storage.preferred_type=persistent
 
 # Configures in which way secure servers will be protected with authentication.
 # Suitable values:

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -49,11 +49,11 @@ public final class Constants {
       "che.workspace.storage.available_types";
 
   /**
-   * The configuration property that defines a default value for storage type that clients like
+   * The configuration property that defines a preferred value for storage type that clients like
    * Dashboard should propose for users during workspace creation/update.
    */
-  public static final String CHE_WORKSPACE_STORAGE_DEFAULT_TYPE =
-      "che.workspace.storage.default_type";
+  public static final String CHE_WORKSPACE_STORAGE_PREFERRED_TYPE =
+      "che.workspace.storage.preferred_type";
 
   /** Property name for Che plugin registry url. */
   public static final String CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY =

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -42,21 +42,18 @@ public final class Constants {
   public static final String CHE_WORKSPACE_AUTO_START = "che.workspace.auto_start";
 
   /**
-   * The configuration property that defines a default value for persist volumes that clients like
-   * Dashboard should propose for users during workspace creation.
-   *
-   * <p>Possible values: true or false
-   *
-   * <ul>
-   *   <li>In case of true - PersistentVolumeClaims are used by declared volumes by user and
-   *       plugins. `true` value is supposed not to be set explicitly in Devfile attributes since
-   *       it's default fixed behaviour.
-   *   <li>In case of false - emptyDir is used instead of PVCs. Note that data will be lost after
-   *       workspace restart.
-   * </ul>
+   * The configuration property that defines available values for storage types that clients like
+   * Dashboard should propose for users during workspace creation/update.
    */
-  public static final String CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY =
-      "che.workspace.persist_volumes.default";
+  public static final String CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES =
+      "che.workspace.storage.available_types";
+
+  /**
+   * The configuration property that defines a default value for storage type that clients like
+   * Dashboard should propose for users during workspace creation/update.
+   */
+  public static final String CHE_WORKSPACE_STORAGE_DEFAULT_TYPE =
+      "che.workspace.storage.default_type";
 
   /** Property name for Che plugin registry url. */
   public static final String CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY =

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -847,15 +847,8 @@ public class WorkspaceService extends Service {
     if (devfileRegistryUrl != null) {
       settings.put("cheWorkspaceDevfileRegistryUrl", devfileRegistryUrl);
     }
-
-    if (availableStorageTypes != null) {
-      settings.put(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES, availableStorageTypes);
-    }
-
-    if (defaultStorageType != null) {
-      settings.put(CHE_WORKSPACE_STORAGE_DEFAULT_TYPE, defaultStorageType);
-    }
-
+    settings.put(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES, availableStorageTypes);
+    settings.put(CHE_WORKSPACE_STORAGE_DEFAULT_TYPE, defaultStorageType);
     return settings.build();
   }
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -21,8 +21,9 @@ import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
 import static org.eclipse.che.api.workspace.server.WorkspaceKeyValidator.validateKey;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_DEVFILE_REGISTRY_URL_PROPERTY;
-import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_DEFAULT_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_START;
 import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_START_LOG_LIMIT_BYTES;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
@@ -110,8 +111,9 @@ public class WorkspaceService extends Service {
   private final String apiEndpoint;
   private final boolean cheWorkspaceAutoStart;
   private final FileContentProvider devfileContentProvider;
-  private final boolean defaultPersistVolumes;
   private final Long logLimitBytes;
+  private final String availableStorageTypes;
+  private final String defaultStorageType;
 
   @Inject
   public WorkspaceService(
@@ -122,9 +124,10 @@ public class WorkspaceService extends Service {
       WorkspaceLinksGenerator linksGenerator,
       @Named(CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY) @Nullable String pluginRegistryUrl,
       @Named(CHE_WORKSPACE_DEVFILE_REGISTRY_URL_PROPERTY) @Nullable String devfileRegistryUrl,
-      @Named(CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY) boolean defaultPersistVolumes,
       URLFetcher urlFetcher,
-      @Named(DEBUG_WORKSPACE_START_LOG_LIMIT_BYTES) Long logLimitBytes) {
+      @Named(DEBUG_WORKSPACE_START_LOG_LIMIT_BYTES) Long logLimitBytes,
+      @Named(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES) String availableStorageTypes,
+      @Named(CHE_WORKSPACE_STORAGE_DEFAULT_TYPE) String defaultStorageType) {
     this.apiEndpoint = apiEndpoint;
     this.cheWorkspaceAutoStart = cheWorkspaceAutoStart;
     this.workspaceManager = workspaceManager;
@@ -133,8 +136,9 @@ public class WorkspaceService extends Service {
     this.pluginRegistryUrl = pluginRegistryUrl;
     this.devfileRegistryUrl = devfileRegistryUrl;
     this.devfileContentProvider = new URLFileContentProvider(null, urlFetcher);
-    this.defaultPersistVolumes = defaultPersistVolumes;
     this.logLimitBytes = logLimitBytes;
+    this.availableStorageTypes = availableStorageTypes;
+    this.defaultStorageType = defaultStorageType;
   }
 
   @POST
@@ -844,7 +848,13 @@ public class WorkspaceService extends Service {
       settings.put("cheWorkspaceDevfileRegistryUrl", devfileRegistryUrl);
     }
 
-    settings.put(CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY, Boolean.toString(defaultPersistVolumes));
+    if (availableStorageTypes != null) {
+      settings.put(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES, availableStorageTypes);
+    }
+
+    if (defaultStorageType != null) {
+      settings.put(CHE_WORKSPACE_STORAGE_DEFAULT_TYPE, defaultStorageType);
+    }
 
     return settings.build();
   }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -23,7 +23,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_DEVFILE_REGISTRY_URL_PROPERTY;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PLUGIN_REGISTRY_URL_PROPERTY;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES;
-import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_DEFAULT_TYPE;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_PREFERRED_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_START;
 import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_START_LOG_LIMIT_BYTES;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
@@ -113,7 +113,7 @@ public class WorkspaceService extends Service {
   private final FileContentProvider devfileContentProvider;
   private final Long logLimitBytes;
   private final String availableStorageTypes;
-  private final String defaultStorageType;
+  private final String preferredStorageType;
 
   @Inject
   public WorkspaceService(
@@ -127,7 +127,7 @@ public class WorkspaceService extends Service {
       URLFetcher urlFetcher,
       @Named(DEBUG_WORKSPACE_START_LOG_LIMIT_BYTES) Long logLimitBytes,
       @Named(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES) String availableStorageTypes,
-      @Named(CHE_WORKSPACE_STORAGE_DEFAULT_TYPE) String defaultStorageType) {
+      @Named(CHE_WORKSPACE_STORAGE_PREFERRED_TYPE) String preferredStorageType) {
     this.apiEndpoint = apiEndpoint;
     this.cheWorkspaceAutoStart = cheWorkspaceAutoStart;
     this.workspaceManager = workspaceManager;
@@ -138,7 +138,7 @@ public class WorkspaceService extends Service {
     this.devfileContentProvider = new URLFileContentProvider(null, urlFetcher);
     this.logLimitBytes = logLimitBytes;
     this.availableStorageTypes = availableStorageTypes;
-    this.defaultStorageType = defaultStorageType;
+    this.preferredStorageType = preferredStorageType;
   }
 
   @POST
@@ -848,7 +848,7 @@ public class WorkspaceService extends Service {
       settings.put("cheWorkspaceDevfileRegistryUrl", devfileRegistryUrl);
     }
     settings.put(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES, availableStorageTypes);
-    settings.put(CHE_WORKSPACE_STORAGE_DEFAULT_TYPE, defaultStorageType);
+    settings.put(CHE_WORKSPACE_STORAGE_PREFERRED_TYPE, preferredStorageType);
     return settings.build();
   }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -25,7 +25,7 @@ import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.RUN
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
 import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES;
-import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_DEFAULT_TYPE;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_PREFERRED_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_START;
 import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_START_LOG_LIMIT_BYTES;
 import static org.eclipse.che.api.workspace.shared.Constants.SUPPORTED_RECIPE_TYPES;
@@ -137,7 +137,7 @@ public class WorkspaceServiceTest {
   private static final EnvironmentFilter FILTER = new EnvironmentFilter();
 
   private final String availableStorageTypes = "persistent,ephemeral,async";
-  private final String defaultStorageType = "persistent";
+  private final String preferredStorageType = "persistent";
 
   @SuppressWarnings("unused") // is declared for deploying by everrest-assured
   private CheJsonProvider jsonProvider = new CheJsonProvider(Collections.emptySet());
@@ -163,7 +163,7 @@ public class WorkspaceServiceTest {
             urlFetcher,
             LOG_LIMIT_BYTES,
             availableStorageTypes,
-            defaultStorageType);
+            preferredStorageType);
   }
 
   @Test
@@ -1375,7 +1375,7 @@ public class WorkspaceServiceTest {
             .put("cheWorkspacePluginRegistryUrl", CHE_WORKSPACE_PLUGIN_REGISTRY_ULR)
             .put("cheWorkspaceDevfileRegistryUrl", CHE_WORKSPACE_DEVFILE_REGISTRY_ULR)
             .put(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES, availableStorageTypes)
-            .put(CHE_WORKSPACE_STORAGE_DEFAULT_TYPE, defaultStorageType)
+            .put(CHE_WORKSPACE_STORAGE_PREFERRED_TYPE, preferredStorageType)
             .build());
   }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceServiceTest.java
@@ -23,9 +23,12 @@ import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.MEMORY_LIMIT_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.runtime.MachineStatus.RUNNING;
 import static org.eclipse.che.api.workspace.server.DtoConverter.asDto;
-import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_AUTO_START;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES;
+import static org.eclipse.che.api.workspace.shared.Constants.CHE_WORKSPACE_STORAGE_DEFAULT_TYPE;
 import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_START;
 import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_START_LOG_LIMIT_BYTES;
+import static org.eclipse.che.api.workspace.shared.Constants.SUPPORTED_RECIPE_TYPES;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
@@ -79,7 +82,6 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.token.MachineTokenProvider;
-import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.api.workspace.shared.dto.CommandDto;
 import org.eclipse.che.api.workspace.shared.dto.EnvironmentDto;
 import org.eclipse.che.api.workspace.shared.dto.MachineDto;
@@ -134,6 +136,9 @@ public class WorkspaceServiceTest {
   @SuppressWarnings("unused")
   private static final EnvironmentFilter FILTER = new EnvironmentFilter();
 
+  private final String availableStorageTypes = "persistent,ephemeral,async";
+  private final String defaultStorageType = "persistent";
+
   @SuppressWarnings("unused") // is declared for deploying by everrest-assured
   private CheJsonProvider jsonProvider = new CheJsonProvider(Collections.emptySet());
 
@@ -155,9 +160,10 @@ public class WorkspaceServiceTest {
             linksGenerator,
             CHE_WORKSPACE_PLUGIN_REGISTRY_ULR,
             CHE_WORKSPACE_DEVFILE_REGISTRY_ULR,
-            CHE_WORKSPACES_DEFAULT_PERSIST_VOLUMES,
             urlFetcher,
-            LOG_LIMIT_BYTES);
+            LOG_LIMIT_BYTES,
+            availableStorageTypes,
+            defaultStorageType);
   }
 
   @Test
@@ -1348,7 +1354,7 @@ public class WorkspaceServiceTest {
   }
 
   @Test
-  public void shouldBeAbleToGetSettings() throws Exception {
+  public void shouldBeAbleToGetSettings() {
     when(wsManager.getSupportedRecipes()).thenReturn(ImmutableSet.of("dockerimage", "dockerfile"));
 
     final Response response =
@@ -1363,17 +1369,14 @@ public class WorkspaceServiceTest {
         new Gson().fromJson(response.print(), new TypeToken<Map<String, String>>() {}.getType());
     assertEquals(
         settings,
-        ImmutableMap.of(
-            Constants.SUPPORTED_RECIPE_TYPES,
-            "dockerimage,dockerfile",
-            Constants.CHE_WORKSPACE_AUTO_START,
-            "true",
-            "cheWorkspacePluginRegistryUrl",
-            CHE_WORKSPACE_PLUGIN_REGISTRY_ULR,
-            "cheWorkspaceDevfileRegistryUrl",
-            CHE_WORKSPACE_DEVFILE_REGISTRY_ULR,
-            CHE_WORKSPACE_PERSIST_VOLUMES_PROPERTY,
-            Boolean.toString(CHE_WORKSPACES_DEFAULT_PERSIST_VOLUMES)));
+        new ImmutableMap.Builder<>()
+            .put(SUPPORTED_RECIPE_TYPES, "dockerimage,dockerfile")
+            .put(CHE_WORKSPACE_AUTO_START, "true")
+            .put("cheWorkspacePluginRegistryUrl", CHE_WORKSPACE_PLUGIN_REGISTRY_ULR)
+            .put("cheWorkspaceDevfileRegistryUrl", CHE_WORKSPACE_DEVFILE_REGISTRY_ULR)
+            .put(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES, availableStorageTypes)
+            .put(CHE_WORKSPACE_STORAGE_DEFAULT_TYPE, defaultStorageType)
+            .build());
   }
 
   private static String unwrapError(Response response) {


### PR DESCRIPTION

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

### What does this PR do?

1. Add properties that defines available values for storage types and default type
2. Property `che.workspace.persist_volumes.default` removed because it is not actual


### What issues does this PR fix or reference?

https://github.com/eclipse/che/issues/17230 

