### PR TITLE
Clean up ending slash in TS_SELENIUM_BASE_URL when run E2E typescript selenium tests

### DIFF
--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -8,11 +8,20 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
+function getBaseUrl(): string {
+    const baseUrl: string | undefined = process.env.TS_SELENIUM_BASE_URL;
+    if (!baseUrl) {
+        return 'http://sample-url';
+    }
+
+    return baseUrl.replace(/\/$/, '');
+}
+
 export const TestConstants = {
     /**
      * Base URL of the application which should be checked
      */
-    TS_SELENIUM_BASE_URL: process.env.TS_SELENIUM_BASE_URL || 'http://sample-url',
+    TS_SELENIUM_BASE_URL: getBaseUrl(),
 
     /**
      * Base URl of web console OpenShift which uses to test OperatorHub.


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Clean up ending slash in TS_SELENIUM_BASE_URL when run E2E typescript selenium tests

### What issues does this PR fix or reference?
Issue: https://github.com/eclipse/che/issues/17533
<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
