### PR TITLE
Ensure all metrics have enough time to be recorded

### DIFF
--- a/core/commons/che-core-commons-observability/src/test/java/org/eclipse/che/commons/observability/MeteredExecutorServiceWrapperTest.java
+++ b/core/commons/che-core-commons-observability/src/test/java/org/eclipse/che/commons/observability/MeteredExecutorServiceWrapperTest.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.commons.observability;
 
 import static org.eclipse.che.commons.test.AssertRetry.assertWithRetry;
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -90,94 +89,17 @@ public class MeteredExecutorServiceWrapperTest {
     runnableTaskStart.await(10, TimeUnit.SECONDS);
     future.get(1, TimeUnit.MINUTES);
 
-    assertEquals(
-        registry
-            .get("thread.factory.terminated")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        0.0);
-    assertEquals(
-        registry
-            .get("thread.factory.running")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .gauge()
-            .value(),
-        1.0);
-    assertEquals(
-        registry
-            .get("thread.factory.created")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        1.0);
-    assertEquals(
-        registry
-            .get("executor.rejected")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        0.0);
-
-    assertEquals(
-        registry
-            .get("executor.pool.size")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        1.0);
-    assertWithRetry(
-        () ->
-            registry
-                .get("executor.completed")
-                .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-                .tags(userTags)
-                .functionCounter()
-                .count(),
-        1.0,
-        10,
-        50);
-    assertEquals(
-        registry
-            .get("executor.queued")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        0.0);
-    assertEquals(
-        registry
-            .get("executor.idle")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .timer()
-            .count(),
-        1);
-    assertEquals(
-        registry
-            .get("executor.queue.remaining")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        (double) Integer.MAX_VALUE);
-    assertEquals(
-        registry
-            .get("executor")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .timer()
-            .count(),
-        1);
-    assertEquals(
-        registry
-            .get("executor.active")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        0.0);
+    assertCounter("thread.factory.terminated", 0.0);
+    assertGauge("thread.factory.running", 1.0);
+    assertCounter("thread.factory.created", 1.0);
+    assertCounter("executor.rejected", 0.0);
+    assertGauge("executor.pool.size", 1.0);
+    assertFunctionCounter("executor.completed", 1.0);
+    assertGauge("executor.queued", 0.0);
+    assertTimerCount("executor.idle", 1L);
+    assertGauge("executor.queue.remaining", (double) Integer.MAX_VALUE);
+    assertTimerCount("executor", 1L);
+    assertGauge("executor.active", 0.0);
   }
 
   @Test
@@ -197,111 +119,19 @@ public class MeteredExecutorServiceWrapperTest {
 
     runnableTaskStart.await(10, TimeUnit.SECONDS);
 
-    assertEquals(
-        registry
-            .get("thread.factory.terminated")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        0.0);
-    assertEquals(
-        registry
-            .get("thread.factory.running")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .gauge()
-            .value(),
-        1.0);
-    assertEquals(
-        registry
-            .get("thread.factory.created")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        1.0);
-    assertEquals(
-        registry
-            .get("executor.rejected")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        0.0);
-
-    assertEquals(
-        registry
-            .get("executor.pool.size")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        1.0);
-    assertWithRetry(
-        () ->
-            registry
-                .get("executor.completed")
-                .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-                .tags(userTags)
-                .functionCounter()
-                .count(),
-        1.0,
-        10,
-        50);
-
-    assertEquals(
-        registry
-            .get("executor.queued")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        1.0);
-    assertEquals(
-        registry
-            .get("executor.idle")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .timer()
-            .count(),
-        0);
-    assertEquals(
-        registry
-            .get("executor.queue.remaining")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        (double) Integer.MAX_VALUE);
-    assertEquals(
-        registry
-            .get("executor")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .timer()
-            .count(),
-        1);
-    assertEquals(
-        registry
-            .get("executor.active")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        0.0);
-    assertEquals(
-        registry
-            .get("executor.scheduled.once")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .counter()
-            .count(),
-        0.0);
-    assertEquals(
-        registry
-            .get("executor.scheduled.repetitively")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .counter()
-            .count(),
-        1.0);
+    assertCounter("thread.factory.terminated", 0.0);
+    assertGauge("thread.factory.running", 1.0);
+    assertCounter("thread.factory.created", 1.0);
+    assertCounter("executor.rejected", 0.0);
+    assertGauge("executor.pool.size", 1.0);
+    assertFunctionCounter("executor.completed", 1.0);
+    assertGauge("executor.queued", 1.0);
+    assertTimerCount("executor.idle", 0L);
+    assertGauge("executor.queue.remaining", (double) Integer.MAX_VALUE);
+    assertTimerCount("executor", 1L);
+    assertGauge("executor.active", 0.0);
+    assertCounter("executor.scheduled.once", 0.0);
+    assertCounter("executor.scheduled.repetitively", 1.0);
   }
 
   @Test
