### PR TITLE
Change xpath for clicking on devfile sample

### DIFF
--- a/tests/e2e/pageobjects/dashboard/GetStarted.ts
+++ b/tests/e2e/pageobjects/dashboard/GetStarted.ts
@@ -79,7 +79,7 @@ export class GetStarted {
     private getSampleLocator(sampleName: string): By {
         Logger.trace(`GetStarted.getSampleLocator sampleName: ${sampleName}`);
 
-        return By.xpath(`//div[contains(@devfile, 'devfile')]/div/b[contains(text(), '${sampleName}')]`);
+        return By.xpath(`//div[contains(@devfile, 'devfile')]/div/b[text()='${sampleName}']`);
     }
 
 }


### PR DESCRIPTION
### What does this PR do?
We found out that due to recent changes, multiple devfile can be selected when clicking on a devfile sample on the `Get Started` page. 

### How to test this PR?
Run devfile test suite.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
