### PR TITLE
CRW-1124 no need to set permissions twice,...

### DIFF
--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -307,13 +307,10 @@ add_cert_to_truststore() {
 
   echo "$1" > $SELF_SIGNED_CERT
 
-  # make sure that owner has permissions to write and other groups have permissions to read
-  # note that this might not work when running as anyuid OpenShift user, which is why we're forcing a true if it fails
-  chmod 644 $JAVA_TRUST_STORE || true
-
+  # make sure that everyone has permission to write
   echo yes | keytool -keystore $JAVA_TRUST_STORE -importcert -alias "$2" -file $SELF_SIGNED_CERT -storepass $DEFAULT_JAVA_TRUST_STOREPASS > /dev/null
-  # allow only read by all groups
-  chmod 444 $JAVA_TRUST_STORE
+  # allow only read by all groups: note that this might not work when running as anyuid OpenShift user, which is why we're forcing a true if it fails
+  chmod 444 $JAVA_TRUST_STORE || true
   if [[ "$JAVA_OPTS" != *"-Djavax.net.ssl.trustStore"* && "$JAVA_OPTS" != *"-Djavax.net.ssl.trustStorePassword"* ]]; then
     export JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=$JAVA_TRUST_STORE -Djavax.net.ssl.trustStorePassword=$DEFAULT_JAVA_TRUST_STOREPASS"
   fi


### PR DESCRIPTION
CRW-1124 no need to set permissions twice, since the first change might make it impossible to make the second one if file is not owned by 'user' user

Change-Id: I67e3a6cde64ee1399a4421d424c76fa6ed0b3332
Signed-off-by: nickboldt <nboldt@redhat.com>