### PR TITLE
Avoid NullPointerException in RouteTlsProvisioner 

### DIFF
--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/RouteTlsProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/provision/RouteTlsProvisioner.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.openshift.provision;
 
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.putAnnotations;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.TlsProvisioner.getSecureProtocol;
 
 import io.fabric8.openshift.api.model.Route;
@@ -73,8 +74,7 @@ public class RouteTlsProvisioner
     servers.values().forEach(s -> s.setProtocol(getSecureProtocol(s.getProtocol())));
 
     Map<String, String> annotations = Annotations.newSerializer().servers(servers).annotations();
-
-    route.getMetadata().getAnnotations().putAll(annotations);
+    putAnnotations(route.getMetadata(), annotations);
   }
 
   private void enableTls(final Route route) {

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/RouteTlsProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/RouteTlsProvisionerTest.java
@@ -83,6 +83,26 @@ public class RouteTlsProvisionerTest {
     assertEquals(servers.get("http-server").getProtocol(), "https");
     assertEquals(servers.get("ws-server").getProtocol(), "wss");
   }
+  @Test
+  public void shouldNotThrowNPE() throws Exception {
+    // given
+    RouteTlsProvisioner tlsProvisioner = new RouteTlsProvisioner(true);
+
+    final Map<String, Route> routes = new HashMap<>();
+    Route route =
+            new RouteBuilder()
+                    .withNewMetadata()
+                    .withName("name")
+                    .endMetadata()
+                    .withNewSpec()
+                    .endSpec()
+                    .build();
+    routes.put("route", route);
+    when(osEnv.getRoutes()).thenReturn(routes);
+
+    // when
+    tlsProvisioner.provision(osEnv, runtimeIdentity);
+  }
 
   private Route createRoute(String name, Map<String, ServerConfigImpl> servers) {
     return new RouteBuilder()

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/RouteTlsProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/provision/RouteTlsProvisionerTest.java
@@ -83,6 +83,7 @@ public class RouteTlsProvisionerTest {
     assertEquals(servers.get("http-server").getProtocol(), "https");
     assertEquals(servers.get("ws-server").getProtocol(), "wss");
   }
+
   @Test
   public void shouldNotThrowNPE() throws Exception {
     // given
@@ -90,13 +91,13 @@ public class RouteTlsProvisionerTest {
 
     final Map<String, Route> routes = new HashMap<>();
     Route route =
-            new RouteBuilder()
-                    .withNewMetadata()
-                    .withName("name")
-                    .endMetadata()
-                    .withNewSpec()
-                    .endSpec()
-                    .build();
+        new RouteBuilder()
+            .withNewMetadata()
+            .withName("name")
+            .endMetadata()
+            .withNewSpec()
+            .endSpec()
+            .build();
     routes.put("route", route);
     when(osEnv.getRoutes()).thenReturn(routes);
 


### PR DESCRIPTION
### What does this PR do?
Added utility method invocation to avoid NullPointerException in RouteTlsProvisioner 

### Screenshot/screencast of this PR
n/a

### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/16760

### How to test this PR?
- checkout source code
- run RouteTlsProvisionerTest.shouldNotThrowNPE
### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
