### PR TITLE
Make Eclipse Che e2e nightly tests more relaible

### DIFF
--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             steps {
                 script {
                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
-                        retry(1) {
+                        retry(2) {
                             build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                     parameters: [
                                             string(name: 'cheImageRepo',
@@ -67,7 +67,7 @@ pipeline {
             steps {
                 script {
                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
-                        retry(1) {
+                        retry(2) {
                             build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                     parameters: [
                                             string(name: 'cheImageRepo',
@@ -113,7 +113,7 @@ pipeline {
             steps {
                 script {
                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
-                        retry(1) {
+                        retry(2) {
                             withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
                                 build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                         parameters: [

--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
                 artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '30'))
     }
 
-    triggers { cron("@midnight") }
+    triggers { cron("H 2 * * *") }
 
     parameters {
         string(name: 'emails',
@@ -17,10 +17,94 @@ pipeline {
     }
 
     stages {
-        stage("Run E2E tests") {
-            parallel {
-                stage('Run Happy path tests') {
-                    steps {
+        stage('Run Happy path tests') {
+            steps {
+                retry(1) {
+                    build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                            parameters: [
+                                    string(name: 'cheImageRepo',
+                                            value: 'quay.io/eclipse/che-server'),
+
+                                    string(name: 'cheImageTag',
+                                            value: 'nightly'),
+
+                                    booleanParam(name: 'buildChe',
+                                            value: false),
+
+                                    string(name: 'ghprbSourceBranch',
+                                            value: 'master'),
+
+                                    string(name: 'ghprbPullId',
+                                            value: ''),
+
+                                    string(name: 'e2eTestToRun',
+                                            value: 'test-happy-path'),
+
+                                    string(name: 'testWorkspaceDevfileUrl',
+                                            value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
+
+                                    booleanParam(name: 'createTestWorkspace',
+                                            value: true),
+
+                                    string(name: 'e2eTestParameters',
+                                            value: ''),
+
+                                    string(name: 'chectlPackageUrl',
+                                            value: ''),
+
+                                    string(name: 'cheE2eImageTag',
+                                            value: 'nightly')
+                            ]
+                }
+            }
+        }
+
+        stage('Run devfile tests') {
+            steps {
+                retry(1) {
+                    build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                            parameters: [
+                                    string(name: 'cheImageRepo',
+                                            value: 'quay.io/eclipse/che-server'),
+
+                                    string(name: 'cheImageTag',
+                                            value: 'nightly'),
+
+                                    booleanParam(name: 'buildChe',
+                                            value: false),
+
+                                    string(name: 'ghprbSourceBranch',
+                                            value: 'master'),
+
+                                    string(name: 'ghprbPullId',
+                                            value: ''),
+
+                                    string(name: 'e2eTestToRun',
+                                            value: 'test-all-devfiles'),
+
+                                    string(name: 'testWorkspaceDevfileUrl',
+                                            value: ''),
+
+                                    booleanParam(name: 'createTestWorkspace',
+                                            value: false),
+
+                                    string(name: 'e2eTestParameters',
+                                            value: ''),
+
+                                    string(name: 'chectlPackageUrl',
+                                            value: ''),
+
+                                    string(name: 'cheE2eImageTag',
+                                            value: 'nightly')
+                            ]
+                }
+            }
+        }
+
+        stage('Run Git SSH flow tests') {
+            steps {
+                retry(1) {
+                    withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
                         build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                 parameters: [
                                         string(name: 'cheImageRepo',
@@ -39,47 +123,7 @@ pipeline {
                                                 value: ''),
 
                                         string(name: 'e2eTestToRun',
-                                                value: 'test-happy-path'),
-
-                                        string(name: 'testWorkspaceDevfileUrl',
-                                                value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
-
-                                        booleanParam(name: 'createTestWorkspace',
-                                                value: true),
-
-                                        string(name: 'e2eTestParameters',
-                                                value: ''),
-
-                                        string(name: 'chectlPackageUrl',
-                                                value: ''),
-
-                                        string(name: 'cheE2eImageTag',
-                                                value: 'nightly')
-                                ]
-                    }
-                }
-
-                stage('Run devfile tests') {
-                    steps {
-                        build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                parameters: [
-                                        string(name: 'cheImageRepo',
-                                                value: 'quay.io/eclipse/che-server'),
-
-                                        string(name: 'cheImageTag',
-                                                value: 'nightly'),
-
-                                        booleanParam(name: 'buildChe',
-                                                value: false),
-
-                                        string(name: 'ghprbSourceBranch',
-                                                value: 'master'),
-
-                                        string(name: 'ghprbPullId',
-                                                value: ''),
-
-                                        string(name: 'e2eTestToRun',
-                                                value: 'test-all-devfiles'),
+                                                value: 'test-git-ssh'),
 
                                         string(name: 'testWorkspaceDevfileUrl',
                                                 value: ''),
@@ -88,7 +132,7 @@ pipeline {
                                                 value: false),
 
                                         string(name: 'e2eTestParameters',
-                                                value: ''),
+                                                value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
 
                                         string(name: 'chectlPackageUrl',
                                                 value: ''),
@@ -96,52 +140,11 @@ pipeline {
                                         string(name: 'cheE2eImageTag',
                                                 value: 'nightly')
                                 ]
-                    }
-                }
-
-                stage('Run Git SSH flow tests') {
-                    steps {
-                        withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
-                                build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                        parameters: [
-                                                string(name: 'cheImageRepo',
-                                                        value: 'quay.io/eclipse/che-server'),
-
-                                                string(name: 'cheImageTag',
-                                                        value: 'nightly'),
-
-                                                booleanParam(name: 'buildChe',
-                                                        value: false),
-
-                                                string(name: 'ghprbSourceBranch',
-                                                        value: 'master'),
-
-                                                string(name: 'ghprbPullId',
-                                                        value: ''),
-
-                                                string(name: 'e2eTestToRun',
-                                                        value: 'test-git-ssh'),
-
-                                                string(name: 'testWorkspaceDevfileUrl',
-                                                        value: ''),
-
-                                                booleanParam(name: 'createTestWorkspace',
-                                                        value: false),
-
-                                                string(name: 'e2eTestParameters',
-                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
-
-                                                string(name: 'chectlPackageUrl',
-                                                        value: ''),
-
-                                                string(name: 'cheE2eImageTag',
-                                                        value: 'nightly')
-                                        ]
-                        }
                     }
                 }
             }
         }
+
     }
 
     post {

--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -22,52 +22,92 @@ pipeline {
                 script {
                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
                         stage('Run Happy path tests') {
-                            steps {
-                                retry(2) {
-                                    build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                            parameters: [
-                                                    string(name: 'cheImageRepo',
-                                                            value: 'quay.io/eclipse/che-server'),
+                            retry(2) {
+                                build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                        parameters: [
+                                                string(name: 'cheImageRepo',
+                                                        value: 'quay.io/eclipse/che-server'),
 
-                                                    string(name: 'cheImageTag',
-                                                            value: 'nightly'),
+                                                string(name: 'cheImageTag',
+                                                        value: 'nightly'),
 
-                                                    booleanParam(name: 'buildChe',
-                                                            value: false),
+                                                booleanParam(name: 'buildChe',
+                                                        value: false),
 
-                                                    string(name: 'ghprbSourceBranch',
-                                                            value: 'master'),
+                                                string(name: 'ghprbSourceBranch',
+                                                        value: 'master'),
 
-                                                    string(name: 'ghprbPullId',
-                                                            value: ''),
+                                                string(name: 'ghprbPullId',
+                                                        value: ''),
 
-                                                    string(name: 'e2eTestToRun',
-                                                            value: 'test-happy-path'),
+                                                string(name: 'e2eTestToRun',
+                                                        value: 'test-happy-path'),
 
-                                                    string(name: 'testWorkspaceDevfileUrl',
-                                                            value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
+                                                string(name: 'testWorkspaceDevfileUrl',
+                                                        value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
 
-                                                    booleanParam(name: 'createTestWorkspace',
-                                                            value: true),
+                                                booleanParam(name: 'createTestWorkspace',
+                                                        value: true),
 
-                                                    string(name: 'e2eTestParameters',
-                                                            value: ''),
+                                                string(name: 'e2eTestParameters',
+                                                        value: ''),
 
-                                                    string(name: 'chectlPackageUrl',
-                                                            value: ''),
+                                                string(name: 'chectlPackageUrl',
+                                                        value: ''),
 
-                                                    string(name: 'cheE2eImageTag',
-                                                            value: 'nightly')
-                                            ]
-                                }
+                                                string(name: 'cheE2eImageTag',
+                                                        value: 'nightly')
+                                        ]
                             }
                         }
                     }
 
                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
                         stage('Run devfile tests') {
-                            steps {
-                                retry(2) {
+                            retry(2) {
+                                build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                        parameters: [
+                                                string(name: 'cheImageRepo',
+                                                        value: 'quay.io/eclipse/che-server'),
+
+                                                string(name: 'cheImageTag',
+                                                        value: 'nightly'),
+
+                                                booleanParam(name: 'buildChe',
+                                                        value: false),
+
+                                                string(name: 'ghprbSourceBranch',
+                                                        value: 'master'),
+
+                                                string(name: 'ghprbPullId',
+                                                        value: ''),
+
+                                                string(name: 'e2eTestToRun',
+                                                        value: 'test-all-devfiles'),
+
+                                                string(name: 'testWorkspaceDevfileUrl',
+                                                        value: ''),
+
+                                                booleanParam(name: 'createTestWorkspace',
+                                                        value: false),
+
+                                                string(name: 'e2eTestParameters',
+                                                        value: ''),
+
+                                                string(name: 'chectlPackageUrl',
+                                                        value: ''),
+
+                                                string(name: 'cheE2eImageTag',
+                                                        value: 'nightly')
+                                        ]
+                            }
+                        }
+                    }
+
+                    catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
+                        stage('Run Git SSH flow tests') {
+                            retry(2) {
+                                withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
                                     build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
                                             parameters: [
                                                     string(name: 'cheImageRepo',
@@ -86,7 +126,7 @@ pipeline {
                                                             value: ''),
 
                                                     string(name: 'e2eTestToRun',
-                                                            value: 'test-all-devfiles'),
+                                                            value: 'test-git-ssh'),
 
                                                     string(name: 'testWorkspaceDevfileUrl',
                                                             value: ''),
@@ -95,7 +135,7 @@ pipeline {
                                                             value: false),
 
                                                     string(name: 'e2eTestParameters',
-                                                            value: ''),
+                                                            value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
 
                                                     string(name: 'chectlPackageUrl',
                                                             value: ''),
@@ -103,52 +143,6 @@ pipeline {
                                                     string(name: 'cheE2eImageTag',
                                                             value: 'nightly')
                                             ]
-                                }
-                            }
-                        }
-                    }
-
-                    catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
-                        stage('Run Git SSH flow tests') {
-                            steps {
-                                retry(2) {
-                                    withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
-                                        build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                                parameters: [
-                                                        string(name: 'cheImageRepo',
-                                                                value: 'quay.io/eclipse/che-server'),
-
-                                                        string(name: 'cheImageTag',
-                                                                value: 'nightly'),
-
-                                                        booleanParam(name: 'buildChe',
-                                                                value: false),
-
-                                                        string(name: 'ghprbSourceBranch',
-                                                                value: 'master'),
-
-                                                        string(name: 'ghprbPullId',
-                                                                value: ''),
-
-                                                        string(name: 'e2eTestToRun',
-                                                                value: 'test-git-ssh'),
-
-                                                        string(name: 'testWorkspaceDevfileUrl',
-                                                                value: ''),
-
-                                                        booleanParam(name: 'createTestWorkspace',
-                                                                value: false),
-
-                                                        string(name: 'e2eTestParameters',
-                                                                value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
-
-                                                        string(name: 'chectlPackageUrl',
-                                                                value: ''),
-
-                                                        string(name: 'cheE2eImageTag',
-                                                                value: 'nightly')
-                                                ]
-                                    }
                                 }
                             }
                         }

--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -19,127 +19,139 @@ pipeline {
     stages {
         stage('Run Happy path tests') {
             steps {
-                retry(1) {
-                    build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                            parameters: [
-                                    string(name: 'cheImageRepo',
-                                            value: 'quay.io/eclipse/che-server'),
+                script {
+                    catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
+                        retry(1) {
+                            build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                    parameters: [
+                                            string(name: 'cheImageRepo',
+                                                    value: 'quay.io/eclipse/che-server'),
 
-                                    string(name: 'cheImageTag',
-                                            value: 'nightly'),
+                                            string(name: 'cheImageTag',
+                                                    value: 'nightly'),
 
-                                    booleanParam(name: 'buildChe',
-                                            value: false),
+                                            booleanParam(name: 'buildChe',
+                                                    value: false),
 
-                                    string(name: 'ghprbSourceBranch',
-                                            value: 'master'),
+                                            string(name: 'ghprbSourceBranch',
+                                                    value: 'master'),
 
-                                    string(name: 'ghprbPullId',
-                                            value: ''),
+                                            string(name: 'ghprbPullId',
+                                                    value: ''),
 
-                                    string(name: 'e2eTestToRun',
-                                            value: 'test-happy-path'),
+                                            string(name: 'e2eTestToRun',
+                                                    value: 'test-happy-path'),
 
-                                    string(name: 'testWorkspaceDevfileUrl',
-                                            value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
+                                            string(name: 'testWorkspaceDevfileUrl',
+                                                    value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
 
-                                    booleanParam(name: 'createTestWorkspace',
-                                            value: true),
+                                            booleanParam(name: 'createTestWorkspace',
+                                                    value: true),
 
-                                    string(name: 'e2eTestParameters',
-                                            value: ''),
+                                            string(name: 'e2eTestParameters',
+                                                    value: ''),
 
-                                    string(name: 'chectlPackageUrl',
-                                            value: ''),
+                                            string(name: 'chectlPackageUrl',
+                                                    value: ''),
 
-                                    string(name: 'cheE2eImageTag',
-                                            value: 'nightly')
-                            ]
+                                            string(name: 'cheE2eImageTag',
+                                                    value: 'nightly')
+                                    ]
+                        }
+                    }
                 }
             }
         }
 
         stage('Run devfile tests') {
             steps {
-                retry(1) {
-                    build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                            parameters: [
-                                    string(name: 'cheImageRepo',
-                                            value: 'quay.io/eclipse/che-server'),
+                script {
+                    catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
+                        retry(1) {
+                            build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                    parameters: [
+                                            string(name: 'cheImageRepo',
+                                                    value: 'quay.io/eclipse/che-server'),
 
-                                    string(name: 'cheImageTag',
-                                            value: 'nightly'),
+                                            string(name: 'cheImageTag',
+                                                    value: 'nightly'),
 
-                                    booleanParam(name: 'buildChe',
-                                            value: false),
+                                            booleanParam(name: 'buildChe',
+                                                    value: false),
 
-                                    string(name: 'ghprbSourceBranch',
-                                            value: 'master'),
+                                            string(name: 'ghprbSourceBranch',
+                                                    value: 'master'),
 
-                                    string(name: 'ghprbPullId',
-                                            value: ''),
+                                            string(name: 'ghprbPullId',
+                                                    value: ''),
 
-                                    string(name: 'e2eTestToRun',
-                                            value: 'test-all-devfiles'),
+                                            string(name: 'e2eTestToRun',
+                                                    value: 'test-all-devfiles'),
 
-                                    string(name: 'testWorkspaceDevfileUrl',
-                                            value: ''),
+                                            string(name: 'testWorkspaceDevfileUrl',
+                                                    value: ''),
 
-                                    booleanParam(name: 'createTestWorkspace',
-                                            value: false),
+                                            booleanParam(name: 'createTestWorkspace',
+                                                    value: false),
 
-                                    string(name: 'e2eTestParameters',
-                                            value: ''),
+                                            string(name: 'e2eTestParameters',
+                                                    value: ''),
 
-                                    string(name: 'chectlPackageUrl',
-                                            value: ''),
+                                            string(name: 'chectlPackageUrl',
+                                                    value: ''),
 
-                                    string(name: 'cheE2eImageTag',
-                                            value: 'nightly')
-                            ]
+                                            string(name: 'cheE2eImageTag',
+                                                    value: 'nightly')
+                                    ]
+                        }
+                    }
                 }
             }
         }
 
         stage('Run Git SSH flow tests') {
             steps {
-                retry(1) {
-                    withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
-                        build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                parameters: [
-                                        string(name: 'cheImageRepo',
-                                                value: 'quay.io/eclipse/che-server'),
+                script {
+                    catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
+                        retry(1) {
+                            withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
+                                build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                        parameters: [
+                                                string(name: 'cheImageRepo',
+                                                        value: 'quay.io/eclipse/che-server'),
 
-                                        string(name: 'cheImageTag',
-                                                value: 'nightly'),
+                                                string(name: 'cheImageTag',
+                                                        value: 'nightly'),
 
-                                        booleanParam(name: 'buildChe',
-                                                value: false),
+                                                booleanParam(name: 'buildChe',
+                                                        value: false),
 
-                                        string(name: 'ghprbSourceBranch',
-                                                value: 'master'),
+                                                string(name: 'ghprbSourceBranch',
+                                                        value: 'master'),
 
-                                        string(name: 'ghprbPullId',
-                                                value: ''),
+                                                string(name: 'ghprbPullId',
+                                                        value: ''),
 
-                                        string(name: 'e2eTestToRun',
-                                                value: 'test-git-ssh'),
+                                                string(name: 'e2eTestToRun',
+                                                        value: 'test-git-ssh'),
 
-                                        string(name: 'testWorkspaceDevfileUrl',
-                                                value: ''),
+                                                string(name: 'testWorkspaceDevfileUrl',
+                                                        value: ''),
 
-                                        booleanParam(name: 'createTestWorkspace',
-                                                value: false),
+                                                booleanParam(name: 'createTestWorkspace',
+                                                        value: false),
 
-                                        string(name: 'e2eTestParameters',
-                                                value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+                                                string(name: 'e2eTestParameters',
+                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
 
-                                        string(name: 'chectlPackageUrl',
-                                                value: ''),
+                                                string(name: 'chectlPackageUrl',
+                                                        value: ''),
 
-                                        string(name: 'cheE2eImageTag',
-                                                value: 'nightly')
-                                ]
+                                                string(name: 'cheE2eImageTag',
+                                                        value: 'nightly')
+                                        ]
+                            }
+                        }
                     }
                 }
             }

--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
     options {
         timestamps()
-        timeout(time: 3, unit: 'HOURS')
+        timeout(time: 6, unit: 'HOURS')
         buildDiscarder(logRotator(artifactDaysToKeepStr: '',
                 artifactNumToKeepStr: '', daysToKeepStr: '60', numToKeepStr: '30'))
     }

--- a/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/Jenkinsfile
@@ -17,139 +17,139 @@ pipeline {
     }
 
     stages {
-        stage('Run Happy path tests') {
+        stage("Run E2E tests") {
             steps {
                 script {
                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
-                        retry(2) {
-                            build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                    parameters: [
-                                            string(name: 'cheImageRepo',
-                                                    value: 'quay.io/eclipse/che-server'),
+                        stage('Run Happy path tests') {
+                            steps {
+                                retry(2) {
+                                    build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                            parameters: [
+                                                    string(name: 'cheImageRepo',
+                                                            value: 'quay.io/eclipse/che-server'),
 
-                                            string(name: 'cheImageTag',
-                                                    value: 'nightly'),
+                                                    string(name: 'cheImageTag',
+                                                            value: 'nightly'),
 
-                                            booleanParam(name: 'buildChe',
-                                                    value: false),
+                                                    booleanParam(name: 'buildChe',
+                                                            value: false),
 
-                                            string(name: 'ghprbSourceBranch',
-                                                    value: 'master'),
+                                                    string(name: 'ghprbSourceBranch',
+                                                            value: 'master'),
 
-                                            string(name: 'ghprbPullId',
-                                                    value: ''),
+                                                    string(name: 'ghprbPullId',
+                                                            value: ''),
 
-                                            string(name: 'e2eTestToRun',
-                                                    value: 'test-happy-path'),
+                                                    string(name: 'e2eTestToRun',
+                                                            value: 'test-happy-path'),
 
-                                            string(name: 'testWorkspaceDevfileUrl',
-                                                    value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
+                                                    string(name: 'testWorkspaceDevfileUrl',
+                                                            value: 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/happy-path/happy-path-workspace.yaml'),
 
-                                            booleanParam(name: 'createTestWorkspace',
-                                                    value: true),
+                                                    booleanParam(name: 'createTestWorkspace',
+                                                            value: true),
 
-                                            string(name: 'e2eTestParameters',
-                                                    value: ''),
+                                                    string(name: 'e2eTestParameters',
+                                                            value: ''),
 
-                                            string(name: 'chectlPackageUrl',
-                                                    value: ''),
+                                                    string(name: 'chectlPackageUrl',
+                                                            value: ''),
 
-                                            string(name: 'cheE2eImageTag',
-                                                    value: 'nightly')
-                                    ]
+                                                    string(name: 'cheE2eImageTag',
+                                                            value: 'nightly')
+                                            ]
+                                }
+                            }
                         }
                     }
-                }
-            }
-        }
 
-        stage('Run devfile tests') {
-            steps {
-                script {
                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
-                        retry(2) {
-                            build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                    parameters: [
-                                            string(name: 'cheImageRepo',
-                                                    value: 'quay.io/eclipse/che-server'),
+                        stage('Run devfile tests') {
+                            steps {
+                                retry(2) {
+                                    build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                            parameters: [
+                                                    string(name: 'cheImageRepo',
+                                                            value: 'quay.io/eclipse/che-server'),
 
-                                            string(name: 'cheImageTag',
-                                                    value: 'nightly'),
+                                                    string(name: 'cheImageTag',
+                                                            value: 'nightly'),
 
-                                            booleanParam(name: 'buildChe',
-                                                    value: false),
+                                                    booleanParam(name: 'buildChe',
+                                                            value: false),
 
-                                            string(name: 'ghprbSourceBranch',
-                                                    value: 'master'),
+                                                    string(name: 'ghprbSourceBranch',
+                                                            value: 'master'),
 
-                                            string(name: 'ghprbPullId',
-                                                    value: ''),
+                                                    string(name: 'ghprbPullId',
+                                                            value: ''),
 
-                                            string(name: 'e2eTestToRun',
-                                                    value: 'test-all-devfiles'),
+                                                    string(name: 'e2eTestToRun',
+                                                            value: 'test-all-devfiles'),
 
-                                            string(name: 'testWorkspaceDevfileUrl',
-                                                    value: ''),
+                                                    string(name: 'testWorkspaceDevfileUrl',
+                                                            value: ''),
 
-                                            booleanParam(name: 'createTestWorkspace',
-                                                    value: false),
+                                                    booleanParam(name: 'createTestWorkspace',
+                                                            value: false),
 
-                                            string(name: 'e2eTestParameters',
-                                                    value: ''),
+                                                    string(name: 'e2eTestParameters',
+                                                            value: ''),
 
-                                            string(name: 'chectlPackageUrl',
-                                                    value: ''),
+                                                    string(name: 'chectlPackageUrl',
+                                                            value: ''),
 
-                                            string(name: 'cheE2eImageTag',
-                                                    value: 'nightly')
-                                    ]
+                                                    string(name: 'cheE2eImageTag',
+                                                            value: 'nightly')
+                                            ]
+                                }
+                            }
                         }
                     }
-                }
-            }
-        }
 
-        stage('Run Git SSH flow tests') {
-            steps {
-                script {
                     catchError(buildResult: 'UNSTABLE', stageResult: 'FAILED') {
-                        retry(2) {
-                            withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
-                                build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
-                                        parameters: [
-                                                string(name: 'cheImageRepo',
-                                                        value: 'quay.io/eclipse/che-server'),
+                        stage('Run Git SSH flow tests') {
+                            steps {
+                                retry(2) {
+                                    withCredentials([string(credentialsId: 'e45af3e6-8061-4d02-b187-b1c3bb133d3a', variable: 'github_oauth_token')]) {
+                                        build job: 'basic-MultiUser-Che-check-e2e-tests-against-k8s',
+                                                parameters: [
+                                                        string(name: 'cheImageRepo',
+                                                                value: 'quay.io/eclipse/che-server'),
 
-                                                string(name: 'cheImageTag',
-                                                        value: 'nightly'),
+                                                        string(name: 'cheImageTag',
+                                                                value: 'nightly'),
 
-                                                booleanParam(name: 'buildChe',
-                                                        value: false),
+                                                        booleanParam(name: 'buildChe',
+                                                                value: false),
 
-                                                string(name: 'ghprbSourceBranch',
-                                                        value: 'master'),
+                                                        string(name: 'ghprbSourceBranch',
+                                                                value: 'master'),
 
-                                                string(name: 'ghprbPullId',
-                                                        value: ''),
+                                                        string(name: 'ghprbPullId',
+                                                                value: ''),
 
-                                                string(name: 'e2eTestToRun',
-                                                        value: 'test-git-ssh'),
+                                                        string(name: 'e2eTestToRun',
+                                                                value: 'test-git-ssh'),
 
-                                                string(name: 'testWorkspaceDevfileUrl',
-                                                        value: ''),
+                                                        string(name: 'testWorkspaceDevfileUrl',
+                                                                value: ''),
 
-                                                booleanParam(name: 'createTestWorkspace',
-                                                        value: false),
+                                                        booleanParam(name: 'createTestWorkspace',
+                                                                value: false),
 
-                                                string(name: 'e2eTestParameters',
-                                                        value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+                                                        string(name: 'e2eTestParameters',
+                                                                value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
 
-                                                string(name: 'chectlPackageUrl',
-                                                        value: ''),
+                                                        string(name: 'chectlPackageUrl',
+                                                                value: ''),
 
-                                                string(name: 'cheE2eImageTag',
-                                                        value: 'nightly')
-                                        ]
+                                                        string(name: 'cheE2eImageTag',
+                                                                value: 'nightly')
+                                                ]
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
### What does this PR do?
Eclipse Che E2E nightly tests shows some flakiness last few weeks on CRW CCI.
These changes are aimed to:
- start E2E tests 2 hours later
- run the tests one-by-one
- retry test execution in case of failure

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17722

### How to test this PR?
Run E2E nightly tests against PR branch. 
Jenkins build is [here](https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/MultiUser-Che-nightly-check-e2e-tests-against-k8s/detail/MultiUser-Che-nightly-check-e2e-tests-against-k8s/402/).

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
