### PR TITLE
Pass CA Bundle args to plugin brokers if CA bundle is configured

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/Openshift4TrustedCAProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/Openshift4TrustedCAProvisioner.java
@@ -58,6 +58,10 @@ public class Openshift4TrustedCAProvisioner {
     this.configMapLabelKeyValue = Splitter.on(",").withKeyValueSeparator("=").split(configMapLabel);
   }
 
+  public boolean isTrustedStoreInitialized() {
+    return trustedStoreInitialized;
+  }
+
   public void provision(KubernetesEnvironment k8sEnv, OpenShiftProject project)
       throws InfrastructureException {
     if (!trustedStoreInitialized) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
@@ -93,8 +93,10 @@ public class OpenshiftBrokerEnvironmentFactory
   protected List<String> getCommandLineArgs(RuntimeIdentity runtimeId) {
     List<String> cmdArgs = super.getCommandLineArgs(runtimeId);
 
-    cmdArgs.add("--cadir");
-    cmdArgs.add(caCertificatesMountPath);
+    if (trustedCAProvisioner.isTrustedStoreInitialized()) {
+      cmdArgs.add("--cadir");
+      cmdArgs.add(caCertificatesMountPath);
+    }
 
     return cmdArgs;
   }


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Pass CA bundle args to plugin brokers only if CA Bundle is configured.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17670