### PR TITLE
[Helm] Add POD_NAMESPACE environment variable into Che server pod

### DIFF
--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -72,7 +72,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-
+        - name: KUBERNETES_NAMESPACE
+          value: {{ .Release.Namespace }}
 
         # If git-self-signed-cert is used then configure Che Server with certificate content
         # to propagate it to the specified location and provide particular configuration for Git service


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Adds `POD_NAMESPACE` environment variable with value of Che server namespace name into Che server container in Helm chart.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17766