### PR TITLE
Update plugin brokers to v3.4.0 and enable plugin merging

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -543,8 +543,17 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
+#
+# Note these images are overridden by the Che Operator by default; changing the images here will not
+# have an effect if Che is installed via Operator.
 che.workspace.plugin_broker.metadata.image=quay.io/eclipse/che-plugin-metadata-broker:v3.4.0
 che.workspace.plugin_broker.artifacts.image=quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
+
+# Configures the default behavior of the plugin brokers when provisioning plugins into a workspace.
+# If set to true, the plugin brokers will attempt to merge plugins when possible (i.e. they run in
+# the same sidecar image and do not have conflicting settings). This value is the default setting
+# used when the devfile does not specify otherwise, via the "mergePlugins" attribute.
+che.workspace.plugin_broker.default_merge_plugins=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesArtifactsBrokerApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesArtifactsBrokerApplier.java
@@ -50,10 +50,14 @@ public class KubernetesArtifactsBrokerApplier<E extends KubernetesEnvironment> {
    * broker's configmap, machines, and volumes added in addition to the init container
    */
   public void apply(
-      E workspaceEnvironment, RuntimeIdentity runtimeID, Collection<PluginFQN> pluginFQNs)
+      E workspaceEnvironment,
+      RuntimeIdentity runtimeID,
+      Collection<PluginFQN> pluginFQNs,
+      boolean mergePlugins)
       throws InfrastructureException {
 
-    E brokerEnvironment = brokerEnvironmentFactory.createForArtifactsBroker(pluginFQNs, runtimeID);
+    E brokerEnvironment =
+        brokerEnvironmentFactory.createForArtifactsBroker(pluginFQNs, runtimeID, mergePlugins);
 
     Map<String, PodData> workspacePods = workspaceEnvironment.getPodsData();
     if (workspacePods.size() != 1) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/PluginBrokerManager.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/PluginBrokerManager.java
@@ -102,6 +102,7 @@ public class PluginBrokerManager<E extends KubernetesEnvironment> {
       StartSynchronizer startSynchronizer,
       Collection<PluginFQN> pluginFQNs,
       boolean isEphemeral,
+      boolean mergePlugins,
       Map<String, String> startOptions)
       throws InfrastructureException {
 
@@ -109,7 +110,8 @@ public class PluginBrokerManager<E extends KubernetesEnvironment> {
     KubernetesNamespace kubernetesNamespace = factory.getOrCreate(identity);
     BrokersResult brokersResult = new BrokersResult();
 
-    E brokerEnvironment = brokerEnvironmentFactory.createForMetadataBroker(pluginFQNs, identity);
+    E brokerEnvironment =
+        brokerEnvironmentFactory.createForMetadataBroker(pluginFQNs, identity, mergePlugins);
     if (isEphemeral) {
       EphemeralWorkspaceUtility.makeEphemeral(brokerEnvironment.getAttributes());
     }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesArtifactsBrokerApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesArtifactsBrokerApplierTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes;
 
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Names.createMachineNameAnnotations;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -123,14 +124,14 @@ public class KubernetesArtifactsBrokerApplierTest {
             .build();
     doReturn(brokerEnvironment)
         .when(brokerEnvironmentFactory)
-        .createForArtifactsBroker(any(), any());
+        .createForArtifactsBroker(any(), any(), anyBoolean());
 
     applier = new KubernetesArtifactsBrokerApplier<>(brokerEnvironmentFactory);
   }
 
   @Test
   public void shouldAddBrokerMachineToWorkspaceEnvironment() throws Exception {
-    applier.apply(workspaceEnvironment, runtimeID, pluginFQNs);
+    applier.apply(workspaceEnvironment, runtimeID, pluginFQNs, false);
 
     assertNotNull(workspaceEnvironment.getMachines());
     assertTrue(workspaceEnvironment.getMachines().values().contains(brokerMachine));
@@ -138,7 +139,7 @@ public class KubernetesArtifactsBrokerApplierTest {
 
   @Test
   public void shouldAddBrokerConfigMapsToWorkspaceEnvironment() throws Exception {
-    applier.apply(workspaceEnvironment, runtimeID, pluginFQNs);
+    applier.apply(workspaceEnvironment, runtimeID, pluginFQNs, false);
 
     ConfigMap workspaceConfigMap = workspaceEnvironment.getConfigMaps().get(BROKER_CONFIGMAP_NAME);
     assertNotNull(workspaceConfigMap);
@@ -153,7 +154,7 @@ public class KubernetesArtifactsBrokerApplierTest {
 
   @Test
   public void shouldAddBrokerAsInitContainerOnWorkspacePod() throws Exception {
-    applier.apply(workspaceEnvironment, runtimeID, pluginFQNs);
+    applier.apply(workspaceEnvironment, runtimeID, pluginFQNs, false);
 
     List<Container> initContainers = workspacePod.getSpec().getInitContainers();
     assertEquals(initContainers.size(), 1);
@@ -162,7 +163,7 @@ public class KubernetesArtifactsBrokerApplierTest {
 
   @Test
   public void shouldAddBrokerVolumesToWorkspacePod() throws Exception {
-    applier.apply(workspaceEnvironment, runtimeID, pluginFQNs);
+    applier.apply(workspaceEnvironment, runtimeID, pluginFQNs, false);
 
     List<Volume> workspaceVolumes = workspacePod.getSpec().getVolumes();
     assertEquals(workspaceVolumes.size(), 1);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/SidecarToolingProvisionerTest.java
@@ -12,7 +12,10 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes;
 
 import static java.util.Collections.emptyMap;
+import static org.eclipse.che.api.workspace.shared.Constants.MERGE_PLUGINS_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
@@ -55,6 +58,8 @@ public class SidecarToolingProvisionerTest {
   @Mock private PluginBrokerManager<KubernetesEnvironment> brokerManager;
   @Mock private KubernetesEnvironment nonEphemeralEnvironment;
   @Mock private KubernetesEnvironment ephemeralEnvironment;
+  @Mock private KubernetesEnvironment mergePluginsEnvironment;
+  @Mock private KubernetesEnvironment noMergePluginsEnvironment;
   @Mock private RuntimeIdentity runtimeId;
   @Mock private ChePluginsApplier chePluginsApplier;
 
@@ -66,43 +71,93 @@ public class SidecarToolingProvisionerTest {
   private Collection<PluginFQN> pluginFQNs = ImmutableList.of(new PluginFQN(null, PLUGIN_FQN_ID));
 
   private SidecarToolingProvisioner<KubernetesEnvironment> provisioner;
+  private SidecarToolingProvisioner<KubernetesEnvironment> mergePluginsProvisioner;
 
   @BeforeMethod
   public void setUp() throws Exception {
-    Map<String, ChePluginsApplier> workspaceNextAppliers =
-        ImmutableMap.of(RECIPE_TYPE, chePluginsApplier);
-    Map<String, String> ephemeralEnvironmentAttributes = new HashMap<>(environmentAttributesBase);
-    EphemeralWorkspaceUtility.makeEphemeral(ephemeralEnvironmentAttributes);
-    Map<String, String> nonEphemeralEnvironmentAttributes =
-        new HashMap<>(environmentAttributesBase);
+    Map<String, String> ephemeralEnvAttributes = new HashMap<>(environmentAttributesBase);
+    EphemeralWorkspaceUtility.makeEphemeral(ephemeralEnvAttributes);
+    Map<String, String> nonEphemeralEnvAttributes = new HashMap<>(environmentAttributesBase);
+
+    Map<String, String> mergePluginsEnvAttributes = new HashMap<>(environmentAttributesBase);
+    mergePluginsEnvAttributes.put(MERGE_PLUGINS_ATTRIBUTE, "true");
+    Map<String, String> noMergePluginsEnvAttributes = new HashMap<>(environmentAttributesBase);
+    noMergePluginsEnvAttributes.put(MERGE_PLUGINS_ATTRIBUTE, "false");
 
     lenient().doReturn(RECIPE_TYPE).when(nonEphemeralEnvironment).getType();
     lenient().doReturn(RECIPE_TYPE).when(ephemeralEnvironment).getType();
-    lenient()
-        .doReturn(nonEphemeralEnvironmentAttributes)
-        .when(nonEphemeralEnvironment)
-        .getAttributes();
-    lenient().doReturn(ephemeralEnvironmentAttributes).when(ephemeralEnvironment).getAttributes();
+    lenient().doReturn(RECIPE_TYPE).when(mergePluginsEnvironment).getType();
+    lenient().doReturn(RECIPE_TYPE).when(noMergePluginsEnvironment).getType();
+    lenient().doReturn(nonEphemeralEnvAttributes).when(nonEphemeralEnvironment).getAttributes();
+    lenient().doReturn(ephemeralEnvAttributes).when(ephemeralEnvironment).getAttributes();
+    lenient().doReturn(mergePluginsEnvAttributes).when(mergePluginsEnvironment).getAttributes();
+    lenient().doReturn(noMergePluginsEnvAttributes).when(noMergePluginsEnvironment).getAttributes();
     doReturn(pluginFQNs).when(pluginFQNParser).parsePlugins(any());
-
-    provisioner =
-        new SidecarToolingProvisioner<>(
-            workspaceNextAppliers, artifactsBrokerApplier, pluginFQNParser, brokerManager);
   }
 
   @Test
   public void shouldIncludexArtifactsBrokerWhenWorkspaceIsNotEphemeral() throws Exception {
+    provisioner = getSidecarToolingProvisioner("false");
     provisioner.provision(runtimeId, startSynchronizer, nonEphemeralEnvironment, emptyMap());
 
     verify(chePluginsApplier, times(1)).apply(any(), any(), any());
-    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any());
+    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any(), anyBoolean());
   }
 
   @Test
   public void shouldIncludeArtifactsBrokerWhenWorkspaceIsEphemeral() throws Exception {
+    provisioner = getSidecarToolingProvisioner("false");
     provisioner.provision(runtimeId, startSynchronizer, ephemeralEnvironment, emptyMap());
 
     verify(chePluginsApplier, times(1)).apply(any(), any(), any());
-    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any());
+    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any(), anyBoolean());
+  }
+
+  @Test
+  public void shouldMergePluginsWhenDefaultPropertyIsTrue() throws Exception {
+    provisioner = getSidecarToolingProvisioner("true");
+    provisioner.provision(runtimeId, startSynchronizer, nonEphemeralEnvironment, emptyMap());
+
+    verify(brokerManager, times(1)).getTooling(any(), any(), any(), anyBoolean(), eq(true), any());
+    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any(), eq(true));
+  }
+
+  @Test
+  public void shouldNotMergePluginsWhenDefaultPropertyIsFalse() throws Exception {
+    provisioner = getSidecarToolingProvisioner("false");
+    provisioner.provision(runtimeId, startSynchronizer, nonEphemeralEnvironment, emptyMap());
+
+    verify(brokerManager, times(1)).getTooling(any(), any(), any(), anyBoolean(), eq(false), any());
+    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any(), eq(false));
+  }
+
+  @Test
+  public void shouldMergePluginsWhenEnvironmentOverridesToTrue() throws Exception {
+    provisioner = getSidecarToolingProvisioner("false");
+    provisioner.provision(runtimeId, startSynchronizer, mergePluginsEnvironment, emptyMap());
+
+    verify(brokerManager, times(1)).getTooling(any(), any(), any(), anyBoolean(), eq(true), any());
+    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any(), eq(true));
+  }
+
+  @Test
+  public void shouldNotMergePluginsWhenEnvironmentOverridesToFalse() throws Exception {
+    provisioner = getSidecarToolingProvisioner("true");
+    provisioner.provision(runtimeId, startSynchronizer, noMergePluginsEnvironment, emptyMap());
+
+    verify(brokerManager, times(1)).getTooling(any(), any(), any(), anyBoolean(), eq(false), any());
+    verify(artifactsBrokerApplier, times(1)).apply(any(), any(), any(), eq(false));
+  }
+
+  private SidecarToolingProvisioner<KubernetesEnvironment> getSidecarToolingProvisioner(
+      String mergePlugins) {
+    Map<String, ChePluginsApplier> workspaceNextAppliers =
+        ImmutableMap.of(RECIPE_TYPE, chePluginsApplier);
+    return new SidecarToolingProvisioner<>(
+        workspaceNextAppliers,
+        artifactsBrokerApplier,
+        pluginFQNParser,
+        brokerManager,
+        mergePlugins);
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/brokerphases/BrokerEnvironmentFactoryTest.java
@@ -100,7 +100,7 @@ public class BrokerEnvironmentFactoryTest {
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
-    factory.createForMetadataBroker(pluginFQNs, runtimeId);
+    factory.createForMetadataBroker(pluginFQNs, runtimeId, false);
 
     // then
     verify(factory).doCreate(captor.capture());
@@ -128,11 +128,12 @@ public class BrokerEnvironmentFactoryTest {
           "/tmp/che/cacert",
           "--registry-address",
           DEFAULT_REGISTRY,
-          "-metas",
+          "--metas",
           "/broker-config/config.json",
         });
   }
 
+  @Test
   public void testArtifactsBrokerSelfSignedCertificate() throws Exception {
     when(certProvisioner.isConfigured()).thenReturn(true);
     when(certProvisioner.getCertPath()).thenReturn("/tmp/che/cacert");
@@ -141,7 +142,7 @@ public class BrokerEnvironmentFactoryTest {
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
-    factory.createForArtifactsBroker(pluginFQNs, runtimeId);
+    factory.createForArtifactsBroker(pluginFQNs, runtimeId, false);
 
     // then
     verify(factory).doCreate(captor.capture());
@@ -159,19 +160,69 @@ public class BrokerEnvironmentFactoryTest {
     assertEquals(
         container.getArgs().toArray(),
         new String[] {
-          "-push-endpoint",
+          "--push-endpoint",
           PUSH_ENDPOINT,
-          "-runtime-id",
+          "--runtime-id",
           String.format(
               "%s:%s:%s",
               runtimeId.getWorkspaceId(), runtimeId.getEnvName(), runtimeId.getOwnerId()),
-          "-cacert",
+          "--cacert",
           "/tmp/che/cacert",
           "--registry-address",
           DEFAULT_REGISTRY,
-          "-metas",
+          "--metas",
           "/broker-config/config.json",
         });
+  }
+
+  @Test
+  public void testAddsMergeArgToArtifactsBroker() throws Exception {
+    // given
+    Collection<PluginFQN> pluginFQNs = singletonList(new PluginFQN(null, "id"));
+    ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
+
+    // when
+    factory.createForArtifactsBroker(pluginFQNs, runtimeId, true);
+
+    // then
+    verify(factory).doCreate(captor.capture());
+    BrokersConfigs brokersConfigs = captor.getValue();
+
+    List<Container> containers =
+        brokersConfigs
+            .pods
+            .values()
+            .stream()
+            .flatMap(p -> p.getSpec().getContainers().stream())
+            .collect(Collectors.toList());
+    assertEquals(containers.size(), 1);
+    Container container = containers.get(0);
+    assertTrue(container.getArgs().stream().anyMatch(e -> "--merge-plugins".equals(e)));
+  }
+
+  @Test
+  public void testAddsMergeArgToMetadataBroker() throws Exception {
+    // given
+    Collection<PluginFQN> pluginFQNs = singletonList(new PluginFQN(null, "id"));
+    ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
+
+    // when
+    factory.createForMetadataBroker(pluginFQNs, runtimeId, true);
+
+    // then
+    verify(factory).doCreate(captor.capture());
+    BrokersConfigs brokersConfigs = captor.getValue();
+
+    List<Container> containers =
+        brokersConfigs
+            .pods
+            .values()
+            .stream()
+            .flatMap(p -> p.getSpec().getContainers().stream())
+            .collect(Collectors.toList());
+    assertEquals(containers.size(), 1);
+    Container container = containers.get(0);
+    assertTrue(container.getArgs().stream().anyMatch(e -> "--merge-plugins".equals(e)));
   }
 
   @Test
@@ -181,7 +232,7 @@ public class BrokerEnvironmentFactoryTest {
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
-    factory.createForMetadataBroker(pluginFQNs, runtimeId);
+    factory.createForMetadataBroker(pluginFQNs, runtimeId, false);
 
     // then
     verify(factory).doCreate(captor.capture());
@@ -200,7 +251,7 @@ public class BrokerEnvironmentFactoryTest {
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
-    factory.createForArtifactsBroker(pluginFQNs, runtimeId);
+    factory.createForArtifactsBroker(pluginFQNs, runtimeId, false);
 
     // then
     verify(factory).doCreate(captor.capture());
@@ -222,7 +273,7 @@ public class BrokerEnvironmentFactoryTest {
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
-    factory.createForMetadataBroker(pluginFQNs, runtimeId);
+    factory.createForMetadataBroker(pluginFQNs, runtimeId, false);
 
     // then
     verify(factory).doCreate(captor.capture());
@@ -254,7 +305,7 @@ public class BrokerEnvironmentFactoryTest {
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
-    factory.createForArtifactsBroker(pluginFQNs, runtimeId);
+    factory.createForArtifactsBroker(pluginFQNs, runtimeId, false);
 
     // then
     verify(factory).doCreate(captor.capture());
@@ -283,7 +334,7 @@ public class BrokerEnvironmentFactoryTest {
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
-    factory.createForArtifactsBroker(pluginFQNs, runtimeId);
+    factory.createForArtifactsBroker(pluginFQNs, runtimeId, false);
 
     // then
     verify(factory).doCreate(captor.capture());
@@ -300,7 +351,7 @@ public class BrokerEnvironmentFactoryTest {
     ArgumentCaptor<BrokersConfigs> captor = ArgumentCaptor.forClass(BrokersConfigs.class);
 
     // when
-    factory.createForMetadataBroker(pluginFQNs, runtimeId);
+    factory.createForMetadataBroker(pluginFQNs, runtimeId, false);
 
     // then
     verify(factory).doCreate(captor.capture());

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/wsplugins/brokerphases/OpenshiftBrokerEnvironmentFactory.java
@@ -81,8 +81,10 @@ public class OpenshiftBrokerEnvironmentFactory
 
   @Override
   public OpenShiftEnvironment createForMetadataBroker(
-      Collection<PluginFQN> pluginFQNs, RuntimeIdentity runtimeID) throws InfrastructureException {
-    BrokersConfigs brokersConfigs = getBrokersConfigs(pluginFQNs, runtimeID, metadataBrokerImage);
+      Collection<PluginFQN> pluginFQNs, RuntimeIdentity runtimeID, boolean mergePlugins)
+      throws InfrastructureException {
+    BrokersConfigs brokersConfigs =
+        getBrokersConfigs(pluginFQNs, runtimeID, metadataBrokerImage, mergePlugins);
     OpenShiftEnvironment openShiftEnvironment = doCreate(brokersConfigs);
     OpenShiftProject openshiftProject = factory.getOrCreate(runtimeID);
     trustedCAProvisioner.provision(openShiftEnvironment, openshiftProject);
@@ -90,8 +92,8 @@ public class OpenshiftBrokerEnvironmentFactory
   }
 
   @Override
-  protected List<String> getCommandLineArgs(RuntimeIdentity runtimeId) {
-    List<String> cmdArgs = super.getCommandLineArgs(runtimeId);
+  protected List<String> getCommandLineArgs(RuntimeIdentity runtimeId, boolean mergePlugins) {
+    List<String> cmdArgs = super.getCommandLineArgs(runtimeId, mergePlugins);
 
     if (trustedCAProvisioner.isTrustedStoreInitialized()) {
       cmdArgs.add("--cadir");

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.shared;
 
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
+import org.eclipse.che.api.core.model.workspace.devfile.Devfile;
 import org.eclipse.che.api.core.model.workspace.runtime.Machine;
 import org.eclipse.che.api.core.model.workspace.runtime.Server;
 
@@ -105,7 +106,7 @@ public final class Constants {
 
   /**
    * The attribute allows to configure workspace to be ephemeral with no PVC attached on K8S /
-   * OpenShift infrastructure. Should be set/read from {@link WorkspaceConfig#getAttributes}.
+   * OpenShift infrastructure. Should be set/read from {@link Devfile#getAttributes}.
    *
    * <p>Value is expected to be boolean, and if set to 'false' regardless of the PVC strategy,
    * workspace volumes would be created as `emptyDir`. When a workspace Pod is removed for any
@@ -119,11 +120,24 @@ public final class Constants {
   public static final String PERSIST_VOLUMES_ATTRIBUTE = "persistVolumes";
 
   /**
+   * This attribute enables or disables merging plugins while provisioning a workspace. When
+   * enabled, the plugin broker will be configured to attempt to merge plugins where possible (when
+   * two or more plugins share the same image and do not have conflicting settings). Should be
+   * set/read from {@link Devfile#getAttributes}.
+   *
+   * <p>Value is expected to be boolean; if it set to true, then the broker will attempt to merge
+   * plugins in the current devfile, otherwise it will not. The behavior when this property is not
+   * present in a devfile is governed by the configuration property {@code
+   * che.workspace.plugin_broker.default_merge_plugins}.
+   */
+  public static final String MERGE_PLUGINS_ATTRIBUTE = "mergePlugins";
+
+  /**
    * The attribute allows to configure workspace with async storage support this configuration. Make
    * sense only in case org.eclipse.che.api.workspace.shared.Constants#PERSIST_VOLUMES_ATTRIBUTE set
    * to 'false'.
    *
-   * <p>Should be set/read from {@link WorkspaceConfig#getAttributes}.
+   * <p>Should be set/read from {@link Devfile#getAttributes}.
    *
    * <p>Value is expected to be boolean, and if set to 'true' special plugin will be added to
    * workspace. It will provide ability to backup/restore project source to the async storage.
@@ -134,7 +148,7 @@ public final class Constants {
 
   /**
    * Contains a list of workspace tooling plugins that should be used in a workspace. Should be
-   * set/read from {@link WorkspaceConfig#getAttributes}.
+   * set/read from {@link Devfile#getAttributes}.
    *
    * <p>Value is comma separated list of plugins in a format: '< plugin1ID >,<plugin2ID >'<br>
    * Spaces around commas are trimmed. <br>


### PR DESCRIPTION
### What does this PR do?
Update plugin brokers to v3.4.0 to pick up changes from https://github.com/eclipse/che-plugin-broker/pull/111 and enable merging plugins.

**Note**: This PR depends on https://github.com/eclipse/che-operator/pull/429. If a Che server with these changes is deployed, workspace start will fail unless the v3.4.0 brokers are used (as the commandline argument is not recognized)

### What issues does this PR fix or reference?
Required for https://github.com/eclipse/che/issues/15373

#### Release Notes
The plugin broker, which downloads Theia plugins while workspaces are starting up, now has the capability to merge plugins that run in the same sidecar container.

#### Docs PR
https://github.com/eclipse/che-docs/pull/1576

