### PR TITLE
Implement devfile test for Java Spring Boot

### DIFF
--- a/tests/e2e/pageobjects/ide/DialogWindow.ts
+++ b/tests/e2e/pageobjects/ide/DialogWindow.ts
@@ -72,7 +72,7 @@ export class DialogWindow {
     async waitDialogAndOpenLink(dialogText: string = '', applicationReaddyTimeout: number) {
         Logger.debug('DialogWindow.waitDialogAndOpenLink');
 
-        await this.waitDialog(dialogText);
+        await this.waitDialog(dialogText, applicationReaddyTimeout);
         await this.ide.waitApllicationIsReady(await this.getApplicationUrlFromDialog(dialogText), applicationReaddyTimeout);
         await this.clickToOpenLinkButton();
         await this.waitDialogDissappearance();

--- a/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
@@ -20,7 +20,9 @@ const workspaceRootFolderName: string = 'src';
 const fileFolderPath: string = `${workspaceSampleName}/${workspaceRootFolderName}/main/java/org/springframework/samples/petclinic`;
 const tabTitle: string = 'PetClinicApplication.java';
 const codeNavigationClassName: string = 'SpringApplication.class';
-const taskName: string = 'maven build';
+const buildTaskName: string = 'maven build';
+const runTaskName: string = 'run webapp';
+const runTaskExpectedDialogue: string = 'A process is now listening on port 8080.';
 
 suite(`${stack} test`, async () => {
     suite (`Create ${stack} workspace`, async () => {
@@ -33,15 +35,20 @@ suite(`${stack} test`, async () => {
         projectAndFileTests.openFile(fileFolderPath, tabTitle);
     });
 
-    suite('Validation of workspace build and run', async () => {
-        codeExecutionTests.runTask(taskName, 240_000);
-        codeExecutionTests.closeTerminal(taskName);
+    suite('Validation of workspace build', async () => {
+        codeExecutionTests.runTask(buildTaskName, 360_000);
+        codeExecutionTests.closeTerminal(buildTaskName);
+    });
+
+    suite('Validation of workspace execution', async () => {
+        codeExecutionTests.runTaskWithDialogShellAndOpenLink(runTaskName, runTaskExpectedDialogue, 30_000);
+        codeExecutionTests.closeTerminal(runTaskName);
     });
 
     suite('Language server validation', async () => {
         commonLsTests.autocomplete(tabTitle, 32, 56, 'args : String[]');
         commonLsTests.errorHighlighting(tabTitle, 'error_text', 30);
-        commonLsTests.codeNavigation(tabTitle, 32, 23, codeNavigationClassName, 30_000); // extended timout to give LS enough time to start
+        commonLsTests.codeNavigation(tabTitle, 32, 23, codeNavigationClassName);
         commonLsTests.suggestionInvoking(tabTitle, 32, 23, 'run(Class<?>');
     });
 

--- a/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
@@ -1,0 +1,60 @@
+/*********************************************************************
+ * Copyright (c) 2020 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import 'reflect-metadata';
+import { WorkspaceNameHandler} from '../..';
+import * as projectAndFileTests from '../../testsLibrary/ProjectAndFileTests';
+import * as commonLsTests from '../../testsLibrary/LsTests';
+import * as workspaceHandling from '../../testsLibrary/WorksapceHandlingTests';
+import * as codeExecutionTests from '../../testsLibrary/CodeExecutionTests';
+
+const stack : string = 'Java Spring Boot';
+const workspaceSampleName: string = 'java-web-spring';
+const workspaceRootFolderName: string = 'src';
+const fileFolderPath: string = `${workspaceSampleName}/${workspaceRootFolderName}/main/java/org/springframework/samples/petclinic`;
+const tabTitle: string = 'PetClinicApplication.java';
+const codeNavigationClassName: string = 'SpringApplication.class';
+const taskName: string = 'maven build';
+
+suite(`${stack} test`, async () => {
+    suite (`Create ${stack} workspace`, async () => {
+        workspaceHandling.createAndOpenWorkspace(stack);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+    });
+
+    suite('Test opening file', async () => {
+        // opening file that soon should give time for LS to initialize
+        projectAndFileTests.openFile(fileFolderPath, tabTitle);
+    });
+
+    suite('Validation of workspace build and run', async () => {
+        codeExecutionTests.runTask(taskName, 240_000);
+        codeExecutionTests.closeTerminal(taskName);
+    });
+
+    suite('Language server validation', async () => {
+        commonLsTests.autocomplete(tabTitle, 32, 56, 'args : String[]');
+        commonLsTests.errorHighlighting(tabTitle, 'error_text', 30);
+        commonLsTests.codeNavigation(tabTitle, 32, 23, codeNavigationClassName, 30_000); // extended timout to give LS enough time to start
+        commonLsTests.suggestionInvoking(tabTitle, 32, 23, 'run(Class<?>');
+    });
+
+    suite ('Stopping and deleting the workspace', async () => {
+        let workspaceName = 'not defined';
+        suiteSetup( async () => {
+            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
+        });
+        test (`Stop worksapce`, async () => {
+            await workspaceHandling.stopWorkspace(workspaceName);
+        });
+        test (`Remove workspace`, async () => {
+            await workspaceHandling.removeWorkspace(workspaceName);
+        });
+    });
+});


### PR DESCRIPTION
### What does this PR do?
* Linter fix for Terminal class - replacing `"` with `'`
* Adding devfile test for Java Spring Boot devfile

### What issues does this PR fix or reference?
#18166

### How to test this PR?
* Go into Eclipse repository che/tests/e2e
* Run `npm i` and verify that all packages install without errors
* Run `tsc` and verify that no errors are present
* Export following variables:
  * `TS_SELENIUM_BASE_URL`
  * `TS_SELENIUM_MULTIUSER=true`
  * `NODE_TLS_REJECT_UNAUTHORIZED=0`
  * `TS_SELENIUM_LOG_LEVEL="TRACE"`
  * `TS_SELENIUM_USERNAME`
  * `TS_SELENIUM_PASSWORD`
* Run `npm run test-java-vertx` to execute the smoke test devfile and verify that the tests are working correctly or run entire suite using `npm run test-all-devfiles`
* Tests should pass without a failure (you may encounter stop and delete workspace failures if not using ephemeral mode by default)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
