### PR TITLE
Use spring-petclinic-2.3.0 example in E2E Happy path tests

### DIFF
--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -53,19 +53,19 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: java -jar spring-petclinic-2.3.1.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
+        command: java -jar spring-petclinic-2.3.0.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
         workdir: /projects/petclinic/target
   - name: run-with-changes
     actions:
       - type: exec
         component: maven-container
-        command: java -jar spring-petclinic-2.3.1.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
+        command: java -jar spring-petclinic-2.3.0.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
         workdir: /projects/petclinic/target
   - name: run-debug
     actions:
       - type: exec
         component: maven-container
-        command: java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 spring-petclinic-2.3.1.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
+        command: java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 spring-petclinic-2.3.0.BUILD-SNAPSHOT.jar --spring.profiles.active=mysql
         workdir: /projects/petclinic/target
   - name: Debug remote java application
     actions:


### PR DESCRIPTION
### What does this PR do?
It changes E2E Happy path tests to use **spring-petclinic-2.3.0** example instead of disappeared absent [**spring-petclinic-2.3.1** example](https://github.com/spring-projects/spring-petclinic/commit/27109010a52600eb9bf227d631fac3f81ed6ba15).

### What issues does this PR fix or reference?
It resolves #17745