@@ -318,70 +148,15 @@ public class MeteredExecutorServiceWrapperTest {
     executor.schedule(runnableTaskStart::countDown, new CronExpression(" * * * ? * * *"));
     // then
     runnableTaskStart.await(10, TimeUnit.SECONDS);
-    assertEquals(
-        registry
-            .get("thread.factory.terminated")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        0.0);
-    assertEquals(
-        registry
-            .get("thread.factory.running")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .gauge()
-            .value(),
-        2.0);
-    assertEquals(
-        registry
-            .get("thread.factory.created")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        2.0);
-    assertEquals(
-        registry
-            .get("executor.rejected")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .counter()
-            .count(),
-        0.0);
 
-    assertEquals(
-        registry
-            .get("executor.pool.size")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        2.0);
-    assertEquals(
-        registry
-            .get("executor.completed")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .functionCounter()
-            .count(),
-        1.0);
-    assertWithRetry(
-        () ->
-            registry
-                .get("executor.queued")
-                .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-                .tags(userTags)
-                .gauge()
-                .value(),
-        1.0,
-        10,
-        50);
-    assertEquals(
-        registry
-            .get("executor.idle")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .timer()
-            .count(),
-        0);
+    assertCounter("thread.factory.terminated", 0.0);
+    assertGauge("thread.factory.running", 2.0);
+    assertCounter("thread.factory.created", 2.0);
+    assertCounter("executor.rejected", 0.0);
+    assertGauge("executor.pool.size", 2.0);
+    assertFunctionCounter("executor.completed", 1.0);
+    assertGauge("executor.queued", 1.0);
+    assertTimerCount("executor.idle", 0L);
     assertTrue(
         registry
                 .get("executor.queue.remaining")
@@ -390,45 +165,67 @@ public class MeteredExecutorServiceWrapperTest {
                 .gauge()
                 .value()
             > 0.0);
-    assertEquals(
-        registry
-            .get("executor")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .timer()
-            .count(),
-        1);
-    assertEquals(
-        registry
-            .get("executor.active")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .gauge()
-            .value(),
-        1.0);
-    assertEquals(
-        registry
-            .get("executor.scheduled.once")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .counter()
-            .count(),
-        0.0);
-    assertEquals(
-        registry
-            .get("executor.scheduled.repetitively")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .counter()
-            .count(),
-        0.0);
-    assertEquals(
-        registry
-            .get("executor.scheduled.cron")
-            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
-            .tags(userTags)
-            .counter()
-            .count(),
-        1.0);
+
+    assertTimerCount("executor", 1L);
+    assertGauge("executor.active", 1.0);
+    assertCounter("executor.scheduled.once", 0.0);
+    assertCounter("executor.scheduled.repetitively", 0.0);
+    assertCounter("executor.scheduled.cron", 1.0);
+  }
+
+  public void assertCounter(String counterName, Double value) throws InterruptedException {
+    assertWithRetry(
+        () ->
+            registry
+                .get(counterName)
+                .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
+                .tags(userTags)
+                .counter()
+                .count(),
+        value,
+        20,
+        50);
+  }
+
+  public void assertFunctionCounter(String counterName, Double value) throws InterruptedException {
+    assertWithRetry(
+        () ->
+            registry
+                .get(counterName)
+                .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
+                .tags(userTags)
+                .functionCounter()
+                .count(),
+        value,
+        20,
+        50);
+  }
+
+  public void assertGauge(String gaugeName, Double value) throws InterruptedException {
+    assertWithRetry(
+        () ->
+            registry
+                .get(gaugeName)
+                .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
+                .tags(userTags)
+                .gauge()
+                .value(),
+        value,
+        20,
+        50);
+  }
+
+  public void assertTimerCount(String timerName, Long value) throws InterruptedException {
+    assertWithRetry(
+        () ->
+            registry
+                .get(timerName)
+                .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
+                .tags(userTags)
+                .timer()
+                .count(),
+        value,
+        20,
+        50);
   }
 }


### PR DESCRIPTION

### What does this PR do?
Test was failing because this metric
```
    assertEquals(
        registry
            .get("executor.completed")
            .tag("name", MeteredExecutorServiceWrapperTest.class.getName())
            .tags(userTags)
            .functionCounter()
            .count(),
        1.0);
```
has not enough time to be recorded. With this pr all metrics have some timeout to be recorder `~1sec`
Ensure all metrics have enough time to be recorder

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
fixes  https://github.com/eclipse/che/issues/18012


### How to test this PR?
```mvn clean install```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
