### PR TITLE
Allow users to define workspace deployment labels

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntime.java
@@ -14,6 +14,8 @@ package org.eclipse.che.workspace.infrastructure.kubernetes;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toMap;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putAnnotations;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabels;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.shouldCreateInCheNamespace;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.util.TracingSpanConstants.CHECK_SERVERS;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.util.TracingSpanConstants.WAIT_MACHINES_START;
@@ -782,7 +784,8 @@ public class KubernetesInternalRuntime<E extends KubernetesEnvironment>
           injectables.add(new PodData(toCreate));
           Deployment deployment = podMerger.merge(injectables);
           deployment.getMetadata().setName(toCreate.getMetadata().getName());
-
+          putAnnotations(deployment.getMetadata(), toCreate.getMetadata().getAnnotations());
+          putLabels(deployment.getMetadata(), toCreate.getMetadata().getLabels());
           createdPod = namespace.deployments().deploy(deployment);
         } catch (ValidationException e) {
           throw new InfrastructureException(e);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
@@ -59,5 +59,14 @@ public final class Warnings {
   public static final String NOT_ABLE_TO_PROVISION_SSH_KEYS_MESSAGE =
       "Not able to provision SSH Keys. Message: '%s'";
 
+  public static final int NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT = 4200;
+  public static final String NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_MESSAGE =
+      "Not able to find workspace attributes for %s. Reason %s";
+
+  public static final int NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS = 4250;
+  public static final String
+      NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS_MESSAGE =
+          "Not able to provision workspace %s deployment labels or annotations because of invalid configuration. Reason: '%s'";
+
   private Warnings() {}
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironment.java
@@ -437,4 +437,29 @@ public class KubernetesEnvironment extends InternalEnvironment {
       return "PodData{" + "podSpec=" + podSpec + ", podMeta=" + podMeta + ", role=" + role + '}';
     }
   }
+
+  @Override
+  public String toString() {
+    return "KubernetesEnvironment{"
+        + "pods="
+        + pods
+        + ", deployments="
+        + deployments
+        + ", podData="
+        + podData
+        + ", services="
+        + services
+        + ", ingresses="
+        + ingresses
+        + ", persistentVolumeClaims="
+        + persistentVolumeClaims
+        + ", secrets="
+        + secrets
+        + ", configMaps="
+        + configMaps
+        + ", injectablePods="
+        + injectablePods
+        + "} "
+        + super.toString();
+  }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/DeploymentMetadataProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/DeploymentMetadataProvisioner.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
+
+import static java.lang.String.format;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS_MESSAGE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_MESSAGE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putAnnotations;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putLabels;
+
+import com.google.common.base.Splitter;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import java.util.Map;
+import javax.inject.Inject;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.Workspace;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class that is provisioning deployment labels and annotations that are configured in workspace
+ * attributes.
+ */
+public class DeploymentMetadataProvisioner
+    implements ConfigurationProvisioner<KubernetesEnvironment> {
+
+  public static final String WS_DEPLOYMENT_LABELS_ATTR_NAME = "workspaceDeploymentLabels";
+  public static final String WS_DEPLOYMENT_ANNOTATIONS_ATTR_NAME = "workspaceDeploymentAnnotations";
+  private static final Logger LOG = LoggerFactory.getLogger(DeploymentMetadataProvisioner.class);
+
+  private final WorkspaceManager workspaceManager;
+  private final Splitter.MapSplitter splitter = Splitter.on(",").withKeyValueSeparator("=");
+
+  @Inject
+  public DeploymentMetadataProvisioner(WorkspaceManager workspaceManager) {
+    this.workspaceManager = workspaceManager;
+  }
+
+  @Override
+  public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+    try {
+      Workspace wsg = workspaceManager.getWorkspace(identity.getWorkspaceId());
+      for (Deployment d : k8sEnv.getDeploymentsCopy().values()) {
+        Map<String, String> workspaceAttributes = wsg.getAttributes();
+        if (workspaceAttributes.containsKey(WS_DEPLOYMENT_LABELS_ATTR_NAME)) {
+          putLabels(
+              d.getMetadata(),
+              splitter.split(workspaceAttributes.get(WS_DEPLOYMENT_LABELS_ATTR_NAME)));
+        }
+        if (workspaceAttributes.containsKey(WS_DEPLOYMENT_ANNOTATIONS_ATTR_NAME)) {
+          putAnnotations(
+              d.getMetadata(),
+              splitter.split(workspaceAttributes.get(WS_DEPLOYMENT_ANNOTATIONS_ATTR_NAME)));
+        }
+      }
+    } catch (NotFoundException | ServerException e) {
+      String message =
+          format(
+              NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_MESSAGE,
+              identity.getWorkspaceId(),
+              e.getMessage());
+      LOG.warn(message);
+      k8sEnv.addWarning(new WarningImpl(NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT, message));
+    } catch (IllegalArgumentException e) {
+      String message =
+          format(
+              NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS_MESSAGE,
+              identity.getWorkspaceId(),
+              e.getMessage());
+      LOG.warn(message);
+      k8sEnv.addWarning(
+          new WarningImpl(
+              NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS, message));
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/DeploymentMetadataProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/DeploymentMetadataProvisionerTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.DeploymentMetadataProvisioner.WS_DEPLOYMENT_ANNOTATIONS_ATTR_NAME;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.DeploymentMetadataProvisioner.WS_DEPLOYMENT_LABELS_ATTR_NAME;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
+import java.util.Collections;
+import java.util.Map;
+import org.eclipse.che.api.core.NotFoundException;
+import org.eclipse.che.api.core.ServerException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.server.model.impl.WarningImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class DeploymentMetadataProvisionerTest {
+  static final String WS_ID = "ws-123";
+  static final String DEPLOYMENT_NAME = "dep-324";
+  @Mock KubernetesEnvironment k8sEnv;
+  @Mock RuntimeIdentity identity;
+  @Mock WorkspaceManager workspaceManager;
+  @Mock WorkspaceImpl workspace;
+  @InjectMocks DeploymentMetadataProvisioner provisioner;
+
+  @BeforeMethod
+  public void setup() {
+    when(identity.getWorkspaceId()).thenReturn(WS_ID);
+  }
+
+  @Test
+  public void shouldProvisionWorkspaceDeploymentLabels()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    when(workspace.getAttributes())
+        .thenReturn(ImmutableMap.of(WS_DEPLOYMENT_LABELS_ATTR_NAME, "L1=V1"));
+    when(workspaceManager.getWorkspace(eq(WS_ID))).thenReturn(workspace);
+
+    Deployment deployment = newDeployment();
+    doReturn(ImmutableMap.of(DEPLOYMENT_NAME, deployment)).when(k8sEnv).getDeploymentsCopy();
+    // when
+    provisioner.provision(k8sEnv, identity);
+    // then
+    Map<String, String> labels = deployment.getMetadata().getLabels();
+    assertEquals(1, labels.size());
+    assertEquals(labels.get("L1"), "V1");
+  }
+
+  @Test
+  public void shouldProvisionWorkspaceDeploymentAnnotations()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    when(workspace.getAttributes())
+        .thenReturn(ImmutableMap.of(WS_DEPLOYMENT_ANNOTATIONS_ATTR_NAME, "A1=V1"));
+    when(workspaceManager.getWorkspace(eq(WS_ID))).thenReturn(workspace);
+
+    Deployment deployment = newDeployment();
+    doReturn(ImmutableMap.of(DEPLOYMENT_NAME, deployment)).when(k8sEnv).getDeploymentsCopy();
+    // when
+    provisioner.provision(k8sEnv, identity);
+    // then
+    Map<String, String> labels = deployment.getMetadata().getAnnotations();
+    assertEquals(1, labels.size());
+    assertEquals(labels.get("A1"), "V1");
+  }
+
+  @Test
+  public void shouldDoNothingWithDeploymentIfNoAttributesIsSet()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    when(workspace.getAttributes()).thenReturn(Collections.emptyMap());
+    when(workspaceManager.getWorkspace(eq(WS_ID))).thenReturn(workspace);
+
+    Deployment deployment = mock(Deployment.class);
+    doReturn(ImmutableMap.of(DEPLOYMENT_NAME, deployment)).when(k8sEnv).getDeploymentsCopy();
+    // when
+    provisioner.provision(k8sEnv, identity);
+    // then
+    verifyZeroInteractions(deployment);
+  }
+
+  @Test
+  public void shouldAddWarningIfNotAbleToGetWorkspaceAttributes()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    doThrow(new NotFoundException("Element not found"))
+        .when(workspaceManager)
+        .getWorkspace(eq(WS_ID));
+    // when
+    provisioner.provision(k8sEnv, identity);
+    // then
+    ArgumentCaptor<WarningImpl> argumentCaptor = ArgumentCaptor.forClass(WarningImpl.class);
+    verify(k8sEnv).addWarning(argumentCaptor.capture());
+    assertEquals(argumentCaptor.getAllValues().size(), 1);
+    assertEquals(
+        argumentCaptor.getValue(),
+        new WarningImpl(
+            4200,
+            "Not able to find workspace attributes for " + WS_ID + ". Reason Element not found"));
+  }
+
+  @Test
+  public void shouldAddWarningIfNotAbleToGetWorkspaceAttributesServerException()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    doThrow(new ServerException("Connection problem"))
+        .when(workspaceManager)
+        .getWorkspace(eq(WS_ID));
+    // when
+    provisioner.provision(k8sEnv, identity);
+    // then
+    ArgumentCaptor<WarningImpl> argumentCaptor = ArgumentCaptor.forClass(WarningImpl.class);
+    verify(k8sEnv).addWarning(argumentCaptor.capture());
+    assertEquals(argumentCaptor.getAllValues().size(), 1);
+    assertEquals(
+        argumentCaptor.getValue(),
+        new WarningImpl(
+            NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT,
+            "Not able to find workspace attributes for " + WS_ID + ". Reason Connection problem"));
+  }
+
+  @Test
+  public void shouldAddWarningIfLabelAttributeInInvalidFormat()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    when(workspace.getAttributes())
+        .thenReturn(ImmutableMap.of(WS_DEPLOYMENT_LABELS_ATTR_NAME, "L1~V1"));
+    when(workspaceManager.getWorkspace(eq(WS_ID))).thenReturn(workspace);
+
+    Deployment deployment = newDeployment();
+    doReturn(ImmutableMap.of(DEPLOYMENT_NAME, deployment)).when(k8sEnv).getDeploymentsCopy();
+    // when
+    provisioner.provision(k8sEnv, identity);
+    // then
+    ArgumentCaptor<WarningImpl> argumentCaptor = ArgumentCaptor.forClass(WarningImpl.class);
+    verify(k8sEnv).addWarning(argumentCaptor.capture());
+    assertEquals(argumentCaptor.getAllValues().size(), 1);
+    assertEquals(
+        argumentCaptor.getValue(),
+        new WarningImpl(
+            NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS,
+            "Not able to provision workspace "
+                + WS_ID
+                + " deployment labels or annotations because of invalid configuration. Reason: 'Chunk [L1~V1] is not a valid entry'"));
+  }
+
+  @Test
+  public void shouldAddWarningIfAnnotationAttributeInInvalidFormat()
+      throws NotFoundException, ServerException, InfrastructureException {
+    // given
+    when(workspace.getAttributes())
+        .thenReturn(ImmutableMap.of(WS_DEPLOYMENT_ANNOTATIONS_ATTR_NAME, "A1~V1"));
+    when(workspaceManager.getWorkspace(eq(WS_ID))).thenReturn(workspace);
+
+    Deployment deployment = newDeployment();
+    doReturn(ImmutableMap.of(DEPLOYMENT_NAME, deployment)).when(k8sEnv).getDeploymentsCopy();
+    // when
+    provisioner.provision(k8sEnv, identity);
+    // then
+    ArgumentCaptor<WarningImpl> argumentCaptor = ArgumentCaptor.forClass(WarningImpl.class);
+    verify(k8sEnv).addWarning(argumentCaptor.capture());
+    assertEquals(argumentCaptor.getAllValues().size(), 1);
+    assertEquals(
+        argumentCaptor.getValue(),
+        new WarningImpl(
+            NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS,
+            "Not able to provision workspace "
+                + WS_ID
+                + " deployment labels or annotations because of invalid configuration. Reason: 'Chunk [A1~V1] is not a valid entry'"));
+  }
+
+  private static Deployment newDeployment() {
+    return new DeploymentBuilder()
+        .withNewMetadata()
+        .withName(DEPLOYMENT_NAME)
+        .endMetadata()
+        .withNewSpec()
+        .withNewTemplate()
+        .withNewMetadata()
+        .withName("POD_NAME")
+        .endMetadata()
+        .endTemplate()
+        .endSpec()
+        .build();
+  }
+}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -23,6 +23,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.Workspa
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.AsyncStoragePodInterceptor;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.AsyncStorageProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.DeploymentMetadataProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayRouterProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ImagePullSecretProvisioner;
@@ -82,6 +83,7 @@ public class OpenShiftEnvironmentProvisioner
   private final PreviewUrlExposer<OpenShiftEnvironment> previewUrlExposer;
   private final VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
   private final GatewayRouterProvisioner gatewayRouterProvisioner;
