### PR TITLE
Allow using factories with gitub repositories with the default branch that is not equal to "master"

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubUrl.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.che.api.factory.server.github;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
+
 import com.google.common.base.Strings;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,17 +31,14 @@ import org.eclipse.che.api.factory.server.urlfactory.RemoteFactoryUrl;
  */
 public class GithubUrl implements RemoteFactoryUrl {
 
-  /** Master branch is the default. */
-  private static final String DEFAULT_BRANCH_NAME = "master";
-
   /** Username part of github URL */
   private String username;
 
   /** Repository part of the URL. */
   private String repository;
 
-  /** Branch name (by default if it is omitted it is "master" branch) */
-  private String branch = DEFAULT_BRANCH_NAME;
+  /** Branch name */
+  private String branch;
 
   /** Subfolder if any */
   private String subfolder;
@@ -184,7 +183,7 @@ public class GithubUrl implements RemoteFactoryUrl {
         .add("https://raw.githubusercontent.com")
         .add(username)
         .add(repository)
-        .add(branch)
+        .add(firstNonNull(branch, "HEAD"))
         .add(fileName)
         .toString();
   }

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolverTest.java
@@ -151,7 +151,7 @@ public class GithubFactoryParametersResolverTest {
     assertEquals(factory, computedFactory);
     SourceDto source = factory.getDevfile().getProjects().get(0).getSource();
     assertEquals(source.getLocation(), githubUrl + ".git");
-    assertEquals(source.getBranch(), "master");
+    assertEquals(source.getBranch(), null);
   }
 
   @Test
@@ -180,7 +180,7 @@ public class GithubFactoryParametersResolverTest {
     verify(urlFactoryBuilder, never()).buildDefaultDevfile(eq("che"));
     assertEquals(
         factoryUrlArgumentCaptor.getValue().devfileFileLocations().iterator().next().location(),
-        "https://raw.githubusercontent.com/eclipse/che/master/devfile.yaml");
+        "https://raw.githubusercontent.com/eclipse/che/HEAD/devfile.yaml");
   }
 
   @Test
