### PR TITLE
Fixes #18065 - Handle the mixed endpoints correctly with singlehost strategy (attempt 2)

### DIFF
--- a/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
+++ b/core/che-core-api-model/src/main/java/org/eclipse/che/api/core/model/workspace/config/ServerConfig.java
@@ -228,6 +228,26 @@ public interface ServerConfig {
   }
 
   /**
+   * This is checking if the attributes configure the server to be exposed on a subdomain if we're
+   * on single-host. It has no effect on other server exposure strategies.
+   */
+  static boolean isRequireSubdomain(Map<String, String> attributes) {
+    return AttributesEvaluator.booleanAttr(attributes, REQUIRE_SUBDOMAIN, false);
+  }
+
+  /**
+   * Modify the attributes to configure the server to be exposed on a subdomain if we're on
+   * single-host. It has no effect on other server exposure strategies.
+   */
+  static void setRequireSubdomain(Map<String, String> attributes, boolean value) {
+    if (value) {
+      attributes.put(REQUIRE_SUBDOMAIN, Boolean.TRUE.toString());
+    } else {
+      attributes.remove(REQUIRE_SUBDOMAIN);
+    }
+  }
+
+  /**
    * Finds the unsecured paths configuration in the provided attributes.s
    *
    * @param attributes the attributes with additional server configuration
@@ -278,6 +298,11 @@ public interface ServerConfig {
   /** @see #isDiscoverable(Map) */
   default boolean isDiscoverable() {
     return isDiscoverable(getAttributes());
+  }
+
+  /** @see #isRequireSubdomain(Map) */
+  default boolean isRequireSubdomain() {
+    return isRequireSubdomain(getAttributes());
   }
 }
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GatewayTlsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GatewayTlsProvisioner.java
@@ -24,6 +24,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.WorkspaceExposureType;
 import org.eclipse.che.workspace.infrastructure.kubernetes.util.GatewayConfigmapLabels;
 
 /**
@@ -35,13 +36,16 @@ public class GatewayTlsProvisioner<T extends KubernetesEnvironment>
 
   private final boolean isTlsEnabled;
   private final GatewayConfigmapLabels configmapLabels;
+  private final TlsProvisioner<T> nativeProvisioner;
 
   @Inject
   public GatewayTlsProvisioner(
       @Named("che.infra.kubernetes.tls_enabled") boolean isTlsEnabled,
-      GatewayConfigmapLabels configmapLabels) {
+      GatewayConfigmapLabels configmapLabels,
+      TlsProvisionerProvider<T> provisionerProvider) {
     this.isTlsEnabled = isTlsEnabled;
     this.configmapLabels = configmapLabels;
+    this.nativeProvisioner = provisionerProvider.get(WorkspaceExposureType.NATIVE);
   }
 
   @Override
@@ -55,6 +59,8 @@ public class GatewayTlsProvisioner<T extends KubernetesEnvironment>
         useSecureProtocolForGatewayConfigMap(configMap);
       }
     }
+
+    nativeProvisioner.provision(k8sEnv, identity);
   }
 
   private void useSecureProtocolForGatewayConfigMap(ConfigMap configMap)

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/AbstractExposureStrategyAwareProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/AbstractExposureStrategyAwareProvider.java
@@ -25,6 +25,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.Singl
 public abstract class AbstractExposureStrategyAwareProvider<T> implements Provider<T> {
 
   protected final T instance;
+  protected final Map<WorkspaceExposureType, T> instanceMap;
 
   /**
    * Constructs a new provider returning one of the instances from the provided mapping
@@ -57,9 +58,17 @@ public abstract class AbstractExposureStrategyAwareProvider<T> implements Provid
     if (instance == null) {
       throw new IllegalStateException(String.format(errorMessageTemplate, wsExposureType));
     }
+
+    instanceMap = mapping;
   }
 
+  /** Returns the object mapped to the configured exposure type. */
   public T get() {
     return instance;
+  }
+
+  /** Returns the object mapped to the provided exposure type. */
+  public T get(WorkspaceExposureType exposureType) {
+    return instanceMap.get(exposureType);
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/CombinedSingleHostServerExposer.java
@@ -11,11 +11,9 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
-import static java.lang.Boolean.FALSE;
-import static org.eclipse.che.api.core.model.workspace.config.ServerConfig.REQUIRE_SUBDOMAIN;
+import static java.util.stream.Collectors.toMap;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
-import java.util.HashMap;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
@@ -72,18 +70,8 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
       serverId = servicePort.getName();
     }
 
