### PR TITLE
Fix plugin-registry url in multi-host mode

### DIFF
--- a/deploy/kubernetes/helm/che/templates/_pluginRegistryUrlHelper.tpl
+++ b/deploy/kubernetes/helm/che/templates/_pluginRegistryUrlHelper.tpl
@@ -7,9 +7,9 @@
     {{- end }}
   {{- else }}
     {{- if .Values.global.tls.enabled }}
-      https://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+      https://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
     {{- else }}
-      http://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}
+      http://{{ printf .Values.global.chePluginRegistryUrlFormat .Release.Namespace .Values.global.ingressDomain }}/v3
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Anatolii Bazko <abazko@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Adds `v3` to plugin-registry url (broken by https://github.com/eclipse/che/pull/17392)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/16103
