### PR TITLE
SingleHost devfile endpoints on subdomains

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -256,7 +256,11 @@ che.infra.kubernetes.server_strategy=multi-host
 # - 'native': Exposes servers using k8s Ingresses. Works only on Kubernetes.
 # - 'gateway': Exposes servers using reverse-proxy gateway.
 che.infra.kubernetes.singlehost.workspace.exposure=native
-che.infra.kubernetes.singlehost.workspace.force_subdomain_devfile_endpoints=true
+
+# Expose devfile public endpoints on subdomans using dedicated Ingress/Route with single-host server_strategy.
+# 'true' - expose on subdomains
+# 'false' - expose on subpaths
+che.infra.kubernetes.singlehost.workspace.expose_devfile_endpoints_on_subdomains=false
 
 # Defines labels which will be set to ConfigMaps configuring single-host gateway.
 che.infra.kubernetes.singlehost.gateway.configmap_labels=app=che,component=che-gateway-config

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -256,6 +256,7 @@ che.infra.kubernetes.server_strategy=multi-host
 # - 'native': Exposes servers using k8s Ingresses. Works only on Kubernetes.
 # - 'gateway': Exposes servers using reverse-proxy gateway.
 che.infra.kubernetes.singlehost.workspace.exposure=native
+che.infra.kubernetes.singlehost.workspace.force_subdomain_devfile_endpoints=true
 
 # Defines labels which will be set to ConfigMaps configuring single-host gateway.
 che.infra.kubernetes.singlehost.gateway.configmap_labels=app=che,component=che-gateway-config

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -261,7 +261,7 @@ che.infra.kubernetes.singlehost.workspace.exposure=native
 # They can either follow the single-host strategy and be exposed on subpaths, or they can be exposed on subdomains.
 # - 'multi-host': expose on subdomains
 # - 'single-host': expose on subpaths
-che.infra.kubernetes.singlehost.workspace.devfile_endpoint_exposure=single-host
+che.infra.kubernetes.singlehost.workspace.devfile_endpoint_exposure=multi-host
 
 # Defines labels which will be set to ConfigMaps configuring single-host gateway.
 che.infra.kubernetes.singlehost.gateway.configmap_labels=app=che,component=che-gateway-config

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -257,10 +257,11 @@ che.infra.kubernetes.server_strategy=multi-host
 # - 'gateway': Exposes servers using reverse-proxy gateway.
 che.infra.kubernetes.singlehost.workspace.exposure=native
 
