### PR TITLE
Add namespace name cleanup before applying

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -281,6 +281,7 @@ che.infra.kubernetes.namespace=
 
 # Indicates whether Che server is allowed to create namespaces/projects for user
 # workspaces, or they're intended to be created manually by cluster administrator.
+# This property is also used by the OpenShift infra.
 che.infra.kubernetes.namespace.creation_allowed=true
 
 # Defines Kubernetes default namespace in which user's workspaces are created

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -274,6 +274,11 @@ che.infra.kubernetes.ingress.domain=
 # the namespace specified by the che.infra.kubernetes.namespace.default will be created and used.
 che.infra.kubernetes.namespace=
 
+
+# Indicates whether Che server is allowed to create namespaces/projects for user
+# workspaces, or they're intended to be created manually by cluster administrator.
+che.infra.kubernetes.namespace.creation_allowed=true
+
 # Defines Kubernetes default namespace in which user's workspaces are created
 # if user does not override it.
 # It's possible to use <username>, <userid> and <workspaceid> placeholders (e.g.: che-workspace-<username>).

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -463,20 +463,20 @@ public class KubernetesNamespaceFactory {
 
     if (!NamespaceNameValidator.isValid(namespace)) {
       Optional<KubernetesNamespaceMeta> namespaceMetaOptional;
-      String modified = NamespaceNameValidator.reduceToValid(namespace);
-      if (modified.isEmpty()) {
+      String normalizedNamespace = NamespaceNameValidator.normalize(namespace);
+      if (normalizedNamespace.isEmpty()) {
         throw new InfrastructureException(
             format(
                 "Evaluated empty namespace name for workspace %s", resolutionCtx.getWorkspaceId()));
       }
       do {
-        modified =
-            modified
-                .substring(0, Math.min(55, modified.length()))
+        normalizedNamespace =
+            normalizedNamespace
+                .substring(0, Math.min(55, normalizedNamespace.length()))
                 .concat(NameGenerator.generate("-", 6));
-        namespaceMetaOptional = fetchNamespace(modified);
+        namespaceMetaOptional = fetchNamespace(normalizedNamespace);
       } while (namespaceMetaOptional.isPresent());
-      namespace = modified;
+      namespace = normalizedNamespace;
     }
 
     LOG.debug(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -468,7 +468,8 @@ public class KubernetesNamespaceFactory {
   public String evaluateNamespaceName(NamespaceResolutionContext resolutionCtx)
       throws InfrastructureException {
     String namespace;
-    Optional<Pair<String, String>> namespaceOptional = getPreferencesNamespaceName(resolutionCtx);
+    Optional<Pair<String, String>> namespaceOptional =
+        allowUserDefinedNamespaces ? getPreferencesNamespaceName(resolutionCtx) : Optional.empty();
     if (namespaceOptional.isEmpty() || !isStoredTemplateValid(namespaceOptional.get().second)) {
       namespace = evalPlaceholders(defaultNamespaceName, resolutionCtx);
     } else {
@@ -498,7 +499,8 @@ public class KubernetesNamespaceFactory {
         resolutionCtx.getWorkspaceId(),
         namespace);
 
-    if (resolutionCtx.isPersistAfterCreate()
+    if (allowUserDefinedNamespaces
+        && resolutionCtx.isPersistAfterCreate()
         && !defaultNamespaceName.contains(WORKSPACEID_PLACEHOLDER)) {
       recordEvaluatedNamespaceName(namespace);
     }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -502,7 +502,7 @@ public class KubernetesNamespaceFactory {
     if (allowUserDefinedNamespaces
         && resolutionCtx.isPersistAfterCreate()
         && !defaultNamespaceName.contains(WORKSPACEID_PLACEHOLDER)) {
-      recordEvaluatedNamespaceName(namespace);
+      recordEvaluatedNamespaceName(namespace, resolutionCtx);
     }
     return namespace;
   }
@@ -566,9 +566,9 @@ public class KubernetesNamespaceFactory {
    * Stores computed namespace name and it's template into user preferences. Template is required to
    * track its changes and re-generate namespace in case it didn't matches.
    */
-  private void recordEvaluatedNamespaceName(String namespace) {
+  private void recordEvaluatedNamespaceName(String namespace, NamespaceResolutionContext context) {
     try {
-      String owner = EnvironmentContext.getCurrent().getSubject().getUserId();
+      final String owner = context.getUserId();
       Map<String, String> preferences = preferenceManager.find(owner);
       preferences.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, namespace);
       preferences.put(NAMESPACE_TEMPLATE_ATTRIBUTE, defaultNamespaceName);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidator.java
@@ -15,6 +15,7 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.eclipse.che.api.core.ValidationException;
 
@@ -49,6 +50,15 @@ public final class NamespaceNameValidator {
    */
   public static boolean isValid(String name) {
     return validateInternal(name).isOk();
+  }
+
+  public static String reduceToValid(String namespaceName) {
+    Matcher m = METADATA_NAME_PATTERN.matcher(namespaceName);
+    String reduced = "";
+    while (m.find()) {
+      reduced = reduced.concat(m.group(0));
+    }
+    return reduced.substring(0, Math.min(METADATA_NAME_MAX_LENGTH, reduced.length()));
   }
 
   @VisibleForTesting

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidator.java
@@ -55,7 +55,7 @@ public final class NamespaceNameValidator {
    * Normalizes input namespace name to K8S accepted format
    *
    * @param namespaceName input namespace name
-   * @return normalized namespoace name
+   * @return normalized namespace name
    */
   public static String normalize(String namespaceName) {
     namespaceName =

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidator.java
@@ -20,7 +20,7 @@ import org.eclipse.che.api.core.ValidationException;
 
 public final class NamespaceNameValidator {
 
-  private static final int METADATA_NAME_MAX_LENGTH = 63;
+  static final int METADATA_NAME_MAX_LENGTH = 63;
   private static final String METADATA_NAME_REGEX = "[a-z0-9]([-a-z0-9]*[a-z0-9])?";
   private static final Pattern METADATA_NAME_PATTERN = Pattern.compile(METADATA_NAME_REGEX);
 
@@ -49,25 +49,6 @@ public final class NamespaceNameValidator {
    */
   public static boolean isValid(String name) {
     return validateInternal(name).isOk();
-  }
-
-  /**
-   * Normalizes input namespace name to K8S accepted format
-   *
-   * @param namespaceName input namespace name
-   * @return normalized namespace name
-   */
-  public static String normalize(String namespaceName) {
-    namespaceName =
-        namespaceName
-            .replaceAll("[^-a-zA-Z0-9]", "-") // replace invalid chars with '-'
-            .replaceAll("-+", "-") // replace multiple '-' with single ones
-            .replaceAll("^-|-$", ""); // trim dashes at beginning/end of the string
-    return namespaceName.substring(
-        0,
-        Math.min(
-            namespaceName.length(),
-            METADATA_NAME_MAX_LENGTH)); // limit length to METADATA_NAME_MAX_LENGTH
   }
 
   @VisibleForTesting

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -689,7 +689,7 @@ public class KubernetesNamespaceFactoryTest {
             Collections.singletonMap(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123"));
     String namespace =
         namespaceFactory.evaluateNamespaceName(
-            new NamespaceResolutionContext("workspace123", "user123", "jodoe"));
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
 
     assertEquals(namespace, "che-123");
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -419,6 +419,36 @@ public class KubernetesNamespaceFactoryTest {
   }
 
   @Test
+  public void shouldReturnDefaultNamespaceWhenCreatingIsNotIsNotAllowed() throws Exception {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "predefined",
+                "",
+                "",
+                "new-default",
+                true,
+                false,
+                clientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
+    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
+
+    // then
+    assertEquals(toReturnNamespace, namespace);
+    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
+    verify(toReturnNamespace).prepare(eq(false));
+  }
+
+  @Test
   public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndNamespaceIsNotPredefined()
       throws Exception {
     // given

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -74,6 +74,7 @@ import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 import org.testng.collections.Sets;
@@ -834,6 +835,57 @@ public class KubernetesNamespaceFactoryTest {
 
     // this is an invalid name, but that is not a purpose of this test.
     assertEquals(namespace, "<userid>");
+  }
+
+  @Test(dataProvider = "invalidUsernames")
+  public void normalizeTest(String raw, String expected) {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "",
+            "",
+            "",
+            "che-<userid>",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    assertEquals(expected, namespaceFactory.normalizeNamespaceName(raw));
+  }
+
+  @Test
+  public void normalizeLengthTest() {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "",
+            "",
+            "",
+            "che-<userid>",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    assertEquals(
+        63,
+        namespaceFactory
+            .normalizeNamespaceName(
+                "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
+            .length());
+  }
+
+  @DataProvider
+  public static Object[][] invalidUsernames() {
+    return new Object[][] {
+      new Object[] {"gmail@foo.bar", "gmail-foo-bar"},
+      new Object[] {"_fef_123-ah_*zz**", "fef-123-ah-zz"},
+      new Object[] {"a-b#-hello", "a-b-hello"},
+      new Object[] {"a---------b", "a-b"},
+      new Object[] {"--ab--", "ab"}
+    };
   }
 
   private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -680,7 +680,7 @@ public class KubernetesNamespaceFactoryTest {
             "",
             "",
             "che-<userid>",
-            false,
+            true,
             true,
             clientFactory,
             userManager,
@@ -701,6 +701,35 @@ public class KubernetesNamespaceFactoryTest {
 
   @Test
   public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateChanged()
+      throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "",
+            "che-<userid>-<username>",
+            true,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    Map<String, String> prefs = new HashMap<>();
+    // returned but ignored
+    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
+
+    when(preferenceManager.find(anyString())).thenReturn(prefs);
+    String namespace =
+        namespaceFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+
+    assertEquals(namespace, "che-user123-jondoe");
+  }
+
+  @Test
+  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfUserAllowedPropertySetFalse()
       throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
@@ -737,7 +766,7 @@ public class KubernetesNamespaceFactoryTest {
             "",
             "",
             "che-<workspaceid>-<username>",
-            false,
+            true,
             true,
             clientFactory,
             userManager,
@@ -766,7 +795,7 @@ public class KubernetesNamespaceFactoryTest {
             "",
             "",
             "che-<userid>",
-            false,
+            true,
             true,
             clientFactory,
             userManager,

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -13,9 +13,11 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.lenient;
@@ -44,18 +46,21 @@ import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.user.server.PreferenceManager;
 import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl.WorkspaceImplBuilder;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
 import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.commons.subject.SubjectImpl;
@@ -86,6 +91,7 @@ public class KubernetesNamespaceFactoryTest {
   @Mock private KubernetesClientFactory clientFactory;
   private KubernetesClient k8sClient;
   @Mock private UserManager userManager;
+  @Mock private PreferenceManager preferenceManager;
 
   @Mock
   private NonNamespaceOperation<
@@ -124,7 +130,16 @@ public class KubernetesNamespaceFactoryTest {
       throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "legacy", "", "", "defaultNs", false, true, clientFactory, userManager, pool);
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
 
     namespaceFactory.checkIfNamespaceIsAllowed("defaultNs");
   }
@@ -135,7 +150,16 @@ public class KubernetesNamespaceFactoryTest {
           throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "legacy", "", "", "defaultNs", true, true, clientFactory, userManager, pool);
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            true,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
 
     namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
   }
@@ -149,7 +173,16 @@ public class KubernetesNamespaceFactoryTest {
           throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "legacy", "", "", "defaultNs", false, true, clientFactory, userManager, pool);
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
 
     namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
   }
@@ -160,7 +193,16 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", null, false, true, clientFactory, userManager, pool);
+            "predefined",
+            "",
+            "",
+            null,
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
   }
 
   @Test
@@ -178,7 +220,16 @@ public class KubernetesNamespaceFactoryTest {
             .build());
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "che-default", false, true, clientFactory, userManager, pool);
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
 
     List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
     assertEquals(availableNamespaces.size(), 1);
@@ -195,7 +246,16 @@ public class KubernetesNamespaceFactoryTest {
 
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "che-default", false, true, clientFactory, userManager, pool);
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
 
     List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
     assertEquals(availableNamespaces.size(), 1);
@@ -215,7 +275,16 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "che", false, true, clientFactory, userManager, pool);
+            "predefined",
+            "",
+            "",
+            "che",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
     throwOnTryToGetNamespaceByName("che", new KubernetesClientException("connection refused"));
 
     namespaceFactory.list();
@@ -230,7 +299,16 @@ public class KubernetesNamespaceFactoryTest {
 
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "default", true, true, clientFactory, userManager, pool);
+            "predefined",
+            "",
+            "",
+            "default",
+            true,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
 
     List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
 
@@ -254,7 +332,16 @@ public class KubernetesNamespaceFactoryTest {
 
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "default", true, true, clientFactory, userManager, pool);
+            "predefined",
+            "",
+            "",
+            "default",
+            true,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
 
     List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
     assertEquals(availableNamespaces.size(), 2);
@@ -279,7 +366,16 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "default_ns", true, true, clientFactory, userManager, pool);
+            "predefined",
+            "",
+            "",
+            "default_ns",
+            true,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
     throwOnTryToGetNamespacesList(new KubernetesClientException("connection refused"));
 
     namespaceFactory.list();
@@ -306,6 +402,7 @@ public class KubernetesNamespaceFactoryTest {
                 true,
                 clientFactory,
                 userManager,
+                preferenceManager,
                 pool));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
@@ -336,6 +433,7 @@ public class KubernetesNamespaceFactoryTest {
                 true,
                 clientFactory,
                 userManager,
+                preferenceManager,
                 pool));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
@@ -370,6 +468,7 @@ public class KubernetesNamespaceFactoryTest {
                 true,
                 clientFactory,
                 userManager,
+                preferenceManager,
                 pool));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
@@ -435,6 +534,7 @@ public class KubernetesNamespaceFactoryTest {
                 true,
                 clientFactory,
                 userManager,
+                preferenceManager,
                 pool));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
@@ -488,6 +588,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             clientFactory,
             userManager,
+            preferenceManager,
             pool);
     assertTrue(namespaceFactory.getClusterRoleNames().isEmpty());
   }
@@ -504,6 +605,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             clientFactory,
             userManager,
+            preferenceManager,
             pool);
     Set<String> expected = Sets.newHashSet("one", "two", "three", "five");
     assertTrue(namespaceFactory.getClusterRoleNames().containsAll(expected));
@@ -524,6 +626,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             clientFactory,
             userManager,
+            preferenceManager,
             pool);
 
     when(namespaceResource.get()).thenReturn(null);
@@ -532,6 +635,31 @@ public class KubernetesNamespaceFactoryTest {
         new WorkspaceImplBuilder().setId("workspace123").setAttributes(emptyMap()).build();
     EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
     String namespace = namespaceFactory.getNamespaceName(workspace);
+
+    assertEquals(namespace, "che-123");
+  }
+
+  @Test
+  public void testEvalNamespaceUsesNamespaceFromUserPreferencesIfExist() throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "",
+            "che-<userid>",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    when(preferenceManager.find(anyString()))
+        .thenReturn(
+            Collections.singletonMap(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123"));
+    String namespace =
+        namespaceFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jodoe"));
 
     assertEquals(namespace, "che-123");
   }
@@ -550,6 +678,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             clientFactory,
             userManager,
+            preferenceManager,
             pool);
 
     WorkspaceImpl workspace = new WorkspaceImplBuilder().build();
@@ -574,6 +703,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             clientFactory,
             userManager,
+            preferenceManager,
             pool);
 
     WorkspaceImpl workspace =
@@ -600,6 +730,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             clientFactory,
             userManager,
+            preferenceManager,
             pool);
 
     WorkspaceImpl workspace =

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -124,7 +124,7 @@ public class KubernetesNamespaceFactoryTest {
       throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "legacy", "", "", "defaultNs", false, clientFactory, userManager, pool);
+            "legacy", "", "", "defaultNs", false, true, clientFactory, userManager, pool);
 
     namespaceFactory.checkIfNamespaceIsAllowed("defaultNs");
   }
@@ -135,7 +135,7 @@ public class KubernetesNamespaceFactoryTest {
           throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "legacy", "", "", "defaultNs", true, clientFactory, userManager, pool);
+            "legacy", "", "", "defaultNs", true, true, clientFactory, userManager, pool);
 
     namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
   }
@@ -149,7 +149,7 @@ public class KubernetesNamespaceFactoryTest {
           throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "legacy", "", "", "defaultNs", false, clientFactory, userManager, pool);
+            "legacy", "", "", "defaultNs", false, true, clientFactory, userManager, pool);
 
     namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
   }