+  private final DeploymentMetadataProvisioner deploymentMetadataProvisioner;
 
   @Inject
   public OpenShiftEnvironmentProvisioner(
@@ -106,7 +108,8 @@ public class OpenShiftEnvironmentProvisioner
       GitConfigProvisioner gitConfigProvisioner,
       OpenShiftPreviewUrlExposer previewUrlEndpointsProvisioner,
       VcsSslCertificateProvisioner vcsSslCertificateProvisioner,
-      GatewayRouterProvisioner gatewayRouterProvisioner) {
+      GatewayRouterProvisioner gatewayRouterProvisioner,
+      DeploymentMetadataProvisioner deploymentMetadataProvisioner) {
     this.pvcEnabled = pvcEnabled;
     this.volumesStrategy = volumesStrategy;
     this.uniqueNamesProvisioner = uniqueNamesProvisioner;
@@ -129,6 +132,7 @@ public class OpenShiftEnvironmentProvisioner
     this.previewUrlExposer = previewUrlEndpointsProvisioner;
     this.vcsSslCertificateProvisioner = vcsSslCertificateProvisioner;
     this.gatewayRouterProvisioner = gatewayRouterProvisioner;
+    this.deploymentMetadataProvisioner = deploymentMetadataProvisioner;
   }
 
   @Override