-# Expose devfile public endpoints on subdomans using dedicated Ingress/Route with single-host server_strategy.
-# 'true' - expose on subdomains
-# 'false' - expose on subpaths
-che.infra.kubernetes.singlehost.workspace.expose_devfile_endpoints_on_subdomains=false
+# Defines the way how to expose devfile endpoints, thus end-user's applications, in single-host server strategy.
+# They can either follow the single-host strategy and be exposed on subpaths, or they can be exposed on subdomains.
+# - 'multi-host': expose on subdomains
+# - 'single-host': expose on subpaths
+che.infra.kubernetes.singlehost.workspace.devfile_endpoint_exposure=single-host
 
 # Defines labels which will be set to ConfigMaps configuring single-host gateway.
 che.infra.kubernetes.singlehost.gateway.configmap_labels=app=che,component=che-gateway-config

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -91,6 +91,8 @@ public interface ServerConfig {
    */
   String SERVICE_PORT_ATTRIBUTE = "servicePort";
 
+  String DEVFILE_ENDPOINT = "devfileEndpoint";
+
   /**
    * Port used by server.
    *

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -91,6 +91,7 @@ public interface ServerConfig {
    */
   String SERVICE_PORT_ATTRIBUTE = "servicePort";
 
+  // TODO: javadoc
   String DEVFILE_ENDPOINT = "devfileEndpoint";
 
   /**

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -91,7 +91,9 @@ public interface ServerConfig {
    */
   String SERVICE_PORT_ATTRIBUTE = "servicePort";
 
-  // TODO: javadoc
+  /**
+   * This attributes is marking that server come from the devfile endpoint. Used internally only.
+   */
   String DEVFILE_ENDPOINT = "devfileEndpoint";
 
   /**

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -64,7 +64,7 @@ data:
   CHE_INFRA_KUBERNETES_POD_SECURITY__CONTEXT_FS__GROUP: "{{ .Values.global.securityContext.fsGroup }}"
   CHE_LOCAL_CONF_DIR: /etc/conf
   CHE_LOGS_DIR: /data/logs
-  CHE_LOG_LEVEL: "INFO"
+  CHE_LOG_LEVEL: {{ .Values.che.logLevel | quote }}
   CHE_MULTIUSER: {{ .Values.global.multiuser | quote }}
   CHE_OAUTH_GITHUB_CLIENTID: {{ .Values.global.gitHubClientID | quote}}
   CHE_OAUTH_GITHUB_CLIENTSECRET: {{ .Values.global.gitHubClientSecret | quote}}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -108,6 +108,7 @@ che:
 #      waitTimeoutMin: "3"
 #    pluginRegistryUrl: "https://che-plugin-registry.openshift.io/v3"
   disableProbes: false
+  logLevel: "INFO"
 
 cheDevfileRegistry:
   deploy: true

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -166,7 +166,9 @@ public class KubernetesInfraModule extends AbstractModule {
                 binder(),
                 new TypeLiteral<WorkspaceExposureType>() {},
                 new TypeLiteral<ExternalServerExposer<KubernetesEnvironment>>() {});
-    exposureStrategies.addBinding(WorkspaceExposureType.NATIVE).to(IngressServerExposer.class);
+    exposureStrategies
+        .addBinding(WorkspaceExposureType.NATIVE)
+        .to(new TypeLiteral<IngressServerExposer<KubernetesEnvironment>>() {});
     exposureStrategies
         .addBinding(WorkspaceExposureType.GATEWAY)
         .to(new TypeLiteral<GatewayServerExposer<KubernetesEnvironment>>() {});

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -75,6 +75,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.Gatew
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.IngressServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.KubernetesExternalServerExposerProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultihostIngressServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposer;
@@ -171,6 +172,10 @@ public class KubernetesInfraModule extends AbstractModule {
     exposureStrategies
         .addBinding(WorkspaceExposureType.GATEWAY)
         .to(new TypeLiteral<GatewayServerExposer<KubernetesEnvironment>>() {});
+
+    bind(new TypeLiteral<ExternalServerExposer<KubernetesEnvironment>>() {})
+        .annotatedWith(com.google.inject.name.Names.named("multihost-exposer"))
+        .to(new TypeLiteral<MultihostIngressServerExposer<KubernetesEnvironment>>() {});
 
     bind(new TypeLiteral<ExternalServerExposerProvider<KubernetesEnvironment>>() {})
         .to(new TypeLiteral<KubernetesExternalServerExposerProvider<KubernetesEnvironment>>() {});

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -69,9 +69,11 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.PreviewUrlExpo
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.DefaultHostExternalServiceExposureStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServiceExposureStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.GatewayServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.IngressServerExposer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.KubernetesExternalServerExposerProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy;
@@ -162,16 +164,15 @@ public class KubernetesInfraModule extends AbstractModule {
 
     MapBinder<WorkspaceExposureType, ExternalServerExposer<KubernetesEnvironment>>
         exposureStrategies =
-            MapBinder.newMapBinder(
-                binder(),
-                new TypeLiteral<WorkspaceExposureType>() {},
-                new TypeLiteral<ExternalServerExposer<KubernetesEnvironment>>() {});
+            MapBinder.newMapBinder(binder(), new TypeLiteral<>() {}, new TypeLiteral<>() {});
     exposureStrategies
         .addBinding(WorkspaceExposureType.NATIVE)
         .to(new TypeLiteral<IngressServerExposer<KubernetesEnvironment>>() {});
     exposureStrategies
         .addBinding(WorkspaceExposureType.GATEWAY)
         .to(new TypeLiteral<GatewayServerExposer<KubernetesEnvironment>>() {});
+
+    bind(ExternalServerExposerProvider.class).to(KubernetesExternalServerExposerProvider.class);
 
     bind(ServersConverter.class).to(new TypeLiteral<ServersConverter<KubernetesEnvironment>>() {});
     bind(PreviewUrlExposer.class)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -172,7 +172,8 @@ public class KubernetesInfraModule extends AbstractModule {
         .addBinding(WorkspaceExposureType.GATEWAY)
         .to(new TypeLiteral<GatewayServerExposer<KubernetesEnvironment>>() {});
 
-    bind(ExternalServerExposerProvider.class).to(KubernetesExternalServerExposerProvider.class);
+    bind(new TypeLiteral<ExternalServerExposerProvider<KubernetesEnvironment>>() {})
+        .to(new TypeLiteral<KubernetesExternalServerExposerProvider<KubernetesEnvironment>>() {});
 
     bind(ServersConverter.class).to(new TypeLiteral<ServersConverter<KubernetesEnvironment>>() {});
     bind(PreviewUrlExposer.class)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
@@ -141,8 +141,8 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
                 .getEndpoints()
                 .stream()
                 .collect(
-                    Collectors.toMap(Endpoint::getName,
-                        e -> ServerConfigImpl.createFromEndpoint(e, true))));
+                    Collectors.toMap(
+                        Endpoint::getName, e -> ServerConfigImpl.createFromEndpoint(e, true))));
 
     dockerimageComponent
         .getVolumes()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
@@ -142,7 +142,8 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
                 .stream()
                 .collect(
                     Collectors.toMap(
-                        Endpoint::getName, e -> ServerConfigImpl.createFromEndpoint(e, true))));
+                        Endpoint::getName,
+                        e -> ServerConfigImpl.createFromEndpoint(e, true)))); // TODO: test
 
     dockerimageComponent
         .getVolumes()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
@@ -141,7 +141,8 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
                 .getEndpoints()
                 .stream()
                 .collect(
-                    Collectors.toMap(Endpoint::getName, ServerConfigImpl::createFromEndpoint)));
+                    Collectors.toMap(Endpoint::getName,
+                        e -> ServerConfigImpl.createFromEndpoint(e, true))));
 
     dockerimageComponent
         .getVolumes()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
@@ -142,8 +142,7 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
                 .stream()
                 .collect(
                     Collectors.toMap(
-                        Endpoint::getName,
-                        e -> ServerConfigImpl.createFromEndpoint(e, true)))); // TODO: test
+                        Endpoint::getName, e -> ServerConfigImpl.createFromEndpoint(e, true))));
 
     dockerimageComponent
         .getVolumes()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
@@ -264,7 +264,8 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
                 .getEndpoints()
                 .stream()
                 .collect(
-                    Collectors.toMap(Endpoint::getName, e -> ServerConfigImpl.createFromEndpoint(e, true))));
+                    Collectors.toMap(
+                        Endpoint::getName, e -> ServerConfigImpl.createFromEndpoint(e, true))));
   }
 
   private void provisionVolumes(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
@@ -265,8 +265,7 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
                 .stream()
                 .collect(
                     Collectors.toMap(
-                        Endpoint::getName,
-                        e -> ServerConfigImpl.createFromEndpoint(e, true)))); // TODO: test
+                        Endpoint::getName, e -> ServerConfigImpl.createFromEndpoint(e, true))));
   }
 
   private void provisionVolumes(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
@@ -264,7 +264,7 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
                 .getEndpoints()
                 .stream()
                 .collect(
-                    Collectors.toMap(Endpoint::getName, ServerConfigImpl::createFromEndpoint)));
+                    Collectors.toMap(Endpoint::getName, e -> ServerConfigImpl.createFromEndpoint(e, true))));
   }
 
   private void provisionVolumes(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
@@ -265,7 +265,8 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
                 .stream()
                 .collect(
                     Collectors.toMap(
-                        Endpoint::getName, e -> ServerConfigImpl.createFromEndpoint(e, true))));
+                        Endpoint::getName,
+                        e -> ServerConfigImpl.createFromEndpoint(e, true)))); // TODO: test
   }
 
   private void provisionVolumes(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
+
+import io.fabric8.kubernetes.api.model.ServicePort;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Singleton;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+
+@Singleton
+public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
+    implements ExternalServerExposer<T> {
+
+  private final ExternalServerExposer<T> subdomainServerExposer;
+  private final ExternalServerExposer<T> subpathServerExposer;
+
+  public CombinedSingleHostServerExposer(
+      ExternalServerExposer<T> subdomainServerExposer,
+      ExternalServerExposer<T> subpathServerExposer) {
+    this.subdomainServerExposer = subdomainServerExposer;
+    this.subpathServerExposer = subpathServerExposer;
+  }
+
+  @Override
+  public void expose(
+      T k8sEnv,
+      String machineName,
+      String serviceName,
+      String serverId,
+      ServicePort servicePort,
+      Map<String, ServerConfig> externalServers) {
+
+    if (serverId == null) {
+      // this is the ID for non-unique servers
+      serverId = servicePort.getName();
+    }
+
+    Map<String, ServerConfig> subpathServers = new HashMap<>();
+    Map<String, ServerConfig> subdomainServers = new HashMap<>();
+
+    for (String esKey : externalServers.keySet()) {
+      ServerConfig serverConfig = externalServers.get(esKey);
+      if (TRUE.toString()
+          .equals(
+              serverConfig
+                  .getAttributes()
+                  .getOrDefault(DEVFILE_ENDPOINT, FALSE.toString()))) {
+        subdomainServers.put(esKey, serverConfig);
+      } else {
+        subpathServers.put(esKey, serverConfig);
+      }
+    }
+
+    if (!subpathServers.isEmpty()) {
+      subpathServerExposer.expose(
+          k8sEnv, machineName, serviceName, serverId, servicePort, subpathServers);
+    }
+
+    if (!subdomainServers.isEmpty()) {
+      subdomainServerExposer.expose(
+          k8sEnv, machineName, serviceName, serverId, servicePort, subdomainServers);
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -56,10 +56,7 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
     for (String esKey : externalServers.keySet()) {
       ServerConfig serverConfig = externalServers.get(esKey);
       if (TRUE.toString()
-          .equals(
-              serverConfig
-                  .getAttributes()
-                  .getOrDefault(DEVFILE_ENDPOINT, FALSE.toString()))) {
+          .equals(serverConfig.getAttributes().getOrDefault(DEVFILE_ENDPOINT, FALSE.toString()))) {
         subdomainServers.put(esKey, serverConfig);
       } else {
         subpathServers.put(esKey, serverConfig);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -17,7 +17,6 @@ import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFI
 import io.fabric8.kubernetes.api.model.ServicePort;
 import java.util.HashMap;
 import java.util.Map;
-import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
@@ -33,7 +32,6 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
  *
  * @param <T> environment type
  */
-@Singleton
 public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
     implements ExternalServerExposer<T> {
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -21,7 +21,6 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
-// TODO: test
 /**
  * This {@link ExternalServerExposer} is used in single-host mode when we need to expose some
  * servers on subdomain, instead of subpaths.

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -21,8 +21,19 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
-// TODO: javadocs
 // TODO: test
+/**
+ * This {@link ExternalServerExposer} is used in single-host mode when we need to expose some
+ * servers on subdomain, instead of subpaths.
+ *
+ * <p>It aggregates 2 {@link ExternalServerExposer}s, using one to expose servers on subdomand, and
+ * 2nd to expose servers on subpaths. It determines which to use for individual server based on some
+ * attribute in {@link ServerConfig#getAttributes()} (see implementation {@link
+ * CombinedSingleHostServerExposer#expose(KubernetesEnvironment, String, String, String,
+ * ServicePort, Map)} for the details).
+ *
+ * @param <T> environment type
+ */
 @Singleton
 public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
     implements ExternalServerExposer<T> {
@@ -37,6 +48,19 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
     this.subpathServerExposer = subpathServerExposer;
   }
 
+  /**
+   * Exposes given 'externalServers' to either subdomain or subpath, using 2 different {@link
+   * ExternalServerExposer}s. Which one to use for individual server is determined with {@link
+   * ServerConfig#DEVFILE_ENDPOINT} attribute.
+   *
+   * @param k8sEnv environment
+   * @param machineName machine containing servers
+   * @param serviceName service associated with machine, mapping all machine server ports
+   * @param serverId non-null for a unique server, null for a compound set of servers that should be
+   *     exposed together.
+   * @param servicePort specific service port to be exposed externally
+   * @param externalServers server configs of servers to be exposed externally
+   */
   @Override
   public void expose(
       T k8sEnv,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -55,8 +54,8 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
 
     for (String esKey : externalServers.keySet()) {
       ServerConfig serverConfig = externalServers.get(esKey);
-      if (TRUE.toString()
-          .equals(serverConfig.getAttributes().getOrDefault(DEVFILE_ENDPOINT, FALSE.toString()))) {
+      if (Boolean.parseBoolean(
+          serverConfig.getAttributes().getOrDefault(DEVFILE_ENDPOINT, FALSE.toString()))) {
         subdomainServers.put(esKey, serverConfig);
       } else {
         subpathServers.put(esKey, serverConfig);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -21,6 +21,8 @@ import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
+// TODO: javadocs
+// TODO: test
 @Singleton
 public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
     implements ExternalServerExposer<T> {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
@@ -14,6 +14,10 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 import javax.inject.Provider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
-// TODO: javadocs
+/**
+ * Provides {@link ExternalServerExposer} implementations based on configuration.
+ *
+ * @param <T> type of environment
+ */
 public interface ExternalServerExposerProvider<T extends KubernetesEnvironment>
     extends Provider<ExternalServerExposer<T>> {}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.INGRESS_DOMAIN_PROPERTY;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy.SINGLE_HOST_STRATEGY;
 
 import java.util.Map;
 import javax.inject.Inject;
@@ -40,8 +41,8 @@ public class ExternalServerExposerProvider<T extends KubernetesEnvironment>
   public ExternalServerExposerProvider(
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
       @Named("che.infra.kubernetes.singlehost.workspace.exposure") String exposureType,
-      @Named("che.infra.kubernetes.singlehost.workspace.force_subdomain_devfile_endpoints")
-          boolean forceSubdomainEndpoints,
+      @Named("che.infra.kubernetes.singlehost.workspace.expose_devfile_endpoints_on_subdomains")
+          boolean exposeDevfileEndpointsOnSubdomains,
       @Named(INGRESS_DOMAIN_PROPERTY) String domain,
       @Named("infra.kubernetes.ingress.annotations") Map<String, String> annotations,
       @Nullable @Named("che.infra.kubernetes.ingress.labels") String labelsProperty,
@@ -53,8 +54,8 @@ public class ExternalServerExposerProvider<T extends KubernetesEnvironment>
         exposureType,
         exposers,
         "Could not find an external server exposer implementation for the exposure type '%s'.");
-    this.forceSubdomainEndpoints = forceSubdomainEndpoints;
-    if (forceSubdomainEndpoints) {
+    if (SINGLE_HOST_STRATEGY.equals(exposureStrategy) && exposeDevfileEndpointsOnSubdomains) {
+      this.forceSubdomainEndpoints = true;
       this.combinedInstance =
           new CombinedSingleHostServerExposer<>(
               new IngressServerExposer<>(
@@ -64,6 +65,7 @@ public class ExternalServerExposerProvider<T extends KubernetesEnvironment>
                   pathTransformFmt),
               instance);
     } else {
+      this.forceSubdomainEndpoints = false;
       this.combinedInstance = null;
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
@@ -14,5 +14,6 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 import javax.inject.Provider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
+// TODO: javadocs
 public interface ExternalServerExposerProvider<T extends KubernetesEnvironment>
     extends Provider<ExternalServerExposer<T>> {}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
@@ -11,10 +11,14 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.INGRESS_DOMAIN_PROPERTY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
+
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.AbstractExposureStrategyAwareProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
@@ -28,10 +32,20 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExpos
 @Singleton
 public class ExternalServerExposerProvider<T extends KubernetesEnvironment>
     extends AbstractExposureStrategyAwareProvider<ExternalServerExposer<T>> {
+
+  private final boolean forceSubdomainEndpoints;
+  private final ExternalServerExposer<T> combinedInstance;
+
   @Inject
   public ExternalServerExposerProvider(
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
       @Named("che.infra.kubernetes.singlehost.workspace.exposure") String exposureType,
+      @Named("che.infra.kubernetes.singlehost.workspace.force_subdomain_devfile_endpoints")
+          boolean forceSubdomainEndpoints,
+      @Named(INGRESS_DOMAIN_PROPERTY) String domain,
+      @Named("infra.kubernetes.ingress.annotations") Map<String, String> annotations,
+      @Nullable @Named("che.infra.kubernetes.ingress.labels") String labelsProperty,
+      @Nullable @Named("che.infra.kubernetes.ingress.path_transform") String pathTransformFmt,
       Map<WorkspaceExposureType, ExternalServerExposer<T>> exposers) {
 
     super(
@@ -39,5 +53,27 @@ public class ExternalServerExposerProvider<T extends KubernetesEnvironment>
         exposureType,
         exposers,
         "Could not find an external server exposer implementation for the exposure type '%s'.");
+    this.forceSubdomainEndpoints = forceSubdomainEndpoints;
+    if (forceSubdomainEndpoints) {
+      this.combinedInstance =
+          new CombinedSingleHostServerExposer<>(
+              new IngressServerExposer<>(
+                  new MultiHostExternalServiceExposureStrategy(domain, MULTI_HOST_STRATEGY),
+                  annotations,
+                  labelsProperty,
+                  pathTransformFmt),
+              instance);
+    } else {
+      this.combinedInstance = null;
+    }
+  }
+
+  @Override
+  public ExternalServerExposer<T> get() {
+    if (forceSubdomainEndpoints) {
+      return combinedInstance;
+    } else {
+      return instance;
+    }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposerProvider.java
@@ -11,71 +11,8 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
-import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.INGRESS_DOMAIN_PROPERTY;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy.SINGLE_HOST_STRATEGY;
-
-import java.util.Map;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
-import org.eclipse.che.commons.annotation.Nullable;
+import javax.inject.Provider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.AbstractExposureStrategyAwareProvider;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
 
-/**
- * Provides {@link ExternalServerExposer} based on `che.infra.kubernetes.server_strategy` and
- * `che.infra.kubernetes.singlehost.workspace.exposure` properties.
- *
- * @param <T> type of environment
- */
-@Singleton
-public class ExternalServerExposerProvider<T extends KubernetesEnvironment>
-    extends AbstractExposureStrategyAwareProvider<ExternalServerExposer<T>> {
-
-  private final boolean forceSubdomainEndpoints;
-  private final ExternalServerExposer<T> combinedInstance;
-
-  @Inject
-  public ExternalServerExposerProvider(
-      @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
-      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String exposureType,
-      @Named("che.infra.kubernetes.singlehost.workspace.expose_devfile_endpoints_on_subdomains")
-          boolean exposeDevfileEndpointsOnSubdomains,
-      @Named(INGRESS_DOMAIN_PROPERTY) String domain,
-      @Named("infra.kubernetes.ingress.annotations") Map<String, String> annotations,
-      @Nullable @Named("che.infra.kubernetes.ingress.labels") String labelsProperty,
-      @Nullable @Named("che.infra.kubernetes.ingress.path_transform") String pathTransformFmt,
-      Map<WorkspaceExposureType, ExternalServerExposer<T>> exposers) {
-
-    super(
-        exposureStrategy,
-        exposureType,
-        exposers,
-        "Could not find an external server exposer implementation for the exposure type '%s'.");
-    if (SINGLE_HOST_STRATEGY.equals(exposureStrategy) && exposeDevfileEndpointsOnSubdomains) {
-      this.forceSubdomainEndpoints = true;
-      this.combinedInstance =
-          new CombinedSingleHostServerExposer<>(
-              new IngressServerExposer<>(
-                  new MultiHostExternalServiceExposureStrategy(domain, MULTI_HOST_STRATEGY),
-                  annotations,
-                  labelsProperty,
-                  pathTransformFmt),
-              instance);
-    } else {
-      this.forceSubdomainEndpoints = false;
-      this.combinedInstance = null;
-    }
-  }
-
-  @Override
-  public ExternalServerExposer<T> get() {
-    if (forceSubdomainEndpoints) {
-      return combinedInstance;
-    } else {
-      return instance;
-    }
-  }
-}
+public interface ExternalServerExposerProvider<T extends KubernetesEnvironment>
+    extends Provider<ExternalServerExposer<T>> {}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/IngressServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/IngressServerExposer.java
@@ -31,7 +31,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.KubernetesServ
  * @see ExternalServerExposer
  */
 @Singleton
-public class IngressServerExposer implements ExternalServerExposer<KubernetesEnvironment> {
+public class IngressServerExposer<T extends KubernetesEnvironment>
+    implements ExternalServerExposer<T> {
 
   /**
    * A string to look for in the value of the "che.infra.kubernetes.ingress.path_transform"
@@ -69,7 +70,7 @@ public class IngressServerExposer implements ExternalServerExposer<KubernetesEnv
    */
   @Override
   public void expose(
-      KubernetesEnvironment k8sEnv,
+      T k8sEnv,
       @Nullable String machineName,
       String serviceName,
       String serverId,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
@@ -50,8 +50,8 @@ public class KubernetesExternalServerExposerProvider<T extends KubernetesEnviron
   public KubernetesExternalServerExposerProvider(
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
       @Named("che.infra.kubernetes.singlehost.workspace.exposure") String exposureType,
-      @Named("che.infra.kubernetes.singlehost.workspace.expose_devfile_endpoints_on_subdomains")
-          boolean exposeDevfileEndpointsOnSubdomains,
+      @Named("che.infra.kubernetes.singlehost.workspace.devfile_endpoint_exposure")
+          String devfileEndpointsExposure,
       @Named(INGRESS_DOMAIN_PROPERTY) String domain,
       @Named("infra.kubernetes.ingress.annotations") Map<String, String> annotations,
       @Nullable @Named("che.infra.kubernetes.ingress.labels") String labelsProperty,
@@ -69,7 +69,8 @@ public class KubernetesExternalServerExposerProvider<T extends KubernetesEnviron
     this.labelsProperty = labelsProperty;
     this.pathTransformFmt = pathTransformFmt;
 
-    if (SINGLE_HOST_STRATEGY.equals(exposureStrategy) && exposeDevfileEndpointsOnSubdomains) {
+    if (SINGLE_HOST_STRATEGY.equals(exposureStrategy)
+        && SINGLE_HOST_STRATEGY.equals(devfileEndpointsExposure)) {
       this.combinedInstance =
           new CombinedSingleHostServerExposer<>(createSubdomainServerExposer(), instance);
     } else {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
@@ -28,9 +28,11 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExpos
  * Provides {@link ExternalServerExposer} based on `che.infra.kubernetes.server_strategy` and
  * `che.infra.kubernetes.singlehost.workspace.exposure` properties.
  *
+ * <p>Based on server strategy, it can create a {@link CombinedSingleHostServerExposer} with
+ * Kubernetes specific {@link IngressServerExposer} for exposing servers on subdomains.
+ *
  * @param <T> type of environment
  */
-// TODO: update javadocs with "combined" thing
 @Singleton
 public class KubernetesExternalServerExposerProvider<T extends KubernetesEnvironment>
     extends AbstractExposureStrategyAwareProvider<ExternalServerExposer<T>>

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
@@ -30,6 +30,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExpos
  *
  * @param <T> type of environment
  */
+// TODO: update javadocs with "combined" thing
 @Singleton
 public class KubernetesExternalServerExposerProvider<T extends KubernetesEnvironment>
     extends AbstractExposureStrategyAwareProvider<ExternalServerExposer<T>>

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
@@ -35,7 +35,6 @@ public class KubernetesExternalServerExposerProvider<T extends KubernetesEnviron
     extends AbstractExposureStrategyAwareProvider<ExternalServerExposer<T>>
     implements ExternalServerExposerProvider<T> {
 
-  private final boolean forceSubdomainEndpoints;
   private final ExternalServerExposer<T> combinedInstance;
 
   protected final String labelsProperty;
@@ -68,22 +67,16 @@ public class KubernetesExternalServerExposerProvider<T extends KubernetesEnviron
     this.pathTransformFmt = pathTransformFmt;
 
     if (SINGLE_HOST_STRATEGY.equals(exposureStrategy) && exposeDevfileEndpointsOnSubdomains) {
-      this.forceSubdomainEndpoints = true;
       this.combinedInstance =
           new CombinedSingleHostServerExposer<>(createSubdomainServerExposer(), instance);
     } else {
-      this.forceSubdomainEndpoints = false;
       this.combinedInstance = null;
     }
   }
 
   @Override
   public ExternalServerExposer<T> get() {
-    if (forceSubdomainEndpoints) {
-      return combinedInstance;
-    } else {
-      return instance;
-    }
+    return combinedInstance != null ? combinedInstance : instance;
   }
 
   protected ExternalServerExposer<T> createSubdomainServerExposer() {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/KubernetesExternalServerExposerProvider.java
@@ -70,7 +70,7 @@ public class KubernetesExternalServerExposerProvider<T extends KubernetesEnviron
     this.pathTransformFmt = pathTransformFmt;
 
     if (SINGLE_HOST_STRATEGY.equals(exposureStrategy)
-        && SINGLE_HOST_STRATEGY.equals(devfileEndpointsExposure)) {
+        && MULTI_HOST_STRATEGY.equals(devfileEndpointsExposure)) {
       this.combinedInstance =
           new CombinedSingleHostServerExposer<>(createSubdomainServerExposer(), instance);
     } else {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/MultiHostExternalServiceExposureStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/MultiHostExternalServiceExposureStrategy.java
@@ -46,7 +46,7 @@ import org.eclipse.che.inject.ConfigurationException;
 public class MultiHostExternalServiceExposureStrategy implements ExternalServiceExposureStrategy {
 
   public static final String MULTI_HOST_STRATEGY = "multi-host";
-  private static final String INGRESS_DOMAIN_PROPERTY = "che.infra.kubernetes.ingress.domain";
+  protected static final String INGRESS_DOMAIN_PROPERTY = "che.infra.kubernetes.ingress.domain";
 
   private final String domain;
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/MultihostIngressServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/MultihostIngressServerExposer.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
+
+import io.fabric8.kubernetes.api.model.extensions.Ingress;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+
+/**
+ * Uses Kubernetes {@link Ingress}es to expose the services using subdomains a.k.a. multi-host.
+ *
+ * @see ExternalServerExposer
+ */
+@Singleton
+public class MultihostIngressServerExposer<T extends KubernetesEnvironment>
+    extends IngressServerExposer<T> implements ExternalServerExposer<T> {
+  @Inject
+  public MultihostIngressServerExposer(
+      MultiHostExternalServiceExposureStrategy serviceExposureStrategy,
+      @Named("infra.kubernetes.ingress.annotations") Map<String, String> annotations,
+      @Nullable @Named("che.infra.kubernetes.ingress.labels") String labelsProperty,
+      @Nullable @Named("che.infra.kubernetes.ingress.path_transform") String pathTransformFmt) {
+    super(serviceExposureStrategy, annotations, labelsProperty, pathTransformFmt);
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/AbstractServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/AbstractServerResolver.java
@@ -76,12 +76,4 @@ public abstract class AbstractServerResolver implements ServerResolver {
                         .build(),
                 (s1, s2) -> s2));
   }
-
-  /**
-   * Resolve external servers from implementation specific k8s object and it's annotations.
-   *
-   * @param machineName machine to resolve servers
-   * @return resolved servers
-   */
-  protected abstract Map<String, ServerImpl> resolveExternalServers(String machineName);
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolver.java
@@ -24,18 +24,17 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.RuntimeServerBuilder;
 
 /** Resolves servers from ConfigMaps, used with Gateway based single-host */
-// TODO: test native resolver
 public class ConfigMapServerResolver extends AbstractServerResolver {
 
   private final Multimap<String, ConfigMap> configMaps;
   private final String cheHost;
-  private final AbstractServerResolver nativeServerResolver;
+  private final ServerResolver nativeServerResolver;
 
   public ConfigMapServerResolver(
       Iterable<Service> services,
       Iterable<ConfigMap> configMaps,
       String cheHost,
-      AbstractServerResolver nativeServerResolver) {
+      ServerResolver nativeServerResolver) {
     super(services);
     this.nativeServerResolver = nativeServerResolver;
     this.cheHost = cheHost;
@@ -51,7 +50,7 @@ public class ConfigMapServerResolver extends AbstractServerResolver {
   }
 
   @Override
-  protected Map<String, ServerImpl> resolveExternalServers(String machineName) {
+  public Map<String, ServerImpl> resolveExternalServers(String machineName) {
     Map<String, ServerImpl> serverMap = new HashMap<>();
     serverMap.putAll(nativeServerResolver.resolveExternalServers(machineName));
     serverMap.putAll(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolver.java
@@ -24,6 +24,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.RuntimeServerBuilder;
 
 /** Resolves servers from ConfigMaps, used with Gateway based single-host */
+// TODO: test native resolver
 public class ConfigMapServerResolver extends AbstractServerResolver {
 
   private final Multimap<String, ConfigMap> configMaps;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/IngressServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/IngressServerResolver.java
@@ -61,7 +61,7 @@ public class IngressServerResolver extends AbstractServerResolver {
   }
 
   @Override
-  protected Map<String, ServerImpl> resolveExternalServers(String machineName) {
+  public Map<String, ServerImpl> resolveExternalServers(String machineName) {
     return ingresses
         .get(machineName)
         .stream()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/KubernetesServerResolverFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/KubernetesServerResolverFactory.java
@@ -38,7 +38,10 @@ public class KubernetesServerResolverFactory extends AbstractServerResolverFacto
         exposureStrategy,
         wsExposureType,
         ImmutableMap.of(
-            GATEWAY, (ss, is, cs) -> new ConfigMapServerResolver(ss, cs, cheHost),
+            GATEWAY,
+                (ss, is, cs) ->
+                    new ConfigMapServerResolver(
+                        ss, cs, cheHost, new IngressServerResolver(pathTransformInverter, ss, is)),
             NATIVE, (ss, is, cs) -> new IngressServerResolver(pathTransformInverter, ss, is)),
         "Failed to initialize KubernetesServerResolverFactory for workspace exposure type '%s'.");
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ServerResolver.java
@@ -35,4 +35,12 @@ public interface ServerResolver {
    * @return resolved servers
    */
   Map<String, ServerImpl> resolve(String machineName);
+
+  /**
+   * Resolve external servers from implementation specific k8s object and it's annotations.
+   *
+   * @param machineName machine to resolve servers
+   * @return resolved servers
+   */
+  Map<String, ServerImpl> resolveExternalServers(String machineName);
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
@@ -350,6 +350,7 @@ public class DockerimageComponentToWorkspaceApplierTest {
     Map<String, String> attributes = serverConfig.getAttributes();
     assertEquals(attributes.get(ServerConfig.INTERNAL_SERVER_ATTRIBUTE), "true");
     assertEquals(attributes.get("secure"), "false");
+    assertEquals(attributes.get(ServerConfig.DEVFILE_ENDPOINT), "true");
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
@@ -18,6 +18,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.DEVFILE_COMPONENT_ALIAS_ATTRIBUTE;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.OPENSHIFT_COMPONENT_TYPE;
@@ -678,6 +679,8 @@ public class KubernetesComponentToWorkspaceApplierTest {
               assertEquals(serverConfigs.get(endpointName).getPort(), endpointPort.toString());
               assertEquals(serverConfigs.get(endpointName).getPath(), endpointPath);
               assertEquals(serverConfigs.get(endpointName).getProtocol(), endpointProtocol);
+              assertEquals(
+                  serverConfigs.get(endpointName).getAttributes().get(DEVFILE_ENDPOINT), "true");
               assertEquals(
                   serverConfigs.get(endpointName).isSecure(), Boolean.parseBoolean(endpointSecure));
               assertEquals(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposerTest.java
@@ -1,0 +1,51 @@
+package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.*;
+
+import io.fabric8.kubernetes.api.model.ServicePort;
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class CombinedSingleHostServerExposerTest {
+
+  @Mock private KubernetesEnvironment env;
+
+  private final String MACHINE = "machine";
+  private final String SERVICE = "service";
+  private final String SERVER = "server";
+  private final ServicePort PORT = new ServicePort();
+
+  @Mock private ExternalServerExposer<KubernetesEnvironment> subdomainExposer;
+  @Mock private ExternalServerExposer<KubernetesEnvironment> subpathExposer;
+
+  @Test
+  public void shouldExposeDevfileServersOnSubdomans() {
+    // given
+    ServerConfig s1 = new ServerConfigImpl("1", "http", "/", emptyMap());
+    ServerConfig s2 =
+        new ServerConfigImpl("2", "http", "/", singletonMap(DEVFILE_ENDPOINT, "false"));
+    ServerConfig s3 =
+        new ServerConfigImpl("3", "http", "/", singletonMap(DEVFILE_ENDPOINT, "true"));
+
+    CombinedSingleHostServerExposer<KubernetesEnvironment> serverExposer =
+        new CombinedSingleHostServerExposer<>(subdomainExposer, subpathExposer);
+
+    // when
+    serverExposer.expose(env, MACHINE, SERVICE, SERVER, PORT, Map.of("s1", s1, "s2", s2, "s3", s3));
+
+    // then
+    verify(subdomainExposer).expose(env, MACHINE, SERVICE, SERVER, PORT, Map.of("s3", s3));
+    verify(subpathExposer).expose(env, MACHINE, SERVICE, SERVER, PORT, Map.of("s1", s1, "s2", s2));
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposerTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static java.util.Collections.emptyMap;

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolverTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.resolver;
 
 import static java.util.Collections.emptyList;

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolverTest.java
@@ -1,0 +1,38 @@
+package org.eclipse.che.workspace.infrastructure.kubernetes.server.resolver;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonMap;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
+import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class ConfigMapServerResolverTest {
+  @Mock private ServerResolver nativeServerResolver;
+
+  @Test
+  public void shouldIncludeServersFromNativeResolver() {
+    // given
+    ServerImpl server = new ServerImpl("server", ServerStatus.UNKNOWN, emptyMap());
+    when(nativeServerResolver.resolveExternalServers("test"))
+        .thenReturn(singletonMap("s1", server));
+
+    ConfigMapServerResolver serverResolver =
+        new ConfigMapServerResolver(emptyList(), emptyList(), "che.host", nativeServerResolver);
+
+    // when
+    Map<String, ServerImpl> resolvedServers = serverResolver.resolve("test");
+
+    // then
+    assertTrue(resolvedServers.containsKey("s1"));
+    assertEquals(resolvedServers.get("s1"), server);
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -72,6 +72,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.server.Serv
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.PreviewUrlExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServiceExposureStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.GatewayServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
@@ -101,6 +102,7 @@ import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftCookie
 import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftPreviewUrlExposer;
 import org.eclipse.che.workspace.infrastructure.openshift.server.OpenShiftServerExposureStrategy;
 import org.eclipse.che.workspace.infrastructure.openshift.server.RouteServerExposer;
+import org.eclipse.che.workspace.infrastructure.openshift.server.external.OpenShiftExternalServerExposerProvider;
 import org.eclipse.che.workspace.infrastructure.openshift.wsplugins.brokerphases.OpenshiftBrokerEnvironmentFactory;
 
 /** @author Sergii Leshchenko */
@@ -146,14 +148,14 @@ public class OpenShiftInfraModule extends AbstractModule {
 
     MapBinder<WorkspaceExposureType, ExternalServerExposer<OpenShiftEnvironment>>
         exposureStrategies =
-            MapBinder.newMapBinder(
-                binder(),
-                new TypeLiteral<WorkspaceExposureType>() {},
-                new TypeLiteral<ExternalServerExposer<OpenShiftEnvironment>>() {});
+            MapBinder.newMapBinder(binder(), new TypeLiteral<>() {}, new TypeLiteral<>() {});
     exposureStrategies.addBinding(WorkspaceExposureType.NATIVE).to(RouteServerExposer.class);
     exposureStrategies
         .addBinding(WorkspaceExposureType.GATEWAY)
         .to(new TypeLiteral<GatewayServerExposer<OpenShiftEnvironment>>() {});
+
+    bind(new TypeLiteral<ExternalServerExposerProvider<OpenShiftEnvironment>>() {})
+        .to(OpenShiftExternalServerExposerProvider.class);
 
     bind(ServersConverter.class).to(new TypeLiteral<ServersConverter<OpenShiftEnvironment>>() {});
     bind(PreviewUrlExposer.class).to(new TypeLiteral<OpenShiftPreviewUrlExposer>() {});

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -154,6 +154,10 @@ public class OpenShiftInfraModule extends AbstractModule {
         .addBinding(WorkspaceExposureType.GATEWAY)
         .to(new TypeLiteral<GatewayServerExposer<OpenShiftEnvironment>>() {});
 
+    bind(new TypeLiteral<ExternalServerExposer<OpenShiftEnvironment>>() {})
+        .annotatedWith(com.google.inject.name.Names.named("multihost-exposer"))
+        .to(RouteServerExposer.class);
+
     bind(new TypeLiteral<ExternalServerExposerProvider<OpenShiftEnvironment>>() {})
         .to(OpenShiftExternalServerExposerProvider.class);
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerResolverFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerResolverFactory.java
@@ -37,7 +37,7 @@ public class OpenShiftServerResolverFactory extends AbstractServerResolverFactor
         exposureStrategy,
         wsExposureType,
         ImmutableMap.of(
-            GATEWAY, (ss, rs, cs) -> new ConfigMapServerResolver(ss, cs, cheHost),
+            GATEWAY, (ss, rs, cs) -> new ConfigMapServerResolver(ss, cs, cheHost, new RouteServerResolver(ss, rs)),
             NATIVE, (ss, rs, cs) -> new RouteServerResolver(ss, rs)),
         "Failed to initialize OpenShiftServerResolverFactory for workspace exposure type '%s'.");
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerResolverFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftServerResolverFactory.java
@@ -37,7 +37,9 @@ public class OpenShiftServerResolverFactory extends AbstractServerResolverFactor
         exposureStrategy,
         wsExposureType,
         ImmutableMap.of(
-            GATEWAY, (ss, rs, cs) -> new ConfigMapServerResolver(ss, cs, cheHost, new RouteServerResolver(ss, rs)),
+            GATEWAY,
+                (ss, rs, cs) ->
+                    new ConfigMapServerResolver(ss, cs, cheHost, new RouteServerResolver(ss, rs)),
             NATIVE, (ss, rs, cs) -> new RouteServerResolver(ss, rs)),
         "Failed to initialize OpenShiftServerResolverFactory for workspace exposure type '%s'.");
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerResolver.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerResolver.java
@@ -51,7 +51,7 @@ public class RouteServerResolver extends AbstractServerResolver {
   }
 
   @Override
-  protected Map<String, ServerImpl> resolveExternalServers(String machineName) {
+  public Map<String, ServerImpl> resolveExternalServers(String machineName) {
     return routes
         .get(machineName)
         .stream()

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/external/OpenShiftExternalServerExposerProvider.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/external/OpenShiftExternalServerExposerProvider.java
@@ -38,14 +38,14 @@ public class OpenShiftExternalServerExposerProvider
   public OpenShiftExternalServerExposerProvider(
       @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
       @Named("che.infra.kubernetes.singlehost.workspace.exposure") String exposureType,
-      @Named("che.infra.kubernetes.singlehost.workspace.expose_devfile_endpoints_on_subdomains")
-          boolean exposeDevfileEndpointsOnSubdomains,
+      @Named("che.infra.kubernetes.singlehost.workspace.devfile_endpoint_exposure")
+          String devfileEndpointExposure,
       @Nullable @Named("che.infra.openshift.route.labels") String labelsProperty,
       Map<WorkspaceExposureType, ExternalServerExposer<OpenShiftEnvironment>> exposers) {
     super(
         exposureStrategy,
         exposureType,
-        exposeDevfileEndpointsOnSubdomains,
+        devfileEndpointExposure,
         null,
         null,
         labelsProperty,

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/external/OpenShiftExternalServerExposerProvider.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/external/OpenShiftExternalServerExposerProvider.java
@@ -16,12 +16,20 @@ import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.CombinedSingleHostServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.KubernetesExternalServerExposerProvider;
 import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
 import org.eclipse.che.workspace.infrastructure.openshift.server.RouteServerExposer;
 
+/**
+ * Provides {@link ExternalServerExposer} based on `che.infra.kubernetes.server_strategy` and
+ * `che.infra.kubernetes.singlehost.workspace.exposure` properties.
+ *
+ * <p>Based on server strategy, it can create a {@link CombinedSingleHostServerExposer} with
+ * OpenShift specific {@link RouteServerExposer} for exposing servers on subdomains.
+ */
 public class OpenShiftExternalServerExposerProvider
     extends KubernetesExternalServerExposerProvider<OpenShiftEnvironment>
     implements ExternalServerExposerProvider<OpenShiftEnvironment> {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/external/OpenShiftExternalServerExposerProvider.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/external/OpenShiftExternalServerExposerProvider.java
@@ -14,7 +14,6 @@ package org.eclipse.che.workspace.infrastructure.openshift.server.external;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
-import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.CombinedSingleHostServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposer;
@@ -40,21 +39,8 @@ public class OpenShiftExternalServerExposerProvider
       @Named("che.infra.kubernetes.singlehost.workspace.exposure") String exposureType,
       @Named("che.infra.kubernetes.singlehost.workspace.devfile_endpoint_exposure")
           String devfileEndpointExposure,
-      @Nullable @Named("che.infra.openshift.route.labels") String labelsProperty,
+      @Named("multihost-exposer") ExternalServerExposer<OpenShiftEnvironment> multihostExposer,
       Map<WorkspaceExposureType, ExternalServerExposer<OpenShiftEnvironment>> exposers) {
-    super(
-        exposureStrategy,
-        exposureType,
-        devfileEndpointExposure,
-        null,
-        null,
-        labelsProperty,
-        null,
-        exposers);
-  }
-
-  @Override
-  protected ExternalServerExposer<OpenShiftEnvironment> createSubdomainServerExposer() {
-    return new RouteServerExposer(labelsProperty);
+    super(exposureStrategy, exposureType, devfileEndpointExposure, multihostExposer, exposers);
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/external/OpenShiftExternalServerExposerProvider.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/external/OpenShiftExternalServerExposerProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.server.external;
+
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposerProvider;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.KubernetesExternalServerExposerProvider;
+import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftEnvironment;
+import org.eclipse.che.workspace.infrastructure.openshift.server.RouteServerExposer;
+
+public class OpenShiftExternalServerExposerProvider
+    extends KubernetesExternalServerExposerProvider<OpenShiftEnvironment>
+    implements ExternalServerExposerProvider<OpenShiftEnvironment> {
+
+  @Inject
+  public OpenShiftExternalServerExposerProvider(
+      @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
+      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String exposureType,
+      @Named("che.infra.kubernetes.singlehost.workspace.expose_devfile_endpoints_on_subdomains")
+          boolean exposeDevfileEndpointsOnSubdomains,
+      @Nullable @Named("che.infra.openshift.route.labels") String labelsProperty,
+      Map<WorkspaceExposureType, ExternalServerExposer<OpenShiftEnvironment>> exposers) {
+    super(
+        exposureStrategy,
+        exposureType,
+        exposeDevfileEndpointsOnSubdomains,
+        null,
+        null,
+        labelsProperty,
+        null,
+        exposers);
+  }
+
+  @Override
+  protected ExternalServerExposer<OpenShiftEnvironment> createSubdomainServerExposer() {
+    return new RouteServerExposer(labelsProperty);
+  }
+}

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -180,8 +180,7 @@ public class ServerConfigImpl implements ServerConfig {
         + '}';
   }
 
-  public static ServerConfigImpl createFromEndpoint(
-      Endpoint endpoint, boolean devfileEndpoint) {
+  public static ServerConfigImpl createFromEndpoint(Endpoint endpoint, boolean devfileEndpoint) {
     HashMap<String, String> attributes = new HashMap<>(endpoint.getAttributes());
     attributes.put(SERVER_NAME_ATTRIBUTE, endpoint.getName());
 

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -180,6 +180,7 @@ public class ServerConfigImpl implements ServerConfig {
         + '}';
   }
 
+  // TODO: test
   public static ServerConfigImpl createFromEndpoint(Endpoint endpoint, boolean devfileEndpoint) {
     HashMap<String, String> attributes = new HashMap<>(endpoint.getAttributes());
     attributes.put(SERVER_NAME_ATTRIBUTE, endpoint.getName());

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -180,7 +180,8 @@ public class ServerConfigImpl implements ServerConfig {
         + '}';
   }
 
-  public static ServerConfigImpl createFromEndpoint(Endpoint endpoint) {
+  public static ServerConfigImpl createFromEndpoint(
+      Endpoint endpoint, boolean devfileEndpoint) {
     HashMap<String, String> attributes = new HashMap<>(endpoint.getAttributes());
     attributes.put(SERVER_NAME_ATTRIBUTE, endpoint.getName());
 
@@ -196,6 +197,14 @@ public class ServerConfigImpl implements ServerConfig {
       ServerConfig.setInternal(attributes, true);
     }
 
+    if (devfileEndpoint) {
+      attributes.put(DEVFILE_ENDPOINT, Boolean.TRUE.toString());
+    }
+
     return new ServerConfigImpl(Integer.toString(endpoint.getPort()), protocol, path, attributes);
+  }
+
+  public static ServerConfigImpl createFromEndpoint(Endpoint endpoint) {
+    return createFromEndpoint(endpoint, false);
   }
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -180,7 +180,6 @@ public class ServerConfigImpl implements ServerConfig {
         + '}';
   }
 
-  // TODO: test
   public static ServerConfigImpl createFromEndpoint(Endpoint endpoint, boolean devfileEndpoint) {
     HashMap<String, String> attributes = new HashMap<>(endpoint.getAttributes());
     attributes.put(SERVER_NAME_ATTRIBUTE, endpoint.getName());

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImplTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImplTest.java
@@ -13,11 +13,13 @@ package org.eclipse.che.api.workspace.server.model.impl;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.INTERNAL_SERVER_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVER_NAME_ATTRIBUTE;
 import static org.testng.Assert.*;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.model.impl.devfile.EndpointImpl;
@@ -105,5 +107,30 @@ public class ServerConfigImplTest {
     assertFalse(serverConfig.getAttributes().isEmpty());
     assertEquals(
         serverConfig.getAttributes().get(INTERNAL_SERVER_ATTRIBUTE), Boolean.TRUE.toString());
+  }
+
+  @Test
+  public void testCreateFromEndpointDevfileEndpointAttributeSet() {
+    ServerConfig serverConfig =
+        ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()), true);
+
+    assertTrue(serverConfig.getAttributes().containsKey(DEVFILE_ENDPOINT));
+    assertTrue(Boolean.parseBoolean(serverConfig.getAttributes().get(DEVFILE_ENDPOINT)));
+  }
+
+  @Test
+  public void testCreateFromEndpointDevfileEndpointAttributeNotSet() {
+    ServerConfig serverConfig =
+        ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()), false);
+
+    assertFalse(serverConfig.getAttributes().containsKey(DEVFILE_ENDPOINT));
+  }
+
+  @Test
+  public void testCreateFromEndpointDevfileEndpointAttributeNotSetWhenDefault() {
+    ServerConfig serverConfig =
+        ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()));
+
+    assertFalse(serverConfig.getAttributes().containsKey(DEVFILE_ENDPOINT));
   }
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Introduces new property `che.infra.kubernetes.singlehost.workspace.devfile_endpoint_exposure` (effective only if `che.infra.kubernetes.server_strategy=single-host`) with options `single-host` and `multi-host`. When is set to `multi-host`, the devfile public endpoints are exposed on subdomains using dedicated Ingresses/Routes, instead of using subpath as other single-host endpoints. `single-host` keeps endpoints on subpaths.

The subdomain devfile endpoints are exposed on HTTP only, because the lack of wildcard certificate for subdomains when using single-host strategy. This has limitation that preview can't be opened directly in editor's window, but must be opened in separate browser tab.

TODO:
 - [x] OpenShift
 - [x] Docs (especially document certificate limitations) -> https://github.com/eclipse/che-docs/pull/1617

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
#17840

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
test image: `quay.io/mvala/che-server:gh17840-shEndpointRoutes`

1. Install Che in single-host
1. set `che.infra.kubernetes.singlehost.workspace.expose_devfile_endpoints_on_subdomains=true`
1. start any devfile with public endpoint.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
