### PR TITLE
Remove default timeout

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -21,6 +21,7 @@
 ## Custom launch
 
 - Use environment variables which described in the **```'TestConstants.ts'```** file
+- Use environment variables for setting timeouts if needed. You can see the list in **```'TimeoutConstants.ts'```**. You can see the list of those variables and their value if you set the ```'TS_SELENIUM_PRINT_TIMEOUT_VARIABLES = true'```
 
 ## Docker launch
 

--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -232,6 +232,11 @@ export const TestConstants = {
     /**
      * The name of project in the Openshidt plugin tree
      */
-    TS_TEST_OPENSHIFT_PLUGIN_PROJECT: process.env.TS_TEST_OPENSHIFT_PLUGIN_PROJECT || ''
+    TS_TEST_OPENSHIFT_PLUGIN_PROJECT: process.env.TS_TEST_OPENSHIFT_PLUGIN_PROJECT || '',
+
+    /**
+     * Print all timeout variables when tests launch, defaulte to false
+     */
+    TS_SELENIUM_PRINT_TIMEOUT_VARIABLES: process.env.TS_SELENIUM_PRINT_TIMEOUT_VARIABLES || false
 
 };

--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -49,31 +49,6 @@ export const TestConstants = {
     TS_SELENIUM_RESOLUTION_HEIGHT: Number(process.env.TS_SELENIUM_RESOLUTION_HEIGHT) || 1080,
 
     /**
-     * Timeout in milliseconds waiting for install Eclipse Che by OperatorHub UI, "600 000" by default.
-     */
-    TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 600000,
-
-    /**
-     * Timeout in milliseconds waiting for workspace start, "240 000" by default.
-     */
-    TS_SELENIUM_START_WORKSPACE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 360000,
-
-    /**
-     * Timeout in milliseconds waiting for page load, "120 000" by default.
-     */
-    TS_SELENIUM_LOAD_PAGE_TIMEOUT: Number(process.env.TS_SELENIUM_LOAD_PAGE_TIMEOUT) || 180000,
-
-    /**
-     * Timeout in milliseconds waiting for language server initialization, "180 000" by default.
-     */
-    TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT: Number(process.env.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT) || 180000,
-
-    /**
-     * Default timeout for most of the waitings, "20 000" by default.
-     */
-    TS_SELENIUM_DEFAULT_TIMEOUT: Number(process.env.TS_SELENIUM_DEFAULT_TIMEOUT) || 60000,
-
-    /**
      * Default ammount of tries, "5" by default.
      */
     TS_SELENIUM_DEFAULT_ATTEMPTS: Number(process.env.TS_SELENIUM_DEFAULT_ATTEMPTS) || 5,

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -1,0 +1,189 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+export const TimeoutConstants = {
+    // -------------------------------------------- INSTALLING AND STARTUP --------------------------------------------
+
+    /**
+     * Timeout in milliseconds waiting for install Eclipse Che by OperatorHub UI, "600 000" by default.
+     */
+    TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 600000,
+
+    /**
+     * Wait between workspace started and IDE ready to be used, "20 000" by default.
+     */
+    TS_IDE_LOAD_TIMEOUT: Number(process.env.TS_IDE_LOAD_TIMEOUT) || 20_000,
+
+    /**
+     * Timeout in milliseconds waiting for workspace start, "360 000" by default.
+     */
+    TS_SELENIUM_START_WORKSPACE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 360000,
+
+    /**
+     * Timeout in milliseconds waiting for page load, "20 000" by default.
+     */
+    TS_SELENIUM_LOAD_PAGE_TIMEOUT: Number(process.env.TS_SELENIUM_LOAD_PAGE_TIMEOUT) || 20_000,
+
+    /**
+     * Wait for loader absence, "60 000" by default
+     */
+    TS_WAIT_LOADER_ABSENCE_TIMEOUT: Number(process.env.TS_WAIT_LOADER_ABSENCE_TIMEOUT) || 60_000,
+
+    /**
+     * Wait for loader absence, "60 000" by default
+     */
+    TS_WAIT_LOADER_PRESENCE_TIMEOUT: Number(process.env.TS_WAIT_LOADER_PRESENCE_TIMEOUT) || 60_000,
+
+    // -------------------------------------------- DASHBOARD --------------------------------------------
+    /**
+     * Common timeout for dashboard items, "5 000" by default
+     */
+    TS_COMMON_DASHBOARD_WAIT_TIMEOUT: Number(process.env.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) || 5_000,
+
+    /**
+     * Timeout for clicking on dashboard menu items, "2 000" by default
+     */
+    TS_CLICK_DASHBOARD_ITEM_TIMEOUT: Number(process.env.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) || 2_000,
+
+
+    // -------------------------------------------- LANGUAGE SERVER VALIDATION --------------------------------------------
+
+    /**
+     * Timeout in milliseconds waiting for language server initialization, "180 000" by default.
+     */
+    TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT: Number(process.env.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT) || 180_000,
+
+    /**
+     * Timeout for suggestion invoking, "30 000" by default.
+     */
+    TS_SUGGESTION_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 30_000,
+
+    /**
+     * Timeout for error highlighting presence, "10 000" by default
+     */
+    TS_ERROR_HIGHLIGHTING_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 10_000,
+
+
+    // -------------------------------------------- PROJECT TREE --------------------------------------------
+
+    /**
+     * Wait for IDE showing project tree tab, "20 000" by default.
+     */
+    TS_PROJECT_TREE_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 20_000,
+
+    /**
+     * Click on item timeout (project tree), "10 000" by default.
+     */
+    TS_PROJECT_TREE_CLICK_ON_ITEM_TIMEOUT: Number(process.env.TS_PROJECT_TREE_CLICK_ON_ITEM_TIMEOUT) || 10_000,
+
+    /**
+     * Expand item in project tree, "5 000" by default.
+     */
+    TS_EXPAND_PROJECT_TREE_ITEM_TIMEOUT: Number(process.env.TS_EXPAND_PROJECT_TREE_ITEM_TIMEOUT) || 5_000,
+
+    // -------------------------------------------- EDITOR --------------------------------------------
+
+    /**
+     * Timeout for inetractions with editor tab - wait, click, select, "5 000" by default.
+     */
+    TS_EDITOR_TAB_INTERACTION_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 5_000,
+
+    /**
+     * Wait for file to be opened in editor, "30 000" by default.
+     */
+    TS_OPEN_EDITOR_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 30_000,
+
+
+    // -------------------------------------------- IDE --------------------------------------------
+
+    /**
+     * Timeout for context menu manipulation, "10 000" by default
+     */
+    TS_CONTEXT_MENU_TIMEOUT: Number(process.env.TS_CONTEXT_MENU_TIMEOUT) || 10_000,
+
+    /**
+     * Timeout for interactions with Notification center - open, close, "10 000" by default.
+     */
+    TS_NOTIFICATION_CENTER_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 10_000,
+
+    /**
+     * Timeout for debugger to connect, "30 000" by default
+     */
+    TS_DEBUGGER_CONNECTION_TIMEOUT: Number(process.env.TS_DEBUGGER_CONNECTION_TIMEOUT) || 30_000,
+
+    /**
+     * Timeout for context menu manipulation, "10 000" by default
+     */
+    TS_DIALOG_WINDOW_DEFAULT_TIMEOUT: Number(process.env.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT) || 10_000,
+
+    /**
+     * Timeout for breakpoint interactions, "20 000" by default
+     */
+    TS_BREAKPOINT_DEFAULT_TIMEOUT: Number(process.env.TS_BREAKPOINT_DEFAULT_TIMEOUT) || 20_000,
+
+    /**
+     * Timeout for interactions with Git Plugin container, "20 000" by default
+     */
+    TS_GIT_CONAINER_INTERACTION_TIMEOUT: Number(process.env.TS_GIT_CONAINER_INTERACTION_TIMEOUT) || 20_000,
+
+    /**
+     * Timeout for toolbars interaction, "20 000" by default
+     */
+    TS_SELENIUM_TOOLBAR_TIMEOUT: Number(process.env.TS_SELENIUM_TOOLBAR_TIMEOUT) || 20_000,
+
+    /**
+     * Timeout for clicking on visible item, "3 000" by default
+     */
+    TS_SELENIUM_CLICK_ON_VISIBLE_ITEM: Number(process.env.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) || 3_000,
+
+    /**
+     * Timeout for OpenDialogWidget class, "5 000" by default
+     */
+    TS_SELENIUM_DIALOG_WIDGET_TIMEOUT: Number(process.env.TS_SELENIUM_DIALOG_WIDGET_TIMEOUT) || 5_000,
+
+    /**
+     * Default timeout for interaction with terminal, "3 000" by default
+     */
+    TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT: Number(process.env.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) || 3_000,
+
+    /**
+     * Default timeout for preview widget, "10 000" by default
+     */
+    TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT: Number(process.env.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT) || 10_000,
+
+    /**
+     * Timeout for opening quick menu from top panel, "10 000" by default
+     */
+    TS_SELENIUM_TOP_MENU_QUICK_CONTAINER_TIMEOUT: Number(process.env.TS_SELENIUM_TOP_MENU_QUICK_CONTAINER_TIMEOUT) || 10_000,
+
+    /**
+     * Timeout waiting for url, "10 000" by default
+     */
+    TS_SELENIUM_WAIT_FOR_URL: Number(process.env.TS_SELENIUM_WAIT_FOR_URL) || 10_000,
+
+
+
+    // ------------------------------------ OCP WEB CONSOLE PAGE ------------------------------------
+
+    /**
+     * Timeout for OcpWebConsolePage.waitOverviewCsvEclipseCheOperator, "20 000" by default
+     */
+    TS_SELENIUM_CSV_OPERATOR_TIMEOUT: Number(process.env.TS_SELENIUM_CSV_OPERATOR_TIMEOUT) || 20_000,
+
+    /**
+     * Timeout for listing the namespaces on subscription in OcpWebConsolePage, "10 000" by default
+     */
+    TS_SELENIUM_LIST_NAMESPACES_ON_SUBSCRIPTION_TIMEOUT: Number(process.env.TS_SELENIUM_LIST_NAMESPACES_ON_SUBSCRIPTION_TIMEOUT) || 10_000,
+
+    /**
+     * Timeout for Che cluster title visibility in OcpWebConsolePage, "10 000" by default.
+     */
+    TS_SELENIUM_RESOURCES_CHE_CLUSTER_TITLE_TIMEOUT: Number(process.env.TS_SELENIUM_RESOURCES_CHE_CLUSTER_TITLE_TIMEOUT) || 10_000
+};

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -32,14 +32,19 @@ export const TimeoutConstants = {
     TS_SELENIUM_LOAD_PAGE_TIMEOUT: Number(process.env.TS_SELENIUM_LOAD_PAGE_TIMEOUT) || 20_000,
 
     /**
-     * Wait for loader absence, "60 000" by default
+     * Wait for loader absence, "60 000" by default.
      */
     TS_WAIT_LOADER_ABSENCE_TIMEOUT: Number(process.env.TS_WAIT_LOADER_ABSENCE_TIMEOUT) || 60_000,
 
     /**
-     * Wait for loader absence, "60 000" by default
+     * Wait for loader absence, "60 000" by default.
      */
     TS_WAIT_LOADER_PRESENCE_TIMEOUT: Number(process.env.TS_WAIT_LOADER_PRESENCE_TIMEOUT) || 60_000,
+
+    /**
+     * Timeout waiting for URL, "5 000" by default.
+     */
+    TS_WAIT_URL_TIMEOUT: Number(process.env.TS_WAIT_URL_TIMEOUT) || 5_000,
 
     // -------------------------------------------- DASHBOARD --------------------------------------------
     /**
@@ -156,7 +161,7 @@ export const TimeoutConstants = {
     /**
      * Default timeout for interaction with terminal, "3 000" by default
      */
-    TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT: Number(process.env.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) || 3_000,
+    TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT: Number(process.env.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) || 5_000,
 
     /**
      * Default timeout for preview widget, "10 000" by default

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -14,7 +14,7 @@ export const TimeoutConstants = {
     /**
      * Timeout in milliseconds waiting for install Eclipse Che by OperatorHub UI, "600 000" by default.
      */
-    TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 600000,
+    TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 600_000,
 
     /**
      * Wait between workspace started and IDE ready to be used, "20 000" by default.
@@ -24,7 +24,7 @@ export const TimeoutConstants = {
     /**
      * Timeout in milliseconds waiting for workspace start, "360 000" by default.
      */
-    TS_SELENIUM_START_WORKSPACE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 360000,
+    TS_SELENIUM_START_WORKSPACE_TIMEOUT: Number(process.env.TS_SELENIUM_START_WORKSPACE_TIMEOUT) || 360_000,
 
     /**
      * Timeout in milliseconds waiting for page load, "20 000" by default.
@@ -99,6 +99,11 @@ export const TimeoutConstants = {
      * Wait for file to be opened in editor, "30 000" by default.
      */
     TS_OPEN_EDITOR_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 30_000,
+
+    /**
+     * Wait for suggestion container closure, "3 000" by default.
+     */
+    TS_CLOSE_SUGGESTION_CONTAINER_TIMEOUT: Number(process.env.TS_CLOSE_SUGGESTION_CONTAINER_TIMEOUT) || 3_000,
 
 
     // -------------------------------------------- IDE --------------------------------------------
@@ -185,5 +190,25 @@ export const TimeoutConstants = {
     /**
      * Timeout for Che cluster title visibility in OcpWebConsolePage, "10 000" by default.
      */
-    TS_SELENIUM_RESOURCES_CHE_CLUSTER_TITLE_TIMEOUT: Number(process.env.TS_SELENIUM_RESOURCES_CHE_CLUSTER_TITLE_TIMEOUT) || 10_000
+    TS_SELENIUM_RESOURCES_CHE_CLUSTER_TITLE_TIMEOUT: Number(process.env.TS_SELENIUM_RESOURCES_CHE_CLUSTER_TITLE_TIMEOUT) || 10_000,
+
+
+    // ------------------------------------ OPENSHIFT RELATED ------------------------------------
+
+    /**
+     * Timeout for obtaining cluster IP, "10 000" by default.
+     */
+    TS_GET_CLUSTER_IP_TIMEOUT: Number(process.env.TS_GET_CLUSTER_IP_TIMEOUT) || 10_000,
+
+    /**
+     * Timeout for waiting fr openshift connector tree, "10 000" by default.
+     */
+    TS_WAIT_OPENSHIFT_CONNECTOR_TREE_TIMEOUT: Number(process.env.TS_WAIT_OPENSHIFT_CONNECTOR_TREE_TIMEOUT) || 10_000,
+
+    /**
+     * Timeout for creating CheCluster yaml, "10 000" by default.
+     */
+    TS_CREATE_CHECLUSTER_YAML_TIMEOUT: Number(process.env.TS_CREATE_CHECLUSTER_YAML_TIMEOUT) || 10_000,
+
+
 };

--- a/tests/e2e/driver/CheReporter.ts
+++ b/tests/e2e/driver/CheReporter.ts
@@ -20,6 +20,7 @@ import { ScreenCatcher } from '../utils/ScreenCatcher';
 import { ITestWorkspaceUtil } from '../utils/workspace/ITestWorkspaceUtil';
 import { PreferencesHandler, AskForConfirmationType } from '../utils/PreferencesHandler';
 import { CheApiRequestHandler } from '../utils/requestHandlers/CheApiRequestHandler';
+import { TimeoutConstants } from '../TimeoutConstants';
 
 const e2eContainer = inversifyConfig.e2eContainer;
 const driver: IDriver = e2eContainer.get(TYPES.Driver);
@@ -43,11 +44,10 @@ class CheReporter extends mocha.reporters.Spec {
 
       TS_SELENIUM_DEFAULT_ATTEMPTS: ${TestConstants.TS_SELENIUM_DEFAULT_ATTEMPTS}
       TS_SELENIUM_DEFAULT_POLLING: ${TestConstants.TS_SELENIUM_DEFAULT_POLLING}
-      TS_SELENIUM_DEFAULT_TIMEOUT: ${TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT}
 
-      TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT: ${TestConstants.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT}
-      TS_SELENIUM_LOAD_PAGE_TIMEOUT: ${TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT}
-      TS_SELENIUM_START_WORKSPACE_TIMEOUT: ${TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT}
+      TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT: ${TimeoutConstants.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT}
+      TS_SELENIUM_LOAD_PAGE_TIMEOUT: ${TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT}
+      TS_SELENIUM_START_WORKSPACE_TIMEOUT: ${TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT}
       TS_SELENIUM_WORKSPACE_STATUS_ATTEMPTS: ${TestConstants.TS_SELENIUM_WORKSPACE_STATUS_ATTEMPTS}
       TS_SELENIUM_WORKSPACE_STATUS_POLLING: ${TestConstants.TS_SELENIUM_WORKSPACE_STATUS_POLLING}
       TS_SELENIUM_PLUGIN_PRECENCE_ATTEMPTS: ${TestConstants.TS_SELENIUM_PLUGIN_PRECENCE_ATTEMPTS}

--- a/tests/e2e/driver/CheReporter.ts
+++ b/tests/e2e/driver/CheReporter.ts
@@ -36,25 +36,16 @@ class CheReporter extends mocha.reporters.Spec {
     super(runner, options);
 
     runner.on('start', async (test: mocha.Test) => {
-      const launchInformation: string =
+      let launchInformation: string =
         `################## Launch Information ##################
 
       TS_SELENIUM_BASE_URL: ${TestConstants.TS_SELENIUM_BASE_URL}
       TS_SELENIUM_HEADLESS: ${TestConstants.TS_SELENIUM_HEADLESS}
 
-      TS_SELENIUM_DEFAULT_ATTEMPTS: ${TestConstants.TS_SELENIUM_DEFAULT_ATTEMPTS}
-      TS_SELENIUM_DEFAULT_POLLING: ${TestConstants.TS_SELENIUM_DEFAULT_POLLING}
-
-      TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT: ${TimeoutConstants.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT}
-      TS_SELENIUM_LOAD_PAGE_TIMEOUT: ${TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT}
-      TS_SELENIUM_START_WORKSPACE_TIMEOUT: ${TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT}
-      TS_SELENIUM_WORKSPACE_STATUS_ATTEMPTS: ${TestConstants.TS_SELENIUM_WORKSPACE_STATUS_ATTEMPTS}
-      TS_SELENIUM_WORKSPACE_STATUS_POLLING: ${TestConstants.TS_SELENIUM_WORKSPACE_STATUS_POLLING}
-      TS_SELENIUM_PLUGIN_PRECENCE_ATTEMPTS: ${TestConstants.TS_SELENIUM_PLUGIN_PRECENCE_ATTEMPTS}
-      TS_SELENIUM_PLUGIN_PRECENCE_POLLING: ${TestConstants.TS_SELENIUM_DEFAULT_POLLING}
-      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: ${TestConstants.TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME}
       TS_SELENIUM_USERNAME: ${TestConstants.TS_SELENIUM_USERNAME}
       TS_SELENIUM_PASSWORD: ${TestConstants.TS_SELENIUM_PASSWORD}
+
+      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: ${TestConstants.TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME}
       TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: ${TestConstants.TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS}
       TS_SELENIUM_REPORT_FOLDER: ${TestConstants.TS_SELENIUM_REPORT_FOLDER}
       TS_SELENIUM_EXECUTION_SCREENCAST: ${TestConstants.TS_SELENIUM_EXECUTION_SCREENCAST}
@@ -62,9 +53,24 @@ class CheReporter extends mocha.reporters.Spec {
       TS_SELENIUM_REMOTE_DRIVER_URL: ${TestConstants.TS_SELENIUM_REMOTE_DRIVER_URL}
       DELETE_WORKSPACE_ON_FAILED_TEST: ${TestConstants.DELETE_WORKSPACE_ON_FAILED_TEST}
       TS_SELENIUM_LOG_LEVEL: ${TestConstants.TS_SELENIUM_LOG_LEVEL}
+`;
 
+      if ( TestConstants.TS_SELENIUM_PRINT_TIMEOUT_VARIABLES ) {
+        launchInformation = launchInformation + `
+      TS_SELENIUM_PRINT_TIMEOUT_VARIABLES is set to true:
+        `;
+        Object.entries(TimeoutConstants).forEach(
+          ([key, value]) => launchInformation = launchInformation + `
+          ${key}: ${value}`);
+      } else {
+        launchInformation = launchInformation + `
+      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true`;
+      }
+
+      launchInformation = launchInformation + `
 ########################################################
       `;
+
       console.log(launchInformation);
 
       rm.sync(TestConstants.TS_SELENIUM_REPORT_FOLDER);

--- a/tests/e2e/driver/CheReporter.ts
+++ b/tests/e2e/driver/CheReporter.ts
@@ -56,20 +56,14 @@ class CheReporter extends mocha.reporters.Spec {
 `;
 
       if ( TestConstants.TS_SELENIUM_PRINT_TIMEOUT_VARIABLES ) {
-        launchInformation = launchInformation + `
-      TS_SELENIUM_PRINT_TIMEOUT_VARIABLES is set to true:
-        `;
+        launchInformation += `\n      TS_SELENIUM_PRINT_TIMEOUT_VARIABLES is set to true: \n`;
         Object.entries(TimeoutConstants).forEach(
-          ([key, value]) => launchInformation = launchInformation + `
-          ${key}: ${value}`);
+          ([key, value]) => launchInformation += `\n         ${key}: ${value}`);
       } else {
-        launchInformation = launchInformation + `
-      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true`;
+        launchInformation += `\n      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true`;
       }
 
-      launchInformation = launchInformation + `
-########################################################
-      `;
+      launchInformation += `\n ######################################################## \n`;
 
       console.log(launchInformation);
 

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -7,12 +7,12 @@
     "@eclipse-che/api": {
       "version": "7.5.0-SNAPSHOT",
       "resolved": "https://registry.npmjs.org/@eclipse-che/api/-/api-7.5.0-SNAPSHOT.tgz",
-      "integrity": "sha512-4CgKEGCBOIOBGBNoH0dhN8TkP1Sj39fG4LGCXYw3JB7nQucVooJyq7AhIV+w7L4iZ+ln+y2KEfZugCmOIuzIeQ=="
+      "integrity": "sha1-vwxb5gNU40xzvFKy4YvoaAzo2QA="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "integrity": "sha1-Olgr21OATGum0UZXnEblITDPSjs=",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "2.0.3",
@@ -22,13 +22,13 @@
     "@nodelib/fs.stat": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "integrity": "sha1-NNxfTKu8cg9OYPdadH5+zWwXW9M=",
       "dev": true
     },
     "@nodelib/fs.walk": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "integrity": "sha1-ARuSAqcKY2bkNspcBlhEUoqwSXY=",
       "dev": true,
       "requires": {
         "@nodelib/fs.scandir": "2.1.3",
@@ -38,25 +38,25 @@
     "@testim/chrome-version": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@testim/chrome-version/-/chrome-version-1.0.7.tgz",
-      "integrity": "sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==",
+      "integrity": "sha1-DNkVeF7EGQ8Io6asybYfw4+18ak=",
       "dev": true
     },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
-      "integrity": "sha512-2Y8uPt0/jwjhQ6EiluT0XCri1Dbplr0ZxfFXUz+ye13gaqE8u5gL5ppao1JrUYr9cIip5S6MvQzBS7Kke7U9VA==",
+      "integrity": "sha1-G44zthqMCcvh+FEzBxuqDb+fpxo=",
       "dev": true
     },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
       "dev": true
     },
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
       "dev": true,
       "requires": {
         "@types/events": "*",
@@ -67,25 +67,25 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
       "dev": true
     },
     "@types/mocha": {
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.6.tgz",
-      "integrity": "sha512-1axi39YdtBI7z957vdqXI4Ac25e7YihYQtJa+Clnxg1zTJEaIRbndt71O3sP4GAMgiAm0pY26/b9BrY4MR/PMw==",
+      "integrity": "sha1-uGItUFV90VXp8vY0t9aP043l6Us=",
       "dev": true
     },
     "@types/node": {
       "version": "11.13.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.4.tgz",
-      "integrity": "sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==",
+      "integrity": "sha1-+D7Dw+BbF0tyQfretmiCZ/5bIso=",
       "dev": true
     },
     "@types/rimraf": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/rimraf/-/rimraf-2.0.2.tgz",
-      "integrity": "sha512-Hm/bnWq0TCy7jmjeN5bKYij9vw5GrDFWME4IuxV08278NtU/VdGbzsBohcCUJ7+QMqmUq5hpRKB39HeQWJjztQ==",
+      "integrity": "sha1-fw/Dzw/wrSqZu3I64XZPMKyvi24=",
       "dev": true,
       "requires": {
         "@types/glob": "*",
@@ -95,13 +95,13 @@
     "@types/selenium-webdriver": {
       "version": "3.0.16",
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-3.0.16.tgz",
-      "integrity": "sha512-lMC2G0ItF2xv4UCiwbJGbnJlIuUixHrioOhNGHSCsYCJ8l4t9hMCUimCytvFv7qy6AfSzRxhRHoGa+UqaqwyeA==",
+      "integrity": "sha1-UKR1X44z7azZxAZynpuTDSRRkCo=",
       "dev": true
     },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
-      "integrity": "sha512-quoaXsZ9/BLNae5yiNoUz+Nhkwz83GhWwtYFglcjEQB2NDHCIpApbqXxIFnm4Pq/Nvhrsq5sYJFyohrrxnTGAA==",
+      "integrity": "sha1-2y/nJG5Tb0DZtUQqOeEX191qJOA=",
       "dev": true,
       "requires": {
         "clean-stack": "^2.0.0",
@@ -111,7 +111,7 @@
     "ansi-colors": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "integrity": "sha1-V9NbhoboUeLMBMQD8cACA5dqGBM=",
       "dev": true
     },
     "ansi-regex": {
@@ -123,7 +123,7 @@
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
@@ -132,7 +132,7 @@
     "anymatch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-      "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+      "integrity": "sha1-xV7PAhheJGklk5kxDBc84xIzsUI=",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -148,7 +148,7 @@
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -157,19 +157,19 @@
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "integrity": "sha1-t5hCCtvrHego2ErNii4j0+/oXo0=",
       "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "integrity": "sha1-5gtrDo8wG9l+U3UhW9pAbIURjAs=",
       "dev": true
     },
     "axios": {
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "integrity": "sha1-/z8N4ue10YDnV62YAA8Qgbh7zqM=",
       "dev": true,
       "requires": {
         "follow-redirects": "1.5.10",
@@ -238,13 +238,13 @@
     "binary-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -254,7 +254,7 @@
     "braces": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
       "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
@@ -263,7 +263,7 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
     },
     "buffer-crc32": {
@@ -275,7 +275,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "integrity": "sha1-MnE7wCj3XAL9txDXx7zsHyxgcO8=",
       "dev": true
     },
     "builtin-modules": {
@@ -287,13 +287,13 @@
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
       "dev": true
     },
     "chai": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
-      "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
+      "integrity": "sha1-dgqnLPION5XoSxKHfODoNzeqKeU=",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
@@ -307,7 +307,7 @@
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
@@ -318,7 +318,7 @@
         "supports-color": {
           "version": "5.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -335,7 +335,7 @@
     "chokidar": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "integrity": "sha1-EsBxRmjFWAD2WeJi1JYql/r1VKY=",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
@@ -351,7 +351,7 @@
     "chromedriver": {
       "version": "80.0.1",
       "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-80.0.1.tgz",
-      "integrity": "sha512-VfRtZUpBUIjeypS+xM40+VD9g4Drv7L2VibG/4+0zX3mMx4KayN6gfKETycPfO6JwQXTLSxEr58fRcrsa8r5xQ==",
+      "integrity": "sha1-NcFkLi2GS56CYvKRAD5FWw5CKRc=",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
@@ -365,7 +365,7 @@
         "axios": {
           "version": "0.19.2",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "integrity": "sha1-PqNsXYgY0NX4qKl6bTa4bNwAyyc=",
           "dev": true,
           "requires": {
             "follow-redirects": "1.5.10"
@@ -382,13 +382,13 @@
     "clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "integrity": "sha1-7oRy27Ep5yezHooQpCfe6d/kAIs=",
       "dev": true
     },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
       "dev": true,
       "requires": {
         "string-width": "^3.1.0",
@@ -399,13 +399,13 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -416,7 +416,7 @@
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -427,7 +427,7 @@
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
         "color-name": "1.1.3"
@@ -454,7 +454,7 @@
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
@@ -487,7 +487,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -502,7 +502,7 @@
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
@@ -511,7 +511,7 @@
     "del": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/del/-/del-5.1.0.tgz",
-      "integrity": "sha512-wH9xOVHnczo9jN2IW68BabcecVPxacIA3g/7z6vhSU/4stOKQzeCRK0yD0A24WiAAUJmmVpWqrERcTxnLo3AnA==",
+      "integrity": "sha1-2Uh8lONnQQ5u/ykl7ljAyEp1s6c=",
       "dev": true,
       "requires": {
         "globby": "^10.0.1",
@@ -527,7 +527,7 @@
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+          "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
@@ -538,13 +538,13 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "integrity": "sha1-Vtv3PZkqSpO6FYT0U0Bj/S5BcX8=",
       "dev": true,
       "requires": {
         "path-type": "^4.0.0"
@@ -553,13 +553,13 @@
     "emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
       "dev": true
     },
     "es-abstract": {
       "version": "1.17.5",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "integrity": "sha1-2MnR1myJgfuSAOIlHXme7pJ3Suk=",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -578,7 +578,7 @@
     "es-to-primitive": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
       "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
@@ -595,7 +595,7 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esutils": {
@@ -607,7 +607,7 @@
     "extract-zip": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
-      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
+      "integrity": "sha1-VWzDrp339FLEk6DPtRzDAneUCSc=",
       "dev": true,
       "requires": {
         "concat-stream": "^1.6.2",
@@ -619,7 +619,7 @@
     "fast-glob": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
-      "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+      "integrity": "sha1-reGp2RFIll1L98UfcuHKZi0y5j0=",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -651,7 +651,7 @@
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
       "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
@@ -660,7 +660,7 @@
     "find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "integrity": "sha1-SRafHXmTQwZG2mHsxa41XCHJe3M=",
       "dev": true,
       "requires": {
         "locate-path": "^3.0.0"
@@ -669,7 +669,7 @@
     "flat": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "integrity": "sha1-CQvsiwXjnLowl0fx1YjwTbr5jbI=",
       "dev": true,
       "requires": {
         "is-buffer": "~2.0.3"
@@ -678,7 +678,7 @@
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "integrity": "sha1-e3qfmuov3/NnhqlP9kPtB/T/Xio=",
       "dev": true,
       "requires": {
         "debug": "=3.1.0"
@@ -711,13 +711,13 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
       "dev": true
     },
     "get-func-name": {
@@ -752,7 +752,7 @@
     "globby": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.2.tgz",
-      "integrity": "sha512-7dUi7RvCoT/xast/o/dLN53oqND4yk0nsHkhRgn9w65C4PofCLOoJ39iSOg+qVDdWQPIEj+eszMHQ+aLVwwQSg==",
+      "integrity": "sha1-J3WT50WsqkZGw6tBEonsR6A5JUM=",
       "dev": true,
       "requires": {
         "@types/glob": "^7.1.1",
@@ -768,19 +768,19 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "integrity": "sha1-ShL/G2A3bvCYYsIJPt2Qgyi+hCM=",
       "dev": true
     },
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+      "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
       "dev": true
     },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
@@ -812,19 +812,19 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+      "integrity": "sha1-n1IUdYpEGWxAbZvXbOv4HsLdMeg=",
       "dev": true
     },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
     },
     "ignore": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-      "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+      "integrity": "sha1-hLez2+ZFUrbvDsqZ9nQ9vsbZet8=",
       "dev": true
     },
     "immediate": {
@@ -836,7 +836,7 @@
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "integrity": "sha1-Yk+PRJfWGbLZdoUx1Y9BIoVNclE=",
       "dev": true
     },
     "inflight": {
@@ -858,7 +858,7 @@
     "inversify": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/inversify/-/inversify-5.0.1.tgz",
-      "integrity": "sha512-Ieh06s48WnEYGcqHepdsJUIJUXpwH5o5vodAX+DK2JA/gjy4EbEcQZxw+uFfzysmKjiLXGYwNG3qDZsKVMcINQ=="
+      "integrity": "sha1-UA1wmxQ0iWzloNWJFcSkIQ40+24="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -869,7 +869,7 @@
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
       "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
@@ -884,13 +884,13 @@
     "is-callable": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "integrity": "sha1-9+RrWWiQRW23Tn9ul2yzJz0G+qs=",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
+      "integrity": "sha1-vac28s2P0G0yhE53Q7+nSUw7/X4=",
       "dev": true
     },
     "is-extglob": {
@@ -908,7 +908,7 @@
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -917,25 +917,25 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
       "dev": true
     },
     "is-path-cwd": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "integrity": "sha1-Z9Q7gmZKe1GR/ZEZEn6zAASKn9s=",
       "dev": true
     },
     "is-path-inside": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
-      "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==",
+      "integrity": "sha1-9SIPyCo+IzdXKR3dycWHfyofMBc=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "integrity": "sha1-OdWJo1i/GJZ/cmlnEguPwa7XTq4=",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
@@ -944,7 +944,7 @@
     "is-symbol": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "integrity": "sha1-OOEBS55jKb4N6dJKQU/XRB7GGTc=",
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
@@ -953,13 +953,13 @@
     "is-url": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
-      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==",
+      "integrity": "sha1-BKTfRtKMTP89c9Af8Gq+sxihqlI=",
       "dev": true
     },
     "is2": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.1.tgz",
-      "integrity": "sha512-+WaJvnaA7aJySz2q/8sLjMb2Mw14KTplHmSwcSpZ/fWJPkUmqw3YTzSWbPJ7OAwRvdYTWF2Wg+yYJ1AdP5Z8CA==",
+      "integrity": "sha1-isNVZEhAkhzkNdlPBdOpRjTTSBo=",
       "dev": true,
       "requires": {
         "deep-is": "^0.1.3",
@@ -988,7 +988,7 @@
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -1010,7 +1010,7 @@
     "lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "integrity": "sha1-3Pgt7lRfRgdNryAMfBxaCOD0D2o=",
       "dev": true,
       "requires": {
         "immediate": "~3.0.5"
@@ -1019,7 +1019,7 @@
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "integrity": "sha1-2+w7OrdZdYBxtY/ln8QYca8hQA4=",
       "dev": true,
       "requires": {
         "p-locate": "^3.0.0",
@@ -1035,7 +1035,7 @@
     "log-symbols": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-      "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+      "integrity": "sha1-86CFFqXeqJMzan3uFNGKHP2rd8Q=",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2"
@@ -1050,13 +1050,13 @@
     "merge2": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+      "integrity": "sha1-WzZu6DsvFYLEj4fkfPGpNSEDyoE=",
       "dev": true
     },
     "micromatch": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "integrity": "sha1-T8sJmb+fvC/L3SEvbWKbmlbDklk=",
       "dev": true,
       "requires": {
         "braces": "^3.0.1",
@@ -1066,7 +1066,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -1075,7 +1075,7 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
       "dev": true
     },
     "mkdirp": {
@@ -1090,7 +1090,7 @@
     "mocha": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+      "integrity": "sha1-ifuzDQlCmEWxu4k6gwv1dxBJpEE=",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -1122,7 +1122,7 @@
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "integrity": "sha1-6D0X3hbYp++3cX7b5fsQE17uYps=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -1131,7 +1131,7 @@
         "mkdirp": {
           "version": "0.5.3",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "integrity": "sha1-WlFLcXklkoeVKIHpRBDsVGVln4w=",
           "dev": true,
           "requires": {
             "minimist": "^1.2.5"
@@ -1148,7 +1148,7 @@
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
         }
       }
@@ -1162,7 +1162,7 @@
     "node-environment-flags": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
+      "integrity": "sha1-owrBNiH299Z0JgpU3t4EjDmCwIg=",
       "dev": true,
       "requires": {
         "object.getownpropertydescriptors": "^2.0.3",
@@ -1172,25 +1172,25 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
       "dev": true
     },
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "integrity": "sha1-9Pa9GBrXfwBrXs5gvQtvOY/3Smc=",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
     "object.assign": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "integrity": "sha1-lovxEA15Vrs8oIbwBvhGs7xACNo=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
@@ -1202,7 +1202,7 @@
     "object.getownpropertydescriptors": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "integrity": "sha1-Npvx+VktiridcS3O1cuBx8U1Jkk=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -1227,7 +1227,7 @@
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "integrity": "sha1-PdM8ZHohT9//2DWTPrCG2g3CHbE=",
       "dev": true,
       "requires": {
         "p-try": "^2.0.0"
@@ -1236,7 +1236,7 @@
     "p-locate": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "integrity": "sha1-Mi1poFwCZLJZl9n0DNiokasAZKQ=",
       "dev": true,
       "requires": {
         "p-limit": "^2.0.0"
@@ -1245,7 +1245,7 @@
     "p-map": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
+      "integrity": "sha1-1wTZr4orpoTiYA2aIVmD1BQal50=",
       "dev": true,
       "requires": {
         "aggregate-error": "^3.0.0"
@@ -1254,7 +1254,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "pako": {
@@ -1278,13 +1278,13 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "integrity": "sha1-hO0BwKe6OAr+CdkKjBgNzZ0DBDs=",
       "dev": true
     },
     "pathval": {
@@ -1329,7 +1329,7 @@
     "readdirp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "integrity": "sha1-wwwzNSsSyW37S4lUIaSf1alZODk=",
       "dev": true,
       "requires": {
         "picomatch": "^2.0.4"
@@ -1338,7 +1338,7 @@
     "reflect-metadata": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
-      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
+      "integrity": "sha1-Z648pXyXKiqhZCsQ/jY/4y1J3Ag="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -1349,7 +1349,7 @@
     "require-main-filename": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
     "resolve": {
@@ -1364,13 +1364,13 @@
     "reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "integrity": "sha1-kNo4Kx4SbvwCFG6QhFqI2xKSXXY=",
       "dev": true
     },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
       "dev": true,
       "requires": {
         "glob": "^7.0.5"
@@ -1379,25 +1379,25 @@
     "run-parallel": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+      "integrity": "sha1-yd06fPn0ssS2JE4XOm7YZuYd1nk=",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
       "dev": true
     },
     "selenium-webdriver": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
-      "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
+      "integrity": "sha1-K6h6FmLAILiYjJga5iyyoBKY6vw=",
       "dev": true,
       "requires": {
         "jszip": "^3.1.3",
@@ -1427,13 +1427,13 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "integrity": "sha1-ZTm+hwwWWtvVJAIg2+Nh8bxNRjQ=",
       "dev": true
     },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
       "dev": true
     },
     "source-map-support": {
@@ -1455,7 +1455,7 @@
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
@@ -1475,7 +1475,7 @@
     "string.prototype.trimleft": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+      "integrity": "sha1-RAiqLl1t3QyagHObCH+8BnwDs8w=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -1486,7 +1486,7 @@
     "string.prototype.trimright": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
+      "integrity": "sha1-x28c7zDyG7rYr+uNsVEUls+w8qM=",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -1507,7 +1507,7 @@
     "string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
@@ -1531,7 +1531,7 @@
     "supports-color": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+      "integrity": "sha1-ds/nQs8fQbubHCmtAwaMBbTA5Ao=",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
@@ -1540,7 +1540,7 @@
     "tcp-port-used": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
-      "integrity": "sha512-rwi5xJeU6utXoEIiMvVBMc9eJ2/ofzB+7nLOdnZuFTmNCLqRiQh2sMG9MqCxHU/69VC/Fwp5dV9306Qd54ll1Q==",
+      "integrity": "sha1-RgYQeOLTjHOXmiwsErWmdOZonXA=",
       "dev": true,
       "requires": {
         "debug": "4.1.0",
@@ -1550,7 +1550,7 @@
         "debug": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+          "integrity": "sha1-NzaHv/pnizixzZH4YbY4UANd3Ic=",
           "dev": true,
           "requires": {
             "ms": "^2.1.1"
@@ -1559,7 +1559,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
       }
@@ -1576,7 +1576,7 @@
     "to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
       "dev": true,
       "requires": {
         "is-number": "^7.0.0"
@@ -1585,7 +1585,7 @@
     "ts-node": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.0.3.tgz",
-      "integrity": "sha512-2qayBA4vdtVRuDo11DEFSsD/SFsBXQBRZZhbRGSIkmYmVkWjULn/GGMdG10KVqkaGndljfaTD8dKjWgcejO8YA==",
+      "integrity": "sha1-qmC4NqJNr9i/IbVHZoQaIy/bxkE=",
       "dev": true,
       "requires": {
         "arg": "^4.1.0",
@@ -1624,7 +1624,7 @@
     "tsutils": {
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
-      "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+      "integrity": "sha1-MrSIUBRnrL7dS4VJhnOggSrKC5k=",
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
@@ -1639,13 +1639,13 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "integrity": "sha1-dkb7XxiHHPu3dJ5pvTmmOI63RQw=",
       "dev": true
     },
     "typed-rest-client": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "integrity": "sha1-cjCF0gPzjX0UcnHl7Tp1SI60SgI=",
       "dev": true,
       "requires": {
         "tunnel": "0.0.4",
@@ -1661,7 +1661,7 @@
     "typescript": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
-      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
+      "integrity": "sha1-DrMg5KzpsQ6t9bxhAyhrD4t8Ik8=",
       "dev": true
     },
     "underscore": {
@@ -1679,7 +1679,7 @@
     "which": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -1694,7 +1694,7 @@
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
@@ -1703,7 +1703,7 @@
     "wrap-ansi": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
       "dev": true,
       "requires": {
         "ansi-styles": "^3.2.0",
@@ -1714,13 +1714,13 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -1731,7 +1731,7 @@
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -1764,13 +1764,13 @@
     "y18n": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "integrity": "sha1-le+U+F7MgdAHwmThkKEg8KPIVms=",
       "dev": true
     },
     "yargs": {
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-      "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "integrity": "sha1-rX/+/sGqWVZayRX4Lcyzipwxot0=",
       "dev": true,
       "requires": {
         "cliui": "^5.0.0",
@@ -1788,13 +1788,13 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
           "dev": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
           "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
@@ -1805,7 +1805,7 @@
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
@@ -1816,7 +1816,7 @@
     "yargs-parser": {
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-      "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "integrity": "sha1-Ew8JcC667vJlDVTObj5XBvek+zg=",
       "dev": true,
       "requires": {
         "camelcase": "^5.0.0",
@@ -1826,7 +1826,7 @@
     "yargs-unparser": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "integrity": "sha1-7yXCx2n/a9CeSw+dfGBfsnhG6p8=",
       "dev": true,
       "requires": {
         "flat": "^4.1.0",

--- a/tests/e2e/pageobjects/dashboard/Dashboard.ts
+++ b/tests/e2e/pageobjects/dashboard/Dashboard.ts
@@ -13,6 +13,7 @@ import { CLASSES } from '../../inversify.types';
 import { By } from 'selenium-webdriver';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { TestConstants } from '../../TestConstants';
+import { TimeoutConstants } from '../../TimeoutConstants';
 import { Workspaces } from './Workspaces';
 import { Logger } from '../../utils/Logger';
 
@@ -62,7 +63,7 @@ export class Dashboard {
 
     }
 
-    async waitPage(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitPage(timeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
         Logger.debug('Dashboard.waitPage');
 
         await this.driverHelper.waitVisibility(By.css(Dashboard.WORKSPACES_BUTTON_CSS), timeout);
@@ -70,49 +71,49 @@ export class Dashboard {
         await this.driverHelper.waitVisibility(By.xpath(Dashboard.GET_STARTED_BUTTON_XPATH), timeout);
     }
 
-    async clickDashboardButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickDashboardButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('Dashboard.clickDashboardButton');
 
         await this.driverHelper.waitAndClick(By.css(Dashboard.DASHBOARD_BUTTON_CSS), timeout);
     }
 
-    async clickWorkspacesButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickWorkspacesButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('Dashboard.clickWorkspacesButton');
 
         await this.driverHelper.waitAndClick(By.css(Dashboard.WORKSPACES_BUTTON_CSS), timeout);
     }
 
-    async clickStacksdButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickStacksdButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('Dashboard.clickStacksdButton');
 
         await this.driverHelper.waitAndClick(By.css(Dashboard.STACKS_BUTTON_CSS), timeout);
     }
 
-    async clickGetStartedButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickGetStartedButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('Dashboard.clickGetStartedButton');
 
         await this.driverHelper.waitAndClick(By.xpath(Dashboard.GET_STARTED_BUTTON_XPATH), timeout);
     }
 
-    async clickFactoriesButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickFactoriesButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('Dashboard.clickFactoriesButton');
 
         await this.driverHelper.waitAndClick(By.css(Dashboard.FACTORIES_BUTTON_CSS), timeout);
     }
 
-    async waitLoader(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitLoader(timeout: number = TimeoutConstants.TS_WAIT_LOADER_PRESENCE_TIMEOUT) {
         Logger.debug('Dashboard.waitLoader');
 
         await this.driverHelper.waitVisibility(By.css(Dashboard.LOADER_PAGE_CSS), timeout);
     }
 
-    async waitLoaderDisappearance(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitLoaderDisappearance(timeout: number = TimeoutConstants.TS_WAIT_LOADER_ABSENCE_TIMEOUT) {
         Logger.debug('Dashboard.waitLoaderDisappearance');
 
         await this.driverHelper.waitDisappearance(By.css(Dashboard.LOADER_PAGE_CSS), timeout);
     }
 
-    async waitDisappearanceNavigationMenu(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitDisappearanceNavigationMenu(timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug('Dashboard.waitDisappearanceNavigationMenu');
 
         await this.driverHelper.waitDisappearance(By.id('chenavmenu'), timeout);

--- a/tests/e2e/pageobjects/dashboard/GetStarted.ts
+++ b/tests/e2e/pageobjects/dashboard/GetStarted.ts
@@ -11,15 +11,15 @@
 import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { TestConstants } from '../../TestConstants';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class GetStarted {
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
-    async waitTitleContains(expectedText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitTitleContains(expectedText: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`GetStarted.waitTitleContains text: "${expectedText}"`);
 
         const pageTitleLocator: By = By.xpath(`//div[contains(@title, '${expectedText}')]`);
@@ -27,13 +27,13 @@ export class GetStarted {
         await this.driverHelper.waitVisibility(pageTitleLocator, timeout);
     }
 
-    async waitPage(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitPage(timeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
         Logger.debug('GetStarted.waitPage');
 
         await this.waitTitleContains('Getting Started', timeout);
     }
 
-    async waitSample(sampleName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitSample(sampleName: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`GetStarted.waitSample sampleName: "${sampleName}"`);
 
         const sampleLocator: By = this.getSampleLocator(sampleName);
@@ -41,7 +41,7 @@ export class GetStarted {
         await this.driverHelper.waitVisibility(sampleLocator, timeout);
     }
 
-    async clickOnSample(sampleName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnSample(sampleName: string, timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug(`GetStarted.clickOnSample sampleName: "${sampleName}"`);
 
         const sampleLocator: By = this.getSampleLocator(sampleName);
@@ -49,7 +49,7 @@ export class GetStarted {
         await this.driverHelper.waitAndClick(sampleLocator, timeout);
     }
 
-    async waitSampleSelected(sampleName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitSampleSelected(sampleName: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`GetStarted.waitSampleSelected sampleName: "${sampleName}"`);
 
         const selectedSampleLocator: By =
@@ -58,7 +58,7 @@ export class GetStarted {
         await this.driverHelper.waitVisibility(selectedSampleLocator, timeout);
     }
 
-    async waitSampleUnselected(sampleName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitSampleUnselected(sampleName: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`GetStarted.waitSampleUnselected sampleName: "${sampleName}"`);
 
         const unselectedSampleLocator: By =
@@ -67,7 +67,7 @@ export class GetStarted {
         await this.driverHelper.waitVisibility(unselectedSampleLocator, timeout);
     }
 
-    async clickCreateAndOpenButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickCreateAndOpenButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('GetStarted.clickCreateAndOpenButton');
 
         const createAndOpenButtonLocator: By =

--- a/tests/e2e/pageobjects/dashboard/Workspaces.ts
+++ b/tests/e2e/pageobjects/dashboard/Workspaces.ts
@@ -14,6 +14,7 @@ import { DriverHelper } from '../../utils/DriverHelper';
 import { CLASSES } from '../../inversify.types';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 
 @injectable()
@@ -22,19 +23,19 @@ export class Workspaces {
 
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
-    async waitPage(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitPage(timeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
         Logger.debug('Workspaces.waitPage');
 
         await this.driverHelper.waitVisibility(By.css(Workspaces.ADD_WORKSPACE_BUTTON_CSS), timeout);
     }
 
-    async clickAddWorkspaceButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickAddWorkspaceButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('Workspaces.clickAddWorkspaceButton');
 
         await this.driverHelper.waitAndClick(By.css(Workspaces.ADD_WORKSPACE_BUTTON_CSS), timeout);
     }
 
-    async waitWorkspaceListItem(workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitWorkspaceListItem(workspaceName: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`Workspaces.waitWorkspaceListItem "${workspaceName}"`);
 
         const workspaceListItemLocator: By = By.css(this.getWorkspaceListItemLocator(workspaceName));
@@ -42,7 +43,7 @@ export class Workspaces {
         await this.driverHelper.waitVisibility(workspaceListItemLocator, timeout);
     }
 
-    async clickOnStopWorkspaceButton(workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnStopWorkspaceButton(workspaceName: string, timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug(`Workspaces.clickOnStopWorkspaceButton "${workspaceName}"`);
 
         const stopWorkspaceButtonLocator: By = By.css(`#ws-name-${workspaceName} .workspace-status[uib-tooltip="Stop workspace"]`);
@@ -50,7 +51,7 @@ export class Workspaces {
         await this.driverHelper.waitAndClick(stopWorkspaceButtonLocator, timeout);
     }
 
-    async waitWorkspaceWithRunningStatus(workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+    async waitWorkspaceWithRunningStatus(workspaceName: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`Workspaces.waitWorkspaceWithRunningStatus "${workspaceName}"`);
 
         const runningStatusLocator: By = By.css(this.getWorkspaceStatusCssLocator(workspaceName, 'RUNNING'));
@@ -58,7 +59,7 @@ export class Workspaces {
         await this.driverHelper.waitVisibility(runningStatusLocator, timeout);
     }
 
-    async waitWorkspaceWithStoppedStatus(workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+    async waitWorkspaceWithStoppedStatus(workspaceName: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`Workspaces.waitWorkspaceWithStoppedStatus "${workspaceName}"`);
 
         const stoppedStatusLocator: By = By.css(this.getWorkspaceStatusCssLocator(workspaceName, 'STOPPED'));
@@ -66,7 +67,7 @@ export class Workspaces {
         await this.driverHelper.waitVisibility(stoppedStatusLocator, timeout);
     }
 
-    async clickWorkspaceListItem(workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+    async clickWorkspaceListItem(workspaceName: string, timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug(`Workspaces.clickWorkspaceListItem "${workspaceName}"`);
 
         let namespace: string = TestConstants.TS_SELENIUM_USERNAME;
@@ -75,7 +76,7 @@ export class Workspaces {
         await this.driverHelper.waitAndClick(workspaceListItemLocator, timeout);
     }
 
-    async clickDeleteButtonOnWorkspaceDetails(timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+    async clickDeleteButtonOnWorkspaceDetails(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('Workspaces.clickDeleteButtonOnWorkspaceDetails');
 
         const deleteButtonOnWorkspaceDetailsLocator: By = By.css('che-button-danger[che-button-title=\'Delete\']');
@@ -83,7 +84,7 @@ export class Workspaces {
         await this.driverHelper.waitAndClick(deleteButtonOnWorkspaceDetailsLocator, timeout);
     }
 
-    async waitWorkspaceListItemAbcence(workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+    async waitWorkspaceListItemAbcence(workspaceName: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`Workspaces.waitWorkspaceListItemAbcence "${workspaceName}"`);
 
         let namespace: string = TestConstants.TS_SELENIUM_USERNAME;
@@ -92,7 +93,7 @@ export class Workspaces {
         await this.driverHelper.waitDisappearance(workspaceListItemLocator, timeout);
     }
 
-    async confirmWorkspaceDeletion(timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+    async confirmWorkspaceDeletion(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('Workspaces.confirmWorkspaceDeletion');
 
         const checkbox: By = By.xpath(`//che-popup//input[@id='enable-button' and contains(@class, 'ng-empty')]`);

--- a/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
+++ b/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
@@ -17,6 +17,7 @@ import { Ide } from '../../ide/Ide';
 import { ITestWorkspaceUtil } from '../../../utils/workspace/ITestWorkspaceUtil';
 import { WorkspaceStatus } from '../../../utils/workspace/WorkspaceStatus';
 import { Logger } from '../../../utils/Logger';
+import { TimeoutConstants } from '../../../TimeoutConstants';
 
 
 @injectable()
@@ -44,7 +45,7 @@ export class WorkspaceDetails {
         await this.waitSaveButtonDisappearance();
     }
 
-    async waitPage(workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitPage(workspaceName: string, timeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
         Logger.debug(`WorkspaceDetails.saveChanges workspace: "${workspaceName}"`);
 
         await this.waitWorkspaceTitle(workspaceName, timeout);
@@ -54,7 +55,7 @@ export class WorkspaceDetails {
         await this.waitLoaderDisappearance(timeout);
     }
 
-    async waitWorkspaceTitle(workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitWorkspaceTitle(workspaceName: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`WorkspaceDetails.waitWorkspaceTitle title: "${workspaceName}"`);
 
         const workspaceTitleLocator: By = By.css(this.getWorkspaceTitleCssLocator(workspaceName));
@@ -62,33 +63,33 @@ export class WorkspaceDetails {
         await this.driverHelper.waitVisibility(workspaceTitleLocator, timeout);
     }
 
-    async waitRunButton(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitRunButton(timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug('WorkspaceDetails.waitRunButton');
 
         await this.driverHelper.waitVisibility(By.css(WorkspaceDetails.RUN_BUTTON_CSS), timeout);
     }
 
-    async clickOnRunButton(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async clickOnRunButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         Logger.debug('WorkspaceDetails.clickOnRunButton');
 
         await this.driverHelper.waitAndClick(By.css(WorkspaceDetails.RUN_BUTTON_CSS), timeout);
     }
 
-    async waitOpenButton(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitOpenButton(timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug('WorkspaceDetails.waitOpenButton');
 
         await this.driverHelper.waitVisibility(By.css(WorkspaceDetails.OPEN_BUTTON_CSS), timeout);
     }
 
-    async openWorkspace(namespace: string, workspaceName: string, timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async openWorkspace(namespace: string, workspaceName: string, timeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
         Logger.debug(`WorkspaceDetails.openWorkspace "${namespace}/${workspaceName}"`);
 
         await this.clickOnOpenButton(timeout);
-        await this.driverHelper.waitVisibility(By.css(Ide.ACTIVATED_IDE_IFRAME_CSS));
+        await this.driverHelper.waitVisibility(By.css(Ide.ACTIVATED_IDE_IFRAME_CSS), TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT);
         await this.testWorkspaceUtil.waitWorkspaceStatus(namespace, workspaceName, WorkspaceStatus.STARTING);
     }
 
-    async waitTabsPresence(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitTabsPresence(timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug('WorkspaceDetails.waitTabsPresence');
 
         const workspaceDetailsTabs: Array<string> = ['Overview', 'Projects', 'Containers', 'Servers',
@@ -101,7 +102,7 @@ export class WorkspaceDetails {
         }
     }
 
-    async selectTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async selectTab(tabTitle: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         Logger.debug(`WorkspaceDetails.selectTab ${tabTitle}`);
 
         await this.clickOnTab(tabTitle, timeout);
@@ -120,7 +121,7 @@ export class WorkspaceDetails {
         return `//md-tabs-canvas[@role='tablist']//md-tab-item[@aria-selected='true']//span[text()='${tabTitle}']`;
     }
 
-    private async waitSaveButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    private async waitSaveButton(timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         await this.driverHelper.waitVisibility(By.css(WorkspaceDetails.ENABLED_SAVE_BUTTON_CSS), timeout);
     }
 
@@ -128,22 +129,22 @@ export class WorkspaceDetails {
         await this.driverHelper.waitDisappearance(By.css(WorkspaceDetails.SAVE_BUTTON_CSS), attempts, polling);
     }
 
-    private async clickOnSaveButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    private async clickOnSaveButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         await this.driverHelper.waitAndClick(By.css(WorkspaceDetails.ENABLED_SAVE_BUTTON_CSS), timeout);
     }
 
-    private async clickOnOpenButton(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    private async clickOnOpenButton(timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         await this.driverHelper.waitAndClick(By.css(WorkspaceDetails.OPEN_BUTTON_CSS), timeout);
     }
 
-    private async clickOnTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    private async clickOnTab(tabTitle: string, timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
         const workspaceDetailsTabLocator: By = By.xpath(this.getTabXpathLocator(tabTitle));
 
 
         await this.driverHelper.waitAndClick(workspaceDetailsTabLocator, timeout);
     }
 
-    private async waitTabSelected(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    private async waitTabSelected(tabTitle: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         const selectedTabLocator: By = By.xpath(this.getSelectedTabXpathLocator(tabTitle));
 
         await this.driverHelper.waitVisibility(selectedTabLocator, timeout);

--- a/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetailsPlugins.ts
+++ b/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetailsPlugins.ts
@@ -11,12 +11,12 @@ import { DriverHelper } from '../../../utils/DriverHelper';
 import { injectable, inject } from 'inversify';
 import 'reflect-metadata';
 import { CLASSES, TYPES } from '../../../inversify.types';
-import { TestConstants } from '../../../TestConstants';
 import { By } from 'selenium-webdriver';
 import { WorkspaceDetails } from './WorkspaceDetails';
 import { ITestWorkspaceUtil } from '../../../utils/workspace/ITestWorkspaceUtil';
 import { WorkspaceStatus } from '../../../utils/workspace/WorkspaceStatus';
 import { Logger } from '../../../utils/Logger';
+import { TimeoutConstants } from '../../../TimeoutConstants';
 
 
 @injectable()
@@ -25,28 +25,28 @@ export class WorkspaceDetailsPlugins {
         @inject(CLASSES.WorkspaceDetails) private readonly workspaceDetails: WorkspaceDetails,
         @inject(TYPES.WorkspaceUtil) private readonly testWorkspaceUtil: ITestWorkspaceUtil) { }
 
-    async waitPluginListItem(pluginName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitPluginListItem(pluginName: string) {
         Logger.debug(`WorkspaceDetailsPlugins.waitPluginListItem ${pluginName}`);
 
         const pluginListItemLocator: By = By.css(this.getPluginListItemCssLocator(pluginName));
 
-        await this.driverHelper.waitVisibility(pluginListItemLocator, timeout);
+        await this.driverHelper.waitVisibility(pluginListItemLocator, TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT);
     }
 
-    async enablePlugin(pluginName: string, pluginVersion?: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async enablePlugin(pluginName: string, pluginVersion?: string) {
         Logger.debug(`WorkspaceDetailsPlugins.enablePlugin ${pluginName}:${pluginVersion}`);
 
-        await this.waitPluginDisabling(pluginName, pluginVersion, timeout);
-        await this.clickOnPluginListItemSwitcher(pluginName, pluginVersion, timeout);
-        await this.waitPluginEnabling(pluginName, pluginVersion, timeout);
+        await this.waitPluginDisabling(pluginName, pluginVersion);
+        await this.clickOnPluginListItemSwitcher(pluginName, pluginVersion);
+        await this.waitPluginEnabling(pluginName, pluginVersion);
     }
 
-    async disablePlugin(pluginName: string, pluginVersion?: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async disablePlugin(pluginName: string, pluginVersion?: string) {
         Logger.debug(`WorkspaceDetailsPlugins.disablePlugin ${pluginName}:${pluginVersion}`);
 
-        await this.waitPluginEnabling(pluginName, pluginVersion, timeout);
-        await this.clickOnPluginListItemSwitcher(pluginName, pluginVersion, timeout);
-        await this.waitPluginDisabling(pluginName, pluginVersion, timeout);
+        await this.waitPluginEnabling(pluginName, pluginVersion);
+        await this.clickOnPluginListItemSwitcher(pluginName, pluginVersion);
+        await this.waitPluginDisabling(pluginName, pluginVersion);
     }
 
     async addPluginAndOpenWorkspace(namespace: string, workspaceName: string, pluginName: string, pluginId: string, pluginVersion?: string) {
@@ -74,20 +74,20 @@ export class WorkspaceDetailsPlugins {
 
     private async clickOnPluginListItemSwitcher(pluginName: string,
         pluginVersion?: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+        timeout: number = TimeoutConstants.TS_CLICK_DASHBOARD_ITEM_TIMEOUT) {
 
         const pluginListItemSwitcherLocator = By.css(this.getPluginListItemSwitcherCssLocator(pluginName, pluginVersion));
 
         await this.driverHelper.waitAndClick(pluginListItemSwitcherLocator, timeout);
     }
 
-    private async waitPluginEnabling(pluginName: string, pluginVersion?: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    private async waitPluginEnabling(pluginName: string, pluginVersion?: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         const enabledPluginSwitcherLocator: By = By.css(`${this.getPluginListItemCssLocator(pluginName, pluginVersion)} md-switch[aria-checked='true']`);
 
         await this.driverHelper.waitVisibility(enabledPluginSwitcherLocator, timeout);
     }
 
-    private async waitPluginDisabling(pluginName: string, pluginVersion?: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    private async waitPluginDisabling(pluginName: string, pluginVersion?: string, timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
         const disabledPluginSwitcherLocator: By = By.css(`${this.getPluginListItemCssLocator(pluginName, pluginVersion)} md-switch[aria-checked='false']`);
 
         await this.driverHelper.waitVisibility(disabledPluginSwitcherLocator, timeout);

--- a/tests/e2e/pageobjects/ide/ContextMenu.ts
+++ b/tests/e2e/pageobjects/ide/ContextMenu.ts
@@ -3,8 +3,8 @@ import { injectable, inject } from 'inversify';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { CLASSES } from '../../inversify.types';
 import { WebElement, Button, By, Key } from 'selenium-webdriver';
-import { TestConstants } from '../../TestConstants';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 
 
@@ -15,33 +15,33 @@ export class ContextMenu {
      constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
 
-     async invokeContextMenuOnTheElementWithMouse(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+     async invokeContextMenuOnTheElementWithMouse(elementLocator: By) {
           Logger.debug(`ContextMenu.invokeContextMenuOnTheElementWithMouse ${elementLocator}`);
 
-          const webElement: WebElement = await this.driverHelper.waitVisibility(elementLocator, timeout);
+          const webElement: WebElement = await this.driverHelper.waitVisibility(elementLocator, TimeoutConstants.TS_CONTEXT_MENU_TIMEOUT);
           await this.driverHelper.getAction().click(webElement, Button.RIGHT).perform();
-          this.waitContextMenu(timeout);
+          this.waitContextMenu();
      }
 
-     async invokeContextMenuOnActiveElementWithKeys(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+     async invokeContextMenuOnActiveElementWithKeys() {
           Logger.debug('ContextMenu.invokeContextMenuOnActiveElementWithKeys');
 
           this.driverHelper.getDriver().switchTo().activeElement().sendKeys(Key.SHIFT + Key.F10);
-          this.waitContextMenu(timeout);
+          this.waitContextMenu();
      }
 
-     async waitContextMenuAndClickOnItem(nameOfItem: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+     async waitContextMenuAndClickOnItem(nameOfItem: string) {
           Logger.debug(`ContextMenu.waitContextMenuAndClickOnItem "${nameOfItem}"`);
 
           const itemLocator: string = `//div[@class='p-Menu-itemLabel' and text()='${nameOfItem}']`;
           await this.waitContextMenu();
-          await this.driverHelper.waitAndClick(By.xpath(itemLocator), timeout);
+          await this.driverHelper.waitAndClick(By.xpath(itemLocator), TimeoutConstants.TS_CONTEXT_MENU_TIMEOUT);
      }
 
-     async waitContextMenu(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+     async waitContextMenu() {
           Logger.debug(`ContextMenu.waitContextMenu`);
 
-          await this.driverHelper.waitVisibility(By.css(ContextMenu.SUGGESTION_WIDGET_BODY_CSS), timeout);
+          await this.driverHelper.waitVisibility(By.css(ContextMenu.SUGGESTION_WIDGET_BODY_CSS), TimeoutConstants.TS_CONTEXT_MENU_TIMEOUT);
      }
 
 }

--- a/tests/e2e/pageobjects/ide/DebugView.ts
+++ b/tests/e2e/pageobjects/ide/DebugView.ts
@@ -13,7 +13,7 @@ import { DriverHelper } from '../../utils/DriverHelper';
 import { By, Key, WebElement } from 'selenium-webdriver';
 import { Ide } from './Ide';
 import { Logger } from '../../utils/Logger';
-import { TestConstants } from '../../TestConstants';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 
 @injectable()
@@ -24,7 +24,7 @@ export class DebugView {
     async clickOnDebugConfigurationDropDown() {
         Logger.debug('DebugView.clickOnDebugConfigurationDropDown');
 
-        await this.driverHelper.waitAndClick(By.css('select.debug-configuration'));
+        await this.driverHelper.waitAndClick(By.css('select.debug-configuration'), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async clickOnDebugConfigurationItem(itemText: string) {
@@ -32,7 +32,7 @@ export class DebugView {
 
         const configurationItemLocator: By = By.xpath(`//select[contains(@class,'debug-configuration')]//option[text()=\'${itemText}\']`);
 
-        await this.driverHelper.waitAndClick(configurationItemLocator);
+        await this.driverHelper.waitAndClick(configurationItemLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
         await this.ide.performKeyCombination(Key.ESCAPE);
     }
 
@@ -41,7 +41,7 @@ export class DebugView {
 
         const runDebugButtonLocator: By = By.xpath('//span[@title=\'Start Debugging\']');
 
-        await this.driverHelper.waitAndClick(runDebugButtonLocator);
+        await this.driverHelper.waitAndClick(runDebugButtonLocator, TimeoutConstants.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
     }
 
     /**
@@ -49,7 +49,7 @@ export class DebugView {
      *
      * @param timeout
      */
-    async waitForDebuggerToConnect(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitForDebuggerToConnect(timeout: number = TimeoutConstants.TS_DEBUGGER_CONNECTION_TIMEOUT) {
         await this.driverHelper.getDriver().wait(async () => {
             Logger.debug(`Waiting for debugger to connect (threads to appear in "Threads" view)`);
             const threadElements: WebElement[] = await this.driverHelper.getDriver().findElements(By.xpath(`//div[contains(@class, 'theia-debug-thread')]`));

--- a/tests/e2e/pageobjects/ide/DebugView.ts
+++ b/tests/e2e/pageobjects/ide/DebugView.ts
@@ -24,7 +24,7 @@ export class DebugView {
     async clickOnDebugConfigurationDropDown() {
         Logger.debug('DebugView.clickOnDebugConfigurationDropDown');
 
-        await this.driverHelper.waitAndClick(By.css('select.debug-configuration'), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(By.css('select.debug-configuration'));
     }
 
     async clickOnDebugConfigurationItem(itemText: string) {
@@ -32,7 +32,7 @@ export class DebugView {
 
         const configurationItemLocator: By = By.xpath(`//select[contains(@class,'debug-configuration')]//option[text()=\'${itemText}\']`);
 
-        await this.driverHelper.waitAndClick(configurationItemLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(configurationItemLocator);
         await this.ide.performKeyCombination(Key.ESCAPE);
     }
 

--- a/tests/e2e/pageobjects/ide/DialogWindow.ts
+++ b/tests/e2e/pageobjects/ide/DialogWindow.ts
@@ -12,8 +12,8 @@ import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
-import { TestConstants } from '../../TestConstants';
 import { Ide } from './Ide';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class DialogWindow {
@@ -28,37 +28,37 @@ export class DialogWindow {
         return await this.driverHelper.isVisible(By.xpath(DialogWindow.DIALOG_BODY_XPATH_LOCATOR));
     }
 
-    async waitAndCloseIfAppear(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitAndCloseIfAppear() {
         Logger.debug('DialogWindow.waitAndCloseIfAppear');
 
         const dialogDisplayes: boolean = await this.driverHelper.waitVisibilityBoolean(By.xpath(DialogWindow.DIALOG_BODY_XPATH_LOCATOR));
 
         if (dialogDisplayes) {
-            await this.closeDialog(timeout);
-            await this.waitDialogDissappearance(timeout);
+            await this.closeDialog();
+            await this.waitDialogDissappearance();
         }
 
     }
 
-    async clickToButton(buttonText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickToButton(buttonText: string) {
         Logger.debug('DialogWindow.clickToButton');
         const buttonLocator: By = By.xpath(`${DialogWindow.DIALOG_BODY_XPATH_LOCATOR}//button[text()='${buttonText}']`);
-        await this.driverHelper.waitAndClick(buttonLocator, timeout);
+        await this.driverHelper.waitAndClick(buttonLocator, TimeoutConstants.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
     }
 
-    async closeDialog(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async closeDialog() {
         Logger.debug('DialogWindow.closeDialog');
 
-        await this.clickToButton('close', timeout);
+        await this.clickToButton('close');
     }
 
-    async clickToOpenLinkButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickToOpenLinkButton() {
         Logger.debug('DialogWindow.clickToOpenLinkButton');
 
-        await this.clickToButton('Open Link', timeout);
+        await this.clickToButton('Open Link');
     }
 
-    async waitDialog(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT, dialogText: string = '') {
+    async waitDialog(dialogText: string = '', timeout: number = TimeoutConstants.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT) {
         Logger.debug('DialogWindow.waitDialog');
 
         // if dialog text is provided uses xpath with this text
@@ -69,25 +69,25 @@ export class DialogWindow {
         await this.driverHelper.waitVisibility(By.xpath(dialogXpathLocator), timeout);
     }
 
-    async waitDialogAndOpenLink(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT, dialogText: string = '') {
+    async waitDialogAndOpenLink(dialogText: string = '', applicationReaddyTimeout: number) {
         Logger.debug('DialogWindow.waitDialogAndOpenLink');
 
-        await this.waitDialog(timeout, dialogText);
-        await this.ide.waitApllicationIsReady(await this.getApplicationUrlFromDialog(dialogText), timeout);
-        await this.clickToOpenLinkButton(timeout);
-        await this.waitDialogDissappearance(timeout);
+        await this.waitDialog(dialogText);
+        await this.ide.waitApllicationIsReady(await this.getApplicationUrlFromDialog(dialogText), applicationReaddyTimeout);
+        await this.clickToOpenLinkButton();
+        await this.waitDialogDissappearance();
     }
 
-    async waitDialogDissappearance(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitDialogDissappearance() {
         Logger.debug('DialogWindow.waitDialogDissappearance');
 
-        await this.driverHelper.waitDisappearanceWithTimeout(By.xpath(DialogWindow.CLOSE_BUTTON_XPATH_LOCATOR));
+        await this.driverHelper.waitDisappearanceWithTimeout(By.xpath(DialogWindow.CLOSE_BUTTON_XPATH_LOCATOR), TimeoutConstants.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
     }
 
     async getApplicationUrlFromDialog(dialogWindowText: string) {
         const notificationTextLocator: By = By.xpath(`${DialogWindow.DIALOG_BODY_XPATH_LOCATOR}//*[contains(text(), '${dialogWindowText}')]`);
 
-        let dialogWindow = await this.driverHelper.waitAndGetText(notificationTextLocator);
+        let dialogWindow = await this.driverHelper.waitAndGetText(notificationTextLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
         let regexp: RegExp = new RegExp('^.*(https?://.*)$');
 
         if (!regexp.test(dialogWindow)) {

--- a/tests/e2e/pageobjects/ide/DialogWindow.ts
+++ b/tests/e2e/pageobjects/ide/DialogWindow.ts
@@ -87,7 +87,7 @@ export class DialogWindow {
     async getApplicationUrlFromDialog(dialogWindowText: string) {
         const notificationTextLocator: By = By.xpath(`${DialogWindow.DIALOG_BODY_XPATH_LOCATOR}//*[contains(text(), '${dialogWindowText}')]`);
 
-        let dialogWindow = await this.driverHelper.waitAndGetText(notificationTextLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        let dialogWindow = await this.driverHelper.waitAndGetText(notificationTextLocator);
         let regexp: RegExp = new RegExp('^.*(https?://.*)$');
 
         if (!regexp.test(dialogWindow)) {

--- a/tests/e2e/pageobjects/ide/Editor.ts
+++ b/tests/e2e/pageobjects/ide/Editor.ts
@@ -242,7 +242,7 @@ export class Editor {
 
         const editorBodyLocator: By = By.xpath(`//div[contains(@data-uri, \'${tabTitle}')]//div[@class=\'view-lines\']`);
         // const editorBodyLocator: By = By.xpath('//div[@class=\'view-lines\']');
-        const editorText: string = await this.driverHelper.waitAndGetText(editorBodyLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        const editorText: string = await this.driverHelper.waitAndGetText(editorBodyLocator);
         return editorText;
     }
 
@@ -307,7 +307,7 @@ export class Editor {
         Logger.debug(`Editor.performKeyCombination title: "${editorTabTitle}" text: "${text}"`);
 
         const interactionContainerLocator: By = this.getEditorActionArreaLocator(editorTabTitle);
-        await this.driverHelper.type(interactionContainerLocator, text, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.type(interactionContainerLocator, text);
     }
 
     async type(editorTabTitle: string, text: string, line: number) {

--- a/tests/e2e/pageobjects/ide/Editor.ts
+++ b/tests/e2e/pageobjects/ide/Editor.ts
@@ -112,7 +112,7 @@ export class Editor {
                     throw err;
                 }
 
-                await this.closeSuggestionContainer(editorTabTitle, 3_000);
+                await this.closeSuggestionContainer(editorTabTitle, TimeoutConstants.TS_CLOSE_SUGGESTION_CONTAINER_TIMEOUT);
                 await this.pressControlSpaceCombination(editorTabTitle);
             }
         }, timeout);

--- a/tests/e2e/pageobjects/ide/Editor.ts
+++ b/tests/e2e/pageobjects/ide/Editor.ts
@@ -14,6 +14,7 @@ import { CLASSES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
 import { By, Key, error, ActionSequence, Button } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 
 @injectable()
@@ -26,13 +27,13 @@ export class Editor {
 
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
-    public async waitSuggestionContainer(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitSuggestionContainer(timeout: number = TimeoutConstants.TS_SUGGESTION_TIMEOUT) {
         Logger.debug('Editor.waitSuggestionContainer');
 
         await this.driverHelper.waitVisibility(By.css(Editor.SUGGESTION_WIDGET_BODY_CSS), timeout);
     }
 
-    public async waitSuggestionContainerClosed(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitSuggestionContainerClosed(timeout: number = TimeoutConstants.TS_SUGGESTION_TIMEOUT) {
         Logger.debug('Editor.waitSuggestionContainerClosed');
 
         await this.driverHelper.waitDisappearanceWithTimeout(By.css(Editor.SUGGESTION_WIDGET_BODY_CSS), timeout);
@@ -40,7 +41,7 @@ export class Editor {
 
     public async waitSuggestion(editorTabTitle: string,
         suggestionText: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT,
+        timeout: number = TimeoutConstants.TS_SUGGESTION_TIMEOUT,
         lineNumber?: number,
         charNumber?: number) {
 
@@ -61,7 +62,7 @@ export class Editor {
 
     }
 
-    public async closeSuggestionContainer(editorTabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async closeSuggestionContainer(editorTabTitle: string, timeout: number = TimeoutConstants.TS_SUGGESTION_TIMEOUT) {
         Logger.debug(`Editor.closeSuggestionContainer tabTitle: "${editorTabTitle}"`);
 
         await this.driverHelper.getDriver().wait(async () => {
@@ -96,7 +97,7 @@ export class Editor {
 
     public async waitSuggestionWithScrolling(editorTabTitle: string,
         suggestionText: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+        timeout: number = TimeoutConstants.TS_SUGGESTION_TIMEOUT) {
 
         Logger.debug(`Editor.waitSuggestion tabTitle: "${editorTabTitle}" suggestion: "${suggestionText}"`);
 
@@ -104,14 +105,14 @@ export class Editor {
 
         await this.driverHelper.getDriver().wait(async () => {
             try {
-                await this.scrollAndSearchSuggestion(editorTabTitle, suggestionLocator, 40000);
+                await this.scrollAndSearchSuggestion(editorTabTitle, suggestionLocator, timeout / 3);
                 return true;
             } catch (err) {
                 if (!(err instanceof error.TimeoutError)) {
                     throw err;
                 }
 
-                await this.closeSuggestionContainer(editorTabTitle, timeout);
+                await this.closeSuggestionContainer(editorTabTitle, 3_000);
                 await this.pressControlSpaceCombination(editorTabTitle);
             }
         }, timeout);
@@ -129,13 +130,13 @@ export class Editor {
         await this.performKeyCombination(editorTabTitle, Key.ESCAPE);
     }
 
-    public async clickOnSuggestion(suggestionText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async clickOnSuggestion(suggestionText: string, timeout: number = TimeoutConstants.TS_SUGGESTION_TIMEOUT) {
         Logger.debug(`Editor.clickOnSuggestion "${suggestionText}"`);
 
         await this.driverHelper.waitAndClick(this.getSuggestionLineXpathLocator(suggestionText), timeout);
     }
 
-    public async waitTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitTab(tabTitle: string, timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT) {
         Logger.debug(`Editor.waitTab "${tabTitle}"`);
 
         await this.driverHelper.waitVisibility(By.xpath(this.getTabXpathLocator(tabTitle)), timeout);
@@ -150,13 +151,13 @@ export class Editor {
         await this.driverHelper.waitDisappearance(By.xpath(this.getTabXpathLocator(tabTitle)), attempt, polling);
     }
 
-    public async clickOnTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async clickOnTab(tabTitle: string, timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT) {
         Logger.debug(`Editor.clickOnTab "${tabTitle}"`);
 
         await this.driverHelper.waitAndClick(By.xpath(this.getTabXpathLocator(tabTitle)), timeout);
     }
 
-    public async waitTabFocused(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitTabFocused(tabTitle: string, timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT) {
         Logger.debug(`Editor.waitTabFocused "${tabTitle}"`);
 
         const focusedTabLocator: By = By.xpath(`//li[contains(@class, 'p-TabBar-tab') and contains(@class, 'theia-mod-active')]//div[text()='${tabTitle}']`);
@@ -164,15 +165,15 @@ export class Editor {
         await this.driverHelper.waitVisibility(focusedTabLocator, timeout);
     }
 
-    public async selectTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async selectTab(tabTitle: string) {
         Logger.debug(`Editor.selectTab "${tabTitle}"`);
 
-        await this.waitTab(tabTitle, timeout);
-        await this.clickOnTab(tabTitle, timeout);
-        await this.waitTabFocused(tabTitle, timeout);
+        await this.waitTab(tabTitle);
+        await this.clickOnTab(tabTitle);
+        await this.waitTabFocused(tabTitle);
     }
 
-    async closeTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async closeTab(tabTitle: string, timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT) {
         Logger.debug(`Editor.closeTab "${tabTitle}"`);
 
         const tabCloseButtonLocator: By = By.xpath(`//div[text()='${tabTitle}']/parent::li//div[contains(@class, 'p-TabBar-tabCloseIcon')]`);
@@ -180,7 +181,7 @@ export class Editor {
         await this.driverHelper.waitAndClick(tabCloseButtonLocator, timeout);
     }
 
-    async waitTabWithUnsavedStatus(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitTabWithUnsavedStatus(tabTitle: string, timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT) {
         Logger.debug(`Editor.waitTabWithUnsavedStatus "${tabTitle}"`);
 
         const unsavedTabLocator: By = this.getTabWithUnsavedStatus(tabTitle);
@@ -188,7 +189,7 @@ export class Editor {
         await this.driverHelper.waitVisibility(unsavedTabLocator, timeout);
     }
 
-    async waitTabWithSavedStatus(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitTabWithSavedStatus(tabTitle: string, timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT) {
         Logger.debug(`Editor.waitTabWithSavedStatus "${tabTitle}"`);
 
         const unsavedTabLocator: By = this.getTabWithUnsavedStatus(tabTitle);
@@ -209,7 +210,7 @@ export class Editor {
 
     }
 
-    async waitEditorOpened(editorTabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitEditorOpened(editorTabTitle: string, timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT) {
         Logger.debug(`Editor.waitEditorOpened "${editorTabTitle}"`);
 
         const firstEditorLineLocator: By = By.xpath(this.getEditorLineXpathLocator(1));
@@ -218,7 +219,7 @@ export class Editor {
         await this.driverHelper.waitPresence(firstEditorLineLocator, timeout);
     }
 
-    async waitEditorAvailable(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitEditorAvailable(tabTitle: string, timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT) {
         Logger.debug(`Editor.waitEditorAvailable "${tabTitle}"`);
 
         await this.waitTab(tabTitle, timeout);
@@ -241,12 +242,12 @@ export class Editor {
 
         const editorBodyLocator: By = By.xpath(`//div[contains(@data-uri, \'${tabTitle}')]//div[@class=\'view-lines\']`);
         // const editorBodyLocator: By = By.xpath('//div[@class=\'view-lines\']');
-        const editorText: string = await this.driverHelper.waitAndGetText(editorBodyLocator);
+        const editorText: string = await this.driverHelper.waitAndGetText(editorBodyLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
         return editorText;
     }
 
     async waitText(tabTitle: string, expectedText: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT,
+        timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT,
         polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING) {
 
         Logger.debug(`Editor.waitText "${tabTitle}"`);
@@ -265,12 +266,12 @@ export class Editor {
 
     async followAndWaitForText(editorTabTitle: string,
         expectedText: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT,
+        timeout: number = TimeoutConstants.TS_EDITOR_TAB_INTERACTION_TIMEOUT,
         polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING) {
 
         Logger.debug(`Editor.followAndWaitForText title: "${editorTabTitle}" text: "${expectedText}"`);
 
-        await this.selectTab(editorTabTitle, timeout);
+        await this.selectTab(editorTabTitle);
         await this.driverHelper.getDriver().wait(async () => {
             await this.performKeyCombination(editorTabTitle, Key.chord(Key.CONTROL, Key.END));
             const editorText: string = await this.getEditorVisibleText(editorTabTitle);
@@ -306,7 +307,7 @@ export class Editor {
         Logger.debug(`Editor.performKeyCombination title: "${editorTabTitle}" text: "${text}"`);
 
         const interactionContainerLocator: By = this.getEditorActionArreaLocator(editorTabTitle);
-        await this.driverHelper.type(interactionContainerLocator, text);
+        await this.driverHelper.type(interactionContainerLocator, text, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async type(editorTabTitle: string, text: string, line: number) {
@@ -317,33 +318,33 @@ export class Editor {
         await this.performKeyCombination(editorTabTitle, text);
     }
 
-    async waitErrorInLine(lineNumber: number, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitErrorInLine(lineNumber: number, timeout: number = TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT) {
         Logger.debug(`Editor.waitErrorInLine line: "${lineNumber}"`);
 
         const errorInLineLocator: By = await this.getErrorInLineLocator(lineNumber);
         await this.driverHelper.waitVisibility(errorInLineLocator, timeout);
     }
 
-    async waitErrorInLineDisappearance(lineNumber: number, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitErrorInLineDisappearance(lineNumber: number, timeout: number = TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT) {
         Logger.debug(`Editor.waitErrorInLineDisappearance line: "${lineNumber}"`);
 
         const errorInLineLocator: By = await this.getErrorInLineLocator(lineNumber);
         await this.driverHelper.waitDisappearanceWithTimeout(errorInLineLocator, timeout);
     }
 
-    async waitStoppedDebugBreakpoint(tabTitle: string, lineNumber: number, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitStoppedDebugBreakpoint(tabTitle: string, lineNumber: number, timeout: number = TimeoutConstants.TS_BREAKPOINT_DEFAULT_TIMEOUT) {
         Logger.debug(`Editor.waitStoppedDebugBreakpoint title: "${tabTitle}" line: "${lineNumber}"`);
 
         await this.driverHelper.waitUntilTrue(() => this.isBreakpointPresent(tabTitle, lineNumber, true), timeout);
     }
 
-    async waitBreakpoint(tabTitle: string, lineNumber: number, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitBreakpoint(tabTitle: string, lineNumber: number, timeout: number =  TimeoutConstants.TS_BREAKPOINT_DEFAULT_TIMEOUT) {
         Logger.debug(`Editor.waitBreakpoint title: "${tabTitle}" line: "${lineNumber}"`);
 
         await this.driverHelper.waitUntilTrue(() => this.isBreakpointPresent(tabTitle, lineNumber), timeout);
     }
 
-    async waitBreakpointAbsence(tabTitle: string, lineNumber: number, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitBreakpointAbsence(tabTitle: string, lineNumber: number, timeout: number =  TimeoutConstants.TS_BREAKPOINT_DEFAULT_TIMEOUT) {
         Logger.debug(`Editor.waitBreakpointAbsence title: "${tabTitle}" line: "${lineNumber}"`);
         await this.driverHelper.waitUntilTrue(() => !this.isBreakpointPresent(tabTitle, lineNumber), timeout);
     }
@@ -379,7 +380,7 @@ export class Editor {
 
         const lineNumberLocator: By = By.xpath(`//div[contains(@class, 'line-numbers') and text()='${lineNumber}']` +
             `//parent::div[contains(@style, 'position')]`);
-        let elementStyleValue: string = await this.driverHelper.waitAndGetElementAttribute(lineNumberLocator, 'style');
+        let elementStyleValue: string = await this.driverHelper.waitAndGetElementAttribute(lineNumberLocator, 'style', TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
 
         elementStyleValue = elementStyleValue.replace('position: absolute; top: ', '');
         elementStyleValue = elementStyleValue.replace('px; width: 100%; height: 19px;', '');
@@ -482,7 +483,7 @@ export class Editor {
 
     private async waitSuggestionWithResettingCursor(editorTabTitle: string,
         suggestionText: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT,
+        timeout: number = TimeoutConstants.TS_SUGGESTION_TIMEOUT,
         lineNumber: number,
         charNumber: number) {
 
@@ -514,7 +515,7 @@ export class Editor {
 
     private async waitSuggestionWithoutResettingCursor(editorTabTitle: string,
         suggestionText: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+        timeout: number = TimeoutConstants.TS_SUGGESTION_TIMEOUT) {
 
         Logger.debug(`Editor.waitSuggestion tabTitle: "${editorTabTitle}" suggestion: "${suggestionText}"`);
 

--- a/tests/e2e/pageobjects/ide/GitPlugin.ts
+++ b/tests/e2e/pageobjects/ide/GitPlugin.ts
@@ -1,9 +1,9 @@
 import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { TestConstants } from '../../TestConstants';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 /*********************************************************************
  * Copyright (c) 2019 Red Hat, Inc.
@@ -21,7 +21,7 @@ export class GitPlugin {
 
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
-    async openGitPluginContainer(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async openGitPluginContainer(timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.openGitPluginContainer');
 
         const sourceControlGitBtnXpathLocator: string = '//li[@id=\'shell-tab-scm-view-container\' and contains(@style, \'height\')]';
@@ -29,67 +29,68 @@ export class GitPlugin {
         await this.waitViewOfContainer(timeout);
     }
 
-    async waitViewOfContainer(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitViewOfContainer(timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.waitViewOfContainer');
 
         const gitHubContainerIdLocator: By = By.id('scm-view-container--scm-view');
         await this.driverHelper.waitVisibility(gitHubContainerIdLocator, timeout);
     }
 
-    async waitCommitMessageTextArea(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitCommitMessageTextArea(timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.waitCommitMessageTextArea');
 
         const textAreaCssLocator: By = By.css(GitPlugin.COMMIT_MESSAGE_TEXTAREA_CSS);
         await this.driverHelper.waitVisibility(textAreaCssLocator, timeout);
     }
 
-    async typeCommitMessage(commitMessage: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async typeCommitMessage(commitMessage: string, timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.typeCommitMessage');
 
         await this.waitCommitMessageTextArea(timeout);
         await this.driverHelper.type(By.css(GitPlugin.COMMIT_MESSAGE_TEXTAREA_CSS), commitMessage, timeout);
     }
 
-    async selectCommandInMoreActionsMenu(commandName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async selectCommandInMoreActionsMenu(commandName: string, timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.selectCommandInMoreActionsMenu');
 
         await this.clickOnMoreActions(timeout);
         await this.driverHelper.waitAndClick(By.xpath(`//li[@data-command]/div[text()=\'${commandName}\']`), timeout);
     }
 
-    async clickOnMoreActions(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnMoreActions(timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.clickOnMoreActions');
 
         await this.driverHelper.waitAndClick(By.id('__more__'), timeout);
     }
 
-    async waitChangedFileInChagesList(expectedItem: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitChangedFileInChagesList(expectedItem: string, timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.waitChangedFileInChagesList');
 
         await this.driverHelper.waitPresence(By.xpath(`//span[@class='name' and text()=\'${expectedItem}\']`), timeout);
     }
 
-    async waitStagedFileInStagedChanges(expectedStagedItem: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitStagedFileInStagedChanges(expectedStagedItem: string, timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.waitStagedFileInStagedChanges');
 
         await this.driverHelper.waitPresence(By.xpath(`//div[text()='Staged Changes']/parent::div/parent::div/parent::div/following-sibling::div//span[text()=\'${expectedStagedItem}\']`), timeout);
     }
 
-    async commitFromScmView(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async commitFromScmView(timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.commitFromScmView');
 
         await this.driverHelper.waitAndClick(By.id('__scm-view-container_title:__plugin.scm.title.action.git.commit'), timeout);
     }
 
-    async stageAllChanges(expectedStagedItem: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async stageAllChanges(expectedStagedItem: string, timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.stageAllChanges');
 
-        await this.driverHelper.scrollTo(By.xpath('//div[@class=\'noWrapInfo theia-TreeNodeSegmentGrow\' and text()=\'Changes\']'), timeout);
+        await this.driverHelper.waitVisibility(By.xpath('//div[@class=\'noWrapInfo theia-TreeNodeSegmentGrow\' and text()=\'Changes\']'), timeout);
+        await this.driverHelper.scrollTo(By.xpath('//div[@class=\'noWrapInfo theia-TreeNodeSegmentGrow\' and text()=\'Changes\']'));
         await this.driverHelper.waitAndClick(By.xpath('//a[@title=\'Stage All Changes\']'), timeout);
         await this.waitStagedFileInStagedChanges(expectedStagedItem);
     }
 
-    async waitDataIsSynchronized(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitDataIsSynchronized(timeout: number = TimeoutConstants.TS_GIT_CONAINER_INTERACTION_TIMEOUT) {
         Logger.debug('GitPlugin.waitDataIsSynchronized');
         await this.driverHelper.waitDisappearance(By.xpath(`//div[contains(@title,'Synchronize Changes')]//span[contains(.,' 0↓')]`), timeout);
     }

--- a/tests/e2e/pageobjects/ide/Ide.ts
+++ b/tests/e2e/pageobjects/ide/Ide.ts
@@ -15,6 +15,7 @@ import { TestConstants } from '../../TestConstants';
 import { By, error } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
 import { NotificationCenter } from './NotificationCenter';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 export enum LeftToolbarButton {
     Explorer = 'Explorer',
@@ -39,7 +40,7 @@ export class Ide {
         @inject(CLASSES.NotificationCenter) private readonly notificationCenter: NotificationCenter
     ) { }
 
-    async waitAndSwitchToIdeFrame(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitAndSwitchToIdeFrame(timeout: number = TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
         Logger.debug('Ide.waitAndSwitchToIdeFrame');
         try {
             await this.driverHelper.waitAndSwitchToFrame(By.css(Ide.IDE_IFRAME_CSS), timeout);
@@ -52,7 +53,7 @@ export class Ide {
         }
     }
 
-    async waitNotification(notificationText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitNotification(notificationText: string, timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
         Logger.debug(`Ide.waitNotification "${notificationText}"`);
 
         const notificationLocator: By = By.xpath(this.getNotificationXpathLocator(notificationText));
@@ -61,7 +62,7 @@ export class Ide {
 
     async waitNotificationAndClickOnButton(notificationText: string,
         buttonText: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+        timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
 
         Logger.debug(`Ide.waitNotificationAndClickOnButton "${notificationText}" buttonText: "${buttonText}"`);
 
@@ -85,15 +86,14 @@ export class Ide {
         }, timeout);
     }
 
-    async waitNotificationAndConfirm(notificationText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitNotificationAndConfirm(notificationText: string, timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
         Logger.debug(`Ide.waitNotificationAndConfirm "${notificationText}"`);
 
         await this.waitNotificationAndClickOnButton(notificationText, 'yes', timeout);
     }
 
-    async waitNotificationAndOpenLink(notificationText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitNotificationAndOpenLink(notificationText: string, timeout: number) {
         Logger.debug(`Ide.waitNotificationAndOpenLink "${notificationText}"`);
-
         await this.waitNotification(notificationText, timeout);
         await this.waitApllicationIsReady(await this.getApplicationUrlFromNotification(notificationText), timeout);
         await this.waitNotificationAndClickOnButton(notificationText, 'Open Link', timeout);
@@ -120,10 +120,10 @@ export class Ide {
         Logger.debug(`Ide.clickOnNotificationButton "${notificationText}" buttonText: "${buttonText}"`);
 
         const yesButtonLocator: string = `//div[@class='theia-notification-list']//span[contains(.,'${notificationText}')]/parent::div/parent::div/parent::div/div[@class='theia-notification-list-item-content-bottom']//div[@class='theia-notification-buttons']//button[text()='${buttonText}'] `;
-        await this.driverHelper.waitAndClick(By.xpath(yesButtonLocator));
+        await this.driverHelper.waitAndClick(By.xpath(yesButtonLocator), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
-    async waitWorkspaceAndIde(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitWorkspaceAndIde(timeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
 
         Logger.debug('Ide.waitWorkspaceAndIde');
 
@@ -131,7 +131,7 @@ export class Ide {
         await this.waitIde(timeout);
     }
 
-    async waitIde(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitIde(timeout: number = TimeoutConstants.TS_IDE_LOAD_TIMEOUT) {
         Logger.debug('Ide.waitIde');
 
         const mainIdeParts: Array<By> = [By.css(Ide.TOP_MENU_PANEL_CSS), By.css(Ide.LEFT_CONTENT_PANEL_CSS), By.id(Ide.EXPLORER_BUTTON_ID)];
@@ -147,33 +147,33 @@ export class Ide {
         }
     }
 
-    async waitLeftToolbarButton(buttonTitle: LeftToolbarButton, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitLeftToolbarButton(buttonTitle: LeftToolbarButton, timeout: number = TimeoutConstants.TS_SELENIUM_TOOLBAR_TIMEOUT) {
         Logger.debug('Ide.waitLeftToolbarButton');
 
         const buttonLocator: By = this.getLeftToolbarButtonLocator(buttonTitle);
         await this.driverHelper.waitVisibility(buttonLocator, timeout);
     }
 
-    async waitAndClickLeftToolbarButton(buttonTitle: LeftToolbarButton, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitAndClickLeftToolbarButton(buttonTitle: LeftToolbarButton, timeout: number = TimeoutConstants.TS_SELENIUM_TOOLBAR_TIMEOUT) {
         Logger.debug('Ide.waitAndClickLeftToolbarButton');
 
         const buttonLocator: By = this.getLeftToolbarButtonLocator(buttonTitle);
         await this.driverHelper.waitAndClick(buttonLocator, timeout);
     }
 
-    async waitTopMenuPanel(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitTopMenuPanel(timeout: number = TimeoutConstants.TS_SELENIUM_TOOLBAR_TIMEOUT) {
         Logger.debug('Ide.waitTopMenuPanel');
 
         await this.driverHelper.waitVisibility(By.css(Ide.TOP_MENU_PANEL_CSS), timeout);
     }
 
-    async waitLeftContentPanel(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitLeftContentPanel(timeout: number = TimeoutConstants.TS_SELENIUM_TOOLBAR_TIMEOUT) {
         Logger.debug('Ide.waitLeftContentPanel');
 
-        await this.driverHelper.waitVisibility(By.css(Ide.LEFT_CONTENT_PANEL_CSS));
+        await this.driverHelper.waitVisibility(By.css(Ide.LEFT_CONTENT_PANEL_CSS), timeout);
     }
 
-    async waitPreloaderAbsent(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async waitPreloaderAbsent(timeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = timeout / polling;
         Logger.debug('Ide.waitPreloaderAbsent');
@@ -181,13 +181,13 @@ export class Ide {
         await this.driverHelper.waitDisappearance(By.css(Ide.PRELOADER_CSS), attempts, polling);
     }
 
-    async waitPreloaderVisible(timeout: number = TestConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+    async waitPreloaderVisible(timeout: number = TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
         Logger.debug('Ide.waitPreloaderVisible');
 
         await this.driverHelper.waitVisibility(By.css(Ide.PRELOADER_CSS), timeout);
     }
 
-    async waitStatusBarContains(expectedText: string, timeout: number = TestConstants.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT) {
+    async waitStatusBarContains(expectedText: string, timeout: number = TimeoutConstants.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT) {
         const statusBarLocator: By = By.css('div[id=\'theia-statusBar\']');
 
         Logger.debug(`Ide.waitStatusBarContains "${expectedText}"`);
@@ -205,7 +205,7 @@ export class Ide {
         }, timeout);
     }
 
-    async waitStatusBarTextAbsence(expectedText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitStatusBarTextAbsence(expectedText: string, timeout: number = TimeoutConstants.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT) {
         const statusBarLocator: By = By.css('div[id=\'theia-statusBar\']');
 
         Logger.debug(`Ide.waitStatusBarTextAbsence "${expectedText}"`);
@@ -233,21 +233,21 @@ export class Ide {
         await this.waitStatusBarContains(expectedTextInStatusBar, 20000);
     }
 
-    async performKeyCombination(keyCombination: string) {
+    async performKeyCombination(keyCombination: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`Ide.performKeyCombination "${keyCombination}"`);
 
         const bodyLocator: By = By.tagName('body');
-        await this.driverHelper.type(bodyLocator, keyCombination);
+        await this.driverHelper.type(bodyLocator, keyCombination, timeout);
     }
 
-    async waitRightToolbarButtonSelection(buttonTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitRightToolbarButtonSelection(buttonTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TOOLBAR_TIMEOUT) {
         Logger.debug('Ide.waitRightToolbarButtonSelection');
 
         const selectedRightToolbarButtonLocator: By = this.getSelectedRightToolbarButtonLocator(buttonTitle);
         await this.driverHelper.waitVisibility(selectedRightToolbarButtonLocator, timeout);
     }
 
-    async getApplicationUrlFromNotification(notificationText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async getApplicationUrlFromNotification(notificationText: string, timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
         Logger.debug(`Ide.getApplicationUrlFromNotification ${notificationText}`);
 
         const notificationTextLocator: By = By.xpath(`//div[@class='theia-notification-message']/span[contains(.,'${notificationText}')]`);
@@ -261,11 +261,11 @@ export class Ide {
         return notification.split(regexp)[1];
     }
 
-    async closeAllNotifications(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async closeAllNotifications(timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
         Logger.debug(`Ide.closeAllNotifications`);
 
         for (let i: number = 0; i < 5; i++) {
-            await this.notificationCenter.open(timeout);
+            await this.notificationCenter.open();
             try {
                 await this.notificationCenter.closeAll(timeout);
                 break;
@@ -284,7 +284,7 @@ export class Ide {
     }
 
     async waitApllicationIsReady(url: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+        timeout: number) {
 
         Logger.debug(`Ide.waitApllicationIsReady ${url}`);
 

--- a/tests/e2e/pageobjects/ide/Ide.ts
+++ b/tests/e2e/pageobjects/ide/Ide.ts
@@ -120,7 +120,7 @@ export class Ide {
         Logger.debug(`Ide.clickOnNotificationButton "${notificationText}" buttonText: "${buttonText}"`);
 
         const yesButtonLocator: string = `//div[@class='theia-notification-list']//span[contains(.,'${notificationText}')]/parent::div/parent::div/parent::div/div[@class='theia-notification-list-item-content-bottom']//div[@class='theia-notification-buttons']//button[text()='${buttonText}'] `;
-        await this.driverHelper.waitAndClick(By.xpath(yesButtonLocator), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(By.xpath(yesButtonLocator));
     }
 
     async waitWorkspaceAndIde(timeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {

--- a/tests/e2e/pageobjects/ide/LeftToolBar.ts
+++ b/tests/e2e/pageobjects/ide/LeftToolBar.ts
@@ -10,9 +10,9 @@
 import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { TestConstants } from '../../TestConstants';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 
 
@@ -20,13 +20,13 @@ import { Logger } from '../../utils/Logger';
 export class LeftToolbar {
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
-    async waitToolbar(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitToolbar(timeout: number = TimeoutConstants.TS_SELENIUM_TOOLBAR_TIMEOUT) {
         Logger.debug('RightToolbar.waitToolbar');
 
         await this.driverHelper.waitVisibility(By.css('div.theia-app-right'), timeout);
     }
 
-    async clickOnToolIcon(iconTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnToolIcon(iconTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`RightToolbar.clickOnToolIcon "${iconTitle}"`);
 
         const toolIconLocator: By = By.css(`div.theia-app-right .p-TabBar-content li[title='${iconTitle}']`);

--- a/tests/e2e/pageobjects/ide/NotificationCenter.ts
+++ b/tests/e2e/pageobjects/ide/NotificationCenter.ts
@@ -12,12 +12,8 @@ import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { Logger } from '../../utils/Logger';
-<<<<<<< HEAD
 import { By } from 'selenium-webdriver';
-=======
-import { By, error } from 'selenium-webdriver';
 import { TimeoutConstants } from '../../TimeoutConstants';
->>>>>>> e10526bbec... Removing default timeout
 
 
 

--- a/tests/e2e/pageobjects/ide/NotificationCenter.ts
+++ b/tests/e2e/pageobjects/ide/NotificationCenter.ts
@@ -11,9 +11,13 @@
 import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { TestConstants } from '../../TestConstants';
 import { Logger } from '../../utils/Logger';
+<<<<<<< HEAD
 import { By } from 'selenium-webdriver';
+=======
+import { By, error } from 'selenium-webdriver';
+import { TimeoutConstants } from '../../TimeoutConstants';
+>>>>>>> e10526bbec... Removing default timeout
 
 
 
@@ -21,13 +25,13 @@ import { By } from 'selenium-webdriver';
 export class NotificationCenter {
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
-    async waitOpening(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitOpening(timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
         Logger.debug('NotificationCenter.waitOpening');
 
         await this.driverHelper.waitVisibility(By.css('div.theia-notification-center-header'), timeout);
     }
 
-    async clickIconOnStatusBar(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickIconOnStatusBar(timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug('NotificationCenter.clickIconOnStatusBar');
 
         const statusBarNotificationsLocator: By =
@@ -36,14 +40,14 @@ export class NotificationCenter {
         await this.driverHelper.waitAndClick(statusBarNotificationsLocator, timeout);
     }
 
-    async open(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async open() {
         Logger.debug(`NotificationCenter.open`);
 
-        await this.clickIconOnStatusBar(timeout);
-        await this.waitOpening(timeout);
+        await this.clickIconOnStatusBar(TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.waitOpening(TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT);
     }
 
-    async clickCloseAllNotificationsButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickCloseAllNotificationsButton(timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`NotificationCenter.clickCloseAllNotificationsButton`);
 
         const closeAllButtonLocator: By = By.css('.theia-notification-center-header-actions .clear-all');
@@ -51,7 +55,7 @@ export class NotificationCenter {
         await this.driverHelper.waitAndClick(closeAllButtonLocator, timeout);
     }
 
-    async waitClosing(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitClosing(timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
         Logger.debug(`NotificationCenter.waitClosing`);
 
         const notificationCenterClosedLocator: By = By.css('.theia-notification-center.closed');
@@ -59,7 +63,7 @@ export class NotificationCenter {
         await this.driverHelper.waitPresence(notificationCenterClosedLocator, timeout);
     }
 
-    async waitClearNotificationsList(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitClearNotificationsList(timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
         Logger.debug(`NotificationCenter.waitClearNotificationsList`);
 
         const notificationLocator: By = By.css('.theia-notification-center .theia-notification-list > *');
@@ -67,7 +71,7 @@ export class NotificationCenter {
         await this.driverHelper.waitDisappearance(notificationLocator, timeout);
     }
 
-    async closeAll(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async closeAll(timeout: number = TimeoutConstants.TS_NOTIFICATION_CENTER_TIMEOUT) {
         Logger.debug('NotificationCenter.closeAll');
 
         await this.clickCloseAllNotificationsButton(timeout);

--- a/tests/e2e/pageobjects/ide/OpenDialogWidget.ts
+++ b/tests/e2e/pageobjects/ide/OpenDialogWidget.ts
@@ -10,11 +10,11 @@
 import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { TestConstants } from '../../TestConstants';
 import { Logger } from '../../utils/Logger';
 import { DialogWindow } from '../ide/DialogWindow';
 import { OpenWorkspaceWidget } from '../ide/OpenWorkspaceWidget';
 import { By } from 'selenium-webdriver';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 export enum Locations {
     Theia = 'theia',
@@ -36,36 +36,31 @@ export class OpenDialogWidget {
         @inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper
     ) { }
 
-    async waitOpenDialogWindow(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug(`OpenDialogWidget.waitOpenDialogWindow`);
-        await this.dialogWindow.waitDialog(timeout);
-    }
-
-    async selectLocation(location: Locations, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async selectLocation(location: Locations, timeout: number = TimeoutConstants.TS_SELENIUM_DIALOG_WIDGET_TIMEOUT) {
         Logger.debug(`OpenDialogWidget.selectLocation`);
         await this.driverHelper.type(By.css('div.theia-NavigationPanel select'), location, timeout);
     }
 
-    async selectItemInTree(pathToItem: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async selectItemInTree(pathToItem: string) {
         Logger.debug(`OpenDialogWidget.selectItemInTree "${pathToItem}"`);
         await this.openWorkspaceWidget.selectItemInTree(pathToItem);
     }
 
 
-    async expandItemInTreeToPath(pathToItem: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async expandItemInTreeToPath(pathToItem: string, timeout: number = TimeoutConstants.TS_SELENIUM_DIALOG_WIDGET_TIMEOUT) {
         Logger.debug(`OpenDialogWidget.expandItemInTreeToPath "${pathToItem}"`);
         await this.openWorkspaceWidget.expandTreeToPath(pathToItem, timeout);
     }
 
-    async clickOnButton(button: Buttons, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnButton(button: Buttons) {
         Logger.debug(`OpenDialogWidget.clickOnButton ${button}`);
         await this.dialogWindow.clickToButton(button);
     }
 
-    async selectLocationAndAddContextFolder(location: Locations, path: string, button: Buttons, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        await this.selectLocation(location, timeout);
-        await this.expandItemInTreeToPath(path, timeout);
-        await this.clickOnButton(button, timeout);
+    async selectLocationAndAddContextFolder(location: Locations, path: string, button: Buttons) {
+        await this.selectLocation(location, TimeoutConstants.TS_SELENIUM_DIALOG_WIDGET_TIMEOUT);
+        await this.expandItemInTreeToPath(path, TimeoutConstants.TS_SELENIUM_DIALOG_WIDGET_TIMEOUT);
+        await this.clickOnButton(button);
         await this.dialogWindow.waitDialogDissappearance();
     }
 

--- a/tests/e2e/pageobjects/ide/OpenDialogWidget.ts
+++ b/tests/e2e/pageobjects/ide/OpenDialogWidget.ts
@@ -58,8 +58,8 @@ export class OpenDialogWidget {
     }
 
     async selectLocationAndAddContextFolder(location: Locations, path: string, button: Buttons) {
-        await this.selectLocation(location, TimeoutConstants.TS_SELENIUM_DIALOG_WIDGET_TIMEOUT);
-        await this.expandItemInTreeToPath(path, TimeoutConstants.TS_SELENIUM_DIALOG_WIDGET_TIMEOUT);
+        await this.selectLocation(location);
+        await this.expandItemInTreeToPath(path);
         await this.clickOnButton(button);
         await this.dialogWindow.waitDialogDissappearance();
     }

--- a/tests/e2e/pageobjects/ide/OpenWorkspaceWidget.ts
+++ b/tests/e2e/pageobjects/ide/OpenWorkspaceWidget.ts
@@ -11,50 +11,22 @@ import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { By } from 'selenium-webdriver';
-import { TestConstants } from '../../TestConstants';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class OpenWorkspaceWidget {
-    private static readonly OPEN_WORKSPACE_MAIN_VIEW_XPATH = '//div[@class=\'dialogTitle\']/div[text()=\'Open Workspace\']';
-    private static readonly OPEN_WORKSPACE_OPEN_BTN_CSS = 'div.dialogControl>button.main';
 
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) {
     }
 
-    async waitOpenWorkspaceWidget(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug('OpenWorkspaceWidget.waitOpenWorkspaceWidget');
-
-        await this.driverHelper.waitVisibility(By.xpath(OpenWorkspaceWidget.OPEN_WORKSPACE_MAIN_VIEW_XPATH), timeout);
-    }
-
-    async waitWidgetIsClosed(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug('OpenWorkspaceWidget.waitWidgetIsClosed');
-
-        await this.driverHelper.waitDisappearance(By.xpath(OpenWorkspaceWidget.OPEN_WORKSPACE_MAIN_VIEW_XPATH), timeout);
-    }
-
-    async selectItemInTree(pathToItem: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async selectItemInTree(pathToItem: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`OpenWorkspaceWidget.selectItemInTree "${pathToItem}"`);
 
         await this.driverHelper.waitAndClick(By.id(pathToItem), timeout);
     }
 
-    async clickOnOpenButton(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug('OpenWorkspaceWidget.clickOnOpenButton');
-
-        await this.driverHelper.waitAndClick(By.css(OpenWorkspaceWidget.OPEN_WORKSPACE_OPEN_BTN_CSS), timeout);
-    }
-
-    async selectItemInTreeAndOpenWorkspace(item: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug(`OpenWorkspaceWidget.selectItemInTreeAndOpenWorkspace "${item}"`);
-
-        await this.selectItemInTree(item, timeout);
-        await this.clickOnOpenButton();
-        await this.waitWidgetIsClosed();
-    }
-
-    async expandTreeToPath(path: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<any> {
+    async expandTreeToPath(path: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM): Promise<any> {
         Logger.debug(`OpenWorkspaceWidget.expandTreeToPath "${path}"`);
         const pathNodes: string[] = path.split('/');
         let buildPath: string = '';

--- a/tests/e2e/pageobjects/ide/OpenshiftPlugin.ts
+++ b/tests/e2e/pageobjects/ide/OpenshiftPlugin.ts
@@ -11,10 +11,10 @@ import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { Ide, LeftToolbarButton } from './Ide';
-import { TestConstants } from '../../TestConstants';
 import { Logger } from '../../utils/Logger';
 import { By } from 'selenium-webdriver';
 import { ContextMenu } from './ContextMenu';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 export enum OpenshiftAppExplorerToolbar {
     ReportExtensionIssueOnGitHub = 'Report Extension Issue on GitHub',
@@ -39,43 +39,43 @@ export class OpenshiftPlugin {
     }
 
 
-    async clickOnOpenshiftToollBarIcon(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnOpenshiftToollBarIcon(timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`OpenshiftPlugin.clickOnOpenshiftTollBar`);
         await this.ide.waitAndClickLeftToolbarButton(LeftToolbarButton.Openshift, timeout);
     }
 
-    async waitOpenshiftConnectorTree(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitOpenshiftConnectorTree(timeout: number) {
         Logger.debug(`OpenshiftPlugin.waitOpenshiftConnectorTree`);
         await this.driverHelper.waitPresence(By.id('openshiftProjectExplorer'), timeout);
     }
 
-    async clickOnApplicationToolbarItem(item: OpenshiftAppExplorerToolbar, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnApplicationToolbarItem(item: OpenshiftAppExplorerToolbar, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`OpenshiftPlugin.clickOnApplicationToolbarItem`);
         await this.driverHelper.waitAndClick(By.css(`div [title='${item}']`), timeout);
     }
 
-    async getClusterIP(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<string> {
+    async getClusterIP(timeout: number): Promise<string> {
         Logger.debug(`OpenshiftPlugin.getClusterIP`);
         return await this.driverHelper.waitAndGetText(By.xpath('//div[@id=\'openshiftProjectExplorer\']//div[@title [contains(text(), https)]]'), timeout);
     }
-    async waitItemInTree(item: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitItemInTree(item: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`OpenshiftPlugin.waitItemInTree`);
         await this.driverHelper.waitPresence(By.xpath(`//div[contains(@id, ':${item}')]`), timeout);
     }
 
-    async clickOnItemInTree(item: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnItemInTree(item: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`OpenshiftPlugin.clickOnItemInTree`);
         await this.driverHelper.waitAndClick(By.xpath(`//div[contains(@id, ':${item}')]`), timeout);
     }
 
-    async invokeContextMenuOnItem(treeItem: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug(`OpenshiftPlugin.clickOnItemInTree`);
-        await this.contextMenu.invokeContextMenuOnTheElementWithMouse(By.xpath(`//div[contains(@id, ':${treeItem}')]`), timeout);
+    async invokeContextMenuOnItem(treeItem: string) {
+        Logger.debug(`OpenshiftPlugin.invokeContextMenuOnItem`);
+        await this.contextMenu.invokeContextMenuOnTheElementWithMouse(By.xpath(`//div[contains(@id, ':${treeItem}')]`));
     }
 
-    async invokeContextMenuCommandOnItem(treeItem: string, menuItem: OpenshiftContextMenuItems, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async invokeContextMenuCommandOnItem(treeItem: string, menuItem: OpenshiftContextMenuItems) {
         Logger.debug(`OpenshiftPlugin.clickOnItemInTree`);
-        await this.contextMenu.invokeContextMenuOnTheElementWithMouse(By.xpath(`//div[contains(@id, ':${treeItem}')]`), timeout);
+        await this.contextMenu.invokeContextMenuOnTheElementWithMouse(By.xpath(`//div[contains(@id, ':${treeItem}')]`));
         await this.contextMenu.waitContextMenuAndClickOnItem(menuItem);
     }
 }

--- a/tests/e2e/pageobjects/ide/OpenshiftPlugin.ts
+++ b/tests/e2e/pageobjects/ide/OpenshiftPlugin.ts
@@ -44,7 +44,7 @@ export class OpenshiftPlugin {
         await this.ide.waitAndClickLeftToolbarButton(LeftToolbarButton.Openshift, timeout);
     }
 
-    async waitOpenshiftConnectorTree(timeout: number) {
+    async waitOpenshiftConnectorTree(timeout: number = TimeoutConstants.TS_WAIT_OPENSHIFT_CONNECTOR_TREE_TIMEOUT) {
         Logger.debug(`OpenshiftPlugin.waitOpenshiftConnectorTree`);
         await this.driverHelper.waitPresence(By.id('openshiftProjectExplorer'), timeout);
     }
@@ -54,7 +54,7 @@ export class OpenshiftPlugin {
         await this.driverHelper.waitAndClick(By.css(`div [title='${item}']`), timeout);
     }
 
-    async getClusterIP(timeout: number): Promise<string> {
+    async getClusterIP(timeout: number = TimeoutConstants.TS_GET_CLUSTER_IP_TIMEOUT): Promise<string> {
         Logger.debug(`OpenshiftPlugin.getClusterIP`);
         return await this.driverHelper.waitAndGetText(By.xpath('//div[@id=\'openshiftProjectExplorer\']//div[@title [contains(text(), https)]]'), timeout);
     }

--- a/tests/e2e/pageobjects/ide/PreviewWidget.ts
+++ b/tests/e2e/pageobjects/ide/PreviewWidget.ts
@@ -14,6 +14,7 @@ import { By, error, Key } from 'selenium-webdriver';
 import { TestConstants } from '../../TestConstants';
 import { Ide } from './Ide';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class PreviewWidget {
@@ -22,33 +23,33 @@ export class PreviewWidget {
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
         @inject(CLASSES.Ide) private readonly ide: Ide) { }
 
-    async waitUrl(expectedUrl: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitUrl(expectedUrl: string, timeout: number) {
         Logger.debug(`PreviewWidget.waitUrl ${expectedUrl}`);
 
         await this.driverHelper.waitAttributeValue(PreviewWidget.WIDGET_URL_LOCATOR, 'value', expectedUrl, timeout);
     }
 
-    async typeUrl(url: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async typeUrl(url: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`PreviewWidget.typeUrl ${url}`);
 
         await this.driverHelper.type(PreviewWidget.WIDGET_URL_LOCATOR, url, timeout);
     }
 
-    async clearUrl(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clearUrl() {
         Logger.debug('PreviewWidget.clearUrl');
 
         await this.typeUrl(Key.chord(Key.CONTROL, 'a', Key.DELETE));
-        await this.waitUrl('', timeout);
+        await this.waitUrl('', 5_000);
     }
 
-    async typeAndApplyUrl(url: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async typeAndApplyUrl(url: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`PreviewWidget.typeAndApplyUrl ${url}`);
 
-        await this.clearUrl(timeout);
+        await this.clearUrl();
         await this.typeUrl(Key.chord(url, Key.ENTER), timeout);
     }
 
-    async waitApplicationOpened(expectedUrl: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitApplicationOpened(expectedUrl: string, timeout: number) {
         Logger.debug(`PreviewWidget.waitApplicationOpened ${expectedUrl}`);
 
         await this.driverHelper.getDriver().wait(async () => {
@@ -69,14 +70,8 @@ export class PreviewWidget {
         Logger.debug('PreviewWidget.waitAndSwitchToWidgetFrame');
 
         const iframeLocator: By = By.css('div.theia-mini-browser iframe');
-        await this.driverHelper.waitAndSwitchToFrame(iframeLocator);
+        await this.driverHelper.waitAndSwitchToFrame(iframeLocator, TimeoutConstants.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT);
 
-    }
-
-    async waitPreviewWidget(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug('PreviewWidget.waitPreviewWidget');
-
-        await this.driverHelper.waitVisibility(By.css('div.theia-mini-browser'), timeout);
     }
 
     async waitPreviewWidgetAbsence() {
@@ -86,7 +81,7 @@ export class PreviewWidget {
     }
 
     async waitContentAvailable(contentLocator: By,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT,
+        timeout: number,
         polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING * 5) {
 
         Logger.debug(`PreviewWidget.waitContentAvailable ${contentLocator}`);
@@ -107,34 +102,13 @@ export class PreviewWidget {
         }, timeout);
     }
 
-    async waitContentAvailableInAssociatedWorkspace(contentLocator: By,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT,
-        polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING * 5) {
-
-        Logger.debug(`PreviewWidget.waitContentAvailableInAssociatedWorkspace ${contentLocator}`);
-
-        await this.waitAndSwitchToWidgetFrame();
-        await this.driverHelper.getDriver().wait(async () => {
-            const isApplicationTitleVisible: boolean = await this.driverHelper.isVisible(contentLocator);
-            if (isApplicationTitleVisible) {
-                await this.driverHelper.getDriver().switchTo().defaultContent();
-                return true;
-            }
-
-            await this.driverHelper.getDriver().switchTo().defaultContent();
-            await this.refreshPage();
-            await this.waitAndSwitchToWidgetFrame();
-            await this.driverHelper.wait(polling);
-        }, timeout);
-    }
-
-    async waitVisibility(element: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitVisibility(element: By, timeout: number) {
         Logger.debug(`PreviewWidget.waitVisibility ${element}`);
 
         await this.driverHelper.waitVisibility(element, timeout);
     }
 
-    async waitAndClick(element: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitAndClick(element: By, timeout: number = TimeoutConstants.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT) {
         Logger.debug(`PreviewWidget.waitAndClick ${element}`);
 
         await this.driverHelper.waitAndClick(element, timeout);
@@ -144,7 +118,7 @@ export class PreviewWidget {
         Logger.debug('PreviewWidget.refreshPage');
 
         const refreshButtonLocator: By = By.css('.theia-mini-browser .theia-mini-browser-refresh');
-        await this.driverHelper.waitAndClick(refreshButtonLocator);
+        await this.driverHelper.waitAndClick(refreshButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async switchBackToIdeFrame() {

--- a/tests/e2e/pageobjects/ide/PreviewWidget.ts
+++ b/tests/e2e/pageobjects/ide/PreviewWidget.ts
@@ -23,7 +23,7 @@ export class PreviewWidget {
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
         @inject(CLASSES.Ide) private readonly ide: Ide) { }
 
-    async waitUrl(expectedUrl: string, timeout: number) {
+    async waitUrl(expectedUrl: string, timeout: number = TimeoutConstants.TS_WAIT_URL_TIMEOUT) {
         Logger.debug(`PreviewWidget.waitUrl ${expectedUrl}`);
 
         await this.driverHelper.waitAttributeValue(PreviewWidget.WIDGET_URL_LOCATOR, 'value', expectedUrl, timeout);
@@ -39,7 +39,7 @@ export class PreviewWidget {
         Logger.debug('PreviewWidget.clearUrl');
 
         await this.typeUrl(Key.chord(Key.CONTROL, 'a', Key.DELETE));
-        await this.waitUrl('', 5_000);
+        await this.waitUrl('');
     }
 
     async typeAndApplyUrl(url: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
@@ -118,7 +118,7 @@ export class PreviewWidget {
         Logger.debug('PreviewWidget.refreshPage');
 
         const refreshButtonLocator: By = By.css('.theia-mini-browser .theia-mini-browser-refresh');
-        await this.driverHelper.waitAndClick(refreshButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(refreshButtonLocator);
     }
 
     async switchBackToIdeFrame() {

--- a/tests/e2e/pageobjects/ide/ProjectTree.ts
+++ b/tests/e2e/pageobjects/ide/ProjectTree.ts
@@ -16,6 +16,7 @@ import { TestConstants } from '../../TestConstants';
 import { By, error } from 'selenium-webdriver';
 import { Editor } from './Editor';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class ProjectTree {
@@ -30,14 +31,14 @@ export class ProjectTree {
         Logger.debug('ProjectTree.clickCollapseAllButton');
 
         const collapseAllButtonLocator: By = By.css('div.theia-sidepanel-toolbar div.theia-collapse-all-icon');
-        await this.driverHelper.waitAndClick(collapseAllButtonLocator);
+        await this.driverHelper.waitAndClick(collapseAllButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitTreeCollapsed(projectName: string, rootSubItem: string) {
         Logger.debug(`ProjectTree.waitTreeCollapsed project: "${projectName}", subitem: "${rootSubItem}"`);
 
         const rootSubitemLocator: By = By.css(this.getTreeItemCssLocator(`${projectName}/${rootSubItem}`));
-        await this.driverHelper.waitDisappearanceWithTimeout(rootSubitemLocator);
+        await this.driverHelper.waitDisappearanceWithTimeout(rootSubitemLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async collapseProjectTree(projectName: string, rootSubItem: string) {
@@ -54,14 +55,7 @@ export class ProjectTree {
         await this.waitItemCollapsed(`${projectName}/${expandedRootItem}`);
     }
 
-    async collapseAssociatedWorkspaceProjectTree(projectName: string, rootSubItem: string) {
-        Logger.debug(`ProjectTree.collapseProjectTree project: "${projectName}", subitem: "${rootSubItem}"`);
-
-        await this.clickCollapseAllButton();
-        await this.waitTreeCollapsed(projectName, rootSubItem);
-    }
-
-    async openProjectTreeContainer(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async openProjectTreeContainer(timeout: number = TimeoutConstants.TS_PROJECT_TREE_TIMEOUT) {
         Logger.debug('ProjectTree.openProjectTreeContainer');
 
         const selectedExplorerButtonLocator: By = By.css(Ide.SELECTED_EXPLORER_BUTTON_CSS);
@@ -77,7 +71,7 @@ export class ProjectTree {
         await this.waitProjectTreeContainer();
     }
 
-    async waitItemExpanded(itemPath: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitItemExpanded(itemPath: string, timeout: number = TimeoutConstants.TS_PROJECT_TREE_TIMEOUT) {
         Logger.debug(`ProjectTree.waitItemExpanded "${itemPath}"`);
 
         const locator: string = await this.getExpandedItemCssLocator(itemPath);
@@ -85,7 +79,7 @@ export class ProjectTree {
         await this.driverHelper.waitVisibility(expandedItemLocator, timeout);
     }
 
-    async waitItemCollapsed(itemPath: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitItemCollapsed(itemPath: string, timeout: number = TimeoutConstants.TS_PROJECT_TREE_TIMEOUT) {
         Logger.debug(`ProjectTree.waitItemCollapsed "${itemPath}"`);
 
         const locator: string = await this.getCollapsedItemCssLocator(itemPath);
@@ -94,7 +88,7 @@ export class ProjectTree {
         await this.driverHelper.waitVisibility(collapsedItemLocator, timeout);
     }
 
-    async waitProjectTreeContainer(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitProjectTreeContainer(timeout: number = TimeoutConstants.TS_PROJECT_TREE_TIMEOUT) {
         Logger.debug('ProjectTree.waitProjectTreeContainer');
 
         await this.driverHelper.waitPresence(By.css(ProjectTree.PROJECT_TREE_CONTAINER_CSS), timeout);
@@ -108,7 +102,7 @@ export class ProjectTree {
         await this.driverHelper.waitDisappearance(By.css(ProjectTree.PROJECT_TREE_CONTAINER_CSS), attempts, polling);
     }
 
-    async waitItem(itemPath: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitItem(itemPath: string, timeout: number = TimeoutConstants.TS_PROJECT_TREE_TIMEOUT) {
         Logger.debug(`ProjectTree.waitItem "${itemPath}"`);
 
         const locator: string = await this.getItemCss(itemPath);
@@ -125,7 +119,7 @@ export class ProjectTree {
         await this.driverHelper.waitDisappearance(By.css(locator), attempts, polling);
     }
 
-    async clickOnItem(itemPath: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnItem(itemPath: string, timeout: number = TimeoutConstants.TS_PROJECT_TREE_CLICK_ON_ITEM_TIMEOUT) {
         Logger.debug(`ProjectTree.clickOnItem "${itemPath}"`);
 
         const locator: string = await this.getItemCss(itemPath);
@@ -133,14 +127,14 @@ export class ProjectTree {
         await this.waitItemSelected(itemPath, timeout);
     }
 
-    async waitItemSelected(itemPath: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitItemSelected(itemPath: string, timeout: number = TimeoutConstants.TS_PROJECT_TREE_TIMEOUT) {
         Logger.debug(`ProjectTree.waitItemSelected "${itemPath}"`);
 
         const selectedItemLocator: By = By.css(`div[title='/projects/${itemPath}'].theia-mod-selected.theia-mod-focus`);
         await this.driverHelper.waitVisibility(selectedItemLocator, timeout);
     }
 
-    async expandItem(itemPath: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async expandItem(itemPath: string, timeout: number = TimeoutConstants.TS_PROJECT_TREE_CLICK_ON_ITEM_TIMEOUT) {
         Logger.debug(`ProjectTree.expandItem "${itemPath}"`);
 
         const locator: string = await this.getExpandIconCssLocator(itemPath);
@@ -171,7 +165,7 @@ export class ProjectTree {
         }, timeout);
     }
 
-    async collapseItem(itemPath: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async collapseItem(itemPath: string, timeout: number = TimeoutConstants.TS_PROJECT_TREE_CLICK_ON_ITEM_TIMEOUT) {
         Logger.debug(`ProjectTree.collapseItem "${itemPath}"`);
 
         const locator: string = await this.getExpandIconCssLocator(itemPath);
@@ -188,7 +182,7 @@ export class ProjectTree {
         await this.waitItemCollapsed(itemPath, timeout);
     }
 
-    async expandPath(path: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async expandPath(path: string, timeout: number = TimeoutConstants.TS_EXPAND_PROJECT_TREE_ITEM_TIMEOUT) {
         Logger.debug(`ProjectTree.expandPath "${path}"`);
 
         let items: Array<string> = path.split('/');
@@ -209,48 +203,13 @@ export class ProjectTree {
         }
     }
 
-    async expandPathAndOpenFile(pathToItem: string, fileName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async expandPathAndOpenFile(pathToItem: string, fileName: string, timeoutForSigleItem: number = TimeoutConstants.TS_OPEN_EDITOR_TIMEOUT) {
         Logger.debug(`ProjectTree.expandPathAndOpenFile "${pathToItem}" filename: ${fileName}`);
 
-        await this.expandPath(pathToItem, timeout);
-        await this.clickOnItem(`${pathToItem}/${fileName}`, timeout);
+        await this.expandPath(pathToItem, timeoutForSigleItem);
+        await this.clickOnItem(`${pathToItem}/${fileName}`, timeoutForSigleItem);
 
-        await this.editor.waitEditorOpened(fileName, timeout);
-        await this.editor.waitTab(fileName);
-    }
-
-    async expandPathAndOpenFileInAssociatedWorkspace(pathToItem: string, fileName: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug(`ProjectTree.expandPathAndOpenFileInAssociatedWorkspace "${pathToItem}"`);
-
-        let projectName: string = pathToItem.split('/')[0];
-        let pathEntry = `${projectName}`;
-        let pathToItemInAssociatedWorkspace = pathToItem.replace(`${projectName}/`, '');
-        let paths: Array<string> = new Array();
-        // if we in the root of project
-        if (pathToItem.split('/').length < 2) {
-            Logger.trace(`ProjectTree.expandPathAndOpenFileInAssociatedWorkspace has no subpaths, expanding root folder "${projectName}"`);
-            await this.expandItem(projectName);
-            Logger.trace(`ProjectTree.expandPathAndOpenFileInAssociatedWorkspace clicking on file "${projectName}/${fileName}"`);
-            await this.clickOnItem(`${projectName}/${fileName}`, timeout);
-            return;
-        }
-        // make direct path for each project tree item
-        pathToItemInAssociatedWorkspace.split('/')
-            .forEach(item => {
-                pathEntry = pathEntry + `/${item}`;
-                paths.push(pathEntry);
-            });
-
-
-        // expand each project tree item
-        for (const path of paths) {
-            await this.expandItem(path, timeout);
-        }
-        // open file
-        await this.clickOnItem(`${projectName}/${pathToItemInAssociatedWorkspace}/${fileName}`, timeout);
-
-        // check file appearance in the editor
-        await this.editor.waitEditorOpened(fileName, timeout);
+        await this.editor.waitEditorOpened(fileName);
         await this.editor.waitTab(fileName);
     }
 
@@ -332,7 +291,7 @@ export class ProjectTree {
     private async  getWorkspacePathEntry(): Promise<string> {
         const nodeAttribute: string = 'data-node-id';
         const splitDelimeter = ':';
-        const attribute: string = await this.driverHelper.waitAndGetElementAttribute(By.css(`div[${nodeAttribute}]`), nodeAttribute);
+        const attribute: string = await this.driverHelper.waitAndGetElementAttribute(By.css(`div[${nodeAttribute}]`), nodeAttribute, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
         return attribute.split(splitDelimeter)[0] + splitDelimeter;
     }
 

--- a/tests/e2e/pageobjects/ide/ProjectTree.ts
+++ b/tests/e2e/pageobjects/ide/ProjectTree.ts
@@ -31,7 +31,7 @@ export class ProjectTree {
         Logger.debug('ProjectTree.clickCollapseAllButton');
 
         const collapseAllButtonLocator: By = By.css('div.theia-sidepanel-toolbar div.theia-collapse-all-icon');
-        await this.driverHelper.waitAndClick(collapseAllButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(collapseAllButtonLocator);
     }
 
     async waitTreeCollapsed(projectName: string, rootSubItem: string) {
@@ -203,6 +203,12 @@ export class ProjectTree {
         }
     }
 
+    /**
+     *
+     * @param pathToItem path to the file that should be opened
+     * @param fileName file that should be opened
+     * @param timeoutForSigleItem timeout applied for every item in path to be opened
+     */
     async expandPathAndOpenFile(pathToItem: string, fileName: string, timeoutForSigleItem: number = TimeoutConstants.TS_OPEN_EDITOR_TIMEOUT) {
         Logger.debug(`ProjectTree.expandPathAndOpenFile "${pathToItem}" filename: ${fileName}`);
 

--- a/tests/e2e/pageobjects/ide/QuickOpenContainer.ts
+++ b/tests/e2e/pageobjects/ide/QuickOpenContainer.ts
@@ -1,9 +1,9 @@
 import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { TestConstants } from '../../TestConstants';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 /*********************************************************************
  * Copyright (c) 2019 Red Hat, Inc.
@@ -19,7 +19,7 @@ import { Logger } from '../../utils/Logger';
 export class QuickOpenContainer {
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
-    public async waitContainer(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitContainer(timeout: number = TimeoutConstants.TS_SELENIUM_TOP_MENU_QUICK_CONTAINER_TIMEOUT) {
         Logger.debug('QuickOpenContainer.waitContainer');
 
         const monacoQuickOpenContainerLocator: By = By.xpath('//div[@class=\'monaco-quick-open-widget\']');
@@ -33,7 +33,7 @@ export class QuickOpenContainer {
         await this.driverHelper.waitDisappearance(monacoQuickOpenContainerLocator);
     }
 
-    public async clickOnContainerItem(itemText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async clickOnContainerItem(itemText: string, timeout: number = TimeoutConstants.TS_SELENIUM_TOP_MENU_QUICK_CONTAINER_TIMEOUT) {
         Logger.debug(`QuickOpenContainer.clickOnContainerItem "${itemText}"`);
 
         const quickContainerItemLocator: By = By.css(`div[aria-label="${itemText}, picker"]`);
@@ -50,7 +50,7 @@ export class QuickOpenContainer {
     public async typeAndSelectSuggestion(text: string, suggestedText: string) {
         Logger.debug('QuickOpenContainer.typeAndSelectSuggestion');
 
-        await this.driverHelper.type(By.css('div.monaco-inputbox  input.input'), text);
+        await this.driverHelper.type(By.css('div.monaco-inputbox  input.input'), text, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
         // sometimes the UI dropdawn may closed unexpectedly for more stability add 500ms delay.
         await this.driverHelper.wait(500);
         await this.clickOnContainerItem(suggestedText);

--- a/tests/e2e/pageobjects/ide/QuickOpenContainer.ts
+++ b/tests/e2e/pageobjects/ide/QuickOpenContainer.ts
@@ -50,7 +50,7 @@ export class QuickOpenContainer {
     public async typeAndSelectSuggestion(text: string, suggestedText: string) {
         Logger.debug('QuickOpenContainer.typeAndSelectSuggestion');
 
-        await this.driverHelper.type(By.css('div.monaco-inputbox  input.input'), text, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.type(By.css('div.monaco-inputbox  input.input'), text);
         // sometimes the UI dropdawn may closed unexpectedly for more stability add 500ms delay.
         await this.driverHelper.wait(500);
         await this.clickOnContainerItem(suggestedText);

--- a/tests/e2e/pageobjects/ide/Terminal.ts
+++ b/tests/e2e/pageobjects/ide/Terminal.ts
@@ -11,23 +11,15 @@ import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { By, Key, WebElement, error } from 'selenium-webdriver';
-import { TestConstants } from '../../TestConstants';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class Terminal {
     private static readonly TERMINAL_ROWS_XPATH_LOCATOR_PREFFIX = '(//div[contains(@class, \'terminal-container\')]//div[contains(@class, \'terminal\')]//div[contains(@class, \'xterm-rows\')])';
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
-    async waitTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.debug(`Terminal.waitTab "${tabTitle}"`);
-
-        const terminalTabLocator: By = By.css(this.getTerminalTabCssLocator(tabTitle));
-
-        await this.driverHelper.waitVisibility(terminalTabLocator, timeout);
-    }
-
-    async waitTabAbsence(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitTabAbsence(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.waitTabAbsence "${tabTitle}"`);
 
         const terminalTabLocator: By = By.css(this.getTerminalTabCssLocator(tabTitle));
@@ -35,7 +27,7 @@ export class Terminal {
         await this.driverHelper.waitDisappearanceWithTimeout(terminalTabLocator, timeout);
     }
 
-    async clickOnTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnTab(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.clickOnTab "${tabTitle}"`);
 
         const terminalTabLocator: By = By.css(this.getTerminalTabCssLocator(tabTitle));
@@ -43,7 +35,7 @@ export class Terminal {
         await this, this.driverHelper.waitAndClick(terminalTabLocator, timeout);
     }
 
-    async waitTabFocused(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitTabFocused(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.waitTabFocused "${tabTitle}"`);
 
         const focusedTerminalTabLocator: By = this.getFocusedTerminalTabLocator(tabTitle);
@@ -51,14 +43,14 @@ export class Terminal {
         await this.driverHelper.waitVisibility(focusedTerminalTabLocator, timeout);
     }
 
-    async selectTerminalTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async selectTerminalTab(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.selectTerminalTab "${tabTitle}"`);
 
         await this.clickOnTab(tabTitle, timeout);
         await this.waitTabFocused(tabTitle, timeout);
     }
 
-    async clickOnTabCloseIcon(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async clickOnTabCloseIcon(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.clickOnTabCloseIcon "${tabTitle}"`);
 
         const terminalTabCloseIconLocator: By =
@@ -67,7 +59,7 @@ export class Terminal {
         await this.driverHelper.waitAndClick(terminalTabCloseIconLocator, timeout);
     }
 
-    async closeTerminalTab(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async closeTerminalTab(tabTitle: string, timeout: number = 5_000) {
         Logger.debug(`Terminal.closeTerminalTab "${tabTitle}"`);
 
         await this.clickOnTabCloseIcon(tabTitle, timeout);
@@ -83,14 +75,14 @@ export class Terminal {
         await this.driverHelper.typeToInvisible(terminalInteractionContainer, text);
     }
 
-    async rejectTerminalProcess(tabTitle: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async rejectTerminalProcess(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.rejectTerminalProcess "${tabTitle}"`);
 
         await this.selectTerminalTab(tabTitle, timeout);
         await this.type(tabTitle, Key.chord(Key.CONTROL, 'c'));
     }
 
-    async getText(terminalTab: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<string> {
+    async getText(terminalTab: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT): Promise<string> {
         Logger.debug(`Terminal.getText tab: ${terminalTab}`);
 
         const terminalIndex: number = await this.getTerminalIndex(terminalTab);
@@ -98,7 +90,7 @@ export class Terminal {
         return await this.driverHelper.waitAndGetText(By.xpath(Terminal.TERMINAL_ROWS_XPATH_LOCATOR_PREFFIX + `[${terminalIndex}]`), timeout);
     }
 
-    async selectTabByPrefixAndWaitText(terminalTab: string, expectedText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async selectTabByPrefixAndWaitText(terminalTab: string, expectedText: string, timeout: number) {
         Logger.debug(`Terminal.selectTabByPrefixAndWaitText tab: ${terminalTab} text: ${expectedText}`);
 
         const terminalTabLocatorWithPreffix: string = `//li[contains(@title, '${terminalTab}')]`;
@@ -112,7 +104,7 @@ export class Terminal {
         }, timeout);
     }
 
-    async waitText(terminalTab: string, expectedText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    async waitText(terminalTab: string, expectedText: string, timeout: number) {
         Logger.debug(`Terminal.waitText tab: ${terminalTab} text: ${expectedText}`);
 
         await this.selectTerminalTab(terminalTab, timeout);
@@ -151,13 +143,13 @@ export class Terminal {
             `//li[contains(@id, 'shell-tab-terminal') or contains(@id, 'shell-tab-plugin')]` +
             `//div[@class='p-TabBar-tabLabel']`;
 
-        const terminalTabs: WebElement[] = await this.driverHelper.waitAllPresence(By.xpath(terminalTabTitleXpathLocator));
+        const terminalTabs: WebElement[] = await this.driverHelper.waitAllPresence(By.xpath(terminalTabTitleXpathLocator), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
         let terminalTitles: string[] = [];
 
 
         for (let i: number = 1; i <= terminalTabs.length; i++) {
             const terminalTabLocator: By = By.xpath(`(${terminalTabTitleXpathLocator})[${i}]`);
-            const currentTerminalTitle: string = await this.driverHelper.waitAndGetText(terminalTabLocator);
+            const currentTerminalTitle: string = await this.driverHelper.waitAndGetText(terminalTabLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
 
             if (currentTerminalTitle.search(terminalTitle) > -1) {
                 Logger.debug(`Terminal index: ${i}`);

--- a/tests/e2e/pageobjects/ide/Terminal.ts
+++ b/tests/e2e/pageobjects/ide/Terminal.ts
@@ -59,7 +59,7 @@ export class Terminal {
         await this.driverHelper.waitAndClick(terminalTabCloseIconLocator, timeout);
     }
 
-    async closeTerminalTab(tabTitle: string, timeout: number = 5_000) {
+    async closeTerminalTab(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.closeTerminalTab "${tabTitle}"`);
 
         await this.clickOnTabCloseIcon(tabTitle, timeout);
@@ -143,13 +143,13 @@ export class Terminal {
             `//li[contains(@id, 'shell-tab-terminal') or contains(@id, 'shell-tab-plugin')]` +
             `//div[@class='p-TabBar-tabLabel']`;
 
-        const terminalTabs: WebElement[] = await this.driverHelper.waitAllPresence(By.xpath(terminalTabTitleXpathLocator), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        const terminalTabs: WebElement[] = await this.driverHelper.waitAllPresence(By.xpath(terminalTabTitleXpathLocator));
         let terminalTitles: string[] = [];
 
 
         for (let i: number = 1; i <= terminalTabs.length; i++) {
             const terminalTabLocator: By = By.xpath(`(${terminalTabTitleXpathLocator})[${i}]`);
-            const currentTerminalTitle: string = await this.driverHelper.waitAndGetText(terminalTabLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+            const currentTerminalTitle: string = await this.driverHelper.waitAndGetText(terminalTabLocator);
 
             if (currentTerminalTitle.search(terminalTitle) > -1) {
                 Logger.debug(`Terminal index: ${i}`);

--- a/tests/e2e/pageobjects/ide/Terminal.ts
+++ b/tests/e2e/pageobjects/ide/Terminal.ts
@@ -90,7 +90,7 @@ export class Terminal {
         return await this.driverHelper.waitAndGetText(By.xpath(Terminal.TERMINAL_ROWS_XPATH_LOCATOR_PREFFIX + `[${terminalIndex}]`), timeout);
     }
 
-    async selectTabByPrefixAndWaitText(terminalTab: string, expectedText: string, timeout: number) {
+    async selectTabByPrefixAndWaitText(terminalTab: string, expectedText: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.selectTabByPrefixAndWaitText tab: ${terminalTab} text: ${expectedText}`);
 
         const terminalTabLocatorWithPreffix: string = `//li[contains(@title, '${terminalTab}')]`;

--- a/tests/e2e/pageobjects/ide/Terminal.ts
+++ b/tests/e2e/pageobjects/ide/Terminal.ts
@@ -19,6 +19,14 @@ export class Terminal {
     private static readonly TERMINAL_ROWS_XPATH_LOCATOR_PREFFIX = '(//div[contains(@class, \'terminal-container\')]//div[contains(@class, \'terminal\')]//div[contains(@class, \'xterm-rows\')])';
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
 
+    async waitTab(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
+        Logger.debug(`Terminal.waitTab "${tabTitle}"`);
+
+        const terminalTabLocator: By = By.css(this.getTerminalTabCssLocator(tabTitle));
+
+        await this.driverHelper.waitVisibility(terminalTabLocator, timeout);
+    }
+    
     async waitTabAbsence(tabTitle: string, timeout: number = TimeoutConstants.TS_SELENIUM_TERMINAL_DEFAULT_TIMEOUT) {
         Logger.debug(`Terminal.waitTabAbsence "${tabTitle}"`);
 

--- a/tests/e2e/pageobjects/ide/TopMenu.ts
+++ b/tests/e2e/pageobjects/ide/TopMenu.ts
@@ -1,11 +1,11 @@
 import { injectable, inject } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { TestConstants } from '../../TestConstants';
 import { By, error } from 'selenium-webdriver';
 import { Ide } from './Ide';
 import { Logger } from '../../utils/Logger';
 import { QuickOpenContainer } from './QuickOpenContainer';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 /*********************************************************************
  * Copyright (c) 2019 Red Hat, Inc.
@@ -25,7 +25,7 @@ export class TopMenu {
         @inject(CLASSES.Ide) private readonly ide: Ide,
         @inject(CLASSES.QuickOpenContainer) private readonly quickOpenContainer: QuickOpenContainer) { }
 
-    public async waitTopMenu(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitTopMenu(timeout: number = TimeoutConstants.TS_SELENIUM_TOOLBAR_TIMEOUT) {
         Logger.debug('TopMenu.waitTopMenu');
 
         for (const buttonText of TopMenu.TOP_MENU_BUTTONS) {
@@ -41,7 +41,7 @@ export class TopMenu {
         await this.clickOnSubmenuItem(submenuItemtext);
     }
 
-    public async clickOnTopMenuButton(buttonText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async clickOnTopMenuButton(buttonText: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`TopMenu.clickOnTopMenuButton "${buttonText}"`);
 
         const buttonLocator: By = this.getTopMenuButtonLocator(buttonText);
@@ -50,7 +50,7 @@ export class TopMenu {
         await this.driverHelper.waitAndClick(buttonLocator, timeout);
     }
 
-    public async clickOnSubmenuItem(itemText: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async clickOnSubmenuItem(itemText: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.debug(`TopMenu.clickOnSubmenuItem "${itemText}"`);
 
         const submenuItemLocator: By = this.getSubmenuItemLocator(itemText);

--- a/tests/e2e/pageobjects/login/SingleUserLoginPage.ts
+++ b/tests/e2e/pageobjects/login/SingleUserLoginPage.ts
@@ -10,13 +10,12 @@
 import 'reflect-metadata';
 import { ICheLoginPage } from './ICheLoginPage';
 import { injectable } from 'inversify';
-import { TestConstants } from '../../TestConstants';
 import { Logger } from '../../utils/Logger';
 
 @injectable()
 export class SingleUserLoginPage implements ICheLoginPage {
 
-    async login(timeout: number = TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT) {
+    async login() {
         Logger.debug('SingleUserLoginPage.login');
 
         // do nothing

--- a/tests/e2e/pageobjects/openshift/CheLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/CheLoginPage.ts
@@ -13,6 +13,7 @@ import { DriverHelper } from '../../utils/DriverHelper';
 import { CLASSES } from '../../inversify.types';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class CheLoginPage {
@@ -23,7 +24,7 @@ export class CheLoginPage {
     async waitEclipseCheLoginFormPage() {
             Logger.debug('CheLoginPage.waitEclipseCheLoginFormPage');
 
-            await this.driverHelper.waitVisibility(By.id('kc-form-login'));
+            await this.driverHelper.waitVisibility(By.id('kc-form-login'), TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async inputUserNameEclipseCheLoginPage(userName: string) {
@@ -41,7 +42,7 @@ export class CheLoginPage {
     async clickEclipseCheLoginButton() {
         Logger.debug('CheLoginPage.clickEclipseCheLoginButton');
 
-        await this.driverHelper.waitAndClick(By.id('kc-login'));
+        await this.driverHelper.waitAndClick(By.id('kc-login'), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async isFirstBrokerLoginPageVisible(): Promise<boolean> {
@@ -53,7 +54,7 @@ export class CheLoginPage {
     async waitFirstBrokerLoginPage() {
         Logger.debug('CheLoginPage.waitFirstBrokerLoginPage');
 
-        await this.driverHelper.waitVisibility(By.id('kc-update-profile-form'));
+        await this.driverHelper.waitVisibility(By.id('kc-update-profile-form'), TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async enterEmailFirstBrokerLoginPage(email: string) {
@@ -78,7 +79,7 @@ export class CheLoginPage {
         Logger.debug('CheLoginPage.clickOnSubmitButton');
 
         const submitButtonlocator: By = By.css('input[type=submit]');
-        await this.driverHelper.waitAndClick(submitButtonlocator);
+        await this.driverHelper.waitAndClick(submitButtonlocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitDisappearanceBrokerLoginPage() {

--- a/tests/e2e/pageobjects/openshift/CheLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/CheLoginPage.ts
@@ -42,7 +42,7 @@ export class CheLoginPage {
     async clickEclipseCheLoginButton() {
         Logger.debug('CheLoginPage.clickEclipseCheLoginButton');
 
-        await this.driverHelper.waitAndClick(By.id('kc-login'), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(By.id('kc-login'));
     }
 
     async isFirstBrokerLoginPageVisible(): Promise<boolean> {
@@ -79,7 +79,7 @@ export class CheLoginPage {
         Logger.debug('CheLoginPage.clickOnSubmitButton');
 
         const submitButtonlocator: By = By.css('input[type=submit]');
-        await this.driverHelper.waitAndClick(submitButtonlocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(submitButtonlocator);
     }
 
     async waitDisappearanceBrokerLoginPage() {

--- a/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
@@ -14,6 +14,7 @@ import { CLASSES } from '../../inversify.types';
 import { By } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
 import { TestConstants } from '../../TestConstants';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class OcpLoginPage {
@@ -32,14 +33,14 @@ export class OcpLoginPage {
     async waitOpenShiftLoginWelcomePage() {
         Logger.debug('OcpLoginPage.waitOpenShiftLoginWelcomePage');
 
-        await this.driverHelper.waitVisibility(By.xpath(OcpLoginPage.LOGIN_PAGE_OPENSHIFT_XPATH));
+        await this.driverHelper.waitVisibility(By.xpath(OcpLoginPage.LOGIN_PAGE_OPENSHIFT_XPATH), TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async clickOnLoginProviderTitle() {
         Logger.debug('OcpLoginPage.clickOnLoginProviderTitle');
 
         const loginProviderTitleLocator: By = By.xpath(`//a[text()=\'${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
-        await this.driverHelper.waitAndClick(loginProviderTitleLocator);
+        await this.driverHelper.waitAndClick(loginProviderTitleLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async isIdentityProviderLinkVisible(): Promise<boolean> {
@@ -60,14 +61,14 @@ export class OcpLoginPage {
         Logger.debug('OcpLoginPage.waitAuthorizeOpenShiftIdentityProviderPage');
 
         const authorizeOpenshiftIdentityProviderPageLocator: By = By.xpath('//h1[text()=\'Authorize Access\']');
-        await this.driverHelper.waitVisibility(authorizeOpenshiftIdentityProviderPageLocator);
+        await this.driverHelper.waitVisibility(authorizeOpenshiftIdentityProviderPageLocator, TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async clickOnApproveAuthorizeAccessButton() {
         Logger.debug('OcpLoginPage.clickOnApproveAuthorizeAccessOpenshift');
 
         const approveAuthorizeAccessOcpLocator: By = By.css('input[name=\'approve\']');
-        await this.driverHelper.waitAndClick(approveAuthorizeAccessOcpLocator);
+        await this.driverHelper.waitAndClick(approveAuthorizeAccessOcpLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async enterUserNameOpenShift(userName: string) {
@@ -86,7 +87,7 @@ export class OcpLoginPage {
         Logger.debug('OcpLoginPage.clickOnLoginButton');
 
         const loginButtonlocator: By = By.css('button[type=submit]');
-        await this.driverHelper.waitAndClick(loginButtonlocator);
+        await this.driverHelper.waitAndClick(loginButtonlocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitDisappearanceOpenShiftLoginWelcomePage() {
@@ -106,7 +107,7 @@ export class OcpLoginPage {
         Logger.debug('OcpLoginPage.clickOnLinkAccountButton');
 
         const linkAccountLocator: By = By.id(`linkAccount`);
-        this.driverHelper.waitAndClick(linkAccountLocator);
+        this.driverHelper.waitAndClick(linkAccountLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
 }

--- a/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
@@ -40,7 +40,7 @@ export class OcpLoginPage {
         Logger.debug('OcpLoginPage.clickOnLoginProviderTitle');
 
         const loginProviderTitleLocator: By = By.xpath(`//a[text()=\'${TestConstants.TS_OCP_LOGIN_PAGE_PROVIDER_TITLE}\']`);
-        await this.driverHelper.waitAndClick(loginProviderTitleLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(loginProviderTitleLocator);
     }
 
     async isIdentityProviderLinkVisible(): Promise<boolean> {
@@ -68,7 +68,7 @@ export class OcpLoginPage {
         Logger.debug('OcpLoginPage.clickOnApproveAuthorizeAccessOpenshift');
 
         const approveAuthorizeAccessOcpLocator: By = By.css('input[name=\'approve\']');
-        await this.driverHelper.waitAndClick(approveAuthorizeAccessOcpLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(approveAuthorizeAccessOcpLocator);
     }
 
     async enterUserNameOpenShift(userName: string) {
@@ -87,7 +87,7 @@ export class OcpLoginPage {
         Logger.debug('OcpLoginPage.clickOnLoginButton');
 
         const loginButtonlocator: By = By.css('button[type=submit]');
-        await this.driverHelper.waitAndClick(loginButtonlocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(loginButtonlocator);
     }
 
     async waitDisappearanceOpenShiftLoginWelcomePage() {
@@ -107,7 +107,7 @@ export class OcpLoginPage {
         Logger.debug('OcpLoginPage.clickOnLinkAccountButton');
 
         const linkAccountLocator: By = By.id(`linkAccount`);
-        this.driverHelper.waitAndClick(linkAccountLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        this.driverHelper.waitAndClick(linkAccountLocator);
     }
 
 }

--- a/tests/e2e/pageobjects/openshift/OcpWebConsolePage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpWebConsolePage.ts
@@ -14,6 +14,7 @@ import { CLASSES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
 import { By, Key } from 'selenium-webdriver';
 import { Logger } from '../../utils/Logger';
+import { TimeoutConstants } from '../../TimeoutConstants';
 
 @injectable()
 export class OcpWebConsolePage {
@@ -28,13 +29,7 @@ export class OcpWebConsolePage {
     async waitNavpanelOpenShift() {
         Logger.debug('OcpWebConsolePage.waitNavpanelOpenShift');
 
-        await this.driverHelper.waitVisibility(By.css(OcpWebConsolePage.NAV_PANEL_OPENSHIFT_CSS));
-    }
-
-    async waitDisappearanceNavpanelOpenShift() {
-        Logger.debug('OcpWebConsolePage.waitDisappearanceNavpanelOpenShift');
-
-        await this.driverHelper.waitDisappearanceWithTimeout(By.css(OcpWebConsolePage.NAV_PANEL_OPENSHIFT_CSS));
+        await this.driverHelper.waitVisibility(By.css(OcpWebConsolePage.NAV_PANEL_OPENSHIFT_CSS), TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async openOperatorHubMainPageByUrl(url: string) {
@@ -47,48 +42,48 @@ export class OcpWebConsolePage {
         Logger.debug('OcpWebConsolePage.waitOperatorHubMainPage');
 
         const catalogOperatorHubPageLocator: By = By.xpath('//span[text()=\'OperatorHub\']');
-        await this.driverHelper.waitVisibility(catalogOperatorHubPageLocator);
+        await this.driverHelper.waitVisibility(catalogOperatorHubPageLocator, TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async clickOnCatalogOperatorIcon() {
         Logger.debug('OcpWebConsolePage.clickOnCatalogOperatorIcon');
 
         const catalogTileOperatorNameLocator: By = By.css(`a[data-test^=${TestConstants.TS_SELENIUM_CATALOG_TILE_OPERATOR_NAME}]`);
-        await this.driverHelper.waitAndClick(catalogTileOperatorNameLocator, TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+        await this.driverHelper.waitAndClick(catalogTileOperatorNameLocator, TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
     async clickOnInstallButton() {
         Logger.debug('OcpWebConsolePage.clickOnInstallButton');
 
         const installOperatorButtonLocator: By = By.xpath('//*[text()=\'Install\']');
-        await this.driverHelper.waitAndClick(installOperatorButtonLocator);
+        await this.driverHelper.waitAndClick(installOperatorButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitCreateOperatorSubscriptionPage() {
         Logger.debug('OcpWebConsolePage.waitCreateOperatorSubscriptionPage');
 
         const createOperatorSubscriptionPageLocator: By = By.xpath('//h1[text()=\'Create Operator Subscription\']');
-        await this.driverHelper.waitVisibility(createOperatorSubscriptionPageLocator, TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+        await this.driverHelper.waitVisibility(createOperatorSubscriptionPageLocator, TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async selectUpdateChannelOnSubscriptionPage() {
         Logger.debug('OcpWebConsolePage.selectUpdateChannelOnSubscriptionPage');
 
         const updateChannelOperatorLocator: By = By.css(`input[value=${TestConstants.TS_OCP_OPERATOR_UPDATE_CHANNEL}]`);
-        await this.driverHelper.waitAndClick(updateChannelOperatorLocator, TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+        await this.driverHelper.waitAndClick(updateChannelOperatorLocator, TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async clickOnDropdownNamespaceListOnSubscriptionPage() {
         Logger.debug('OcpWebConsolePage.clickOnDropdownNamespaceListOnSubscriptionPage');
 
         const selectNamespaceLocator: By = By.id('dropdown-selectbox');
-        await this.driverHelper.waitAndClick(selectNamespaceLocator);
+        await this.driverHelper.waitAndClick(selectNamespaceLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitListBoxNamespacesOnSubscriptionPage() {
         Logger.debug('OcpWebConsolePage.waitListBoxNamespacesOnSubscriptionPage');
 
         const listBoxNamespaceLocator: By = By.css('ul[class^=dropdown-menu]');
-        await this.driverHelper.waitVisibility(listBoxNamespaceLocator);
+        await this.driverHelper.waitVisibility(listBoxNamespaceLocator, TimeoutConstants.TS_SELENIUM_LIST_NAMESPACES_ON_SUBSCRIPTION_TIMEOUT);
     }
 
     async selectDefinedNamespaceOnSubscriptionPage() {
@@ -96,55 +91,55 @@ export class OcpWebConsolePage {
 
         const namespaceItemInDropDownId: string = `${TestConstants.TS_SELENIUM_INSTALL_PROJECT_NAME}-Project-link`;
         const namespaceItemInDropDownLocator: By = By.id(namespaceItemInDropDownId);
-        await this.driverHelper.waitAndClick(namespaceItemInDropDownLocator);
+        await this.driverHelper.waitAndClick(namespaceItemInDropDownLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async clickOnSubscribeButtonOnSubscriptionPage() {
         Logger.debug('OcpWebConsolePage.clickOnSubscribeButtonOnSubscriptionPage');
 
         const subscribeOperatorButtonLocator: By = By.xpath('//button[text()=\'Subscribe\']');
-        await this.driverHelper.waitAndClick(subscribeOperatorButtonLocator);
+        await this.driverHelper.waitAndClick(subscribeOperatorButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async selectInstalledOperatorsOnNavPanel() {
         Logger.debug('OcpWebConsolePage.selectInstalledOperatorsOnNavPanel');
 
         const installedOperatorsItemNavPanelLocator: By = By.xpath('//a[text()=\'Installed Operators\']');
-        await this.driverHelper.waitAndClick(installedOperatorsItemNavPanelLocator);
+        await this.driverHelper.waitAndClick(installedOperatorsItemNavPanelLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitInstalledOperatorLogoName() {
         Logger.debug('OcpWebConsolePage.waitInstalledOperatorLogoName');
 
-        await this.driverHelper.waitVisibility(By.xpath(OcpWebConsolePage.OPERATOR_LOGO_NAME_XPATH), TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+        await this.driverHelper.waitVisibility(By.xpath(OcpWebConsolePage.OPERATOR_LOGO_NAME_XPATH), TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
     }
 
     async clickOnInstalledOperatorLogoName() {
         Logger.debug('OcpWebConsolePage.clickOnInstalledOperatorLogoName');
 
-        await this.driverHelper.waitAndClick(By.xpath(OcpWebConsolePage.OPERATOR_LOGO_NAME_XPATH));
+        await this.driverHelper.waitAndClick(By.xpath(OcpWebConsolePage.OPERATOR_LOGO_NAME_XPATH), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitOverviewCsvOperator() {
         Logger.debug('OcpWebConsolePage.waitOverviewCsvEclipseCheOperator');
 
-        await this.driverHelper.waitVisibility(By.xpath(OcpWebConsolePage.OPERATOR_LOGO_NAME_XPATH));
+        await this.driverHelper.waitVisibility(By.xpath(OcpWebConsolePage.OPERATOR_LOGO_NAME_XPATH), TimeoutConstants.TS_SELENIUM_CSV_OPERATOR_TIMEOUT);
     }
 
     async clickCreateNewCheClusterLink() {
         Logger.debug('OcpWebConsolePage.clickCreateNewCheClusterLink');
 
         const createNewCheLusterLinkLocator: By = By.partialLinkText('Create');
-        await this.driverHelper.waitAndClick(createNewCheLusterLinkLocator);
+        await this.driverHelper.waitAndClick(createNewCheLusterLinkLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
-    async waitCreateCheClusterYaml() {
+    async waitCreateCheClusterYaml(timeout: number) {
         Logger.debug('OcpWebConsolePage.waitCreateCheClusterYaml');
 
         const headerTextCheClusterLocator: By = By.xpath('//h1[contains(text(), \'Cluster\')]');
         const createCheClusterYamlLocator: By = By.css('div[class=yaml-editor]');
-        await this.driverHelper.waitVisibility(headerTextCheClusterLocator);
-        await this.driverHelper.waitVisibility(createCheClusterYamlLocator);
+        await this.driverHelper.waitVisibility(headerTextCheClusterLocator, timeout);
+        await this.driverHelper.waitVisibility(createCheClusterYamlLocator, timeout);
     }
 
     async openEditorReplaceWidget() {
@@ -166,35 +161,35 @@ export class OcpWebConsolePage {
         Logger.debug('OcpWebConsolePage.clickOnCreateCheClusterButton');
 
         const createCheClusterButtonLocator: By = By.id('save-changes');
-        await this.driverHelper.waitAndClick(createCheClusterButtonLocator);
+        await this.driverHelper.waitAndClick(createCheClusterButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitResourcesCheClusterTitle() {
         Logger.debug('OcpWebConsolePage.waitResourcesCheClusterTitle');
 
         const resourcesCheClusterTitleLocator: By = By.xpath('//*[contains(text(), \'Clusters\')]');
-        await this.driverHelper.waitVisibility(resourcesCheClusterTitleLocator);
+        await this.driverHelper.waitVisibility(resourcesCheClusterTitleLocator, TimeoutConstants.TS_SELENIUM_RESOURCES_CHE_CLUSTER_TITLE_TIMEOUT);
     }
 
     async clickOnCheClusterResourcesName() {
         Logger.debug('OcpWebConsolePage.clickOnCheClusterResourcesName');
 
         const cheClusterResourcesNameLocator: By = By.css('a[class^=co-resource-item]');
-        await this.driverHelper.waitAndClick(cheClusterResourcesNameLocator);
+        await this.driverHelper.waitAndClick(cheClusterResourcesNameLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
     async waitKeycloakAdminConsoleUrl() {
         Logger.debug('OcpWebConsolePage.waitKeycloakAdminConsoleUrl');
 
         const keyCloakAdminWebConsoleUrl: By = By.partialLinkText(`keycloak-${TestConstants.TS_SELENIUM_INSTALL_PROJECT_NAME}`);
-        await this.driverHelper.waitVisibility(keyCloakAdminWebConsoleUrl, TestConstants.TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT);
+        await this.driverHelper.waitVisibility(keyCloakAdminWebConsoleUrl, TimeoutConstants.TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT);
     }
 
     async waitInstalledAppUrl() {
         Logger.debug('OcpWebConsolePage.waitInstalledAppUrl');
 
         const installedAppUrlLocator: By = By.partialLinkText(`${OcpWebConsolePage.INSTALLED_APP_URL_XPATH}`);
-        await this.driverHelper.waitVisibility(installedAppUrlLocator, TestConstants.TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT);
+        await this.driverHelper.waitVisibility(installedAppUrlLocator, TimeoutConstants.TS_SELENIUM_INSTALL_ECLIPSE_CHE_TIMEOUT);
     }
 
     async logoutFromWebConsole() {
@@ -203,9 +198,9 @@ export class OcpWebConsolePage {
         const userDropdownLocator: By = By.css('*[data-test=user-dropdown]');
         const dropdownMenuLocator: By = By.css('*[role=menu]');
         const dropdownMenuItemLocator: By = By.xpath('//a[text()=\'Log out\']');
-        await this.driverHelper.waitAndClick(userDropdownLocator);
-        await this.driverHelper.waitVisibility(dropdownMenuLocator);
-        await this.driverHelper.waitAndClick(dropdownMenuItemLocator);
+        await this.driverHelper.waitAndClick(userDropdownLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitVisibility(dropdownMenuLocator, TimeoutConstants.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
+        await this.driverHelper.waitAndClick(dropdownMenuItemLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
 }

--- a/tests/e2e/pageobjects/openshift/OcpWebConsolePage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpWebConsolePage.ts
@@ -55,7 +55,7 @@ export class OcpWebConsolePage {
         Logger.debug('OcpWebConsolePage.clickOnInstallButton');
 
         const installOperatorButtonLocator: By = By.xpath('//*[text()=\'Install\']');
-        await this.driverHelper.waitAndClick(installOperatorButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(installOperatorButtonLocator);
     }
 
     async waitCreateOperatorSubscriptionPage() {
@@ -76,7 +76,7 @@ export class OcpWebConsolePage {
         Logger.debug('OcpWebConsolePage.clickOnDropdownNamespaceListOnSubscriptionPage');
 
         const selectNamespaceLocator: By = By.id('dropdown-selectbox');
-        await this.driverHelper.waitAndClick(selectNamespaceLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(selectNamespaceLocator);
     }
 
     async waitListBoxNamespacesOnSubscriptionPage() {
@@ -91,21 +91,21 @@ export class OcpWebConsolePage {
 
         const namespaceItemInDropDownId: string = `${TestConstants.TS_SELENIUM_INSTALL_PROJECT_NAME}-Project-link`;
         const namespaceItemInDropDownLocator: By = By.id(namespaceItemInDropDownId);
-        await this.driverHelper.waitAndClick(namespaceItemInDropDownLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(namespaceItemInDropDownLocator);
     }
 
     async clickOnSubscribeButtonOnSubscriptionPage() {
         Logger.debug('OcpWebConsolePage.clickOnSubscribeButtonOnSubscriptionPage');
 
         const subscribeOperatorButtonLocator: By = By.xpath('//button[text()=\'Subscribe\']');
-        await this.driverHelper.waitAndClick(subscribeOperatorButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(subscribeOperatorButtonLocator);
     }
 
     async selectInstalledOperatorsOnNavPanel() {
         Logger.debug('OcpWebConsolePage.selectInstalledOperatorsOnNavPanel');
 
         const installedOperatorsItemNavPanelLocator: By = By.xpath('//a[text()=\'Installed Operators\']');
-        await this.driverHelper.waitAndClick(installedOperatorsItemNavPanelLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(installedOperatorsItemNavPanelLocator);
     }
 
     async waitInstalledOperatorLogoName() {
@@ -117,7 +117,7 @@ export class OcpWebConsolePage {
     async clickOnInstalledOperatorLogoName() {
         Logger.debug('OcpWebConsolePage.clickOnInstalledOperatorLogoName');
 
-        await this.driverHelper.waitAndClick(By.xpath(OcpWebConsolePage.OPERATOR_LOGO_NAME_XPATH), TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(By.xpath(OcpWebConsolePage.OPERATOR_LOGO_NAME_XPATH));
     }
 
     async waitOverviewCsvOperator() {
@@ -130,7 +130,7 @@ export class OcpWebConsolePage {
         Logger.debug('OcpWebConsolePage.clickCreateNewCheClusterLink');
 
         const createNewCheLusterLinkLocator: By = By.partialLinkText('Create');
-        await this.driverHelper.waitAndClick(createNewCheLusterLinkLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(createNewCheLusterLinkLocator);
     }
 
     async waitCreateCheClusterYaml(timeout: number = TimeoutConstants.TS_CREATE_CHECLUSTER_YAML_TIMEOUT) {
@@ -163,7 +163,7 @@ export class OcpWebConsolePage {
         Logger.debug('OcpWebConsolePage.clickOnCreateCheClusterButton');
 
         const createCheClusterButtonLocator: By = By.id('save-changes');
-        await this.driverHelper.waitAndClick(createCheClusterButtonLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(createCheClusterButtonLocator);
     }
 
     async waitResourcesCheClusterTitle() {
@@ -177,7 +177,7 @@ export class OcpWebConsolePage {
         Logger.debug('OcpWebConsolePage.clickOnCheClusterResourcesName');
 
         const cheClusterResourcesNameLocator: By = By.css('a[class^=co-resource-item]');
-        await this.driverHelper.waitAndClick(cheClusterResourcesNameLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(cheClusterResourcesNameLocator);
     }
 
     async waitKeycloakAdminConsoleUrl() {
@@ -200,9 +200,9 @@ export class OcpWebConsolePage {
         const userDropdownLocator: By = By.css('*[data-test=user-dropdown]');
         const dropdownMenuLocator: By = By.css('*[role=menu]');
         const dropdownMenuItemLocator: By = By.xpath('//a[text()=\'Log out\']');
-        await this.driverHelper.waitAndClick(userDropdownLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(userDropdownLocator);
         await this.driverHelper.waitVisibility(dropdownMenuLocator, TimeoutConstants.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT);
-        await this.driverHelper.waitAndClick(dropdownMenuItemLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+        await this.driverHelper.waitAndClick(dropdownMenuItemLocator);
     }
 
 }

--- a/tests/e2e/pageobjects/openshift/OcpWebConsolePage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpWebConsolePage.ts
@@ -133,13 +133,15 @@ export class OcpWebConsolePage {
         await this.driverHelper.waitAndClick(createNewCheLusterLinkLocator, TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
     }
 
-    async waitCreateCheClusterYaml(timeout: number) {
+    async waitCreateCheClusterYaml(timeout: number = TimeoutConstants.TS_CREATE_CHECLUSTER_YAML_TIMEOUT) {
         Logger.debug('OcpWebConsolePage.waitCreateCheClusterYaml');
 
         const headerTextCheClusterLocator: By = By.xpath('//h1[contains(text(), \'Cluster\')]');
         const createCheClusterYamlLocator: By = By.css('div[class=yaml-editor]');
+
         await this.driverHelper.waitVisibility(headerTextCheClusterLocator, timeout);
         await this.driverHelper.waitVisibility(createCheClusterYamlLocator, timeout);
+
     }
 
     async openEditorReplaceWidget() {

--- a/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
+++ b/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
@@ -76,13 +76,13 @@ suite('Openshift connector user story', async () => {
     await projectTree.waitProjectImported(projectName, 'index.js');
     await dashboard.waitDisappearanceNavigationMenu();
     await openshiftPlugin.clickOnOpenshiftToollBarIcon();
-    await openshiftPlugin.waitOpenshiftConnectorTree();
+    await openshiftPlugin.waitOpenshiftConnectorTree(10_000);
   });
 
   test('Login into current cluster', async () => {
     const provideAuthenticationSuffix: string = `for basic authentication to the API server ${selectSugestionSuffix}`;
     const loginIntoClusterMessage: string = 'You are already logged in the cluster. Do you want to login to a different cluster?';
-    const openshiftIP: string = await openshiftPlugin.getClusterIP();
+    const openshiftIP: string = await openshiftPlugin.getClusterIP(10_000);
     await openshiftPlugin.clickOnApplicationToolbarItem(OpenshiftAppExplorerToolbar.LogIntoCluster);
     await ide.clickOnNotificationButton(loginIntoClusterMessage, 'Yes');
     await quickOpenContainer.clickOnContainerItem('Credentials');
@@ -117,7 +117,7 @@ suite('Openshift connector user story', async () => {
     await quickOpenContainer.clickOnContainerItem(TestConstants.TS_TEST_OPENSHIFT_PLUGIN_PROJECT);
     await quickOpenContainer.clickOnContainerItem('node-js-app');
     await quickOpenContainer.clickOnContainerItem('component-node-js');
-    await terminal.selectTabByPrefixAndWaitText('OpenShift: Push', 'Changes successfully pushed to component', TestConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+    await terminal.selectTabByPrefixAndWaitText('OpenShift: Push', 'Changes successfully pushed to component', 30_000);
   });
 
 });

--- a/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
+++ b/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
@@ -76,13 +76,13 @@ suite('Openshift connector user story', async () => {
     await projectTree.waitProjectImported(projectName, 'index.js');
     await dashboard.waitDisappearanceNavigationMenu();
     await openshiftPlugin.clickOnOpenshiftToollBarIcon();
-    await openshiftPlugin.waitOpenshiftConnectorTree(10_000);
+    await openshiftPlugin.waitOpenshiftConnectorTree();
   });
 
   test('Login into current cluster', async () => {
     const provideAuthenticationSuffix: string = `for basic authentication to the API server ${selectSugestionSuffix}`;
     const loginIntoClusterMessage: string = 'You are already logged in the cluster. Do you want to login to a different cluster?';
-    const openshiftIP: string = await openshiftPlugin.getClusterIP(10_000);
+    const openshiftIP: string = await openshiftPlugin.getClusterIP();
     await openshiftPlugin.clickOnApplicationToolbarItem(OpenshiftAppExplorerToolbar.LogIntoCluster);
     await ide.clickOnNotificationButton(loginIntoClusterMessage, 'Yes');
     await quickOpenContainer.clickOnContainerItem('Credentials');

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -203,16 +203,6 @@ suite('Display source code changes in the running application', async () => {
         await projectTree.collapseProjectTree(projectName + '/src', 'main');
         await projectTree.expandPathAndOpenFile(projectName, 'result-build.txt', 300_000);
         await editor.waitText('result-build.txt', '[INFO] BUILD SUCCESS');
-
-        // workaround for issue: https://github.com/eclipse/che/issues/14771
-
-        /*await projectTree.expandPathAndOpenFileInAssociatedWorkspace(projectName, 'build.txt');
-        await editor.waitEditorAvailable('build.txt');
-        await editor.clickOnTab('build.txt');
-        await editor.waitTabFocused('build.txt');
-        await editor.followAndWaitForText('build.txt', '[INFO] BUILD SUCCESS', 300000, 5000);*/
-
-
     });
 
     test('Run application with changes', async () => {
@@ -288,14 +278,14 @@ async function checkErrorMessageInApplicationController() {
     await previewWidget.waitAndClick(SpringAppLocators.springErrorButtonLocator);
 
     try {
-        await previewWidget.waitVisibility(SpringAppLocators.springErrorMessageLocator);
+        await previewWidget.waitVisibility(SpringAppLocators.springErrorMessageLocator, 15_000);
     } catch (err) {
 
         await driverHelper.getDriver().switchTo().defaultContent();
         await ide.waitAndSwitchToIdeFrame();
 
         await previewWidget.waitAndSwitchToWidgetFrame();
-        await previewWidget.waitVisibility(SpringAppLocators.springErrorMessageLocator);
+        await previewWidget.waitVisibility(SpringAppLocators.springErrorMessageLocator, 15_000);
     }
 
 

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -25,6 +25,7 @@ import { Terminal } from '../../pageobjects/ide/Terminal';
 import { ICheLoginPage } from '../../pageobjects/login/ICheLoginPage';
 import * as fs from 'fs';
 import { ContextMenu } from '../../pageobjects/ide/ContextMenu';
+import * as projectAndFileTests from '../../testsLibrary/ProjectAndFileTests';
 
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
@@ -38,11 +39,12 @@ const terminal: Terminal = e2eContainer.get(CLASSES.Terminal);
 const debugView: DebugView = e2eContainer.get(CLASSES.DebugView);
 const warningDialog: DialogWindow = e2eContainer.get(CLASSES.DialogWindow);
 const projectName: string = 'petclinic';
+const workspaceRootFolderName: string = 'src';
 const namespace: string = TestConstants.TS_SELENIUM_USERNAME;
 const workspaceName: string = TestConstants.TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME;
 const workspaceUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/dashboard/#/ide/${namespace}/${workspaceName}`;
-const pathToJavaFolder: string = `${projectName}/src/main/java/org/springframework/samples/petclinic`;
-const pathToChangedJavaFileFolder: string = `${projectName}/src/main/java/org/springframework/samples/petclinic/system`;
+const pathToJavaFolder: string = `${projectName}/${workspaceRootFolderName}/main/java/org/springframework/samples/petclinic`;
+const pathToChangedJavaFileFolder: string = `${projectName}/${workspaceRootFolderName}/main/java/org/springframework/samples/petclinic/system`;
 const classPathFilename: string = '.classpath';
 const javaFileName: string = 'PetClinicApplication.java';
 const weclomeControllerJavaFileName: string = 'WelcomeController.java';
@@ -68,15 +70,7 @@ suite('Validation of workspace start', async () => {
         await loginPage.login();
     });
 
-    test('Wait workspace running state', async () => {
-        await ide.waitWorkspaceAndIde();
-    });
-
-    test('Wait until project is imported', async () => {
-        await projectTree.openProjectTreeContainer(10_000);
-        await projectTree.waitProjectImported(projectName, 'src');
-    });
-
+    await projectAndFileTests.waitWorkspaceReadiness(projectName, workspaceRootFolderName);
 });
 
 suite('Language server validation', async () => {

--- a/tests/e2e/tests/e2e_install_che_operatorhub/InstallCheByOperatorHub.spec.ts
+++ b/tests/e2e/tests/e2e_install_che_operatorhub/InstallCheByOperatorHub.spec.ts
@@ -25,7 +25,7 @@ suite('E2E', async () => {
 
         test('Click on the Create New, wait CSV yaml', async () => {
             await ocpWebConsole.clickCreateNewCheClusterLink();
-            await ocpWebConsole.waitCreateCheClusterYaml();
+            await ocpWebConsole.waitCreateCheClusterYaml(10_000);
         });
 
         test('Open editor replace widget in the Che Cluster yaml', async () => {

--- a/tests/e2e/tests/e2e_install_che_operatorhub/InstallCheByOperatorHub.spec.ts
+++ b/tests/e2e/tests/e2e_install_che_operatorhub/InstallCheByOperatorHub.spec.ts
@@ -25,7 +25,7 @@ suite('E2E', async () => {
 
         test('Click on the Create New, wait CSV yaml', async () => {
             await ocpWebConsole.clickCreateNewCheClusterLink();
-            await ocpWebConsole.waitCreateCheClusterYaml(10_000);
+            await ocpWebConsole.waitCreateCheClusterYaml();
         });
 
         test('Open editor replace widget in the Che Cluster yaml', async () => {

--- a/tests/e2e/testsLibrary/CodeExecutionTests.ts
+++ b/tests/e2e/testsLibrary/CodeExecutionTests.ts
@@ -28,14 +28,14 @@ export function runTask(taskName: string, timeout: number) {
 export function runTaskWithDialogShellAndOpenLink(taskName: string, expectedDialogText: string, timeout: number) {
     test(`Run command '${taskName}' expecting dialog shell`, async () => {
         await topMenu.runTask(taskName);
-        await dialogWindow.waitDialogAndOpenLink(timeout, expectedDialogText);
+        await dialogWindow.waitDialogAndOpenLink(expectedDialogText, timeout);
     });
 }
 
 export function runTaskWithDialogShellDjangoWorkaround(taskName: string, expectedDialogText: string, urlSubPath: string, timeout: number) {
     test(`Run command '${taskName}' expecting dialog shell`, async () => {
         await topMenu.runTask(taskName);
-        await dialogWindow.waitDialog(timeout, expectedDialogText);
+        await dialogWindow.waitDialog(expectedDialogText, timeout);
         const dialogRedirectUrl: string = await dialogWindow.getApplicationUrlFromDialog(expectedDialogText);
         const augmentedPreviewUrl: string = dialogRedirectUrl + urlSubPath;
         await dialogWindow.closeDialog();
@@ -52,7 +52,7 @@ export function runTaskWithDialogShellDjangoWorkaround(taskName: string, expecte
 export function runTaskWithDialogShellAndClose(taskName: string, expectedDialogText: string, timeout: number) {
     test(`Run command '${taskName}' expecting dialog shell`, async () => {
         await topMenu.runTask(taskName);
-        await dialogWindow.waitDialog(timeout, expectedDialogText);
+        await dialogWindow.waitDialog(expectedDialogText, timeout);
         await dialogWindow.closeDialog();
         await dialogWindow.waitDialogDissappearance();
     });

--- a/tests/e2e/testsLibrary/LsTests.ts
+++ b/tests/e2e/testsLibrary/LsTests.ts
@@ -45,7 +45,7 @@ const ide: Ide = e2eContainer.get(CLASSES.Ide);
         await editor.waitTabFocused(openedTab);
         await editor.moveCursorToLineAndChar(openedTab, line, char);
         await editor.pressControlSpaceCombination(openedTab);
-        await editor.waitSuggestion(openedTab, suggestionText)
+        await editor.waitSuggestion(openedTab, suggestionText);
     });
  }
 

--- a/tests/e2e/testsLibrary/LsTests.ts
+++ b/tests/e2e/testsLibrary/LsTests.ts
@@ -45,7 +45,7 @@ const ide: Ide = e2eContainer.get(CLASSES.Ide);
         await editor.waitTabFocused(openedTab);
         await editor.moveCursorToLineAndChar(openedTab, line, char);
         await editor.pressControlSpaceCombination(openedTab);
-        await editor.waitSuggestionWithScrolling(openedTab, suggestionText);
+        await editor.waitSuggestion(openedTab, suggestionText)
     });
  }
 

--- a/tests/e2e/testsLibrary/ProjectAndFileTests.ts
+++ b/tests/e2e/testsLibrary/ProjectAndFileTests.ts
@@ -39,7 +39,6 @@ export function waitWorkspaceReadinessNoSubfolder(sampleName : string) {
 
 export function openFile(filePath: string, fileName: string) {
     test('Expand project and open file in editor', async () => {
-        await projectTree.expandPathAndOpenFileInAssociatedWorkspace(filePath, fileName);
         await projectTree.expandPathAndOpenFile(filePath, fileName);
         await editor.selectTab(fileName);
     });

--- a/tests/e2e/utils/DriverHelper.ts
+++ b/tests/e2e/utils/DriverHelper.ts
@@ -15,6 +15,7 @@ import 'reflect-metadata';
 import { ThenableWebDriver, By, until, WebElement } from 'selenium-webdriver';
 import { TestConstants } from '../TestConstants';
 import { Logger } from './Logger';
+import { TimeoutConstants } from '../TimeoutConstants';
 
 
 @injectable()
@@ -87,7 +88,7 @@ export class DriverHelper {
         return false;
     }
 
-    public async waitVisibility(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<WebElement> {
+    public async waitVisibility(elementLocator: By, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM): Promise<WebElement> {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -145,7 +146,7 @@ export class DriverHelper {
         throw new error.TimeoutError(`Exceeded maximum visibility checkings attempts, problems with 'StaleElementReferenceError' of '${elementLocator}' element`);
     }
 
-    public async waitPresence(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<WebElement> {
+    public async waitPresence(elementLocator: By, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM): Promise<WebElement> {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -174,7 +175,7 @@ export class DriverHelper {
         throw new error.TimeoutError(`Exceeded maximum presence checkings attempts, problems with 'StaleElementReferenceError' of '${elementLocator}' element`);
     }
 
-    public async waitAllPresence(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<Array<WebElement>> {
+    public async waitAllPresence(elementLocator: By, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM): Promise<Array<WebElement>> {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -203,7 +204,7 @@ export class DriverHelper {
         throw new error.TimeoutError(`Exceeded maximum presence checkings attempts, problems with 'StaleElementReferenceError' of '${elementLocator}' element`);
     }
 
-    public async waitAllVisibility(locators: Array<By>, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitAllVisibility(locators: Array<By>, timeout: number) {
         Logger.trace(`DriverHelper.waitAllVisibility ${locators}`);
 
         for (const elementLocator of locators) {
@@ -224,7 +225,7 @@ export class DriverHelper {
         }
     }
 
-    public async waitDisappearanceWithTimeout(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitDisappearanceWithTimeout(elementLocator: By, timeout: number) {
         Logger.trace(`DriverHelper.waitDisappearanceWithTimeout ${elementLocator}`);
 
         await this.getDriver().wait(async () => {
@@ -247,7 +248,7 @@ export class DriverHelper {
         }
     }
 
-    public async waitAndClick(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitAndClick(elementLocator: By, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -292,7 +293,7 @@ export class DriverHelper {
     }
 
     public async waitAndGetElementAttribute(elementLocator: By, attribute: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<string> {
+        timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM): Promise<string> {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -335,7 +336,7 @@ export class DriverHelper {
     }
 
     public async waitAndGetCssValue(elementLocator: By, cssAttribute: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<string> {
+        timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM): Promise<string> {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -380,7 +381,7 @@ export class DriverHelper {
     public async waitAttributeValue(elementLocator: By,
         attribute: string,
         expectedValue: string,
-        timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+        timeout: number) {
 
         Logger.trace(`DriverHelper.waitAttributeValue ${elementLocator}`);
 
@@ -393,7 +394,7 @@ export class DriverHelper {
             `The '${attribute}' attribute value doesn't match with expected value '${expectedValue}'`);
     }
 
-    public async type(elementLocator: By, text: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async type(elementLocator: By, text: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -435,7 +436,7 @@ export class DriverHelper {
         throw new error.TimeoutError(`Exceeded maximum typing attempts, to the '${elementLocator}' element`);
     }
 
-    public async typeToInvisible(elementLocator: By, text: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async typeToInvisible(elementLocator: By, text: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -477,7 +478,7 @@ export class DriverHelper {
         throw new error.TimeoutError(`Exceeded maximum typing attempts, to the '${elementLocator}' element`);
     }
 
-    public async clear(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async clear(elementLocator: By, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -519,7 +520,7 @@ export class DriverHelper {
         throw new error.TimeoutError(`Exceeded maximum clearing attempts, to the '${elementLocator}' element`);
     }
 
-    public async clearInvisible(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async clearInvisible(elementLocator: By, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -561,23 +562,23 @@ export class DriverHelper {
         throw new error.TimeoutError(`Exceeded maximum clearing attempts, to the '${elementLocator}' element`);
     }
 
-    public async enterValue(elementLocator: By, text: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async enterValue(elementLocator: By, text: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         Logger.trace(`DriverHelper.enterValue ${elementLocator} text: ${text}`);
 
         await this.waitVisibility(elementLocator, timeout);
-        await this.clear(elementLocator, timeout);
+        await this.clear(elementLocator);
         await this.waitAttributeValue(elementLocator, 'value', '', timeout);
         await this.type(elementLocator, text, timeout);
         await this.waitAttributeValue(elementLocator, 'value', text, timeout);
     }
 
-    public async waitAndSwitchToFrame(iframeLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitAndSwitchToFrame(iframeLocator: By, timeout: number) {
         Logger.trace(`DriverHelper.waitAndSwitchToFrame ${iframeLocator}`);
 
         await this.driver.wait(until.ableToSwitchToFrame(iframeLocator), timeout);
     }
 
-    public async waitAndGetText(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<string> {
+    public async waitAndGetText(elementLocator: By, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM): Promise<string> {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -619,14 +620,14 @@ export class DriverHelper {
         throw new error.TimeoutError(`Exceeded maximum text obtaining attempts, from the '${elementLocator}' element`);
     }
 
-    public async waitAndGetValue(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT): Promise<string> {
+    public async waitAndGetValue(elementLocator: By, timeout: number): Promise<string> {
         Logger.trace(`DriverHelper.waitAndGetValue ${elementLocator}`);
 
         const elementValue: string = await this.waitAndGetElementAttribute(elementLocator, 'value', timeout);
         return elementValue;
     }
 
-    public async waitUntilTrue(callback: any, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitUntilTrue(callback: any, timeout: number) {
         Logger.trace('DriverHelper.waitUntilTrue');
 
         await this.driver.wait(callback, timeout);
@@ -638,11 +639,11 @@ export class DriverHelper {
         await this.driver.navigate().refresh();
     }
 
-    public async navigateAndWaitToUrl(url: string) {
+    public async navigateAndWaitToUrl(url: string, timeout: number = TimeoutConstants.TS_SELENIUM_WAIT_FOR_URL) {
         Logger.trace(`DriverHelper.navigateAndWaitToUrl ${url}`);
 
         await this.navigateToUrl(url);
-        await this.waitURL(url);
+        await this.waitURL(url, timeout);
     }
 
     public async navigateToUrl(url: string) {
@@ -651,7 +652,7 @@ export class DriverHelper {
         await this.driver.navigate().to(url);
     }
 
-    public async waitURL(expectedUrl: string, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async waitURL(expectedUrl: string, timeout: number) {
         Logger.trace(`DriverHelper.waitURL ${expectedUrl}`);
 
         await this.getDriver().wait(async () => {
@@ -664,7 +665,7 @@ export class DriverHelper {
         }, timeout);
     }
 
-    public async scrollTo(elementLocator: By, timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
+    public async scrollTo(elementLocator: By, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
@@ -715,25 +716,4 @@ export class DriverHelper {
 
         return this.driver;
     }
-
-    async waitOpenningSecondWindow(timeout: number = TestConstants.TS_SELENIUM_DEFAULT_TIMEOUT) {
-        Logger.trace('DriverHelper.waitOpenningSecondWindow');
-
-        await this.driver.wait(async () => {
-            const handles: string[] = await this.driver.getAllWindowHandles();
-            if (handles.length > 1) {
-                return true;
-            }
-        }, timeout);
-    }
-
-    async switchToSecondWindow(mainWindowHandle: string) {
-        Logger.debug('DriverHelper.switchToSecondWindow');
-
-        await this.waitOpenningSecondWindow();
-        const handles: string[] = await this.driver.getAllWindowHandles();
-        handles.splice(handles.indexOf(mainWindowHandle), 1);
-        await this.driver.switchTo().window(handles[0]);
-    }
-
 }


### PR DESCRIPTION
### What does this PR do?
Remove `TS_SELENIUM_DEFAULT_TIMEOUT` variable and replace that with new variables. It should be clear what is every variable setting timeout for. 
As a part of this PR, new variable was added to enable printing of all those variables as a part of the startup `Launch info` [1] [2].
[1]
![Screenshot from 2020-07-28 15-16-03](https://user-images.githubusercontent.com/29278800/88670866-e5d12a80-d0e5-11ea-800b-5ec4d4ef7b26.png)

[2]
![Screenshot from 2020-07-28 15-16-48](https://user-images.githubusercontent.com/29278800/88670824-d651e180-d0e5-11ea-87db-bc6e6a967e87.png)


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17362

