### PR TITLE
Add 'java.server.launchMode: Standard' preference to Happy path test devfile

### DIFF
--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -35,6 +35,8 @@ components:
     mountSources: true
   - type: chePlugin
     id: redhat/java/latest
+    preferences:
+      java.server.launchMode: Standard
   - type: chePlugin
     id: redhat/vscode-yaml/latest
 commands:


### PR DESCRIPTION
### What does this PR do?
It's adding `java.server.launchMode: Standard` preference to Happy path test devfile, according to suggesting in here https://github.com/eclipse/che/issues/18193#issuecomment-716511897

### What issues does this PR fix or reference?
#18193, #18196

### How to test this PR?
Run Happy path tests.

### PR Checklist
- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
