### PR TITLE
[QE_TASK] Change default value of the "TS_SELENIUM_VALUE_TLS_SUPPORT" environment variable

### DIFF
--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -117,7 +117,7 @@ export const TestConstants = {
     /**
      * Value of TLS Support property in the 'Create Che Cluster' yaml using OperatorHub.
      */
-    TS_SELENIUM_VALUE_TLS_SUPPORT: process.env.TS_SELENIUM_VALUE_TLS_SUPPORT || 'false',
+    TS_SELENIUM_VALUE_TLS_SUPPORT: process.env.TS_SELENIUM_VALUE_TLS_SUPPORT || 'true',
 
     /**
      * Value of Self Sign Cert property in the 'Create Che Cluster' yaml using OperatorHub.


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Change default value of the "TS_SELENIUM_VALUE_TLS_SUPPORT" environment variable

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/17503
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