@@ -160,7 +160,7 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", null, false, clientFactory, userManager, pool);
+            "predefined", "", "", null, false, true, clientFactory, userManager, pool);
   }
 
   @Test
@@ -178,7 +178,7 @@ public class KubernetesNamespaceFactoryTest {
             .build());
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "che-default", false, clientFactory, userManager, pool);
+            "predefined", "", "", "che-default", false, true, clientFactory, userManager, pool);
 
     List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
     assertEquals(availableNamespaces.size(), 1);
@@ -195,7 +195,7 @@ public class KubernetesNamespaceFactoryTest {
 
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "che-default", false, clientFactory, userManager, pool);
+            "predefined", "", "", "che-default", false, true, clientFactory, userManager, pool);
 
     List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
     assertEquals(availableNamespaces.size(), 1);
@@ -215,7 +215,7 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "che", false, clientFactory, userManager, pool);
+            "predefined", "", "", "che", false, true, clientFactory, userManager, pool);
     throwOnTryToGetNamespaceByName("che", new KubernetesClientException("connection refused"));
 
     namespaceFactory.list();
@@ -230,7 +230,7 @@ public class KubernetesNamespaceFactoryTest {
 
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "default", true, clientFactory, userManager, pool);
+            "predefined", "", "", "default", true, true, clientFactory, userManager, pool);
 
     List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
 