-    Map<String, ServerConfig> subpathServers = new HashMap<>();
-    Map<String, ServerConfig> subdomainServers = new HashMap<>();
-
-    for (String esKey : externalServers.keySet()) {
-      ServerConfig serverConfig = externalServers.get(esKey);
-      if (Boolean.parseBoolean(
-          serverConfig.getAttributes().getOrDefault(REQUIRE_SUBDOMAIN, FALSE.toString()))) {
-        subdomainServers.put(esKey, serverConfig);
-      } else {
-        subpathServers.put(esKey, serverConfig);
-      }
-    }
+    Map<String, ServerConfig> subpathServers = getStrategyConformingServers(externalServers);
+    Map<String, ServerConfig> subdomainServers = getServersRequiringSubdomain(externalServers);
 
     if (!subpathServers.isEmpty()) {
       subpathServerExposer.expose(
@@ -94,5 +82,25 @@ public class CombinedSingleHostServerExposer<T extends KubernetesEnvironment>
       subdomainServerExposer.expose(
           k8sEnv, machineName, serviceName, serverId, servicePort, subdomainServers);
     }
+  }
+
+  @Override
+  public Map<String, ServerConfig> getStrategyConformingServers(
+      Map<String, ServerConfig> externalServers) {
+    return externalServers
+        .entrySet()
+        .stream()
+        .filter(e -> !e.getValue().isRequireSubdomain())
+        .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Map<String, ServerConfig> getServersRequiringSubdomain(
+      Map<String, ServerConfig> externalServers) {
+    return externalServers
+        .entrySet()
+        .stream()
+        .filter(e -> e.getValue().isRequireSubdomain())
+        .collect(toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposer.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ExternalServerExposer.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.server.external;
 
 import io.fabric8.kubernetes.api.model.ServicePort;
+import java.util.Collections;
 import java.util.Map;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.commons.annotation.Nullable;
@@ -48,4 +49,28 @@ public interface ExternalServerExposer<T extends KubernetesEnvironment> {
       String serverId,
       ServicePort servicePort,
       Map<String, ServerConfig> externalServers);
+
+  /**
+   * Returns the servers from the provided map that should be deployed using the current configured
+   * server exposure strategy.
+   *
+   * @param externalServers all the external servers that are being deployed
+   * @return a view of the provided map
+   */
+  default Map<String, ServerConfig> getStrategyConformingServers(
+      Map<String, ServerConfig> externalServers) {
+    return externalServers;
+  }
+
+  /**
+   * Returns the servers from the provided map that should be deployed on a subdomain regardless of
+   * the current configured server exposure strategy.
+   *
+   * @param externalServers all the external servers that are being deployed
+   * @return a view of the provided map
+   */
+  default Map<String, ServerConfig> getServersRequiringSubdomain(
+      Map<String, ServerConfig> externalServers) {
+    return Collections.emptyMap();
+  }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ServiceExposureStrategyProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ServiceExposureStrategyProvider.java
@@ -49,12 +49,20 @@ public class ServiceExposureStrategyProvider implements Provider<ExternalService
     }
   }
 
+  /**
+   * Returns the configured exposure strategy.
+   */
   @Override
   public ExternalServiceExposureStrategy get() {
     return namingStrategy;
   }
 
-  public ExternalServiceExposureStrategy getMultiHost() {
+  /**
+   * Returns the multi-host exposure strategy, regardless of which default exposure strategy is configured.
+   * This is used in workspaces with mixed endpoints (i.e. plugins by default deployed using the configured strategy and devfile endpoints
+   * by default deployed using multi-host).
+   */
+  public ExternalServiceExposureStrategy getMultiHostStrategy() {
     return multiHostStrategy;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ServiceExposureStrategyProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ServiceExposureStrategyProvider.java
@@ -26,6 +26,7 @@ public class ServiceExposureStrategyProvider implements Provider<ExternalService
   public static final String STRATEGY_PROPERTY = "che.infra.kubernetes.server_strategy";
 
   private final ExternalServiceExposureStrategy namingStrategy;
+  private final ExternalServiceExposureStrategy multiHostStrategy;
 
   @Inject
   public ServiceExposureStrategyProvider(
@@ -38,10 +39,22 @@ public class ServiceExposureStrategyProvider implements Provider<ExternalService
       throw new ConfigurationException(
           format("Unsupported server naming strategy '%s' configured", strategy));
     }
+
+    multiHostStrategy =
+        strategies.get(MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY);
+    if (multiHostStrategy == null) {
+      throw new ConfigurationException(
+          "No implementation for 'multi-host' server exposure strategy configured even though it is"
+              + " mandatory.");
+    }
   }
 
   @Override
   public ExternalServiceExposureStrategy get() {
     return namingStrategy;
+  }
+
+  public ExternalServiceExposureStrategy getMultiHost() {
+    return multiHostStrategy;
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ServiceExposureStrategyProvider.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/external/ServiceExposureStrategyProvider.java
@@ -49,18 +49,16 @@ public class ServiceExposureStrategyProvider implements Provider<ExternalService
     }
   }
 
-  /**
-   * Returns the configured exposure strategy.
-   */
+  /** Returns the configured exposure strategy. */
   @Override
   public ExternalServiceExposureStrategy get() {
     return namingStrategy;
   }
 
   /**
-   * Returns the multi-host exposure strategy, regardless of which default exposure strategy is configured.
-   * This is used in workspaces with mixed endpoints (i.e. plugins by default deployed using the configured strategy and devfile endpoints
-   * by default deployed using multi-host).
+   * Returns the multi-host exposure strategy, regardless of which default exposure strategy is
+   * configured. This is used in workspaces with mixed endpoints (i.e. plugins by default deployed
+   * using the configured strategy and devfile endpoints by default deployed using multi-host).
    */
   public ExternalServiceExposureStrategy getMultiHostStrategy() {
     return multiHostStrategy;

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/ProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/ProxyProvisioner.java
@@ -38,6 +38,8 @@ public interface ProxyProvisioner {
    * @param backendServiceName service name that will be exposed
    * @param backendServicePort service port that will be exposed
    * @param protocol protocol that will be used for exposed port
+   * @param requireSubdomain if true, the supplied servers are supposed to require a subdomain, if
+   *     false the servers are considered to follow the configured exposure strategy
    * @param secureServers secure servers to expose
    * @return JWTProxy service port that expose the specified one
    * @throws InfrastructureException if any exception occurs during port exposing
@@ -49,6 +51,7 @@ public interface ProxyProvisioner {
       @Nullable String backendServiceName,
       ServicePort backendServicePort,
       String protocol,
+      boolean requireSubdomain,
       Map<String, ServerConfig> secureServers)
       throws InfrastructureException;
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/AbstractJwtProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/AbstractJwtProxyProvisioner.java
@@ -73,7 +73,9 @@ abstract class AbstractJwtProxyProvisioner implements ProxyProvisioner {
   private final Map<String, String> attributes;
   private final String serviceName;
   private final ExternalServiceExposureStrategy externalServiceExposureStrategy;
+  private final ExternalServiceExposureStrategy multiHostExternalServiceExposureStrategy;
   private final CookiePathStrategy cookiePathStrategy;
+  private final MultiHostCookiePathStrategy multihostCookiePathStrategy;
   private final String imagePullPolicy;
   private int availablePort;
   private final KeyPair keyPair;
@@ -97,7 +99,9 @@ abstract class AbstractJwtProxyProvisioner implements ProxyProvisioner {
       KeyPair signatureKeyPair,
       JwtProxyConfigBuilderFactory jwtProxyConfigBuilderFactory,
       ExternalServiceExposureStrategy externalServiceExposureStrategy,
+      ExternalServiceExposureStrategy multiHostStrategy,
       CookiePathStrategy cookiePathStrategy,
+      MultiHostCookiePathStrategy multihostCookiePathStrategy,
       String jwtProxyImage,
       String memoryLimitBytes,
       String cpuLimitCores,
@@ -108,7 +112,9 @@ abstract class AbstractJwtProxyProvisioner implements ProxyProvisioner {
     this.proxyConfigBuilder = jwtProxyConfigBuilderFactory.create(workspaceId);
     this.jwtProxyImage = jwtProxyImage;
     this.externalServiceExposureStrategy = externalServiceExposureStrategy;
+    this.multiHostExternalServiceExposureStrategy = multiHostStrategy;
     this.cookiePathStrategy = cookiePathStrategy;
+    this.multihostCookiePathStrategy = multihostCookiePathStrategy;
     this.imagePullPolicy = imagePullPolicy;
     this.serviceName = generate(SERVER_PREFIX, SERVER_UNIQUE_PART_SIZE) + "-jwtproxy";
 
@@ -156,6 +162,7 @@ abstract class AbstractJwtProxyProvisioner implements ProxyProvisioner {
       String backendServiceName,
       ServicePort backendServicePort,
       String protocol,
+      boolean requireSubdomain,
       Map<String, ServerConfig> secureServers)
       throws InfrastructureException {
     Preconditions.checkArgument(
@@ -197,6 +204,13 @@ abstract class AbstractJwtProxyProvisioner implements ProxyProvisioner {
 
     k8sEnv.getServices().get(serviceName).getSpec().getPorts().add(exposedPort);
 
+    CookiePathStrategy actualCookiePathStrategy =
+        requireSubdomain ? multihostCookiePathStrategy : cookiePathStrategy;
+    ExternalServiceExposureStrategy actualExposureStrategy =
+        requireSubdomain
+            ? multiHostExternalServiceExposureStrategy
+            : externalServiceExposureStrategy;
+
     // JwtProxySecureServerExposer creates no service for the exposed secure servers and
     // assumes everything will be proxied from localhost, because JWT proxy is collocated
     // with the workspace pod (because it is added to the environment as an injectable pod).
@@ -212,8 +226,8 @@ abstract class AbstractJwtProxyProvisioner implements ProxyProvisioner {
         "http://" + backendServiceName + ":" + backendServicePort.getTargetPort().getIntVal(),
         excludes,
         cookiesAuthEnabled == null ? false : cookiesAuthEnabled,
-        cookiePathStrategy.get(serviceName, exposedPort),
-        externalServiceExposureStrategy.getExternalPath(serviceName, exposedPort.getName()));
+        actualCookiePathStrategy.get(serviceName, exposedPort),
+        actualExposureStrategy.getExternalPath(serviceName, exposedPort.getName()));
     k8sEnv
         .getConfigMaps()
         .get(getConfigMapName())

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
@@ -20,7 +20,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
 import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManager;
 import org.eclipse.che.multiuser.machine.authentication.server.signature.SignatureKeyManagerException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServiceExposureStrategy;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyConfigBuilderFactory;
 
 /**
@@ -49,8 +49,9 @@ public class JwtProxyProvisioner extends AbstractJwtProxyProvisioner {
   public JwtProxyProvisioner(
       SignatureKeyManager signatureKeyManager,
       JwtProxyConfigBuilderFactory jwtProxyConfigBuilderFactory,
-      ExternalServiceExposureStrategy externalServiceExposureStrategy,
+      ServiceExposureStrategyProvider serviceExposureStrategyProvider,
       CookiePathStrategy cookiePathStrategy,
+      MultiHostCookiePathStrategy multiHostCookiePathStrategy,
       @Named("che.server.secure_exposer.jwtproxy.image") String jwtProxyImage,
       @Named("che.server.secure_exposer.jwtproxy.memory_limit") String memoryLimitBytes,
       @Named("che.server.secure_exposer.jwtproxy.cpu_limit") String cpuLimitCores,
@@ -60,8 +61,10 @@ public class JwtProxyProvisioner extends AbstractJwtProxyProvisioner {
     super(
         constructKeyPair(signatureKeyManager, identity),
         jwtProxyConfigBuilderFactory,
-        externalServiceExposureStrategy,
+        serviceExposureStrategyProvider.get(),
+        serviceExposureStrategyProvider.getMultiHost(),
         cookiePathStrategy,
+        multiHostCookiePathStrategy,
         jwtProxyImage,
         memoryLimitBytes,
         cpuLimitCores,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisioner.java
@@ -62,7 +62,7 @@ public class JwtProxyProvisioner extends AbstractJwtProxyProvisioner {
         constructKeyPair(signatureKeyManager, identity),
         jwtProxyConfigBuilderFactory,
         serviceExposureStrategyProvider.get(),
-        serviceExposureStrategyProvider.getMultiHost(),
+        serviceExposureStrategyProvider.getMultiHostStrategy(),
         cookiePathStrategy,
         multiHostCookiePathStrategy,
         jwtProxyImage,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/MultiHostCookiePathStrategy.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/MultiHostCookiePathStrategy.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy;
+
+import static org.eclipse.che.workspace.infrastructure.kubernetes.server.external.MultiHostExternalServiceExposureStrategy.MULTI_HOST_STRATEGY;
+
+import javax.inject.Singleton;
+
+/**
+ * A specialization of the {@link CookiePathStrategy} for multi-host server strategy. We need this
+ * declared specifically to be able to use both the configured strategy and multi-host in case of
+ * workspaces with mixed endpoints.
+ */
+@Singleton
+public class MultiHostCookiePathStrategy extends CookiePathStrategy {
+  public MultiHostCookiePathStrategy() {
+    super(MULTI_HOST_STRATEGY);
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/PassThroughProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/PassThroughProxyProvisioner.java
@@ -48,7 +48,7 @@ public class PassThroughProxyProvisioner extends AbstractJwtProxyProvisioner {
         constructSignatureKeyPair(),
         jwtProxyConfigBuilderFactory,
         serviceExposureStrategyProvider.get(),
-        serviceExposureStrategyProvider.getMultiHost(),
+        serviceExposureStrategyProvider.getMultiHostStrategy(),
         cookiePathStrategy,
         multiHostCookiePathStrategy,
         jwtImage,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/PassThroughProxyProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/PassThroughProxyProvisioner.java
@@ -22,7 +22,7 @@ import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServiceExposureStrategy;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyConfigBuilderFactory;
 
 /**
@@ -35,8 +35,9 @@ public class PassThroughProxyProvisioner extends AbstractJwtProxyProvisioner {
   @Inject
   public PassThroughProxyProvisioner(
       JwtProxyConfigBuilderFactory jwtProxyConfigBuilderFactory,
-      ExternalServiceExposureStrategy externalServiceExposureStrategy,
+      ServiceExposureStrategyProvider serviceExposureStrategyProvider,
       CookiePathStrategy cookiePathStrategy,
+      MultiHostCookiePathStrategy multiHostCookiePathStrategy,
       @Named("che.server.secure_exposer.jwtproxy.image") String jwtImage,
       @Named("che.server.secure_exposer.jwtproxy.memory_limit") String memoryLimitBytes,
       @Named("che.server.secure_exposer.jwtproxy.cpu_limit") String cpuLimitCores,
@@ -46,8 +47,10 @@ public class PassThroughProxyProvisioner extends AbstractJwtProxyProvisioner {
     super(
         constructSignatureKeyPair(),
         jwtProxyConfigBuilderFactory,
-        externalServiceExposureStrategy,
+        serviceExposureStrategyProvider.get(),
+        serviceExposureStrategyProvider.getMultiHost(),
         cookiePathStrategy,
+        multiHostCookiePathStrategy,
         jwtImage,
         memoryLimitBytes,
         cpuLimitCores,

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/JwtProxyProvisionerTest.java
@@ -105,7 +105,7 @@ public class JwtProxyProvisionerTest {
                 URI.create("http://che.api"), "iss", "1h", "", runtimeId.getWorkspaceId()));
 
     when(serviceExposureStrategyProvider.get()).thenReturn(externalServiceExposureStrategy);
-    when(serviceExposureStrategyProvider.getMultiHost())
+    when(serviceExposureStrategyProvider.getMultiHostStrategy())
         .thenReturn(multiHostExternalServiceExposureStrategy);
 
     jwtProxyProvisioner =

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/PassThroughProxyProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/PassThroughProxyProvisionerTest.java
@@ -61,7 +61,7 @@ public class PassThroughProxyProvisionerTest {
     ServiceExposureStrategyProvider exposureStrategyProvider =
         mock(ServiceExposureStrategyProvider.class);
     when(exposureStrategyProvider.get()).thenReturn(mock(ExternalServiceExposureStrategy.class));
-    when(exposureStrategyProvider.getMultiHost())
+    when(exposureStrategyProvider.getMultiHostStrategy())
         .thenReturn(mock(ExternalServiceExposureStrategy.class));
 
     PassThroughProxyProvisioner passThroughProxyProvisioner =

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/PassThroughProxyProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/server/secure/jwtproxy/PassThroughProxyProvisionerTest.java
@@ -33,6 +33,7 @@ import org.eclipse.che.api.workspace.server.model.impl.ServerConfigImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServiceExposureStrategy;
+import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ServiceExposureStrategyProvider;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.secure.jwtproxy.factory.JwtProxyConfigBuilderFactory;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.Listeners;
@@ -57,11 +58,18 @@ public class PassThroughProxyProvisionerTest {
     JwtProxyConfigBuilder configBuilder = mock(JwtProxyConfigBuilder.class);
     when(configBuilderFactory.create(any())).thenReturn(configBuilder);
 
+    ServiceExposureStrategyProvider exposureStrategyProvider =
+        mock(ServiceExposureStrategyProvider.class);
+    when(exposureStrategyProvider.get()).thenReturn(mock(ExternalServiceExposureStrategy.class));
+    when(exposureStrategyProvider.getMultiHost())
+        .thenReturn(mock(ExternalServiceExposureStrategy.class));
+
     PassThroughProxyProvisioner passThroughProxyProvisioner =
         new PassThroughProxyProvisioner(
             configBuilderFactory,
-            mock(ExternalServiceExposureStrategy.class),
+            exposureStrategyProvider,
             new CookiePathStrategy(MULTI_HOST_STRATEGY),
+            new MultiHostCookiePathStrategy(),
             "eclipse/che-jwtproxy",
             "128mb",
             "0.5",
@@ -84,6 +92,7 @@ public class PassThroughProxyProvisionerTest {
         "terminal",
         port,
         "TCP",
+        false,
         ImmutableMap.of("server1", server1));
 
     // then

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/model/impl/ServerConfigImpl.java
@@ -196,9 +196,7 @@ public class ServerConfigImpl implements ServerConfig {
       ServerConfig.setInternal(attributes, true);
     }
 
-    if (devfileEndpoint) {
-      attributes.put(REQUIRE_SUBDOMAIN, Boolean.TRUE.toString());
-    }
+    ServerConfig.setRequireSubdomain(attributes, devfileEndpoint);
 
     return new ServerConfigImpl(Integer.toString(endpoint.getPort()), protocol, path, attributes);
   }


### PR DESCRIPTION
### What does this PR do?
This is a second attempt to fix #18065. This differs from the original #18121 by injecting the `ServiceExposureStrategyProvider` into `JwtProxyProvisioner` and `PassthroughProxyProvisioner` and using that to pick the configured exposure strategy + the bound multi-host strategy. This makes sure that we pick the correct multi-host strategy implementation based on the infrastructure.

This then avoids the problem reported in #18157.

### What issues does this PR fix or reference?
#18065 #18157 

### How to test this PR?
See #18121 for the repro steps

There is a test che-server image built from this PR: `quay.io/lkrejci/che-server:issue-18065`
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
