### PR TITLE
set default server strategy to mult-host in che-server

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -249,7 +249,7 @@ che.infra.kubernetes.trust_certs=
 
 # Defines the way how servers are exposed to the world in k8s infra.
 # List of strategies implemented in Che: default-host, multi-host, single-host
-che.infra.kubernetes.server_strategy=default-host
+che.infra.kubernetes.server_strategy=multi-host
 
 # Defines the way in which the workspace plugins and editors are exposed in the single-host mode.
 # Supported exposures:


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Setting default server strategy to `multi-host`. This is last fallback value, which was ignored before. However, since https://github.com/eclipse/che/issues/17061, we've started to using this property on OpenShift as well and operator does not explicitly set it for OpenShift. This fails, because `default-host` is not valid configuration on OpenShift.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17770

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