@@ -254,7 +254,7 @@ public class KubernetesNamespaceFactoryTest {
 
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "default", true, clientFactory, userManager, pool);
+            "predefined", "", "", "default", true, true, clientFactory, userManager, pool);
 
     List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
     assertEquals(availableNamespaces.size(), 2);
@@ -279,7 +279,7 @@ public class KubernetesNamespaceFactoryTest {
   public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
     namespaceFactory =
         new KubernetesNamespaceFactory(
-            "predefined", "", "", "default_ns", true, clientFactory, userManager, pool);
+            "predefined", "", "", "default_ns", true, true, clientFactory, userManager, pool);
     throwOnTryToGetNamespacesList(new KubernetesClientException("connection refused"));
 
     namespaceFactory.list();
@@ -298,7 +298,15 @@ public class KubernetesNamespaceFactoryTest {
     namespaceFactory =
         spy(
             new KubernetesNamespaceFactory(
-                "predefined", "", "", "new-default", false, clientFactory, userManager, pool));
+                "predefined",
+                "",
+                "",
+                "new-default",
+                false,
+                true,
+                clientFactory,
+                userManager,
+                pool));
     KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
     doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
 
@@ -325,6 +333,7 @@ public class KubernetesNamespaceFactoryTest {
                 "",
                 "<workspaceid>",
                 false,
+                true,
                 clientFactory,
                 userManager,
                 pool));
