### PR TITLE
cleanup che namespace only when needed

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeCleaner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeCleaner.java
@@ -15,15 +15,20 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.server.externa
 
 import javax.inject.Inject;
 import javax.inject.Named;
+import javax.inject.Singleton;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.CheNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
 
+/**
+ * Little helper bean that decides what is needed to cleanup for given workspace. It does not delete
+ * anything on it's own, but delegates the cleaning operations to provided {@link
+ * KubernetesNamespace} and {@link CheNamespace}.
+ */
+@Singleton
 public class RuntimeCleaner {
-
   private final boolean cleanupCheNamespace;
-
   private final CheNamespace cheNamespace;
 
   @Inject
@@ -38,6 +43,14 @@ public class RuntimeCleaner {
             && WorkspaceExposureType.GATEWAY.getConfigValue().equals(singleHostStrategy);
   }
 
+  /**
+   * Remove all workspace related k8s objects in both workspace's namespace and in Che namespace if
+   * needed.
+   *
+   * @param namespace to cleanup
+   * @param workspaceId to cleanup
+   * @throws InfrastructureException when exception during cleaning occurs.
+   */
   public void cleanUp(KubernetesNamespace namespace, String workspaceId)
       throws InfrastructureException {
     namespace.cleanUp();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeCleaner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeCleaner.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy.SINGLE_HOST_STRATEGY;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.CheNamespace;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
+
+public class RuntimeCleaner {
+
+  private final boolean cleanupCheNamespace;
+
+  private final CheNamespace cheNamespace;
+
+  @Inject
+  public RuntimeCleaner(
+      @Named("che.infra.kubernetes.server_strategy") String exposureStrategy,
+      @Named("che.infra.kubernetes.singlehost.workspace.exposure") String singleHostStrategy,
+      CheNamespace cheNamespace) {
+    this.cheNamespace = cheNamespace;
+
+    this.cleanupCheNamespace =
+        SINGLE_HOST_STRATEGY.equals(exposureStrategy)
+            && WorkspaceExposureType.GATEWAY.getConfigValue().equals(singleHostStrategy);
+  }
+
+  public void cleanUp(KubernetesNamespace namespace, String workspaceId)
+      throws InfrastructureException {
+    namespace.cleanUp();
+    if (cleanupCheNamespace) {
+      cheNamespace.cleanUp(workspaceId);
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -433,8 +433,7 @@ public class KubernetesInternalRuntimeTest {
     verify(services).create(any());
     verify(secrets).create(any());
     verify(configMaps).create(any());
-    verify(namespace).cleanUp();
-    verify(cheNamespace).cleanUp(WORKSPACE_ID);
+    verify(runtimeCleaner).cleanUp(namespace, WORKSPACE_ID);
     verify(namespace.deployments(), times(1)).watchEvents(any());
     verify(eventService, times(4)).publish(any());
     verifyOrderedEventsChains(
@@ -451,9 +450,8 @@ public class KubernetesInternalRuntimeTest {
     internalRuntime.start(emptyMap());
 
     InOrder cleanupInOrderExecutionVerification =
-        Mockito.inOrder(namespace, cheNamespace, deployments, toolingProvisioner);
-    cleanupInOrderExecutionVerification.verify(namespace).cleanUp();
-    cleanupInOrderExecutionVerification.verify(cheNamespace).cleanUp(WORKSPACE_ID);
+        Mockito.inOrder(runtimeCleaner, deployments, toolingProvisioner);
+    cleanupInOrderExecutionVerification.verify(runtimeCleaner).cleanUp(namespace, WORKSPACE_ID);
     cleanupInOrderExecutionVerification
         .verify(toolingProvisioner)
         .provision(any(), any(), any(), any());
@@ -656,8 +654,7 @@ public class KubernetesInternalRuntimeTest {
     try {
       internalRuntime.start(emptyMap());
     } catch (Exception rethrow) {
-      verify(namespace, times(2)).cleanUp();
-      verify(cheNamespace, times(2)).cleanUp(WORKSPACE_ID);
+      verify(runtimeCleaner, times(2)).cleanUp(namespace, WORKSPACE_ID);
       verify(namespace, never()).services();
       verify(namespace, never()).ingresses();
       throw rethrow;
@@ -695,7 +692,10 @@ public class KubernetesInternalRuntimeTest {
 
   @Test(expectedExceptions = InfrastructureException.class)
   public void throwsInfrastructureExceptionWhenErrorOccursAndCleanupFailed() throws Exception {
-    doNothing().doThrow(InfrastructureException.class).when(namespace).cleanUp();
+    doNothing()
+        .doThrow(InfrastructureException.class)
+        .when(runtimeCleaner)
+        .cleanUp(namespace, WORKSPACE_ID);
     when(k8sEnv.getServices()).thenReturn(singletonMap("testService", mock(Service.class)));
     when(services.create(any())).thenThrow(new InfrastructureException("service creation failed"));
     doThrow(IllegalStateException.class).when(namespace).services();
@@ -703,7 +703,7 @@ public class KubernetesInternalRuntimeTest {
     try {
       internalRuntime.start(emptyMap());
     } catch (Exception rethrow) {
-      verify(namespace, times(2)).cleanUp();
+      verify(runtimeCleaner, times(2)).cleanUp(namespace, WORKSPACE_ID);
       verify(namespace).services();
       verify(namespace, never()).ingresses();
       throw rethrow;
@@ -736,21 +736,12 @@ public class KubernetesInternalRuntimeTest {
     internalRuntime.internalStop(emptyMap());
 
     verify(runtimeHangingDetector).stopTracking(IDENTITY);
-    verify(namespace).cleanUp();
-    verify(cheNamespace).cleanUp(WORKSPACE_ID);
+    verify(runtimeCleaner).cleanUp(namespace, WORKSPACE_ID);
   }
 
   @Test(expectedExceptions = InfrastructureException.class)
   public void throwsInfrastructureExceptionWhenKubernetesNamespaceCleanupFailed() throws Exception {
-    doThrow(InfrastructureException.class).when(namespace).cleanUp();
-
-    internalRuntime.internalStop(emptyMap());
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwsInfrastructureExceptionWhenKubernetesCheNamespaceCleanupFailed()
-      throws Exception {
-    doThrow(InfrastructureException.class).when(cheNamespace).cleanUp(WORKSPACE_ID);
+    doThrow(InfrastructureException.class).when(runtimeCleaner).cleanUp(namespace, WORKSPACE_ID);
 
     internalRuntime.internalStop(emptyMap());
   }
@@ -1163,7 +1154,7 @@ public class KubernetesInternalRuntimeTest {
     verify(cheNamespace)
         .createConfigMaps(
             expectedCreatedCheNamespaceConfigmaps, internalRuntime.getContext().getIdentity());
-    verify(cheNamespace).cleanUp(WORKSPACE_ID);
+    verify(runtimeCleaner).cleanUp(namespace, WORKSPACE_ID);
   }
 
   private static MachineStatusEvent newEvent(String machineName, MachineStatus status) {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -216,6 +216,7 @@ public class KubernetesInternalRuntimeTest {
   @Mock private RuntimeHangingDetector runtimeHangingDetector;
   @Mock private KubernetesPreviewUrlCommandProvisioner previewUrlCommandProvisioner;
   @Mock private SecretAsContainerResourceProvisioner secretAsContainerResourceProvisioner;
+  @Mock private RuntimeCleaner runtimeCleaner;
   private KubernetesServerResolverFactory serverResolverFactory;
 
   @Mock
@@ -290,6 +291,7 @@ public class KubernetesInternalRuntimeTest {
             previewUrlCommandProvisioner,
             secretAsContainerResourceProvisioner,
             serverResolverFactory,
+            runtimeCleaner,
             cheNamespace,
             tracer,
             context,

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeCleanerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeCleanerTest.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.che.workspace.infrastructure.kubernetes;
 
 import static org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType.GATEWAY;

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeCleanerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/RuntimeCleanerTest.java
@@ -1,0 +1,62 @@
+package org.eclipse.che.workspace.infrastructure.kubernetes;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType.GATEWAY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType.NATIVE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.DefaultHostExternalServiceExposureStrategy.DEFAULT_HOST_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.SingleHostExternalServiceExposureStrategy.SINGLE_HOST_STRATEGY;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.testng.Assert.*;
+
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.CheNamespace;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class RuntimeCleanerTest {
+  private final String WS_ID = "123";
+
+  @Mock private CheNamespace cheNamespace;
+  @Mock private KubernetesNamespace kubeNamespace;
+
+  @Test
+  public void shouldCleanupEverythingIfSinglehostGateway() throws InfrastructureException {
+    RuntimeCleaner runtimeCleaner =
+        new RuntimeCleaner(SINGLE_HOST_STRATEGY, GATEWAY.getConfigValue(), cheNamespace);
+
+    runtimeCleaner.cleanUp(kubeNamespace, WS_ID);
+
+    verify(cheNamespace).cleanUp(WS_ID);
+    verify(kubeNamespace).cleanUp();
+  }
+
+  @Test(dataProvider = "notSinglehostGateway")
+  public void shouldNotCleanupCheNamespaceIfNotSinglehostGateway(
+      String serverStrategy, String singleHostStrategy) throws InfrastructureException {
+    RuntimeCleaner runtimeCleaner =
+        new RuntimeCleaner(serverStrategy, singleHostStrategy, cheNamespace);
+
+    runtimeCleaner.cleanUp(kubeNamespace, WS_ID);
+
+    verify(kubeNamespace).cleanUp();
+    verify(cheNamespace, never()).cleanUp(any());
+  }
+
+  @DataProvider
+  public static Object[][] notSinglehostGateway() {
+    return new Object[][] {
+      {SINGLE_HOST_STRATEGY, NATIVE.getConfigValue()},
+      {MULTI_HOST_STRATEGY, GATEWAY.getConfigValue()},
+      {MULTI_HOST_STRATEGY, NATIVE.getConfigValue()},
+      {DEFAULT_HOST_STRATEGY, GATEWAY.getConfigValue()},
+      {DEFAULT_HOST_STRATEGY, NATIVE.getConfigValue()},
+    };
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntime.java
@@ -34,6 +34,7 @@ import org.eclipse.che.commons.annotation.Traced;
 import org.eclipse.che.commons.tracing.TracingTags;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesRuntimeContext;
+import org.eclipse.che.workspace.infrastructure.kubernetes.RuntimeCleaner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.RuntimeHangingDetector;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.cache.KubernetesMachineCache;
@@ -84,6 +85,7 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
       SecretAsContainerResourceProvisioner<OpenShiftEnvironment>
           secretAsContainerResourceProvisioner,
       OpenShiftServerResolverFactory serverResolverFactory,
+      RuntimeCleaner runtimeCleaner,
       CheNamespace cheNamespace,
       Tracer tracer,
       Openshift4TrustedCAProvisioner trustedCAProvisioner,
@@ -110,6 +112,7 @@ public class OpenShiftInternalRuntime extends KubernetesInternalRuntime<OpenShif
         previewUrlCommandProvisioner,
         secretAsContainerResourceProvisioner,
         null,
+        runtimeCleaner,
         cheNamespace,
         tracer,
         context,

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -66,6 +66,7 @@ import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
 import org.eclipse.che.api.workspace.server.spi.environment.InternalMachineConfig;
 import org.eclipse.che.api.workspace.server.spi.provision.InternalEnvironmentProvisioner;
 import org.eclipse.che.api.workspace.shared.dto.event.MachineStatusEvent;
+import org.eclipse.che.workspace.infrastructure.kubernetes.RuntimeCleaner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.RuntimeHangingDetector;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizer;
 import org.eclipse.che.workspace.infrastructure.kubernetes.StartSynchronizerFactory;
@@ -150,6 +151,7 @@ public class OpenShiftInternalRuntimeTest {
   @Mock private SecretAsContainerResourceProvisioner secretAsContainerResourceProvisioner;
   @Mock private Openshift4TrustedCAProvisioner trustedCAProvisioner;
   @Mock private CheNamespace cheNamespace;
+  @Mock private RuntimeCleaner runtimeCleaner;
   private OpenShiftServerResolverFactory serverResolverFactory;
 
   @Mock(answer = Answers.RETURNS_MOCKS)
@@ -194,6 +196,7 @@ public class OpenShiftInternalRuntimeTest {
             previewUrlCommandProvisioner,
             secretAsContainerResourceProvisioner,
             serverResolverFactory,
+            runtimeCleaner,
             cheNamespace,
             tracer,
             trustedCAProvisioner,


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Cleanup workspace object in `che` namespace only if we're on gateway single-host. 


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/17999


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. remove list configmaps permissions for `che` serviceaccount
    1. `che` SA has `edit` ClusteRole, which can't be changed and there is no DENY permission in k8s. I did this so I've copied whole `edit` ClusterRole as `che-edit` and removed list configmaps from the copy. Then remove RoleBinding of `che` SA to `edit` ClusterRole and create new binding to `che-edit`. If you deploy with operator, you have to stop it or it will not allow you to change the objects. iiiizy :) GL
1. try to start any workspace, it must not fail (fails before)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
