### PR TITLE
Fixing import in MultiuserWorkspaceJpaModule

### DIFF
--- a/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserWorkspaceJpaModule.java
+++ b/multiuser/permission/che-multiuser-permission-workspace/src/main/java/org/eclipse/che/multiuser/permission/workspace/server/jpa/MultiuserWorkspaceJpaModule.java
@@ -14,7 +14,6 @@ package org.eclipse.che.multiuser.permission.workspace.server.jpa;
 import com.google.inject.AbstractModule;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
-import org.eclipse.che.api.workspace.server.jpa.JpaWorkspaceDao.RemoveWorkspaceBeforeAccountRemovedEventSubscriber;
 import org.eclipse.che.api.workspace.server.spi.WorkspaceDao;
 import org.eclipse.che.multiuser.api.permission.server.AbstractPermissionsDomain;
 import org.eclipse.che.multiuser.api.permission.server.model.impl.AbstractPermissions;
@@ -24,6 +23,7 @@ import org.eclipse.che.multiuser.permission.workspace.server.model.impl.WorkerIm
 import org.eclipse.che.multiuser.permission.workspace.server.spi.WorkerDao;
 import org.eclipse.che.multiuser.permission.workspace.server.spi.jpa.JpaWorkerDao;
 import org.eclipse.che.multiuser.permission.workspace.server.spi.jpa.MultiuserJpaWorkspaceDao;
+import org.eclipse.che.multiuser.permission.workspace.server.spi.jpa.MultiuserJpaWorkspaceDao.RemoveWorkspaceBeforeAccountRemovedEventSubscriber;
 
 /** @author Yevhenii Voevodin */
 public class MultiuserWorkspaceJpaModule extends AbstractModule {


### PR DESCRIPTION

Signed-off-by: Vitalii Parfonov <vparfono@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixing import in MultiuserWorkspaceJpaModule: should be `RemoveWorkspaceBeforeAccountRemovedEventSubscriber` from `MultiuserJpaWorkspaceDao` instead of `JpaWorkspaceDao`

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18000



### How to test this PR?

  - The test platform: openshift
  - Installation method: che-operator
  - steps to reproduce:

1. Create user in Keycloak
2. Update password for created user, cleanup `Required User Actions`, set `Email Verified` to `on`
3. Set Che Admin with just created username: 
  `oc patch checluster/eclipse-che --patch "{\"spec\":{\"server\":{\"customCheProperties\": {\"CHE_SYSTEM_ADMIN__NAME\": \"<username>\"}}}}" --type=merge -n che`
4. Obtain Keycloak token for Che Admin:
`curl -X POST "https://<keycloak-host>/auth/realms/che/protocol/openid-connect/token" -H "Content-Type: application/x-www-form-urlencoded" -d "username=username" -d "password=password" -d 'grant_type=password' -d 'client_id=che-public' | jq .access_token`
5. Delete given user with userId: 
 `curl -iv -X DELETE "https://<che-host>/api/user/<user-id>" -H "Accept: application/json" -H "Authorization: Bearer <Keycloak token>"`


 




### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