@@ -358,6 +367,7 @@ public class KubernetesNamespaceFactoryTest {
                 "cr2, cr3",
                 "<workspaceid>",
                 false,
+                true,
                 clientFactory,
                 userManager,
                 pool));
@@ -422,6 +432,7 @@ public class KubernetesNamespaceFactoryTest {
                 "",
                 "<workspaceid>",
                 false,
+                true,
                 clientFactory,
                 userManager,
                 pool));
@@ -474,6 +485,7 @@ public class KubernetesNamespaceFactoryTest {
             null,
             "che-<userid>",
             false,
+            true,
             clientFactory,
             userManager,
             pool);
@@ -489,6 +501,7 @@ public class KubernetesNamespaceFactoryTest {
             "  one,two, three ,,five  ",
             "che-<userid>",
             false,
+            true,
             clientFactory,
             userManager,
             pool);
@@ -508,6 +521,7 @@ public class KubernetesNamespaceFactoryTest {
             "",
             "che-<userid>",
             false,
+            true,
             clientFactory,
             userManager,
             pool);
@@ -533,6 +547,7 @@ public class KubernetesNamespaceFactoryTest {
             "",
             "che-<userid>",
             false,
+            true,
             clientFactory,
             userManager,
             pool);
@@ -556,6 +571,7 @@ public class KubernetesNamespaceFactoryTest {
             "",
             "che-<userid>",
             false,
+            true,
             clientFactory,
             userManager,
             pool);
