### PR TITLE
CRW-1093 copy downstream Dockerfile to...

### DIFF
--- a/dockerfiles/che/rhel.Dockerfile
+++ b/dockerfiles/che/rhel.Dockerfile
@@ -12,32 +12,38 @@
 # https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
 FROM registry.access.redhat.com/ubi8-minimal:8.2-345
 USER root
+ENV CHE_HOME=/home/user/codeready
+ENV JAVA_HOME=/usr/lib/jvm/jre
 RUN microdnf install java-11-openjdk-headless tar gzip shadow-utils findutils && \
     microdnf update -y gnutls && \
     microdnf -y clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages" && \
-    adduser -G root jboss && mkdir -p /home/jboss/codeready
-ENV JAVA_HOME=/usr/lib/jvm/jre
+    adduser -G root user && mkdir -p /home/user/codeready && \
+    # fix certs & dir permissions - see file references in entrypoint.sh
+    for d in /home/user ${JAVA_HOME}/lib/security; do \
+      mkdir -p ${d}; cp /etc/pki/ca-trust/extracted/java/cacerts ${d}/cacerts && chmod 644 ${d}/cacerts; \
+    done
 
 COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 
 # NOTE: if built in Brew, use get-sources-jenkins.sh to pull latest
 # OR, if you intend to build the Che Server tarball locally, 
 # see https://github.com/redhat-developer/codeready-workspaces-productization/blob/master/devdoc/building/building-crw.adoc#make-changes-to-crw-and-re-deploy-to-minishift
 # then copy /home/${USER}/projects/codeready-workspaces/assembly/codeready-workspaces-assembly-main/target/codeready-workspaces-assembly-main.tar.gz into this folder
 COPY assembly/codeready-workspaces-assembly-main/target/codeready-workspaces-assembly-main.tar.gz /tmp/codeready-workspaces-assembly-main.tar.gz
-RUN tar xzf /tmp/codeready-workspaces-assembly-main.tar.gz --transform="s#.*codeready-workspaces-assembly-main/*##" -C /home/jboss/codeready && \
+RUN tar xzf /tmp/codeready-workspaces-assembly-main.tar.gz --transform="s#.*codeready-workspaces-assembly-main/*##" -C /home/user/codeready && \
     rm -f /tmp/codeready-workspaces-assembly-main.tar.gz
-# this should fail if the startup script is not found in correct path /home/jboss/codeready/tomcat/bin/catalina.sh
-RUN java -version && \
-    echo -n "Server startup script in: " && find /home/jboss/codeready -name catalina.sh | grep -z /home/jboss/codeready/tomcat/bin/catalina.sh && \
-    # fix certs & dir permissions
-    cp /etc/pki/ca-trust/extracted/java/cacerts /home/jboss/cacerts && chmod 644 /home/jboss/cacerts && \
-    mkdir -p /logs /data && \
-    chgrp -R 0     /home/jboss /data /logs && \
-    chmod -R g+rwX /home/jboss /data /logs && \
-    chown -R jboss /home/jboss
+# this should fail if the startup script is not found in correct path /home/user/codeready/tomcat/bin/catalina.sh
+RUN mkdir /logs /data && \
+    chmod 0777 /logs /data && \
+    chgrp -R 0 /home/user /logs /data && \
+    chown -R user /home/user && \
+    chmod -R g+rwX /home/user && \
+    find /home/user -type d -exec chmod 777 {} \; && \
+    java -version && echo -n "Server startup script in: " && \
+    find /home/user/codeready -name catalina.sh | grep -z /home/user/codeready/tomcat/bin/catalina.sh
 
-USER jboss
-ENTRYPOINT ["/entrypoint.sh"]
+USER user
+
 
 # append Brew metadata here

