### PR TITLE
Fix expected message when wait on Java LS init in Happy path tests

### DIFF
--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -79,18 +79,18 @@ suite('Language server validation', async () => {
         await editor.selectTab(javaFileName);
 
         try {
-            await ide.checkLsInitializationStart('Activating Java Test Runner');
+            await ide.checkLsInitializationStart('Activating Language Support for Java');
+            await ide.waitStatusBarTextAbsence('Activating Language Support for Java', 900_000);
         } catch (err) {
             if (!(err instanceof error.TimeoutError)) {
                 throw err;
             }
 
-            console.log('Known flakiness has occurred https://github.com/eclipse/che/issues/14944');
-            await driverHelper.reloadPage();
+            console.log('Known flakiness has occurred https://github.com/eclipse/che/issues/17864');
             await ide.waitStatusBarContains('Activating Java Test Runner');
+            await ide.waitStatusBarTextAbsence('Activating Java Test Runner', 900_000);
         }
 
-        await ide.waitStatusBarTextAbsence('Activating Java Test Runner', 900_000);
         await checkJavaPathCompletion();
     });
 

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -79,7 +79,7 @@ suite('Language server validation', async () => {
         await editor.selectTab(javaFileName);
 
         try {
-            await ide.checkLsInitializationStart('Activating Language Support for Java');
+            await ide.checkLsInitializationStart('Activating Java Test Runner');
         } catch (err) {
             if (!(err instanceof error.TimeoutError)) {
                 throw err;
@@ -87,10 +87,10 @@ suite('Language server validation', async () => {
 
             console.log('Known flakiness has occurred https://github.com/eclipse/che/issues/14944');
             await driverHelper.reloadPage();
-            await ide.waitStatusBarContains('Activating Language Support for Java');
+            await ide.waitStatusBarContains('Activating Java Test Runner');
         }
 
-        await ide.waitStatusBarTextAbsence('Activating Language Support for Java', 900_000);
+        await ide.waitStatusBarTextAbsence('Activating Java Test Runner', 900_000);
         await checkJavaPathCompletion();
     });
 


### PR DESCRIPTION
### What does this PR do?
This is follow up suggesting from https://github.com/eclipse/che/issues/17864#issuecomment-692675842 - to replace expected message "_Activating Language Support for Java_" with "_Activating Java Test Runner_" when wait on Java LS initialization in Happy path tests.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17864

### How to test this PR?
Run E2E Happy path tests.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