@@ -581,6 +597,7 @@ public class KubernetesNamespaceFactoryTest {
             "",
             "che-<userid>",
             false,
+            true,
             clientFactory,
             userManager,
             pool);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -16,7 +16,7 @@ import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_CHECKSUM_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -53,8 +53,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.zip.CRC32;
-import java.util.zip.Checksum;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.user.server.PreferenceManager;
@@ -688,12 +686,9 @@ public class KubernetesNamespaceFactoryTest {
             preferenceManager,
             pool);
 
-    Checksum checksum = new CRC32();
-    checksum.update("che-<userid>".getBytes());
-
     Map<String, String> prefs = new HashMap<>();
     prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-    prefs.put(NAMESPACE_TEMPLATE_CHECKSUM_ATTRIBUTE, Long.toString(checksum.getValue()));
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
 
     when(preferenceManager.find(anyString())).thenReturn(prefs);
     String namespace =
@@ -719,14 +714,10 @@ public class KubernetesNamespaceFactoryTest {
             preferenceManager,
             pool);
 
-    Checksum checksum = new CRC32();
-    // didn't match current template
-    checksum.update("che-<userid>".getBytes());
-
     Map<String, String> prefs = new HashMap<>();
     // returned but ignored
     prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-    prefs.put(NAMESPACE_TEMPLATE_CHECKSUM_ATTRIBUTE, Long.toString(checksum.getValue()));
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
 
     when(preferenceManager.find(anyString())).thenReturn(prefs);
     String namespace =
@@ -752,14 +743,10 @@ public class KubernetesNamespaceFactoryTest {
             preferenceManager,
             pool);
 
