### PR TITLE
Prevent inconsistency when allowed user namespaces is false and namespace contains random part.

### DIFF
--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -167,6 +167,31 @@ public class KubernetesNamespaceFactoryTest {
     namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
   }
 
+  @Test
+  public void shouldLookAtStoredNamespacesOnCheckingIfNamespaceIsAllowed() throws Exception {
+
+    Map<String, String> prefs = new HashMap<>();
+    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "any-namespace");
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "defaultNs");
+
+    when(preferenceManager.find(anyString())).thenReturn(prefs);
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
+  }
+
   @Test(
       expectedExceptions = ValidationException.class,
       expectedExceptionsMessageRegExp =

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceManager.java
@@ -542,7 +542,7 @@ public class WorkspaceManager {
   private NamespaceResolutionContext buildResolutionContext(WorkspaceImpl workspace) {
     Subject currentSubject = EnvironmentContext.getCurrent().getSubject();
     return new NamespaceResolutionContext(
-        workspace.getId(), currentSubject.getUserId(), currentSubject.getUserName(), true);
+        workspace.getId(), currentSubject.getUserId(), currentSubject.getUserName());
   }
 
   /** Returns first non-null argument or null if both are null. */

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/NamespaceResolutionContext.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/spi/NamespaceResolutionContext.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.api.workspace.server.spi;
 
 import java.util.Objects;
+import org.eclipse.che.commons.subject.Subject;
 
 /**
  * Holds information needed for resolving placeholders in the namespace name. The {@code
@@ -25,18 +26,15 @@ public class NamespaceResolutionContext {
   private final String workspaceId;
   private final String userId;
   private final String userName;
-  private final boolean persistAfterCreate;
 
-  public NamespaceResolutionContext(String workspaceId, String userId, String userName) {
-    this(workspaceId, userId, userName, false);
+  public NamespaceResolutionContext(Subject subject) {
+    this(null, subject.getUserId(), subject.getUserName());
   }
 
-  public NamespaceResolutionContext(
-      String workspaceId, String userId, String userName, boolean persistAfterCreate) {
+  public NamespaceResolutionContext(String workspaceId, String userId, String userName) {
     this.workspaceId = workspaceId;
     this.userId = userId;
     this.userName = userName;
-    this.persistAfterCreate = persistAfterCreate;
   }
 
   public String getWorkspaceId() {
@@ -51,10 +49,6 @@ public class NamespaceResolutionContext {
     return userName;
   }
 
-  public boolean isPersistAfterCreate() {
-    return persistAfterCreate;
-  }
-
   @Override
   public boolean equals(Object obj) {
     if (this == obj) {
@@ -66,13 +60,12 @@ public class NamespaceResolutionContext {
     final NamespaceResolutionContext that = (NamespaceResolutionContext) obj;
     return Objects.equals(workspaceId, that.workspaceId)
         && Objects.equals(userId, that.userId)
-        && Objects.equals(userName, that.userName)
-        && Objects.equals(persistAfterCreate, that.persistAfterCreate);
+        && Objects.equals(userName, that.userName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(workspaceId, userId, userName, persistAfterCreate);
+    return Objects.hash(workspaceId, userId, userName);
   }
 
   @Override
@@ -86,9 +79,6 @@ public class NamespaceResolutionContext {
         + '\''
         + ", userName='"
         + userName
-        + '\''
-        + ", persistAfterCreate='"
-        + persistAfterCreate
         + '\''
         + '}';
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/WorkspaceManagerTest.java
@@ -243,7 +243,7 @@ public class WorkspaceManagerTest {
     verify(workspaceDao).create(workspace);
     verify(runtimes)
         .evalInfrastructureNamespace(
-            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1, true));
+            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1));
   }
 
   @Test
@@ -628,7 +628,7 @@ public class WorkspaceManagerTest {
         "evaluated-legacy");
     verify(runtimes)
         .evalLegacyInfrastructureNamespace(
-            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1, true));
+            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1));
   }
 
   @Test
@@ -670,7 +670,7 @@ public class WorkspaceManagerTest {
         "evaluated-legal");
     verify(runtimes)
         .evalInfrastructureNamespace(
-            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1, true));
+            new NamespaceResolutionContext(workspace.getId(), USER_ID, NAMESPACE_1));
   }
 
   @Test


### PR DESCRIPTION

### What does this PR do?
Some namespace naming inconsistency spotted, when che.infra.kubernetes.namespace.allow_user_defined=false and when we need to normalize the namespace name. PR fixes this situation.



### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
#18178


### How to test this PR?
Create a user with invalid symbols in username. Try create/run custom workspaces. Everything should run smooth. namespace name should remain the same.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
