### PR TITLE
Add support for path on secure endpoints

### DIFF
--- a/assembly/assembly-root-war/src/main/webapp/_app/loader.js
+++ b/assembly/assembly-root-war/src/main/webapp/_app/loader.js
@@ -167,9 +167,9 @@ class Loader {
      * @param {string} redirectUrl a redirect URL
      * @param {string} token
      */
-    asyncAuthenticate(redirectUrl, token) {
+    asyncAuthenticate(redirectUrl, endpointOrigin, token) {
         redirectUrl = new URL(redirectUrl);
-        const url = redirectUrl.origin + redirectUrl.pathname.replace("//", "/") + "jwt/auth";
+        const url = "https://" + redirectUrl.host + ("/" + endpointOrigin + "/jwt/auth").replace("//", "/");
         return new Promise((resolve, reject) => {
             const request = new XMLHttpRequest();
             request.open('GET', url);
@@ -228,7 +228,7 @@ class Loader {
         const workspace = await loader.asyncGetWorkspace(workspaceId);
         const server = await loader.asyncGetMatchedServer(workspace, redirectUrl);
         const token = await loader.asyncGetWsToken(workspace);
-        await loader.asyncAuthenticate(server.url, token);
+        await loader.asyncAuthenticate(server.url, server.attributes.endpointOrigin, token);
 
         window.location.replace(redirectUrl);
     } catch (errorMessage) {

--- a/assembly/assembly-root-war/src/main/webapp/_app/loader.js
+++ b/assembly/assembly-root-war/src/main/webapp/_app/loader.js
@@ -170,7 +170,7 @@ class Loader {
     asyncAuthenticate(redirectUrl, endpointOrigin, token) {
         redirectUrl = new URL(redirectUrl);
         // if endpointOrigin is just "/", we'd end up with "///jwt/auth". So we replace two or more consecutive / with a single /.
-        const url = "https://" + redirectUrl.host + ("/" + endpointOrigin + "/jwt/auth").replace(/\/{2,}/g, "/");
+        const url = redirectUrl.protocol + "//" + redirectUrl.host + ("/" + endpointOrigin + "/jwt/auth").replace(/\/{2,}/g, "/");
         return new Promise((resolve, reject) => {
             const request = new XMLHttpRequest();
             request.open('GET', url);

--- a/assembly/assembly-root-war/src/main/webapp/_app/loader.js
+++ b/assembly/assembly-root-war/src/main/webapp/_app/loader.js
@@ -169,7 +169,8 @@ class Loader {
      */
     asyncAuthenticate(redirectUrl, endpointOrigin, token) {
         redirectUrl = new URL(redirectUrl);
-        const url = "https://" + redirectUrl.host + ("/" + endpointOrigin + "/jwt/auth").replace("//", "/");
+        // if endpointOrigin is just "/", we'd end up with "///jwt/auth". So we replace two or more consecutive / with a single /.
+        const url = "https://" + redirectUrl.host + ("/" + endpointOrigin + "/jwt/auth").replace(/\/{2,}/g, "/");
         return new Promise((resolve, reject) => {
             const request = new XMLHttpRequest();
             request.open('GET', url);

--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -97,6 +97,9 @@ public interface ServerConfig {
    */
   String REQUIRE_SUBDOMAIN = "requireSubdomain";
 
+  /** Attribute that specifies the base location of the JWT authenticating callback. */
+  String ENDPOINT_ORIGIN = "endpointOrigin";
+
   /**
    * Port used by server.
    *
@@ -248,6 +251,29 @@ public interface ServerConfig {
   }
 
   /**
+   * Returns the base location of the JWT authenticating callback.
+   *
+   * @param attributes the server attributes
+   */
+  static @Nullable String getEndpointOrigin(Map<String, String> attributes) {
+    return attributes.get(ENDPOINT_ORIGIN);
+  }
+
+  /**
+   * Sets the base location of the JWT authenticating callback.
+   *
+   * @param attributes the server attributes
+   * @param value the auth origin or null if none should be used
+   */
+  static void setEndpointOrigin(Map<String, String> attributes, @Nullable String value) {
+    if (value == null) {
+      attributes.remove(ENDPOINT_ORIGIN);
+    } else {
+      attributes.putIfAbsent(ENDPOINT_ORIGIN, value);
+    }
+  }
+
+  /**
    * Finds the unsecured paths configuration in the provided attributes.s
    *
    * @param attributes the attributes with additional server configuration
@@ -303,6 +329,11 @@ public interface ServerConfig {
   /** @see #isRequireSubdomain(Map) */
   default boolean isRequireSubdomain() {
     return isRequireSubdomain(getAttributes());
+  }
+
+  /** @see #getEndpointOrigin(Map) */
+  default String getEndpointOrigin() {
+    return getEndpointOrigin(getAttributes());
   }
 }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/RuntimeServerBuilder.java
@@ -31,6 +31,7 @@ public class RuntimeServerBuilder {
   private String host;
   private String port;
   private String path;
+  private String endpointOrigin;
   private Map<String, String> attributes;
   private String targetPort;
 
@@ -54,6 +55,11 @@ public class RuntimeServerBuilder {
     return this;
   }
 
+  public RuntimeServerBuilder endpointOrigin(String authPath) {
+    this.endpointOrigin = authPath;
+    return this;
+  }
+
   public RuntimeServerBuilder attributes(Map<String, String> attributes) {
     this.attributes = attributes;
     return this;
@@ -65,6 +71,9 @@ public class RuntimeServerBuilder {
   }
 
   public ServerImpl build() {
+    if (endpointOrigin == null) {
+      endpointOrigin = "/";
+    }
     StringBuilder ub = new StringBuilder();
     if (protocol != null) {
       ub.append(protocol).append("://");
@@ -83,6 +92,7 @@ public class RuntimeServerBuilder {
     }
     Map<String, String> completeAttributes = new HashMap<>(attributes);
     completeAttributes.put(Constants.SERVER_PORT_ATTRIBUTE, targetPort);
+    ServerConfig.setEndpointOrigin(completeAttributes, endpointOrigin);
     return new ServerImpl()
         .withUrl(ub.toString())
         .withStatus(ServerStatus.UNKNOWN)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/GatewayServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/GatewayServerExposer.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import java.util.Map;
 import javax.inject.Inject;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
-import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
@@ -103,13 +102,14 @@ public class GatewayServerExposer<T extends KubernetesEnvironment>
 
     final String path = ensureEndsWithSlash(strategy.getExternalPath(serviceName, serverName));
     serverConfig.getAttributes().put(SERVICE_NAME_ATTRIBUTE, serviceName);
+    ServerConfig.setEndpointOrigin(serverConfig.getAttributes(), path);
     serverConfig
         .getAttributes()
         .put(SERVICE_PORT_ATTRIBUTE, getTargetPort(servicePort.getTargetPort()));
 
     final Map<String, String> annotations =
         Annotations.newSerializer()
-            .server(scRef, new ServerConfigImpl(serverConfig).withPath(path))
+            .server(scRef, serverConfig)
             .machineName(machineName)
             .annotations();
     annotations.put(CREATE_IN_CHE_INSTALLATION_NAMESPACE, TRUE.toString());

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGenerator.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGenerator.java
@@ -95,7 +95,7 @@ public class TraefikGatewayRouteConfigGenerator implements GatewayRouteConfigGen
           generate(
               routeConfig.getKey(),
               createServiceUrl(serviceName, servicePort, namespace),
-              server.getPath());
+              server.getEndpointOrigin());
       cmData.put(routeConfig.getKey() + ".yml", traefikRouteConfig);
     }
     return cmData;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/AbstractServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/AbstractServerResolver.java
@@ -43,7 +43,15 @@ public abstract class AbstractServerResolver implements ServerResolver {
     }
   }
 
-  public static String buildPath(String fragment1, @Nullable String fragment2) {
+  /**
+   * Joins together the two URL path fragments together and makes sure the returned path ends with a
+   * slash.
+   *
+   * @param fragment1 the root path fragment
+   * @param fragment2 the sub-path fragment
+   * @return the two path fragments joined together
+   */
+  protected static String buildPath(String fragment1, @Nullable String fragment2) {
     StringBuilder sb = new StringBuilder(fragment1);
 
     if (!isNullOrEmpty(fragment2)) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolver.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolver.java
@@ -71,14 +71,20 @@ public class ConfigMapServerResolver extends AbstractServerResolver {
         .collect(
             Collectors.toMap(
                 Entry::getKey,
-                e ->
-                    new RuntimeServerBuilder()
-                        .protocol(e.getValue().getProtocol())
-                        .host(cheHost)
-                        .path(e.getValue().getPath())
-                        .attributes(e.getValue().getAttributes())
-                        .targetPort(e.getValue().getPort())
-                        .build(),
+                e -> {
+                  boolean requiresSubdomain = e.getValue().isRequireSubdomain();
+                  String root = requiresSubdomain ? "/" : e.getValue().getEndpointOrigin();
+                  String path = buildPath(root, e.getValue().getPath());
+
+                  return new RuntimeServerBuilder()
+                      .protocol(e.getValue().getProtocol())
+                      .host(cheHost)
+                      .path(path)
+                      .endpointOrigin(root)
+                      .attributes(e.getValue().getAttributes())
+                      .targetPort(e.getValue().getPort())
+                      .build();
+                },
                 (s1, s2) -> s2));
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/SecureServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/SecureServerExposer.java
@@ -31,6 +31,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
  */
 public interface SecureServerExposer<T extends KubernetesEnvironment> {
 
+  String AUTH_ENDPOINT_PATH = "/jwt/auth";
+
   /**
    * Creates a service that should handle the traffic for the provided secure ports that are exposed
    * on the container from the pod.

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/CookiePathStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/CookiePathStrategy.java
@@ -32,7 +32,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.Servi
  * {@link
  * org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServiceExposureStrategy}),
  * this class merely internally uses different functions for different service exposure strategies.
- * This is done because the full-blown stragegy pattern implementation felt like over-engineering
+ * This is done because the full-blown strategy pattern implementation felt like over-engineering
  * when compared with the simplicity of the functions.
  */
 @Singleton

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesInternalRuntimeTest.java
@@ -140,6 +140,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesP
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.SecretAsContainerResourceProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.IngressPathTransformInverter;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.resolver.KubernetesServerResolverFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.resolver.ServerResolver;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
@@ -216,6 +217,7 @@ public class KubernetesInternalRuntimeTest {
   @Mock private RuntimeHangingDetector runtimeHangingDetector;
   @Mock private KubernetesPreviewUrlCommandProvisioner previewUrlCommandProvisioner;
   @Mock private SecretAsContainerResourceProvisioner secretAsContainerResourceProvisioner;
+  @Mock private ServiceExposureStrategyProvider serviceExposureStrategyProvider;
   @Mock private RuntimeCleaner runtimeCleaner;
   private KubernetesServerResolverFactory serverResolverFactory;
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/IngressServerResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/IngressServerResolverTest.java
@@ -37,9 +37,12 @@ import org.eclipse.che.api.workspace.shared.Constants;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations.Serializer;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServiceExposureStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.IngressPathTransformInverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.resolver.IngressServerResolver;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.resolver.ServerResolver;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -54,6 +57,13 @@ public class IngressServerResolverTest {
   private static final String INGRESS_IP = "127.0.0.1";
   private static final String INGRESS_RULE_PATH_PREFIX = "/server-8080";
   private static final String INGRESS_PATH_PREFIX = "server-8080";
+
+  private ExternalServiceExposureStrategy externalServiceExposureStrategy;
+
+  @BeforeMethod
+  public void setupMocks() {
+    externalServiceExposureStrategy = Mockito.mock(ExternalServiceExposureStrategy.class);
+  }
 
   @Test
   public void
@@ -100,7 +110,12 @@ public class IngressServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX + "/api/")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(
+                defaultAttributeAnd(
+                    Constants.SERVER_PORT_ATTRIBUTE,
+                    "3054",
+                    ServerConfig.ENDPOINT_ORIGIN,
+                    INGRESS_PATH_PREFIX + "/")));
   }
 
   @Test
@@ -123,7 +138,12 @@ public class IngressServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX + "/")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(
+                defaultAttributeAnd(
+                    Constants.SERVER_PORT_ATTRIBUTE,
+                    "3054",
+                    ServerConfig.ENDPOINT_ORIGIN,
+                    INGRESS_PATH_PREFIX + "/")));
   }
 
   @Test
@@ -146,7 +166,12 @@ public class IngressServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX + "/")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(
+                defaultAttributeAnd(
+                    Constants.SERVER_PORT_ATTRIBUTE,
+                    "3054",
+                    ServerConfig.ENDPOINT_ORIGIN,
+                    INGRESS_PATH_PREFIX + "/")));
   }
 
   @Test
@@ -169,7 +194,12 @@ public class IngressServerResolverTest {
         new ServerImpl()
             .withUrl("http://" + INGRESS_IP + INGRESS_RULE_PATH_PREFIX + "/api/")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(
+                defaultAttributeAnd(
+                    Constants.SERVER_PORT_ATTRIBUTE,
+                    "3054",
+                    ServerConfig.ENDPOINT_ORIGIN,
+                    INGRESS_PATH_PREFIX + "/")));
   }
 
   @Test
@@ -194,7 +224,9 @@ public class IngressServerResolverTest {
         new ServerImpl()
             .withUrl("http://service11:3054/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(
+                defaultAttributeAnd(
+                    Constants.SERVER_PORT_ATTRIBUTE, "3054", ServerConfig.ENDPOINT_ORIGIN, "/")));
   }
 
   @Test
@@ -219,7 +251,9 @@ public class IngressServerResolverTest {
         new ServerImpl()
             .withUrl("xxx://service11:3054/api")
             .withStatus(ServerStatus.UNKNOWN)
-            .withAttributes(defaultAttributeAnd(Constants.SERVER_PORT_ATTRIBUTE, "3054")));
+            .withAttributes(
+                defaultAttributeAnd(
+                    Constants.SERVER_PORT_ATTRIBUTE, "3054", ServerConfig.ENDPOINT_ORIGIN, "/")));
   }
 
   private Service createService(
@@ -278,9 +312,17 @@ public class IngressServerResolverTest {
         .build();
   }
 
-  private Map<String, String> defaultAttributeAnd(String key, String value) {
+  private Map<String, String> defaultAttributeAnd(String... keyValues) {
     HashMap<String, String> attributes = new HashMap<>(ATTRIBUTES_MAP);
-    attributes.put(key, value);
+    String key = null;
+    for (String v : keyValues) {
+      if (key == null) {
+        key = v;
+      } else {
+        attributes.put(key, v);
+        key = null;
+      }
+    }
     return attributes;
   }
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/GatewayServerExposerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/GatewayServerExposerTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -96,6 +97,7 @@ public class GatewayServerExposerTest {
     assertEquals(s1.getAttributes().get(ServerConfigImpl.SERVICE_PORT_ATTRIBUTE), "1234");
     assertEquals(s1.getPort(), "1111");
     assertEquals(s1.getProtocol(), "ws");
-    assertEquals(s1.getPath(), "/service/server/");
+    assertNull(s1.getPath());
+    assertEquals(s1.getEndpointOrigin(), "/service/server/");
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGeneratorTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/TraefikGatewayRouteConfigGeneratorTest.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
@@ -61,8 +62,14 @@ public class TraefikGatewayRouteConfigGeneratorTest {
         new ServerConfigImpl(
             "123",
             "https",
-            "/blabol-cesta",
-            ImmutableMap.of(SERVICE_NAME_ATTRIBUTE, "service-url", SERVICE_PORT_ATTRIBUTE, "1234"));
+            "/",
+            ImmutableMap.of(
+                SERVICE_NAME_ATTRIBUTE,
+                "service-url",
+                SERVICE_PORT_ATTRIBUTE,
+                "1234",
+                ServerConfig.ENDPOINT_ORIGIN,
+                "/blabol-cesta"));
     Map<String, String> annotations =
         new Annotations.Serializer().server("s1", serverConfig).annotations();
     ConfigMap routeConfig =
@@ -87,8 +94,14 @@ public class TraefikGatewayRouteConfigGeneratorTest {
         new ServerConfigImpl(
             "123",
             "https",
-            "/blabol-cesta",
-            ImmutableMap.of(SERVICE_NAME_ATTRIBUTE, "service-url", SERVICE_PORT_ATTRIBUTE, "1234"));
+            "/",
+            ImmutableMap.of(
+                SERVICE_NAME_ATTRIBUTE,
+                "service-url",
+                SERVICE_PORT_ATTRIBUTE,
+                "1234",
+                ServerConfig.ENDPOINT_ORIGIN,
+                "/blabol-cesta"));
     Map<String, String> annotations =
         new Annotations.Serializer().server("s1", serverConfig).annotations();
     ConfigMap routeConfig =
@@ -112,8 +125,14 @@ public class TraefikGatewayRouteConfigGeneratorTest {
         new ServerConfigImpl(
             "123",
             "https",
-            "/blabol-cesta",
-            ImmutableMap.of(SERVICE_NAME_ATTRIBUTE, "service-url", SERVICE_PORT_ATTRIBUTE, "1234"));
+            "/",
+            ImmutableMap.of(
+                SERVICE_NAME_ATTRIBUTE,
+                "service-url",
+                SERVICE_PORT_ATTRIBUTE,
+                "1234",
+                ServerConfig.ENDPOINT_ORIGIN,
+                "/blabol-cesta"));
     Map<String, String> annotations =
         new Annotations.Serializer()
             .server("s1", serverConfig)

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/AbstractServerResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/AbstractServerResolverTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.server.resolver;
+
+import static org.testng.Assert.assertEquals;
+
+import org.eclipse.che.commons.annotation.Nullable;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class AbstractServerResolverTest {
+
+  @Test(dataProvider = "buildPathFragments")
+  public void testBuildPath(String fragment1, @Nullable String fragment2, String expectedResult) {
+    assertEquals(AbstractServerResolver.buildPath(fragment1, fragment2), expectedResult);
+  }
+
+  @DataProvider
+  public static Object[][] buildPathFragments() {
+    return new Object[][] {
+      new Object[] {"/", null, "/"},
+      new Object[] {"/a", null, "/a/"},
+      new Object[] {"/a/", null, "/a/"},
+      new Object[] {"/a", "", "/a/"},
+      new Object[] {"/a", "", "/a/"},
+      new Object[] {"/a", "/", "/a/"},
+      new Object[] {"/a", "b", "/a/b/"},
+      new Object[] {"/a", "/b", "/a/b/"},
+      new Object[] {"/a", "b/", "/a/b/"},
+      new Object[] {"/a", "/b/", "/a/b/"},
+    };
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolverTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/resolver/ConfigMapServerResolverTest.java
@@ -13,13 +13,22 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.server.resolver;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
 import static java.util.Collections.singletonMap;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import java.util.Map;
+import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.ServerStatus;
+import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.model.impl.ServerImpl;
+import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.Listeners;
@@ -45,5 +54,41 @@ public class ConfigMapServerResolverTest {
     // then
     assertTrue(resolvedServers.containsKey("s1"));
     assertEquals(resolvedServers.get("s1"), server);
+  }
+
+  @Test
+  public void shouldSetEndpointOrigin() {
+    // given
+    ConfigMap serverConfigMap =
+        new ConfigMapBuilder()
+            .withNewMetadata()
+            .addToAnnotations(
+                Annotations.newSerializer()
+                    .machineName("m1")
+                    .server(
+                        "svr",
+                        new ServerConfigImpl()
+                            .withPort("8080")
+                            .withProtocol("http")
+                            .withPath("/kachny")
+                            .withAttributes(
+                                ImmutableMap.of(ServerConfig.ENDPOINT_ORIGIN, "/kachny")))
+                    .annotations())
+            .endMetadata()
+            .build();
+
+    ConfigMapServerResolver serverResolver =
+        new ConfigMapServerResolver(
+            emptyList(), singletonList(serverConfigMap), "che.host", nativeServerResolver);
+
+    // when
+    Map<String, ServerImpl> resolvedServers = serverResolver.resolve("m1");
+
+    // then
+    ServerImpl svr = resolvedServers.get("svr");
+    assertNotNull(svr);
+
+    assertEquals("/kachny", ServerConfig.getEndpointOrigin(svr.getAttributes()));
+    assertEquals("http://che.host/kachny/kachny/", svr.getUrl());
   }
 }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerResolver.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerResolver.java
@@ -55,12 +55,12 @@ public class RouteServerResolver extends AbstractServerResolver {
     return routes
         .get(machineName)
         .stream()
-        .map(this::resolveRouteServers)
+        .map(r -> resolveRouteServers(machineName, r))
         .flatMap(m -> m.entrySet().stream())
         .collect(Collectors.toMap(Entry::getKey, Entry::getValue, (v1, v2) -> v2));
   }
 
-  private Map<String, ServerImpl> resolveRouteServers(Route route) {
+  private Map<String, ServerImpl> resolveRouteServers(String serviceName, Route route) {
     return Annotations.newDeserializer(route.getMetadata().getAnnotations())
         .servers()
         .entrySet()
@@ -73,6 +73,8 @@ public class RouteServerResolver extends AbstractServerResolver {
                         .protocol(e.getValue().getProtocol())
                         .host(route.getSpec().getHost())
                         .path(e.getValue().getPath())
+                        .endpointOrigin(
+                            "/") // routes are always multihost, so we don't need to think here...
                         .attributes(e.getValue().getAttributes())
                         .targetPort(e.getValue().getPort())
                         .build(),

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftInternalRuntimeTest.java
@@ -80,6 +80,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesS
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.pvc.WorkspaceVolumesStrategy;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.SecretAsContainerResourceProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.RuntimeEventsPublisher;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.UnrecoverablePodEventListenerFactory;
@@ -151,6 +152,7 @@ public class OpenShiftInternalRuntimeTest {
   @Mock private SecretAsContainerResourceProvisioner secretAsContainerResourceProvisioner;
   @Mock private Openshift4TrustedCAProvisioner trustedCAProvisioner;
   @Mock private CheNamespace cheNamespace;
+  @Mock private ServiceExposureStrategyProvider serviceExposureStrategyProvider;
   @Mock private RuntimeCleaner runtimeCleaner;
   private OpenShiftServerResolverFactory serverResolverFactory;
 


### PR DESCRIPTION
### What does this PR do?
This PR adds a notion of `endpointOrigin` (separate from the endpoint path) of "servers" which is used as the basis for determining the `/jwt/auth` endpoint to perform the authentication against.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
#15867 #18065

### How to test this PR?
1. Create a workspace using the below specified PR
1. Run the "Start development mode" command
1. Open the `hello-greeting-endpoint`
1. Notice that the runtime token is established, the auth cookie is set and the endpoint is accessed successfully.

There is a test che-server image for this PR: `quay.io/lkrejci/che-server:issue-15867`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Additional Context

The devfile for the repro steps:

```yaml
metadata:
  name: secure-endpoints-reproducer
projects:
  - name: quarkus-quickstarts
    source:
      location: 'https://github.com/quarkusio/quarkus-quickstarts.git'
      type: git
      sparseCheckoutDir: getting-started
components:
  - id: redhat/quarkus-java11/latest
    type: chePlugin
  - mountSources: true
    endpoints:
      - name: hello-greeting-endpoint
        port: 8080
        attributes:
          path: /hello/greeting/che-user
          secure: 'true'
          cookiesAuthEnabled: 'true'
    memoryLimit: 4927M
    type: dockerimage
    volumes:
      - name: m2
        containerPath: /home/user/.m2
    alias: centos-quarkus-maven
    image: 'quay.io/eclipse/che-quarkus:nightly'
    env:
      - value: >-
          -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
          -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
          -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true
          -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/user
        name: JAVA_OPTS
      - value: $(JAVA_OPTS)
        name: MAVEN_OPTS
  - mountSources: true
    endpoints:
      - name: hello-greeting-endpoint
        port: 8080
        attributes:
          path: /hello/greeting/che-user
    command:
      - tail
    args:
      - '-f'
      - /dev/null
    memoryLimit: 32M
    type: dockerimage
    alias: ubi-minimal
    image: registry.access.redhat.com/ubi8/ubi-minimal
apiVersion: 1.0.0
commands:
  - name: Package
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started'
        type: exec
        command: ./mvnw package
        component: centos-quarkus-maven
  - name: Start Development mode (Hot reload + debug)
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started'
        type: exec
        command: './mvnw compile quarkus:dev'
        component: centos-quarkus-maven
  - name: Package Native
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started'
        type: exec
        command: ./mvnw package -Dnative -Dmaven.test.skip
        component: centos-quarkus-maven
  - name: Start Native
    actions:
      - workdir: '${CHE_PROJECTS_ROOT}/quarkus-quickstarts/getting-started/target'
        type: exec
        command: ./getting-started-1.0-SNAPSHOT-runner
        component: ubi-minimal
  - name: Attach remote debugger
    actions:
      - referenceContent: |
          {
            "version": "0.2.0",
            "configurations": [
              {
                "type": "java",
                "request": "attach",
                "name": "Attach to Remote Quarkus App",
                "hostName": "localhost",
                "port": 5005
              }
            ]
          }
        type: vscode-launch
```