--- a/dockerfiles/che/rhel.Dockerfile
+++ b/dockerfiles/che/rhel.Dockerfile
@@ -1,0 +1,43 @@
+# Copyright (c) 2018-2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+# https://access.redhat.com/containers/?tab=tags#/registry.access.redhat.com/ubi8-minimal
+FROM registry.access.redhat.com/ubi8-minimal:8.2-345
+USER root
+RUN microdnf install java-11-openjdk-headless tar gzip shadow-utils findutils && \
+    microdnf update -y gnutls && \
+    microdnf -y clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages" && \
+    adduser -G root jboss && mkdir -p /home/jboss/codeready
+ENV JAVA_HOME=/usr/lib/jvm/jre
+
+COPY entrypoint.sh /entrypoint.sh
+
+# NOTE: if built in Brew, use get-sources-jenkins.sh to pull latest
+# OR, if you intend to build the Che Server tarball locally, 
+# see https://github.com/redhat-developer/codeready-workspaces-productization/blob/master/devdoc/building/building-crw.adoc#make-changes-to-crw-and-re-deploy-to-minishift
+# then copy /home/${USER}/projects/codeready-workspaces/assembly/codeready-workspaces-assembly-main/target/codeready-workspaces-assembly-main.tar.gz into this folder
+COPY assembly/codeready-workspaces-assembly-main/target/codeready-workspaces-assembly-main.tar.gz /tmp/codeready-workspaces-assembly-main.tar.gz
+RUN tar xzf /tmp/codeready-workspaces-assembly-main.tar.gz --transform="s#.*codeready-workspaces-assembly-main/*##" -C /home/jboss/codeready && \
+    rm -f /tmp/codeready-workspaces-assembly-main.tar.gz
+# this should fail if the startup script is not found in correct path /home/jboss/codeready/tomcat/bin/catalina.sh
+RUN java -version && \
+    echo -n "Server startup script in: " && find /home/jboss/codeready -name catalina.sh | grep -z /home/jboss/codeready/tomcat/bin/catalina.sh && \
+    # fix certs & dir permissions
+    cp /etc/pki/ca-trust/extracted/java/cacerts /home/jboss/cacerts && chmod 644 /home/jboss/cacerts && \
+    mkdir -p /logs /data && \
+    chgrp -R 0     /home/jboss /data /logs && \
+    chmod -R g+rwX /home/jboss /data /logs && \
+    chown -R jboss /home/jboss
+
+USER jboss
+ENTRYPOINT ["/entrypoint.sh"]
+
+# append Brew metadata here

--- a/dockerfiles/che/rhel.Dockerfile
+++ b/dockerfiles/che/rhel.Dockerfile
@@ -26,13 +26,7 @@ RUN microdnf install java-11-openjdk-headless tar gzip shadow-utils findutils &&
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
-# NOTE: if built in Brew, use get-sources-jenkins.sh to pull latest
-# OR, if you intend to build the Che Server tarball locally, 
-# see https://github.com/redhat-developer/codeready-workspaces-productization/blob/master/devdoc/building/building-crw.adoc#make-changes-to-crw-and-re-deploy-to-minishift
-# then copy /home/${USER}/projects/codeready-workspaces/assembly/codeready-workspaces-assembly-main/target/codeready-workspaces-assembly-main.tar.gz into this folder
-COPY assembly/codeready-workspaces-assembly-main/target/codeready-workspaces-assembly-main.tar.gz /tmp/codeready-workspaces-assembly-main.tar.gz
-RUN tar xzf /tmp/codeready-workspaces-assembly-main.tar.gz --transform="s#.*codeready-workspaces-assembly-main/*##" -C /home/user/codeready && \
-    rm -f /tmp/codeready-workspaces-assembly-main.tar.gz
+ADD eclipse-che /home/user/eclipse-che
 # this should fail if the startup script is not found in correct path /home/user/codeready/tomcat/bin/catalina.sh
 RUN mkdir /logs /data && \
     chmod 0777 /logs /data && \


### PR DESCRIPTION
CRW-1093 copy downstream Dockerfile to rhel.Dockerfile upstream so we can better sync che server w/ crw server

Change-Id: Id76c6c38c4e17708e577de8abc5acde4b8376edf
Signed-off-by: nickboldt <nboldt@redhat.com>