### PR TITLE
don't set X-Forwarded-Proto explicitly with traefik servers

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGenerator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGenerator.java
@@ -40,7 +40,6 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
  *       service: {name}
  *       middlewares:
  *       - "{name}"
- *       - "{name}_headers"
  *       priority: 100
  *   services:
  *     {name}:
@@ -52,9 +51,6 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
  *       stripPrefix:
  *         prefixes:
  *         - "{GatewayRouteConfig#routePath}"
- *     {name}_headers:
- *       customRequestHeaders:
- *         X-Forwarded-Proto: "{protocol}"
  * </pre>
  */
 public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGenerator {
@@ -99,8 +95,7 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
           generate(
               routeConfig.getKey(),
               createServiceUrl(serviceName, servicePort, namespace),
-              server.getPath(),
-              server.getProtocol());
+              server.getPath());
       cmData.put(routeConfig.getKey() + ".yml", traefikRouteConfig);
     }
     return cmData;
@@ -112,10 +107,9 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
    * @param name name of the service
    * @param serviceUrl url of service we want to route to
    * @param path path to route and strip
-   * @param protocol protocol of the service to properly set the headers
    * @return traefik service route config
    */
-  private String generate(String name, String serviceUrl, String path, String protocol)
+  private String generate(String name, String serviceUrl, String path)
       throws InfrastructureException {
     StringWriter sw = new StringWriter();
     try {
@@ -133,7 +127,7 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
       generateServices(generator, name, serviceUrl);
 
       generator.writeFieldName("middlewares");
-      generateMiddlewares(generator, name, path, protocol);
+      generateMiddlewares(generator, name, path);
 
       generator.writeEndObject();
       generator.writeEndObject();
@@ -155,7 +149,6 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
    *   service: "{name}"
    *   middlewares:
    *   - "{name}"
-   *   - "{name}_headers
    *   priority: 100
    * </pre>
    */
@@ -171,7 +164,6 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
     generator.writeFieldName("middlewares");
     generator.writeStartArray();
     generator.writeString(name);
-    generator.writeString(name + "_headers");
     generator.writeEndArray();
     generator.writeFieldName("priority");
     generator.writeNumber(100);
@@ -216,14 +208,10 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
    *   stripPrefix:
    *     prefixes:
    *     - "{path}"
-   * {name}_headers:
-   *   headers:
-   *     customRequestHeaders:
-   *       X-Forwarded-Proto: "{protocol}"
    * </pre>
    */
-  private void generateMiddlewares(
-      YAMLGenerator generator, String name, String path, String protocol) throws IOException {
+  private void generateMiddlewares(YAMLGenerator generator, String name, String path)
+      throws IOException {
     generator.writeStartObject();
     generator.writeFieldName(name);
     generator.writeStartObject();
@@ -235,19 +223,6 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
     generator.writeEndArray();
     generator.writeEndObject();
     generator.writeEndObject();
-
-    generator.writeFieldName(name + "_headers");
-    generator.writeStartObject();
-    generator.writeFieldName("headers");
-    generator.writeStartObject();
-    generator.writeFieldName("customRequestHeaders");
-    generator.writeStartObject();
-    generator.writeFieldName("X-Forwarded-Proto");
-    generator.writeString(protocol);
-    generator.writeEndObject();
-    generator.writeEndObject();
-    generator.writeEndObject();
-
     generator.writeEndObject();
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGeneratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGeneratorTest.java
@@ -45,7 +45,6 @@ public class TraefikGatewayRouteConfigGeneratorTest {
             + "      service: \"external-server-1\"\n"
             + "      middlewares:\n"
             + "      - \"external-server-1\"\n"
-            + "      - \"external-server-1_headers\"\n"
             + "      priority: 100\n"
             + "  services:\n"
             + "    external-server-1:\n"
@@ -56,11 +55,7 @@ public class TraefikGatewayRouteConfigGeneratorTest {
             + "    external-server-1:\n"
             + "      stripPrefix:\n"
             + "        prefixes:\n"
-            + "        - \"/blabol-cesta\"\n"
-            + "    external-server-1_headers:\n"
-            + "      headers:\n"
-            + "        customRequestHeaders:\n"
-            + "          X-Forwarded-Proto: \"https\"";
+            + "        - \"/blabol-cesta\"";
 
     ServerConfigImpl serverConfig =
         new ServerConfigImpl(


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

### What does this PR do?
since we've came up with traefik configuration that is properly forwarding the `X-Forwarded-*` headers, we don't need to set `X-Forwarded-Proto` explicitly.

### What issues does this PR fix or reference?
related to:
 - helm deployment https://github.com/eclipse/che/issues/17064
 - operator deployment https://github.com/eclipse/che/issues/17065
 - keycloak behind traefik issue https://github.com/eclipse/che/issues/17809

<!-- #### Changelog -->
<!-- The changelog will be pulled from the PR's title. 
     Please provide a clear and meaningful title to the PR and don't include issue number -->


#### Release Notes
<!-- markdown to be included in marketing announcement - N/A for bugs -->
n/a


#### Docs PR
<!-- Please add a matching PR to [the docs repo](https://github.com/eclipse/che-docs) and link that PR to this issue.
Both will be merged at the same time. -->
n/a
