### PR TITLE
[Selenium] Fix PR check / nightly E2E tests Jenkins jobs to having OS OAuth support enabled by default

### DIFF
--- a/tests/.infra/centos-ci/cico_pr_test.sh
+++ b/tests/.infra/centos-ci/cico_pr_test.sh
@@ -24,6 +24,7 @@ spec:
       CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'
   auth:
     updateAdminPassword: false
+    openShiftoAuth: false
     identityProviderPassword: admin
 EOL
 

--- a/tests/.infra/centos-ci/nightly/cico-devfiles-test.sh
+++ b/tests/.infra/centos-ci/nightly/cico-devfiles-test.sh
@@ -15,6 +15,7 @@ function prepareCustomResourcePatchFile() {
 spec:
   auth:
     updateAdminPassword: false
+    openShiftoAuth: false
 EOL
 
   cat /tmp/custom-resource-patch.yaml

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-all-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-all-tests.sh
@@ -20,6 +20,7 @@ spec:
       CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'
   auth:
     updateAdminPassword: false
+    openShiftoAuth: false
     identityProviderPassword: admin
 EOL
 

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-hot-update-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-hot-update-tests.sh
@@ -18,6 +18,7 @@ spec:
       CHE_LIMITS_USER_WORKSPACES_RUN_COUNT: '-1'
   auth:
     updateAdminPassword: false
+    openShiftoAuth: false
     identityProviderPassword: admin
 EOL
 

--- a/tests/.infra/centos-ci/nightly/cico-multiuser-stable-selenium-tests.sh
+++ b/tests/.infra/centos-ci/nightly/cico-multiuser-stable-selenium-tests.sh
@@ -19,6 +19,7 @@ spec:
       CHE_WORKSPACE_AGENT_DEV_INACTIVE__STOP__TIMEOUT__MS: '300000'
   auth:
     updateAdminPassword: false
+    openShiftoAuth: false
     identityProviderPassword: admin
 EOL
 

--- a/tests/.infra/centos-ci/nightly/cico-openshift-connector-test.sh
+++ b/tests/.infra/centos-ci/nightly/cico-openshift-connector-test.sh
@@ -42,6 +42,7 @@ function prepareCustomResourcePatchFile() {
 spec:
   auth:
     updateAdminPassword: false
+    openShiftoAuth: false
 EOL
     
     cat /tmp/custom-resource-patch.yaml

--- a/tests/.infra/centos-ci/nightly/nightly-happypath-test.sh
+++ b/tests/.infra/centos-ci/nightly/nightly-happypath-test.sh
@@ -15,6 +15,7 @@ function prepareCustomResourcePatchFile() {
 spec:
   auth:
     updateAdminPassword: false
+    openShiftoAuth: false
 EOL
 
   cat /tmp/custom-resource-patch.yaml


### PR DESCRIPTION
### What does this PR do?
Fix PR check / nightly E2E tests Jenkins jobs to having OS OAuth support enabled by default

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17547