@@ -169,6 +173,7 @@ public class OpenShiftEnvironmentProvisioner
     vcsSslCertificateProvisioner.provision(osEnv, identity);
     gitConfigProvisioner.provision(osEnv, identity);
     gatewayRouterProvisioner.provision(osEnv, identity);
+    deploymentMetadataProvisioner.provision(osEnv, identity);
     LOG.debug(
         "Provisioning OpenShift environment done for workspace '{}'", identity.getWorkspaceId());
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -20,6 +20,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.Workspa
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.AsyncStoragePodInterceptor;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.AsyncStorageProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.CertificateProvisioner;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.DeploymentMetadataProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GatewayRouterProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ImagePullSecretProvisioner;
@@ -78,6 +79,7 @@ public class OpenShiftEnvironmentProvisionerTest {
   @Mock private VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
   @Mock private NodeSelectorProvisioner nodeSelectorProvisioner;
   @Mock private GatewayRouterProvisioner gatewayRouterProvisioner;
+  @Mock private DeploymentMetadataProvisioner deploymentMetadataProvisioner;
 
   private OpenShiftEnvironmentProvisioner osInfraProvisioner;
 
@@ -109,7 +111,8 @@ public class OpenShiftEnvironmentProvisionerTest {
             gitConfigProvisioner,
             previewUrlEndpointsProvisioner,
             vcsSslCertificateProvisioner,
-            gatewayRouterProvisioner);
+            gatewayRouterProvisioner,
+            deploymentMetadataProvisioner);
     provisionOrder =
         inOrder(
             logsVolumeMachineProvisioner,
@@ -130,7 +133,8 @@ public class OpenShiftEnvironmentProvisionerTest {
             vcsSslCertificateProvisioner,
             gitConfigProvisioner,
             previewUrlEndpointsProvisioner,
-            gatewayRouterProvisioner);
+            gatewayRouterProvisioner,
+            deploymentMetadataProvisioner);
   }
 
   @Test
