### PR TITLE
CRW-1124 no need to set permissions twice,...

### DIFF
--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -44,5 +44,3 @@ RUN mkdir /logs /data && \
     chmod g+w /home/user/cacerts && \
     java -version && echo -n "Server startup script in: " && \
     find /home/user/eclipse-che -name catalina.sh | grep -z /home/user/eclipse-che/tomcat/bin/catalina.sh
-
-USER user

--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -1,9 +1,12 @@
-# Copyright (c) 2012-2019 Red Hat, Inc.
+# Copyright (c) 2012-2020 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
 #
 # SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
 #
 
 # Variables in `COPY --from=` is not supported see https://github.com/moby/moby/issues/34482
@@ -25,10 +28,21 @@ RUN echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && rm -rf /tmp/*
 EXPOSE 8000 8080
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
-RUN mkdir /logs /data && \
-    chmod 0777 /logs /data
 COPY --from=che_dashboard_base /usr/local/apache2/htdocs/dashboard /home/user/eclipse-che/tomcat/webapps/dashboard
 COPY --from=che_dashboard_next /usr/local/apache2/htdocs/dashboard /home/user/eclipse-che/tomcat/webapps/dashboard/next
 COPY --from=che_workspace_loader_base /usr/local/apache2/htdocs/workspace-loader/ /home/user/eclipse-che/tomcat/webapps/workspace-loader
 ADD eclipse-che /home/user/eclipse-che
-RUN find /home/user -type d -exec chmod 777 {} \;
+
+# this should fail if the startup script is not found in correct path /home/user/eclipse-che/tomcat/bin/catalina.sh
+RUN mkdir /logs /data && \
+    chmod 0777 /logs /data && \
+    chgrp -R 0 /home/user /logs /data && \
+    chown -R user /home/user && \
+    chmod -R g+rwX /home/user && \
+    find /home/user -type d -exec chmod 777 {} \; && \
+    # set group write permission so that entrypoint.sh can update permissions once file is updated w/ new cert
+    chmod g+w /home/user/cacerts && \
+    java -version && echo -n "Server startup script in: " && \
+    find /home/user/eclipse-che -name catalina.sh | grep -z /home/user/eclipse-che/tomcat/bin/catalina.sh
+
+USER user

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -305,13 +305,10 @@ add_cert_to_truststore() {
 
   echo "$1" > $SELF_SIGNED_CERT
 
-  # make sure that owner has permissions to write and other groups have permissions to read
-  # note that this might not work when running as anyuid OpenShift user, which is why we're forcing a true if it fails
-  chmod 644 $JAVA_TRUST_STORE || true
-
+  # make sure that everyone has permission to write
   echo yes | keytool -keystore $JAVA_TRUST_STORE -importcert -alias "$2" -file $SELF_SIGNED_CERT -storepass $DEFAULT_JAVA_TRUST_STOREPASS > /dev/null
-  # allow only read by all groups
-  chmod 444 $JAVA_TRUST_STORE
+  # allow only read by all groups: note that this might not work when running as anyuid OpenShift user, which is why we're forcing a true if it fails
+  chmod 444 $JAVA_TRUST_STORE || true
   if [[ "$JAVA_OPTS" != *"-Djavax.net.ssl.trustStore"* && "$JAVA_OPTS" != *"-Djavax.net.ssl.trustStorePassword"* ]]; then
     export JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=$JAVA_TRUST_STORE -Djavax.net.ssl.trustStorePassword=$DEFAULT_JAVA_TRUST_STOREPASS"
   fi

--- a/dockerfiles/che/rhel.Dockerfile
+++ b/dockerfiles/che/rhel.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir /logs /data && \
     chmod -R g+rwX /home/user && \
     find /home/user -type d -exec chmod 777 {} \; && \
     # set group write permission so that entrypoint.sh can update permissions once file is updated w/ new cert
-    chmod g+w /home/user/cacerts && \
+    chmod 777 /home/user/cacerts && \
     java -version && echo -n "Server startup script in: " && \
     find /home/user/codeready -name catalina.sh | grep -z /home/user/codeready/tomcat/bin/catalina.sh
 


### PR DESCRIPTION
CRW-1124 no need to set permissions twice, since the first change might make it impossible to make the second one if file is not owned by 'user' user

Change-Id: I67e3a6cde64ee1399a4421d424c76fa6ed0b3332
Signed-off-by: nickboldt <nboldt@redhat.com>