### PR TITLE
Set CHE_OPENSHIFT_PROJECT=eclipse-che in E2E java selenium tests

### DIFF
--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -408,7 +408,10 @@ function installDockerCompose() {
 function seleniumTestsSetup() {
   echo "======== Start selenium tests ========"
   cd /root/payload
+
   export CHE_INFRASTRUCTURE=openshift
+  export CHE_OPENSHIFT_PROJECT=eclipse-che
+
   defineCheRoute
 
   mvn clean install -pl :che-selenium-test -am -DskipTests=true -U


### PR DESCRIPTION
### What does this PR do?
It adds `CHE_OPENSHIFT_PROJECT=eclipse-che` variable to fix test user creation in Java selenium tests on ci.centos.org.

It actually works [on ci.centos.org](https://ci.centos.org/view/Devtools/job/devtools-che-pullrequests-java-selenium-tests/353/):
> 2020-09-16 11:19:02,123[main]             [INFO ] [.c.s.c.c.k.c.KeycloakCliClient 85]   - Default test user with name='user1600251523605' and id='140aa3e9-3300-4e16-97d9-79f6ebc38e22' has been created.

### What issues does this PR fix or reference?
#17395

### How to test this PR?
Run Java selenium tests on ci.centos.org.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