-    Checksum checksum = new CRC32();
-    // didn't match current template
-    checksum.update("che-<workspaceid>-<username>".getBytes());
-
     Map<String, String> prefs = new HashMap<>();
     // returned but ignored
     prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-    prefs.put(NAMESPACE_TEMPLATE_CHECKSUM_ATTRIBUTE, Long.toString(checksum.getValue()));
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<workspaceid>-<username>");
 
     String namespace =
         namespaceFactory.evaluateNamespaceName(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
@@ -14,8 +14,9 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.INVALID;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.NULL_OR_EMPTY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.TOO_LONG;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.reduceToValid;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.validateInternal;
-import static org.testng.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -42,6 +43,15 @@ public class NamespaceNameValidatorTest {
   @Test(dataProvider = "invalidDnsNames")
   public void testFailsOnInvalidChars(String invalidName) {
     assertEquals(INVALID, validateInternal(invalidName));
+  }
+
+  @Test
+  public void reduceToValidTest() {
+    assertEquals("fef123-ahzz", reduceToValid("_fef_123-ah_*zz**"));
+    assertEquals(
+        63,
+        reduceToValid("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
+            .length());
   }
 
   @DataProvider

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
@@ -65,6 +65,7 @@ public class NamespaceNameValidatorTest {
       new Object[] {"_fef_123-ah_*zz**", "fef-123-ah-zz"},
       new Object[] {"a-b#-hello", "a-b-hello"},
       new Object[] {"a---------b", "a-b"},
+      new Object[] {"--ab--", "ab"}
     };
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
@@ -16,7 +16,7 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.Name
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.TOO_LONG;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.normalize;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.validateInternal;
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -25,35 +25,47 @@ public class NamespaceNameValidatorTest {
 
   @Test
   public void testFailsOnNull() {
-    assertEquals(NULL_OR_EMPTY, validateInternal(null));
+    assertEquals(validateInternal(null), NULL_OR_EMPTY);
   }
 
   @Test
   public void testFailsOnEmpty() {
-    assertEquals(NULL_OR_EMPTY, validateInternal(""));
+    assertEquals(validateInternal(""), NULL_OR_EMPTY);
   }
 
   @Test
   public void testFailsOnTooLong() {
     assertEquals(
-        TOO_LONG,
-        validateInternal("0123456789012345678901234567890123456789012345678901234567890123"));
+        validateInternal("0123456789012345678901234567890123456789012345678901234567890123"),
+        TOO_LONG);
   }
 
   @Test(dataProvider = "invalidDnsNames")
   public void testFailsOnInvalidChars(String invalidName) {
-    assertEquals(INVALID, validateInternal(invalidName));
+    assertEquals(validateInternal(invalidName), INVALID);
+  }
+
+  @Test(dataProvider = "invalidUsernames")
+  public void normalizeTest(String raw, String expected) {
+    assertEquals(expected, normalize(raw));
   }
 
   @Test
-  public void normalizeTest() {
-    assertEquals("gmail-foo-bar", normalize("gmail@foo.bar"));
-    assertEquals("fef-123-ah-zz", normalize("_fef_123-ah_*zz**"));
-    assertEquals("a-b-hello", normalize("a-b#-hello"));
+  public void normalizeLengthTest() {
     assertEquals(
         63,
         normalize("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
             .length());
+  }
+
+  @DataProvider
+  public static Object[][] invalidUsernames() {
+    return new Object[][] {
+      new Object[] {"gmail@foo.bar", "gmail-foo-bar"},
+      new Object[] {"_fef_123-ah_*zz**", "fef-123-ah-zz"},
+      new Object[] {"a-b#-hello", "a-b-hello"},
+      new Object[] {"a---------b", "a-b"},
+    };
   }
 
   @DataProvider

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
@@ -14,7 +14,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.INVALID;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.NULL_OR_EMPTY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.TOO_LONG;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.normalize;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.validateInternal;
 import static org.testng.Assert.assertEquals;
 
@@ -43,30 +42,6 @@ public class NamespaceNameValidatorTest {
   @Test(dataProvider = "invalidDnsNames")
   public void testFailsOnInvalidChars(String invalidName) {
     assertEquals(validateInternal(invalidName), INVALID);
-  }
-
-  @Test(dataProvider = "invalidUsernames")
-  public void normalizeTest(String raw, String expected) {
-    assertEquals(expected, normalize(raw));
-  }
-
-  @Test
-  public void normalizeLengthTest() {
-    assertEquals(
-        63,
-        normalize("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
-            .length());
-  }
-
-  @DataProvider
-  public static Object[][] invalidUsernames() {
-    return new Object[][] {
-      new Object[] {"gmail@foo.bar", "gmail-foo-bar"},
-      new Object[] {"_fef_123-ah_*zz**", "fef-123-ah-zz"},
-      new Object[] {"a-b#-hello", "a-b-hello"},
-      new Object[] {"a---------b", "a-b"},
-      new Object[] {"--ab--", "ab"}
-    };
   }
 
   @DataProvider

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/NamespaceNameValidatorTest.java
@@ -14,7 +14,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.INVALID;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.NULL_OR_EMPTY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.ValidationResult.TOO_LONG;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.reduceToValid;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.normalize;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.NamespaceNameValidator.validateInternal;
 import static org.junit.Assert.assertEquals;
 
@@ -46,11 +46,13 @@ public class NamespaceNameValidatorTest {
   }
 
   @Test
-  public void reduceToValidTest() {
-    assertEquals("fef123-ahzz", reduceToValid("_fef_123-ah_*zz**"));
+  public void normalizeTest() {
+    assertEquals("gmail-foo-bar", normalize("gmail@foo.bar"));
+    assertEquals("fef-123-ah-zz", normalize("_fef_123-ah_*zz**"));
+    assertEquals("a-b-hello", normalize("a-b#-hello"));
     assertEquals(
         63,
-        reduceToValid("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
+        normalize("looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
             .length());
   }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -71,7 +71,6 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
       OpenShiftClientConfigFactory clientConfigFactory,
       OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner,
       UserManager userManager,
-
       PreferenceManager preferenceManager,
       KubernetesSharedPool sharedPool,
       @Nullable @Named("che.infra.openshift.oauth_identity_provider")

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.Workspace;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.user.server.PreferenceManager;
 import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
@@ -65,10 +66,13 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
       @Nullable @Named("che.infra.kubernetes.namespace.default") String defaultNamespaceName,
       @Named("che.infra.kubernetes.namespace.allow_user_defined")
           boolean allowUserDefinedNamespaces,
+      @Named("che.infra.kubernetes.namespace.creation_allowed") boolean namespaceCreationAllowed,
       OpenShiftClientFactory clientFactory,
       OpenShiftClientConfigFactory clientConfigFactory,
       OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner,
       UserManager userManager,
+
+      PreferenceManager preferenceManager,
       KubernetesSharedPool sharedPool,
       @Nullable @Named("che.infra.openshift.oauth_identity_provider")
           String oAuthIdentityProvider) {
@@ -78,8 +82,10 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
         clusterRoleNames,
         defaultNamespaceName,
         allowUserDefinedNamespaces,
+        namespaceCreationAllowed,
         clientFactory,
         userManager,
+        preferenceManager,
         sharedPool);
     if (allowUserDefinedNamespaces && !clientConfigFactory.isPersonalized()) {
       LOG.warn(

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.user.server.PreferenceManager;
 import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.api.user.server.model.impl.UserImpl;
 import org.eclipse.che.api.workspace.server.WorkspaceManager;
@@ -83,6 +84,7 @@ public class OpenShiftProjectFactoryTest {
   @Mock private OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner;
   @Mock private WorkspaceManager workspaceManager;
   @Mock private UserManager userManager;
+  @Mock private PreferenceManager preferenceManager;
   @Mock private KubernetesSharedPool pool;
 
   @Mock
@@ -123,10 +125,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "defaultNs",
             false,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
@@ -144,10 +148,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "defaultNs",
             true,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
@@ -168,11 +174,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "defaultNs",
             false,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
-            pool,
+            preferenceManager, pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
     projectFactory.checkIfNamespaceIsAllowed("any-namespace");
@@ -191,10 +198,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             null,
             false,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
   }
@@ -225,10 +234,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "che-default",
             false,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
@@ -258,10 +269,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "che-default",
             false,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
@@ -291,10 +304,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "che-default",
             false,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
@@ -316,10 +331,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "default",
             true,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
@@ -357,10 +374,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "default",
             true,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
@@ -393,10 +412,12 @@ public class OpenShiftProjectFactoryTest {
             null,
             "default-ns",
             true,
+            true,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
+            preferenceManager,
             pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
@@ -421,10 +442,12 @@ public class OpenShiftProjectFactoryTest {
                 null,
                 "new-default",
                 false,
+                true,
                 clientFactory,
                 configFactory,
                 stopWorkspaceRoleProvisioner,
                 userManager,
+                preferenceManager,
                 pool,
                 NO_OAUTH_IDENTITY_PROVIDER));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
@@ -453,10 +476,12 @@ public class OpenShiftProjectFactoryTest {
                 null,
                 "<workspaceid>",
                 false,
+                true,
                 clientFactory,
                 configFactory,
                 stopWorkspaceRoleProvisioner,
                 userManager,
+                preferenceManager,
                 pool,
                 NO_OAUTH_IDENTITY_PROVIDER));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
@@ -487,10 +512,12 @@ public class OpenShiftProjectFactoryTest {
                 null,
                 "<workspaceid>",
                 false,
+                true,
                 clientFactory,
                 configFactory,
                 stopWorkspaceRoleProvisioner,
                 userManager,
+                preferenceManager,
                 pool,
                 OAUTH_IDENTITY_PROVIDER));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
@@ -523,10 +550,12 @@ public class OpenShiftProjectFactoryTest {
                 null,
                 "<workspaceid>",
                 false,
+                true,
                 clientFactory,
                 configFactory,
                 stopWorkspaceRoleProvisioner,
                 userManager,
+                preferenceManager,
                 pool,
                 NO_OAUTH_IDENTITY_PROVIDER));
     OpenShiftProject toReturnProject = mock(OpenShiftProject.class);

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -179,7 +179,8 @@ public class OpenShiftProjectFactoryTest {
             configFactory,
             stopWorkspaceRoleProvisioner,
             userManager,
-            preferenceManager, pool,
+            preferenceManager,
+            pool,
             NO_OAUTH_IDENTITY_PROVIDER);
 
     projectFactory.checkIfNamespaceIsAllowed("any-namespace");

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -456,17 +456,6 @@ public class WorkspaceManager {
     }
   }
 
-  private void recordEvaluatedNamespaceName(String namespace) {
-    try {
-      String owner = EnvironmentContext.getCurrent().getSubject().getUserId();
-      Map<String, String> preferences = preferenceManager.find(owner);
-      preferences.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, namespace);
-      preferenceManager.update(owner, preferences);
-    } catch (ServerException e) {
-      LOG.error(e.getMessage(), e);
-    }
-  }
-
   private void cleanLastWorkspaceStoppedTime(String owner) {
     try {
       preferenceManager.remove(
@@ -525,7 +514,6 @@ public class WorkspaceManager {
         workspace
             .getAttributes()
             .put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, targetNamespace);
-        recordEvaluatedNamespaceName(targetNamespace);
       } catch (InfrastructureException e) {
         throw new ServerException(e);
       }
@@ -551,7 +539,7 @@ public class WorkspaceManager {
   private NamespaceResolutionContext buildResolutionContext(WorkspaceImpl workspace) {
     Subject currentSubject = EnvironmentContext.getCurrent().getSubject();
     return new NamespaceResolutionContext(
-        workspace.getId(), currentSubject.getUserId(), currentSubject.getUserName());
+        workspace.getId(), currentSubject.getUserId(), currentSubject.getUserName(), true);
   }
 
   /** Returns first non-null argument or null if both are null. */
@@ -686,7 +674,6 @@ public class WorkspaceManager {
         workspace
             .getAttributes()
             .put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, targetNamespace);
-        recordEvaluatedNamespaceName(targetNamespace);
       } catch (InfrastructureException e) {
         throw new ServerException(e);
       }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -456,6 +456,17 @@ public class WorkspaceManager {
     }
   }
 
+  private void recordEvaluatedNamespaceName(String namespace) {
+    try {
+      String owner = EnvironmentContext.getCurrent().getSubject().getUserId();
+      Map<String, String> preferences = preferenceManager.find(owner);
+      preferences.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, namespace);
+      preferenceManager.update(owner, preferences);
+    } catch (ServerException e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
   private void cleanLastWorkspaceStoppedTime(String owner) {
     try {
       preferenceManager.remove(
@@ -514,6 +525,7 @@ public class WorkspaceManager {
         workspace
             .getAttributes()
             .put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, targetNamespace);
+        recordEvaluatedNamespaceName(targetNamespace);
       } catch (InfrastructureException e) {
         throw new ServerException(e);
       }
@@ -674,6 +686,7 @@ public class WorkspaceManager {
         workspace
             .getAttributes()
             .put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, targetNamespace);
+        recordEvaluatedNamespaceName(targetNamespace);
       } catch (InfrastructureException e) {
         throw new ServerException(e);
       }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/NamespaceResolutionContext.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/NamespaceResolutionContext.java
@@ -14,9 +14,10 @@ package org.eclipse.che.api.workspace.server.spi;
 import java.util.Objects;
 
 /**
- * Holds information needed for resolving placeholders in the namespace name.
- * The {@code persistAfterCreate} attribute indicates whether namespace name should be persisted after
+ * Holds information needed for resolving placeholders in the namespace name. The {@code
+ * persistAfterCreate} attribute indicates whether namespace name should be persisted after
  * resolution (if the infrastructure supports it).
+ *
  * @author Lukas Krejci
  * @author Sergii Leshchenko
  */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/NamespaceResolutionContext.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/NamespaceResolutionContext.java
@@ -15,7 +15,8 @@ import java.util.Objects;
 
 /**
  * Holds information needed for resolving placeholders in the namespace name.
- *
+ * The {@code persistAfterCreate} attribute indicates whether namespace name should be persisted after
+ * resolution (if the infrastructure supports it).
  * @author Lukas Krejci
  * @author Sergii Leshchenko
  */
@@ -23,7 +24,6 @@ public class NamespaceResolutionContext {
   private final String workspaceId;
   private final String userId;
   private final String userName;
-
   private final boolean persistAfterCreate;
 
   public NamespaceResolutionContext(String workspaceId, String userId, String userName) {

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/NamespaceResolutionContext.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/NamespaceResolutionContext.java
@@ -24,10 +24,18 @@ public class NamespaceResolutionContext {
   private final String userId;
   private final String userName;
 
+  private final boolean persistAfterCreate;
+
   public NamespaceResolutionContext(String workspaceId, String userId, String userName) {
+    this(workspaceId, userId, userName, false);
+  }
+
+  public NamespaceResolutionContext(
+      String workspaceId, String userId, String userName, boolean persistAfterCreate) {
     this.workspaceId = workspaceId;
     this.userId = userId;
     this.userName = userName;
+    this.persistAfterCreate = persistAfterCreate;
   }
 
   public String getWorkspaceId() {
@@ -42,6 +50,10 @@ public class NamespaceResolutionContext {
     return userName;
   }
 
+  public boolean isPersistAfterCreate() {
+    return persistAfterCreate;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -53,12 +65,13 @@ public class NamespaceResolutionContext {
     final NamespaceResolutionContext that = (NamespaceResolutionContext) obj;
     return Objects.equals(workspaceId, that.workspaceId)
         && Objects.equals(userId, that.userId)
-        && Objects.equals(userName, that.userName);
+        && Objects.equals(userName, that.userName)
+        && Objects.equals(persistAfterCreate, that.persistAfterCreate);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(workspaceId, userId, userName);
+    return Objects.hash(workspaceId, userId, userName, persistAfterCreate);
   }
 
   @Override
@@ -72,6 +85,9 @@ public class NamespaceResolutionContext {
         + '\''
         + ", userName='"
         + userName
+        + '\''
+        + ", persistAfterCreate='"
+        + persistAfterCreate
         + '\''
         + '}';
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -241,7 +241,7 @@ public class WorkspaceManagerTest {
     verify(workspaceDao).create(workspace);
     verify(runtimes)
         .evalInfrastructureNamespace(
-            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1));
+            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1, true));
   }
 
   @Test
@@ -260,21 +260,6 @@ public class WorkspaceManagerTest {
         "user-defined");
     verify(workspaceDao).create(workspace);
     verify(runtimes, never()).evalInfrastructureNamespace(any());
-  }
-
-  @Test
-  @SuppressWarnings("unchecked") // for captor
-  public void updatesPreferencesWithInfraNamespaceOnWorkspaceCreation() throws Exception {
-    final WorkspaceConfig cfg = createConfig();
-    ArgumentCaptor<Map<String, String>> prefsCaptor = ArgumentCaptor.forClass(Map.class);
-    when(runtimes.evalInfrastructureNamespace(any(NamespaceResolutionContext.class)))
-        .thenReturn("user-defined");
-
-    workspaceManager.createWorkspace(cfg, NAMESPACE_1, emptyMap());
-
-    verify(preferenceManager).update(anyString(), prefsCaptor.capture());
-    assertEquals(
-        prefsCaptor.getValue().get(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE), "user-defined");
   }
 
   @Test
@@ -641,7 +626,7 @@ public class WorkspaceManagerTest {
         "evaluated-legacy");
     verify(runtimes)
         .evalLegacyInfrastructureNamespace(
-            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1));
+            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1, true));
   }
 
   @Test
@@ -683,7 +668,7 @@ public class WorkspaceManagerTest {
         "evaluated-legal");
     verify(runtimes)
         .evalInfrastructureNamespace(
-            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1));
+            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1, true));
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -263,6 +263,21 @@ public class WorkspaceManagerTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked") // for captor
+  public void updatesPreferencesWithInfraNamespaceOnWorkspaceCreation() throws Exception {
+    final WorkspaceConfig cfg = createConfig();
+    ArgumentCaptor<Map<String, String>> prefsCaptor = ArgumentCaptor.forClass(Map.class);
+    when(runtimes.evalInfrastructureNamespace(any(NamespaceResolutionContext.class)))
+        .thenReturn("user-defined");
+
+    workspaceManager.createWorkspace(cfg, NAMESPACE_1, emptyMap());
+
+    verify(preferenceManager).update(anyString(), prefsCaptor.capture());
+    assertEquals(
+        prefsCaptor.getValue().get(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE), "user-defined");
+  }
+
+  @Test
   public void nameIsUsedWhenNameAndGenerateNameSet()
       throws ValidationException, ConflictException, NotFoundException, ServerException,
           InfrastructureException {


### PR DESCRIPTION
### What does this PR do?

Sometimes users may have names incompartible with K8S objects naming (simplest example is using email as a username),
so in that case user-defined namespace creation with names generated using templates like `abc-<username>` will fail. 

This PR adds checks for symbols and length validity, sanitizes username if required, and stores it into user preferences for further usage.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/17841

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Configure Che to use `<username>` placeholder namespace template. Register user with name containing symbol(s) not allowed in kubernetes names. Log in with that user and start workspace. Namespace with sanitized name should be created.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
