### PR TITLE
CRW-1124 just in case we need other to have...

### DIFF
--- a/dockerfiles/che/rhel.Dockerfile
+++ b/dockerfiles/che/rhel.Dockerfile
@@ -33,7 +33,7 @@ RUN mkdir /logs /data && \
     chmod -R g+rwX /home/user && \
     find /home/user -type d -exec chmod 777 {} \; && \
     # set group write permission so that entrypoint.sh can update permissions once file is updated w/ new cert
-    chmod g+w /home/user/cacerts && \
+    chmod 777 /home/user/cacerts && \
     java -version && echo -n "Server startup script in: " && \
     find /home/user/codeready -name catalina.sh | grep -z /home/user/codeready/tomcat/bin/catalina.sh
 


### PR DESCRIPTION
CRW-1124 just in case we need other to have write permissions, let's set it in Dockerfile (and then switch to 444 after updating cacerts file)

Change-Id: I26db795b876849e2b2e66c6ef116cee5764ff0f8
Signed-off-by: nickboldt <nboldt@redhat.com>