### PR TITLE
make single-host gateway configmap labels configurable

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -256,6 +256,9 @@ che.infra.kubernetes.server_strategy=multi-host
 # - 'native': Exposes servers using k8s Ingresses. Works only on Kubernetes.
 che.infra.kubernetes.single_host.workspace.exposure=native
 
+# Defines labels which will be set to ConfigMaps configuring single-host gateway.
+che.infra.kubernetes.single_host.gateway.configmap.labels=app=che,component=che-gateway-config
+
 # Used to generate domain for a server in a workspace in case property `che.infra.kubernetes.server_strategy` is set to `multi-host`
 che.infra.kubernetes.ingress.domain=
 

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -254,10 +254,11 @@ che.infra.kubernetes.server_strategy=multi-host
 # Defines the way in which the workspace plugins and editors are exposed in the single-host mode.
 # Supported exposures:
 # - 'native': Exposes servers using k8s Ingresses. Works only on Kubernetes.
-che.infra.kubernetes.single_host.workspace.exposure=native
+# - 'gateway': Exposes servers using reverse-proxy gateway.
+che.infra.kubernetes.singlehost.workspace.exposure=native
 
 # Defines labels which will be set to ConfigMaps configuring single-host gateway.
-che.infra.kubernetes.single_host.gateway.configmap.labels=app=che,component=che-gateway-config
+che.infra.kubernetes.singlehost.gateway.configmap_labels=app=che,component=che-gateway-config
 
 # Used to generate domain for a server in a workspace in case property `che.infra.kubernetes.server_strategy` is set to `multi-host`
 che.infra.kubernetes.ingress.domain=

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GatewayTlsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GatewayTlsProvisioner.java
@@ -24,6 +24,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.GatewayConfigmapLabels;
 
 /**
  * Enables Transport Layer Security (TLS) for external server implemented with gateway ConfigMaps.
@@ -32,11 +33,15 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 public class GatewayTlsProvisioner<T extends KubernetesEnvironment>
     implements ConfigurationProvisioner<T>, TlsProvisioner<T> {
 
-  final boolean isTlsEnabled;
+  private final boolean isTlsEnabled;
+  private final GatewayConfigmapLabels configmapLabels;
 
   @Inject
-  public GatewayTlsProvisioner(@Named("che.infra.kubernetes.tls_enabled") boolean isTlsEnabled) {
+  public GatewayTlsProvisioner(
+      @Named("che.infra.kubernetes.tls_enabled") boolean isTlsEnabled,
+      GatewayConfigmapLabels configmapLabels) {
     this.isTlsEnabled = isTlsEnabled;
+    this.configmapLabels = configmapLabels;
   }
 
   @Override
@@ -46,7 +51,7 @@ public class GatewayTlsProvisioner<T extends KubernetesEnvironment>
     }
 
     for (ConfigMap configMap : k8sEnv.getConfigMaps().values()) {
-      if (GatewayRouterProvisioner.isGatewayConfig(configMap)) {
+      if (configmapLabels.isGatewayConfig(configMap)) {
         useSecureProtocolForGatewayConfigMap(configMap);
       }
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TlsProvisionerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TlsProvisionerProvider.java
@@ -20,7 +20,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExpos
 
 /**
  * Provides {@link TlsProvisioner} based on `che.infra.kubernetes.server_strategy` and
- * `che.infra.kubernetes.single_host.workspace.exposure` properties.
+ * `che.infra.kubernetes.singlehost.workspace.exposure` properties.
  *
  * @param <T> type of environment
  */