@@ -157,6 +161,7 @@ public class OpenShiftEnvironmentProvisionerTest {
     provisionOrder.verify(vcsSslCertificateProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(gitConfigProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(gatewayRouterProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
+    provisionOrder.verify(deploymentMetadataProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verifyNoMoreInteractions();
   }
 }


### PR DESCRIPTION
### What does this PR do?
MVP of ability to use workspace.attrubutes to allow a user to define workspace deployment labels and annotations.

### Screenshot/screencast of this PR
<img width="940" alt="Знімок екрана 2020-10-19 о 15 35 47" src="https://user-images.githubusercontent.com/1614429/96457128-0f52ab80-1228-11eb-9649-e61b8b3e4838.png">
<img width="1064" alt="Знімок екрана 2020-10-19 о 15 35 31" src="https://user-images.githubusercontent.com/1614429/96457139-124d9c00-1228-11eb-8bb3-f31909265507.png">



### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/18027

### How to test this PR?
 - deploy che server image `quay.io/skabashn/che-server:che18027`
 - Run this script in OpenShift https://gist.github.com/skabashnyuk/3efa94ab02f26de344b8bb2f2cf94043#file-che18027-sh
- Or click on a link `https://{che-host-here}/f?url=https://github.com/eclipse/che&workspaceDeploymentLabels=ike.target%3Dpreference-v1%2Cike.session%3Dtest&workspaceDeploymentAnnotations=ke.A1%3Dpreference-v1%2Cike.A%3Dtest`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
