### PR TITLE
Fix test flakiness in Java devfiles

### DIFF
--- a/tests/e2e/tests/devfiles/Go.spec.ts
+++ b/tests/e2e/tests/devfiles/Go.spec.ts
@@ -17,7 +17,7 @@ import * as projectManager from '../../testsLibrary/ProjectAndFileTests';
 import { Logger } from '../../utils/Logger';
 import { PreferencesHandler } from '../../utils/PreferencesHandler';
 
-const preferencesHalder: PreferencesHandler = e2eContainer.get(CLASSES.PreferencesHandler);
+const preferencesHandler: PreferencesHandler = e2eContainer.get(CLASSES.PreferencesHandler);
 
 const workspaceStack: string = 'Go';
 const workspaceSampleName: string = 'src';
@@ -35,7 +35,7 @@ suite(`${workspaceStack} test`, async () => {
     suite(`Create ${workspaceStack} workspace`, async () => {
         test('Workaround for issue #16113', async () => {
             Logger.warn(`Manually setting a preference for golang devfile LS based on issue: https://github.com/eclipse/che/issues/16113`);
-            await preferencesHalder.setUseGoLanaguageServer();
+            await preferencesHandler.setUseGoLanaguageServer();
         });
         workspaceHandler.createAndOpenWorkspace(workspaceStack);
         projectManager.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);

--- a/tests/e2e/tests/devfiles/JavaMaven.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaMaven.spec.ts
@@ -40,7 +40,7 @@ suite(`${stack} test`, async () => {
 
     suite('Language server validation', async () => {
         commonLsTests.suggestionInvoking(tabTitle, 10, 20, 'append(char c) : PrintStream');
-        commonLsTests.errorHighlighting(tabTitle, 'error', 11);
+        commonLsTests.errorHighlighting(tabTitle, 'error_text', 11);
         commonLsTests.autocomplete(tabTitle, 10, 11, 'System - java.lang');
         commonLsTests.codeNavigation(tabTitle, 9, 10, codeNavigationClassName);
     });

--- a/tests/e2e/tests/devfiles/JavaVertx.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaVertx.spec.ts
@@ -30,7 +30,7 @@ suite(`${stack} test`, async () => {
 
     suite('Language server validation', async () => {
         projectAndFileTests.openFile(fileFolderPath, tabTitle);
-        commonLsTests.errorHighlighting(tabTitle, 'error', 20);
+        commonLsTests.errorHighlighting(tabTitle, 'error_text', 20);
         commonLsTests.suggestionInvoking(tabTitle, 19, 31, 'router(Vertx vertx) : Router');
         commonLsTests.autocomplete(tabTitle, 19, 7, 'Router - io.vertx.ext.web');
         commonLsTests.codeNavigation(tabTitle, 19, 7, codeNavigationClassName);


### PR DESCRIPTION
### What does this PR do?
Fix the test for error highlighting to avoid flakiness. Change word `error` to `error_text` when testing error highlighting. 
As a part of this PR, I'm fixing a small typo in the Go test file.

### What issues does this PR fix or reference?

In the current state, the flow can come to the point when the suggestion is invoked instead of highlighting typed text.

![image](https://user-images.githubusercontent.com/29278800/91045334-0625d380-e617-11ea-84ff-8bcda8df433c.png)