@@ -30,7 +30,7 @@ public class TlsProvisionerProvider<T extends KubernetesEnvironment>
   @Inject
   public TlsProvisionerProvider(
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
-      @Named("che.infra.kubernetes.single_host.workspace.exposure") String wsExposureType,
+      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String wsExposureType,
       Map<WorkspaceExposureType, TlsProvisioner<T>> mapping) {
     super(
         exposureStrategy,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/AbstractExposureStrategyAwareProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/AbstractExposureStrategyAwareProvider.java
@@ -45,7 +45,7 @@ public abstract class AbstractExposureStrategyAwareProvider<T> implements Provid
    */
   protected AbstractExposureStrategyAwareProvider(
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
-      @Named("che.infra.kubernetes.single_host.workspace.exposure") String wsExposureType,
+      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String wsExposureType,
       Map<WorkspaceExposureType, T> mapping,
       String errorMessageTemplate) {
     if (exposureStrategy.equals(SingleHostExternalServiceExposureStrategy.SINGLE_HOST_STRATEGY)) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
@@ -21,7 +21,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExpos
 
 /**
  * Provides {@link ExternalServerExposer} based on `che.infra.kubernetes.server_strategy` and
- * `che.infra.kubernetes.single_host.workspace.exposure` properties.
+ * `che.infra.kubernetes.singlehost.workspace.exposure` properties.
  *
  * @param <T> type of environment
  */
@@ -31,7 +31,7 @@ public class ExternalServerExposerProvider<T extends KubernetesEnvironment>
   @Inject
   public ExternalServerExposerProvider(
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
-      @Named("che.infra.kubernetes.single_host.workspace.exposure") String exposureType,
+      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String exposureType,
       Map<WorkspaceExposureType, ExternalServerExposer<T>> exposers) {
 
     super(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/GatewayRouteConfigGenerator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/GatewayRouteConfigGenerator.java
@@ -26,11 +26,12 @@ public interface GatewayRouteConfigGenerator {
    * Add prepared {@link ConfigMap},that will hold gateway route configuration, to the generator. So
    * it can be generated later with {@link GatewayRouteConfigGenerator#generate(String)}.
    *
-   * <p>Provided {@link ConfigMap} must be properly labeled and must be annotated with {@link
-   * org.eclipse.che.api.core.model.workspace.config.ServerConfig} annotations.
+   * <p>Provided {@link ConfigMap} must be annotated with {@link
+   * org.eclipse.che.api.core.model.workspace.config.ServerConfig} annotations. It's responsibility
+   * of the caller to ensure that. The {@link GatewayRouteConfigGenerator} fails on {@link
+   * GatewayRouteConfigGenerator#generate(String)} when invalid {@link ConfigMap}s are added to it.
    *
    * @param routeConfig config to add
-   * @throws InfrastructureException when passed ConfigMap is not gateway configuration ConfigMap
    */
   void addRouteConfig(String name, ConfigMap routeConfig) throws InfrastructureException;
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/GatewayServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/GatewayServerExposer.java
@@ -27,8 +27,8 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayRouterProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.KubernetesServerExposer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.GatewayConfigmapLabels;
 
 /**
  * Uses gateway configured with ConfigMaps to expose servers.
@@ -39,10 +39,13 @@ public class GatewayServerExposer<T extends KubernetesEnvironment>
     implements ExternalServerExposer<T> {
 
   private final ExternalServiceExposureStrategy strategy;
+  private final GatewayConfigmapLabels configmapLabels;
 
   @Inject
-  public GatewayServerExposer(ExternalServiceExposureStrategy strategy) {
+  public GatewayServerExposer(
+      ExternalServiceExposureStrategy strategy, GatewayConfigmapLabels configmapLabels) {
     this.strategy = strategy;
+    this.configmapLabels = configmapLabels;
   }
 
   /**
@@ -115,7 +118,7 @@ public class GatewayServerExposer<T extends KubernetesEnvironment>
         new ConfigMapBuilder()
             .withNewMetadata()
             .withName(name)
-            .withLabels(GatewayRouterProvisioner.GATEWAY_CONFIGMAP_LABELS)
+            .withLabels(configmapLabels.getLabels())
             .withAnnotations(annotations)
             .endMetadata();
     return gatewayConfigMap.build();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGenerator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGenerator.java
@@ -14,7 +14,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.WRITE_DOC_START_MARKER;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVICE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVICE_PORT_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayRouterProvisioner.isGatewayConfig;
 
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
@@ -65,15 +64,8 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
   private final Map<String, ConfigMap> routeConfigs = new HashMap<>();
 
   @Override
-  public void addRouteConfig(String name, ConfigMap routeConfig) throws InfrastructureException {
-    if (isGatewayConfig(routeConfig)) {
-      this.routeConfigs.put(name, routeConfig);
-    } else {
-      throw new InfrastructureException(
-          "Not a gateway configuration ConfigMap '"
-              + routeConfig.getMetadata().getName()
-              + "'. This is a bug, please report.");
-    }
+  public void addRouteConfig(String name, ConfigMap routeConfig) {
+    this.routeConfigs.put(name, routeConfig);
   }
 
   /**

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/AbstractServerResolverFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/AbstractServerResolverFactory.java
@@ -32,7 +32,7 @@ public class AbstractServerResolverFactory<T> {
 
   protected AbstractServerResolverFactory(
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
-      @Named("che.infra.kubernetes.single_host.workspace.exposure") String wsExposureType,
+      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String wsExposureType,
       Map<WorkspaceExposureType, ResolverConstructor<T>> mapping,
       String errorMessageTemplate) {
     constructorProvider =

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/KubernetesServerResolverFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/KubernetesServerResolverFactory.java
@@ -32,7 +32,7 @@ public class KubernetesServerResolverFactory extends AbstractServerResolverFacto
       IngressPathTransformInverter pathTransformInverter,
       @Named("che.host") String cheHost,
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
-      @Named("che.infra.kubernetes.single_host.workspace.exposure") String wsExposureType) {
+      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String wsExposureType) {
 
     super(
         exposureStrategy,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabels.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabels.java
@@ -30,17 +30,17 @@ public class GatewayConfigmapLabels {
 
   @Inject
   public GatewayConfigmapLabels(
-      @Named("che.infra.kubernetes.single_host.gateway.configmap.labels") String labelsProperty)
+      @Named("che.infra.kubernetes.singlehost.gateway.configmap_labels") String labelsProperty)
       throws InfrastructureException {
     if (labelsProperty == null || labelsProperty.isEmpty()) {
       throw new InfrastructureException(
-          "for gateway single-host, 'che.infra.kubernetes.single_host.gateway.configmap.labels' property must be defined");
+          "for gateway single-host, 'che.infra.kubernetes.singlehost.gateway.configmap_labels' property must be defined");
     }
     try {
       this.labels = Splitter.on(",").trimResults().withKeyValueSeparator("=").split(labelsProperty);
     } catch (IllegalArgumentException iae) {
       throw new InfrastructureException(
-          "'che.infra.kubernetes.single_host.gateway.configmap.labels' is set to invalid value. It must be in format `name1=value1,name2=value2`. Check the documentation for further details.",
+          "'che.infra.kubernetes.singlehost.gateway.configmap_labels' is set to invalid value. It must be in format `name1=value1,name2=value2`. Check the documentation for further details.",
           iae);
     }
   }
@@ -51,7 +51,7 @@ public class GatewayConfigmapLabels {
 
   /**
    * Check whether configmap is gateway route configuration. That is defined with labels provided by
-   * `che.infra.kubernetes.single_host.gateway.configmap.labels` configuration property.
+   * `che.infra.kubernetes.singlehost.gateway.configmap_labels` configuration property.
    *
    * @param configMap to check
    * @return `true` if ConfigMap is gateway route configuration, `false` otherwise

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabels.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabels.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.util;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.isLabeled;
 
 import com.google.common.base.Splitter;
@@ -20,7 +21,7 @@ import java.util.Map.Entry;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.inject.ConfigurationException;
 
 /** Little utility bean helping with Gateway ConfigMaps labels. */
 @Singleton
@@ -30,16 +31,15 @@ public class GatewayConfigmapLabels {
 
   @Inject
   public GatewayConfigmapLabels(
-      @Named("che.infra.kubernetes.singlehost.gateway.configmap_labels") String labelsProperty)
-      throws InfrastructureException {
-    if (labelsProperty == null || labelsProperty.isEmpty()) {
-      throw new InfrastructureException(
+      @Named("che.infra.kubernetes.singlehost.gateway.configmap_labels") String labelsProperty) {
+    if (isNullOrEmpty(labelsProperty)) {
+      throw new ConfigurationException(
           "for gateway single-host, 'che.infra.kubernetes.singlehost.gateway.configmap_labels' property must be defined");
     }
     try {
       this.labels = Splitter.on(",").trimResults().withKeyValueSeparator("=").split(labelsProperty);
     } catch (IllegalArgumentException iae) {
-      throw new InfrastructureException(
+      throw new ConfigurationException(
           "'che.infra.kubernetes.singlehost.gateway.configmap_labels' is set to invalid value. It must be in format `name1=value1,name2=value2`. Check the documentation for further details.",
           iae);
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabels.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabels.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.util;
+
+import static java.util.stream.Collectors.toMap;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.isLabeled;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+/** Little utility bean helping with Gateway ConfigMaps labels. */
+@Singleton
+public class GatewayConfigmapLabels {
+
+  private final Map<String, String> labels;
+
+  @Inject
+  public GatewayConfigmapLabels(
+      @Named("che.infra.kubernetes.single_host.gateway.configmap.labels") String[] labelsProperty) {
+    // TODO: use Collectors.toUnmodifiableMap when JDK11 features are allowed
+    this.labels =
+        ImmutableMap.copyOf(
+            Arrays.stream(labelsProperty)
+                .map(label -> label.split("=", 2))
+                .collect(toMap(l -> l[0], l -> l[1])));
+  }
+
+  public Map<String, String> getLabels() {
+    return labels;
+  }
+
+  /**
+   * Check whether configmap is gateway route configuration. That is defined with labels provided by
+   * `che.infra.kubernetes.single_host.gateway.configmap.labels` configuration property.
+   *
+   * @param configMap to check
+   * @return `true` if ConfigMap is gateway route configuration, `false` otherwise
+   */
+  public boolean isGatewayConfig(ConfigMap configMap) {
+    for (Entry<String, String> labelEntry : labels.entrySet()) {
+      if (!isLabeled(configMap, labelEntry.getKey(), labelEntry.getValue())) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -26,7 +26,6 @@ import static org.eclipse.che.api.workspace.shared.Constants.DEBUG_WORKSPACE_STA
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Annotations.CREATE_IN_CHE_INSTALLATION_NAMESPACE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_ORIGINAL_NAME_LABEL;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayRouterProvisioner.GATEWAY_CONFIGMAP_LABELS;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -1136,7 +1135,6 @@ public class KubernetesInternalRuntimeTest {
         new ConfigMapBuilder()
             .withNewMetadata()
             .withName("route1")
-            .withLabels(GATEWAY_CONFIGMAP_LABELS)
             .withAnnotations(ImmutableMap.of(CREATE_IN_CHE_INSTALLATION_NAMESPACE, "true"))
             .endMetadata()
             .build();
@@ -1144,7 +1142,6 @@ public class KubernetesInternalRuntimeTest {
         new ConfigMapBuilder()
             .withNewMetadata()
             .withName("route2")
-            .withLabels(GATEWAY_CONFIGMAP_LABELS)
             .withAnnotations(ImmutableMap.of(CREATE_IN_CHE_INSTALLATION_NAMESPACE, "true"))
             .endMetadata()
             .build();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GatewayRouterProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GatewayRouterProvisionerTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVI
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVICE_PORT_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -127,6 +128,30 @@ public class GatewayRouterProvisionerTest {
     gatewayRouterProvisioner.provision(env, identity);
 
     // then exception
+  }
+
+  @Test
+  public void testNoProvisionWhenNoMatchingLabels() throws InfrastructureException {
+    // given
+    Map<String, String> annotationsWith2Servers =
+        new Annotations.Serializer().server("s1", serverConfig).annotations();
+
+    ConfigMap gatewayRouteConfigMap =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .withName("route")
+            .withAnnotations(annotationsWith2Servers)
+            .endMetadata()
+            .build();
+    when(env.getConfigMaps()).thenReturn(Collections.singletonMap("route", gatewayRouteConfigMap));
+
+    when(gatewayConfigmapLabels.isGatewayConfig(gatewayRouteConfigMap)).thenReturn(false);
+
+    // when
+    gatewayRouterProvisioner.provision(env, identity);
+
+    // then
+    verify(configGeneratorFactory, never()).create();
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGeneratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGeneratorTest.java
@@ -13,7 +13,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVICE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVICE_PORT_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayRouterProvisioner.GATEWAY_CONFIGMAP_LABELS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -75,7 +74,6 @@ public class TraefikGatewayRouteConfigGeneratorTest {
         new ConfigMapBuilder()
             .withNewMetadata()
             .withName("route")
-            .withLabels(GATEWAY_CONFIGMAP_LABELS)
             .withAnnotations(annotations)
             .endMetadata()
             .build();
@@ -102,7 +100,6 @@ public class TraefikGatewayRouteConfigGeneratorTest {
         new ConfigMapBuilder()
             .withNewMetadata()
             .withName("route")
-            .withLabels(GATEWAY_CONFIGMAP_LABELS)
             .withAnnotations(annotations)
             .endMetadata()
             .build();
@@ -131,19 +128,11 @@ public class TraefikGatewayRouteConfigGeneratorTest {
         new ConfigMapBuilder()
             .withNewMetadata()
             .withName("route")
-            .withLabels(GATEWAY_CONFIGMAP_LABELS)
             .withAnnotations(annotations)
             .endMetadata()
             .build();
     gatewayConfigGenerator.addRouteConfig("c1", routeConfig);
 
     gatewayConfigGenerator.generate("che-namespace");
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void failWhenAddConfigmapWithoutLabels() throws InfrastructureException {
-    ConfigMap routeConfig =
-        new ConfigMapBuilder().withNewMetadata().withName("route").endMetadata().build();
-    gatewayConfigGenerator.addRouteConfig("c1", routeConfig);
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabelsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabelsTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.util;
+
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
+import java.util.Map;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class GatewayConfigmapLabelsTest {
+
+  @Test(dataProvider = "isGatewayConfigData")
+  public void testIsGatewayConfig(
+      String[] labelsProperty, Map<String, String> labels, boolean isGatewayConfigExpected) {
+    GatewayConfigmapLabels gatewayConfigmapLabels = new GatewayConfigmapLabels(labelsProperty);
+    ConfigMap cm =
+        new ConfigMapBuilder().withNewMetadata().withLabels(labels).endMetadata().build();
+    assertEquals(gatewayConfigmapLabels.isGatewayConfig(cm), isGatewayConfigExpected);
+  }
+
+  @DataProvider
+  public Object[][] isGatewayConfigData() {
+    return new Object[][] {
+      {
+        new String[] {"app=che", "component=che-gateway-config"},
+        ImmutableMap.of("app", "che", "component", "che-gateway-config"),
+        true
+      },
+      {
+        new String[] {"app=che"},
+        ImmutableMap.of("app", "che", "component", "che-gateway-config"),
+        true
+      },
+      {new String[] {}, ImmutableMap.of("any", "label"), true},
+      {new String[] {}, ImmutableMap.of(), true},
+      {
+        new String[] {"app=che", "component=che-gateway-config"},
+        ImmutableMap.of("app", "cheche", "component", "che-gateway-config"),
+        false
+      },
+      {
+        new String[] {"app=che", "component=che-gateway-config"},
+        ImmutableMap.of("app", "cheche"),
+        false
+      },
+      {
+        new String[] {"app=che", "component=che-gateway-config"},
+        ImmutableMap.of("component", "che-gateway-config"),
+        false
+      },
+    };
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabelsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/GatewayConfigmapLabelsTest.java
@@ -17,7 +17,7 @@ import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import java.util.Map;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.inject.ConfigurationException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -25,26 +25,25 @@ public class GatewayConfigmapLabelsTest {
 
   @Test(dataProvider = "isGatewayConfigData")
   public void testIsGatewayConfig(
-      String labelsProperty, Map<String, String> labels, boolean isGatewayConfigExpected)
-      throws InfrastructureException {
+      String labelsProperty, Map<String, String> labels, boolean isGatewayConfigExpected) {
     GatewayConfigmapLabels gatewayConfigmapLabels = new GatewayConfigmapLabels(labelsProperty);
     ConfigMap cm =
         new ConfigMapBuilder().withNewMetadata().withLabels(labels).endMetadata().build();
     assertEquals(gatewayConfigmapLabels.isGatewayConfig(cm), isGatewayConfigExpected);
   }
 
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void failsToConstructWhenLabelsAreNull() throws InfrastructureException {
+  @Test(expectedExceptions = ConfigurationException.class)
+  public void failsToConstructWhenLabelsAreNull() {
     new GatewayConfigmapLabels(null);
   }
 
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void failsToConstructWhenLabelsAreEmpty() throws InfrastructureException {
+  @Test(expectedExceptions = ConfigurationException.class)
+  public void failsToConstructWhenLabelsAreEmpty() {
     new GatewayConfigmapLabels("");
   }
 
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void failsToConstructWhenLabelsAreNotValid() throws InfrastructureException {
+  @Test(expectedExceptions = ConfigurationException.class)
+  public void failsToConstructWhenLabelsAreNotValid() {
     new GatewayConfigmapLabels("badvalue");
   }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerResolverFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerResolverFactory.java
@@ -32,7 +32,7 @@ public class OpenShiftServerResolverFactory extends AbstractServerResolverFactor
   public OpenShiftServerResolverFactory(
       @Named("che.host") String cheHost,
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
-      @Named("che.infra.kubernetes.single_host.workspace.exposure") String wsExposureType) {
+      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String wsExposureType) {
     super(
         exposureStrategy,
         wsExposureType,


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests

COMMITTERS: please include labels on each PR. Labels are listed here: https://github.com/eclipse/che/wiki/Labels but at a minimum you should include `kind/..` and `Dev Open Pull Request Status` labels.
-->

### What does this PR do?
Configurable labels for single-host gateway configmaps with `che.infra.kubernetes.singlehost.gateway.configmap_labels` config property.

changed `che.infra.kubernetes.single_host.workspace.exposure` to `che.infra.kubernetes.singlehost.workspace.exposure`


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17768

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
