### PR TITLE
Update plugin brokers to v3.4.0

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -543,8 +543,8 @@ che.singleport.wildcard_domain.ipless=false
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace
-che.workspace.plugin_broker.metadata.image=quay.io/eclipse/che-plugin-metadata-broker:v3.3.0
-che.workspace.plugin_broker.artifacts.image=quay.io/eclipse/che-plugin-artifacts-broker:v3.3.0
+che.workspace.plugin_broker.metadata.image=quay.io/eclipse/che-plugin-metadata-broker:v3.4.0
+che.workspace.plugin_broker.artifacts.image=quay.io/eclipse/che-plugin-artifacts-broker:v3.4.0
 
 # Docker image of Che plugin broker app that resolves workspace tooling configuration and copies
 # plugins dependencies to a workspace


### PR DESCRIPTION
### What does this PR do?
*Just* updates the plugin brokers to version 3.4.0 to avoid an issue with happy path tests:
- The Che operator syncs with che.properties to get brokers version
- The Che operator also overrides che.properties with its own setting

This makes it difficult to merge PRs like https://github.com/eclipse/che/pull/17785 that update the broker and adapt Che to use it in one changeset.

Functionally, nothing is changed with the PR as added functionality in v3.4.0 (plugin merging) is enabled via flag.

### What issues does this PR fix or reference?
Necessary for #15373