### PR TITLE
chore(repositories): Add yaml with all repositories used in Eclipse Che

### DIFF
--- a/.github/workflows/contributing-repositories-check.yml
+++ b/.github/workflows/contributing-repositories-check.yml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# Eclipse Che workflow for checking repository list in CONTRIBUTING.md file
+name: CI
+
+# Trigger the workflow on push or pull request
+on: 
+  push:
+    paths:
+      - '.repositories.yaml'
+  pull_request:
+    paths:
+      - '.repositories.yaml'
+jobs:
+  check-contributing-up-to-date:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout che-theia source code
+    - name: check
+      run: |
+        ./.repositories-update-contributing.sh check

--- a/.repositories-update-contributing.sh
+++ b/.repositories-update-contributing.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# ./.repositories-update-contributing.sh
+#    no parameter = execute it with docker command
+# ./.repositories-update-contributing.sh -w
+#   execute in native mode (need to have mikefarah/yq installed )
+
+set -e
+set -u
+
+YQ_IMAGE="mikefarah/yq:3.3.2"
+
+DIR=$(cd "$(dirname "$0")"; pwd)
+
+init() {
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  NC='\033[0m'
+  BOLD='\033[1m'
+}
+
+LAUNCH_IN_DOCKER=true
+CHECK_MODE=false
+analyze_args() {
+  if [ $# -eq 0 ]; then
+    return
+  fi
+  if [ "$1" = "IN_DOCKER" ] || [ "$1" = "-w" ]; then
+    LAUNCH_IN_DOCKER=false
+    shift
+  fi
+  if [ $# -eq 0 ]; then
+    return
+  fi
+  if [ "$1" = "check" ] ; then
+    CHECK_MODE=true
+  fi
+}
+
+markdown_link() {
+  name=$1
+  url=$2
+  if [ "${url}" != "" ]; then
+    echo "[${name}](${url})"
+  else
+    echo ""
+  fi
+}
+
+compute() {
+  repo_names=$(yq r .repositories.yaml "repositories.*.name")
+  echo "Repository | Component | Description | Devfile | Documentation"
+  echo "--- | --- | ---  | --- | ---"
+  for repo_name in ${repo_names}; do
+    url=$(yq r .repositories.yaml "repositories.name==${repo_name}.url")
+    description=$(yq r .repositories.yaml "repositories.name==${repo_name}.description")
+    devfile=$(yq r .repositories.yaml "repositories.name==${repo_name}.devfile")
+    doc=$(yq r .repositories.yaml "repositories.name==${repo_name}.doc")
+    echo "$(markdown_link "${repo_name}" "${url}") | | ${description} | $(markdown_link "devfile" "${devfile}") | $(markdown_link "doc" "${doc}")"
+    # components ?
+    components_names=$(yq r .repositories.yaml "repositories.(name==${repo_name}).components.*.name")
+    for component_name in ${components_names}; do
+      component_url=$(yq r .repositories.yaml "repositories.(name==${repo_name}).components.(name==${component_name}).url")
+      component_description=$(yq r .repositories.yaml "repositories.(name==${repo_name}).components.(name==${component_name}).description")
+      echo "---| $(markdown_link "${component_name}" "${component_url}") | ${component_description} | | |"
+    done   
+  done
+}
+
+update_contributing() {
+  CONTRIBUTING_FILE=${DIR}/CONTRIBUTING.md
+  TARGET_FILE=${DIR}/CONTRIBUTING.md
+
+  if [ ${CHECK_MODE} = true ]; then
+    TARGET_FILE=${DIR}/target/CONTRIBUTING.md
+  fi
+
+
+  content_to_include=$(compute)
+
+  # get begin/end lines
+  begin_line=$(grep -n '<!-- begin repository list -->' "${CONTRIBUTING_FILE}" | cut -d ":" -f 1 | head -n 1) 
+  end_line=$(grep -n '<!-- end repository list -->' "${CONTRIBUTING_FILE}" | cut -d ":" -f 1 | head -n 1)
+
+  # update content
+  mkdir -p "${DIR}/target"
+  cp "${CONTRIBUTING_FILE}" "${DIR}/target/contributing.original"
+  (head -n "${begin_line}" "${CONTRIBUTING_FILE}" && echo "${content_to_include}" && tail -n "+${end_line}" "${CONTRIBUTING_FILE}") > "${DIR}/.tmp-contributing"
+  mv "${DIR}/.tmp-contributing" "${TARGET_FILE}"
+}
+
+run_in_docker() {
+  printf "%bRunning%b $*\n" "${BOLD}" "${NC}"
+  GIT_ROOT_DIRECTORY=$(git rev-parse --show-toplevel)
+  if docker run --rm -v "${GIT_ROOT_DIRECTORY}":/workdir --entrypoint=/bin/sh "${YQ_IMAGE}" "/workdir/$0" "IN_DOCKER" "$@"
+  then
+    printf "Script execution %b[OK]%b\n" "${GREEN}" "${NC}"
+  else
+    printf "%bFail to run the script%b\n" "${RED}" "${NC}"
+    exit 1
+  fi
+}
+
+init "$@"
+analyze_args "$@"
+if [ ${LAUNCH_IN_DOCKER} = true ]; then
+  run_in_docker "$@"
+else
+  update_contributing
+fi
+
+if [ ${CHECK_MODE} = true ]; then
+ if ! diff "${DIR}/target/contributing.original" "${DIR}/target/CONTRIBUTING.md"; then
+    printf "%bError: %bCONTRIBUTING.md should be updated as repositories.yaml file has been updated\n" "${RED}" "${NC}"
+    printf "%s" "Run the command: ./.repositories-update-contributing.sh"
+    exit 1
+ fi
+
+fi

--- a/.repositories.yaml
+++ b/.repositories.yaml
@@ -1,0 +1,284 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# List of repositories of Eclipse Che components
+---
+repositories:
+  - url: https://github.com/eclipse/che
+    name: che
+    description: >-
+      (this repository) the main project repository
+    devfile: https://github.com/eclipse/che/blob/master/devfile.yaml
+    doc: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#che-server-aka-ws-master
+    useCheReleaseLifecycle: true
+    components: 
+     - name: dockerfiles
+       url: https://github.com/eclipse/che/tree/master/dockerfiles
+       description: >-
+         source code, dockerfiles to build our main docker images. Note that Che-theia related dockerfiles are located in che-theia repo.
+     - name: wsmaster
+       url: https://github.com/eclipse/che/tree/master/wsmaster
+       description: >-
+         orchestrates the Che workspaces with devfiles on Kubernetes
+     - name: tests
+       url: https://github.com/eclipse/che/tree/master/tests
+       description: >-
+         source code of our integration tests.
+  - url: https://github.com/eclipse/che-theia
+    name: che-theia
+    description: >- 
+      Theia IDE integrated in Che.
+    devfile: https://github.com/eclipse/che-theia/blob/master/devfiles/che-theia-all.devfile.yaml
+    doc: https://github.com/eclipse/che-theia/blob/master/CONTRIBUTING.md
+    useCheReleaseLifecycle: true
+    components: 
+     - name: generator
+       url: https://github.com/eclipse/che-theia/tree/master/generator
+       description: >-
+         `che:theia init` CLI to prepare and build che-theia
+       doc: https://github.com/eclipse/che-theia/blob/master/generator/CONTRIBUTING.md
+  - url: https://github.com/che-incubator/chectl
+    name: chectl
+    description: >-
+      The CLI to install Che, create and start workspaces and devfiles
+    devfile: https://github.com/che-incubator/chectl/blob/master/devfile.yaml
+    doc: https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md
+    useCheReleaseLifecycle: true
+  - url: https://github.com/eclipse/che-dashboard
+    name: dashboard
+    description: >-
+     UI to manage workspaces, devfiles, etc.
+    devfile: https://github.com/eclipse/che-dashboard/blob/master/devfile.yaml
+    doc: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#dashboard
+    useCheReleaseLifecycle: true
+  - url: https://github.com/eclipse/che-devfile-registry
+    name: devfile-registry
+    description: >-
+      The default set of devfiles that would be made available on the Che dashboard stacks.
+    useCheReleaseLifecycle: true
+  - url: https://github.com/eclipse/che-docs
+    name: docs
+    description: >-
+      Eclipse Che documentation https://www.eclipse.org/che/docs/ source code.
+    devfile: https://github.com/eclipse/che-docs/blob/master/devfile.yaml
+    doc: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#dashboard
+    useCheReleaseLifecycle: true
+  - url: https://github.com/eclipse/che-machine-exec
+    name: machine-exec
+    description: >-
+      Interface to execute tasks and terminals on other containers within a workspace.
+    devfile: https://github.com/eclipse/che-machine-exec/blob/master/devfile.yaml
+    doc: https://github.com/eclipse/che-machine-exec/blob/master/CONTRIBUTING.md
+    useCheReleaseLifecycle: true
+  - url: https://github.com/eclipse/che-operator
+    name: operator
+    description: >-
+      Che operator to deploy, update and manage K8S/OpenShift resources of Che.
+    devfile: https://github.com/eclipse/che-operator/blob/master/devfile.yaml
+    useCheReleaseLifecycle: true
+  - url: https://github.com/eclipse/che-plugin-broker
+    name: plugin-broker
+    description: >-
+      The workspace microservice that is in charge of analyzing, preparing and installing the workspace components defined in a Devfile.
+    devfile: https://github.com/eclipse/che-plugin-broker/blob/master/devfile.yaml
+    doc: https://github.com/eclipse/che-plugin-broker/blob/master/CONTRIBUTING.md
+    useCheReleaseLifecycle: false
+  - url: https://github.com/eclipse/che-plugin-registry
+    name: plugin-registry
+    description: >-
+      The default set of Che plugins (vscode extension + containers) or editors that could be installed on any Che workspaces.
+    useCheReleaseLifecycle: true
+  - url: https://github.com/eclipse/che-website
+    name: website
+    description: >-
+      https://eclipse.org/che website source code.
+    devfile: https://github.com/eclipse/che-website/blob/master/devfile.yaml
+    useCheReleaseLifecycle: false
+  - url: https://github.com/eclipse/che-workspace-client
+    name: workspace-client
+    description: >-
+      JS library to interact with a che-server.
+    useCheReleaseLifecycle: false
+  - url: https://github.com/eclipse/che-workspace-loader
+    name: workspace-loader
+    description: >-
+      UI to load workspaces within dashboard
+    devfile: https://github.com/eclipse/che-workspace-loader/blob/master/devfile.yaml
+    doc: https://github.com/eclipse/che-workspace-loader/blob/master/CONTRIBUTING.md
+    useCheReleaseLifecycle: true
+  - url: https://github.com/che-dockerfiles/che-sidecar-bazel
+    name: che-sidecar-bazel
+    description: >-
+      Eclipse Che Sidecar container for Bazel tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-protobuf
+    name: che-sidecar-protobuf
+    description: >-
+      Eclipse Che Sidecar container for Protobuf tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-tekton
+    name: che-sidecar-tekton
+    description: >-
+      Eclipse Che Sidecar container for Tekton tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-kubernetes-tooling
+    name: che-sidecar-kubernetes-tooling
+    description: >-
+      Eclipse Che Sidecar container for Kubernetes tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-openshift-connector
+    name: che-sidecar-openshift-connector
+    description: >-
+      Eclipse Che Sidecar container for OpenShift connector tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-container-tools
+    name: che-container-tools
+    description: >-
+      Base image used for sidecars that service container tooling plugins
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-python
+    name: che-sidecar-python
+    description: >-
+      Eclipse Che Sidecar container for python tooling
+  - url: https://github.com/che-dockerfiles/che-custom-nodejs-deasync
+    name: che-custom-nodejs-deasync
+    description: >-
+      Provides a custom nodejs binary embedding deasync node-gyp module as builtin module
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-go
+    name: che-sidecar-go
+    description: >-
+      Eclipse Che sidecar container for go
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-sonarlint
+    name: che-sidecar-sonarlint
+    description: >-
+      Eclipse Che sidecar container for sonalint extension
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-dotnet
+    name: che-sidecar-dotnet
+    description: >-
+      Eclipse Che sidecar container for dotnet
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-shellcheck
+    name: che-sidecar-shellcheck
+    description: >-
+      Eclipse Che sidecar container for shellcheck
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-camelk
+    name: che-sidecar-camelk
+    description: >-
+      Eclipse Che sidecar container for camelk
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-vale
+    name: che-sidecar-vale
+    description: >-
+      Eclipse Che sidecar container for vale
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-cert-manager-ca-cert-generator-image
+    name: che-cert-manager-ca-cert-generator-image
+    description: >-
+      CA cert generation job image used by chectl
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-buildkit-base
+    name: che-buildkit-base
+    description: >-
+      Eclipse Che Sidecar container for buildkit tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-scala
+    name: che-sidecar-scala
+    description: >-
+      Eclipse Che Sidecar container for scala tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-buildah-base
+    name: che-buildah-base
+    description: >-
+      Use this image to build docker images using buildah
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-docker-registry-image-copier
+    name: che-docker-registry-image-copier
+    description: >-
+      copy images between public and private docker registry inside k8s cluster
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-php-base
+    name: che-php-base
+    description: >-
+      Base image to be used for the PHP devfile
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-tls-secret-creator
+    name: che-tls-secret-creator
+    description: >-
+      This images generates TLS certificates
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/build-action
+    name: build-action
+    description: >- 
+      Custom GitHub Action for building sidecar Dockerfiles
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-podman
+    name: che-sidecar-podman
+    description: >-
+      Eclipse Che Sidecar container for podman tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-clang
+    name: che-sidecar-clang
+    description: >-
+      Eclipse Che Sidecar container for clang tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-php
+    name: che-sidecar-php
+    description: >-
+      Eclipse Che Sidecar container for php tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-java
+    name: che-sidecar-java
+    description: >-
+      Eclipse Che Sidecar container for java tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-dependency-analytics
+    name: che-sidecar-dependency-analytics
+    description: >-
+      Eclipse Che Sidecar container for dependency analytics tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-dockerfiles/che-sidecar-node
+    name: che-sidecar-node
+    description: >-
+      Eclipse Che Sidecar container for node tooling
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-incubator/che-dashboard-next
+    name: che-dashboard-next
+    description: >-
+      New dashboard for Eclipse CHE
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-incubator/che-theia-openshift-auth
+    name: che-theia-openshift-auth
+    description: >-
+      OpenShift authentication plugin
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-incubator/configbump
+    name: configbump
+    description: >-
+      Simple Kubernetes controller that is able to quickly synchronize a set of config maps
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-incubator/workspace-data-sync
+    name: workspace-data-sync
+    description: >-
+      Provides the ability to increase I/O performance for a developer workspaces
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-incubator/che-workspace-telemetry-client
+    name: che-workspace-telemetry-client
+    description: >-
+      abstract telemetry API and a Typescript implementation of the API.
+    useCheReleaseLifecycle: false
+  - url: https://github.com/che-incubator/kubernetes-image-puller
+    name: kubernetes-image-puller
+    description: >-
+      ensures that all nodes in the cluster have those images cached
+    useCheReleaseLifecycle: false
+
+
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,27 +11,61 @@
 
 Che is composed of multiple sub projects. For each projects we provide a *CONTRIBUTE.md* file describing how to setup the development environment to start your contribution. Most of the time, we encourage you to use Che to contribute to Che.
 
-Repository | Component | Description | Devfile | Contributing.md
+<!-- begin repository list -->
+Repository | Component | Description | Devfile | Documentation
 --- | --- | ---  | --- | ---
-[che](https://github.com/eclipse/che) | | (this repository) the main project repository | |
----| [wsmaster](https://github.com/eclipse/che/tree/master/wsmaster) | orchestrates the Che workspaces with devfiles on Kubernetes | [devfile ](https://github.com/eclipse/che/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#che-server-aka-ws-master)
---- | [dockerfiles](https://github.com/eclipse/che/tree/master/dockerfiles) | source code, dockerfiles to build our main docker images. Note that Che-theia related dockerfiles are located in che-theia repo. | | 
---- | [e2e](https://github.com/eclipse/che/tree/master/e2e) | source code of our integration tests. | | 
-[workspace-loader](https://github.com/eclipse/che-workspace-loader) |  |  | [devfile](https://github.com/eclipse/che-workspace-loader/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che-workspace-loader/blob/master/CONTRIBUTING.md)
-[dashboard](https://github.com/eclipse/che-dashboard) | | UI to manage workspaces, devfiles, etc. | [devfile](https://github.com/eclipse/che-dashboard/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#dashboard)
-[chectl](https://github.com/che-incubator/chectl) | | The CLI to install Che, create and start workspaces and devfiles | [devfile](https://github.com/che-incubator/chectl/blob/master/devfile.yaml) | [doc](https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md)
+[che](https://github.com/eclipse/che) | | (this repository) the main project repository | [devfile](https://github.com/eclipse/che/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#che-server-aka-ws-master)
+---| [dockerfiles](https://github.com/eclipse/che/tree/master/dockerfiles) | source code, dockerfiles to build our main docker images. Note that Che-theia related dockerfiles are located in che-theia repo. | | |
+---| [wsmaster](https://github.com/eclipse/che/tree/master/wsmaster) | orchestrates the Che workspaces with devfiles on Kubernetes | | |
+---| [tests](https://github.com/eclipse/che/tree/master/tests) | source code of our integration tests. | | |
 [che-theia](https://github.com/eclipse/che-theia) | | Theia IDE integrated in Che. | [devfile](https://github.com/eclipse/che-theia/blob/master/devfiles/che-theia-all.devfile.yaml) | [doc](https://github.com/eclipse/che-theia/blob/master/CONTRIBUTING.md)
---- | [generator](https://github.com/eclipse/che-theia/tree/master/generator) | `che:theia init` CLI to prepare and build che-theia | | [doc](https://github.com/eclipse/che-theia/blob/master/generator/CONTRIBUTING.md)
-[devfile-registry](https://github.com/eclipse/che-devfile-registry) | | The default set of devfiles that would be made available on the Che dashboard stacks. | | 
-[docs](https://github.com/eclipse/che-docs) | | Eclipse Che documentation https://www.eclipse.org/che/docs/ source code. | [devfile](https://github.com/eclipse/che-docs/blob/master/devfile.yaml) | 
+---| [generator](https://github.com/eclipse/che-theia/tree/master/generator) | `che:theia init` CLI to prepare and build che-theia | | |
+[chectl](https://github.com/che-incubator/chectl) | | The CLI to install Che, create and start workspaces and devfiles | [devfile](https://github.com/che-incubator/chectl/blob/master/devfile.yaml) | [doc](https://github.com/che-incubator/chectl/blob/master/CONTRIBUTING.md)
+[dashboard](https://github.com/eclipse/che-dashboard) | | UI to manage workspaces, devfiles, etc. | [devfile](https://github.com/eclipse/che-dashboard/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#dashboard)
+[devfile-registry](https://github.com/eclipse/che-devfile-registry) | | The default set of devfiles that would be made available on the Che dashboard stacks. |  | 
+[docs](https://github.com/eclipse/che-docs) | | Eclipse Che documentation https://www.eclipse.org/che/docs/ source code. | [devfile](https://github.com/eclipse/che-docs/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#dashboard)
 [machine-exec](https://github.com/eclipse/che-machine-exec) | | Interface to execute tasks and terminals on other containers within a workspace. | [devfile](https://github.com/eclipse/che-machine-exec/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che-machine-exec/blob/master/CONTRIBUTING.md)
-[operator](https://github.com/eclipse/che-operator) | | Che operator to deploy, update and manage K8S/OpenShift resources of Che. | | 
+[operator](https://github.com/eclipse/che-operator) | | Che operator to deploy, update and manage K8S/OpenShift resources of Che. | [devfile](https://github.com/eclipse/che-operator/blob/master/devfile.yaml) | 
 [plugin-broker](https://github.com/eclipse/che-plugin-broker) | | The workspace microservice that is in charge of analyzing, preparing and installing the workspace components defined in a Devfile. | [devfile](https://github.com/eclipse/che-plugin-broker/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che-plugin-broker/blob/master/CONTRIBUTING.md)
-[plugin-registry](https://github.com/eclipse/che-plugin-registry) | | The default set of Che plugins (vscode extension + containers) or editors that could be installed on any Che workspaces. | |
-[redhat-developer/devfile](https://github.com/redhat-developer/devfile) | | Contribute to the devfile documentation: https://redhat-developer.github.io/devfile/ | | 
+[plugin-registry](https://github.com/eclipse/che-plugin-registry) | | The default set of Che plugins (vscode extension + containers) or editors that could be installed on any Che workspaces. |  | 
 [website](https://github.com/eclipse/che-website) | | https://eclipse.org/che website source code. | [devfile](https://github.com/eclipse/che-website/blob/master/devfile.yaml) | 
-[workspace-client](https://github.com/eclipse/che-workspace-client) | | JS library to interact with a che-server. | | 
-
+[workspace-client](https://github.com/eclipse/che-workspace-client) | | JS library to interact with a che-server. |  | 
+[workspace-loader](https://github.com/eclipse/che-workspace-loader) | | UI to load workspaces within dashboard | [devfile](https://github.com/eclipse/che-workspace-loader/blob/master/devfile.yaml) | [doc](https://github.com/eclipse/che-workspace-loader/blob/master/CONTRIBUTING.md)
+[che-sidecar-bazel](https://github.com/che-dockerfiles/che-sidecar-bazel) | | Eclipse Che Sidecar container for Bazel tooling |  | 
+[che-sidecar-protobuf](https://github.com/che-dockerfiles/che-sidecar-protobuf) | | Eclipse Che Sidecar container for Protobuf tooling |  | 
+[che-sidecar-tekton](https://github.com/che-dockerfiles/che-sidecar-tekton) | | Eclipse Che Sidecar container for Tekton tooling |  | 
+[che-sidecar-kubernetes-tooling](https://github.com/che-dockerfiles/che-sidecar-kubernetes-tooling) | | Eclipse Che Sidecar container for Kubernetes tooling |  | 
+[che-sidecar-openshift-connector](https://github.com/che-dockerfiles/che-sidecar-openshift-connector) | | Eclipse Che Sidecar container for OpenShift connector tooling |  | 
+[che-container-tools](https://github.com/che-dockerfiles/che-container-tools) | | Base image used for sidecars that service container tooling plugins |  | 
+[che-sidecar-python](https://github.com/che-dockerfiles/che-sidecar-python) | | Eclipse Che Sidecar container for python tooling |  | 
+[che-custom-nodejs-deasync](https://github.com/che-dockerfiles/che-custom-nodejs-deasync) | | Provides a custom nodejs binary embedding deasync node-gyp module as builtin module |  | 
+[che-sidecar-go](https://github.com/che-dockerfiles/che-sidecar-go) | | Eclipse Che sidecar container for go |  | 
+[che-sidecar-sonarlint](https://github.com/che-dockerfiles/che-sidecar-sonarlint) | | Eclipse Che sidecar container for sonalint extension |  | 
+[che-sidecar-dotnet](https://github.com/che-dockerfiles/che-sidecar-dotnet) | | Eclipse Che sidecar container for dotnet |  | 
+[che-sidecar-shellcheck](https://github.com/che-dockerfiles/che-sidecar-shellcheck) | | Eclipse Che sidecar container for shellcheck |  | 
+[che-sidecar-camelk](https://github.com/che-dockerfiles/che-sidecar-camelk) | | Eclipse Che sidecar container for camelk |  | 
+[che-sidecar-vale](https://github.com/che-dockerfiles/che-sidecar-vale) | | Eclipse Che sidecar container for vale |  | 
+[che-cert-manager-ca-cert-generator-image](https://github.com/che-dockerfiles/che-cert-manager-ca-cert-generator-image) | | CA cert generation job image used by chectl |  | 
+[che-buildkit-base](https://github.com/che-dockerfiles/che-buildkit-base) | | Eclipse Che Sidecar container for buildkit tooling |  | 
+[che-sidecar-scala](https://github.com/che-dockerfiles/che-sidecar-scala) | | Eclipse Che Sidecar container for scala tooling |  | 
+[che-buildah-base](https://github.com/che-dockerfiles/che-buildah-base) | | Use this image to build docker images using buildah |  | 
+[che-docker-registry-image-copier](https://github.com/che-dockerfiles/che-docker-registry-image-copier) | | copy images between public and private docker registry inside k8s cluster |  | 
+[che-php-base](https://github.com/che-dockerfiles/che-php-base) | | Base image to be used for the PHP devfile |  | 
+[che-tls-secret-creator](https://github.com/che-dockerfiles/che-tls-secret-creator) | | This images generates TLS certificates |  | 
+[build-action](https://github.com/che-dockerfiles/build-action) | | Custom GitHub Action for building sidecar Dockerfiles |  | 
+[che-sidecar-podman](https://github.com/che-dockerfiles/che-sidecar-podman) | | Eclipse Che Sidecar container for podman tooling |  | 
+[che-sidecar-clang](https://github.com/che-dockerfiles/che-sidecar-clang) | | Eclipse Che Sidecar container for clang tooling |  | 
+[che-sidecar-php](https://github.com/che-dockerfiles/che-sidecar-php) | | Eclipse Che Sidecar container for php tooling |  | 
+[che-sidecar-java](https://github.com/che-dockerfiles/che-sidecar-java) | | Eclipse Che Sidecar container for java tooling |  | 
+[che-sidecar-dependency-analytics](https://github.com/che-dockerfiles/che-sidecar-dependency-analytics) | | Eclipse Che Sidecar container for dependency analytics tooling |  | 
+[che-sidecar-node](https://github.com/che-dockerfiles/che-sidecar-node) | | Eclipse Che Sidecar container for node tooling |  | 
+[che-dashboard-next](https://github.com/che-incubator/che-dashboard-next) | | New dashboard for Eclipse CHE |  | 
+[che-theia-openshift-auth](https://github.com/che-incubator/che-theia-openshift-auth) | | OpenShift authentication plugin |  | 
+[configbump](https://github.com/che-incubator/configbump) | | Simple Kubernetes controller that is able to quickly synchronize a set of config maps |  | 
+[workspace-data-sync](https://github.com/che-incubator/workspace-data-sync) | | Provides the ability to increase I/O performance for a developer workspaces |  | 
+[che-workspace-telemetry-client](https://github.com/che-incubator/che-workspace-telemetry-client) | | abstract telemetry API and a Typescript implementation of the API. |  | 
+[kubernetes-image-puller](https://github.com/che-incubator/kubernetes-image-puller) | | ensures that all nodes in the cluster have those images cached |  | 
+<!-- end repository list -->
 
 ## Devfile to contribute
 


### PR DESCRIPTION
### What does this PR do?
Introduce a file with list of components repositories used by Eclipse Che
This list was previously inside CONTRIBUTING.md file. Extract it to yaml file and allow update of CONTRIBUTING.md with a script

This PR includes
- yaml file with repositories list
- script to update (or check) CONTRINBUTING.md
- sort components by their names in CONTRIBUTING.md
- github action to check if CONTRIBUTING.md need to be updated or not (triggered only if the list of repositories is updated)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17421


Change-Id: Idf551383bb806e11308d1e157af2f2921c593cd3
Signed-off-by: Florent Benoit <fbenoit@redhat.com>

