### PR TITLE
Update the "LinkCheAndOcpUsers" test for allowing to work with selected permissions.

### DIFF
--- a/tests/e2e/pageobjects/login/UpdateAccountInformationPage.ts
+++ b/tests/e2e/pageobjects/login/UpdateAccountInformationPage.ts
@@ -61,4 +61,10 @@ export class UpdateAccountInformationPage {
         await this.driverHelper.waitAndClick(By.id('kc-login'), timeout);
     }
 
+    async clickToAllowSelectedPermissionsButton(timeout: number){
+        Logger.debug('UpdateAccountInformationPage.clickToAllowSelectedPermissionsButton');
+
+        await this.driverHelper.waitAndClick(By.xpath('//input[@name=\'approve\']'), timeout);
+    }
+
 }

--- a/tests/e2e/tests/login/LinkCheAndOcpUsers.spec.ts
+++ b/tests/e2e/tests/login/LinkCheAndOcpUsers.spec.ts
@@ -20,25 +20,28 @@ const ocpLogin: IOcpLoginPage = e2eContainer.get<IOcpLoginPage>(TYPES.OcpLogin);
 const updateAccountInformation: UpdateAccountInformationPage = e2eContainer.get(CLASSES.UpdateAccountInformationPage);
 const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
 
+const commonTimeout: number = TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2;
+
 suite('Link users', async () => {
     test('Login to OCP', async () => {
         await driverHelper.navigateToUrl(TestConstants.TS_SELENIUM_BASE_URL);
 
         await ocpLogin.login();
+        await updateAccountInformation.clickToAllowSelectedPermissionsButton(commonTimeout);
     });
 
     test('Update account information', async () => {
-        await updateAccountInformation.enterEmail('admin@admin.com', TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2);
-        await updateAccountInformation.enterFirstName(TestConstants.TS_SELENIUM_USERNAME, TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2);
-        await updateAccountInformation.enterLastName(TestConstants.TS_SELENIUM_USERNAME, TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2);
-        await updateAccountInformation.clickConfirmButton(TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2);
-        await updateAccountInformation.clickAddToExistingAccountButton(TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2);
+        await updateAccountInformation.enterEmail('admin@admin.com', commonTimeout);
+        await updateAccountInformation.enterFirstName(TestConstants.TS_SELENIUM_USERNAME, commonTimeout);
+        await updateAccountInformation.enterLastName(TestConstants.TS_SELENIUM_USERNAME, commonTimeout);
+        await updateAccountInformation.clickConfirmButton(commonTimeout);
+        await updateAccountInformation.clickAddToExistingAccountButton(commonTimeout);
     });
 
     test('Login to Che', async () => {
-        await updateAccountInformation.enterPassword(TestConstants.TS_SELENIUM_PASSWORD, TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2);
-        await updateAccountInformation.clickLogInButton(TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2);
-        await dashboard.waitPage(TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT * 2);
+        await updateAccountInformation.enterPassword(TestConstants.TS_SELENIUM_PASSWORD, commonTimeout);
+        await updateAccountInformation.clickLogInButton(commonTimeout);
+        await dashboard.waitPage(commonTimeout);
     });
 
 });


### PR DESCRIPTION
Signed-off-by: Ihor Okhrimenko <iokhrime@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Update the "LinkCheAndOcpUsers" test for allowing to work with selected permissions.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Issue: https://github.com/eclipse/che/issues/18207

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
```
################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://che-smoke-intelij-che-tls-oauth.apps.ocp45.crw-qe.com
      TS_SELENIUM_HEADLESS: false

      TS_SELENIUM_USERNAME: admin
      TS_SELENIUM_PASSWORD: admin

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: petclinic-dev-environment
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: false
      TS_SELENIUM_LOG_LEVEL: DEBUG

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 

          ▼ PreferencesHandler.setConfirmExit to never

(node:15680) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
  Link users
          ▼ DriverHelper.navigateToUrl https://che-smoke-intelij-che-tls-oauth.apps.ocp45.crw-qe.com
          ▼ PreferencesHandler.setTerminalToDom
          ▼ OcpUserLoginPage.login
          ▼ OcpLoginPage.clickOnLoginProviderTitle
          ▼ OcpLoginPage.waitOpenShiftLoginWelcomePage
          ▼ OcpLoginPage.enterUserNameOpenShift "admin"
          ▼ OcpLoginPage.enterPasswordOpenShift "crw4ever!"
          ▼ OcpLoginPage.clickOnLoginButton
          ▼ OcpLoginPage.waitDisappearanceOpenShiftLoginWelcomePage
          ▼ UpdateAccountInformationPage.clickToAllowSelectedPermissionsButton
    ✓ Login to OCP (24466ms)
          ▼ UpdateAccountInformationPage.enterEmail
          ▼ UpdateAccountInformationPage.enterFirstName
          ▼ UpdateAccountInformationPage.enterLastName
          ▼ UpdateAccountInformationPage.clickConfirmButton
          ▼ UpdateAccountInformationPage.clickAddToExistingAccountButton
    ✓ Update account information (1225ms)
          ▼ UpdateAccountInformationPage.enterPassword
          ▼ UpdateAccountInformationPage.clickLogInButton
          ▼ Dashboard.waitPage
    ✓ Login to Che (5769ms)


  3 passing (31s)
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
