### PR TITLE
Mount volumes into init containers of Kubertenes\Openshift components recipe 

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
@@ -240,7 +240,10 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
       List<PodData> podsData, ComponentImpl component) throws DevfileException {
     Map<String, MachineConfigImpl> machineConfigs = new HashMap<>();
     for (PodData podData : podsData) {
-      for (Container container : podData.getSpec().getContainers()) {
+      List<Container> containers = new ArrayList<>();
+      containers.addAll(podData.getSpec().getContainers());
+      containers.addAll(podData.getSpec().getInitContainers());
+      for (Container container : containers) {
         String machineName = machineName(podData, container);
 
         MachineConfigImpl config = new MachineConfigImpl();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplier.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.WorkspaceConfig;
@@ -161,7 +162,10 @@ public class KubernetesComponentToWorkspaceApplier implements ComponentToWorkspa
     List<PodData> podsData = getPodDatas(componentObjects);
     podsData
         .stream()
-        .flatMap(e -> e.getSpec().getContainers().stream())
+        .flatMap(
+            e ->
+                Stream.concat(
+                    e.getSpec().getContainers().stream(), e.getSpec().getInitContainers().stream()))
         .forEach(c -> c.setImagePullPolicy(imagePullPolicy));
 
     if (Boolean.TRUE.equals(k8sComponent.getMountSources())) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
@@ -119,7 +119,7 @@ public class KubernetesEnvironmentFactory
     }
 
     if (deployments.size() + pods.size() > 1) {
-      mergePods(pods, deployments, services);
+      mergePods(pods, deployments, services, machines);
     }
 
     if (isAnyIngressPresent) {
@@ -158,7 +158,7 @@ public class KubernetesEnvironmentFactory
    * @throws ValidationException if the specified lists has pods with conflicting configuration
    */
   private void mergePods(
-      Map<String, Pod> pods, Map<String, Deployment> deployments, Map<String, Service> services)
+      Map<String, Pod> pods, Map<String, Deployment> deployments, Map<String, Service> services, Map<String, InternalMachineConfig> machines)
       throws ValidationException {
     List<PodData> podsData =
         Stream.concat(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentFactory.java
@@ -119,7 +119,7 @@ public class KubernetesEnvironmentFactory
     }
 
     if (deployments.size() + pods.size() > 1) {
-      mergePods(pods, deployments, services, machines);
+      mergePods(pods, deployments, services);
     }
 
     if (isAnyIngressPresent) {
@@ -158,7 +158,7 @@ public class KubernetesEnvironmentFactory
    * @throws ValidationException if the specified lists has pods with conflicting configuration
    */
   private void mergePods(
-      Map<String, Pod> pods, Map<String, Deployment> deployments, Map<String, Service> services, Map<String, InternalMachineConfig> machines)
+      Map<String, Pod> pods, Map<String, Deployment> deployments, Map<String, Service> services)
       throws ValidationException {
     List<PodData> podsData =
         Stream.concat(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidator.java
@@ -93,6 +93,9 @@ public class KubernetesEnvironmentPodsValidator {
         for (Container container : pod.getSpec().getContainers()) {
           missingMachines.remove(Names.machineName(pod, container));
         }
+        for (Container container : pod.getSpec().getInitContainers()) {
+          missingMachines.remove(Names.machineName(pod, container));
+        }
       }
     }
     checkArgument(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidator.java
@@ -18,7 +18,9 @@ import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.PersistentVolumeClaimVolumeSource;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.che.api.core.ValidationException;
@@ -72,7 +74,10 @@ public class KubernetesEnvironmentPodsValidator {
         }
       }
 
-      for (Container container : pod.getSpec().getContainers()) {
+      List<Container> containers = new ArrayList<>();
+      containers.addAll(pod.getSpec().getContainers());
+      containers.addAll(pod.getSpec().getInitContainers());
+      for (Container container : containers) {
         for (VolumeMount volumeMount : container.getVolumeMounts()) {
           if (!volumesNames.contains(volumeMount.getName())) {
             throw new ValidationException(

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
@@ -100,6 +100,8 @@ public class PodMerger {
         while (!initContainerNames.add(initContainer.getName())) {
           initContainer.setName(NameGenerator.generate(initContainer.getName(), 4));
         }
+        // store original recipe machine name
+        Names.putMachineName(basePodMeta, initContainer.getName(), Names.machineName(podMeta, initContainer));
         baseSpec.getInitContainers().add(initContainer);
       }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
@@ -101,7 +101,8 @@ public class PodMerger {
           initContainer.setName(NameGenerator.generate(initContainer.getName(), 4));
         }
         // store original recipe machine name
-        Names.putMachineName(basePodMeta, initContainer.getName(), Names.machineName(podMeta, initContainer));
+        Names.putMachineName(
+            basePodMeta, initContainer.getName(), Names.machineName(podMeta, initContainer));
         baseSpec.getInitContainers().add(initContainer);
       }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/KubernetesComponentToWorkspaceApplierTest.java
@@ -48,6 +48,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.eclipse.che.api.core.ValidationException;
 import org.eclipse.che.api.core.model.workspace.config.MachineConfig;
 import org.eclipse.che.api.workspace.server.devfile.URLFileContentProvider;
@@ -581,7 +582,10 @@ public class KubernetesComponentToWorkspaceApplierTest {
         if (p.getSpec() == null) {
           continue;
         }
-        for (Container con : p.getSpec().getContainers()) {
+        List<Container> containers = new ArrayList<>();
+        containers.addAll(p.getSpec().getContainers());
+        containers.addAll(p.getSpec().getInitContainers());
+        for (Container con : containers) {
           assertEquals(con.getImagePullPolicy(), "Never");
         }
       }
@@ -699,7 +703,11 @@ public class KubernetesComponentToWorkspaceApplierTest {
         .filter(item -> item instanceof Pod)
         .map(item -> (Pod) item)
         .filter(pod -> pod.getSpec() != null)
-        .flatMap(pod -> pod.getSpec().getContainers().stream())
+        .flatMap(
+            pod ->
+                Stream.concat(
+                    pod.getSpec().getContainers().stream(),
+                    pod.getSpec().getInitContainers().stream()))
         .forEach(c -> c.setImagePullPolicy(imagePullPolicy));
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidatorTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.environment;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -81,6 +82,29 @@ public class KubernetesEnvironmentPodsValidatorTest {
     podsValidator.validate(kubernetesEnvironment);
   }
 
+  @Test
+  public void shouldPassWhenMachineIsDeclaredAndIsInitContainerInKubernetesRecipe()
+      throws Exception {
+    // given
+    String podName = "pod1";
+    Pod pod =
+        new PodBuilder()
+            .withNewMetadata()
+            .withName(podName)
+            .endMetadata()
+            .withNewSpec()
+            .withInitContainers(singletonList(createContainer("init")))
+            .endSpec()
+            .build();
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of(podName, podData));
+    when(kubernetesEnvironment.getMachines())
+        .thenReturn(ImmutableMap.of(podName + "/init", mock(InternalMachineConfig.class)));
+
+    // when
+    podsValidator.validate(kubernetesEnvironment);
+  }
+
   @Test(
       expectedExceptions = ValidationException.class,
       expectedExceptionsMessageRegExp = "Environment contains pod with missing metadata")
@@ -145,6 +169,35 @@ public class KubernetesEnvironmentPodsValidatorTest {
         .get(0)
         .getVolumeMounts()
         .add(new VolumeMountBuilder().withName("non-existing").withMountPath("/tmp/data").build());
+    PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
+    when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of(podName, podData));
+    when(kubernetesEnvironment.getMachines())
+        .thenReturn(ImmutableMap.of(podName + "/main", mock(InternalMachineConfig.class)));
+
+    // when
+    podsValidator.validate(kubernetesEnvironment);
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "Container 'foo' in pod 'pod1' contains volume mount that references missing volume 'non-existing'")
+  public void shouldThrowExceptionWhenInitContainerHasVolumeMountThatReferencesMissingPodVolume()
+      throws Exception {
+    // given
+    String podName = "pod1";
+    Pod pod = createPod("pod1", "main");
+    pod.getSpec()
+        .getInitContainers()
+        .add(
+            new ContainerBuilder()
+                .withName("foo")
+                .withVolumeMounts(
+                    new VolumeMountBuilder()
+                        .withName("non-existing")
+                        .withMountPath("/tmp/data")
+                        .build())
+                .build());
     PodData podData = new PodData(pod.getSpec(), pod.getMetadata());
     when(kubernetesEnvironment.getPodsData()).thenReturn(ImmutableMap.of(podName, podData));
     when(kubernetesEnvironment.getMachines())

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidatorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/KubernetesEnvironmentPodsValidatorTest.java
@@ -103,6 +103,9 @@ public class KubernetesEnvironmentPodsValidatorTest {
 
     // when
     podsValidator.validate(kubernetesEnvironment);
+
+    // then
+    // no exception means machine matches init container - it's expected
   }
 
   @Test(

--- a/infrastructures/kubernetes/src/test/resources/devfile/petclinic.yaml
+++ b/infrastructures/kubernetes/src/test/resources/devfile/petclinic.yaml
@@ -23,6 +23,11 @@ items:
       app.kubernetes.io/component: webapp
       app.kubernetes.io/part-of: petclinic
   spec:
+    initContainers:
+    - command:
+          - "echo foo:bar"
+      image: "openjdk:11-jre-openjdk9"
+      name: "init"
     containers:
     - name: server
       image: mariolet/petclinic


### PR DESCRIPTION
### What does this PR do?

Right now volumes defined in K8S components didn't mount into init containers from component-s recipe. 
This PR fixes this situation, so volumes will be mount into both regular and init containers.



### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/17102




### How to test this PR?

Run any devfile with K8S component contains volume in component description and init container in K8S recipe. Make sure volume is mount into init container.

Example:
```
components:
  - id: redhat/java11/latest
    type: chePlugin
  - referenceContent: |
      apiVersion: v1
      kind: Pod
      metadata:
        name: ws
      spec:
        initContainers:
          - name: init-myservice
            image: adoptopenjdk:11-jre-openj9
            command: ['sh', '-c', "echo starting && cp -R /opt/java/openjdk/ /tmp/jdk && echo done && sleep 20"]
-->>        # no volumes and/or mounts inside the init container recipe. they will be provisioned from component volume
    volumes: 
      - name: jdk
        containerPath: /tmp/jdk  # refers the same volume as maven component below
    type: kubernetes
```
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
