### PR TITLE
FIX: Append gitconfig instead of override in GitCredentialStorageFileSecretApplier

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/GitCredentialStorageFileSecretApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/GitCredentialStorageFileSecretApplier.java
@@ -80,7 +80,8 @@ public class GitCredentialStorageFileSecretApplier extends FileSecretApplier {
         HashMap<String, String> newGitConfigMapData = new HashMap<>(gitConfigMapData);
         newGitConfigMapData.put(
             GitConfigProvisioner.GIT_CONFIG,
-            String.format(GIT_CREDENTIALS_FILE_STORE_PATTERN, gitSecretFilePath.toString()));
+            gitConfig
+                + String.format(GIT_CREDENTIALS_FILE_STORE_PATTERN, gitSecretFilePath.toString()));
         gitConfigMap.setData(newGitConfigMapData);
       }
     }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/GitCredentialStorageFileSecretApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/GitCredentialStorageFileSecretApplierTest.java
@@ -134,6 +134,7 @@ public class GitCredentialStorageFileSecretApplierTest {
     String data = configMap.getData().get(GitConfigProvisioner.GIT_CONFIG);
     assertTrue(
         data.endsWith("[credential]\n\thelper = store --file /home/user/.git/credentials\n"));
+    assertTrue(data.startsWith(GIT_CONFIG_CONTENT));
   }
 
   @Test(


### PR DESCRIPTION
### What does this PR do?
FIX: Append gitconfig instead of override in GitCredentialStorageFileSecretApplier

### What issues does this PR fix or reference?
GitCredentialStorageFileSecretApplier replaces the content of git-config instead of adding to it. 

#### Release Notes
N/A

#### Docs PR
N/A