### PR TITLE
expose endpoints with "requireSubdomain" attribute on subdomain with single-host

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -92,9 +92,10 @@ public interface ServerConfig {
   String SERVICE_PORT_ATTRIBUTE = "servicePort";
 
   /**
-   * This attributes is marking that server come from the devfile endpoint. Used internally only.
+   * This attributes is marking that server should be exposed on subdomain if we're on
+   * single-host. It has no effect on other server exposure strategies.
    */
-  String DEVFILE_ENDPOINT = "devfileEndpoint";
+  String FORCE_SUBDOMAIN = "forceSubdomain";
 
   /**
    * Port used by server.

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -92,10 +92,10 @@ public interface ServerConfig {
   String SERVICE_PORT_ATTRIBUTE = "servicePort";
 
   /**
-   * This attributes is marking that server should be exposed on subdomain if we're on
-   * single-host. It has no effect on other server exposure strategies.
+   * This attributes is marking that server should be exposed on subdomain if we're on single-host.
+   * It has no effect on other server exposure strategies.
    */
-  String FORCE_SUBDOMAIN = "forceSubdomain";
+  String REQUIRE_SUBDOMAIN = "requireSubdomain";
 
   /**
    * Port used by server.

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -12,7 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static java.lang.Boolean.FALSE;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.FORCE_SUBDOMAIN;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
 import java.util.HashMap;
@@ -48,7 +48,7 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
   /**
    * Exposes given 'externalServers' to either subdomain or subpath, using 2 different {@link
    * ExternalServerExposer}s. Which one to use for individual server is determined with {@link
-   * ServerConfig#DEVFILE_ENDPOINT} attribute.
+   * ServerConfig#FORCE_SUBDOMAIN} attribute.
    *
    * @param k8sEnv environment
    * @param machineName machine containing servers
@@ -78,7 +78,7 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
     for (String esKey : externalServers.keySet()) {
       ServerConfig serverConfig = externalServers.get(esKey);
       if (Boolean.parseBoolean(
-          serverConfig.getAttributes().getOrDefault(DEVFILE_ENDPOINT, FALSE.toString()))) {
+          serverConfig.getAttributes().getOrDefault(FORCE_SUBDOMAIN, FALSE.toString()))) {
         subdomainServers.put(esKey, serverConfig);
       } else {
         subpathServers.put(esKey, serverConfig);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -12,7 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static java.lang.Boolean.FALSE;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.FORCE_SUBDOMAIN;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.REQUIRE_SUBDOMAIN;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
 import java.util.HashMap;
@@ -48,7 +48,7 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
   /**
    * Exposes given 'externalServers' to either subdomain or subpath, using 2 different {@link
    * ExternalServerExposer}s. Which one to use for individual server is determined with {@link
-   * ServerConfig#FORCE_SUBDOMAIN} attribute.
+   * ServerConfig#REQUIRE_SUBDOMAIN} attribute.
    *
    * @param k8sEnv environment
    * @param machineName machine containing servers
@@ -78,7 +78,7 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
     for (String esKey : externalServers.keySet()) {
       ServerConfig serverConfig = externalServers.get(esKey);
       if (Boolean.parseBoolean(
-          serverConfig.getAttributes().getOrDefault(FORCE_SUBDOMAIN, FALSE.toString()))) {
+          serverConfig.getAttributes().getOrDefault(REQUIRE_SUBDOMAIN, FALSE.toString()))) {
         subdomainServers.put(esKey, serverConfig);
       } else {
         subpathServers.put(esKey, serverConfig);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
@@ -350,7 +350,7 @@ public class DockerimageComponentToWorkspaceApplierTest {
     Map<String, String> attributes = serverConfig.getAttributes();
     assertEquals(attributes.get(ServerConfig.INTERNAL_SERVER_ATTRIBUTE), "true");
     assertEquals(attributes.get("secure"), "false");
-    assertEquals(attributes.get(ServerConfig.DEVFILE_ENDPOINT), "true");
+    assertEquals(attributes.get(ServerConfig.FORCE_SUBDOMAIN), "true");
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
@@ -350,7 +350,7 @@ public class DockerimageComponentToWorkspaceApplierTest {
     Map<String, String> attributes = serverConfig.getAttributes();
     assertEquals(attributes.get(ServerConfig.INTERNAL_SERVER_ATTRIBUTE), "true");
     assertEquals(attributes.get("secure"), "false");
-    assertEquals(attributes.get(ServerConfig.FORCE_SUBDOMAIN), "true");
+    assertEquals(attributes.get(ServerConfig.REQUIRE_SUBDOMAIN), "true");
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.DEVFILE_COMPONENT_ALIAS_ATTRIBUTE;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.FORCE_SUBDOMAIN;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.REQUIRE_SUBDOMAIN;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.OPENSHIFT_COMPONENT_TYPE;
@@ -680,7 +680,7 @@ public class KubernetesComponentToWorkspaceApplierTest {
               assertEquals(serverConfigs.get(endpointName).getPath(), endpointPath);
               assertEquals(serverConfigs.get(endpointName).getProtocol(), endpointProtocol);
               assertEquals(
-                  serverConfigs.get(endpointName).getAttributes().get(FORCE_SUBDOMAIN), "true");
+                  serverConfigs.get(endpointName).getAttributes().get(REQUIRE_SUBDOMAIN), "true");
               assertEquals(
                   serverConfigs.get(endpointName).isSecure(), Boolean.parseBoolean(endpointSecure));
               assertEquals(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
@@ -18,7 +18,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.eclipse.che.api.core.model.workspace.config.Command.MACHINE_NAME_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.MachineConfig.DEVFILE_COMPONENT_ALIAS_ATTRIBUTE;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.FORCE_SUBDOMAIN;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.COMPONENT_ALIAS_COMMAND_ATTRIBUTE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.KUBERNETES_COMPONENT_TYPE;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.OPENSHIFT_COMPONENT_TYPE;
@@ -680,7 +680,7 @@ public class KubernetesComponentToWorkspaceApplierTest {
               assertEquals(serverConfigs.get(endpointName).getPath(), endpointPath);
               assertEquals(serverConfigs.get(endpointName).getProtocol(), endpointProtocol);
               assertEquals(
-                  serverConfigs.get(endpointName).getAttributes().get(DEVFILE_ENDPOINT), "true");
+                  serverConfigs.get(endpointName).getAttributes().get(FORCE_SUBDOMAIN), "true");
               assertEquals(
                   serverConfigs.get(endpointName).isSecure(), Boolean.parseBoolean(endpointSecure));
               assertEquals(

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposerTest.java
@@ -13,9 +13,8 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.FORCE_SUBDOMAIN;
 import static org.mockito.Mockito.verify;
-import static org.testng.Assert.*;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
 import java.util.Map;
@@ -45,9 +44,8 @@ public class CombinedSingleHostServerExposerTest {
     // given
     ServerConfig s1 = new ServerConfigImpl("1", "http", "/", emptyMap());
     ServerConfig s2 =
-        new ServerConfigImpl("2", "http", "/", singletonMap(DEVFILE_ENDPOINT, "false"));
-    ServerConfig s3 =
-        new ServerConfigImpl("3", "http", "/", singletonMap(DEVFILE_ENDPOINT, "true"));
+        new ServerConfigImpl("2", "http", "/", singletonMap(FORCE_SUBDOMAIN, "false"));
+    ServerConfig s3 = new ServerConfigImpl("3", "http", "/", singletonMap(FORCE_SUBDOMAIN, "true"));
 
     CombinedSingleHostServerExposer<KubernetesEnvironment> serverExposer =
         new CombinedSingleHostServerExposer<>(subdomainExposer, subpathExposer);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposerTest.java
@@ -13,7 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.FORCE_SUBDOMAIN;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.REQUIRE_SUBDOMAIN;
 import static org.mockito.Mockito.verify;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
@@ -44,8 +44,9 @@ public class CombinedSingleHostServerExposerTest {
     // given
     ServerConfig s1 = new ServerConfigImpl("1", "http", "/", emptyMap());
     ServerConfig s2 =
-        new ServerConfigImpl("2", "http", "/", singletonMap(FORCE_SUBDOMAIN, "false"));
-    ServerConfig s3 = new ServerConfigImpl("3", "http", "/", singletonMap(FORCE_SUBDOMAIN, "true"));
+        new ServerConfigImpl("2", "http", "/", singletonMap(REQUIRE_SUBDOMAIN, "false"));
+    ServerConfig s3 =
+        new ServerConfigImpl("3", "http", "/", singletonMap(REQUIRE_SUBDOMAIN, "true"));
 
     CombinedSingleHostServerExposer<KubernetesEnvironment> serverExposer =
         new CombinedSingleHostServerExposer<>(subdomainExposer, subpathExposer);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -197,7 +197,7 @@ public class ServerConfigImpl implements ServerConfig {
     }
 
     if (devfileEndpoint) {
-      attributes.put(DEVFILE_ENDPOINT, Boolean.TRUE.toString());
+      attributes.put(FORCE_SUBDOMAIN, Boolean.TRUE.toString());
     }
 
     return new ServerConfigImpl(Integer.toString(endpoint.getPort()), protocol, path, attributes);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -197,7 +197,7 @@ public class ServerConfigImpl implements ServerConfig {
     }
 
     if (devfileEndpoint) {
-      attributes.put(FORCE_SUBDOMAIN, Boolean.TRUE.toString());
+      attributes.put(REQUIRE_SUBDOMAIN, Boolean.TRUE.toString());
     }
 
     return new ServerConfigImpl(Integer.toString(endpoint.getPort()), protocol, path, attributes);

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImplTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImplTest.java
@@ -13,8 +13,8 @@ package org.eclipse.che.api.workspace.server.model.impl;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.FORCE_SUBDOMAIN;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.INTERNAL_SERVER_ATTRIBUTE;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.REQUIRE_SUBDOMAIN;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVER_NAME_ATTRIBUTE;
 import static org.testng.Assert.*;
 
@@ -114,8 +114,8 @@ public class ServerConfigImplTest {
     ServerConfig serverConfig =
         ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()), true);
 
-    assertTrue(serverConfig.getAttributes().containsKey(FORCE_SUBDOMAIN));
-    assertTrue(Boolean.parseBoolean(serverConfig.getAttributes().get(FORCE_SUBDOMAIN)));
+    assertTrue(serverConfig.getAttributes().containsKey(REQUIRE_SUBDOMAIN));
+    assertTrue(Boolean.parseBoolean(serverConfig.getAttributes().get(REQUIRE_SUBDOMAIN)));
   }
 
   @Test
@@ -123,7 +123,7 @@ public class ServerConfigImplTest {
     ServerConfig serverConfig =
         ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()), false);
 
-    assertFalse(serverConfig.getAttributes().containsKey(FORCE_SUBDOMAIN));
+    assertFalse(serverConfig.getAttributes().containsKey(REQUIRE_SUBDOMAIN));
   }
 
   @Test
@@ -131,6 +131,6 @@ public class ServerConfigImplTest {
     ServerConfig serverConfig =
         ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()));
 
-    assertFalse(serverConfig.getAttributes().containsKey(FORCE_SUBDOMAIN));
+    assertFalse(serverConfig.getAttributes().containsKey(REQUIRE_SUBDOMAIN));
   }
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImplTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImplTest.java
@@ -13,7 +13,7 @@ package org.eclipse.che.api.workspace.server.model.impl;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.DEVFILE_ENDPOINT;
+import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.FORCE_SUBDOMAIN;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.INTERNAL_SERVER_ATTRIBUTE;
 import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.SERVER_NAME_ATTRIBUTE;
 import static org.testng.Assert.*;
@@ -114,8 +114,8 @@ public class ServerConfigImplTest {
     ServerConfig serverConfig =
         ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()), true);
 
-    assertTrue(serverConfig.getAttributes().containsKey(DEVFILE_ENDPOINT));
-    assertTrue(Boolean.parseBoolean(serverConfig.getAttributes().get(DEVFILE_ENDPOINT)));
+    assertTrue(serverConfig.getAttributes().containsKey(FORCE_SUBDOMAIN));
+    assertTrue(Boolean.parseBoolean(serverConfig.getAttributes().get(FORCE_SUBDOMAIN)));
   }
 
   @Test
@@ -123,7 +123,7 @@ public class ServerConfigImplTest {
     ServerConfig serverConfig =
         ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()), false);
 
-    assertFalse(serverConfig.getAttributes().containsKey(DEVFILE_ENDPOINT));
+    assertFalse(serverConfig.getAttributes().containsKey(FORCE_SUBDOMAIN));
   }
 
   @Test
@@ -131,6 +131,6 @@ public class ServerConfigImplTest {
     ServerConfig serverConfig =
         ServerConfigImpl.createFromEndpoint(new EndpointImpl("name", 123, new HashMap<>()));
 
-    assertFalse(serverConfig.getAttributes().containsKey(DEVFILE_ENDPOINT));
+    assertFalse(serverConfig.getAttributes().containsKey(FORCE_SUBDOMAIN));
   }
 }


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Allows endpoints to be forcefully exposed on subdomain in single-host mode. It's done by endpoint attribute `forceSubdomain` set to `true`.

Technically, I've only changed the internal `devfileEndpoint` attribute name to `forceSubdomain`, so it make more sense on plugins endpoints.

:question: opinions about `requireSubdomain` endpoint attribute name?


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/18001
docs PR: https://github.com/eclipse/che-docs/pull/1623

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
```
metadata:
  name: golang-lo30l
attributes:
  persistVolumes: 'false'
projects:
  - name: example
    source:
      location: 'https://github.com/golang/example.git'
      type: git
    clonePath: src/github.com/golang/example/
components:
  - type: cheEditor
    reference: >-
      https://gist.githubusercontent.com/sparkoo/9d5766be0fab04bb78bb2e8220cea82b/raw/b6134f24232e927f7ec06c4d7b374abe3eec895f/meta.yaml
    alias: mayteja
  - id: golang/go/latest
    memoryLimit: 512Mi
    preferences:
      go.lintTool: golangci-lint
      go.useLanguageServer: true
      go.lintFlags: '--fast'
    type: chePlugin
    alias: go-plugin
    env:
      - value: 'off'
        name: GO111MODULE
  - mountSources: true
    memoryLimit: 2Gi
    type: dockerimage
    image: 'quay.io/eclipse/che-golang-1.14:nightly'
    alias: go-cli
    env:
      - value: $(CHE_PROJECTS_ROOT)
        name: GOPATH
      - value: /tmp/.cache
        name: GOCACHE
apiVersion: 1.0.0
commands:
  - name: 1.1 Run outyet
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/src/github.com/golang/example/outyet'
        type: exec
        command: go get -d && go run main.go
        component: go-cli
  - name: 1.2 Stop outyet
    actions:
      - type: exec
        command: kill $(pidof go)
        component: go-cli
```
1. run Che in single-host mode
1. the devfile above has cheTheia with 13131 endpoint having `forceSubdomain:true` and the project is our go sample, but without specified 8080 endpoint
1. run the `Run outyet`, the port 8080 will get automatically mapped into theia port 13131
1. open the preview in another browser tab
1. see the app working and see it's on subdomain
1. you can open other theia ports, to see they're still on subpaths

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