@@ -248,7 +248,7 @@ public class GithubFactoryParametersResolverTest {
     verify(urlFactoryBuilder, never()).buildDefaultDevfile(eq("che"));
     assertEquals(
         factoryUrlArgumentCaptor.getValue().factoryFileLocation(),
-        "https://raw.githubusercontent.com/eclipse/che/master/.factory.json");
+        "https://raw.githubusercontent.com/eclipse/che/HEAD/.factory.json");
 
     assertEquals(factoryUrlArgumentCaptor.getValue().getFactoryFilename(), ".factory.json");
   }

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubURLParserTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubURLParserTest.java
@@ -99,23 +99,17 @@ public class GithubURLParserTest {
   @DataProvider(name = "parsing")
   public Object[][] expectedParsing() {
     return new Object[][] {
-      {"https://github.com/eclipse/che", "eclipse", "che", "master", null},
-      {"https://github.com/eclipse/che123", "eclipse", "che123", "master", null},
-      {"https://github.com/eclipse/che.git", "eclipse", "che", "master", null},
-      {"https://github.com/eclipse/che.with.dot.git", "eclipse", "che.with.dot", "master", null},
-      {"https://github.com/eclipse/-.git", "eclipse", "-", "master", null},
-      {"https://github.com/eclipse/-j.git", "eclipse", "-j", "master", null},
-      {"https://github.com/eclipse/-", "eclipse", "-", "master", null},
-      {"https://github.com/eclipse/che-with-hyphen", "eclipse", "che-with-hyphen", "master", null},
-      {
-        "https://github.com/eclipse/che-with-hyphen.git",
-        "eclipse",
-        "che-with-hyphen",
-        "master",
-        null
-      },
-      {"https://github.com/eclipse/che/", "eclipse", "che", "master", null},
-      {"https://github.com/eclipse/repositorygit", "eclipse", "repositorygit", "master", null},
+      {"https://github.com/eclipse/che", "eclipse", "che", null, null},
+      {"https://github.com/eclipse/che123", "eclipse", "che123", null, null},
+      {"https://github.com/eclipse/che.git", "eclipse", "che", null, null},
+      {"https://github.com/eclipse/che.with.dot.git", "eclipse", "che.with.dot", null, null},
+      {"https://github.com/eclipse/-.git", "eclipse", "-", null, null},
+      {"https://github.com/eclipse/-j.git", "eclipse", "-j", null, null},
+      {"https://github.com/eclipse/-", "eclipse", "-", null, null},
+      {"https://github.com/eclipse/che-with-hyphen", "eclipse", "che-with-hyphen", null, null},
+      {"https://github.com/eclipse/che-with-hyphen.git", "eclipse", "che-with-hyphen", null, null},
+      {"https://github.com/eclipse/che/", "eclipse", "che", null, null},
+      {"https://github.com/eclipse/repositorygit", "eclipse", "repositorygit", null, null},
       {"https://github.com/eclipse/che/tree/4.2.x", "eclipse", "che", "4.2.x", null},
       {
         "https://github.com/eclipse/che/tree/master/dashboard/",

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubUrlTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubUrlTest.java
@@ -63,10 +63,10 @@ public class GithubUrlTest {
     Iterator<DevfileLocation> iterator = githubUrl.devfileFileLocations().iterator();
     assertEquals(
         iterator.next().location(),
-        "https://raw.githubusercontent.com/eclipse/che/master/devfile.yaml");
+        "https://raw.githubusercontent.com/eclipse/che/HEAD/devfile.yaml");
 
     assertEquals(
-        iterator.next().location(), "https://raw.githubusercontent.com/eclipse/che/master/foo.bar");
+        iterator.next().location(), "https://raw.githubusercontent.com/eclipse/che/HEAD/foo.bar");
   }
 
   /** Check when there is .factory.json file in the repository */
@@ -74,7 +74,7 @@ public class GithubUrlTest {
   public void checkFactoryJsonFileLocation() {
     assertEquals(
         githubUrl.factoryFileLocation(),
-        "https://raw.githubusercontent.com/eclipse/che/master/.factory.json");
+        "https://raw.githubusercontent.com/eclipse/che/HEAD/.factory.json");
   }
 
   /** Check the original repository */


### PR DESCRIPTION
### What does this PR do?
Allow using factories with gitub repositories with the default branch that is not equal to "master"
To get a devfile content used @benoitf 's idea https://github.com/eclipse/che/pull/18066#issuecomment-705812774

### Screenshot/screencast of this PR
![Знімок екрана 2020-10-09 о 10 51 40](https://user-images.githubusercontent.com/1614429/95557943-2cb09a00-0a1e-11eb-93c0-84d91db93e40.png)
![Знімок екрана 2020-10-09 о 10 53 41](https://user-images.githubusercontent.com/1614429/95557952-2f12f400-0a1e-11eb-9c93-83f0b57f9f53.png)




### What issues does this PR fix or reference?
 Fixes https://github.com/eclipse/che/issues/18044
### How to test this PR?
### Repo with default branch `main`
 - setup che  with `quay.io/skabashn/che-server:che18044` che server image
 - click on the link `https://che-che.apps.cluster-17ef.17ef.example.opentlc.com/f?url=https://github.com/skabashnyuk/TestMainBranch.git`
 - Expect result : Theia is able to clone  https://github.com/dmytro-ndp/TestMainBranch.git with default branch `main`
### Private  or not existed GitHub repo
 - setup che  with `quay.io/skabashn/che-server:che18044` che server image
 - click on the link `https://che-che.apps.cluster-17ef.17ef.example.opentlc.com//f?url=https://github.com/some/private.git`
 - Expect result : Theia is trying to clone Github repo https://github.com/some/private.git

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
