### PR TITLE
Various fixes after merging PR #16972

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -533,6 +533,12 @@ che.workspace.devfile_registry_url=https://che-devfile-registry.prod-preview.ope
 #   - 'async': Experimental feature: Asynchronous storage is combination of Ephemeral
 #       and Persistent storage. Allows for faster I/O and keep your changes, will backup on stop
 #       and restore on start workspace.
+#       Will work only if:
+#           - che.infra.kubernetes.pvc.strategy='common'
+#           - che.limits.user.workspaces.run.count=1
+#           - che.infra.kubernetes.namespace.allow_user_defined=false
+#           - che.infra.kubernetes.namespace.default contains <username>
+#      in other way remove 'async'.
 che.workspace.storage.available_types=persistent,ephemeral,async
 
 # The configuration property that defines a default value for storage type that clients like

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -538,7 +538,7 @@ che.workspace.devfile_registry_url=https://che-devfile-registry.prod-preview.ope
 #           - che.limits.user.workspaces.run.count=1
 #           - che.infra.kubernetes.namespace.allow_user_defined=false
 #           - che.infra.kubernetes.namespace.default contains <username>
-#      in other way remove 'async'.
+#      in other cases remove 'async' from the list.
 che.workspace.storage.available_types=persistent,ephemeral,async
 
 # The configuration property that defines a default value for storage type that clients like

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidator.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidator.java
@@ -60,7 +60,7 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
   private final int runtimesPerUser;
   private final boolean isNamespaceStrategyNotValid;
   private final boolean isPvcStrategyNotValid;
-  private final boolean runtimesPerUserLimited;
+  private final boolean singleRuntimeAllowed;
 
   @Inject
   public AsyncStorageModeValidator(
@@ -75,7 +75,7 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
     this.runtimesPerUser = runtimesPerUser;
 
     this.isPvcStrategyNotValid = !COMMON_STRATEGY.equals(pvcStrategy);
-    this.runtimesPerUserLimited = runtimesPerUser > 1;
+    this.singleRuntimeAllowed = runtimesPerUser == 1;
     this.isNamespaceStrategyNotValid =
         isNullOrEmpty(defaultNamespaceName) || !defaultNamespaceName.contains("<username>");
   }
@@ -120,7 +120,7 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
   }
 
   private void runtimesPerUserValidation() throws ValidationException {
-    if (runtimesPerUserLimited) {
+    if (!singleRuntimeAllowed) {
       String message =
           format(
               "Workspace configuration not valid: Asynchronous storage available only if 'che.limits.user.workspaces.run.count' set to 1, but got %s",

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidator.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/AsyncStorageModeValidator.java
@@ -11,13 +11,13 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
 import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.CommonPVCStrategy.COMMON_STRATEGY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.EphemeralWorkspaceUtility.isEphemeral;
 
-import com.google.common.base.Strings;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -57,8 +57,10 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
 
   private final String pvcStrategy;
   private final boolean allowUserDefinedNamespaces;
-  private final String defaultNamespaceName;
   private final int runtimesPerUser;
+  private final boolean isNamespaceStrategyNotValid;
+  private final boolean isPvcStrategyNotValid;
+  private final boolean runtimesPerUserLimited;
 
   @Inject
   public AsyncStorageModeValidator(
@@ -70,8 +72,12 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
 
     this.pvcStrategy = pvcStrategy;
     this.allowUserDefinedNamespaces = allowUserDefinedNamespaces;
-    this.defaultNamespaceName = defaultNamespaceName;
     this.runtimesPerUser = runtimesPerUser;
+
+    this.isPvcStrategyNotValid = !COMMON_STRATEGY.equals(pvcStrategy);
+    this.runtimesPerUserLimited = runtimesPerUser > 1;
+    this.isNamespaceStrategyNotValid =
+        isNullOrEmpty(defaultNamespaceName) || !defaultNamespaceName.contains("<username>");
   }
 
   @Override
@@ -114,7 +120,7 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
   }
 
   private void runtimesPerUserValidation() throws ValidationException {
-    if (runtimesPerUser > 1) {
+    if (runtimesPerUserLimited) {
       String message =
           format(
               "Workspace configuration not valid: Asynchronous storage available only if 'che.limits.user.workspaces.run.count' set to 1, but got %s",
@@ -125,8 +131,7 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
   }
 
   private void nameSpaceStrategyValidation() throws ValidationException {
-    if (Strings.isNullOrEmpty(defaultNamespaceName)
-        || !defaultNamespaceName.contains("<username>")) {
+    if (isNamespaceStrategyNotValid) {
       String message =
           "Workspace configuration not valid: Asynchronous storage available only for 'per-user' namespace strategy";
       LOG.warn(message);
@@ -146,7 +151,7 @@ public class AsyncStorageModeValidator implements WorkspaceAttributeValidator {
   }
 
   private void pvcStrategyValidation() throws ValidationException {
-    if (!COMMON_STRATEGY.equals(pvcStrategy)) {
+    if (isPvcStrategyNotValid) {
       String message =
           format(
               "Workspace configuration not valid: Asynchronous storage available only for 'common' PVC strategy, but got %s",

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/AsyncStorageProvisioner.java
@@ -69,6 +69,7 @@ import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.ServerServiceBuilder;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.slf4j.Logger;
@@ -369,15 +370,18 @@ public class AsyncStorageProvisioner {
             .withPort(SERVICE_PORT)
             .withTargetPort(targetPort)
             .build();
+
     ServiceSpec spec = new ServiceSpec();
     spec.setPorts(singletonList(port));
     spec.setSelector(of("app", ASYNC_STORAGE));
 
-    Service service = new Service();
-    service.setApiVersion("v1");
-    service.setKind("Service");
-    service.setMetadata(meta);
-    service.setSpec(spec);
+    ServerServiceBuilder serviceBuilder = new ServerServiceBuilder();
+    Service service =
+        serviceBuilder
+            .withPorts(singletonList(port))
+            .withSelectorEntry("app", ASYNC_STORAGE)
+            .withName(ASYNC_STORAGE)
+            .build();
 
     oc.services().inNamespace(namespace).create(service);
   }


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Various fixes after merging PR #16972:
- use `ServerServiceBuilder` in `AsyncStorageProvisioner` #17399
- move all possible checks to the constructor `AsyncStorageModeValidator` in this case they will be evaluated just once. #17420
- add some comments to the `che.properties` about limitation for async storage


