### PR TITLE
[Performace tests] Fix typos for creating users

### DIFF
--- a/tests/.infra/crw-ci/load-tests/JenkinsfileUsers
+++ b/tests/.infra/crw-ci/load-tests/JenkinsfileUsers
@@ -41,7 +41,7 @@ pipeline {
                 defaultValue: 'admin',
                 description: 'Keycloak admin username, default to "admin".')
 
-        string(name: 'keycloakAdminPassword',
+        password(name: 'keycloakAdminPassword',
                 defaultValue: 'admin',
                 description: 'Keacloak admin password, deafult to "admin".')
 
@@ -86,7 +86,7 @@ pipeline {
                 sh """
                   cd $PATH_TO_SCRIPTS
                   oc config use-context ${env.CHE_CONTEXT}
-                  ./create_users.sh -n $USERNAME_BASE -m $USERNAME_PASS -s $startingIndex -c $numberOfUsers -e $environment -a keycloakAdminUsername -p keycloakAdminPassword
+                  ./create_users.sh -n $USERNAME_BASE -m $USERNAME_PASS -s $startingIndex -c $numberOfUsers -e $environment -a $keycloakAdminUsername -p $keycloakAdminPassword
                 """
             }
         }


### PR DESCRIPTION
### What does this PR do?
Fix typos in Jenkins job for user creation - change `string` to `password` and fix missing `$` when calling variables.

### How to test this PR?
Manually triggering the new job. https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/load%20tests/job/Create%20users/25/console 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
