### PR TITLE
Jwtproxy is the new default for the secure servers

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -321,7 +321,7 @@ public class WsMasterModule extends AbstractModule {
     // In single user mode jwtproxy provisioner isn't actually bound at all, but since
     // it is the new default, we need to "fake it" by binding the passthrough provisioner
     // as the jwtproxy impl.
-    configureFakeJwtProxySecureProvisioner(infrastructure);
+    configureImpostorJwtProxySecureProvisioner(infrastructure);
   }
 
   private void configureMultiUserMode(
@@ -431,7 +431,7 @@ public class WsMasterModule extends AbstractModule {
     }
   }
 
-  private void configureFakeJwtProxySecureProvisioner(String infrastructure) {
+  private void configureImpostorJwtProxySecureProvisioner(String infrastructure) {
     if (KubernetesInfrastructure.NAME.equals(infrastructure)) {
       MapBinder.newMapBinder(
               binder(),

--- a/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
+++ b/assembly/assembly-wsmaster-war/src/main/java/org/eclipse/che/api/deploy/WsMasterModule.java
@@ -92,9 +92,14 @@ import org.eclipse.che.security.oauth.OpenShiftOAuthModule;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfraModule;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructure;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.PassThroughProxySecureServerExposer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyConfigBuilderFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyProvisionerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxySecureServerExposerFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxyProvisionerFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxySecureServerExposerFactory;
 import org.eclipse.che.workspace.infrastructure.metrics.InfrastructureMetricsModule;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
 import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftInfraModule;
@@ -236,10 +241,15 @@ public class WsMasterModule extends AbstractModule {
     bindConstant().annotatedWith(Names.named("jndi.datasource.name")).to("java:/comp/env/jdbc/che");
 
     String infrastructure = System.getenv("CHE_INFRASTRUCTURE_ACTIVE");
+
+    install(new FactoryModuleBuilder().build(JwtProxyConfigBuilderFactory.class));
+    install(new FactoryModuleBuilder().build(PassThroughProxyProvisionerFactory.class));
+    installDefaultSecureServerExposer(infrastructure);
+
     if (Boolean.valueOf(System.getenv("CHE_MULTIUSER"))) {
       configureMultiUserMode(persistenceProperties, infrastructure);
     } else {
-      configureSingleUserMode(persistenceProperties);
+      configureSingleUserMode(persistenceProperties, infrastructure);
     }
 
     install(
@@ -277,7 +287,8 @@ public class WsMasterModule extends AbstractModule {
     install(new OpenShiftOAuthModule());
   }
 
-  private void configureSingleUserMode(Map<String, String> persistenceProperties) {
+  private void configureSingleUserMode(
+      Map<String, String> persistenceProperties, String infrastructure) {
     persistenceProperties.put(
         PersistenceUnitProperties.EXCEPTION_HANDLER_CLASS,
         "org.eclipse.che.core.db.h2.jpa.eclipselink.H2ExceptionHandler");
@@ -305,6 +316,11 @@ public class WsMasterModule extends AbstractModule {
         .to(org.eclipse.che.api.workspace.server.DefaultWorkspaceStatusCache.class);
 
     install(new org.eclipse.che.api.workspace.activity.inject.WorkspaceActivityModule());
+
+    // In single user mode jwtproxy provisioner isn't actually bound at all, but since
+    // it is the new default, we need to "fake it" by binding the passthrough provisioner
+    // as the jwtproxy impl.
+    configureFakeJwtProxySecureProvisioner(infrastructure);
   }
 
   private void configureMultiUserMode(
@@ -410,6 +426,70 @@ public class WsMasterModule extends AbstractModule {
               new TypeLiteral<SecureServerExposerFactory<OpenShiftEnvironment>>() {})
           .addBinding("jwtproxy")
           .to(new TypeLiteral<JwtProxySecureServerExposerFactory<OpenShiftEnvironment>>() {});
+    }
+  }
+
+  private void configureFakeJwtProxySecureProvisioner(String infrastructure) {
+    if (KubernetesInfrastructure.NAME.equals(infrastructure)) {
+      MapBinder.newMapBinder(
+              binder(),
+              new TypeLiteral<String>() {},
+              new TypeLiteral<SecureServerExposerFactory<KubernetesEnvironment>>() {})
+          .addBinding("jwtproxy")
+          .to(
+              new TypeLiteral<
+                  PassThroughProxySecureServerExposerFactory<KubernetesEnvironment>>() {});
+    } else {
+      MapBinder.newMapBinder(
+              binder(),
+              new TypeLiteral<String>() {},
+              new TypeLiteral<SecureServerExposerFactory<OpenShiftEnvironment>>() {})
+          .addBinding("jwtproxy")
+          .to(
+              new TypeLiteral<
+                  PassThroughProxySecureServerExposerFactory<OpenShiftEnvironment>>() {});
+    }
+  }
+
+  private void installDefaultSecureServerExposer(String infrastructure) {
+    if (KubernetesInfrastructure.NAME.equals(infrastructure)) {
+      MapBinder<String, SecureServerExposerFactory<KubernetesEnvironment>>
+          secureServerExposerFactories =
+              MapBinder.newMapBinder(binder(), new TypeLiteral<>() {}, new TypeLiteral<>() {});
+
+      install(
+          new FactoryModuleBuilder()
+              .implement(
+                  new TypeLiteral<SecureServerExposer<KubernetesEnvironment>>() {},
+                  new TypeLiteral<PassThroughProxySecureServerExposer<KubernetesEnvironment>>() {})
+              .build(
+                  new TypeLiteral<
+                      PassThroughProxySecureServerExposerFactory<KubernetesEnvironment>>() {}));
+
+      secureServerExposerFactories
+          .addBinding("default")
+          .to(
+              new TypeLiteral<
+                  PassThroughProxySecureServerExposerFactory<KubernetesEnvironment>>() {});
+    } else {
+      MapBinder<String, SecureServerExposerFactory<OpenShiftEnvironment>>
+          secureServerExposerFactories =
+              MapBinder.newMapBinder(binder(), new TypeLiteral<>() {}, new TypeLiteral<>() {});
+
+      install(
+          new FactoryModuleBuilder()
+              .implement(
+                  new TypeLiteral<SecureServerExposer<OpenShiftEnvironment>>() {},
+                  new TypeLiteral<PassThroughProxySecureServerExposer<OpenShiftEnvironment>>() {})
+              .build(
+                  new TypeLiteral<
+                      PassThroughProxySecureServerExposerFactory<OpenShiftEnvironment>>() {}));
+
+      secureServerExposerFactories
+          .addBinding("default")
+          .to(
+              new TypeLiteral<
+                  PassThroughProxySecureServerExposerFactory<OpenShiftEnvironment>>() {});
     }
   }
 }

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -600,7 +600,7 @@ che.workspace.storage.preferred_type=persistent
 #       So, servers should authenticate requests themselves.
 #   - 'jwtproxy': jwtproxy will authenticate requests.
 #       So, servers will receive only authenticated ones.
-che.server.secure_exposer=default
+che.server.secure_exposer=jwtproxy
 
 # Jwtproxy issuer string, token lifetime and optional auth page path to route unsigned requests to.
 che.server.secure_exposer.jwtproxy.token.issuer=wsmaster

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInfraModule.java
@@ -75,13 +75,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.Ingre
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposer;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.PassThroughProxySecureServerExposer;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyConfigBuilderFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxyProvisionerFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxySecureServerExposerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.NonTlsDistributedClusterModeNotifier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesPluginsToolingApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.PluginBrokerManager;
@@ -195,30 +189,6 @@ public class KubernetesInfraModule extends AbstractModule {
     chePluginsAppliers
         .addBinding(KubernetesEnvironment.TYPE)
         .to(KubernetesPluginsToolingApplier.class);
-
-    MapBinder<String, SecureServerExposerFactory<KubernetesEnvironment>>
-        secureServerExposerFactories =
-            MapBinder.newMapBinder(
-                binder(),
-                new TypeLiteral<String>() {},
-                new TypeLiteral<SecureServerExposerFactory<KubernetesEnvironment>>() {});
-
-    install(new FactoryModuleBuilder().build(JwtProxyConfigBuilderFactory.class));
-    install(new FactoryModuleBuilder().build(PassThroughProxyProvisionerFactory.class));
-    install(
-        new FactoryModuleBuilder()
-            .implement(
-                new TypeLiteral<SecureServerExposer<KubernetesEnvironment>>() {},
-                new TypeLiteral<PassThroughProxySecureServerExposer<KubernetesEnvironment>>() {})
-            .build(
-                new TypeLiteral<
-                    PassThroughProxySecureServerExposerFactory<KubernetesEnvironment>>() {}));
-
-    secureServerExposerFactories
-        .addBinding("default")
-        .to(
-            new TypeLiteral<
-                PassThroughProxySecureServerExposerFactory<KubernetesEnvironment>>() {});
 
     bind(BrokerService.class);
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplier.java
@@ -18,7 +18,6 @@ import static org.eclipse.che.api.core.model.workspace.config.Command.WORKING_DI
 import static org.eclipse.che.api.workspace.shared.Constants.CONTAINER_SOURCE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.PLUGIN_MACHINE_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.shared.Constants.TOOL_CONTAINER_SOURCE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider.SECURE_EXPOSER_IMPL_PROPERTY;
 
 import com.google.common.annotations.Beta;
 import com.google.common.collect.ArrayListMultimap;
@@ -174,12 +173,6 @@ public class KubernetesPluginsToolingApplier implements ChePluginsApplier {
     }
 
     chePlugins.forEach(chePlugin -> populateWorkspaceEnvVars(chePlugin, k8sEnv));
-
-    if (isAuthEnabled) {
-      // enable per-workspace security with JWT proxy for sidecar based workspaces
-      // because it is the only workspace security implementation supported for now
-      k8sEnv.getAttributes().putIfAbsent(SECURE_EXPOSER_IMPL_PROPERTY, "jwtproxy");
-    }
   }
 
   private void addToolingPod(KubernetesEnvironment kubernetesEnvironment) {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/wsplugins/KubernetesPluginsToolingApplierTest.java
@@ -790,25 +790,6 @@ public class KubernetesPluginsToolingApplierTest {
   }
 
   @Test
-  public void shouldSetJWTServerExposerAttributeIfAuthEnabled() throws Exception {
-    applier =
-        new KubernetesPluginsToolingApplier(
-            TEST_IMAGE_POLICY,
-            MEMORY_LIMIT_MB,
-            MEMORY_REQUEST_MB,
-            CPU_LIMIT,
-            CPU_REQUEST,
-            true,
-            projectsRootEnvVariableProvider,
-            chePluginsVolumeApplier,
-            envVars);
-
-    applier.apply(runtimeIdentity, internalEnvironment, singletonList(createChePlugin()));
-
-    assertEquals(internalEnvironment.getAttributes().get(SECURE_EXPOSER_IMPL_PROPERTY), "jwtproxy");
-  }
-
-  @Test
   public void shouldNotSetJWTServerExposerAttributeIfAuthEnabledButAttributeIsPresent()
       throws Exception {
     applier =

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInfraModule.java
@@ -76,14 +76,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.Exter
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.GatewayServerExposer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposer;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.SecureServerExposerFactoryProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.CookiePathStrategy;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.PassThroughProxySecureServerExposer;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyConfigBuilderFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxyProvisionerFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.PassThroughProxySecureServerExposerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.NonTlsDistributedClusterModeNotifier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.KubernetesPluginsToolingApplier;
 import org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.PluginBrokerManager;
@@ -176,28 +170,6 @@ public class OpenShiftInfraModule extends AbstractModule {
 
     bind(SecureServerExposerFactoryProvider.class)
         .to(new TypeLiteral<SecureServerExposerFactoryProvider<OpenShiftEnvironment>>() {});
-
-    MapBinder<String, SecureServerExposerFactory<OpenShiftEnvironment>>
-        secureServerExposerFactories =
-            MapBinder.newMapBinder(
-                binder(),
-                new TypeLiteral<String>() {},
-                new TypeLiteral<SecureServerExposerFactory<OpenShiftEnvironment>>() {});
-
-    install(new FactoryModuleBuilder().build(JwtProxyConfigBuilderFactory.class));
-    install(new FactoryModuleBuilder().build(PassThroughProxyProvisionerFactory.class));
-    install(
-        new FactoryModuleBuilder()
-            .implement(
-                new TypeLiteral<SecureServerExposer<OpenShiftEnvironment>>() {},
-                new TypeLiteral<PassThroughProxySecureServerExposer<OpenShiftEnvironment>>() {})
-            .build(
-                new TypeLiteral<
-                    PassThroughProxySecureServerExposerFactory<OpenShiftEnvironment>>() {}));
-
-    secureServerExposerFactories
-        .addBinding("default")
-        .to(new TypeLiteral<PassThroughProxySecureServerExposerFactory<OpenShiftEnvironment>>() {});
 
     bind(BrokerService.class);
 


### PR DESCRIPTION
### What does this PR do?

This changes the default implementation of the secure servers authentication to "jwtproxy". The previous default was a mere passthrough, which offered no che-provided authentication at all.

This PR also consolidates the secure server behavior of plugins and other workspace components. Before, the plugins and editors were authenticated using jwtproxy regardless of how what the `che.server.secure_exposer` said.

### What issues does this PR fix or reference?
#17852

### How to test this PR?
1. Deploy a fresh che server built from this branch.
1. Deploy a new workspace using the below devfile.
1. Make sure that endpoint works and is correctly authenticated
    1. Start the quarkus application in devmode
    1. Open web tools in the browser
    1. Click on the endpoint link
    1. In the network tab of the web tools check that the auth flow has happened and that the final request to the endpoint page has its authorization cookie set.

```yaml
metadata:
  name: test-for-17852
projects:
  - name: quarkus-quickstarts
    source:
      location: 'https://github.com/quarkusio/quarkus-quickstarts.git'
      type: git
      sparseCheckoutDir: getting-started
components:
  - id: redhat/quarkus-java11/latest
    type: chePlugin
  - mountSources: true
    endpoints:
      - name: hello-greeting-endpoint
        port: 8080
        attributes:
          cookiesAuthEnabled: 'true'
          path: /
          secure: 'true'
    memoryLimit: 4927M
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    alias: centos-quarkus-maven
    image: 'quay.io/eclipse/che-quarkus:nightly'
    env:
      - value: >-
          -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
          -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true
          -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user
        name: JAVA_OPTS
      - value: $(JAVA_OPTS)
        name: MAVEN_OPTS
apiVersion: 1.0.0
commands:
  - name: Start Development mode (Hot reload + debug)
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started'
        type: exec
        command: './mvnw compile quarkus:dev'
        component: centos-quarkus-maven
```
 
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
