### PR TITLE
Stop running workspaces instead of failing on remove user event

### DIFF
--- a/multiuser/permission/che-multiuser-permission-workspace/pom.xml
+++ b/multiuser/permission/che-multiuser-permission-workspace/pom.xml
@@ -75,6 +75,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-test</artifactId>
         </dependency>
         <dependency>

--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaWorkspaceDao.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/MultiuserJpaWorkspaceDao.java
@@ -13,9 +13,13 @@ package org.eclipse.che.multiuser.permission.workspace.server.spi.jpa;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
+import static java.util.Map.of;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.eclipse.che.api.core.Pages.iterate;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
+import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPING;
+import static org.eclipse.che.api.workspace.shared.Constants.REMOVE_WORKSPACE_AFTER_STOP;
 
 import com.google.inject.persist.Transactional;
 import java.util.List;
@@ -40,6 +44,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ProjectConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.api.workspace.shared.event.WorkspaceRemovedEvent;
+import org.eclipse.che.commons.env.EnvironmentContext;
 import org.eclipse.che.core.db.cascade.CascadeEventSubscriber;
 import org.eclipse.che.core.db.jpa.DuplicateKeyException;
 
@@ -306,12 +311,62 @@ public class MultiuserJpaWorkspaceDao implements WorkspaceDao {
 
     @Override
     public void onCascadeEvent(BeforeAccountRemovedEvent event) throws Exception {
+      boolean nonStoppedExists = false;
       for (WorkspaceImpl workspace :
           iterate(
               (maxItems, skipCount) ->
                   workspaceManager.getByNamespace(
                       event.getAccount().getName(), false, maxItems, skipCount))) {
-        workspaceManager.removeWorkspace(workspace.getId());
+        if (STOPPED.equals(workspace.getStatus())) {
+          workspaceManager.removeWorkspace(workspace.getId());
+          continue;
+        }
+
+        nonStoppedExists = true;
+
+        if (STOPPING.equals(workspace.getStatus())) {
+          // it's not possible to forcibly stop workspace. Continue check other and fail after this
+          // to retry
+          continue;
+        }
+
+        // workspace is RUNNING or STARTING. It's needed to stop them and remove after
+        tryStopAndRemoveWithSA(workspace);
+      }
+
+      if (!nonStoppedExists) {
+        // all workspace are already removed
+        return;
+      }
+
+      // There is at least one workspace that was marked to be stop/removed after stop.
+      // It's needed to check if it's finished already
+      for (WorkspaceImpl workspace :
+          iterate(
+              (maxItems, skipCount) ->
+                  workspaceManager.getByNamespace(
+                      event.getAccount().getName(), false, maxItems, skipCount))) {
+        if (!STOPPED.equals(workspace.getStatus())) {
+          throw new ConflictException("User has workspace that is not stopped yet. Try again");
+        }
+      }
+      // Every workspace that was marked as to remove after stop is already removed
+    }
+
+    /**
+     * Going to reset EnvironmentContext, in this case Service Account(SA) credentials will be used
+     * for stopping workspace. If SA have required permissions workspace will be stopped otherwise
+     * exception thrown.
+     */
+    private void tryStopAndRemoveWithSA(WorkspaceImpl workspace)
+        throws ServerException, NotFoundException, ConflictException {
+      EnvironmentContext current = EnvironmentContext.getCurrent();
+      try {
+        EnvironmentContext.reset();
+        // Stop workspace and remove it after it was stopped
+        workspaceManager.stopWorkspace(workspace.getId(), of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+      } finally {
+        EnvironmentContext.setCurrent(current);
       }
     }
   }

--- a/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/RemoveWorkspaceBeforeAccountRemovedEventSubscriberTest.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/test/java/org/eclipse/che/multiuser/permission/workspace/server/spi/jpa/RemoveWorkspaceBeforeAccountRemovedEventSubscriberTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.multiuser.permission.workspace.server.spi.jpa;
+
+import static java.util.Map.of;
+import static org.eclipse.che.api.workspace.shared.Constants.REMOVE_WORKSPACE_AFTER_STOP;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import org.eclipse.che.account.event.BeforeAccountRemovedEvent;
+import org.eclipse.che.account.spi.AccountImpl;
+import org.eclipse.che.api.core.ConflictException;
+import org.eclipse.che.api.core.Page;
+import org.eclipse.che.api.core.model.workspace.Runtime;
+import org.eclipse.che.api.core.model.workspace.WorkspaceStatus;
+import org.eclipse.che.api.core.notification.EventService;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceConfigImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.lang.NameGenerator;
+import org.eclipse.che.commons.subject.Subject;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.multiuser.permission.workspace.server.spi.jpa.MultiuserJpaWorkspaceDao.RemoveWorkspaceBeforeAccountRemovedEventSubscriber;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/** Tests for {@link RemoveWorkspaceBeforeAccountRemovedEventSubscriber} */
+@Listeners(MockitoTestNGListener.class)
+public class RemoveWorkspaceBeforeAccountRemovedEventSubscriberTest {
+  @Mock private EventService eventService;
+  @Mock private WorkspaceManager workspaceManager;
+
+  @InjectMocks RemoveWorkspaceBeforeAccountRemovedEventSubscriber subscriber;
+
+  private static final String user = NameGenerator.generate("user", 6);
+  private static final String otherUser = NameGenerator.generate("otherUser", 6);
+  private static final Subject SUBJECT = new SubjectImpl("user", user, "token", false);
+  private final String workspaceId = NameGenerator.generate("workspace", 6);
+  private AccountImpl account;
+  private WorkspaceImpl workspace;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    account = new AccountImpl("id", "name", "test");
+    workspace = new WorkspaceImpl(workspaceId, account, new WorkspaceConfigImpl());
+    when(workspaceManager.getByNamespace(anyString(), anyBoolean(), anyInt(), anyLong()))
+        .thenReturn(new Page<>(Arrays.asList(workspace), 0, 1, 1));
+  }
+
+  @Test
+  public void shouldSubscribeItself() {
+    subscriber.subscribe();
+
+    verify(eventService).subscribe(eq(subscriber), eq(BeforeAccountRemovedEvent.class));
+  }
+
+  @Test
+  public void shouldUnsubscribeItself() {
+    subscriber.unsubscribe();
+
+    verify(eventService).unsubscribe(eq(subscriber), eq(BeforeAccountRemovedEvent.class));
+  }
+
+  @Test
+  public void shouldRemoveStoppedWorkspace() throws Exception {
+    workspace.setStatus(WorkspaceStatus.STOPPED);
+    subscriber.onCascadeEvent(new BeforeAccountRemovedEvent(account));
+
+    verify(workspaceManager).removeWorkspace(workspaceId);
+  }
+
+  @Test
+  public void shouldStopAndRemoveRunningWorkspaceByOwner() throws Exception {
+    workspace.setStatus(WorkspaceStatus.RUNNING);
+    Runtime runtime = mock(Runtime.class);
+    when(runtime.getOwner()).thenReturn(user);
+    workspace.setRuntime(runtime);
+    EnvironmentContext.getCurrent().setSubject(SUBJECT);
+
+    doAnswer(
+            invocation -> {
+              workspace.setStatus(WorkspaceStatus.STOPPED);
+              return null;
+            })
+        .when(workspaceManager)
+        .stopWorkspace(workspaceId, of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+
+    subscriber.onCascadeEvent(new BeforeAccountRemovedEvent(account));
+
+    verify(workspaceManager).stopWorkspace(workspaceId, of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+  }
+
+  @Test
+  public void shouldStopAndRemoveStartingWorkspaceByOwner() throws Exception {
+    workspace.setStatus(WorkspaceStatus.STARTING);
+    Runtime runtime = mock(Runtime.class);
+    when(runtime.getOwner()).thenReturn(user);
+    workspace.setRuntime(runtime);
+    EnvironmentContext.getCurrent().setSubject(SUBJECT);
+
+    doAnswer(
+            invocation -> {
+              workspace.setStatus(WorkspaceStatus.STOPPED);
+              return null;
+            })
+        .when(workspaceManager)
+        .stopWorkspace(workspaceId, of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+
+    subscriber.onCascadeEvent(new BeforeAccountRemovedEvent(account));
+
+    verify(workspaceManager).stopWorkspace(workspaceId, of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+  }
+
+  @Test
+  public void shouldStopAndRemoveWorkspaceByAdmin() throws Exception {
+    workspace.setStatus(WorkspaceStatus.STARTING);
+    Runtime runtime = mock(Runtime.class);
+    when(runtime.getOwner()).thenReturn(otherUser);
+    workspace.setRuntime(runtime);
+    EnvironmentContext.getCurrent().setSubject(SUBJECT);
+
+    doAnswer(
+            invocation -> {
+              workspace.setStatus(WorkspaceStatus.STOPPED);
+              return null;
+            })
+        .when(workspaceManager)
+        .stopWorkspace(workspaceId, of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+
+    subscriber.onCascadeEvent(new BeforeAccountRemovedEvent(account));
+
+    verify(workspaceManager).stopWorkspace(workspaceId, of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+  }
+
+  @Test(expectedExceptions = ConflictException.class)
+  public void shouldThrowExceptionIfWorkspaceStopping() throws Exception {
+    workspace.setStatus(WorkspaceStatus.STARTING);
+    Runtime runtime = mock(Runtime.class);
+    when(runtime.getOwner()).thenReturn(otherUser);
+    workspace.setRuntime(runtime);
+    EnvironmentContext.getCurrent().setSubject(SUBJECT);
+
+    subscriber.onCascadeEvent(new BeforeAccountRemovedEvent(account));
+
+    verify(workspaceManager).stopWorkspace(workspaceId, of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+  }
+}

--- a/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
+++ b/wsmaster/che-core-api-workspace-shared/src/main/java/org/eclipse/che/api/workspace/shared/Constants.java
@@ -240,5 +240,8 @@ public final class Constants {
   /** The attribute for storing the time then last active workspace was stopped */
   public static final String LAST_ACTIVITY_TIME = "lastActivityTime";
 
+  /** The flag for removing a workspace after it's stopped */
+  public static final String REMOVE_WORKSPACE_AFTER_STOP = "removeWorkspaceImmediatelyAfterStop";
+
   private Constants() {}
 }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -13,6 +13,7 @@ package org.eclipse.che.api.workspace.server;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.Boolean.parseBoolean;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.time.Instant.now;
@@ -24,6 +25,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.CREATED_ATTRIBUTE_N
 import static org.eclipse.che.api.workspace.shared.Constants.ERROR_MESSAGE_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.LAST_ACTIVE_INFRASTRUCTURE_NAMESPACE;
 import static org.eclipse.che.api.workspace.shared.Constants.LAST_ACTIVITY_TIME;
+import static org.eclipse.che.api.workspace.shared.Constants.REMOVE_WORKSPACE_AFTER_STOP;
 import static org.eclipse.che.api.workspace.shared.Constants.STOPPED_ABNORMALLY_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.STOPPED_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.UPDATED_ATTRIBUTE_NAME;
@@ -431,7 +433,8 @@ public class WorkspaceManager {
         .stopAsync(workspace, options)
         .whenComplete(
             (aVoid, throwable) -> {
-              if (workspace.isTemporary()) {
+              if (workspace.isTemporary()
+                  || parseBoolean(options.get(REMOVE_WORKSPACE_AFTER_STOP))) {
                 removeWorkspaceQuietly(workspace.getId());
               }
               try {

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -16,6 +16,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
+import static java.util.Map.of;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.RUNNING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STARTING;
 import static org.eclipse.che.api.core.model.workspace.WorkspaceStatus.STOPPED;
@@ -25,6 +26,7 @@ import static org.eclipse.che.api.workspace.shared.Constants.CREATED_ATTRIBUTE_N
 import static org.eclipse.che.api.workspace.shared.Constants.ERROR_MESSAGE_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.LAST_ACTIVE_INFRASTRUCTURE_NAMESPACE;
 import static org.eclipse.che.api.workspace.shared.Constants.LAST_ACTIVITY_TIME;
+import static org.eclipse.che.api.workspace.shared.Constants.REMOVE_WORKSPACE_AFTER_STOP;
 import static org.eclipse.che.api.workspace.shared.Constants.STOPPED_ABNORMALLY_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.STOPPED_ATTRIBUTE_NAME;
 import static org.eclipse.che.api.workspace.shared.Constants.UPDATED_ATTRIBUTE_NAME;
@@ -745,7 +747,20 @@ public class WorkspaceManagerTest {
   }
 
   @Test
-  public void removesTemporaryWorkspaceAfterStop() throws Exception {
+  public void removesWorkspaceAfterStop() throws Exception {
+    final WorkspaceImpl workspace = createAndMockWorkspace();
+    workspace.setTemporary(true);
+    mockRuntime(workspace, RUNNING);
+    mockAnyWorkspaceStop();
+
+    workspaceManager.stopWorkspace(workspace.getId(), of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+
+    verify(runtimes).stopAsync(workspace, of(REMOVE_WORKSPACE_AFTER_STOP, "true"));
+    verify(workspaceDao).remove(workspace.getId());
+  }
+
+  @Test
+  public void removesTemporaryWorkspaceAfterStopIfRequested() throws Exception {
     final WorkspaceImpl workspace = createAndMockWorkspace();
     workspace.setTemporary(true);
     mockRuntime(workspace, RUNNING);


### PR DESCRIPTION
Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Stop running workspaces instead of failing on remove user event.
Will check is current user is owner of workspace if "yes" - going to stop with current credentials, if "not" reset Current Context and try to stop with SA credentials, in this case SA should have the ability to stop workspace. (Can require additional configuration)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
#18000 

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
