### PR TITLE
best effort to label namespace when starting new workspace

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -261,7 +261,9 @@ che.infra.kubernetes.namespace.creation_allowed=true
 che.infra.kubernetes.namespace.default=<username>-che
 
 # List of labels to find Namespaces/Projects that are used for Che Workspaces.
-# They are used to find prepared Namespaces/Projects for users in combination with `che.infra.kubernetes.namespace.annotations`.
+# They are used to:
+#  - find prepared Namespaces/Projects for users in combination with `che.infra.kubernetes.namespace.annotations`.
+#  - actively label namespaces with any workspace.
 che.infra.kubernetes.namespace.labels=app.kubernetes.io/part-of=che.eclipse.org,app.kubernetes.io/component=workspaces-namespace
 
 # List of annotations to find Namespaces/Projects prepared for Che users workspaces.

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/CheServerKubernetesClientFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/CheServerKubernetesClientFactory.java
@@ -21,8 +21,10 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 
 /**
- * This {@link KubernetesClientFactory} is used to access Che installation namespace. It always
- * provides client with default {@link Config}.
+ * This {@link KubernetesClientFactory} ensures that we use `che` ServiceAccount and not related to
+ * any workspace. It always provides client with default {@link Config}. It's useful for operations
+ * that needs permissions of `che` SA, such as operations inside `che` namespace (like creating a
+ * ConfigMaps for Gateway router) or some cluste-wide actions (like labeling the namespaces).
  */
 @Singleton
 public class CheServerKubernetesClientFactory extends KubernetesClientFactory {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -28,7 +28,6 @@ import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
 import io.fabric8.kubernetes.client.Watcher;
 import io.fabric8.kubernetes.client.dsl.Resource;
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -40,7 +39,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.slf4j.Logger;
@@ -103,8 +101,11 @@ public class KubernetesNamespace {
   }
 
   public KubernetesNamespace(
-      KubernetesClientFactory clientFactory, KubernetesClientFactory cheClientFactory,
-      Executor executor, String name, String workspaceId) {
+      KubernetesClientFactory clientFactory,
+      KubernetesClientFactory cheClientFactory,
+      Executor executor,
+      String name,
+      String workspaceId) {
     this.clientFactory = clientFactory;
     this.cheClientFactory = cheClientFactory;
     this.workspaceId = workspaceId;
@@ -123,10 +124,9 @@ public class KubernetesNamespace {
    * <p>Preparing includes creating if needed and waiting for default service account.
    *
    * @param canCreate defines what to do when the namespace is not found. The namespace is created
-   *                  when {@code true}, otherwise an exception is thrown.
+   *     when {@code true}, otherwise an exception is thrown.
    * @throws InfrastructureException if any exception occurs during namespace preparation or if the
-   *                                 namespace doesn't exist and {@code canCreate} is {@code
-   *                                 false}.
+   *     namespace doesn't exist and {@code canCreate} is {@code false}.
    */
   void prepare(boolean canCreate, Map<String, String> labels) throws InfrastructureException {
     KubernetesClient client = clientFactory.create(workspaceId);
@@ -157,9 +157,7 @@ public class KubernetesNamespace {
     namespace.getMetadata().setLabels(newLabels);
 
     try {
-      return cheClientFactory.create()
-          .namespaces()
-          .createOrReplace(namespace);
+      return cheClientFactory.create().namespaces().createOrReplace(namespace);
     } catch (KubernetesClientException kce) {
       if (kce.getCode() == 403) {
         LOG.debug("Can't label the namespace due to lack of permissions ¯\\_(ツ)_/¯");
@@ -272,14 +270,15 @@ public class KubernetesNamespace {
   private Namespace create(String namespaceName, KubernetesClient client)
       throws InfrastructureException {
     try {
-      Namespace namespace = client
-          .namespaces()
-          .createNew()
-          .withNewMetadata()
-          .withName(namespaceName)
-          .withLabels(Map.of("A", "B"))
-          .endMetadata()
-          .done();
+      Namespace namespace =
+          client
+              .namespaces()
+              .createNew()
+              .withNewMetadata()
+              .withName(namespaceName)
+              .withLabels(Map.of("A", "B"))
+              .endMetadata()
+              .done();
       waitDefaultServiceAccount(namespaceName, client);
       return namespace;
     } catch (KubernetesClientException e) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.fabric8.kubernetes.api.model.ConfigMap;
@@ -116,6 +117,10 @@ public class KubernetesNamespace {
     this.ingresses = new KubernetesIngresses(name, workspaceId, clientFactory);
     this.secrets = new KubernetesSecrets(name, workspaceId, clientFactory);
     this.configMaps = new KubernetesConfigsMaps(name, workspaceId, clientFactory);
+  }
+
+  void prepare(boolean canCreate) throws InfrastructureException {
+    prepare(canCreate, emptyMap());
   }
 
   /**
@@ -276,7 +281,6 @@ public class KubernetesNamespace {
               .createNew()
               .withNewMetadata()
               .withName(namespaceName)
-              .withLabels(Map.of("A", "B"))
               .endMetadata()
               .done();
       waitDefaultServiceAccount(namespaceName, client);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -172,7 +172,8 @@ public class KubernetesNamespaceFactory {
 
   @VisibleForTesting
   KubernetesNamespace doCreateNamespaceAccess(String workspaceId, String name) {
-    return new KubernetesNamespace(clientFactory, cheClientFactory, sharedPool.getExecutor(), name, workspaceId);
+    return new KubernetesNamespace(
+        clientFactory, cheClientFactory, sharedPool.getExecutor(), name, workspaceId);
   }
 
   /**

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -57,6 +57,7 @@ import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.commons.lang.Pair;
 import org.eclipse.che.commons.subject.Subject;
 import org.eclipse.che.inject.ConfigurationException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
@@ -99,6 +100,7 @@ public class KubernetesNamespaceFactory {
   private final String serviceAccountName;
   private final Set<String> clusterRoleNames;
   private final KubernetesClientFactory clientFactory;
+  private final KubernetesClientFactory cheClientFactory;
   private final boolean namespaceCreationAllowed;
   private final UserManager userManager;
   private final PreferenceManager preferenceManager;
@@ -116,6 +118,7 @@ public class KubernetesNamespaceFactory {
       @Named("che.infra.kubernetes.namespace.labels") String namespaceLabels,
       @Named("che.infra.kubernetes.namespace.annotations") String namespaceAnnotations,
       KubernetesClientFactory clientFactory,
+      CheServerKubernetesClientFactory cheClientFactory,
       UserManager userManager,
       PreferenceManager preferenceManager,
       KubernetesSharedPool sharedPool)
@@ -125,6 +128,7 @@ public class KubernetesNamespaceFactory {
     this.legacyNamespaceName = legacyNamespaceName;
     this.serviceAccountName = serviceAccountName;
     this.clientFactory = clientFactory;
+    this.cheClientFactory = cheClientFactory;
     this.defaultNamespaceName = defaultNamespaceName;
     this.allowUserDefinedNamespaces = allowUserDefinedNamespaces;
     this.preferenceManager = preferenceManager;
@@ -168,7 +172,7 @@ public class KubernetesNamespaceFactory {
 
   @VisibleForTesting
   KubernetesNamespace doCreateNamespaceAccess(String workspaceId, String name) {
-    return new KubernetesNamespace(clientFactory, sharedPool.getExecutor(), name, workspaceId);
+    return new KubernetesNamespace(clientFactory, cheClientFactory, sharedPool.getExecutor(), name, workspaceId);
   }
 
   /**
@@ -386,7 +390,7 @@ public class KubernetesNamespaceFactory {
   public KubernetesNamespace getOrCreate(RuntimeIdentity identity) throws InfrastructureException {
     KubernetesNamespace namespace = get(identity);
 
-    namespace.prepare(canCreateNamespace(identity));
+    namespace.prepare(canCreateNamespace(identity), namespaceLabels);
 
     if (!isNullOrEmpty(serviceAccountName)) {
       KubernetesWorkspaceServiceAccount workspaceServiceAccount =

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -1,1293 +1,1311 @@
-/// *
-// * Copyright (c) 2012-2018 Red Hat, Inc.
-// * This program and the accompanying materials are made
-// * available under the terms of the Eclipse Public License 2.0
-// * which is available at https://www.eclipse.org/legal/epl-2.0/
-// *
-// * SPDX-License-Identifier: EPL-2.0
-// *
-// * Contributors:
-// *   Red Hat, Inc. - initial API and implementation
-// */
-// package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
-//
-// import static java.util.Collections.emptyMap;
-// import static java.util.Collections.singletonList;
-// import static
-// org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
-// import static
-// org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
-// import static
-// org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
-// import static
-// org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.ArgumentMatchers.anyMap;
-// import static org.mockito.ArgumentMatchers.anyString;
-// import static org.mockito.ArgumentMatchers.eq;
-// import static org.mockito.Mockito.doReturn;
-// import static org.mockito.Mockito.doThrow;
-// import static org.mockito.Mockito.lenient;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.never;
-// import static org.mockito.Mockito.spy;
-// import static org.mockito.Mockito.verify;
-// import static org.mockito.Mockito.when;
-// import static org.testng.Assert.assertEquals;
-// import static org.testng.Assert.assertFalse;
-// import static org.testng.Assert.assertNull;
-// import static org.testng.Assert.assertTrue;
-//
-// import com.google.common.collect.ImmutableMap;
-// import io.fabric8.kubernetes.api.model.DoneableNamespace;
-// import io.fabric8.kubernetes.api.model.Namespace;
-// import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-// import io.fabric8.kubernetes.api.model.NamespaceList;
-// import io.fabric8.kubernetes.api.model.ServiceAccountList;
-// import io.fabric8.kubernetes.api.model.Status;
-// import io.fabric8.kubernetes.api.model.rbac.Role;
-// import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
-// import io.fabric8.kubernetes.api.model.rbac.RoleList;
-// import io.fabric8.kubernetes.client.KubernetesClient;
-// import io.fabric8.kubernetes.client.KubernetesClientException;
-// import io.fabric8.kubernetes.client.Watch;
-// import io.fabric8.kubernetes.client.Watcher;
-// import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-// import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-// import io.fabric8.kubernetes.client.dsl.Resource;
-// import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-// import java.util.Arrays;
-// import java.util.Collections;
-// import java.util.HashMap;
-// import java.util.List;
-// import java.util.Map;
-// import java.util.Set;
-// import java.util.stream.Collectors;
-// import java.util.stream.Stream;
-// import org.eclipse.che.api.core.ValidationException;
-// import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-// import org.eclipse.che.api.user.server.PreferenceManager;
-// import org.eclipse.che.api.user.server.UserManager;
-// import org.eclipse.che.api.user.server.model.impl.UserImpl;
-// import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-// import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
-// import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl.WorkspaceImplBuilder;
-// import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-// import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
-// import org.eclipse.che.api.workspace.shared.Constants;
-// import org.eclipse.che.commons.env.EnvironmentContext;
-// import org.eclipse.che.commons.subject.SubjectImpl;
-// import org.eclipse.che.inject.ConfigurationException;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
-// import org.mockito.Mock;
-// import org.mockito.testng.MockitoTestNGListener;
-// import org.testng.annotations.AfterMethod;
-// import org.testng.annotations.BeforeMethod;
-// import org.testng.annotations.DataProvider;
-// import org.testng.annotations.Listeners;
-// import org.testng.annotations.Test;
-// import org.testng.collections.Sets;
-//
-/// **
-// * Tests {@link KubernetesNamespaceFactory}.
-// *
-// * @author Sergii Leshchenko
-// */
-// @Listeners(MockitoTestNGListener.class)
-// public class KubernetesNamespaceFactoryTest {
-//
-//  private static final String USER_ID = "userid";
-//  private static final String USER_NAME = "username";
-//  private static final String NAMESPACE_LABEL_NAME = "component";
-//  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
-//  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
-//  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
-//
-//  @Mock private KubernetesSharedPool pool;
-//  @Mock private KubernetesClientFactory clientFactory;
-//  private KubernetesClient k8sClient;
-//  @Mock private UserManager userManager;
-//  @Mock private PreferenceManager preferenceManager;
-//
-//  @Mock
-//  private NonNamespaceOperation<
-//          Namespace, NamespaceList, DoneableNamespace, Resource<Namespace, DoneableNamespace>>
-//      namespaceOperation;
-//
-//  @Mock private Resource<Namespace, DoneableNamespace> namespaceResource;
-//
-//  private KubernetesServer serverMock;
-//
-//  private KubernetesNamespaceFactory namespaceFactory;
-//
-//  @Mock
-//  private FilterWatchListDeletable<Namespace, NamespaceList, Boolean, Watch, Watcher<Namespace>>
-//      namespaceListResource;
-//
-//  @Mock private NamespaceList namespaceList;
-//
-//  @BeforeMethod
-//  public void setUp() throws Exception {
-//    serverMock = new KubernetesServer(true, true);
-//    serverMock.before();
-//    k8sClient = spy(serverMock.getClient());
-//    lenient().when(clientFactory.create()).thenReturn(k8sClient);
-//    lenient().when(k8sClient.namespaces()).thenReturn(namespaceOperation);
-//
-//    lenient().when(namespaceOperation.withName(any())).thenReturn(namespaceResource);
-//    lenient().when(namespaceResource.get()).thenReturn(mock(Namespace.class));
-//
-//    lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(anyMap());
-//    lenient().when(namespaceListResource.list()).thenReturn(namespaceList);
-//    lenient().when(namespaceList.getItems()).thenReturn(Collections.emptyList());
-//
-//    lenient()
-//        .when(userManager.getById(USER_ID))
-//        .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
-//  }
-//
-//  @AfterMethod
-//  public void tearDown() {
-//    EnvironmentContext.reset();
-//    serverMock.after();
-//  }
-//
-//  @Test
-//  public void shouldNotThrowExceptionIfDefaultNamespaceIsSpecifiedOnCheckingIfNamespaceIsAllowed()
-//      throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "legacy",
-//            "",
-//            "",
-//            "defaultNs",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    namespaceFactory.checkIfNamespaceIsAllowed("defaultNs");
-//  }
-//
-//  @Test
-//  public void
-//
-// shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
-//          throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "legacy",
-//            "",
-//            "",
-//            "defaultNs",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
-//  }
-//
-//  @Test
-//  public void shouldLookAtStoredNamespacesOnCheckingIfNamespaceIsAllowed() throws Exception {
-//
-//    Map<String, String> prefs = new HashMap<>();
-//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "any-namespace");
-//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "defaultNs");
-//
-//    when(preferenceManager.find(anyString())).thenReturn(prefs);
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "legacy",
-//            "",
-//            "",
-//            "defaultNs",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
-//  }
-//
-//  @Test(
-//      expectedExceptions = ValidationException.class,
-//      expectedExceptionsMessageRegExp =
-//          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is
-// available.")
-//  public void
-//
-// shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
-//          throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "legacy",
-//            "",
-//            "",
-//            "defaultNs",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
-//  }
-//
-//  @Test(
-//      expectedExceptions = ConfigurationException.class,
-//      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be
-// configured")
-//  public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            null,
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//  }
-//
-//  @Test
-//  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
-//    // given
-//    List<Namespace> namespaces =
-//        Arrays.asList(
-//            new NamespaceBuilder()
-//                .withNewMetadata()
-//                .withName("ns1")
-//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-//                .endMetadata()
-//                .withNewStatus()
-//                .withNewPhase("Active")
-//                .endStatus()
-//                .build(),
-//            new NamespaceBuilder()
-//                .withNewMetadata()
-//                .withName("ns2")
-//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-//                .endMetadata()
-//                .withNewStatus()
-//                .withNewPhase("Active")
-//                .endStatus()
-//                .build(),
-//            new NamespaceBuilder()
-//                .withNewMetadata()
-//                .withName("ns3")
-//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user"))
-//                .endMetadata()
-//                .withNewStatus()
-//                .withNewPhase("Active")
-//                .endStatus()
-//                .build());
-//    doReturn(namespaces).when(namespaceList).getItems();
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-//
-//    // when
-//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-//
-//    // then
-//    assertEquals(availableNamespaces.size(), 2);
-//    verify(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, "workspace"));
-//    assertEquals(availableNamespaces.get(0).getName(), "ns1");
-//    assertEquals(availableNamespaces.get(1).getName(), "ns2");
-//  }
-//
-//  @Test
-//  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
-//    // given
-//    Namespace ns =
-//        new NamespaceBuilder()
-//            .withNewMetadata()
-//            .withName("ns1")
-//            .endMetadata()
-//            .withNewStatus()
-//            .withNewPhase("Active")
-//            .endStatus()
-//            .build();
-//    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
-//        .when(namespaceList)
-//        .getItems();
-//    prepareNamespaceToBeFoundByName("che-default", ns);
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-//
-//    // when
-//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-//
-//    // then
-//    assertEquals(availableNamespaces.get(0).getName(), "ns1");
-//  }
-//
-//  @Test(expectedExceptions = InfrastructureException.class)
-//  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
-//    // given
-//    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
-//        .when(namespaceList)
-//        .getItems();
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    // when
-//    namespaceFactory.list();
-//
-//    // then throw
-//  }
-//
-//  @Test
-//  public void shouldReturnDefaultNamespaceWhenItExistsAndUserDefinedIsNotAllowed()
-//      throws Exception {
-//    prepareNamespaceToBeFoundByName(
-//        "che-default",
-//        new NamespaceBuilder()
-//            .withNewMetadata()
-//            .withName("che-default")
-//            .endMetadata()
-//            .withNewStatus()
-//            .withNewPhase("Active")
-//            .endStatus()
-//            .build());
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-//    assertEquals(availableNamespaces.size(), 1);
-//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
-//    assertEquals(defaultNamespace.getName(), "che-default");
-//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-//    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-//  }
-//
-//  @Test
-//  public void shouldReturnDefaultNamespaceWhenItDoesNotExistAndUserDefinedIsNotAllowed()
-//      throws Exception {
-//    prepareNamespaceToBeFoundByName("che-default", null);
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-//    assertEquals(availableNamespaces.size(), 1);
-//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
-//    assertEquals(defaultNamespace.getName(), "che-default");
-//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-//    assertNull(
-//        defaultNamespace
-//            .getAttributes()
-//            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
-//  }
-//
-//  @Test(
-//      expectedExceptions = InfrastructureException.class,
-//      expectedExceptionsMessageRegExp =
-//          "Error occurred when tried to fetch default namespace. Cause: connection refused")
-//  public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//    throwOnTryToGetNamespaceByName("che", new KubernetesClientException("connection refused"));
-//
-//    namespaceFactory.list();
-//  }
-//
-//  @Test
-//  public void shouldReturnListOfExistingNamespacesAlongWithDefaultIfUserDefinedIsAllowed()
-//      throws Exception {
-//    prepareListedNamespaces(
-//        Arrays.asList(
-//            createNamespace("my-for-ws", "Active"), createNamespace("default", "Active")));
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "default",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-//
-//    assertEquals(availableNamespaces.size(), 2);
-//    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
-//    assertEquals(forWS.getName(), "my-for-ws");
-//    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-//    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
-//
-//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
-//    assertEquals(defaultNamespace.getName(), "default");
-//    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-//  }
-//
-//  @Test
-//  public void
-//      shouldReturnListOfExistingNamespacesAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
-//          throws Exception {
-//    prepareListedNamespaces(singletonList(createNamespace("my-for-ws", "Active")));
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "default",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-//    assertEquals(availableNamespaces.size(), 2);
-//    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
-//    assertEquals(forWS.getName(), "my-for-ws");
-//    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-//    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
-//
-//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
-//    assertEquals(defaultNamespace.getName(), "default");
-//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-//    assertNull(
-//        defaultNamespace
-//            .getAttributes()
-//            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
-//  }
-//
-//  @Test(
-//      expectedExceptions = InfrastructureException.class,
-//      expectedExceptionsMessageRegExp =
-//          "Error occurred when tried to list all available namespaces. Cause: connection refused")
-//  public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "default_ns",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//    throwOnTryToGetNamespacesList(new KubernetesClientException("connection refused"));
-//
-//    namespaceFactory.list();
-//  }
-//
-//  @Test
-//  public void
-// shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
-//      throws Exception {
-//    // There is only one scenario where this can happen. The workspace was created and started in
-//    // some default namespace. Then server was reconfigured to use a different default namespace
-//    // AND the namespace of the workspace was MANUALLY deleted in the cluster. In this case, we
-//    // should NOT try to re-create the namespace because it would be created in a namespace that
-//    // is not configured. We DO allow it to start if the namespace still exists though.
-//
-//    // given
-//    namespaceFactory =
-//        spy(
-//            new KubernetesNamespaceFactory(
-//                "predefined",
-//                "",
-//                "",
-//                "new-default",
-//                false,
-//                true,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                userManager,
-//                preferenceManager,
-//                pool));
-//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
-//    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
-//
-//    // then
-//    assertEquals(toReturnNamespace, namespace);
-//    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
-//    verify(toReturnNamespace).prepare(eq(false));
-//  }
-//
-//  @Test
-//  public void shouldReturnDefaultNamespaceWhenCreatingIsNotIsNotAllowed() throws Exception {
-//    // given
-//    namespaceFactory =
-//        spy(
-//            new KubernetesNamespaceFactory(
-//                "predefined",
-//                "",
-//                "",
-//                "new-default",
-//                true,
-//                false,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                userManager,
-//                preferenceManager,
-//                pool));
-//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
-//    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
-//
-//    // then
-//    assertEquals(toReturnNamespace, namespace);
-//    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
-//    verify(toReturnNamespace).prepare(eq(false));
-//  }
-//
-//  @Test
-//  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndNamespaceIsNotPredefined()
-//      throws Exception {
-//    // given
-//    namespaceFactory =
-//        spy(
-//            new KubernetesNamespaceFactory(
-//                "",
-//                "serviceAccount",
-//                "",
-//                "<workspaceid>",
-//                false,
-//                true,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                userManager,
-//                preferenceManager,
-//                pool));
-//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-//    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
-//    when(toReturnNamespace.getName()).thenReturn("workspace123");
-//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-//
-//    KubernetesWorkspaceServiceAccount serviceAccount =
-//        mock(KubernetesWorkspaceServiceAccount.class);
-//    doReturn(serviceAccount).when(namespaceFactory).doCreateServiceAccount(any(), any());
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-//    namespaceFactory.getOrCreate(identity);
-//
-//    // then
-//    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
-//    verify(serviceAccount).prepare();
-//  }
-//
-//  @Test
-//  public void shouldBindToAllConfiguredClusterRoles() throws Exception {
-//    // given
-//    namespaceFactory =
-//        spy(
-//            new KubernetesNamespaceFactory(
-//                "",
-//                "serviceAccount",
-//                "cr2, cr3",
-//                "<workspaceid>",
-//                false,
-//                true,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                userManager,
-//                preferenceManager,
-//                pool));
-//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-//    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
-//    when(toReturnNamespace.getName()).thenReturn("workspace123");
-//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-//    when(clientFactory.create(any())).thenReturn(k8sClient);
-//
-//    // pre-create the cluster roles
-//    Stream.of("cr1", "cr2", "cr3")
-//        .forEach(
-//            cr ->
-//                k8sClient
-//                    .rbac()
-//                    .clusterRoles()
-//                    .createOrReplaceWithNew()
-//                    .withNewMetadata()
-//                    .withName(cr)
-//                    .endMetadata()
-//                    .done());
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-//    namespaceFactory.getOrCreate(identity);
-//
-//    // then
-//    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
-//
-//    ServiceAccountList sas = k8sClient.serviceAccounts().inNamespace("workspace123").list();
-//    assertEquals(sas.getItems().size(), 1);
-//    assertEquals(sas.getItems().get(0).getMetadata().getName(), "serviceAccount");
-//
-//    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
-//    assertEquals(
-//        Sets.newHashSet("workspace-view", "exec"),
-//        roles.getItems().stream().map(r ->
-// r.getMetadata().getName()).collect(Collectors.toSet()));
-//
-//    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
-//    assertEquals(
-//        bindings
-//            .getItems()
-//            .stream()
-//            .map(r -> r.getMetadata().getName())
-//            .collect(Collectors.toSet()),
-//        Sets.newHashSet(
-//            "serviceAccount-cluster0",
-//            "serviceAccount-cluster1",
-//            "serviceAccount-view",
-//            "serviceAccount-exec"));
-//  }
-//
-//  @Test
-//  public void shouldCreateExecAndViewRolesAndBindings() throws Exception {
-//    // given
-//    namespaceFactory =
-//        spy(
-//            new KubernetesNamespaceFactory(
-//                "",
-//                "serviceAccount",
-//                "",
-//                "<workspaceid>",
-//                false,
-//                true,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                userManager,
-//                preferenceManager,
-//                pool));
-//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-//    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
-//    when(toReturnNamespace.getName()).thenReturn("workspace123");
-//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-//    when(clientFactory.create(any())).thenReturn(k8sClient);
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-//    namespaceFactory.getOrCreate(identity);
-//
-//    // then
-//    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
-//
-//    ServiceAccountList sas = k8sClient.serviceAccounts().inNamespace("workspace123").list();
-//    assertEquals(sas.getItems().size(), 1);
-//    assertEquals(sas.getItems().get(0).getMetadata().getName(), "serviceAccount");
-//
-//    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
-//    assertEquals(
-//        Sets.newHashSet("workspace-view", "exec"),
-//        roles.getItems().stream().map(r ->
-// r.getMetadata().getName()).collect(Collectors.toSet()));
-//    Role role1 = roles.getItems().get(0);
-//    Role role2 = roles.getItems().get(1);
-//
-//    assertFalse(
-//        role1.getRules().containsAll(role2.getRules())
-//            && role2.getRules().containsAll(role1.getRules()),
-//        "exec and view roles should not be the same");
-//
-//    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
-//    assertEquals(
-//        Sets.newHashSet("serviceAccount-view", "serviceAccount-exec"),
-//        bindings
-//            .getItems()
-//            .stream()
-//            .map(r -> r.getMetadata().getName())
-//            .collect(Collectors.toSet()));
-//  }
-//
-//  @Test
-//  public void testNullClusterRolesResultsInEmptySet() {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>--",
-//            "",
-//            null,
-//            "che-<userid>",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//    assertTrue(namespaceFactory.getClusterRoleNames().isEmpty());
-//  }
-//
-//  @Test
-//  public void testClusterRolesProperlyParsed() {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>--",
-//            "",
-//            "  one,two, three ,,five  ",
-//            "che-<userid>",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//    Set<String> expected = Sets.newHashSet("one", "two", "three", "five");
-//    assertTrue(namespaceFactory.getClusterRoleNames().containsAll(expected));
-//    assertTrue(expected.containsAll(namespaceFactory.getClusterRoleNames()));
-//  }
-//
-//  @Test
-//  public void
-//
-// testEvalNamespaceUsesNamespaceDefaultIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceDoesntExist()
-//          throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>--",
-//            "",
-//            "",
-//            "che-<userid>",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    when(namespaceResource.get()).thenReturn(null);
-//
-//    WorkspaceImpl workspace =
-//        new WorkspaceImplBuilder().setId("workspace123").setAttributes(emptyMap()).build();
-//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-//    String namespace = namespaceFactory.getNamespaceName(workspace);
-//
-//    assertEquals(namespace, "che-123");
-//  }
-//
-//  @Test
-//  public void testEvalNamespaceUsesNamespaceFromUserPreferencesIfExist() throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>--",
-//            "",
-//            "",
-//            "che-<userid>",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    Map<String, String> prefs = new HashMap<>();
-//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
-//
-//    when(preferenceManager.find(anyString())).thenReturn(prefs);
-//    String namespace =
-//        namespaceFactory.evaluateNamespaceName(
-//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-//
-//    assertEquals(namespace, "che-123");
-//  }
-//
-//  @Test
-//  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateChanged()
-//      throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>--",
-//            "",
-//            "",
-//            "che-<userid>-<username>",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    Map<String, String> prefs = new HashMap<>();
-//    // returned but ignored
-//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
-//
-//    when(preferenceManager.find(anyString())).thenReturn(prefs);
-//    String namespace =
-//        namespaceFactory.evaluateNamespaceName(
-//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-//
-//    assertEquals(namespace, "che-user123-jondoe");
-//  }
-//
-//  @Test
-//  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfUserAllowedPropertySetFalse()
-//      throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>--",
-//            "",
-//            "",
-//            "che-<userid>-<username>",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    Map<String, String> prefs = new HashMap<>();
-//    // returned but ignored
-//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
-//
-//    when(preferenceManager.find(anyString())).thenReturn(prefs);
-//    String namespace =
-//        namespaceFactory.evaluateNamespaceName(
-//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-//
-//    assertEquals(namespace, "che-user123-jondoe");
-//  }
-//
-//  @Test
-//  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateContainsWorkspaceId()
-//      throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>--",
-//            "",
-//            "",
-//            "che-<workspaceid>-<username>",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    Map<String, String> prefs = new HashMap<>();
-//    // returned but ignored
-//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<workspaceid>-<username>");
-//
-//    String namespace =
-//        namespaceFactory.evaluateNamespaceName(
-//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-//
-//    assertEquals(namespace, "che-workspace123-jondoe");
-//  }
-//
-//  @Test
-//  public void
-//
-// testEvalNamespaceUsesLegacyNamespaceIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceExists()
-//          throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>",
-//            "",
-//            "",
-//            "che-<userid>",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    WorkspaceImpl workspace = new WorkspaceImplBuilder().build();
-//
-//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-//
-//    String namespace = namespaceFactory.getNamespaceName(workspace);
-//
-//    assertEquals(namespace, "blabol-123-jondoe-123-jondoe");
-//  }
-//
-//  @Test
-//  public void testEvalNamespaceUsesWorkspaceRecordedNamespaceIfWorkspaceRecordsIt()
-//      throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>",
-//            "",
-//            "",
-//            "che-<userid>",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    WorkspaceImpl workspace =
-//        new WorkspaceImplBuilder()
-//            .setAttributes(
-//                ImmutableMap.of(
-//                    Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "wkspcnmspc"))
-//            .build();
-//
-//    String namespace = namespaceFactory.getNamespaceName(workspace);
-//
-//    assertEquals(namespace, "wkspcnmspc");
-//  }
-//
-//  @Test
-//  public void testEvalNamespaceTreatsWorkspaceRecordedNamespaceLiterally() throws Exception {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "blabol-<userid>-<username>-<userid>-<username>",
-//            "",
-//            "",
-//            "che-<userid>",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    WorkspaceImpl workspace =
-//        new WorkspaceImplBuilder()
-//            .setAttributes(
-//                ImmutableMap.of(Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE,
-// "<userid>"))
-//            .build();
-//
-//    String namespace = namespaceFactory.getNamespaceName(workspace);
-//
-//    // this is an invalid name, but that is not a purpose of this test.
-//    assertEquals(namespace, "<userid>");
-//  }
-//
-//  @Test
-//  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
-//    List<Namespace> namespaces =
-//        Arrays.asList(
-//            new NamespaceBuilder()
-//                .withNewMetadata()
-//                .withName("ns1")
-//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-//                .endMetadata()
-//                .withNewStatus()
-//                .withNewPhase("Active")
-//                .endStatus()
-//                .build(),
-//            new NamespaceBuilder()
-//                .withNewMetadata()
-//                .withName("ns2")
-//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-//                .endMetadata()
-//                .withNewStatus()
-//                .withNewPhase("Active")
-//                .endStatus()
-//                .build());
-//    doReturn(namespaces).when(namespaceList).getItems();
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "legacy",
-//            "",
-//            "",
-//            "defaultNs",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    String namespace =
-//        namespaceFactory.evaluateNamespaceName(
-//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-//
-//    assertEquals(namespace, "ns1");
-//  }
-//
-//  @Test
-//  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
-//    List<Namespace> namespaces =
-//        singletonList(
-//            new NamespaceBuilder()
-//                .withNewMetadata()
-//                .withName("ns1")
-//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-//                .endMetadata()
-//                .withNewStatus()
-//                .withNewPhase("Active")
-//                .endStatus()
-//                .build());
-//    doReturn(namespaces).when(namespaceList).getItems();
-//
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "legacy",
-//            "",
-//            "",
-//            "defaultNs",
-//            false,
-//            true,
-//            "try_placeholder_here=<username>",
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-//    namespaceFactory.list();
-//
-//    verify(namespaceOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
-//  }
-//
-//  @Test(dataProvider = "invalidUsernames")
-//  public void normalizeTest(String raw, String expected) {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "",
-//            "",
-//            "",
-//            "che-<userid>",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//    assertEquals(expected, namespaceFactory.normalizeNamespaceName(raw));
-//  }
-//
-//  @Test
-//  public void normalizeLengthTest() {
-//    namespaceFactory =
-//        new KubernetesNamespaceFactory(
-//            "",
-//            "",
-//            "",
-//            "che-<userid>",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            userManager,
-//            preferenceManager,
-//            pool);
-//
-//    assertEquals(
-//        63,
-//        namespaceFactory
-//            .normalizeNamespaceName(
-//                "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
-//            .length());
-//  }
-//
-//  @DataProvider
-//  public static Object[][] invalidUsernames() {
-//    return new Object[][] {
-//      new Object[] {"gmail@foo.bar", "gmail-foo-bar"},
-//      new Object[] {"_fef_123-ah_*zz**", "fef-123-ah-zz"},
-//      new Object[] {"a-b#-hello", "a-b-hello"},
-//      new Object[] {"a---------b", "a-b"},
-//      new Object[] {"--ab--", "ab"}
-//    };
-//  }
-//
-//  private void prepareNamespaceToBeFoundByLabel(String username, List<Namespace> namespaces) {
-//    //
-//    //
-// lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, username));
-//    doReturn(namespaceList).when(namespaceListResource).list();
-//  }
-//
-//  private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception
-// {
-//    @SuppressWarnings("unchecked")
-//    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
-//    when(namespaceOperation.withName(name)).thenReturn(getNamespaceByNameOperation);
-//
-//    when(getNamespaceByNameOperation.get()).thenReturn(namespace);
-//  }
-//
-//  private void throwOnTryToGetNamespaceByName(String namespaceName, Throwable e) throws Exception
-// {
-//    @SuppressWarnings("unchecked")
-//    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
-//    when(namespaceOperation.withName(namespaceName)).thenReturn(getNamespaceByNameOperation);
-//
-//    when(getNamespaceByNameOperation.get()).thenThrow(e);
-//  }
-//
-//  private void prepareListedNamespaces(List<Namespace> namespaces) throws Exception {
-//    @SuppressWarnings("unchecked")
-//    NamespaceList namespaceList = mock(NamespaceList.class);
-//    when(namespaceOperation.list()).thenReturn(namespaceList);
-//
-//    when(namespaceList.getItems()).thenReturn(namespaces);
-//  }
-//
-//  private void throwOnTryToGetNamespacesList(Throwable e) throws Exception {
-//    when(namespaceOperation.list()).thenThrow(e);
-//  }
-//
-//  private Namespace createNamespace(String name, String phase) {
-//    return new NamespaceBuilder()
-//        .withNewMetadata()
-//        .withName(name)
-//        .endMetadata()
-//        .withNewStatus()
-//        .withNewPhase(phase)
-//        .endStatus()
-//        .build();
-//  }
-// }
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.DoneableNamespace;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.NamespaceList;
+import io.fabric8.kubernetes.api.model.ServiceAccountList;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.api.model.rbac.Role;
+import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
+import io.fabric8.kubernetes.api.model.rbac.RoleList;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.user.server.PreferenceManager;
+import org.eclipse.che.api.user.server.UserManager;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl.WorkspaceImplBuilder;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+import org.eclipse.che.api.workspace.shared.Constants;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.inject.ConfigurationException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+import org.testng.collections.Sets;
+
+/**
+ * Tests {@link KubernetesNamespaceFactory}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class KubernetesNamespaceFactoryTest {
+
+  private static final String USER_ID = "userid";
+  private static final String USER_NAME = "username";
+  private static final String NAMESPACE_LABEL_NAME = "component";
+  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
+  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
+  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
+
+  @Mock private KubernetesSharedPool pool;
+  @Mock private KubernetesClientFactory clientFactory;
+  @Mock private CheServerKubernetesClientFactory cheClientFactory;
+  private KubernetesClient k8sClient;
+  @Mock private UserManager userManager;
+  @Mock private PreferenceManager preferenceManager;
+
+  @Mock
+  private NonNamespaceOperation<
+          Namespace, NamespaceList, DoneableNamespace, Resource<Namespace, DoneableNamespace>>
+      namespaceOperation;
+
+  @Mock private Resource<Namespace, DoneableNamespace> namespaceResource;
+
+  private KubernetesServer serverMock;
+
+  private KubernetesNamespaceFactory namespaceFactory;
+
+  @Mock
+  private FilterWatchListDeletable<Namespace, NamespaceList, Boolean, Watch, Watcher<Namespace>>
+      namespaceListResource;
+
+  @Mock private NamespaceList namespaceList;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    serverMock = new KubernetesServer(true, true);
+    serverMock.before();
+    k8sClient = spy(serverMock.getClient());
+    lenient().when(clientFactory.create()).thenReturn(k8sClient);
+    lenient().when(k8sClient.namespaces()).thenReturn(namespaceOperation);
+
+    lenient().when(namespaceOperation.withName(any())).thenReturn(namespaceResource);
+    lenient().when(namespaceResource.get()).thenReturn(mock(Namespace.class));
+
+    lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(anyMap());
+    lenient().when(namespaceListResource.list()).thenReturn(namespaceList);
+    lenient().when(namespaceList.getItems()).thenReturn(Collections.emptyList());
+
+    lenient()
+        .when(userManager.getById(USER_ID))
+        .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    EnvironmentContext.reset();
+    serverMock.after();
+  }
+
+  @Test
+  public void shouldNotThrowExceptionIfDefaultNamespaceIsSpecifiedOnCheckingIfNamespaceIsAllowed()
+      throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    namespaceFactory.checkIfNamespaceIsAllowed("defaultNs");
+  }
+
+  @Test
+  public void
+      shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
+          throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
+  }
+
+  @Test
+  public void shouldLookAtStoredNamespacesOnCheckingIfNamespaceIsAllowed() throws Exception {
+
+    Map<String, String> prefs = new HashMap<>();
+    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "any-namespace");
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "defaultNs");
+
+    when(preferenceManager.find(anyString())).thenReturn(prefs);
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is available.")
+  public void
+      shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
+          throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
+  }
+
+  @Test(
+      expectedExceptions = ConfigurationException.class,
+      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
+  public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            null,
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+  }
+
+  @Test
+  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
+    // given
+    List<Namespace> namespaces =
+        Arrays.asList(
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns1")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build(),
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns2")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build(),
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns3")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user"))
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build());
+    doReturn(namespaces).when(namespaceList).getItems();
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+
+    // when
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+
+    // then
+    assertEquals(availableNamespaces.size(), 2);
+    verify(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, "workspace"));
+    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+    assertEquals(availableNamespaces.get(1).getName(), "ns2");
+  }
+
+  @Test
+  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
+    // given
+    Namespace ns =
+        new NamespaceBuilder()
+            .withNewMetadata()
+            .withName("ns1")
+            .endMetadata()
+            .withNewStatus()
+            .withNewPhase("Active")
+            .endStatus()
+            .build();
+    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
+        .when(namespaceList)
+        .getItems();
+    prepareNamespaceToBeFoundByName("che-default", ns);
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+
+    // when
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+
+    // then
+    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
+    // given
+    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
+        .when(namespaceList)
+        .getItems();
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    // when
+    namespaceFactory.list();
+
+    // then throw
+  }
+
+  @Test
+  public void shouldReturnDefaultNamespaceWhenItExistsAndUserDefinedIsNotAllowed()
+      throws Exception {
+    prepareNamespaceToBeFoundByName(
+        "che-default",
+        new NamespaceBuilder()
+            .withNewMetadata()
+            .withName("che-default")
+            .endMetadata()
+            .withNewStatus()
+            .withNewPhase("Active")
+            .endStatus()
+            .build());
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+    assertEquals(availableNamespaces.size(), 1);
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+    assertEquals(defaultNamespace.getName(), "che-default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+  }
+
+  @Test
+  public void shouldReturnDefaultNamespaceWhenItDoesNotExistAndUserDefinedIsNotAllowed()
+      throws Exception {
+    prepareNamespaceToBeFoundByName("che-default", null);
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+    assertEquals(availableNamespaces.size(), 1);
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+    assertEquals(defaultNamespace.getName(), "che-default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertNull(
+        defaultNamespace
+            .getAttributes()
+            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error occurred when tried to fetch default namespace. Cause: connection refused")
+  public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    throwOnTryToGetNamespaceByName("che", new KubernetesClientException("connection refused"));
+
+    namespaceFactory.list();
+  }
+
+  @Test
+  public void shouldReturnListOfExistingNamespacesAlongWithDefaultIfUserDefinedIsAllowed()
+      throws Exception {
+    prepareListedNamespaces(
+        Arrays.asList(
+            createNamespace("my-for-ws", "Active"), createNamespace("default", "Active")));
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "default",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+    assertEquals(defaultNamespace.getName(), "default");
+    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+  }
+
+  @Test
+  public void
+      shouldReturnListOfExistingNamespacesAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
+          throws Exception {
+    prepareListedNamespaces(singletonList(createNamespace("my-for-ws", "Active")));
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "default",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+    assertEquals(defaultNamespace.getName(), "default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertNull(
+        defaultNamespace
+            .getAttributes()
+            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error occurred when tried to list all available namespaces. Cause: connection refused")
+  public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "default_ns",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    throwOnTryToGetNamespacesList(new KubernetesClientException("connection refused"));
+
+    namespaceFactory.list();
+  }
+
+  @Test
+  public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
+      throws Exception {
+    // There is only one scenario where this can happen. The workspace was created and started in
+    // some default namespace. Then server was reconfigured to use a different default namespace
+    // AND the namespace of the workspace was MANUALLY deleted in the cluster. In this case, we
+    // should NOT try to re-create the namespace because it would be created in a namespace that
+    // is not configured. We DO allow it to start if the namespace still exists though.
+
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "predefined",
+                "",
+                "",
+                "new-default",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
+    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
+
+    // then
+    assertEquals(toReturnNamespace, namespace);
+    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
+    verify(toReturnNamespace).prepare(eq(false), any());
+  }
+
+  @Test
+  public void shouldReturnDefaultNamespaceWhenCreatingIsNotIsNotAllowed() throws Exception {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "predefined",
+                "",
+                "",
+                "new-default",
+                true,
+                false,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
+    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
+
+    // then
+    assertEquals(toReturnNamespace, namespace);
+    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
+    verify(toReturnNamespace).prepare(eq(false), any());
+  }
+
+  @Test
+  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndNamespaceIsNotPredefined()
+      throws Exception {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "",
+                "serviceAccount",
+                "",
+                "<workspaceid>",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
+    when(toReturnNamespace.getName()).thenReturn("workspace123");
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+
+    KubernetesWorkspaceServiceAccount serviceAccount =
+        mock(KubernetesWorkspaceServiceAccount.class);
+    doReturn(serviceAccount).when(namespaceFactory).doCreateServiceAccount(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    namespaceFactory.getOrCreate(identity);
+
+    // then
+    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
+    verify(serviceAccount).prepare();
+  }
+
+  @Test
+  public void shouldBindToAllConfiguredClusterRoles() throws Exception {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "",
+                "serviceAccount",
+                "cr2, cr3",
+                "<workspaceid>",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
+    when(toReturnNamespace.getName()).thenReturn("workspace123");
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+    when(clientFactory.create(any())).thenReturn(k8sClient);
+
+    // pre-create the cluster roles
+    Stream.of("cr1", "cr2", "cr3")
+        .forEach(
+            cr ->
+                k8sClient
+                    .rbac()
+                    .clusterRoles()
+                    .createOrReplaceWithNew()
+                    .withNewMetadata()
+                    .withName(cr)
+                    .endMetadata()
+                    .done());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    namespaceFactory.getOrCreate(identity);
+
+    // then
+    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
+
+    ServiceAccountList sas = k8sClient.serviceAccounts().inNamespace("workspace123").list();
+    assertEquals(sas.getItems().size(), 1);
+    assertEquals(sas.getItems().get(0).getMetadata().getName(), "serviceAccount");
+
+    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
+    assertEquals(
+        Sets.newHashSet("workspace-view", "exec"),
+        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
+
+    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
+    assertEquals(
+        bindings
+            .getItems()
+            .stream()
+            .map(r -> r.getMetadata().getName())
+            .collect(Collectors.toSet()),
+        Sets.newHashSet(
+            "serviceAccount-cluster0",
+            "serviceAccount-cluster1",
+            "serviceAccount-view",
+            "serviceAccount-exec"));
+  }
+
+  @Test
+  public void shouldCreateExecAndViewRolesAndBindings() throws Exception {
+    // given
+    namespaceFactory =
+        spy(
+            new KubernetesNamespaceFactory(
+                "",
+                "serviceAccount",
+                "",
+                "<workspaceid>",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                userManager,
+                preferenceManager,
+                pool));
+    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
+    when(toReturnNamespace.getName()).thenReturn("workspace123");
+    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+    when(clientFactory.create(any())).thenReturn(k8sClient);
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    namespaceFactory.getOrCreate(identity);
+
+    // then
+    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
+
+    ServiceAccountList sas = k8sClient.serviceAccounts().inNamespace("workspace123").list();
+    assertEquals(sas.getItems().size(), 1);
+    assertEquals(sas.getItems().get(0).getMetadata().getName(), "serviceAccount");
+
+    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
+    assertEquals(
+        Sets.newHashSet("workspace-view", "exec"),
+        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
+    Role role1 = roles.getItems().get(0);
+    Role role2 = roles.getItems().get(1);
+
+    assertFalse(
+        role1.getRules().containsAll(role2.getRules())
+            && role2.getRules().containsAll(role1.getRules()),
+        "exec and view roles should not be the same");
+
+    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
+    assertEquals(
+        Sets.newHashSet("serviceAccount-view", "serviceAccount-exec"),
+        bindings
+            .getItems()
+            .stream()
+            .map(r -> r.getMetadata().getName())
+            .collect(Collectors.toSet()));
+  }
+
+  @Test
+  public void testNullClusterRolesResultsInEmptySet() {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            null,
+            "che-<userid>",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    assertTrue(namespaceFactory.getClusterRoleNames().isEmpty());
+  }
+
+  @Test
+  public void testClusterRolesProperlyParsed() {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "  one,two, three ,,five  ",
+            "che-<userid>",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    Set<String> expected = Sets.newHashSet("one", "two", "three", "five");
+    assertTrue(namespaceFactory.getClusterRoleNames().containsAll(expected));
+    assertTrue(expected.containsAll(namespaceFactory.getClusterRoleNames()));
+  }
+
+  @Test
+  public void
+      testEvalNamespaceUsesNamespaceDefaultIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceDoesntExist()
+          throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "",
+            "che-<userid>",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    when(namespaceResource.get()).thenReturn(null);
+
+    WorkspaceImpl workspace =
+        new WorkspaceImplBuilder().setId("workspace123").setAttributes(emptyMap()).build();
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+    String namespace = namespaceFactory.getNamespaceName(workspace);
+
+    assertEquals(namespace, "che-123");
+  }
+
+  @Test
+  public void testEvalNamespaceUsesNamespaceFromUserPreferencesIfExist() throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "",
+            "che-<userid>",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    Map<String, String> prefs = new HashMap<>();
+    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
+
+    when(preferenceManager.find(anyString())).thenReturn(prefs);
+    String namespace =
+        namespaceFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+
+    assertEquals(namespace, "che-123");
+  }
+
+  @Test
+  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateChanged()
+      throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "",
+            "che-<userid>-<username>",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    Map<String, String> prefs = new HashMap<>();
+    // returned but ignored
+    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
+
+    when(preferenceManager.find(anyString())).thenReturn(prefs);
+    String namespace =
+        namespaceFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+
+    assertEquals(namespace, "che-user123-jondoe");
+  }
+
+  @Test
+  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfUserAllowedPropertySetFalse()
+      throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "",
+            "che-<userid>-<username>",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    Map<String, String> prefs = new HashMap<>();
+    // returned but ignored
+    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
+
+    when(preferenceManager.find(anyString())).thenReturn(prefs);
+    String namespace =
+        namespaceFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+
+    assertEquals(namespace, "che-user123-jondoe");
+  }
+
+  @Test
+  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateContainsWorkspaceId()
+      throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>--",
+            "",
+            "",
+            "che-<workspaceid>-<username>",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    Map<String, String> prefs = new HashMap<>();
+    // returned but ignored
+    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<workspaceid>-<username>");
+
+    String namespace =
+        namespaceFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+
+    assertEquals(namespace, "che-workspace123-jondoe");
+  }
+
+  @Test
+  public void
+      testEvalNamespaceUsesLegacyNamespaceIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceExists()
+          throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>",
+            "",
+            "",
+            "che-<userid>",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    WorkspaceImpl workspace = new WorkspaceImplBuilder().build();
+
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+
+    String namespace = namespaceFactory.getNamespaceName(workspace);
+
+    assertEquals(namespace, "blabol-123-jondoe-123-jondoe");
+  }
+
+  @Test
+  public void testEvalNamespaceUsesWorkspaceRecordedNamespaceIfWorkspaceRecordsIt()
+      throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>",
+            "",
+            "",
+            "che-<userid>",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    WorkspaceImpl workspace =
+        new WorkspaceImplBuilder()
+            .setAttributes(
+                ImmutableMap.of(
+                    Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "wkspcnmspc"))
+            .build();
+
+    String namespace = namespaceFactory.getNamespaceName(workspace);
+
+    assertEquals(namespace, "wkspcnmspc");
+  }
+
+  @Test
+  public void testEvalNamespaceTreatsWorkspaceRecordedNamespaceLiterally() throws Exception {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "blabol-<userid>-<username>-<userid>-<username>",
+            "",
+            "",
+            "che-<userid>",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    WorkspaceImpl workspace =
+        new WorkspaceImplBuilder()
+            .setAttributes(
+                ImmutableMap.of(Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "<userid>"))
+            .build();
+
+    String namespace = namespaceFactory.getNamespaceName(workspace);
+
+    // this is an invalid name, but that is not a purpose of this test.
+    assertEquals(namespace, "<userid>");
+  }
+
+  @Test
+  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
+    List<Namespace> namespaces =
+        Arrays.asList(
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns1")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build(),
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns2")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build());
+    doReturn(namespaces).when(namespaceList).getItems();
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    String namespace =
+        namespaceFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+
+    assertEquals(namespace, "ns1");
+  }
+
+  @Test
+  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
+    List<Namespace> namespaces =
+        singletonList(
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns1")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build());
+    doReturn(namespaces).when(namespaceList).getItems();
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            "try_placeholder_here=<username>",
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+    namespaceFactory.list();
+
+    verify(namespaceOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
+  }
+
+  @Test(dataProvider = "invalidUsernames")
+  public void normalizeTest(String raw, String expected) {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "",
+            "",
+            "",
+            "che-<userid>",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    assertEquals(expected, namespaceFactory.normalizeNamespaceName(raw));
+  }
+
+  @Test
+  public void normalizeLengthTest() {
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "",
+            "",
+            "",
+            "che-<userid>",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    assertEquals(
+        63,
+        namespaceFactory
+            .normalizeNamespaceName(
+                "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
+            .length());
+  }
+
+  @DataProvider
+  public static Object[][] invalidUsernames() {
+    return new Object[][] {
+      new Object[] {"gmail@foo.bar", "gmail-foo-bar"},
+      new Object[] {"_fef_123-ah_*zz**", "fef-123-ah-zz"},
+      new Object[] {"a-b#-hello", "a-b-hello"},
+      new Object[] {"a---------b", "a-b"},
+      new Object[] {"--ab--", "ab"}
+    };
+  }
+
+  private void prepareNamespaceToBeFoundByLabel(String username, List<Namespace> namespaces) {
+    //
+    // lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, username));
+    doReturn(namespaceList).when(namespaceListResource).list();
+  }
+
+  private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception {
+    @SuppressWarnings("unchecked")
+    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
+    when(namespaceOperation.withName(name)).thenReturn(getNamespaceByNameOperation);
+
+    when(getNamespaceByNameOperation.get()).thenReturn(namespace);
+  }
+
+  private void throwOnTryToGetNamespaceByName(String namespaceName, Throwable e) throws Exception {
+    @SuppressWarnings("unchecked")
+    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
+    when(namespaceOperation.withName(namespaceName)).thenReturn(getNamespaceByNameOperation);
+
+    when(getNamespaceByNameOperation.get()).thenThrow(e);
+  }
+
+  private void prepareListedNamespaces(List<Namespace> namespaces) throws Exception {
+    @SuppressWarnings("unchecked")
+    NamespaceList namespaceList = mock(NamespaceList.class);
+    when(namespaceOperation.list()).thenReturn(namespaceList);
+
+    when(namespaceList.getItems()).thenReturn(namespaces);
+  }
+
+  private void throwOnTryToGetNamespacesList(Throwable e) throws Exception {
+    when(namespaceOperation.list()).thenThrow(e);
+  }
+
+  private Namespace createNamespace(String name, String phase) {
+    return new NamespaceBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .endMetadata()
+        .withNewStatus()
+        .withNewPhase(phase)
+        .endStatus()
+        .build();
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -1,1276 +1,1276 @@
-/*
- * Copyright (c) 2012-2018 Red Hat, Inc.
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
- */
-package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
-
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-
-import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.api.model.DoneableNamespace;
-import io.fabric8.kubernetes.api.model.Namespace;
-import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-import io.fabric8.kubernetes.api.model.NamespaceList;
-import io.fabric8.kubernetes.api.model.ServiceAccountList;
-import io.fabric8.kubernetes.api.model.Status;
-import io.fabric8.kubernetes.api.model.rbac.Role;
-import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
-import io.fabric8.kubernetes.api.model.rbac.RoleList;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.eclipse.che.api.core.ValidationException;
-import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-import org.eclipse.che.api.user.server.PreferenceManager;
-import org.eclipse.che.api.user.server.UserManager;
-import org.eclipse.che.api.user.server.model.impl.UserImpl;
-import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
-import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl.WorkspaceImplBuilder;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
-import org.eclipse.che.api.workspace.shared.Constants;
-import org.eclipse.che.commons.env.EnvironmentContext;
-import org.eclipse.che.commons.subject.SubjectImpl;
-import org.eclipse.che.inject.ConfigurationException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
-import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
-import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
-import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
-import org.testng.collections.Sets;
-
-/**
- * Tests {@link KubernetesNamespaceFactory}.
- *
- * @author Sergii Leshchenko
- */
-@Listeners(MockitoTestNGListener.class)
-public class KubernetesNamespaceFactoryTest {
-
-  private static final String USER_ID = "userid";
-  private static final String USER_NAME = "username";
-  private static final String NAMESPACE_LABEL_NAME = "component";
-  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
-  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
-  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
-
-  @Mock private KubernetesSharedPool pool;
-  @Mock private KubernetesClientFactory clientFactory;
-  private KubernetesClient k8sClient;
-  @Mock private UserManager userManager;
-  @Mock private PreferenceManager preferenceManager;
-
-  @Mock
-  private NonNamespaceOperation<
-          Namespace, NamespaceList, DoneableNamespace, Resource<Namespace, DoneableNamespace>>
-      namespaceOperation;
-
-  @Mock private Resource<Namespace, DoneableNamespace> namespaceResource;
-
-  private KubernetesServer serverMock;
-
-  private KubernetesNamespaceFactory namespaceFactory;
-
-  @Mock
-  private FilterWatchListDeletable<Namespace, NamespaceList, Boolean, Watch, Watcher<Namespace>>
-      namespaceListResource;
-
-  @Mock private NamespaceList namespaceList;
-
-  @BeforeMethod
-  public void setUp() throws Exception {
-    serverMock = new KubernetesServer(true, true);
-    serverMock.before();
-    k8sClient = spy(serverMock.getClient());
-    lenient().when(clientFactory.create()).thenReturn(k8sClient);
-    lenient().when(k8sClient.namespaces()).thenReturn(namespaceOperation);
-
-    lenient().when(namespaceOperation.withName(any())).thenReturn(namespaceResource);
-    lenient().when(namespaceResource.get()).thenReturn(mock(Namespace.class));
-
-    lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(anyMap());
-    lenient().when(namespaceListResource.list()).thenReturn(namespaceList);
-    lenient().when(namespaceList.getItems()).thenReturn(Collections.emptyList());
-
-    lenient()
-        .when(userManager.getById(USER_ID))
-        .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
-  }
-
-  @AfterMethod
-  public void tearDown() {
-    EnvironmentContext.reset();
-    serverMock.after();
-  }
-
-  @Test
-  public void shouldNotThrowExceptionIfDefaultNamespaceIsSpecifiedOnCheckingIfNamespaceIsAllowed()
-      throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "legacy",
-            "",
-            "",
-            "defaultNs",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    namespaceFactory.checkIfNamespaceIsAllowed("defaultNs");
-  }
-
-  @Test
-  public void
-      shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
-          throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "legacy",
-            "",
-            "",
-            "defaultNs",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
-  }
-
-  @Test
-  public void shouldLookAtStoredNamespacesOnCheckingIfNamespaceIsAllowed() throws Exception {
-
-    Map<String, String> prefs = new HashMap<>();
-    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "any-namespace");
-    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "defaultNs");
-
-    when(preferenceManager.find(anyString())).thenReturn(prefs);
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "legacy",
-            "",
-            "",
-            "defaultNs",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
-  }
-
-  @Test(
-      expectedExceptions = ValidationException.class,
-      expectedExceptionsMessageRegExp =
-          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is available.")
-  public void
-      shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
-          throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "legacy",
-            "",
-            "",
-            "defaultNs",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
-  }
-
-  @Test(
-      expectedExceptions = ConfigurationException.class,
-      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
-  public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            null,
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-  }
-
-  @Test
-  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
-    // given
-    List<Namespace> namespaces =
-        Arrays.asList(
-            new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("ns1")
-                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-                .endMetadata()
-                .withNewStatus()
-                .withNewPhase("Active")
-                .endStatus()
-                .build(),
-            new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("ns2")
-                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-                .endMetadata()
-                .withNewStatus()
-                .withNewPhase("Active")
-                .endStatus()
-                .build(),
-            new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("ns3")
-                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user"))
-                .endMetadata()
-                .withNewStatus()
-                .withNewPhase("Active")
-                .endStatus()
-                .build());
-    doReturn(namespaces).when(namespaceList).getItems();
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-
-    // when
-    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-
-    // then
-    assertEquals(availableNamespaces.size(), 2);
-    verify(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, "workspace"));
-    assertEquals(availableNamespaces.get(0).getName(), "ns1");
-    assertEquals(availableNamespaces.get(1).getName(), "ns2");
-  }
-
-  @Test
-  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
-    // given
-    Namespace ns =
-        new NamespaceBuilder()
-            .withNewMetadata()
-            .withName("ns1")
-            .endMetadata()
-            .withNewStatus()
-            .withNewPhase("Active")
-            .endStatus()
-            .build();
-    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
-        .when(namespaceList)
-        .getItems();
-    prepareNamespaceToBeFoundByName("che-default", ns);
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-
-    // when
-    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-
-    // then
-    assertEquals(availableNamespaces.get(0).getName(), "ns1");
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
-    // given
-    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
-        .when(namespaceList)
-        .getItems();
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    // when
-    namespaceFactory.list();
-
-    // then throw
-  }
-
-  @Test
-  public void shouldReturnDefaultNamespaceWhenItExistsAndUserDefinedIsNotAllowed()
-      throws Exception {
-    prepareNamespaceToBeFoundByName(
-        "che-default",
-        new NamespaceBuilder()
-            .withNewMetadata()
-            .withName("che-default")
-            .endMetadata()
-            .withNewStatus()
-            .withNewPhase("Active")
-            .endStatus()
-            .build());
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-    assertEquals(availableNamespaces.size(), 1);
-    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
-    assertEquals(defaultNamespace.getName(), "che-default");
-    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-  }
-
-  @Test
-  public void shouldReturnDefaultNamespaceWhenItDoesNotExistAndUserDefinedIsNotAllowed()
-      throws Exception {
-    prepareNamespaceToBeFoundByName("che-default", null);
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-    assertEquals(availableNamespaces.size(), 1);
-    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
-    assertEquals(defaultNamespace.getName(), "che-default");
-    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-    assertNull(
-        defaultNamespace
-            .getAttributes()
-            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
-  }
-
-  @Test(
-      expectedExceptions = InfrastructureException.class,
-      expectedExceptionsMessageRegExp =
-          "Error occurred when tried to fetch default namespace. Cause: connection refused")
-  public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "che",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-    throwOnTryToGetNamespaceByName("che", new KubernetesClientException("connection refused"));
-
-    namespaceFactory.list();
-  }
-
-  @Test
-  public void shouldReturnListOfExistingNamespacesAlongWithDefaultIfUserDefinedIsAllowed()
-      throws Exception {
-    prepareListedNamespaces(
-        Arrays.asList(
-            createNamespace("my-for-ws", "Active"), createNamespace("default", "Active")));
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "default",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-
-    assertEquals(availableNamespaces.size(), 2);
-    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
-    assertEquals(forWS.getName(), "my-for-ws");
-    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
-
-    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
-    assertEquals(defaultNamespace.getName(), "default");
-    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-  }
-
-  @Test
-  public void
-      shouldReturnListOfExistingNamespacesAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
-          throws Exception {
-    prepareListedNamespaces(singletonList(createNamespace("my-for-ws", "Active")));
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "default",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
-    assertEquals(availableNamespaces.size(), 2);
-    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
-    assertEquals(forWS.getName(), "my-for-ws");
-    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
-
-    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
-    assertEquals(defaultNamespace.getName(), "default");
-    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-    assertNull(
-        defaultNamespace
-            .getAttributes()
-            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
-  }
-
-  @Test(
-      expectedExceptions = InfrastructureException.class,
-      expectedExceptionsMessageRegExp =
-          "Error occurred when tried to list all available namespaces. Cause: connection refused")
-  public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "predefined",
-            "",
-            "",
-            "default_ns",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-    throwOnTryToGetNamespacesList(new KubernetesClientException("connection refused"));
-
-    namespaceFactory.list();
-  }
-
-  @Test
-  public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
-      throws Exception {
-    // There is only one scenario where this can happen. The workspace was created and started in
-    // some default namespace. Then server was reconfigured to use a different default namespace
-    // AND the namespace of the workspace was MANUALLY deleted in the cluster. In this case, we
-    // should NOT try to re-create the namespace because it would be created in a namespace that
-    // is not configured. We DO allow it to start if the namespace still exists though.
-
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "predefined",
-                "",
-                "",
-                "new-default",
-                false,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                userManager,
-                preferenceManager,
-                pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
-    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
-
-    // then
-    assertEquals(toReturnNamespace, namespace);
-    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnNamespace).prepare(eq(false));
-  }
-
-  @Test
-  public void shouldReturnDefaultNamespaceWhenCreatingIsNotIsNotAllowed() throws Exception {
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "predefined",
-                "",
-                "",
-                "new-default",
-                true,
-                false,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                userManager,
-                preferenceManager,
-                pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
-    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
-
-    // then
-    assertEquals(toReturnNamespace, namespace);
-    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnNamespace).prepare(eq(false));
-  }
-
-  @Test
-  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndNamespaceIsNotPredefined()
-      throws Exception {
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "",
-                "serviceAccount",
-                "",
-                "<workspaceid>",
-                false,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                userManager,
-                preferenceManager,
-                pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
-    when(toReturnNamespace.getName()).thenReturn("workspace123");
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-
-    KubernetesWorkspaceServiceAccount serviceAccount =
-        mock(KubernetesWorkspaceServiceAccount.class);
-    doReturn(serviceAccount).when(namespaceFactory).doCreateServiceAccount(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    namespaceFactory.getOrCreate(identity);
-
-    // then
-    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
-    verify(serviceAccount).prepare();
-  }
-
-  @Test
-  public void shouldBindToAllConfiguredClusterRoles() throws Exception {
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "",
-                "serviceAccount",
-                "cr2, cr3",
-                "<workspaceid>",
-                false,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                userManager,
-                preferenceManager,
-                pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
-    when(toReturnNamespace.getName()).thenReturn("workspace123");
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-    when(clientFactory.create(any())).thenReturn(k8sClient);
-
-    // pre-create the cluster roles
-    Stream.of("cr1", "cr2", "cr3")
-        .forEach(
-            cr ->
-                k8sClient
-                    .rbac()
-                    .clusterRoles()
-                    .createOrReplaceWithNew()
-                    .withNewMetadata()
-                    .withName(cr)
-                    .endMetadata()
-                    .done());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    namespaceFactory.getOrCreate(identity);
-
-    // then
-    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
-
-    ServiceAccountList sas = k8sClient.serviceAccounts().inNamespace("workspace123").list();
-    assertEquals(sas.getItems().size(), 1);
-    assertEquals(sas.getItems().get(0).getMetadata().getName(), "serviceAccount");
-
-    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
-    assertEquals(
-        Sets.newHashSet("workspace-view", "exec"),
-        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
-
-    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
-    assertEquals(
-        bindings
-            .getItems()
-            .stream()
-            .map(r -> r.getMetadata().getName())
-            .collect(Collectors.toSet()),
-        Sets.newHashSet(
-            "serviceAccount-cluster0",
-            "serviceAccount-cluster1",
-            "serviceAccount-view",
-            "serviceAccount-exec"));
-  }
-
-  @Test
-  public void shouldCreateExecAndViewRolesAndBindings() throws Exception {
-    // given
-    namespaceFactory =
-        spy(
-            new KubernetesNamespaceFactory(
-                "",
-                "serviceAccount",
-                "",
-                "<workspaceid>",
-                false,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                userManager,
-                preferenceManager,
-                pool));
-    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
-    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
-    when(toReturnNamespace.getName()).thenReturn("workspace123");
-    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
-    when(clientFactory.create(any())).thenReturn(k8sClient);
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    namespaceFactory.getOrCreate(identity);
-
-    // then
-    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
-
-    ServiceAccountList sas = k8sClient.serviceAccounts().inNamespace("workspace123").list();
-    assertEquals(sas.getItems().size(), 1);
-    assertEquals(sas.getItems().get(0).getMetadata().getName(), "serviceAccount");
-
-    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
-    assertEquals(
-        Sets.newHashSet("workspace-view", "exec"),
-        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
-    Role role1 = roles.getItems().get(0);
-    Role role2 = roles.getItems().get(1);
-
-    assertFalse(
-        role1.getRules().containsAll(role2.getRules())
-            && role2.getRules().containsAll(role1.getRules()),
-        "exec and view roles should not be the same");
-
-    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
-    assertEquals(
-        Sets.newHashSet("serviceAccount-view", "serviceAccount-exec"),
-        bindings
-            .getItems()
-            .stream()
-            .map(r -> r.getMetadata().getName())
-            .collect(Collectors.toSet()));
-  }
-
-  @Test
-  public void testNullClusterRolesResultsInEmptySet() {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>--",
-            "",
-            null,
-            "che-<userid>",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-    assertTrue(namespaceFactory.getClusterRoleNames().isEmpty());
-  }
-
-  @Test
-  public void testClusterRolesProperlyParsed() {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>--",
-            "",
-            "  one,two, three ,,five  ",
-            "che-<userid>",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-    Set<String> expected = Sets.newHashSet("one", "two", "three", "five");
-    assertTrue(namespaceFactory.getClusterRoleNames().containsAll(expected));
-    assertTrue(expected.containsAll(namespaceFactory.getClusterRoleNames()));
-  }
-
-  @Test
-  public void
-      testEvalNamespaceUsesNamespaceDefaultIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceDoesntExist()
-          throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>--",
-            "",
-            "",
-            "che-<userid>",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    when(namespaceResource.get()).thenReturn(null);
-
-    WorkspaceImpl workspace =
-        new WorkspaceImplBuilder().setId("workspace123").setAttributes(emptyMap()).build();
-    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-    String namespace = namespaceFactory.getNamespaceName(workspace);
-
-    assertEquals(namespace, "che-123");
-  }
-
-  @Test
-  public void testEvalNamespaceUsesNamespaceFromUserPreferencesIfExist() throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>--",
-            "",
-            "",
-            "che-<userid>",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    Map<String, String> prefs = new HashMap<>();
-    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
-
-    when(preferenceManager.find(anyString())).thenReturn(prefs);
-    String namespace =
-        namespaceFactory.evaluateNamespaceName(
-            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-
-    assertEquals(namespace, "che-123");
-  }
-
-  @Test
-  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateChanged()
-      throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>--",
-            "",
-            "",
-            "che-<userid>-<username>",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    Map<String, String> prefs = new HashMap<>();
-    // returned but ignored
-    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
-
-    when(preferenceManager.find(anyString())).thenReturn(prefs);
-    String namespace =
-        namespaceFactory.evaluateNamespaceName(
-            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-
-    assertEquals(namespace, "che-user123-jondoe");
-  }
-
-  @Test
-  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfUserAllowedPropertySetFalse()
-      throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>--",
-            "",
-            "",
-            "che-<userid>-<username>",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    Map<String, String> prefs = new HashMap<>();
-    // returned but ignored
-    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
-
-    when(preferenceManager.find(anyString())).thenReturn(prefs);
-    String namespace =
-        namespaceFactory.evaluateNamespaceName(
-            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-
-    assertEquals(namespace, "che-user123-jondoe");
-  }
-
-  @Test
-  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateContainsWorkspaceId()
-      throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>--",
-            "",
-            "",
-            "che-<workspaceid>-<username>",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    Map<String, String> prefs = new HashMap<>();
-    // returned but ignored
-    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
-    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<workspaceid>-<username>");
-
-    String namespace =
-        namespaceFactory.evaluateNamespaceName(
-            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-
-    assertEquals(namespace, "che-workspace123-jondoe");
-  }
-
-  @Test
-  public void
-      testEvalNamespaceUsesLegacyNamespaceIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceExists()
-          throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>",
-            "",
-            "",
-            "che-<userid>",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    WorkspaceImpl workspace = new WorkspaceImplBuilder().build();
-
-    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-
-    String namespace = namespaceFactory.getNamespaceName(workspace);
-
-    assertEquals(namespace, "blabol-123-jondoe-123-jondoe");
-  }
-
-  @Test
-  public void testEvalNamespaceUsesWorkspaceRecordedNamespaceIfWorkspaceRecordsIt()
-      throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>",
-            "",
-            "",
-            "che-<userid>",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    WorkspaceImpl workspace =
-        new WorkspaceImplBuilder()
-            .setAttributes(
-                ImmutableMap.of(
-                    Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "wkspcnmspc"))
-            .build();
-
-    String namespace = namespaceFactory.getNamespaceName(workspace);
-
-    assertEquals(namespace, "wkspcnmspc");
-  }
-
-  @Test
-  public void testEvalNamespaceTreatsWorkspaceRecordedNamespaceLiterally() throws Exception {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "blabol-<userid>-<username>-<userid>-<username>",
-            "",
-            "",
-            "che-<userid>",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    WorkspaceImpl workspace =
-        new WorkspaceImplBuilder()
-            .setAttributes(
-                ImmutableMap.of(Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "<userid>"))
-            .build();
-
-    String namespace = namespaceFactory.getNamespaceName(workspace);
-
-    // this is an invalid name, but that is not a purpose of this test.
-    assertEquals(namespace, "<userid>");
-  }
-
-  @Test
-  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
-    List<Namespace> namespaces =
-        Arrays.asList(
-            new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("ns1")
-                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-                .endMetadata()
-                .withNewStatus()
-                .withNewPhase("Active")
-                .endStatus()
-                .build(),
-            new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("ns2")
-                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-                .endMetadata()
-                .withNewStatus()
-                .withNewPhase("Active")
-                .endStatus()
-                .build());
-    doReturn(namespaces).when(namespaceList).getItems();
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "legacy",
-            "",
-            "",
-            "defaultNs",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    String namespace =
-        namespaceFactory.evaluateNamespaceName(
-            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-
-    assertEquals(namespace, "ns1");
-  }
-
-  @Test
-  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
-    List<Namespace> namespaces =
-        singletonList(
-            new NamespaceBuilder()
-                .withNewMetadata()
-                .withName("ns1")
-                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
-                .endMetadata()
-                .withNewStatus()
-                .withNewPhase("Active")
-                .endStatus()
-                .build());
-    doReturn(namespaces).when(namespaceList).getItems();
-
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "legacy",
-            "",
-            "",
-            "defaultNs",
-            false,
-            true,
-            "try_placeholder_here=<username>",
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-    namespaceFactory.list();
-
-    verify(namespaceOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
-  }
-
-  @Test(dataProvider = "invalidUsernames")
-  public void normalizeTest(String raw, String expected) {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "",
-            "",
-            "",
-            "che-<userid>",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-    assertEquals(expected, namespaceFactory.normalizeNamespaceName(raw));
-  }
-
-  @Test
-  public void normalizeLengthTest() {
-    namespaceFactory =
-        new KubernetesNamespaceFactory(
-            "",
-            "",
-            "",
-            "che-<userid>",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            userManager,
-            preferenceManager,
-            pool);
-
-    assertEquals(
-        63,
-        namespaceFactory
-            .normalizeNamespaceName(
-                "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
-            .length());
-  }
-
-  @DataProvider
-  public static Object[][] invalidUsernames() {
-    return new Object[][] {
-      new Object[] {"gmail@foo.bar", "gmail-foo-bar"},
-      new Object[] {"_fef_123-ah_*zz**", "fef-123-ah-zz"},
-      new Object[] {"a-b#-hello", "a-b-hello"},
-      new Object[] {"a---------b", "a-b"},
-      new Object[] {"--ab--", "ab"}
-    };
-  }
-
-  private void prepareNamespaceToBeFoundByLabel(String username, List<Namespace> namespaces) {
-    //
-    // lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, username));
-    doReturn(namespaceList).when(namespaceListResource).list();
-  }
-
-  private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception {
-    @SuppressWarnings("unchecked")
-    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
-    when(namespaceOperation.withName(name)).thenReturn(getNamespaceByNameOperation);
-
-    when(getNamespaceByNameOperation.get()).thenReturn(namespace);
-  }
-
-  private void throwOnTryToGetNamespaceByName(String namespaceName, Throwable e) throws Exception {
-    @SuppressWarnings("unchecked")
-    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
-    when(namespaceOperation.withName(namespaceName)).thenReturn(getNamespaceByNameOperation);
-
-    when(getNamespaceByNameOperation.get()).thenThrow(e);
-  }
-
-  private void prepareListedNamespaces(List<Namespace> namespaces) throws Exception {
-    @SuppressWarnings("unchecked")
-    NamespaceList namespaceList = mock(NamespaceList.class);
-    when(namespaceOperation.list()).thenReturn(namespaceList);
-
-    when(namespaceList.getItems()).thenReturn(namespaces);
-  }
-
-  private void throwOnTryToGetNamespacesList(Throwable e) throws Exception {
-    when(namespaceOperation.list()).thenThrow(e);
-  }
-
-  private Namespace createNamespace(String name, String phase) {
-    return new NamespaceBuilder()
-        .withNewMetadata()
-        .withName(name)
-        .endMetadata()
-        .withNewStatus()
-        .withNewPhase(phase)
-        .endStatus()
-        .build();
-  }
-}
+///*
+// * Copyright (c) 2012-2018 Red Hat, Inc.
+// * This program and the accompanying materials are made
+// * available under the terms of the Eclipse Public License 2.0
+// * which is available at https://www.eclipse.org/legal/epl-2.0/
+// *
+// * SPDX-License-Identifier: EPL-2.0
+// *
+// * Contributors:
+// *   Red Hat, Inc. - initial API and implementation
+// */
+//package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+//
+//import static java.util.Collections.emptyMap;
+//import static java.util.Collections.singletonList;
+//import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
+//import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+//import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
+//import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyMap;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.doReturn;
+//import static org.mockito.Mockito.doThrow;
+//import static org.mockito.Mockito.lenient;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.never;
+//import static org.mockito.Mockito.spy;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//import static org.testng.Assert.assertEquals;
+//import static org.testng.Assert.assertFalse;
+//import static org.testng.Assert.assertNull;
+//import static org.testng.Assert.assertTrue;
+//
+//import com.google.common.collect.ImmutableMap;
+//import io.fabric8.kubernetes.api.model.DoneableNamespace;
+//import io.fabric8.kubernetes.api.model.Namespace;
+//import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+//import io.fabric8.kubernetes.api.model.NamespaceList;
+//import io.fabric8.kubernetes.api.model.ServiceAccountList;
+//import io.fabric8.kubernetes.api.model.Status;
+//import io.fabric8.kubernetes.api.model.rbac.Role;
+//import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
+//import io.fabric8.kubernetes.api.model.rbac.RoleList;
+//import io.fabric8.kubernetes.client.KubernetesClient;
+//import io.fabric8.kubernetes.client.KubernetesClientException;
+//import io.fabric8.kubernetes.client.Watch;
+//import io.fabric8.kubernetes.client.Watcher;
+//import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+//import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+//import io.fabric8.kubernetes.client.dsl.Resource;
+//import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+//import java.util.Arrays;
+//import java.util.Collections;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//import java.util.Set;
+//import java.util.stream.Collectors;
+//import java.util.stream.Stream;
+//import org.eclipse.che.api.core.ValidationException;
+//import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+//import org.eclipse.che.api.user.server.PreferenceManager;
+//import org.eclipse.che.api.user.server.UserManager;
+//import org.eclipse.che.api.user.server.model.impl.UserImpl;
+//import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+//import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+//import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl.WorkspaceImplBuilder;
+//import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+//import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+//import org.eclipse.che.api.workspace.shared.Constants;
+//import org.eclipse.che.commons.env.EnvironmentContext;
+//import org.eclipse.che.commons.subject.SubjectImpl;
+//import org.eclipse.che.inject.ConfigurationException;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
+//import org.mockito.Mock;
+//import org.mockito.testng.MockitoTestNGListener;
+//import org.testng.annotations.AfterMethod;
+//import org.testng.annotations.BeforeMethod;
+//import org.testng.annotations.DataProvider;
+//import org.testng.annotations.Listeners;
+//import org.testng.annotations.Test;
+//import org.testng.collections.Sets;
+//
+///**
+// * Tests {@link KubernetesNamespaceFactory}.
+// *
+// * @author Sergii Leshchenko
+// */
+//@Listeners(MockitoTestNGListener.class)
+//public class KubernetesNamespaceFactoryTest {
+//
+//  private static final String USER_ID = "userid";
+//  private static final String USER_NAME = "username";
+//  private static final String NAMESPACE_LABEL_NAME = "component";
+//  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
+//  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
+//  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
+//
+//  @Mock private KubernetesSharedPool pool;
+//  @Mock private KubernetesClientFactory clientFactory;
+//  private KubernetesClient k8sClient;
+//  @Mock private UserManager userManager;
+//  @Mock private PreferenceManager preferenceManager;
+//
+//  @Mock
+//  private NonNamespaceOperation<
+//          Namespace, NamespaceList, DoneableNamespace, Resource<Namespace, DoneableNamespace>>
+//      namespaceOperation;
+//
+//  @Mock private Resource<Namespace, DoneableNamespace> namespaceResource;
+//
+//  private KubernetesServer serverMock;
+//
+//  private KubernetesNamespaceFactory namespaceFactory;
+//
+//  @Mock
+//  private FilterWatchListDeletable<Namespace, NamespaceList, Boolean, Watch, Watcher<Namespace>>
+//      namespaceListResource;
+//
+//  @Mock private NamespaceList namespaceList;
+//
+//  @BeforeMethod
+//  public void setUp() throws Exception {
+//    serverMock = new KubernetesServer(true, true);
+//    serverMock.before();
+//    k8sClient = spy(serverMock.getClient());
+//    lenient().when(clientFactory.create()).thenReturn(k8sClient);
+//    lenient().when(k8sClient.namespaces()).thenReturn(namespaceOperation);
+//
+//    lenient().when(namespaceOperation.withName(any())).thenReturn(namespaceResource);
+//    lenient().when(namespaceResource.get()).thenReturn(mock(Namespace.class));
+//
+//    lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(anyMap());
+//    lenient().when(namespaceListResource.list()).thenReturn(namespaceList);
+//    lenient().when(namespaceList.getItems()).thenReturn(Collections.emptyList());
+//
+//    lenient()
+//        .when(userManager.getById(USER_ID))
+//        .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
+//  }
+//
+//  @AfterMethod
+//  public void tearDown() {
+//    EnvironmentContext.reset();
+//    serverMock.after();
+//  }
+//
+//  @Test
+//  public void shouldNotThrowExceptionIfDefaultNamespaceIsSpecifiedOnCheckingIfNamespaceIsAllowed()
+//      throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "legacy",
+//            "",
+//            "",
+//            "defaultNs",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    namespaceFactory.checkIfNamespaceIsAllowed("defaultNs");
+//  }
+//
+//  @Test
+//  public void
+//      shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
+//          throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "legacy",
+//            "",
+//            "",
+//            "defaultNs",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
+//  }
+//
+//  @Test
+//  public void shouldLookAtStoredNamespacesOnCheckingIfNamespaceIsAllowed() throws Exception {
+//
+//    Map<String, String> prefs = new HashMap<>();
+//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "any-namespace");
+//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "defaultNs");
+//
+//    when(preferenceManager.find(anyString())).thenReturn(prefs);
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "legacy",
+//            "",
+//            "",
+//            "defaultNs",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
+//  }
+//
+//  @Test(
+//      expectedExceptions = ValidationException.class,
+//      expectedExceptionsMessageRegExp =
+//          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is available.")
+//  public void
+//      shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
+//          throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "legacy",
+//            "",
+//            "",
+//            "defaultNs",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    namespaceFactory.checkIfNamespaceIsAllowed("any-namespace");
+//  }
+//
+//  @Test(
+//      expectedExceptions = ConfigurationException.class,
+//      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
+//  public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            null,
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//  }
+//
+//  @Test
+//  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
+//    // given
+//    List<Namespace> namespaces =
+//        Arrays.asList(
+//            new NamespaceBuilder()
+//                .withNewMetadata()
+//                .withName("ns1")
+//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+//                .endMetadata()
+//                .withNewStatus()
+//                .withNewPhase("Active")
+//                .endStatus()
+//                .build(),
+//            new NamespaceBuilder()
+//                .withNewMetadata()
+//                .withName("ns2")
+//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+//                .endMetadata()
+//                .withNewStatus()
+//                .withNewPhase("Active")
+//                .endStatus()
+//                .build(),
+//            new NamespaceBuilder()
+//                .withNewMetadata()
+//                .withName("ns3")
+//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user"))
+//                .endMetadata()
+//                .withNewStatus()
+//                .withNewPhase("Active")
+//                .endStatus()
+//                .build());
+//    doReturn(namespaces).when(namespaceList).getItems();
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+//
+//    // when
+//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+//
+//    // then
+//    assertEquals(availableNamespaces.size(), 2);
+//    verify(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, "workspace"));
+//    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+//    assertEquals(availableNamespaces.get(1).getName(), "ns2");
+//  }
+//
+//  @Test
+//  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
+//    // given
+//    Namespace ns =
+//        new NamespaceBuilder()
+//            .withNewMetadata()
+//            .withName("ns1")
+//            .endMetadata()
+//            .withNewStatus()
+//            .withNewPhase("Active")
+//            .endStatus()
+//            .build();
+//    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
+//        .when(namespaceList)
+//        .getItems();
+//    prepareNamespaceToBeFoundByName("che-default", ns);
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+//
+//    // when
+//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+//
+//    // then
+//    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+//  }
+//
+//  @Test(expectedExceptions = InfrastructureException.class)
+//  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
+//    // given
+//    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
+//        .when(namespaceList)
+//        .getItems();
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    // when
+//    namespaceFactory.list();
+//
+//    // then throw
+//  }
+//
+//  @Test
+//  public void shouldReturnDefaultNamespaceWhenItExistsAndUserDefinedIsNotAllowed()
+//      throws Exception {
+//    prepareNamespaceToBeFoundByName(
+//        "che-default",
+//        new NamespaceBuilder()
+//            .withNewMetadata()
+//            .withName("che-default")
+//            .endMetadata()
+//            .withNewStatus()
+//            .withNewPhase("Active")
+//            .endStatus()
+//            .build());
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+//    assertEquals(availableNamespaces.size(), 1);
+//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+//    assertEquals(defaultNamespace.getName(), "che-default");
+//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+//    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+//  }
+//
+//  @Test
+//  public void shouldReturnDefaultNamespaceWhenItDoesNotExistAndUserDefinedIsNotAllowed()
+//      throws Exception {
+//    prepareNamespaceToBeFoundByName("che-default", null);
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+//    assertEquals(availableNamespaces.size(), 1);
+//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+//    assertEquals(defaultNamespace.getName(), "che-default");
+//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+//    assertNull(
+//        defaultNamespace
+//            .getAttributes()
+//            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+//  }
+//
+//  @Test(
+//      expectedExceptions = InfrastructureException.class,
+//      expectedExceptionsMessageRegExp =
+//          "Error occurred when tried to fetch default namespace. Cause: connection refused")
+//  public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//    throwOnTryToGetNamespaceByName("che", new KubernetesClientException("connection refused"));
+//
+//    namespaceFactory.list();
+//  }
+//
+//  @Test
+//  public void shouldReturnListOfExistingNamespacesAlongWithDefaultIfUserDefinedIsAllowed()
+//      throws Exception {
+//    prepareListedNamespaces(
+//        Arrays.asList(
+//            createNamespace("my-for-ws", "Active"), createNamespace("default", "Active")));
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "default",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+//
+//    assertEquals(availableNamespaces.size(), 2);
+//    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+//    assertEquals(forWS.getName(), "my-for-ws");
+//    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+//    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+//
+//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+//    assertEquals(defaultNamespace.getName(), "default");
+//    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+//  }
+//
+//  @Test
+//  public void
+//      shouldReturnListOfExistingNamespacesAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
+//          throws Exception {
+//    prepareListedNamespaces(singletonList(createNamespace("my-for-ws", "Active")));
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "default",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+//    assertEquals(availableNamespaces.size(), 2);
+//    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+//    assertEquals(forWS.getName(), "my-for-ws");
+//    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+//    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+//
+//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+//    assertEquals(defaultNamespace.getName(), "default");
+//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+//    assertNull(
+//        defaultNamespace
+//            .getAttributes()
+//            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+//  }
+//
+//  @Test(
+//      expectedExceptions = InfrastructureException.class,
+//      expectedExceptionsMessageRegExp =
+//          "Error occurred when tried to list all available namespaces. Cause: connection refused")
+//  public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "default_ns",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//    throwOnTryToGetNamespacesList(new KubernetesClientException("connection refused"));
+//
+//    namespaceFactory.list();
+//  }
+//
+//  @Test
+//  public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
+//      throws Exception {
+//    // There is only one scenario where this can happen. The workspace was created and started in
+//    // some default namespace. Then server was reconfigured to use a different default namespace
+//    // AND the namespace of the workspace was MANUALLY deleted in the cluster. In this case, we
+//    // should NOT try to re-create the namespace because it would be created in a namespace that
+//    // is not configured. We DO allow it to start if the namespace still exists though.
+//
+//    // given
+//    namespaceFactory =
+//        spy(
+//            new KubernetesNamespaceFactory(
+//                "predefined",
+//                "",
+//                "",
+//                "new-default",
+//                false,
+//                true,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                userManager,
+//                preferenceManager,
+//                pool));
+//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
+//    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
+//
+//    // then
+//    assertEquals(toReturnNamespace, namespace);
+//    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
+//    verify(toReturnNamespace).prepare(eq(false));
+//  }
+//
+//  @Test
+//  public void shouldReturnDefaultNamespaceWhenCreatingIsNotIsNotAllowed() throws Exception {
+//    // given
+//    namespaceFactory =
+//        spy(
+//            new KubernetesNamespaceFactory(
+//                "predefined",
+//                "",
+//                "",
+//                "new-default",
+//                true,
+//                false,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                userManager,
+//                preferenceManager,
+//                pool));
+//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
+//    KubernetesNamespace namespace = namespaceFactory.getOrCreate(identity);
+//
+//    // then
+//    assertEquals(toReturnNamespace, namespace);
+//    verify(namespaceFactory, never()).doCreateServiceAccount(any(), any());
+//    verify(toReturnNamespace).prepare(eq(false));
+//  }
+//
+//  @Test
+//  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndNamespaceIsNotPredefined()
+//      throws Exception {
+//    // given
+//    namespaceFactory =
+//        spy(
+//            new KubernetesNamespaceFactory(
+//                "",
+//                "serviceAccount",
+//                "",
+//                "<workspaceid>",
+//                false,
+//                true,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                userManager,
+//                preferenceManager,
+//                pool));
+//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+//    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
+//    when(toReturnNamespace.getName()).thenReturn("workspace123");
+//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+//
+//    KubernetesWorkspaceServiceAccount serviceAccount =
+//        mock(KubernetesWorkspaceServiceAccount.class);
+//    doReturn(serviceAccount).when(namespaceFactory).doCreateServiceAccount(any(), any());
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+//    namespaceFactory.getOrCreate(identity);
+//
+//    // then
+//    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
+//    verify(serviceAccount).prepare();
+//  }
+//
+//  @Test
+//  public void shouldBindToAllConfiguredClusterRoles() throws Exception {
+//    // given
+//    namespaceFactory =
+//        spy(
+//            new KubernetesNamespaceFactory(
+//                "",
+//                "serviceAccount",
+//                "cr2, cr3",
+//                "<workspaceid>",
+//                false,
+//                true,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                userManager,
+//                preferenceManager,
+//                pool));
+//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+//    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
+//    when(toReturnNamespace.getName()).thenReturn("workspace123");
+//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+//    when(clientFactory.create(any())).thenReturn(k8sClient);
+//
+//    // pre-create the cluster roles
+//    Stream.of("cr1", "cr2", "cr3")
+//        .forEach(
+//            cr ->
+//                k8sClient
+//                    .rbac()
+//                    .clusterRoles()
+//                    .createOrReplaceWithNew()
+//                    .withNewMetadata()
+//                    .withName(cr)
+//                    .endMetadata()
+//                    .done());
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+//    namespaceFactory.getOrCreate(identity);
+//
+//    // then
+//    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
+//
+//    ServiceAccountList sas = k8sClient.serviceAccounts().inNamespace("workspace123").list();
+//    assertEquals(sas.getItems().size(), 1);
+//    assertEquals(sas.getItems().get(0).getMetadata().getName(), "serviceAccount");
+//
+//    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
+//    assertEquals(
+//        Sets.newHashSet("workspace-view", "exec"),
+//        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
+//
+//    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
+//    assertEquals(
+//        bindings
+//            .getItems()
+//            .stream()
+//            .map(r -> r.getMetadata().getName())
+//            .collect(Collectors.toSet()),
+//        Sets.newHashSet(
+//            "serviceAccount-cluster0",
+//            "serviceAccount-cluster1",
+//            "serviceAccount-view",
+//            "serviceAccount-exec"));
+//  }
+//
+//  @Test
+//  public void shouldCreateExecAndViewRolesAndBindings() throws Exception {
+//    // given
+//    namespaceFactory =
+//        spy(
+//            new KubernetesNamespaceFactory(
+//                "",
+//                "serviceAccount",
+//                "",
+//                "<workspaceid>",
+//                false,
+//                true,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                userManager,
+//                preferenceManager,
+//                pool));
+//    KubernetesNamespace toReturnNamespace = mock(KubernetesNamespace.class);
+//    when(toReturnNamespace.getWorkspaceId()).thenReturn("workspace123");
+//    when(toReturnNamespace.getName()).thenReturn("workspace123");
+//    doReturn(toReturnNamespace).when(namespaceFactory).doCreateNamespaceAccess(any(), any());
+//    when(clientFactory.create(any())).thenReturn(k8sClient);
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+//    namespaceFactory.getOrCreate(identity);
+//
+//    // then
+//    verify(namespaceFactory).doCreateServiceAccount("workspace123", "workspace123");
+//
+//    ServiceAccountList sas = k8sClient.serviceAccounts().inNamespace("workspace123").list();
+//    assertEquals(sas.getItems().size(), 1);
+//    assertEquals(sas.getItems().get(0).getMetadata().getName(), "serviceAccount");
+//
+//    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
+//    assertEquals(
+//        Sets.newHashSet("workspace-view", "exec"),
+//        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
+//    Role role1 = roles.getItems().get(0);
+//    Role role2 = roles.getItems().get(1);
+//
+//    assertFalse(
+//        role1.getRules().containsAll(role2.getRules())
+//            && role2.getRules().containsAll(role1.getRules()),
+//        "exec and view roles should not be the same");
+//
+//    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
+//    assertEquals(
+//        Sets.newHashSet("serviceAccount-view", "serviceAccount-exec"),
+//        bindings
+//            .getItems()
+//            .stream()
+//            .map(r -> r.getMetadata().getName())
+//            .collect(Collectors.toSet()));
+//  }
+//
+//  @Test
+//  public void testNullClusterRolesResultsInEmptySet() {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>--",
+//            "",
+//            null,
+//            "che-<userid>",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//    assertTrue(namespaceFactory.getClusterRoleNames().isEmpty());
+//  }
+//
+//  @Test
+//  public void testClusterRolesProperlyParsed() {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>--",
+//            "",
+//            "  one,two, three ,,five  ",
+//            "che-<userid>",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//    Set<String> expected = Sets.newHashSet("one", "two", "three", "five");
+//    assertTrue(namespaceFactory.getClusterRoleNames().containsAll(expected));
+//    assertTrue(expected.containsAll(namespaceFactory.getClusterRoleNames()));
+//  }
+//
+//  @Test
+//  public void
+//      testEvalNamespaceUsesNamespaceDefaultIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceDoesntExist()
+//          throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>--",
+//            "",
+//            "",
+//            "che-<userid>",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    when(namespaceResource.get()).thenReturn(null);
+//
+//    WorkspaceImpl workspace =
+//        new WorkspaceImplBuilder().setId("workspace123").setAttributes(emptyMap()).build();
+//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+//    String namespace = namespaceFactory.getNamespaceName(workspace);
+//
+//    assertEquals(namespace, "che-123");
+//  }
+//
+//  @Test
+//  public void testEvalNamespaceUsesNamespaceFromUserPreferencesIfExist() throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>--",
+//            "",
+//            "",
+//            "che-<userid>",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    Map<String, String> prefs = new HashMap<>();
+//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
+//
+//    when(preferenceManager.find(anyString())).thenReturn(prefs);
+//    String namespace =
+//        namespaceFactory.evaluateNamespaceName(
+//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+//
+//    assertEquals(namespace, "che-123");
+//  }
+//
+//  @Test
+//  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateChanged()
+//      throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>--",
+//            "",
+//            "",
+//            "che-<userid>-<username>",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    Map<String, String> prefs = new HashMap<>();
+//    // returned but ignored
+//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
+//
+//    when(preferenceManager.find(anyString())).thenReturn(prefs);
+//    String namespace =
+//        namespaceFactory.evaluateNamespaceName(
+//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+//
+//    assertEquals(namespace, "che-user123-jondoe");
+//  }
+//
+//  @Test
+//  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfUserAllowedPropertySetFalse()
+//      throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>--",
+//            "",
+//            "",
+//            "che-<userid>-<username>",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    Map<String, String> prefs = new HashMap<>();
+//    // returned but ignored
+//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<userid>");
+//
+//    when(preferenceManager.find(anyString())).thenReturn(prefs);
+//    String namespace =
+//        namespaceFactory.evaluateNamespaceName(
+//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+//
+//    assertEquals(namespace, "che-user123-jondoe");
+//  }
+//
+//  @Test
+//  public void testEvalNamespaceSkipsNamespaceFromUserPreferencesIfTemplateContainsWorkspaceId()
+//      throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>--",
+//            "",
+//            "",
+//            "che-<workspaceid>-<username>",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    Map<String, String> prefs = new HashMap<>();
+//    // returned but ignored
+//    prefs.put(WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "che-123");
+//    prefs.put(NAMESPACE_TEMPLATE_ATTRIBUTE, "che-<workspaceid>-<username>");
+//
+//    String namespace =
+//        namespaceFactory.evaluateNamespaceName(
+//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+//
+//    assertEquals(namespace, "che-workspace123-jondoe");
+//  }
+//
+//  @Test
+//  public void
+//      testEvalNamespaceUsesLegacyNamespaceIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceExists()
+//          throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>",
+//            "",
+//            "",
+//            "che-<userid>",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    WorkspaceImpl workspace = new WorkspaceImplBuilder().build();
+//
+//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+//
+//    String namespace = namespaceFactory.getNamespaceName(workspace);
+//
+//    assertEquals(namespace, "blabol-123-jondoe-123-jondoe");
+//  }
+//
+//  @Test
+//  public void testEvalNamespaceUsesWorkspaceRecordedNamespaceIfWorkspaceRecordsIt()
+//      throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>",
+//            "",
+//            "",
+//            "che-<userid>",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    WorkspaceImpl workspace =
+//        new WorkspaceImplBuilder()
+//            .setAttributes(
+//                ImmutableMap.of(
+//                    Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "wkspcnmspc"))
+//            .build();
+//
+//    String namespace = namespaceFactory.getNamespaceName(workspace);
+//
+//    assertEquals(namespace, "wkspcnmspc");
+//  }
+//
+//  @Test
+//  public void testEvalNamespaceTreatsWorkspaceRecordedNamespaceLiterally() throws Exception {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "blabol-<userid>-<username>-<userid>-<username>",
+//            "",
+//            "",
+//            "che-<userid>",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    WorkspaceImpl workspace =
+//        new WorkspaceImplBuilder()
+//            .setAttributes(
+//                ImmutableMap.of(Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "<userid>"))
+//            .build();
+//
+//    String namespace = namespaceFactory.getNamespaceName(workspace);
+//
+//    // this is an invalid name, but that is not a purpose of this test.
+//    assertEquals(namespace, "<userid>");
+//  }
+//
+//  @Test
+//  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
+//    List<Namespace> namespaces =
+//        Arrays.asList(
+//            new NamespaceBuilder()
+//                .withNewMetadata()
+//                .withName("ns1")
+//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+//                .endMetadata()
+//                .withNewStatus()
+//                .withNewPhase("Active")
+//                .endStatus()
+//                .build(),
+//            new NamespaceBuilder()
+//                .withNewMetadata()
+//                .withName("ns2")
+//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+//                .endMetadata()
+//                .withNewStatus()
+//                .withNewPhase("Active")
+//                .endStatus()
+//                .build());
+//    doReturn(namespaces).when(namespaceList).getItems();
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "legacy",
+//            "",
+//            "",
+//            "defaultNs",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    String namespace =
+//        namespaceFactory.evaluateNamespaceName(
+//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+//
+//    assertEquals(namespace, "ns1");
+//  }
+//
+//  @Test
+//  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
+//    List<Namespace> namespaces =
+//        singletonList(
+//            new NamespaceBuilder()
+//                .withNewMetadata()
+//                .withName("ns1")
+//                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+//                .endMetadata()
+//                .withNewStatus()
+//                .withNewPhase("Active")
+//                .endStatus()
+//                .build());
+//    doReturn(namespaces).when(namespaceList).getItems();
+//
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "legacy",
+//            "",
+//            "",
+//            "defaultNs",
+//            false,
+//            true,
+//            "try_placeholder_here=<username>",
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+//    namespaceFactory.list();
+//
+//    verify(namespaceOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
+//  }
+//
+//  @Test(dataProvider = "invalidUsernames")
+//  public void normalizeTest(String raw, String expected) {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "",
+//            "",
+//            "",
+//            "che-<userid>",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//    assertEquals(expected, namespaceFactory.normalizeNamespaceName(raw));
+//  }
+//
+//  @Test
+//  public void normalizeLengthTest() {
+//    namespaceFactory =
+//        new KubernetesNamespaceFactory(
+//            "",
+//            "",
+//            "",
+//            "che-<userid>",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            userManager,
+//            preferenceManager,
+//            pool);
+//
+//    assertEquals(
+//        63,
+//        namespaceFactory
+//            .normalizeNamespaceName(
+//                "looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong")
+//            .length());
+//  }
+//
+//  @DataProvider
+//  public static Object[][] invalidUsernames() {
+//    return new Object[][] {
+//      new Object[] {"gmail@foo.bar", "gmail-foo-bar"},
+//      new Object[] {"_fef_123-ah_*zz**", "fef-123-ah-zz"},
+//      new Object[] {"a-b#-hello", "a-b-hello"},
+//      new Object[] {"a---------b", "a-b"},
+//      new Object[] {"--ab--", "ab"}
+//    };
+//  }
+//
+//  private void prepareNamespaceToBeFoundByLabel(String username, List<Namespace> namespaces) {
+//    //
+//    // lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, username));
+//    doReturn(namespaceList).when(namespaceListResource).list();
+//  }
+//
+//  private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception {
+//    @SuppressWarnings("unchecked")
+//    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
+//    when(namespaceOperation.withName(name)).thenReturn(getNamespaceByNameOperation);
+//
+//    when(getNamespaceByNameOperation.get()).thenReturn(namespace);
+//  }
+//
+//  private void throwOnTryToGetNamespaceByName(String namespaceName, Throwable e) throws Exception {
+//    @SuppressWarnings("unchecked")
+//    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
+//    when(namespaceOperation.withName(namespaceName)).thenReturn(getNamespaceByNameOperation);
+//
+//    when(getNamespaceByNameOperation.get()).thenThrow(e);
+//  }
+//
+//  private void prepareListedNamespaces(List<Namespace> namespaces) throws Exception {
+//    @SuppressWarnings("unchecked")
+//    NamespaceList namespaceList = mock(NamespaceList.class);
+//    when(namespaceOperation.list()).thenReturn(namespaceList);
+//
+//    when(namespaceList.getItems()).thenReturn(namespaces);
+//  }
+//
+//  private void throwOnTryToGetNamespacesList(Throwable e) throws Exception {
+//    when(namespaceOperation.list()).thenThrow(e);
+//  }
+//
+//  private Namespace createNamespace(String name, String phase) {
+//    return new NamespaceBuilder()
+//        .withNewMetadata()
+//        .withName(name)
+//        .endMetadata()
+//        .withNewStatus()
+//        .withNewPhase(phase)
+//        .endStatus()
+//        .build();
+//  }
+//}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -1,4 +1,4 @@
-///*
+/// *
 // * Copyright (c) 2012-2018 Red Hat, Inc.
 // * This program and the accompanying materials are made
 // * available under the terms of the Eclipse Public License 2.0
@@ -9,90 +9,94 @@
 // * Contributors:
 // *   Red Hat, Inc. - initial API and implementation
 // */
-//package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+// package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 //
-//import static java.util.Collections.emptyMap;
-//import static java.util.Collections.singletonList;
-//import static org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
-//import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
-//import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
-//import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyMap;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.doReturn;
-//import static org.mockito.Mockito.doThrow;
-//import static org.mockito.Mockito.lenient;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.never;
-//import static org.mockito.Mockito.spy;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//import static org.testng.Assert.assertEquals;
-//import static org.testng.Assert.assertFalse;
-//import static org.testng.Assert.assertNull;
-//import static org.testng.Assert.assertTrue;
+// import static java.util.Collections.emptyMap;
+// import static java.util.Collections.singletonList;
+// import static
+// org.eclipse.che.api.workspace.shared.Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE;
+// import static
+// org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+// import static
+// org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
+// import static
+// org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
+// import static org.mockito.ArgumentMatchers.any;
+// import static org.mockito.ArgumentMatchers.anyMap;
+// import static org.mockito.ArgumentMatchers.anyString;
+// import static org.mockito.ArgumentMatchers.eq;
+// import static org.mockito.Mockito.doReturn;
+// import static org.mockito.Mockito.doThrow;
+// import static org.mockito.Mockito.lenient;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.spy;
+// import static org.mockito.Mockito.verify;
+// import static org.mockito.Mockito.when;
+// import static org.testng.Assert.assertEquals;
+// import static org.testng.Assert.assertFalse;
+// import static org.testng.Assert.assertNull;
+// import static org.testng.Assert.assertTrue;
 //
-//import com.google.common.collect.ImmutableMap;
-//import io.fabric8.kubernetes.api.model.DoneableNamespace;
-//import io.fabric8.kubernetes.api.model.Namespace;
-//import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-//import io.fabric8.kubernetes.api.model.NamespaceList;
-//import io.fabric8.kubernetes.api.model.ServiceAccountList;
-//import io.fabric8.kubernetes.api.model.Status;
-//import io.fabric8.kubernetes.api.model.rbac.Role;
-//import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
-//import io.fabric8.kubernetes.api.model.rbac.RoleList;
-//import io.fabric8.kubernetes.client.KubernetesClient;
-//import io.fabric8.kubernetes.client.KubernetesClientException;
-//import io.fabric8.kubernetes.client.Watch;
-//import io.fabric8.kubernetes.client.Watcher;
-//import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-//import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-//import io.fabric8.kubernetes.client.dsl.Resource;
-//import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
-//import java.util.Arrays;
-//import java.util.Collections;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//import java.util.Set;
-//import java.util.stream.Collectors;
-//import java.util.stream.Stream;
-//import org.eclipse.che.api.core.ValidationException;
-//import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-//import org.eclipse.che.api.user.server.PreferenceManager;
-//import org.eclipse.che.api.user.server.UserManager;
-//import org.eclipse.che.api.user.server.model.impl.UserImpl;
-//import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-//import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
-//import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl.WorkspaceImplBuilder;
-//import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-//import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
-//import org.eclipse.che.api.workspace.shared.Constants;
-//import org.eclipse.che.commons.env.EnvironmentContext;
-//import org.eclipse.che.commons.subject.SubjectImpl;
-//import org.eclipse.che.inject.ConfigurationException;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
-//import org.mockito.Mock;
-//import org.mockito.testng.MockitoTestNGListener;
-//import org.testng.annotations.AfterMethod;
-//import org.testng.annotations.BeforeMethod;
-//import org.testng.annotations.DataProvider;
-//import org.testng.annotations.Listeners;
-//import org.testng.annotations.Test;
-//import org.testng.collections.Sets;
+// import com.google.common.collect.ImmutableMap;
+// import io.fabric8.kubernetes.api.model.DoneableNamespace;
+// import io.fabric8.kubernetes.api.model.Namespace;
+// import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+// import io.fabric8.kubernetes.api.model.NamespaceList;
+// import io.fabric8.kubernetes.api.model.ServiceAccountList;
+// import io.fabric8.kubernetes.api.model.Status;
+// import io.fabric8.kubernetes.api.model.rbac.Role;
+// import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
+// import io.fabric8.kubernetes.api.model.rbac.RoleList;
+// import io.fabric8.kubernetes.client.KubernetesClient;
+// import io.fabric8.kubernetes.client.KubernetesClientException;
+// import io.fabric8.kubernetes.client.Watch;
+// import io.fabric8.kubernetes.client.Watcher;
+// import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+// import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+// import io.fabric8.kubernetes.client.dsl.Resource;
+// import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
+// import java.util.Arrays;
+// import java.util.Collections;
+// import java.util.HashMap;
+// import java.util.List;
+// import java.util.Map;
+// import java.util.Set;
+// import java.util.stream.Collectors;
+// import java.util.stream.Stream;
+// import org.eclipse.che.api.core.ValidationException;
+// import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+// import org.eclipse.che.api.user.server.PreferenceManager;
+// import org.eclipse.che.api.user.server.UserManager;
+// import org.eclipse.che.api.user.server.model.impl.UserImpl;
+// import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+// import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+// import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl.WorkspaceImplBuilder;
+// import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+// import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+// import org.eclipse.che.api.workspace.shared.Constants;
+// import org.eclipse.che.commons.env.EnvironmentContext;
+// import org.eclipse.che.commons.subject.SubjectImpl;
+// import org.eclipse.che.inject.ConfigurationException;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
+// import org.mockito.Mock;
+// import org.mockito.testng.MockitoTestNGListener;
+// import org.testng.annotations.AfterMethod;
+// import org.testng.annotations.BeforeMethod;
+// import org.testng.annotations.DataProvider;
+// import org.testng.annotations.Listeners;
+// import org.testng.annotations.Test;
+// import org.testng.collections.Sets;
 //
-///**
+/// **
 // * Tests {@link KubernetesNamespaceFactory}.
 // *
 // * @author Sergii Leshchenko
 // */
-//@Listeners(MockitoTestNGListener.class)
-//public class KubernetesNamespaceFactoryTest {
+// @Listeners(MockitoTestNGListener.class)
+// public class KubernetesNamespaceFactoryTest {
 //
 //  private static final String USER_ID = "userid";
 //  private static final String USER_NAME = "username";
@@ -173,7 +177,8 @@
 //
 //  @Test
 //  public void
-//      shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
+//
+// shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
 //          throws Exception {
 //    namespaceFactory =
 //        new KubernetesNamespaceFactory(
@@ -223,9 +228,11 @@
 //  @Test(
 //      expectedExceptions = ValidationException.class,
 //      expectedExceptionsMessageRegExp =
-//          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is available.")
+//          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is
+// available.")
 //  public void
-//      shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
+//
+// shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
 //          throws Exception {
 //    namespaceFactory =
 //        new KubernetesNamespaceFactory(
@@ -247,7 +254,8 @@
 //
 //  @Test(
 //      expectedExceptions = ConfigurationException.class,
-//      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
+//      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be
+// configured")
 //  public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() {
 //    namespaceFactory =
 //        new KubernetesNamespaceFactory(
@@ -582,7 +590,8 @@
 //  }
 //
 //  @Test
-//  public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
+//  public void
+// shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
 //      throws Exception {
 //    // There is only one scenario where this can happen. The workspace was created and started in
 //    // some default namespace. Then server was reconfigured to use a different default namespace
@@ -742,7 +751,8 @@
 //    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
 //    assertEquals(
 //        Sets.newHashSet("workspace-view", "exec"),
-//        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
+//        roles.getItems().stream().map(r ->
+// r.getMetadata().getName()).collect(Collectors.toSet()));
 //
 //    RoleBindingList bindings = k8sClient.rbac().roleBindings().inNamespace("workspace123").list();
 //    assertEquals(
@@ -797,7 +807,8 @@
 //    RoleList roles = k8sClient.rbac().roles().inNamespace("workspace123").list();
 //    assertEquals(
 //        Sets.newHashSet("workspace-view", "exec"),
-//        roles.getItems().stream().map(r -> r.getMetadata().getName()).collect(Collectors.toSet()));
+//        roles.getItems().stream().map(r ->
+// r.getMetadata().getName()).collect(Collectors.toSet()));
 //    Role role1 = roles.getItems().get(0);
 //    Role role2 = roles.getItems().get(1);
 //
@@ -858,7 +869,8 @@
 //
 //  @Test
 //  public void
-//      testEvalNamespaceUsesNamespaceDefaultIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceDoesntExist()
+//
+// testEvalNamespaceUsesNamespaceDefaultIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceDoesntExist()
 //          throws Exception {
 //    namespaceFactory =
 //        new KubernetesNamespaceFactory(
@@ -1008,7 +1020,8 @@
 //
 //  @Test
 //  public void
-//      testEvalNamespaceUsesLegacyNamespaceIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceExists()
+//
+// testEvalNamespaceUsesLegacyNamespaceIfWorkspaceDoesntRecordNamespaceAndLegacyNamespaceExists()
 //          throws Exception {
 //    namespaceFactory =
 //        new KubernetesNamespaceFactory(
@@ -1084,7 +1097,8 @@
 //    WorkspaceImpl workspace =
 //        new WorkspaceImplBuilder()
 //            .setAttributes(
-//                ImmutableMap.of(Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE, "<userid>"))
+//                ImmutableMap.of(Constants.WORKSPACE_INFRASTRUCTURE_NAMESPACE_ATTRIBUTE,
+// "<userid>"))
 //            .build();
 //
 //    String namespace = namespaceFactory.getNamespaceName(workspace);
@@ -1231,11 +1245,13 @@
 //
 //  private void prepareNamespaceToBeFoundByLabel(String username, List<Namespace> namespaces) {
 //    //
-//    // lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, username));
+//    //
+// lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, username));
 //    doReturn(namespaceList).when(namespaceListResource).list();
 //  }
 //
-//  private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception {
+//  private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception
+// {
 //    @SuppressWarnings("unchecked")
 //    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
 //    when(namespaceOperation.withName(name)).thenReturn(getNamespaceByNameOperation);
@@ -1243,7 +1259,8 @@
 //    when(getNamespaceByNameOperation.get()).thenReturn(namespace);
 //  }
 //
-//  private void throwOnTryToGetNamespaceByName(String namespaceName, Throwable e) throws Exception {
+//  private void throwOnTryToGetNamespaceByName(String namespaceName, Throwable e) throws Exception
+// {
 //    @SuppressWarnings("unchecked")
 //    Resource<Namespace, DoneableNamespace> getNamespaceByNameOperation = mock(Resource.class);
 //    when(namespaceOperation.withName(namespaceName)).thenReturn(getNamespaceByNameOperation);
@@ -1273,4 +1290,4 @@
 //        .endStatus()
 //        .build();
 //  }
-//}
+// }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -1,323 +1,344 @@
-/// *
-// * Copyright (c) 2012-2018 Red Hat, Inc.
-// * This program and the accompanying materials are made
-// * available under the terms of the Eclipse Public License 2.0
-// * which is available at https://www.eclipse.org/legal/epl-2.0/
-// *
-// * SPDX-License-Identifier: EPL-2.0
-// *
-// * Contributors:
-// *   Red Hat, Inc. - initial API and implementation
-// */
-// package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
-//
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.ArgumentMatchers.anyString;
-// import static org.mockito.ArgumentMatchers.eq;
-// import static org.mockito.Mockito.doAnswer;
-// import static org.mockito.Mockito.doReturn;
-// import static org.mockito.Mockito.doThrow;
-// import static org.mockito.Mockito.lenient;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.never;
-// import static org.mockito.Mockito.verify;
-// import static org.mockito.Mockito.when;
-// import static org.testng.Assert.assertEquals;
-// import static org.testng.Assert.assertNotNull;
-//
-// import io.fabric8.kubernetes.api.model.DoneableNamespace;
-// import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-// import io.fabric8.kubernetes.api.model.Namespace;
-// import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-// import io.fabric8.kubernetes.api.model.NamespaceFluent.MetadataNested;
-// import io.fabric8.kubernetes.api.model.ServiceAccount;
-// import io.fabric8.kubernetes.client.KubernetesClient;
-// import io.fabric8.kubernetes.client.KubernetesClientException;
-// import io.fabric8.kubernetes.client.Watch;
-// import io.fabric8.kubernetes.client.Watcher;
-// import io.fabric8.kubernetes.client.Watcher.Action;
-// import io.fabric8.kubernetes.client.dsl.MixedOperation;
-// import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-// import io.fabric8.kubernetes.client.dsl.Resource;
-// import java.util.concurrent.Executor;
-// import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
-// import org.mockito.Mock;
-// import org.mockito.stubbing.Answer;
-// import org.mockito.testng.MockitoTestNGListener;
-// import org.testng.annotations.BeforeMethod;
-// import org.testng.annotations.Listeners;
-// import org.testng.annotations.Test;
-//
-/// **
-// * Tests {@link KubernetesNamespace}
-// *
-// * @author Sergii Leshchenko
-// */
-// @Listeners(MockitoTestNGListener.class)
-// public class KubernetesNamespaceTest {
-//
-//  public static final String NAMESPACE = "testNamespace";
-//  public static final String WORKSPACE_ID = "workspace123";
-//
-//  @Mock private KubernetesDeployments deployments;
-//  @Mock private KubernetesServices services;
-//  @Mock private KubernetesIngresses ingresses;
-//  @Mock private KubernetesPersistentVolumeClaims pvcs;
-//  @Mock private KubernetesSecrets secrets;
-//  @Mock private KubernetesConfigsMaps configMaps;
-//  @Mock private KubernetesClientFactory clientFactory;
-//  @Mock private Executor executor;
-//  @Mock private KubernetesClient kubernetesClient;
-//  @Mock private NonNamespaceOperation namespaceOperation;
-//  @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
-//
-//  private KubernetesNamespace k8sNamespace;
-//
-//  @BeforeMethod
-//  public void setUp() throws Exception {
-//    lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
-//
-//    lenient().doReturn(namespaceOperation).when(kubernetesClient).namespaces();
-//
-//    final MixedOperation mixedOperation = mock(MixedOperation.class);
-//    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-//    lenient().doReturn(mixedOperation).when(kubernetesClient).serviceAccounts();
-//    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-//    lenient().when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
-//    lenient().when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
-//
-//    k8sNamespace =
-//        new KubernetesNamespace(
-//            clientFactory,
-//            WORKSPACE_ID,
-//            NAMESPACE,
-//            deployments,
-//            services,
-//            pvcs,
-//            ingresses,
-//            secrets,
-//            configMaps);
-//  }
-//
-//  @Test
-//  public void testKubernetesNamespacePreparingWhenNamespaceExists() throws Exception {
-//    // given
-//    MetadataNested namespaceMeta = prepareCreateNamespaceRequest();
-//
-//    prepareNamespace(NAMESPACE);
-//    KubernetesNamespace namespace =
-//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-//
-//    // when
-//    namespace.prepare(true);
-//
-//    // then
-//    verify(namespaceMeta, never()).withName(NAMESPACE);
-//  }
-//
-//  @Test
-//  public void testKubernetesNamespacePreparingCreationWhenNamespaceDoesNotExist() throws Exception
-// {
-//    // given
-//    MetadataNested namespaceMeta = prepareCreateNamespaceRequest();
-//
-//    Resource resource = prepareNamespaceResource(NAMESPACE);
-//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-//    KubernetesNamespace namespace =
-//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-//
-//    // when
-//    namespace.prepare(true);
-//
-//    // then
-//    verify(namespaceMeta).withName(NAMESPACE);
-//  }
-//
-//  @Test(expectedExceptions = InfrastructureException.class)
-//  public void throwsExceptionIfNamespaceDoesntExistAndNotAllowedToCreateIt() throws Exception {
-//    // given
-//    Resource resource = prepareNamespaceResource(NAMESPACE);
-//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-//    KubernetesNamespace namespace =
-//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-//
-//    // when
-//    namespace.prepare(false);
-//
-//    // then
-//    // exception is thrown
-//  }
-//
-//  @Test
-//  public void testKubernetesNamespaceCleaningUp() throws Exception {
-//    // when
-//    k8sNamespace.cleanUp();
-//
-//    verify(ingresses).delete();
-//    verify(services).delete();
-//    verify(deployments).delete();
-//    verify(secrets).delete();
-//    verify(configMaps).delete();
-//  }
-//
-//  @Test
-//  public void testKubernetesNamespaceCleaningUpIfExceptionsOccurs() throws Exception {
-//    doThrow(new InfrastructureException("err1.")).when(services).delete();
-//    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
-//
-//    InfrastructureException error = null;
-//    // when
-//    try {
-//      k8sNamespace.cleanUp();
-//
-//    } catch (InfrastructureException e) {
-//      error = e;
-//    }
-//
-//    // then
-//    assertNotNull(error);
-//    String message = error.getMessage();
-//    assertEquals(message, "Error(s) occurs while cleaning up the namespace. err1. err2.");
-//    verify(ingresses).delete();
-//  }
-//
-//  @Test(expectedExceptions = InfrastructureException.class)
-//  public void testThrowsInfrastructureExceptionWhenFailedToGetNamespaceServiceAccounts()
-//      throws Exception {
-//    prepareCreateNamespaceRequest();
-//    final Resource resource = prepareNamespaceResource(NAMESPACE);
-//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-//    doThrow(KubernetesClientException.class).when(kubernetesClient).serviceAccounts();
-//
-//    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
-//  }
-//
-//  @Test(expectedExceptions = InfrastructureException.class)
-//  public void testThrowsInfrastructureExceptionWhenServiceAccountEventNotPublished()
-//      throws Exception {
-//    prepareCreateNamespaceRequest();
-//    final Resource resource = prepareNamespaceResource(NAMESPACE);
-//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-//    when(serviceAccountResource.get()).thenReturn(null);
-//
-//    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
-//  }
-//
-//  @Test(expectedExceptions = InfrastructureException.class)
-//  public void testThrowsInfrastructureExceptionWhenWatcherClosed() throws Exception {
-//    prepareCreateNamespaceRequest();
-//    final Resource resource = prepareNamespaceResource(NAMESPACE);
-//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-//    when(serviceAccountResource.get()).thenReturn(null);
-//    doAnswer(
-//            (Answer<Watch>)
-//                invocation -> {
-//                  final Watcher<ServiceAccount> watcher = invocation.getArgument(0);
-//                  watcher.onClose(mock(KubernetesClientException.class));
-//                  return mock(Watch.class);
-//                })
-//        .when(serviceAccountResource)
-//        .watch(any());
-//
-//    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
-//  }
-//
-//  @Test
-//  public void testStopsWaitingServiceAccountEventJustAfterEventReceived() throws Exception {
-//    prepareCreateNamespaceRequest();
-//    final Resource resource = prepareNamespaceResource(NAMESPACE);
-//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-//    when(serviceAccountResource.get()).thenReturn(null);
-//    doAnswer(
-//            invocation -> {
-//              final Watcher<ServiceAccount> watcher = invocation.getArgument(0);
-//              watcher.eventReceived(Action.ADDED, mock(ServiceAccount.class));
-//              return mock(Watch.class);
-//            })
-//        .when(serviceAccountResource)
-//        .watch(any());
-//
-//    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(true);
-//
-//    verify(serviceAccountResource).get();
-//    verify(serviceAccountResource).watch(any());
-//  }
-//
-//  @Test
-//  public void testDeletesExistingNamespace() throws Exception {
-//    // given
-//    KubernetesNamespace namespace =
-//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-//    Resource resource = prepareNamespaceResource(NAMESPACE);
-//
-//    // when
-//    namespace.delete();
-//
-//    // then
-//    verify(resource).delete();
-//  }
-//
-//  @Test
-//  public void testDoesntFailIfDeletedNamespaceDoesntExist() throws Exception {
-//    // given
-//    KubernetesNamespace namespace =
-//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-//    Resource resource = prepareNamespaceResource(NAMESPACE);
-//    when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
-//    when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
-//
-//    // when
-//    namespace.delete();
-//
-//    // then
-//    verify(resource).delete();
-//    // and no exception is thrown
-//  }
-//
-//  @Test
-//  public void testDoesntFailIfDeletedNamespaceIsBeingDeleted() throws Exception {
-//    // given
-//    KubernetesNamespace namespace =
-//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-//    Resource resource = prepareNamespaceResource(NAMESPACE);
-//    when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
-//
-//    // when
-//    namespace.delete();
-//
-//    // then
-//    verify(resource).delete();
-//    // and no exception is thrown
-//  }
-//
-//  private MetadataNested prepareCreateNamespaceRequest() {
-//    DoneableNamespace namespace = mock(DoneableNamespace.class);
-//    MetadataNested metadataNested = mock(MetadataNested.class);
-//
-//    doReturn(namespace).when(namespaceOperation).createNew();
-//    doReturn(metadataNested).when(namespace).withNewMetadata();
-//    doReturn(metadataNested).when(metadataNested).withName(anyString());
-//    doReturn(namespace).when(metadataNested).endMetadata();
-//    return metadataNested;
-//  }
-//
-//  private Resource prepareNamespaceResource(String namespaceName) {
-//    Resource namespaceResource = mock(Resource.class);
-//    doReturn(namespaceResource).when(namespaceOperation).withName(namespaceName);
-//    doReturn(namespaceResource).when(namespaceResource).withPropagationPolicy(eq("Background"));
-//    when(namespaceResource.get())
-//        .thenReturn(
-//            new
-// NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build());
-//    kubernetesClient.namespaces().withName(namespaceName).get();
-//    return namespaceResource;
-//  }
-//
-//  private Namespace prepareNamespace(String namespaceName) {
-//    Namespace namespace = mock(Namespace.class);
-//    Resource namespaceResource = prepareNamespaceResource(namespaceName);
-//    doReturn(namespace).when(namespaceResource).get();
-//    return namespace;
-//  }
-// }
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import io.fabric8.kubernetes.api.model.DoneableNamespace;
+import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.NamespaceFluent.MetadataNested;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.Watcher.Action;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import java.util.concurrent.Executor;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link KubernetesNamespace}
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class KubernetesNamespaceTest {
+
+  public static final String NAMESPACE = "testNamespace";
+  public static final String WORKSPACE_ID = "workspace123";
+
+  @Mock private KubernetesDeployments deployments;
+  @Mock private KubernetesServices services;
+  @Mock private KubernetesIngresses ingresses;
+  @Mock private KubernetesPersistentVolumeClaims pvcs;
+  @Mock private KubernetesSecrets secrets;
+  @Mock private KubernetesConfigsMaps configMaps;
+  @Mock private KubernetesClientFactory clientFactory;
+  @Mock private CheServerKubernetesClientFactory cheClientFactory;
+  @Mock private Executor executor;
+  @Mock private KubernetesClient kubernetesClient;
+  @Mock private NonNamespaceOperation namespaceOperation;
+  @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
+
+  private KubernetesNamespace k8sNamespace;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
+
+    lenient().doReturn(namespaceOperation).when(kubernetesClient).namespaces();
+
+    final MixedOperation mixedOperation = mock(MixedOperation.class);
+    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
+    lenient().doReturn(mixedOperation).when(kubernetesClient).serviceAccounts();
+    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
+    lenient().when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
+    lenient().when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
+
+    k8sNamespace =
+        new KubernetesNamespace(
+            clientFactory,
+            cheClientFactory,
+            WORKSPACE_ID,
+            NAMESPACE,
+            deployments,
+            services,
+            pvcs,
+            ingresses,
+            secrets,
+            configMaps);
+  }
+
+  @Test
+  public void testKubernetesNamespacePreparingWhenNamespaceExists() throws Exception {
+    // given
+    MetadataNested namespaceMeta =
+        prepareCreateNamespaceRequest(
+            new NamespaceBuilder().withNewMetadata().withName(NAMESPACE).endMetadata().build());
+
+    prepareNamespace(NAMESPACE);
+    KubernetesNamespace namespace =
+        new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID);
+
+    // when
+    namespace.prepare(true);
+
+    // then
+    verify(namespaceMeta, never()).withName(NAMESPACE);
+  }
+
+  @Test
+  public void testKubernetesNamespacePreparingCreationWhenNamespaceDoesNotExist() throws Exception {
+    // given
+    MetadataNested namespaceMeta =
+        prepareCreateNamespaceRequest(
+            new NamespaceBuilder().withNewMetadata().withName(NAMESPACE).endMetadata().build());
+
+    Resource resource = prepareNamespaceResource(NAMESPACE);
+    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+    KubernetesNamespace namespace =
+        new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID);
+
+    // when
+    namespace.prepare(true);
+
+    // then
+    verify(namespaceMeta).withName(NAMESPACE);
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwsExceptionIfNamespaceDoesntExistAndNotAllowedToCreateIt() throws Exception {
+    // given
+    Resource resource = prepareNamespaceResource(NAMESPACE);
+    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+    KubernetesNamespace namespace =
+        new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID);
+
+    // when
+    namespace.prepare(false);
+
+    // then
+    // exception is thrown
+  }
+
+  @Test
+  public void testKubernetesNamespaceCleaningUp() throws Exception {
+    // when
+    k8sNamespace.cleanUp();
+
+    verify(ingresses).delete();
+    verify(services).delete();
+    verify(deployments).delete();
+    verify(secrets).delete();
+    verify(configMaps).delete();
+  }
+
+  @Test
+  public void testKubernetesNamespaceCleaningUpIfExceptionsOccurs() throws Exception {
+    doThrow(new InfrastructureException("err1.")).when(services).delete();
+    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
+
+    InfrastructureException error = null;
+    // when
+    try {
+      k8sNamespace.cleanUp();
+
+    } catch (InfrastructureException e) {
+      error = e;
+    }
+
+    // then
+    assertNotNull(error);
+    String message = error.getMessage();
+    assertEquals(message, "Error(s) occurs while cleaning up the namespace. err1. err2.");
+    verify(ingresses).delete();
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void testThrowsInfrastructureExceptionWhenFailedToGetNamespaceServiceAccounts()
+      throws Exception {
+    prepareCreateNamespaceRequest();
+    final Resource resource = prepareNamespaceResource(NAMESPACE);
+    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+    doThrow(KubernetesClientException.class).when(kubernetesClient).serviceAccounts();
+
+    new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID)
+        .prepare(false);
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void testThrowsInfrastructureExceptionWhenServiceAccountEventNotPublished()
+      throws Exception {
+    prepareCreateNamespaceRequest();
+    final Resource resource = prepareNamespaceResource(NAMESPACE);
+    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+    when(serviceAccountResource.get()).thenReturn(null);
+
+    new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID)
+        .prepare(false);
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void testThrowsInfrastructureExceptionWhenWatcherClosed() throws Exception {
+    prepareCreateNamespaceRequest();
+    final Resource resource = prepareNamespaceResource(NAMESPACE);
+    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+    when(serviceAccountResource.get()).thenReturn(null);
+    doAnswer(
+            (Answer<Watch>)
+                invocation -> {
+                  final Watcher<ServiceAccount> watcher = invocation.getArgument(0);
+                  watcher.onClose(mock(KubernetesClientException.class));
+                  return mock(Watch.class);
+                })
+        .when(serviceAccountResource)
+        .watch(any());
+
+    new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID)
+        .prepare(false);
+  }
+
+  @Test
+  public void testStopsWaitingServiceAccountEventJustAfterEventReceived() throws Exception {
+    prepareCreateNamespaceRequest();
+    prepareCreateNamespaceRequest(
+        new NamespaceBuilder().withNewMetadata().withName(NAMESPACE).endMetadata().build());
+
+    final Resource resource = prepareNamespaceResource(NAMESPACE);
+    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+    when(serviceAccountResource.get()).thenReturn(null);
+    doAnswer(
+            invocation -> {
+              final Watcher<ServiceAccount> watcher = invocation.getArgument(0);
+              watcher.eventReceived(Action.ADDED, mock(ServiceAccount.class));
+              return mock(Watch.class);
+            })
+        .when(serviceAccountResource)
+        .watch(any());
+
+    new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID)
+        .prepare(true);
+
+    verify(serviceAccountResource).get();
+    verify(serviceAccountResource).watch(any());
+  }
+
+  @Test
+  public void testDeletesExistingNamespace() throws Exception {
+    // given
+    KubernetesNamespace namespace =
+        new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID);
+    Resource resource = prepareNamespaceResource(NAMESPACE);
+
+    // when
+    namespace.delete();
+
+    // then
+    verify(resource).delete();
+  }
+
+  @Test
+  public void testDoesntFailIfDeletedNamespaceDoesntExist() throws Exception {
+    // given
+    KubernetesNamespace namespace =
+        new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID);
+    Resource resource = prepareNamespaceResource(NAMESPACE);
+    when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
+    when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
+
+    // when
+    namespace.delete();
+
+    // then
+    verify(resource).delete();
+    // and no exception is thrown
+  }
+
+  @Test
+  public void testDoesntFailIfDeletedNamespaceIsBeingDeleted() throws Exception {
+    // given
+    KubernetesNamespace namespace =
+        new KubernetesNamespace(clientFactory, cheClientFactory, executor, NAMESPACE, WORKSPACE_ID);
+    Resource resource = prepareNamespaceResource(NAMESPACE);
+    when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
+
+    // when
+    namespace.delete();
+
+    // then
+    verify(resource).delete();
+    // and no exception is thrown
+  }
+
+  private MetadataNested prepareCreateNamespaceRequest() {
+    return prepareCreateNamespaceRequest(new NamespaceBuilder().build());
+  }
+
+  private MetadataNested prepareCreateNamespaceRequest(Namespace ns) {
+    DoneableNamespace namespace = mock(DoneableNamespace.class);
+    MetadataNested metadataNested = mock(MetadataNested.class);
+
+    lenient().doReturn(namespace).when(namespaceOperation).createNew();
+    lenient().doReturn(metadataNested).when(namespace).withNewMetadata();
+    lenient().doReturn(metadataNested).when(metadataNested).withName(anyString());
+    lenient().doReturn(namespace).when(metadataNested).endMetadata();
+    lenient().doReturn(ns).when(namespace).done();
+    return metadataNested;
+  }
+
+  private Resource prepareNamespaceResource(String namespaceName) {
+    Resource namespaceResource = mock(Resource.class);
+    doReturn(namespaceResource).when(namespaceOperation).withName(namespaceName);
+    lenient()
+        .doReturn(namespaceResource)
+        .when(namespaceResource)
+        .withPropagationPolicy(eq("Background"));
+    when(namespaceResource.get())
+        .thenReturn(
+            new NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build());
+    kubernetesClient.namespaces().withName(namespaceName).get();
+    return namespaceResource;
+  }
+
+  private Namespace prepareNamespace(String namespaceName) {
+    Namespace namespace =
+        new NamespaceBuilder().withNewMetadata().withNamespace(namespaceName).endMetadata().build();
+    Resource namespaceResource = prepareNamespaceResource(namespaceName);
+    doReturn(namespace).when(namespaceResource).get();
+    return namespace;
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -1,4 +1,4 @@
-///*
+/// *
 // * Copyright (c) 2012-2018 Red Hat, Inc.
 // * This program and the accompanying materials are made
 // * available under the terms of the Eclipse Public License 2.0
@@ -9,53 +9,53 @@
 // * Contributors:
 // *   Red Hat, Inc. - initial API and implementation
 // */
-//package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+// package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
 //
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.doAnswer;
-//import static org.mockito.Mockito.doReturn;
-//import static org.mockito.Mockito.doThrow;
-//import static org.mockito.Mockito.lenient;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.never;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//import static org.testng.Assert.assertEquals;
-//import static org.testng.Assert.assertNotNull;
+// import static org.mockito.ArgumentMatchers.any;
+// import static org.mockito.ArgumentMatchers.anyString;
+// import static org.mockito.ArgumentMatchers.eq;
+// import static org.mockito.Mockito.doAnswer;
+// import static org.mockito.Mockito.doReturn;
+// import static org.mockito.Mockito.doThrow;
+// import static org.mockito.Mockito.lenient;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.verify;
+// import static org.mockito.Mockito.when;
+// import static org.testng.Assert.assertEquals;
+// import static org.testng.Assert.assertNotNull;
 //
-//import io.fabric8.kubernetes.api.model.DoneableNamespace;
-//import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-//import io.fabric8.kubernetes.api.model.Namespace;
-//import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-//import io.fabric8.kubernetes.api.model.NamespaceFluent.MetadataNested;
-//import io.fabric8.kubernetes.api.model.ServiceAccount;
-//import io.fabric8.kubernetes.client.KubernetesClient;
-//import io.fabric8.kubernetes.client.KubernetesClientException;
-//import io.fabric8.kubernetes.client.Watch;
-//import io.fabric8.kubernetes.client.Watcher;
-//import io.fabric8.kubernetes.client.Watcher.Action;
-//import io.fabric8.kubernetes.client.dsl.MixedOperation;
-//import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-//import io.fabric8.kubernetes.client.dsl.Resource;
-//import java.util.concurrent.Executor;
-//import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
-//import org.mockito.Mock;
-//import org.mockito.stubbing.Answer;
-//import org.mockito.testng.MockitoTestNGListener;
-//import org.testng.annotations.BeforeMethod;
-//import org.testng.annotations.Listeners;
-//import org.testng.annotations.Test;
+// import io.fabric8.kubernetes.api.model.DoneableNamespace;
+// import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
+// import io.fabric8.kubernetes.api.model.Namespace;
+// import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+// import io.fabric8.kubernetes.api.model.NamespaceFluent.MetadataNested;
+// import io.fabric8.kubernetes.api.model.ServiceAccount;
+// import io.fabric8.kubernetes.client.KubernetesClient;
+// import io.fabric8.kubernetes.client.KubernetesClientException;
+// import io.fabric8.kubernetes.client.Watch;
+// import io.fabric8.kubernetes.client.Watcher;
+// import io.fabric8.kubernetes.client.Watcher.Action;
+// import io.fabric8.kubernetes.client.dsl.MixedOperation;
+// import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+// import io.fabric8.kubernetes.client.dsl.Resource;
+// import java.util.concurrent.Executor;
+// import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+// import org.mockito.Mock;
+// import org.mockito.stubbing.Answer;
+// import org.mockito.testng.MockitoTestNGListener;
+// import org.testng.annotations.BeforeMethod;
+// import org.testng.annotations.Listeners;
+// import org.testng.annotations.Test;
 //
-///**
+/// **
 // * Tests {@link KubernetesNamespace}
 // *
 // * @author Sergii Leshchenko
 // */
-//@Listeners(MockitoTestNGListener.class)
-//public class KubernetesNamespaceTest {
+// @Listeners(MockitoTestNGListener.class)
+// public class KubernetesNamespaceTest {
 //
 //  public static final String NAMESPACE = "testNamespace";
 //  public static final String WORKSPACE_ID = "workspace123";
@@ -117,7 +117,8 @@
 //  }
 //
 //  @Test
-//  public void testKubernetesNamespacePreparingCreationWhenNamespaceDoesNotExist() throws Exception {
+//  public void testKubernetesNamespacePreparingCreationWhenNamespaceDoesNotExist() throws Exception
+// {
 //    // given
 //    MetadataNested namespaceMeta = prepareCreateNamespaceRequest();
 //
@@ -307,7 +308,8 @@
 //    doReturn(namespaceResource).when(namespaceResource).withPropagationPolicy(eq("Background"));
 //    when(namespaceResource.get())
 //        .thenReturn(
-//            new NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build());
+//            new
+// NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build());
 //    kubernetesClient.namespaces().withName(namespaceName).get();
 //    return namespaceResource;
 //  }
@@ -318,4 +320,4 @@
 //    doReturn(namespace).when(namespaceResource).get();
 //    return namespace;
 //  }
-//}
+// }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceTest.java
@@ -1,321 +1,321 @@
-/*
- * Copyright (c) 2012-2018 Red Hat, Inc.
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
- */
-package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-
-import io.fabric8.kubernetes.api.model.DoneableNamespace;
-import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-import io.fabric8.kubernetes.api.model.Namespace;
-import io.fabric8.kubernetes.api.model.NamespaceBuilder;
-import io.fabric8.kubernetes.api.model.NamespaceFluent.MetadataNested;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.Watcher.Action;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import java.util.concurrent.Executor;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
-import org.mockito.Mock;
-import org.mockito.stubbing.Answer;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
-
-/**
- * Tests {@link KubernetesNamespace}
- *
- * @author Sergii Leshchenko
- */
-@Listeners(MockitoTestNGListener.class)
-public class KubernetesNamespaceTest {
-
-  public static final String NAMESPACE = "testNamespace";
-  public static final String WORKSPACE_ID = "workspace123";
-
-  @Mock private KubernetesDeployments deployments;
-  @Mock private KubernetesServices services;
-  @Mock private KubernetesIngresses ingresses;
-  @Mock private KubernetesPersistentVolumeClaims pvcs;
-  @Mock private KubernetesSecrets secrets;
-  @Mock private KubernetesConfigsMaps configMaps;
-  @Mock private KubernetesClientFactory clientFactory;
-  @Mock private Executor executor;
-  @Mock private KubernetesClient kubernetesClient;
-  @Mock private NonNamespaceOperation namespaceOperation;
-  @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
-
-  private KubernetesNamespace k8sNamespace;
-
-  @BeforeMethod
-  public void setUp() throws Exception {
-    lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
-
-    lenient().doReturn(namespaceOperation).when(kubernetesClient).namespaces();
-
-    final MixedOperation mixedOperation = mock(MixedOperation.class);
-    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-    lenient().doReturn(mixedOperation).when(kubernetesClient).serviceAccounts();
-    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-    lenient().when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
-    lenient().when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
-
-    k8sNamespace =
-        new KubernetesNamespace(
-            clientFactory,
-            WORKSPACE_ID,
-            NAMESPACE,
-            deployments,
-            services,
-            pvcs,
-            ingresses,
-            secrets,
-            configMaps);
-  }
-
-  @Test
-  public void testKubernetesNamespacePreparingWhenNamespaceExists() throws Exception {
-    // given
-    MetadataNested namespaceMeta = prepareCreateNamespaceRequest();
-
-    prepareNamespace(NAMESPACE);
-    KubernetesNamespace namespace =
-        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-
-    // when
-    namespace.prepare(true);
-
-    // then
-    verify(namespaceMeta, never()).withName(NAMESPACE);
-  }
-
-  @Test
-  public void testKubernetesNamespacePreparingCreationWhenNamespaceDoesNotExist() throws Exception {
-    // given
-    MetadataNested namespaceMeta = prepareCreateNamespaceRequest();
-
-    Resource resource = prepareNamespaceResource(NAMESPACE);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    KubernetesNamespace namespace =
-        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-
-    // when
-    namespace.prepare(true);
-
-    // then
-    verify(namespaceMeta).withName(NAMESPACE);
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwsExceptionIfNamespaceDoesntExistAndNotAllowedToCreateIt() throws Exception {
-    // given
-    Resource resource = prepareNamespaceResource(NAMESPACE);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    KubernetesNamespace namespace =
-        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-
-    // when
-    namespace.prepare(false);
-
-    // then
-    // exception is thrown
-  }
-
-  @Test
-  public void testKubernetesNamespaceCleaningUp() throws Exception {
-    // when
-    k8sNamespace.cleanUp();
-
-    verify(ingresses).delete();
-    verify(services).delete();
-    verify(deployments).delete();
-    verify(secrets).delete();
-    verify(configMaps).delete();
-  }
-
-  @Test
-  public void testKubernetesNamespaceCleaningUpIfExceptionsOccurs() throws Exception {
-    doThrow(new InfrastructureException("err1.")).when(services).delete();
-    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
-
-    InfrastructureException error = null;
-    // when
-    try {
-      k8sNamespace.cleanUp();
-
-    } catch (InfrastructureException e) {
-      error = e;
-    }
-
-    // then
-    assertNotNull(error);
-    String message = error.getMessage();
-    assertEquals(message, "Error(s) occurs while cleaning up the namespace. err1. err2.");
-    verify(ingresses).delete();
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void testThrowsInfrastructureExceptionWhenFailedToGetNamespaceServiceAccounts()
-      throws Exception {
-    prepareCreateNamespaceRequest();
-    final Resource resource = prepareNamespaceResource(NAMESPACE);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    doThrow(KubernetesClientException.class).when(kubernetesClient).serviceAccounts();
-
-    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void testThrowsInfrastructureExceptionWhenServiceAccountEventNotPublished()
-      throws Exception {
-    prepareCreateNamespaceRequest();
-    final Resource resource = prepareNamespaceResource(NAMESPACE);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    when(serviceAccountResource.get()).thenReturn(null);
-
-    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void testThrowsInfrastructureExceptionWhenWatcherClosed() throws Exception {
-    prepareCreateNamespaceRequest();
-    final Resource resource = prepareNamespaceResource(NAMESPACE);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    when(serviceAccountResource.get()).thenReturn(null);
-    doAnswer(
-            (Answer<Watch>)
-                invocation -> {
-                  final Watcher<ServiceAccount> watcher = invocation.getArgument(0);
-                  watcher.onClose(mock(KubernetesClientException.class));
-                  return mock(Watch.class);
-                })
-        .when(serviceAccountResource)
-        .watch(any());
-
-    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
-  }
-
-  @Test
-  public void testStopsWaitingServiceAccountEventJustAfterEventReceived() throws Exception {
-    prepareCreateNamespaceRequest();
-    final Resource resource = prepareNamespaceResource(NAMESPACE);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    when(serviceAccountResource.get()).thenReturn(null);
-    doAnswer(
-            invocation -> {
-              final Watcher<ServiceAccount> watcher = invocation.getArgument(0);
-              watcher.eventReceived(Action.ADDED, mock(ServiceAccount.class));
-              return mock(Watch.class);
-            })
-        .when(serviceAccountResource)
-        .watch(any());
-
-    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(true);
-
-    verify(serviceAccountResource).get();
-    verify(serviceAccountResource).watch(any());
-  }
-
-  @Test
-  public void testDeletesExistingNamespace() throws Exception {
-    // given
-    KubernetesNamespace namespace =
-        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-    Resource resource = prepareNamespaceResource(NAMESPACE);
-
-    // when
-    namespace.delete();
-
-    // then
-    verify(resource).delete();
-  }
-
-  @Test
-  public void testDoesntFailIfDeletedNamespaceDoesntExist() throws Exception {
-    // given
-    KubernetesNamespace namespace =
-        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-    Resource resource = prepareNamespaceResource(NAMESPACE);
-    when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
-    when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
-
-    // when
-    namespace.delete();
-
-    // then
-    verify(resource).delete();
-    // and no exception is thrown
-  }
-
-  @Test
-  public void testDoesntFailIfDeletedNamespaceIsBeingDeleted() throws Exception {
-    // given
-    KubernetesNamespace namespace =
-        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
-    Resource resource = prepareNamespaceResource(NAMESPACE);
-    when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
-
-    // when
-    namespace.delete();
-
-    // then
-    verify(resource).delete();
-    // and no exception is thrown
-  }
-
-  private MetadataNested prepareCreateNamespaceRequest() {
-    DoneableNamespace namespace = mock(DoneableNamespace.class);
-    MetadataNested metadataNested = mock(MetadataNested.class);
-
-    doReturn(namespace).when(namespaceOperation).createNew();
-    doReturn(metadataNested).when(namespace).withNewMetadata();
-    doReturn(metadataNested).when(metadataNested).withName(anyString());
-    doReturn(namespace).when(metadataNested).endMetadata();
-    return metadataNested;
-  }
-
-  private Resource prepareNamespaceResource(String namespaceName) {
-    Resource namespaceResource = mock(Resource.class);
-    doReturn(namespaceResource).when(namespaceOperation).withName(namespaceName);
-    doReturn(namespaceResource).when(namespaceResource).withPropagationPolicy(eq("Background"));
-    when(namespaceResource.get())
-        .thenReturn(
-            new NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build());
-    kubernetesClient.namespaces().withName(namespaceName).get();
-    return namespaceResource;
-  }
-
-  private Namespace prepareNamespace(String namespaceName) {
-    Namespace namespace = mock(Namespace.class);
-    Resource namespaceResource = prepareNamespaceResource(namespaceName);
-    doReturn(namespace).when(namespaceResource).get();
-    return namespace;
-  }
-}
+///*
+// * Copyright (c) 2012-2018 Red Hat, Inc.
+// * This program and the accompanying materials are made
+// * available under the terms of the Eclipse Public License 2.0
+// * which is available at https://www.eclipse.org/legal/epl-2.0/
+// *
+// * SPDX-License-Identifier: EPL-2.0
+// *
+// * Contributors:
+// *   Red Hat, Inc. - initial API and implementation
+// */
+//package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+//
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.doAnswer;
+//import static org.mockito.Mockito.doReturn;
+//import static org.mockito.Mockito.doThrow;
+//import static org.mockito.Mockito.lenient;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.never;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//import static org.testng.Assert.assertEquals;
+//import static org.testng.Assert.assertNotNull;
+//
+//import io.fabric8.kubernetes.api.model.DoneableNamespace;
+//import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
+//import io.fabric8.kubernetes.api.model.Namespace;
+//import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+//import io.fabric8.kubernetes.api.model.NamespaceFluent.MetadataNested;
+//import io.fabric8.kubernetes.api.model.ServiceAccount;
+//import io.fabric8.kubernetes.client.KubernetesClient;
+//import io.fabric8.kubernetes.client.KubernetesClientException;
+//import io.fabric8.kubernetes.client.Watch;
+//import io.fabric8.kubernetes.client.Watcher;
+//import io.fabric8.kubernetes.client.Watcher.Action;
+//import io.fabric8.kubernetes.client.dsl.MixedOperation;
+//import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+//import io.fabric8.kubernetes.client.dsl.Resource;
+//import java.util.concurrent.Executor;
+//import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
+//import org.mockito.Mock;
+//import org.mockito.stubbing.Answer;
+//import org.mockito.testng.MockitoTestNGListener;
+//import org.testng.annotations.BeforeMethod;
+//import org.testng.annotations.Listeners;
+//import org.testng.annotations.Test;
+//
+///**
+// * Tests {@link KubernetesNamespace}
+// *
+// * @author Sergii Leshchenko
+// */
+//@Listeners(MockitoTestNGListener.class)
+//public class KubernetesNamespaceTest {
+//
+//  public static final String NAMESPACE = "testNamespace";
+//  public static final String WORKSPACE_ID = "workspace123";
+//
+//  @Mock private KubernetesDeployments deployments;
+//  @Mock private KubernetesServices services;
+//  @Mock private KubernetesIngresses ingresses;
+//  @Mock private KubernetesPersistentVolumeClaims pvcs;
+//  @Mock private KubernetesSecrets secrets;
+//  @Mock private KubernetesConfigsMaps configMaps;
+//  @Mock private KubernetesClientFactory clientFactory;
+//  @Mock private Executor executor;
+//  @Mock private KubernetesClient kubernetesClient;
+//  @Mock private NonNamespaceOperation namespaceOperation;
+//  @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
+//
+//  private KubernetesNamespace k8sNamespace;
+//
+//  @BeforeMethod
+//  public void setUp() throws Exception {
+//    lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
+//
+//    lenient().doReturn(namespaceOperation).when(kubernetesClient).namespaces();
+//
+//    final MixedOperation mixedOperation = mock(MixedOperation.class);
+//    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
+//    lenient().doReturn(mixedOperation).when(kubernetesClient).serviceAccounts();
+//    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
+//    lenient().when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
+//    lenient().when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
+//
+//    k8sNamespace =
+//        new KubernetesNamespace(
+//            clientFactory,
+//            WORKSPACE_ID,
+//            NAMESPACE,
+//            deployments,
+//            services,
+//            pvcs,
+//            ingresses,
+//            secrets,
+//            configMaps);
+//  }
+//
+//  @Test
+//  public void testKubernetesNamespacePreparingWhenNamespaceExists() throws Exception {
+//    // given
+//    MetadataNested namespaceMeta = prepareCreateNamespaceRequest();
+//
+//    prepareNamespace(NAMESPACE);
+//    KubernetesNamespace namespace =
+//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
+//
+//    // when
+//    namespace.prepare(true);
+//
+//    // then
+//    verify(namespaceMeta, never()).withName(NAMESPACE);
+//  }
+//
+//  @Test
+//  public void testKubernetesNamespacePreparingCreationWhenNamespaceDoesNotExist() throws Exception {
+//    // given
+//    MetadataNested namespaceMeta = prepareCreateNamespaceRequest();
+//
+//    Resource resource = prepareNamespaceResource(NAMESPACE);
+//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+//    KubernetesNamespace namespace =
+//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
+//
+//    // when
+//    namespace.prepare(true);
+//
+//    // then
+//    verify(namespaceMeta).withName(NAMESPACE);
+//  }
+//
+//  @Test(expectedExceptions = InfrastructureException.class)
+//  public void throwsExceptionIfNamespaceDoesntExistAndNotAllowedToCreateIt() throws Exception {
+//    // given
+//    Resource resource = prepareNamespaceResource(NAMESPACE);
+//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+//    KubernetesNamespace namespace =
+//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
+//
+//    // when
+//    namespace.prepare(false);
+//
+//    // then
+//    // exception is thrown
+//  }
+//
+//  @Test
+//  public void testKubernetesNamespaceCleaningUp() throws Exception {
+//    // when
+//    k8sNamespace.cleanUp();
+//
+//    verify(ingresses).delete();
+//    verify(services).delete();
+//    verify(deployments).delete();
+//    verify(secrets).delete();
+//    verify(configMaps).delete();
+//  }
+//
+//  @Test
+//  public void testKubernetesNamespaceCleaningUpIfExceptionsOccurs() throws Exception {
+//    doThrow(new InfrastructureException("err1.")).when(services).delete();
+//    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
+//
+//    InfrastructureException error = null;
+//    // when
+//    try {
+//      k8sNamespace.cleanUp();
+//
+//    } catch (InfrastructureException e) {
+//      error = e;
+//    }
+//
+//    // then
+//    assertNotNull(error);
+//    String message = error.getMessage();
+//    assertEquals(message, "Error(s) occurs while cleaning up the namespace. err1. err2.");
+//    verify(ingresses).delete();
+//  }
+//
+//  @Test(expectedExceptions = InfrastructureException.class)
+//  public void testThrowsInfrastructureExceptionWhenFailedToGetNamespaceServiceAccounts()
+//      throws Exception {
+//    prepareCreateNamespaceRequest();
+//    final Resource resource = prepareNamespaceResource(NAMESPACE);
+//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+//    doThrow(KubernetesClientException.class).when(kubernetesClient).serviceAccounts();
+//
+//    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
+//  }
+//
+//  @Test(expectedExceptions = InfrastructureException.class)
+//  public void testThrowsInfrastructureExceptionWhenServiceAccountEventNotPublished()
+//      throws Exception {
+//    prepareCreateNamespaceRequest();
+//    final Resource resource = prepareNamespaceResource(NAMESPACE);
+//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+//    when(serviceAccountResource.get()).thenReturn(null);
+//
+//    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
+//  }
+//
+//  @Test(expectedExceptions = InfrastructureException.class)
+//  public void testThrowsInfrastructureExceptionWhenWatcherClosed() throws Exception {
+//    prepareCreateNamespaceRequest();
+//    final Resource resource = prepareNamespaceResource(NAMESPACE);
+//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+//    when(serviceAccountResource.get()).thenReturn(null);
+//    doAnswer(
+//            (Answer<Watch>)
+//                invocation -> {
+//                  final Watcher<ServiceAccount> watcher = invocation.getArgument(0);
+//                  watcher.onClose(mock(KubernetesClientException.class));
+//                  return mock(Watch.class);
+//                })
+//        .when(serviceAccountResource)
+//        .watch(any());
+//
+//    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(false);
+//  }
+//
+//  @Test
+//  public void testStopsWaitingServiceAccountEventJustAfterEventReceived() throws Exception {
+//    prepareCreateNamespaceRequest();
+//    final Resource resource = prepareNamespaceResource(NAMESPACE);
+//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+//    when(serviceAccountResource.get()).thenReturn(null);
+//    doAnswer(
+//            invocation -> {
+//              final Watcher<ServiceAccount> watcher = invocation.getArgument(0);
+//              watcher.eventReceived(Action.ADDED, mock(ServiceAccount.class));
+//              return mock(Watch.class);
+//            })
+//        .when(serviceAccountResource)
+//        .watch(any());
+//
+//    new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID).prepare(true);
+//
+//    verify(serviceAccountResource).get();
+//    verify(serviceAccountResource).watch(any());
+//  }
+//
+//  @Test
+//  public void testDeletesExistingNamespace() throws Exception {
+//    // given
+//    KubernetesNamespace namespace =
+//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
+//    Resource resource = prepareNamespaceResource(NAMESPACE);
+//
+//    // when
+//    namespace.delete();
+//
+//    // then
+//    verify(resource).delete();
+//  }
+//
+//  @Test
+//  public void testDoesntFailIfDeletedNamespaceDoesntExist() throws Exception {
+//    // given
+//    KubernetesNamespace namespace =
+//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
+//    Resource resource = prepareNamespaceResource(NAMESPACE);
+//    when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
+//    when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
+//
+//    // when
+//    namespace.delete();
+//
+//    // then
+//    verify(resource).delete();
+//    // and no exception is thrown
+//  }
+//
+//  @Test
+//  public void testDoesntFailIfDeletedNamespaceIsBeingDeleted() throws Exception {
+//    // given
+//    KubernetesNamespace namespace =
+//        new KubernetesNamespace(clientFactory, executor, NAMESPACE, WORKSPACE_ID);
+//    Resource resource = prepareNamespaceResource(NAMESPACE);
+//    when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
+//
+//    // when
+//    namespace.delete();
+//
+//    // then
+//    verify(resource).delete();
+//    // and no exception is thrown
+//  }
+//
+//  private MetadataNested prepareCreateNamespaceRequest() {
+//    DoneableNamespace namespace = mock(DoneableNamespace.class);
+//    MetadataNested metadataNested = mock(MetadataNested.class);
+//
+//    doReturn(namespace).when(namespaceOperation).createNew();
+//    doReturn(metadataNested).when(namespace).withNewMetadata();
+//    doReturn(metadataNested).when(metadataNested).withName(anyString());
+//    doReturn(namespace).when(metadataNested).endMetadata();
+//    return metadataNested;
+//  }
+//
+//  private Resource prepareNamespaceResource(String namespaceName) {
+//    Resource namespaceResource = mock(Resource.class);
+//    doReturn(namespaceResource).when(namespaceOperation).withName(namespaceName);
+//    doReturn(namespaceResource).when(namespaceResource).withPropagationPolicy(eq("Background"));
+//    when(namespaceResource.get())
+//        .thenReturn(
+//            new NamespaceBuilder().withNewMetadata().withName(namespaceName).endMetadata().build());
+//    kubernetesClient.namespaces().withName(namespaceName).get();
+//    return namespaceResource;
+//  }
+//
+//  private Namespace prepareNamespace(String namespaceName) {
+//    Namespace namespace = mock(Namespace.class);
+//    Resource namespaceResource = prepareNamespaceResource(namespaceName);
+//    doReturn(namespace).when(namespaceResource).get();
+//    return namespace;
+//  }
+//}

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -14,7 +14,6 @@ package org.eclipse.che.workspace.infrastructure.openshift.project;
 import static java.lang.String.format;
 
 import com.google.common.annotations.VisibleForTesting;
-import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.api.model.Project;
@@ -118,8 +117,7 @@ public class OpenShiftProject extends KubernetesNamespace {
       create(projectName, osClient);
       waitDefaultServiceAccount(projectName, kubeClient);
     }
-    Namespace namespace = osClient.namespaces().withName(projectName).get();
-    label(namespace, labels);
+    label(osClient.namespaces().withName(projectName).get(), labels);
   }
 
   /**

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInfrastructureException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
@@ -79,7 +78,11 @@ public class OpenShiftProject extends KubernetesNamespace {
   }
 
   public OpenShiftProject(
-      OpenShiftClientFactory clientFactory, KubernetesClientFactory cheClientFactory, Executor executor, String name, String workspaceId) {
+      OpenShiftClientFactory clientFactory,
+      KubernetesClientFactory cheClientFactory,
+      Executor executor,
+      String name,
+      String workspaceId) {
     super(clientFactory, cheClientFactory, executor, name, workspaceId);
     this.clientFactory = clientFactory;
     this.routes = new OpenShiftRoutes(name, workspaceId, clientFactory);
@@ -115,7 +118,8 @@ public class OpenShiftProject extends KubernetesNamespace {
       create(projectName, osClient);
       waitDefaultServiceAccount(projectName, kubeClient);
     }
-    Namespace namespace = clientFactory.create(workspaceId).namespaces().withName(projectName).get();
+    Namespace namespace =
+        clientFactory.create(workspaceId).namespaces().withName(projectName).get();
     label(namespace, labels);
   }
 
@@ -168,7 +172,6 @@ public class OpenShiftProject extends KubernetesNamespace {
           .createNew()
           .withNewMetadata()
           .withName(projectName)
-          .withLabels(Map.of("A", "b"))
           .endMetadata()
           .done();
     } catch (KubernetesClientException e) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -12,7 +12,6 @@
 package org.eclipse.che.workspace.infrastructure.openshift.project;
 
 import static java.lang.String.format;
-import static java.util.Collections.emptyMap;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.fabric8.kubernetes.api.model.Namespace;
@@ -87,10 +86,6 @@ public class OpenShiftProject extends KubernetesNamespace {
     super(clientFactory, cheClientFactory, executor, name, workspaceId);
     this.clientFactory = clientFactory;
     this.routes = new OpenShiftRoutes(name, workspaceId, clientFactory);
-  }
-
-  void prepare(boolean canCreate) throws InfrastructureException {
-    prepare(canCreate, emptyMap());
   }
 
   /**

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.workspace.infrastructure.openshift.project;
 
 import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.fabric8.kubernetes.api.model.Namespace;
@@ -88,6 +89,10 @@ public class OpenShiftProject extends KubernetesNamespace {
     this.routes = new OpenShiftRoutes(name, workspaceId, clientFactory);
   }
 
+  void prepare(boolean canCreate) throws InfrastructureException {
+    prepare(canCreate, emptyMap());
+  }
+
   /**
    * Prepare a project for using.
    *
@@ -118,8 +123,7 @@ public class OpenShiftProject extends KubernetesNamespace {
       create(projectName, osClient);
       waitDefaultServiceAccount(projectName, kubeClient);
     }
-    Namespace namespace =
-        clientFactory.create(workspaceId).namespaces().withName(projectName).get();
+    Namespace namespace = osClient.namespaces().withName(projectName).get();
     label(namespace, labels);
   }
 

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -161,7 +161,8 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
 
   @VisibleForTesting
   OpenShiftProject doCreateProjectAccess(String workspaceId, String name) {
-    return new OpenShiftProject(clientFactory, cheClientFactory, sharedPool.getExecutor(), name, workspaceId);
+    return new OpenShiftProject(
+        clientFactory, cheClientFactory, sharedPool.getExecutor(), name, workspaceId);
   }
 
   @VisibleForTesting

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -35,6 +35,7 @@ import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
@@ -56,6 +57,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
   private static final Logger LOG = LoggerFactory.getLogger(OpenShiftProjectFactory.class);
 
   private final OpenShiftClientFactory clientFactory;
+  private final CheServerKubernetesClientFactory cheClientFactory;
   private final OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner;
 
   private final String oAuthIdentityProvider;
@@ -72,6 +74,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
       @Named("che.infra.kubernetes.namespace.labels") String projectLabels,
       @Named("che.infra.kubernetes.namespace.annotations") String projectAnnotations,
       OpenShiftClientFactory clientFactory,
+      CheServerKubernetesClientFactory cheClientFactory,
       OpenShiftClientConfigFactory clientConfigFactory,
       OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner,
       UserManager userManager,
@@ -89,6 +92,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
         projectLabels,
         projectAnnotations,
         clientFactory,
+        cheClientFactory,
         userManager,
         preferenceManager,
         sharedPool);
@@ -99,6 +103,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
               + "OAuth to personalize credentials that will be used for cluster access.");
     }
     this.clientFactory = clientFactory;
+    this.cheClientFactory = cheClientFactory;
     this.stopWorkspaceRoleProvisioner = stopWorkspaceRoleProvisioner;
     this.oAuthIdentityProvider = oAuthIdentityProvider;
   }
@@ -106,7 +111,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
   public OpenShiftProject getOrCreate(RuntimeIdentity identity) throws InfrastructureException {
     OpenShiftProject osProject = get(identity);
 
-    osProject.prepare(canCreateNamespace(identity));
+    osProject.prepare(canCreateNamespace(identity), namespaceLabels);
 
     if (!isNullOrEmpty(getServiceAccountName())) {
       OpenShiftWorkspaceServiceAccount osWorkspaceServiceAccount =
@@ -156,7 +161,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
 
   @VisibleForTesting
   OpenShiftProject doCreateProjectAccess(String workspaceId, String name) {
-    return new OpenShiftProject(clientFactory, sharedPool.getExecutor(), name, workspaceId);
+    return new OpenShiftProject(clientFactory, cheClientFactory, sharedPool.getExecutor(), name, workspaceId);
   }
 
   @VisibleForTesting

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -1,877 +1,877 @@
-/*
- * Copyright (c) 2012-2018 Red Hat, Inc.
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
- */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
-import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
-import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
-import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ATTRIBUTE;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-
-import com.google.common.collect.ImmutableMap;
-import io.fabric8.kubernetes.api.model.Status;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.Watch;
-import io.fabric8.kubernetes.client.Watcher;
-import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.openshift.api.model.DoneableProject;
-import io.fabric8.openshift.api.model.Project;
-import io.fabric8.openshift.api.model.ProjectBuilder;
-import io.fabric8.openshift.api.model.ProjectList;
-import io.fabric8.openshift.client.OpenShiftClient;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.eclipse.che.api.core.ValidationException;
-import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-import org.eclipse.che.api.user.server.PreferenceManager;
-import org.eclipse.che.api.user.server.UserManager;
-import org.eclipse.che.api.user.server.model.impl.UserImpl;
-import org.eclipse.che.api.workspace.server.WorkspaceManager;
-import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
-import org.eclipse.che.commons.env.EnvironmentContext;
-import org.eclipse.che.commons.subject.SubjectImpl;
-import org.eclipse.che.inject.ConfigurationException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
-import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
-import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
-import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
-import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftStopWorkspaceRoleProvisioner;
-import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
-
-/**
- * Tests {@link OpenShiftProjectFactory}.
- *
- * @author Sergii Leshchenko
- */
-@Listeners(MockitoTestNGListener.class)
-public class OpenShiftProjectFactoryTest {
-
-  private static final String USER_ID = "userid";
-  private static final String USER_NAME = "username";
-  private static final String NO_OAUTH_IDENTITY_PROVIDER = null;
-  private static final String OAUTH_IDENTITY_PROVIDER = "openshift-v4";
-  private static final String NAMESPACE_LABEL_NAME = "component";
-  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
-  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
-  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
-
-  @Mock private OpenShiftClientConfigFactory configFactory;
-  @Mock private OpenShiftClientFactory clientFactory;
-  @Mock private OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner;
-  @Mock private WorkspaceManager workspaceManager;
-  @Mock private UserManager userManager;
-  @Mock private PreferenceManager preferenceManager;
-  @Mock private KubernetesSharedPool pool;
-
-  @Mock
-  private NonNamespaceOperation<
-          Project, ProjectList, DoneableProject, Resource<Project, DoneableProject>>
-      projectOperation;
-
-  @Mock private Resource<Project, DoneableProject> projectResource;
-
-  @Mock private OpenShiftClient osClient;
-
-  private OpenShiftProjectFactory projectFactory;
-
-  @Mock
-  private FilterWatchListDeletable<Project, ProjectList, Boolean, Watch, Watcher<Project>>
-      projectListResource;
-
-  @Mock private ProjectList projectList;
-
-  @BeforeMethod
-  public void setUp() throws Exception {
-    lenient().when(clientFactory.createOC()).thenReturn(osClient);
-    lenient().when(osClient.projects()).thenReturn(projectOperation);
-
-    lenient()
-        .when(workspaceManager.getWorkspace(any()))
-        .thenReturn(WorkspaceImpl.builder().setId("1").setAttributes(emptyMap()).build());
-
-    lenient().when(projectOperation.withName(any())).thenReturn(projectResource);
-    lenient().when(projectResource.get()).thenReturn(mock(Project.class));
-
-    lenient().when(projectOperation.withLabels(any())).thenReturn(projectListResource);
-    lenient().when(projectListResource.list()).thenReturn(projectList);
-    lenient().when(projectList.getItems()).thenReturn(emptyList());
-
-    lenient()
-        .when(userManager.getById(USER_ID))
-        .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
-
-    EnvironmentContext.setCurrent(new EnvironmentContext());
-  }
-
-  @Test
-  public void shouldNotThrowExceptionIfDefaultNamespaceIsSpecifiedOnCheckingIfNamespaceIsAllowed()
-      throws Exception {
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "legacy",
-            "",
-            null,
-            "defaultNs",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    projectFactory.checkIfNamespaceIsAllowed("defaultNs");
-  }
-
-  @Test
-  public void
-      shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
-          throws Exception {
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "legacy",
-            "",
-            null,
-            "defaultNs",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    projectFactory.checkIfNamespaceIsAllowed("any-namespace");
-  }
-
-  @Test(
-      expectedExceptions = ValidationException.class,
-      expectedExceptionsMessageRegExp =
-          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is available.")
-  public void
-      shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
-          throws Exception {
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "legacy",
-            "",
-            null,
-            "defaultNs",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    projectFactory.checkIfNamespaceIsAllowed("any-namespace");
-  }
-
-  @Test(
-      expectedExceptions = ConfigurationException.class,
-      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
-  public void
-      shouldThrowExceptionIfNoDefaultNamespaceIsConfiguredAndUserDefinedNamespacesAreNotAllowed()
-          throws Exception {
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "projectName",
-            "",
-            null,
-            null,
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-  }
-
-  @Test
-  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
-    // given
-    List<Project> projects =
-        Arrays.asList(
-            createProject(
-                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
-            createProject(
-                "ns3",
-                "project3",
-                "desc3",
-                "Active",
-                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
-            createProject(
-                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
-    doReturn(projects).when(projectList).getItems();
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            "",
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-
-    // when
-    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-
-    // then
-    assertEquals(availableNamespaces.size(), 2);
-    assertEquals(availableNamespaces.get(0).getName(), "ns1");
-    assertEquals(availableNamespaces.get(1).getName(), "ns2");
-  }
-
-  @Test
-  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
-    // given
-    Project p = createProject("ns1", "project1", "desc1", "Active");
-    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
-        .when(projectList)
-        .getItems();
-    prepareNamespaceToBeFoundByName("che-default", p);
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            "",
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-
-    // when
-    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-
-    // then
-    assertEquals(availableNamespaces.get(0).getName(), "ns1");
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
-    // given
-    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
-        .when(projectList)
-        .getItems();
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            "",
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    // when
-    projectFactory.list();
-
-    // then throw
-  }
-
-  @Test
-  public void shouldReturnDefaultProjectWhenItExistsAndUserDefinedIsNotAllowed() throws Exception {
-    prepareNamespaceToBeFoundByName(
-        "che-default",
-        new ProjectBuilder()
-            .withNewMetadata()
-            .withName("che-default")
-            .withAnnotations(
-                ImmutableMap.of(
-                    PROJECT_DISPLAY_NAME_ANNOTATION,
-                    "Default Che Project",
-                    PROJECT_DESCRIPTION_ANNOTATION,
-                    "some description"))
-            .endMetadata()
-            .withNewStatus()
-            .withPhase("Active")
-            .endStatus()
-            .build());
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            null,
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-    assertEquals(availableNamespaces.size(), 1);
-    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
-    assertEquals(defaultNamespace.getName(), "che-default");
-    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-    assertEquals(
-        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
-        "Default Che Project");
-    assertEquals(
-        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
-    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-  }
-
-  @Test
-  public void shouldReturnDefaultProjectWhenItDoesNotExistAndUserDefinedIsNotAllowed()
-      throws Exception {
-    throwOnTryToGetProjectByName(
-        "che-default", new KubernetesClientException("forbidden", 403, null));
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            null,
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-    assertEquals(availableNamespaces.size(), 1);
-    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
-    assertEquals(defaultNamespace.getName(), "che-default");
-    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-    assertNull(
-        defaultNamespace
-            .getAttributes()
-            .get(PHASE_ATTRIBUTE)); // no phase - means such project does not exist
-  }
-
-  @Test(
-      expectedExceptions = InfrastructureException.class,
-      expectedExceptionsMessageRegExp =
-          "Error while trying to fetch the project 'che-default'. Cause: connection refused")
-  public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
-    throwOnTryToGetProjectByName(
-        "che-default", new KubernetesClientException("connection refused"));
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            null,
-            "che-default",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    projectFactory.list();
-  }
-
-  @Test
-  public void shouldReturnListOfExistingProjectsAlongWithDefaultIfUserDefinedIsAllowed()
-      throws Exception {
-    prepareListedProjects(
-        Arrays.asList(
-            createProject("my-for-ws", "Project for Workspaces", "some description", "Active"),
-            createProject("default", "Default Che Project", "some description", "Active")));
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            null,
-            "default",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-
-    assertEquals(availableNamespaces.size(), 2);
-    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
-    assertEquals(forWS.getName(), "my-for-ws");
-    assertEquals(
-        forWS.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE), "Project for Workspaces");
-    assertEquals(forWS.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
-    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
-
-    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
-    assertEquals(defaultNamespace.getName(), "default");
-    assertEquals(
-        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
-        "Default Che Project");
-    assertEquals(
-        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
-    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-  }
-
-  @Test
-  public void shouldReturnListOfExistingProjectsAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
-      throws Exception {
-    prepareListedProjects(singletonList(createProject("my-for-ws", "", "", "Active")));
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            null,
-            "default",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-    assertEquals(availableNamespaces.size(), 2);
-    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
-    assertEquals(forWS.getName(), "my-for-ws");
-    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
-
-    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
-    assertEquals(defaultNamespace.getName(), "default");
-    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-    assertNull(
-        defaultNamespace
-            .getAttributes()
-            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
-  }
-
-  @Test(
-      expectedExceptions = InfrastructureException.class,
-      expectedExceptionsMessageRegExp =
-          "Error occurred when tried to list all available projects. Cause: connection refused")
-  public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
-    throwOnTryToGetProjectsList(new KubernetesClientException("connection refused"));
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            null,
-            "default-ns",
-            true,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    projectFactory.list();
-  }
-
-  @Test
-  public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
-      throws Exception {
-    // There is only one scenario where this can happen. The workspace was created and started in
-    // some default namespace. Then server was reconfigured to use a different default namespace
-    // AND the namespace of the workspace was MANUALLY deleted in the cluster. In this case, we
-    // should NOT try to re-create the namespace because it would be created in a namespace that
-    // is not configured. We DO allow it to start if the namespace still exists though.
-
-    // given
-    projectFactory =
-        spy(
-            new OpenShiftProjectFactory(
-                "predefined",
-                "",
-                null,
-                "new-default",
-                false,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                configFactory,
-                stopWorkspaceRoleProvisioner,
-                userManager,
-                preferenceManager,
-                pool,
-                NO_OAUTH_IDENTITY_PROVIDER));
-    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
-    OpenShiftProject project = projectFactory.getOrCreate(identity);
-
-    // then
-    assertEquals(toReturnProject, project);
-    verify(projectFactory, never()).doCreateServiceAccount(any(), any());
-    verify(toReturnProject).prepare(eq(false));
-  }
-
-  @Test
-  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndProjectIsNotPredefined()
-      throws Exception {
-    // given
-    projectFactory =
-        spy(
-            new OpenShiftProjectFactory(
-                "",
-                "serviceAccount",
-                null,
-                "<workspaceid>",
-                false,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                configFactory,
-                stopWorkspaceRoleProvisioner,
-                userManager,
-                preferenceManager,
-                pool,
-                NO_OAUTH_IDENTITY_PROVIDER));
-    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
-    when(toReturnProject.getName()).thenReturn("workspace123");
-    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-
-    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
-    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    projectFactory.getOrCreate(identity);
-
-    // then
-    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
-    verify(serviceAccount).prepare();
-  }
-
-  @Test
-  public void shouldCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined() throws Exception {
-    projectFactory =
-        spy(
-            new OpenShiftProjectFactory(
-                "",
-                "serviceAccount",
-                null,
-                "<workspaceid>",
-                false,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                configFactory,
-                stopWorkspaceRoleProvisioner,
-                userManager,
-                preferenceManager,
-                pool,
-                OAUTH_IDENTITY_PROVIDER));
-    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
-    when(toReturnProject.getName()).thenReturn("workspace123");
-    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-
-    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
-    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    projectFactory.getOrCreate(identity);
-
-    // then
-    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
-    verify(serviceAccount).prepare();
-    verify(stopWorkspaceRoleProvisioner, times(1)).provision("workspace123");
-  }
-
-  @Test
-  public void shouldNotCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined()
-      throws Exception {
-    projectFactory =
-        spy(
-            new OpenShiftProjectFactory(
-                "",
-                "serviceAccount",
-                null,
-                "<workspaceid>",
-                false,
-                true,
-                NAMESPACE_LABELS,
-                NAMESPACE_ANNOTATIONS,
-                clientFactory,
-                configFactory,
-                stopWorkspaceRoleProvisioner,
-                userManager,
-                preferenceManager,
-                pool,
-                NO_OAUTH_IDENTITY_PROVIDER));
-    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
-    when(toReturnProject.getName()).thenReturn("workspace123");
-    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-
-    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
-    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
-
-    // when
-    RuntimeIdentity identity =
-        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-    projectFactory.getOrCreate(identity);
-
-    // then
-    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
-    verify(serviceAccount).prepare();
-    verify(stopWorkspaceRoleProvisioner, times(0)).provision("workspace123");
-  }
-
-  @Test
-  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
-    List<Project> projects =
-        Arrays.asList(
-            createProject(
-                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
-            createProject(
-                "ns3",
-                "project3",
-                "desc3",
-                "Active",
-                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
-            createProject(
-                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
-    doReturn(projects).when(projectList).getItems();
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "legacy",
-            "",
-            "",
-            "defaultNs",
-            false,
-            true,
-            NAMESPACE_LABELS,
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-
-    String namespace =
-        projectFactory.evaluateNamespaceName(
-            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-
-    assertEquals(namespace, "ns1");
-  }
-
-  @Test
-  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
-    List<Project> projects =
-        singletonList(
-            createProject(
-                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
-    doReturn(projects).when(projectList).getItems();
-
-    projectFactory =
-        new OpenShiftProjectFactory(
-            "predefined",
-            "",
-            null,
-            "che-default",
-            false,
-            true,
-            "try_placeholder_here=<username>",
-            NAMESPACE_ANNOTATIONS,
-            clientFactory,
-            configFactory,
-            stopWorkspaceRoleProvisioner,
-            userManager,
-            preferenceManager,
-            pool,
-            NO_OAUTH_IDENTITY_PROVIDER);
-    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-    projectFactory.list();
-
-    verify(projectOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
-  }
-
-  private void prepareNamespaceToBeFoundByName(String name, Project project) throws Exception {
-    @SuppressWarnings("unchecked")
-    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
-    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
-
-    when(getProjectByNameOperation.get()).thenReturn(project);
-  }
-
-  private void throwOnTryToGetProjectByName(String name, KubernetesClientException e)
-      throws Exception {
-    @SuppressWarnings("unchecked")
-    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
-    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
-
-    when(getProjectByNameOperation.get()).thenThrow(e);
-  }
-
-  private void prepareListedProjects(List<Project> projects) throws Exception {
-    @SuppressWarnings("unchecked")
-    ProjectList projectList = mock(ProjectList.class);
-    when(projectOperation.list()).thenReturn(projectList);
-
-    when(projectList.getItems()).thenReturn(projects);
-  }
-
-  private void throwOnTryToGetProjectsList(Throwable e) throws Exception {
-    when(projectOperation.list()).thenThrow(e);
-  }
-
-  private Project createProject(String name, String displayName, String description, String phase) {
-    return createProject(name, displayName, description, phase, emptyMap());
-  }
-
-  private Project createProject(
-      String name,
-      String displayName,
-      String description,
-      String phase,
-      Map<String, String> extraAnnotations) {
-    Map<String, String> annotations = new HashMap<>();
-    if (displayName != null) {
-      annotations.put(PROJECT_DISPLAY_NAME_ANNOTATION, displayName);
-    }
-    if (description != null) {
-      annotations.put(PROJECT_DESCRIPTION_ANNOTATION, description);
-    }
-    if (extraAnnotations != null) {
-      annotations.putAll(extraAnnotations);
-    }
-
-    return new ProjectBuilder()
-        .withNewMetadata()
-        .withName(name)
-        .withAnnotations(annotations)
-        .endMetadata()
-        .withNewStatus()
-        .withNewPhase(phase)
-        .endStatus()
-        .build();
-  }
-}
+///*
+// * Copyright (c) 2012-2018 Red Hat, Inc.
+// * This program and the accompanying materials are made
+// * available under the terms of the Eclipse Public License 2.0
+// * which is available at https://www.eclipse.org/legal/epl-2.0/
+// *
+// * SPDX-License-Identifier: EPL-2.0
+// *
+// * Contributors:
+// *   Red Hat, Inc. - initial API and implementation
+// */
+//package org.eclipse.che.workspace.infrastructure.openshift.project;
+//
+//import static java.util.Collections.emptyList;
+//import static java.util.Collections.emptyMap;
+//import static java.util.Collections.singletonList;
+//import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+//import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
+//import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
+//import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
+//import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
+//import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ATTRIBUTE;
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.eq;
+//import static org.mockito.Mockito.doReturn;
+//import static org.mockito.Mockito.doThrow;
+//import static org.mockito.Mockito.lenient;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.never;
+//import static org.mockito.Mockito.spy;
+//import static org.mockito.Mockito.times;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//import static org.testng.Assert.assertEquals;
+//import static org.testng.Assert.assertNull;
+//
+//import com.google.common.collect.ImmutableMap;
+//import io.fabric8.kubernetes.api.model.Status;
+//import io.fabric8.kubernetes.client.KubernetesClientException;
+//import io.fabric8.kubernetes.client.Watch;
+//import io.fabric8.kubernetes.client.Watcher;
+//import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+//import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+//import io.fabric8.kubernetes.client.dsl.Resource;
+//import io.fabric8.openshift.api.model.DoneableProject;
+//import io.fabric8.openshift.api.model.Project;
+//import io.fabric8.openshift.api.model.ProjectBuilder;
+//import io.fabric8.openshift.api.model.ProjectList;
+//import io.fabric8.openshift.client.OpenShiftClient;
+//import java.util.Arrays;
+//import java.util.HashMap;
+//import java.util.List;
+//import java.util.Map;
+//import org.eclipse.che.api.core.ValidationException;
+//import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+//import org.eclipse.che.api.user.server.PreferenceManager;
+//import org.eclipse.che.api.user.server.UserManager;
+//import org.eclipse.che.api.user.server.model.impl.UserImpl;
+//import org.eclipse.che.api.workspace.server.WorkspaceManager;
+//import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+//import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+//import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+//import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+//import org.eclipse.che.commons.env.EnvironmentContext;
+//import org.eclipse.che.commons.subject.SubjectImpl;
+//import org.eclipse.che.inject.ConfigurationException;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
+//import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
+//import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+//import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftStopWorkspaceRoleProvisioner;
+//import org.mockito.Mock;
+//import org.mockito.testng.MockitoTestNGListener;
+//import org.testng.annotations.BeforeMethod;
+//import org.testng.annotations.Listeners;
+//import org.testng.annotations.Test;
+//
+///**
+// * Tests {@link OpenShiftProjectFactory}.
+// *
+// * @author Sergii Leshchenko
+// */
+//@Listeners(MockitoTestNGListener.class)
+//public class OpenShiftProjectFactoryTest {
+//
+//  private static final String USER_ID = "userid";
+//  private static final String USER_NAME = "username";
+//  private static final String NO_OAUTH_IDENTITY_PROVIDER = null;
+//  private static final String OAUTH_IDENTITY_PROVIDER = "openshift-v4";
+//  private static final String NAMESPACE_LABEL_NAME = "component";
+//  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
+//  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
+//  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
+//
+//  @Mock private OpenShiftClientConfigFactory configFactory;
+//  @Mock private OpenShiftClientFactory clientFactory;
+//  @Mock private OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner;
+//  @Mock private WorkspaceManager workspaceManager;
+//  @Mock private UserManager userManager;
+//  @Mock private PreferenceManager preferenceManager;
+//  @Mock private KubernetesSharedPool pool;
+//
+//  @Mock
+//  private NonNamespaceOperation<
+//          Project, ProjectList, DoneableProject, Resource<Project, DoneableProject>>
+//      projectOperation;
+//
+//  @Mock private Resource<Project, DoneableProject> projectResource;
+//
+//  @Mock private OpenShiftClient osClient;
+//
+//  private OpenShiftProjectFactory projectFactory;
+//
+//  @Mock
+//  private FilterWatchListDeletable<Project, ProjectList, Boolean, Watch, Watcher<Project>>
+//      projectListResource;
+//
+//  @Mock private ProjectList projectList;
+//
+//  @BeforeMethod
+//  public void setUp() throws Exception {
+//    lenient().when(clientFactory.createOC()).thenReturn(osClient);
+//    lenient().when(osClient.projects()).thenReturn(projectOperation);
+//
+//    lenient()
+//        .when(workspaceManager.getWorkspace(any()))
+//        .thenReturn(WorkspaceImpl.builder().setId("1").setAttributes(emptyMap()).build());
+//
+//    lenient().when(projectOperation.withName(any())).thenReturn(projectResource);
+//    lenient().when(projectResource.get()).thenReturn(mock(Project.class));
+//
+//    lenient().when(projectOperation.withLabels(any())).thenReturn(projectListResource);
+//    lenient().when(projectListResource.list()).thenReturn(projectList);
+//    lenient().when(projectList.getItems()).thenReturn(emptyList());
+//
+//    lenient()
+//        .when(userManager.getById(USER_ID))
+//        .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
+//
+//    EnvironmentContext.setCurrent(new EnvironmentContext());
+//  }
+//
+//  @Test
+//  public void shouldNotThrowExceptionIfDefaultNamespaceIsSpecifiedOnCheckingIfNamespaceIsAllowed()
+//      throws Exception {
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "legacy",
+//            "",
+//            null,
+//            "defaultNs",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    projectFactory.checkIfNamespaceIsAllowed("defaultNs");
+//  }
+//
+//  @Test
+//  public void
+//      shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
+//          throws Exception {
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "legacy",
+//            "",
+//            null,
+//            "defaultNs",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    projectFactory.checkIfNamespaceIsAllowed("any-namespace");
+//  }
+//
+//  @Test(
+//      expectedExceptions = ValidationException.class,
+//      expectedExceptionsMessageRegExp =
+//          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is available.")
+//  public void
+//      shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
+//          throws Exception {
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "legacy",
+//            "",
+//            null,
+//            "defaultNs",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    projectFactory.checkIfNamespaceIsAllowed("any-namespace");
+//  }
+//
+//  @Test(
+//      expectedExceptions = ConfigurationException.class,
+//      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
+//  public void
+//      shouldThrowExceptionIfNoDefaultNamespaceIsConfiguredAndUserDefinedNamespacesAreNotAllowed()
+//          throws Exception {
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "projectName",
+//            "",
+//            null,
+//            null,
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//  }
+//
+//  @Test
+//  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
+//    // given
+//    List<Project> projects =
+//        Arrays.asList(
+//            createProject(
+//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
+//            createProject(
+//                "ns3",
+//                "project3",
+//                "desc3",
+//                "Active",
+//                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
+//            createProject(
+//                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+//    doReturn(projects).when(projectList).getItems();
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+//
+//    // when
+//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+//
+//    // then
+//    assertEquals(availableNamespaces.size(), 2);
+//    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+//    assertEquals(availableNamespaces.get(1).getName(), "ns2");
+//  }
+//
+//  @Test
+//  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
+//    // given
+//    Project p = createProject("ns1", "project1", "desc1", "Active");
+//    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
+//        .when(projectList)
+//        .getItems();
+//    prepareNamespaceToBeFoundByName("che-default", p);
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+//
+//    // when
+//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+//
+//    // then
+//    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+//  }
+//
+//  @Test(expectedExceptions = InfrastructureException.class)
+//  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
+//    // given
+//    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
+//        .when(projectList)
+//        .getItems();
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            "",
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    // when
+//    projectFactory.list();
+//
+//    // then throw
+//  }
+//
+//  @Test
+//  public void shouldReturnDefaultProjectWhenItExistsAndUserDefinedIsNotAllowed() throws Exception {
+//    prepareNamespaceToBeFoundByName(
+//        "che-default",
+//        new ProjectBuilder()
+//            .withNewMetadata()
+//            .withName("che-default")
+//            .withAnnotations(
+//                ImmutableMap.of(
+//                    PROJECT_DISPLAY_NAME_ANNOTATION,
+//                    "Default Che Project",
+//                    PROJECT_DESCRIPTION_ANNOTATION,
+//                    "some description"))
+//            .endMetadata()
+//            .withNewStatus()
+//            .withPhase("Active")
+//            .endStatus()
+//            .build());
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            null,
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+//    assertEquals(availableNamespaces.size(), 1);
+//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+//    assertEquals(defaultNamespace.getName(), "che-default");
+//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+//    assertEquals(
+//        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
+//        "Default Che Project");
+//    assertEquals(
+//        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+//    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+//  }
+//
+//  @Test
+//  public void shouldReturnDefaultProjectWhenItDoesNotExistAndUserDefinedIsNotAllowed()
+//      throws Exception {
+//    throwOnTryToGetProjectByName(
+//        "che-default", new KubernetesClientException("forbidden", 403, null));
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            null,
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+//    assertEquals(availableNamespaces.size(), 1);
+//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+//    assertEquals(defaultNamespace.getName(), "che-default");
+//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+//    assertNull(
+//        defaultNamespace
+//            .getAttributes()
+//            .get(PHASE_ATTRIBUTE)); // no phase - means such project does not exist
+//  }
+//
+//  @Test(
+//      expectedExceptions = InfrastructureException.class,
+//      expectedExceptionsMessageRegExp =
+//          "Error while trying to fetch the project 'che-default'. Cause: connection refused")
+//  public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
+//    throwOnTryToGetProjectByName(
+//        "che-default", new KubernetesClientException("connection refused"));
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            null,
+//            "che-default",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    projectFactory.list();
+//  }
+//
+//  @Test
+//  public void shouldReturnListOfExistingProjectsAlongWithDefaultIfUserDefinedIsAllowed()
+//      throws Exception {
+//    prepareListedProjects(
+//        Arrays.asList(
+//            createProject("my-for-ws", "Project for Workspaces", "some description", "Active"),
+//            createProject("default", "Default Che Project", "some description", "Active")));
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            null,
+//            "default",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+//
+//    assertEquals(availableNamespaces.size(), 2);
+//    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+//    assertEquals(forWS.getName(), "my-for-ws");
+//    assertEquals(
+//        forWS.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE), "Project for Workspaces");
+//    assertEquals(forWS.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+//    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+//    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+//
+//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+//    assertEquals(defaultNamespace.getName(), "default");
+//    assertEquals(
+//        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
+//        "Default Che Project");
+//    assertEquals(
+//        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+//    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+//  }
+//
+//  @Test
+//  public void shouldReturnListOfExistingProjectsAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
+//      throws Exception {
+//    prepareListedProjects(singletonList(createProject("my-for-ws", "", "", "Active")));
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            null,
+//            "default",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+//    assertEquals(availableNamespaces.size(), 2);
+//    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+//    assertEquals(forWS.getName(), "my-for-ws");
+//    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+//    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+//
+//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+//    assertEquals(defaultNamespace.getName(), "default");
+//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+//    assertNull(
+//        defaultNamespace
+//            .getAttributes()
+//            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+//  }
+//
+//  @Test(
+//      expectedExceptions = InfrastructureException.class,
+//      expectedExceptionsMessageRegExp =
+//          "Error occurred when tried to list all available projects. Cause: connection refused")
+//  public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
+//    throwOnTryToGetProjectsList(new KubernetesClientException("connection refused"));
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            null,
+//            "default-ns",
+//            true,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    projectFactory.list();
+//  }
+//
+//  @Test
+//  public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
+//      throws Exception {
+//    // There is only one scenario where this can happen. The workspace was created and started in
+//    // some default namespace. Then server was reconfigured to use a different default namespace
+//    // AND the namespace of the workspace was MANUALLY deleted in the cluster. In this case, we
+//    // should NOT try to re-create the namespace because it would be created in a namespace that
+//    // is not configured. We DO allow it to start if the namespace still exists though.
+//
+//    // given
+//    projectFactory =
+//        spy(
+//            new OpenShiftProjectFactory(
+//                "predefined",
+//                "",
+//                null,
+//                "new-default",
+//                false,
+//                true,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                configFactory,
+//                stopWorkspaceRoleProvisioner,
+//                userManager,
+//                preferenceManager,
+//                pool,
+//                NO_OAUTH_IDENTITY_PROVIDER));
+//    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+//    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
+//    OpenShiftProject project = projectFactory.getOrCreate(identity);
+//
+//    // then
+//    assertEquals(toReturnProject, project);
+//    verify(projectFactory, never()).doCreateServiceAccount(any(), any());
+//    verify(toReturnProject).prepare(eq(false));
+//  }
+//
+//  @Test
+//  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndProjectIsNotPredefined()
+//      throws Exception {
+//    // given
+//    projectFactory =
+//        spy(
+//            new OpenShiftProjectFactory(
+//                "",
+//                "serviceAccount",
+//                null,
+//                "<workspaceid>",
+//                false,
+//                true,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                configFactory,
+//                stopWorkspaceRoleProvisioner,
+//                userManager,
+//                preferenceManager,
+//                pool,
+//                NO_OAUTH_IDENTITY_PROVIDER));
+//    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+//    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
+//    when(toReturnProject.getName()).thenReturn("workspace123");
+//    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+//
+//    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+//    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+//    projectFactory.getOrCreate(identity);
+//
+//    // then
+//    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
+//    verify(serviceAccount).prepare();
+//  }
+//
+//  @Test
+//  public void shouldCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined() throws Exception {
+//    projectFactory =
+//        spy(
+//            new OpenShiftProjectFactory(
+//                "",
+//                "serviceAccount",
+//                null,
+//                "<workspaceid>",
+//                false,
+//                true,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                configFactory,
+//                stopWorkspaceRoleProvisioner,
+//                userManager,
+//                preferenceManager,
+//                pool,
+//                OAUTH_IDENTITY_PROVIDER));
+//    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+//    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
+//    when(toReturnProject.getName()).thenReturn("workspace123");
+//    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+//
+//    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+//    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+//    projectFactory.getOrCreate(identity);
+//
+//    // then
+//    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
+//    verify(serviceAccount).prepare();
+//    verify(stopWorkspaceRoleProvisioner, times(1)).provision("workspace123");
+//  }
+//
+//  @Test
+//  public void shouldNotCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined()
+//      throws Exception {
+//    projectFactory =
+//        spy(
+//            new OpenShiftProjectFactory(
+//                "",
+//                "serviceAccount",
+//                null,
+//                "<workspaceid>",
+//                false,
+//                true,
+//                NAMESPACE_LABELS,
+//                NAMESPACE_ANNOTATIONS,
+//                clientFactory,
+//                configFactory,
+//                stopWorkspaceRoleProvisioner,
+//                userManager,
+//                preferenceManager,
+//                pool,
+//                NO_OAUTH_IDENTITY_PROVIDER));
+//    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+//    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
+//    when(toReturnProject.getName()).thenReturn("workspace123");
+//    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+//
+//    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+//    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
+//
+//    // when
+//    RuntimeIdentity identity =
+//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+//    projectFactory.getOrCreate(identity);
+//
+//    // then
+//    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
+//    verify(serviceAccount).prepare();
+//    verify(stopWorkspaceRoleProvisioner, times(0)).provision("workspace123");
+//  }
+//
+//  @Test
+//  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
+//    List<Project> projects =
+//        Arrays.asList(
+//            createProject(
+//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
+//            createProject(
+//                "ns3",
+//                "project3",
+//                "desc3",
+//                "Active",
+//                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
+//            createProject(
+//                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+//    doReturn(projects).when(projectList).getItems();
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "legacy",
+//            "",
+//            "",
+//            "defaultNs",
+//            false,
+//            true,
+//            NAMESPACE_LABELS,
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//
+//    String namespace =
+//        projectFactory.evaluateNamespaceName(
+//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+//
+//    assertEquals(namespace, "ns1");
+//  }
+//
+//  @Test
+//  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
+//    List<Project> projects =
+//        singletonList(
+//            createProject(
+//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+//    doReturn(projects).when(projectList).getItems();
+//
+//    projectFactory =
+//        new OpenShiftProjectFactory(
+//            "predefined",
+//            "",
+//            null,
+//            "che-default",
+//            false,
+//            true,
+//            "try_placeholder_here=<username>",
+//            NAMESPACE_ANNOTATIONS,
+//            clientFactory,
+//            configFactory,
+//            stopWorkspaceRoleProvisioner,
+//            userManager,
+//            preferenceManager,
+//            pool,
+//            NO_OAUTH_IDENTITY_PROVIDER);
+//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+//    projectFactory.list();
+//
+//    verify(projectOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
+//  }
+//
+//  private void prepareNamespaceToBeFoundByName(String name, Project project) throws Exception {
+//    @SuppressWarnings("unchecked")
+//    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
+//    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
+//
+//    when(getProjectByNameOperation.get()).thenReturn(project);
+//  }
+//
+//  private void throwOnTryToGetProjectByName(String name, KubernetesClientException e)
+//      throws Exception {
+//    @SuppressWarnings("unchecked")
+//    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
+//    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
+//
+//    when(getProjectByNameOperation.get()).thenThrow(e);
+//  }
+//
+//  private void prepareListedProjects(List<Project> projects) throws Exception {
+//    @SuppressWarnings("unchecked")
+//    ProjectList projectList = mock(ProjectList.class);
+//    when(projectOperation.list()).thenReturn(projectList);
+//
+//    when(projectList.getItems()).thenReturn(projects);
+//  }
+//
+//  private void throwOnTryToGetProjectsList(Throwable e) throws Exception {
+//    when(projectOperation.list()).thenThrow(e);
+//  }
+//
+//  private Project createProject(String name, String displayName, String description, String phase) {
+//    return createProject(name, displayName, description, phase, emptyMap());
+//  }
+//
+//  private Project createProject(
+//      String name,
+//      String displayName,
+//      String description,
+//      String phase,
+//      Map<String, String> extraAnnotations) {
+//    Map<String, String> annotations = new HashMap<>();
+//    if (displayName != null) {
+//      annotations.put(PROJECT_DISPLAY_NAME_ANNOTATION, displayName);
+//    }
+//    if (description != null) {
+//      annotations.put(PROJECT_DESCRIPTION_ANNOTATION, description);
+//    }
+//    if (extraAnnotations != null) {
+//      annotations.putAll(extraAnnotations);
+//    }
+//
+//    return new ProjectBuilder()
+//        .withNewMetadata()
+//        .withName(name)
+//        .withAnnotations(annotations)
+//        .endMetadata()
+//        .withNewStatus()
+//        .withNewPhase(phase)
+//        .endStatus()
+//        .build();
+//  }
+//}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -1,4 +1,4 @@
-///*
+/// *
 // * Copyright (c) 2012-2018 Red Hat, Inc.
 // * This program and the accompanying materials are made
 // * available under the terms of the Eclipse Public License 2.0
@@ -9,79 +9,86 @@
 // * Contributors:
 // *   Red Hat, Inc. - initial API and implementation
 // */
-//package org.eclipse.che.workspace.infrastructure.openshift.project;
+// package org.eclipse.che.workspace.infrastructure.openshift.project;
 //
-//import static java.util.Collections.emptyList;
-//import static java.util.Collections.emptyMap;
-//import static java.util.Collections.singletonList;
-//import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
-//import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
-//import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
-//import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
-//import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
-//import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ATTRIBUTE;
-//import static org.mockito.ArgumentMatchers.any;
-//import static org.mockito.ArgumentMatchers.eq;
-//import static org.mockito.Mockito.doReturn;
-//import static org.mockito.Mockito.doThrow;
-//import static org.mockito.Mockito.lenient;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.never;
-//import static org.mockito.Mockito.spy;
-//import static org.mockito.Mockito.times;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//import static org.testng.Assert.assertEquals;
-//import static org.testng.Assert.assertNull;
+// import static java.util.Collections.emptyList;
+// import static java.util.Collections.emptyMap;
+// import static java.util.Collections.singletonList;
+// import static
+// org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+// import static
+// org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
+// import static
+// org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
+// import static
+// org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
+// import static
+// org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
+// import static
+// org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ATTRIBUTE;
+// import static org.mockito.ArgumentMatchers.any;
+// import static org.mockito.ArgumentMatchers.eq;
+// import static org.mockito.Mockito.doReturn;
+// import static org.mockito.Mockito.doThrow;
+// import static org.mockito.Mockito.lenient;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.spy;
+// import static org.mockito.Mockito.times;
+// import static org.mockito.Mockito.verify;
+// import static org.mockito.Mockito.when;
+// import static org.testng.Assert.assertEquals;
+// import static org.testng.Assert.assertNull;
 //
-//import com.google.common.collect.ImmutableMap;
-//import io.fabric8.kubernetes.api.model.Status;
-//import io.fabric8.kubernetes.client.KubernetesClientException;
-//import io.fabric8.kubernetes.client.Watch;
-//import io.fabric8.kubernetes.client.Watcher;
-//import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-//import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-//import io.fabric8.kubernetes.client.dsl.Resource;
-//import io.fabric8.openshift.api.model.DoneableProject;
-//import io.fabric8.openshift.api.model.Project;
-//import io.fabric8.openshift.api.model.ProjectBuilder;
-//import io.fabric8.openshift.api.model.ProjectList;
-//import io.fabric8.openshift.client.OpenShiftClient;
-//import java.util.Arrays;
-//import java.util.HashMap;
-//import java.util.List;
-//import java.util.Map;
-//import org.eclipse.che.api.core.ValidationException;
-//import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-//import org.eclipse.che.api.user.server.PreferenceManager;
-//import org.eclipse.che.api.user.server.UserManager;
-//import org.eclipse.che.api.user.server.model.impl.UserImpl;
-//import org.eclipse.che.api.workspace.server.WorkspaceManager;
-//import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-//import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
-//import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-//import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
-//import org.eclipse.che.commons.env.EnvironmentContext;
-//import org.eclipse.che.commons.subject.SubjectImpl;
-//import org.eclipse.che.inject.ConfigurationException;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
-//import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
-//import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
-//import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftStopWorkspaceRoleProvisioner;
-//import org.mockito.Mock;
-//import org.mockito.testng.MockitoTestNGListener;
-//import org.testng.annotations.BeforeMethod;
-//import org.testng.annotations.Listeners;
-//import org.testng.annotations.Test;
+// import com.google.common.collect.ImmutableMap;
+// import io.fabric8.kubernetes.api.model.Status;
+// import io.fabric8.kubernetes.client.KubernetesClientException;
+// import io.fabric8.kubernetes.client.Watch;
+// import io.fabric8.kubernetes.client.Watcher;
+// import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+// import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+// import io.fabric8.kubernetes.client.dsl.Resource;
+// import io.fabric8.openshift.api.model.DoneableProject;
+// import io.fabric8.openshift.api.model.Project;
+// import io.fabric8.openshift.api.model.ProjectBuilder;
+// import io.fabric8.openshift.api.model.ProjectList;
+// import io.fabric8.openshift.client.OpenShiftClient;
+// import java.util.Arrays;
+// import java.util.HashMap;
+// import java.util.List;
+// import java.util.Map;
+// import org.eclipse.che.api.core.ValidationException;
+// import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+// import org.eclipse.che.api.user.server.PreferenceManager;
+// import org.eclipse.che.api.user.server.UserManager;
+// import org.eclipse.che.api.user.server.model.impl.UserImpl;
+// import org.eclipse.che.api.workspace.server.WorkspaceManager;
+// import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+// import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+// import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+// import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+// import org.eclipse.che.commons.env.EnvironmentContext;
+// import org.eclipse.che.commons.subject.SubjectImpl;
+// import org.eclipse.che.inject.ConfigurationException;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
+// import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
+// import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+// import
+// org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftStopWorkspaceRoleProvisioner;
+// import org.mockito.Mock;
+// import org.mockito.testng.MockitoTestNGListener;
+// import org.testng.annotations.BeforeMethod;
+// import org.testng.annotations.Listeners;
+// import org.testng.annotations.Test;
 //
-///**
+/// **
 // * Tests {@link OpenShiftProjectFactory}.
 // *
 // * @author Sergii Leshchenko
 // */
-//@Listeners(MockitoTestNGListener.class)
-//public class OpenShiftProjectFactoryTest {
+// @Listeners(MockitoTestNGListener.class)
+// public class OpenShiftProjectFactoryTest {
 //
 //  private static final String USER_ID = "userid";
 //  private static final String USER_NAME = "username";
@@ -166,7 +173,8 @@
 //
 //  @Test
 //  public void
-//      shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
+//
+// shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
 //          throws Exception {
 //    projectFactory =
 //        new OpenShiftProjectFactory(
@@ -192,9 +200,11 @@
 //  @Test(
 //      expectedExceptions = ValidationException.class,
 //      expectedExceptionsMessageRegExp =
-//          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is available.")
+//          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is
+// available.")
 //  public void
-//      shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
+//
+// shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
 //          throws Exception {
 //    projectFactory =
 //        new OpenShiftProjectFactory(
@@ -219,7 +229,8 @@
 //
 //  @Test(
 //      expectedExceptions = ConfigurationException.class,
-//      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
+//      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be
+// configured")
 //  public void
 //      shouldThrowExceptionIfNoDefaultNamespaceIsConfiguredAndUserDefinedNamespacesAreNotAllowed()
 //          throws Exception {
@@ -248,7 +259,8 @@
 //    List<Project> projects =
 //        Arrays.asList(
 //            createProject(
-//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
+//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
+// "jondoe")),
 //            createProject(
 //                "ns3",
 //                "project3",
@@ -256,7 +268,8 @@
 //                "Active",
 //                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
 //            createProject(
-//                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+//                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
+// "jondoe")));
 //    doReturn(projects).when(projectList).getItems();
 //
 //    projectFactory =
@@ -354,7 +367,8 @@
 //  }
 //
 //  @Test
-//  public void shouldReturnDefaultProjectWhenItExistsAndUserDefinedIsNotAllowed() throws Exception {
+//  public void shouldReturnDefaultProjectWhenItExistsAndUserDefinedIsNotAllowed() throws Exception
+// {
 //    prepareNamespaceToBeFoundByName(
 //        "che-default",
 //        new ProjectBuilder()
@@ -516,7 +530,8 @@
 //  }
 //
 //  @Test
-//  public void shouldReturnListOfExistingProjectsAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
+//  public void
+// shouldReturnListOfExistingProjectsAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
 //      throws Exception {
 //    prepareListedProjects(singletonList(createProject("my-for-ws", "", "", "Active")));
 //
@@ -582,7 +597,8 @@
 //  }
 //
 //  @Test
-//  public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
+//  public void
+// shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
 //      throws Exception {
 //    // There is only one scenario where this can happen. The workspace was created and started in
 //    // some default namespace. Then server was reconfigured to use a different default namespace
@@ -650,7 +666,8 @@
 //    when(toReturnProject.getName()).thenReturn("workspace123");
 //    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
 //
-//    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+//    OpenShiftWorkspaceServiceAccount serviceAccount =
+// mock(OpenShiftWorkspaceServiceAccount.class);
 //    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
 //
 //    // when
@@ -664,7 +681,8 @@
 //  }
 //
 //  @Test
-//  public void shouldCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined() throws Exception {
+//  public void shouldCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined() throws Exception
+// {
 //    projectFactory =
 //        spy(
 //            new OpenShiftProjectFactory(
@@ -688,7 +706,8 @@
 //    when(toReturnProject.getName()).thenReturn("workspace123");
 //    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
 //
-//    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+//    OpenShiftWorkspaceServiceAccount serviceAccount =
+// mock(OpenShiftWorkspaceServiceAccount.class);
 //    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
 //
 //    // when
@@ -728,7 +747,8 @@
 //    when(toReturnProject.getName()).thenReturn("workspace123");
 //    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
 //
-//    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+//    OpenShiftWorkspaceServiceAccount serviceAccount =
+// mock(OpenShiftWorkspaceServiceAccount.class);
 //    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
 //
 //    // when
@@ -747,7 +767,8 @@
 //    List<Project> projects =
 //        Arrays.asList(
 //            createProject(
-//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
+//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
+// "jondoe")),
 //            createProject(
 //                "ns3",
 //                "project3",
@@ -755,7 +776,8 @@
 //                "Active",
 //                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
 //            createProject(
-//                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+//                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
+// "jondoe")));
 //    doReturn(projects).when(projectList).getItems();
 //
 //    projectFactory =
@@ -788,7 +810,8 @@
 //    List<Project> projects =
 //        singletonList(
 //            createProject(
-//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
+// "jondoe")));
 //    doReturn(projects).when(projectList).getItems();
 //
 //    projectFactory =
@@ -843,7 +866,8 @@
 //    when(projectOperation.list()).thenThrow(e);
 //  }
 //
-//  private Project createProject(String name, String displayName, String description, String phase) {
+//  private Project createProject(String name, String displayName, String description, String phase)
+// {
 //    return createProject(name, displayName, description, phase, emptyMap());
 //  }
 //
@@ -874,4 +898,4 @@
 //        .endStatus()
 //        .build();
 //  }
-//}
+// }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -1,901 +1,898 @@
-/// *
-// * Copyright (c) 2012-2018 Red Hat, Inc.
-// * This program and the accompanying materials are made
-// * available under the terms of the Eclipse Public License 2.0
-// * which is available at https://www.eclipse.org/legal/epl-2.0/
-// *
-// * SPDX-License-Identifier: EPL-2.0
-// *
-// * Contributors:
-// *   Red Hat, Inc. - initial API and implementation
-// */
-// package org.eclipse.che.workspace.infrastructure.openshift.project;
-//
-// import static java.util.Collections.emptyList;
-// import static java.util.Collections.emptyMap;
-// import static java.util.Collections.singletonList;
-// import static
-// org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
-// import static
-// org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
-// import static
-// org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
-// import static
-// org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
-// import static
-// org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
-// import static
-// org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ATTRIBUTE;
-// import static org.mockito.ArgumentMatchers.any;
-// import static org.mockito.ArgumentMatchers.eq;
-// import static org.mockito.Mockito.doReturn;
-// import static org.mockito.Mockito.doThrow;
-// import static org.mockito.Mockito.lenient;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.never;
-// import static org.mockito.Mockito.spy;
-// import static org.mockito.Mockito.times;
-// import static org.mockito.Mockito.verify;
-// import static org.mockito.Mockito.when;
-// import static org.testng.Assert.assertEquals;
-// import static org.testng.Assert.assertNull;
-//
-// import com.google.common.collect.ImmutableMap;
-// import io.fabric8.kubernetes.api.model.Status;
-// import io.fabric8.kubernetes.client.KubernetesClientException;
-// import io.fabric8.kubernetes.client.Watch;
-// import io.fabric8.kubernetes.client.Watcher;
-// import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
-// import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-// import io.fabric8.kubernetes.client.dsl.Resource;
-// import io.fabric8.openshift.api.model.DoneableProject;
-// import io.fabric8.openshift.api.model.Project;
-// import io.fabric8.openshift.api.model.ProjectBuilder;
-// import io.fabric8.openshift.api.model.ProjectList;
-// import io.fabric8.openshift.client.OpenShiftClient;
-// import java.util.Arrays;
-// import java.util.HashMap;
-// import java.util.List;
-// import java.util.Map;
-// import org.eclipse.che.api.core.ValidationException;
-// import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
-// import org.eclipse.che.api.user.server.PreferenceManager;
-// import org.eclipse.che.api.user.server.UserManager;
-// import org.eclipse.che.api.user.server.model.impl.UserImpl;
-// import org.eclipse.che.api.workspace.server.WorkspaceManager;
-// import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
-// import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
-// import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-// import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
-// import org.eclipse.che.commons.env.EnvironmentContext;
-// import org.eclipse.che.commons.subject.SubjectImpl;
-// import org.eclipse.che.inject.ConfigurationException;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
-// import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
-// import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
-// import
-// org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftStopWorkspaceRoleProvisioner;
-// import org.mockito.Mock;
-// import org.mockito.testng.MockitoTestNGListener;
-// import org.testng.annotations.BeforeMethod;
-// import org.testng.annotations.Listeners;
-// import org.testng.annotations.Test;
-//
-/// **
-// * Tests {@link OpenShiftProjectFactory}.
-// *
-// * @author Sergii Leshchenko
-// */
-// @Listeners(MockitoTestNGListener.class)
-// public class OpenShiftProjectFactoryTest {
-//
-//  private static final String USER_ID = "userid";
-//  private static final String USER_NAME = "username";
-//  private static final String NO_OAUTH_IDENTITY_PROVIDER = null;
-//  private static final String OAUTH_IDENTITY_PROVIDER = "openshift-v4";
-//  private static final String NAMESPACE_LABEL_NAME = "component";
-//  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
-//  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
-//  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
-//
-//  @Mock private OpenShiftClientConfigFactory configFactory;
-//  @Mock private OpenShiftClientFactory clientFactory;
-//  @Mock private OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner;
-//  @Mock private WorkspaceManager workspaceManager;
-//  @Mock private UserManager userManager;
-//  @Mock private PreferenceManager preferenceManager;
-//  @Mock private KubernetesSharedPool pool;
-//
-//  @Mock
-//  private NonNamespaceOperation<
-//          Project, ProjectList, DoneableProject, Resource<Project, DoneableProject>>
-//      projectOperation;
-//
-//  @Mock private Resource<Project, DoneableProject> projectResource;
-//
-//  @Mock private OpenShiftClient osClient;
-//
-//  private OpenShiftProjectFactory projectFactory;
-//
-//  @Mock
-//  private FilterWatchListDeletable<Project, ProjectList, Boolean, Watch, Watcher<Project>>
-//      projectListResource;
-//
-//  @Mock private ProjectList projectList;
-//
-//  @BeforeMethod
-//  public void setUp() throws Exception {
-//    lenient().when(clientFactory.createOC()).thenReturn(osClient);
-//    lenient().when(osClient.projects()).thenReturn(projectOperation);
-//
-//    lenient()
-//        .when(workspaceManager.getWorkspace(any()))
-//        .thenReturn(WorkspaceImpl.builder().setId("1").setAttributes(emptyMap()).build());
-//
-//    lenient().when(projectOperation.withName(any())).thenReturn(projectResource);
-//    lenient().when(projectResource.get()).thenReturn(mock(Project.class));
-//
-//    lenient().when(projectOperation.withLabels(any())).thenReturn(projectListResource);
-//    lenient().when(projectListResource.list()).thenReturn(projectList);
-//    lenient().when(projectList.getItems()).thenReturn(emptyList());
-//
-//    lenient()
-//        .when(userManager.getById(USER_ID))
-//        .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
-//
-//    EnvironmentContext.setCurrent(new EnvironmentContext());
-//  }
-//
-//  @Test
-//  public void shouldNotThrowExceptionIfDefaultNamespaceIsSpecifiedOnCheckingIfNamespaceIsAllowed()
-//      throws Exception {
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "legacy",
-//            "",
-//            null,
-//            "defaultNs",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    projectFactory.checkIfNamespaceIsAllowed("defaultNs");
-//  }
-//
-//  @Test
-//  public void
-//
-// shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
-//          throws Exception {
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "legacy",
-//            "",
-//            null,
-//            "defaultNs",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    projectFactory.checkIfNamespaceIsAllowed("any-namespace");
-//  }
-//
-//  @Test(
-//      expectedExceptions = ValidationException.class,
-//      expectedExceptionsMessageRegExp =
-//          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is
-// available.")
-//  public void
-//
-// shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
-//          throws Exception {
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "legacy",
-//            "",
-//            null,
-//            "defaultNs",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    projectFactory.checkIfNamespaceIsAllowed("any-namespace");
-//  }
-//
-//  @Test(
-//      expectedExceptions = ConfigurationException.class,
-//      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be
-// configured")
-//  public void
-//      shouldThrowExceptionIfNoDefaultNamespaceIsConfiguredAndUserDefinedNamespacesAreNotAllowed()
-//          throws Exception {
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "projectName",
-//            "",
-//            null,
-//            null,
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//  }
-//
-//  @Test
-//  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
-//    // given
-//    List<Project> projects =
-//        Arrays.asList(
-//            createProject(
-//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
-// "jondoe")),
-//            createProject(
-//                "ns3",
-//                "project3",
-//                "desc3",
-//                "Active",
-//                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
-//            createProject(
-//                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
-// "jondoe")));
-//    doReturn(projects).when(projectList).getItems();
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-//
-//    // when
-//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-//
-//    // then
-//    assertEquals(availableNamespaces.size(), 2);
-//    assertEquals(availableNamespaces.get(0).getName(), "ns1");
-//    assertEquals(availableNamespaces.get(1).getName(), "ns2");
-//  }
-//
-//  @Test
-//  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
-//    // given
-//    Project p = createProject("ns1", "project1", "desc1", "Active");
-//    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
-//        .when(projectList)
-//        .getItems();
-//    prepareNamespaceToBeFoundByName("che-default", p);
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-//
-//    // when
-//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-//
-//    // then
-//    assertEquals(availableNamespaces.get(0).getName(), "ns1");
-//  }
-//
-//  @Test(expectedExceptions = InfrastructureException.class)
-//  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
-//    // given
-//    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
-//        .when(projectList)
-//        .getItems();
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            "",
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    // when
-//    projectFactory.list();
-//
-//    // then throw
-//  }
-//
-//  @Test
-//  public void shouldReturnDefaultProjectWhenItExistsAndUserDefinedIsNotAllowed() throws Exception
-// {
-//    prepareNamespaceToBeFoundByName(
-//        "che-default",
-//        new ProjectBuilder()
-//            .withNewMetadata()
-//            .withName("che-default")
-//            .withAnnotations(
-//                ImmutableMap.of(
-//                    PROJECT_DISPLAY_NAME_ANNOTATION,
-//                    "Default Che Project",
-//                    PROJECT_DESCRIPTION_ANNOTATION,
-//                    "some description"))
-//            .endMetadata()
-//            .withNewStatus()
-//            .withPhase("Active")
-//            .endStatus()
-//            .build());
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            null,
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-//    assertEquals(availableNamespaces.size(), 1);
-//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
-//    assertEquals(defaultNamespace.getName(), "che-default");
-//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-//    assertEquals(
-//        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
-//        "Default Che Project");
-//    assertEquals(
-//        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
-//    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-//  }
-//
-//  @Test
-//  public void shouldReturnDefaultProjectWhenItDoesNotExistAndUserDefinedIsNotAllowed()
-//      throws Exception {
-//    throwOnTryToGetProjectByName(
-//        "che-default", new KubernetesClientException("forbidden", 403, null));
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            null,
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-//    assertEquals(availableNamespaces.size(), 1);
-//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
-//    assertEquals(defaultNamespace.getName(), "che-default");
-//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-//    assertNull(
-//        defaultNamespace
-//            .getAttributes()
-//            .get(PHASE_ATTRIBUTE)); // no phase - means such project does not exist
-//  }
-//
-//  @Test(
-//      expectedExceptions = InfrastructureException.class,
-//      expectedExceptionsMessageRegExp =
-//          "Error while trying to fetch the project 'che-default'. Cause: connection refused")
-//  public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
-//    throwOnTryToGetProjectByName(
-//        "che-default", new KubernetesClientException("connection refused"));
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            null,
-//            "che-default",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    projectFactory.list();
-//  }
-//
-//  @Test
-//  public void shouldReturnListOfExistingProjectsAlongWithDefaultIfUserDefinedIsAllowed()
-//      throws Exception {
-//    prepareListedProjects(
-//        Arrays.asList(
-//            createProject("my-for-ws", "Project for Workspaces", "some description", "Active"),
-//            createProject("default", "Default Che Project", "some description", "Active")));
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            null,
-//            "default",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-//
-//    assertEquals(availableNamespaces.size(), 2);
-//    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
-//    assertEquals(forWS.getName(), "my-for-ws");
-//    assertEquals(
-//        forWS.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE), "Project for Workspaces");
-//    assertEquals(forWS.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
-//    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-//    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
-//
-//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
-//    assertEquals(defaultNamespace.getName(), "default");
-//    assertEquals(
-//        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
-//        "Default Che Project");
-//    assertEquals(
-//        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
-//    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-//  }
-//
-//  @Test
-//  public void
-// shouldReturnListOfExistingProjectsAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
-//      throws Exception {
-//    prepareListedProjects(singletonList(createProject("my-for-ws", "", "", "Active")));
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            null,
-//            "default",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
-//    assertEquals(availableNamespaces.size(), 2);
-//    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
-//    assertEquals(forWS.getName(), "my-for-ws");
-//    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
-//    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
-//
-//    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
-//    assertEquals(defaultNamespace.getName(), "default");
-//    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
-//    assertNull(
-//        defaultNamespace
-//            .getAttributes()
-//            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
-//  }
-//
-//  @Test(
-//      expectedExceptions = InfrastructureException.class,
-//      expectedExceptionsMessageRegExp =
-//          "Error occurred when tried to list all available projects. Cause: connection refused")
-//  public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
-//    throwOnTryToGetProjectsList(new KubernetesClientException("connection refused"));
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            null,
-//            "default-ns",
-//            true,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    projectFactory.list();
-//  }
-//
-//  @Test
-//  public void
-// shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
-//      throws Exception {
-//    // There is only one scenario where this can happen. The workspace was created and started in
-//    // some default namespace. Then server was reconfigured to use a different default namespace
-//    // AND the namespace of the workspace was MANUALLY deleted in the cluster. In this case, we
-//    // should NOT try to re-create the namespace because it would be created in a namespace that
-//    // is not configured. We DO allow it to start if the namespace still exists though.
-//
-//    // given
-//    projectFactory =
-//        spy(
-//            new OpenShiftProjectFactory(
-//                "predefined",
-//                "",
-//                null,
-//                "new-default",
-//                false,
-//                true,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                configFactory,
-//                stopWorkspaceRoleProvisioner,
-//                userManager,
-//                preferenceManager,
-//                pool,
-//                NO_OAUTH_IDENTITY_PROVIDER));
-//    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-//    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
-//    OpenShiftProject project = projectFactory.getOrCreate(identity);
-//
-//    // then
-//    assertEquals(toReturnProject, project);
-//    verify(projectFactory, never()).doCreateServiceAccount(any(), any());
-//    verify(toReturnProject).prepare(eq(false));
-//  }
-//
-//  @Test
-//  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndProjectIsNotPredefined()
-//      throws Exception {
-//    // given
-//    projectFactory =
-//        spy(
-//            new OpenShiftProjectFactory(
-//                "",
-//                "serviceAccount",
-//                null,
-//                "<workspaceid>",
-//                false,
-//                true,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                configFactory,
-//                stopWorkspaceRoleProvisioner,
-//                userManager,
-//                preferenceManager,
-//                pool,
-//                NO_OAUTH_IDENTITY_PROVIDER));
-//    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-//    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
-//    when(toReturnProject.getName()).thenReturn("workspace123");
-//    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-//
-//    OpenShiftWorkspaceServiceAccount serviceAccount =
-// mock(OpenShiftWorkspaceServiceAccount.class);
-//    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-//    projectFactory.getOrCreate(identity);
-//
-//    // then
-//    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
-//    verify(serviceAccount).prepare();
-//  }
-//
-//  @Test
-//  public void shouldCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined() throws Exception
-// {
-//    projectFactory =
-//        spy(
-//            new OpenShiftProjectFactory(
-//                "",
-//                "serviceAccount",
-//                null,
-//                "<workspaceid>",
-//                false,
-//                true,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                configFactory,
-//                stopWorkspaceRoleProvisioner,
-//                userManager,
-//                preferenceManager,
-//                pool,
-//                OAUTH_IDENTITY_PROVIDER));
-//    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-//    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
-//    when(toReturnProject.getName()).thenReturn("workspace123");
-//    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-//
-//    OpenShiftWorkspaceServiceAccount serviceAccount =
-// mock(OpenShiftWorkspaceServiceAccount.class);
-//    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-//    projectFactory.getOrCreate(identity);
-//
-//    // then
-//    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
-//    verify(serviceAccount).prepare();
-//    verify(stopWorkspaceRoleProvisioner, times(1)).provision("workspace123");
-//  }
-//
-//  @Test
-//  public void shouldNotCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined()
-//      throws Exception {
-//    projectFactory =
-//        spy(
-//            new OpenShiftProjectFactory(
-//                "",
-//                "serviceAccount",
-//                null,
-//                "<workspaceid>",
-//                false,
-//                true,
-//                NAMESPACE_LABELS,
-//                NAMESPACE_ANNOTATIONS,
-//                clientFactory,
-//                configFactory,
-//                stopWorkspaceRoleProvisioner,
-//                userManager,
-//                preferenceManager,
-//                pool,
-//                NO_OAUTH_IDENTITY_PROVIDER));
-//    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
-//    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
-//    when(toReturnProject.getName()).thenReturn("workspace123");
-//    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
-//
-//    OpenShiftWorkspaceServiceAccount serviceAccount =
-// mock(OpenShiftWorkspaceServiceAccount.class);
-//    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
-//
-//    // when
-//    RuntimeIdentity identity =
-//        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
-//    projectFactory.getOrCreate(identity);
-//
-//    // then
-//    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
-//    verify(serviceAccount).prepare();
-//    verify(stopWorkspaceRoleProvisioner, times(0)).provision("workspace123");
-//  }
-//
-//  @Test
-//  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
-//    List<Project> projects =
-//        Arrays.asList(
-//            createProject(
-//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
-// "jondoe")),
-//            createProject(
-//                "ns3",
-//                "project3",
-//                "desc3",
-//                "Active",
-//                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
-//            createProject(
-//                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
-// "jondoe")));
-//    doReturn(projects).when(projectList).getItems();
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "legacy",
-//            "",
-//            "",
-//            "defaultNs",
-//            false,
-//            true,
-//            NAMESPACE_LABELS,
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//
-//    String namespace =
-//        projectFactory.evaluateNamespaceName(
-//            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
-//
-//    assertEquals(namespace, "ns1");
-//  }
-//
-//  @Test
-//  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
-//    List<Project> projects =
-//        singletonList(
-//            createProject(
-//                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME,
-// "jondoe")));
-//    doReturn(projects).when(projectList).getItems();
-//
-//    projectFactory =
-//        new OpenShiftProjectFactory(
-//            "predefined",
-//            "",
-//            null,
-//            "che-default",
-//            false,
-//            true,
-//            "try_placeholder_here=<username>",
-//            NAMESPACE_ANNOTATIONS,
-//            clientFactory,
-//            configFactory,
-//            stopWorkspaceRoleProvisioner,
-//            userManager,
-//            preferenceManager,
-//            pool,
-//            NO_OAUTH_IDENTITY_PROVIDER);
-//    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
-//    projectFactory.list();
-//
-//    verify(projectOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
-//  }
-//
-//  private void prepareNamespaceToBeFoundByName(String name, Project project) throws Exception {
-//    @SuppressWarnings("unchecked")
-//    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
-//    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
-//
-//    when(getProjectByNameOperation.get()).thenReturn(project);
-//  }
-//
-//  private void throwOnTryToGetProjectByName(String name, KubernetesClientException e)
-//      throws Exception {
-//    @SuppressWarnings("unchecked")
-//    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
-//    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
-//
-//    when(getProjectByNameOperation.get()).thenThrow(e);
-//  }
-//
-//  private void prepareListedProjects(List<Project> projects) throws Exception {
-//    @SuppressWarnings("unchecked")
-//    ProjectList projectList = mock(ProjectList.class);
-//    when(projectOperation.list()).thenReturn(projectList);
-//
-//    when(projectList.getItems()).thenReturn(projects);
-//  }
-//
-//  private void throwOnTryToGetProjectsList(Throwable e) throws Exception {
-//    when(projectOperation.list()).thenThrow(e);
-//  }
-//
-//  private Project createProject(String name, String displayName, String description, String phase)
-// {
-//    return createProject(name, displayName, description, phase, emptyMap());
-//  }
-//
-//  private Project createProject(
-//      String name,
-//      String displayName,
-//      String description,
-//      String phase,
-//      Map<String, String> extraAnnotations) {
-//    Map<String, String> annotations = new HashMap<>();
-//    if (displayName != null) {
-//      annotations.put(PROJECT_DISPLAY_NAME_ANNOTATION, displayName);
-//    }
-//    if (description != null) {
-//      annotations.put(PROJECT_DESCRIPTION_ANNOTATION, description);
-//    }
-//    if (extraAnnotations != null) {
-//      annotations.putAll(extraAnnotations);
-//    }
-//
-//    return new ProjectBuilder()
-//        .withNewMetadata()
-//        .withName(name)
-//        .withAnnotations(annotations)
-//        .endMetadata()
-//        .withNewStatus()
-//        .withNewPhase(phase)
-//        .endStatus()
-//        .build();
-//  }
-// }
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.DEFAULT_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ANNOTATION;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DESCRIPTION_ATTRIBUTE;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ANNOTATION;
+import static org.eclipse.che.workspace.infrastructure.openshift.Constants.PROJECT_DISPLAY_NAME_ATTRIBUTE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import com.google.common.collect.ImmutableMap;
+import io.fabric8.kubernetes.api.model.Status;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.DoneableProject;
+import io.fabric8.openshift.api.model.Project;
+import io.fabric8.openshift.api.model.ProjectBuilder;
+import io.fabric8.openshift.api.model.ProjectList;
+import io.fabric8.openshift.client.OpenShiftClient;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.che.api.core.ValidationException;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.user.server.PreferenceManager;
+import org.eclipse.che.api.user.server.UserManager;
+import org.eclipse.che.api.user.server.model.impl.UserImpl;
+import org.eclipse.che.api.workspace.server.WorkspaceManager;
+import org.eclipse.che.api.workspace.server.model.impl.RuntimeIdentityImpl;
+import org.eclipse.che.api.workspace.server.model.impl.WorkspaceImpl;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
+import org.eclipse.che.commons.env.EnvironmentContext;
+import org.eclipse.che.commons.subject.SubjectImpl;
+import org.eclipse.che.inject.ConfigurationException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
+import org.eclipse.che.workspace.infrastructure.kubernetes.util.KubernetesSharedPool;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientConfigFactory;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.eclipse.che.workspace.infrastructure.openshift.provision.OpenShiftStopWorkspaceRoleProvisioner;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link OpenShiftProjectFactory}.
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class OpenShiftProjectFactoryTest {
+
+  private static final String USER_ID = "userid";
+  private static final String USER_NAME = "username";
+  private static final String NO_OAUTH_IDENTITY_PROVIDER = null;
+  private static final String OAUTH_IDENTITY_PROVIDER = "openshift-v4";
+  private static final String NAMESPACE_LABEL_NAME = "component";
+  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
+  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
+  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
+
+  @Mock private OpenShiftClientConfigFactory configFactory;
+  @Mock private OpenShiftClientFactory clientFactory;
+  @Mock private CheServerKubernetesClientFactory cheClientFactory;
+  @Mock private OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner;
+  @Mock private WorkspaceManager workspaceManager;
+  @Mock private UserManager userManager;
+  @Mock private PreferenceManager preferenceManager;
+  @Mock private KubernetesSharedPool pool;
+
+  @Mock
+  private NonNamespaceOperation<
+          Project, ProjectList, DoneableProject, Resource<Project, DoneableProject>>
+      projectOperation;
+
+  @Mock private Resource<Project, DoneableProject> projectResource;
+
+  @Mock private OpenShiftClient osClient;
+
+  private OpenShiftProjectFactory projectFactory;
+
+  @Mock
+  private FilterWatchListDeletable<Project, ProjectList, Boolean, Watch, Watcher<Project>>
+      projectListResource;
+
+  @Mock private ProjectList projectList;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    lenient().when(clientFactory.createOC()).thenReturn(osClient);
+    lenient().when(osClient.projects()).thenReturn(projectOperation);
+
+    lenient()
+        .when(workspaceManager.getWorkspace(any()))
+        .thenReturn(WorkspaceImpl.builder().setId("1").setAttributes(emptyMap()).build());
+
+    lenient().when(projectOperation.withName(any())).thenReturn(projectResource);
+    lenient().when(projectResource.get()).thenReturn(mock(Project.class));
+
+    lenient().when(projectOperation.withLabels(any())).thenReturn(projectListResource);
+    lenient().when(projectListResource.list()).thenReturn(projectList);
+    lenient().when(projectList.getItems()).thenReturn(emptyList());
+
+    lenient()
+        .when(userManager.getById(USER_ID))
+        .thenReturn(new UserImpl(USER_ID, "test@mail.com", USER_NAME));
+
+    EnvironmentContext.setCurrent(new EnvironmentContext());
+  }
+
+  @Test
+  public void shouldNotThrowExceptionIfDefaultNamespaceIsSpecifiedOnCheckingIfNamespaceIsAllowed()
+      throws Exception {
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "legacy",
+            "",
+            null,
+            "defaultNs",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    projectFactory.checkIfNamespaceIsAllowed("defaultNs");
+  }
+
+  @Test
+  public void
+      shouldNotThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreAllowedOnCheckingIfNamespaceIsAllowed()
+          throws Exception {
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "legacy",
+            "",
+            null,
+            "defaultNs",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    projectFactory.checkIfNamespaceIsAllowed("any-namespace");
+  }
+
+  @Test(
+      expectedExceptions = ValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "User defined namespaces are not allowed. Only the default namespace 'defaultNs' is available.")
+  public void
+      shouldThrowExceptionIfNonDefaultNamespaceIsSpecifiedAndUserDefinedAreNotAllowedOnCheckingIfNamespaceIsAllowed()
+          throws Exception {
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "legacy",
+            "",
+            null,
+            "defaultNs",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    projectFactory.checkIfNamespaceIsAllowed("any-namespace");
+  }
+
+  @Test(
+      expectedExceptions = ConfigurationException.class,
+      expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
+  public void
+      shouldThrowExceptionIfNoDefaultNamespaceIsConfiguredAndUserDefinedNamespacesAreNotAllowed()
+          throws Exception {
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "projectName",
+            "",
+            null,
+            null,
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+  }
+
+  @Test
+  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
+    // given
+    List<Project> projects =
+        Arrays.asList(
+            createProject(
+                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
+            createProject(
+                "ns3",
+                "project3",
+                "desc3",
+                "Active",
+                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
+            createProject(
+                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+    doReturn(projects).when(projectList).getItems();
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+
+    // when
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+
+    // then
+    assertEquals(availableNamespaces.size(), 2);
+    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+    assertEquals(availableNamespaces.get(1).getName(), "ns2");
+  }
+
+  @Test
+  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
+    // given
+    Project p = createProject("ns1", "project1", "desc1", "Active");
+    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
+        .when(projectList)
+        .getItems();
+    prepareNamespaceToBeFoundByName("che-default", p);
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+
+    // when
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+
+    // then
+    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
+    // given
+    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
+        .when(projectList)
+        .getItems();
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    // when
+    projectFactory.list();
+
+    // then throw
+  }
+
+  @Test
+  public void shouldReturnDefaultProjectWhenItExistsAndUserDefinedIsNotAllowed() throws Exception {
+    prepareNamespaceToBeFoundByName(
+        "che-default",
+        new ProjectBuilder()
+            .withNewMetadata()
+            .withName("che-default")
+            .withAnnotations(
+                ImmutableMap.of(
+                    PROJECT_DISPLAY_NAME_ANNOTATION,
+                    "Default Che Project",
+                    PROJECT_DESCRIPTION_ANNOTATION,
+                    "some description"))
+            .endMetadata()
+            .withNewStatus()
+            .withPhase("Active")
+            .endStatus()
+            .build());
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            null,
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+    assertEquals(availableNamespaces.size(), 1);
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+    assertEquals(defaultNamespace.getName(), "che-default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertEquals(
+        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
+        "Default Che Project");
+    assertEquals(
+        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+  }
+
+  @Test
+  public void shouldReturnDefaultProjectWhenItDoesNotExistAndUserDefinedIsNotAllowed()
+      throws Exception {
+    throwOnTryToGetProjectByName(
+        "che-default", new KubernetesClientException("forbidden", 403, null));
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            null,
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+    assertEquals(availableNamespaces.size(), 1);
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(0);
+    assertEquals(defaultNamespace.getName(), "che-default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertNull(
+        defaultNamespace
+            .getAttributes()
+            .get(PHASE_ATTRIBUTE)); // no phase - means such project does not exist
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error while trying to fetch the project 'che-default'. Cause: connection refused")
+  public void shouldThrowExceptionWhenFailedToGetInfoAboutDefaultNamespace() throws Exception {
+    throwOnTryToGetProjectByName(
+        "che-default", new KubernetesClientException("connection refused"));
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            null,
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    projectFactory.list();
+  }
+
+  @Test
+  public void shouldReturnListOfExistingProjectsAlongWithDefaultIfUserDefinedIsAllowed()
+      throws Exception {
+    prepareListedProjects(
+        Arrays.asList(
+            createProject("my-for-ws", "Project for Workspaces", "some description", "Active"),
+            createProject("default", "Default Che Project", "some description", "Active")));
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            null,
+            "default",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(
+        forWS.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE), "Project for Workspaces");
+    assertEquals(forWS.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+    assertEquals(defaultNamespace.getName(), "default");
+    assertEquals(
+        defaultNamespace.getAttributes().get(PROJECT_DISPLAY_NAME_ATTRIBUTE),
+        "Default Che Project");
+    assertEquals(
+        defaultNamespace.getAttributes().get(PROJECT_DESCRIPTION_ATTRIBUTE), "some description");
+    assertEquals(defaultNamespace.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+  }
+
+  @Test
+  public void shouldReturnListOfExistingProjectsAlongWithNonExistingDefaultIfUserDefinedIsAllowed()
+      throws Exception {
+    prepareListedProjects(singletonList(createProject("my-for-ws", "", "", "Active")));
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            null,
+            "default",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    List<KubernetesNamespaceMeta> availableNamespaces = projectFactory.list();
+    assertEquals(availableNamespaces.size(), 2);
+    KubernetesNamespaceMeta forWS = availableNamespaces.get(0);
+    assertEquals(forWS.getName(), "my-for-ws");
+    assertEquals(forWS.getAttributes().get(PHASE_ATTRIBUTE), "Active");
+    assertNull(forWS.getAttributes().get(DEFAULT_ATTRIBUTE));
+
+    KubernetesNamespaceMeta defaultNamespace = availableNamespaces.get(1);
+    assertEquals(defaultNamespace.getName(), "default");
+    assertEquals(defaultNamespace.getAttributes().get(DEFAULT_ATTRIBUTE), "true");
+    assertNull(
+        defaultNamespace
+            .getAttributes()
+            .get(PHASE_ATTRIBUTE)); // no phase - means such namespace does not exist
+  }
+
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Error occurred when tried to list all available projects. Cause: connection refused")
+  public void shouldThrowExceptionWhenFailedToGetNamespaces() throws Exception {
+    throwOnTryToGetProjectsList(new KubernetesClientException("connection refused"));
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            null,
+            "default-ns",
+            true,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    projectFactory.list();
+  }
+
+  @Test
+  public void shouldRequireNamespacePriorExistenceIfDifferentFromDefaultAndUserDefinedIsNotAllowed()
+      throws Exception {
+    // There is only one scenario where this can happen. The workspace was created and started in
+    // some default namespace. Then server was reconfigured to use a different default namespace
+    // AND the namespace of the workspace was MANUALLY deleted in the cluster. In this case, we
+    // should NOT try to re-create the namespace because it would be created in a namespace that
+    // is not configured. We DO allow it to start if the namespace still exists though.
+
+    // given
+    projectFactory =
+        spy(
+            new OpenShiftProjectFactory(
+                "predefined",
+                "",
+                null,
+                "new-default",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                configFactory,
+                stopWorkspaceRoleProvisioner,
+                userManager,
+                preferenceManager,
+                pool,
+                NO_OAUTH_IDENTITY_PROVIDER));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "old-default");
+    OpenShiftProject project = projectFactory.getOrCreate(identity);
+
+    // then
+    assertEquals(toReturnProject, project);
+    verify(projectFactory, never()).doCreateServiceAccount(any(), any());
+    verify(toReturnProject).prepare(eq(false), any());
+  }
+
+  @Test
+  public void shouldPrepareWorkspaceServiceAccountIfItIsConfiguredAndProjectIsNotPredefined()
+      throws Exception {
+    // given
+    projectFactory =
+        spy(
+            new OpenShiftProjectFactory(
+                "",
+                "serviceAccount",
+                null,
+                "<workspaceid>",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                configFactory,
+                stopWorkspaceRoleProvisioner,
+                userManager,
+                preferenceManager,
+                pool,
+                NO_OAUTH_IDENTITY_PROVIDER));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
+    when(toReturnProject.getName()).thenReturn("workspace123");
+    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+
+    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    projectFactory.getOrCreate(identity);
+
+    // then
+    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
+    verify(serviceAccount).prepare();
+  }
+
+  @Test
+  public void shouldCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined() throws Exception {
+    projectFactory =
+        spy(
+            new OpenShiftProjectFactory(
+                "",
+                "serviceAccount",
+                null,
+                "<workspaceid>",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                configFactory,
+                stopWorkspaceRoleProvisioner,
+                userManager,
+                preferenceManager,
+                pool,
+                OAUTH_IDENTITY_PROVIDER));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
+    when(toReturnProject.getName()).thenReturn("workspace123");
+    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+
+    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    projectFactory.getOrCreate(identity);
+
+    // then
+    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
+    verify(serviceAccount).prepare();
+    verify(stopWorkspaceRoleProvisioner, times(1)).provision("workspace123");
+  }
+
+  @Test
+  public void shouldNotCallStopWorkspaceRoleProvisionWhenIdentityProviderIsDefined()
+      throws Exception {
+    projectFactory =
+        spy(
+            new OpenShiftProjectFactory(
+                "",
+                "serviceAccount",
+                null,
+                "<workspaceid>",
+                false,
+                true,
+                NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
+                clientFactory,
+                cheClientFactory,
+                configFactory,
+                stopWorkspaceRoleProvisioner,
+                userManager,
+                preferenceManager,
+                pool,
+                NO_OAUTH_IDENTITY_PROVIDER));
+    OpenShiftProject toReturnProject = mock(OpenShiftProject.class);
+    when(toReturnProject.getWorkspaceId()).thenReturn("workspace123");
+    when(toReturnProject.getName()).thenReturn("workspace123");
+    doReturn(toReturnProject).when(projectFactory).doCreateProjectAccess(any(), any());
+
+    OpenShiftWorkspaceServiceAccount serviceAccount = mock(OpenShiftWorkspaceServiceAccount.class);
+    doReturn(serviceAccount).when(projectFactory).doCreateServiceAccount(any(), any());
+
+    // when
+    RuntimeIdentity identity =
+        new RuntimeIdentityImpl("workspace123", null, USER_ID, "workspace123");
+    projectFactory.getOrCreate(identity);
+
+    // then
+    verify(projectFactory).doCreateServiceAccount("workspace123", "workspace123");
+    verify(serviceAccount).prepare();
+    verify(stopWorkspaceRoleProvisioner, times(0)).provision("workspace123");
+  }
+
+  @Test
+  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
+    List<Project> projects =
+        Arrays.asList(
+            createProject(
+                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
+            createProject(
+                "ns3",
+                "project3",
+                "desc3",
+                "Active",
+                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
+            createProject(
+                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+    doReturn(projects).when(projectList).getItems();
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+
+    String namespace =
+        projectFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+
+    assertEquals(namespace, "ns1");
+  }
+
+  @Test
+  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
+    List<Project> projects =
+        singletonList(
+            createProject(
+                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+    doReturn(projects).when(projectList).getItems();
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            null,
+            "che-default",
+            false,
+            true,
+            "try_placeholder_here=<username>",
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            cheClientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+    projectFactory.list();
+
+    verify(projectOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
+  }
+
+  private void prepareNamespaceToBeFoundByName(String name, Project project) throws Exception {
+    @SuppressWarnings("unchecked")
+    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
+    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
+
+    when(getProjectByNameOperation.get()).thenReturn(project);
+  }
+
+  private void throwOnTryToGetProjectByName(String name, KubernetesClientException e)
+      throws Exception {
+    @SuppressWarnings("unchecked")
+    Resource<Project, DoneableProject> getProjectByNameOperation = mock(Resource.class);
+    when(projectOperation.withName(name)).thenReturn(getProjectByNameOperation);
+
+    when(getProjectByNameOperation.get()).thenThrow(e);
+  }
+
+  private void prepareListedProjects(List<Project> projects) throws Exception {
+    @SuppressWarnings("unchecked")
+    ProjectList projectList = mock(ProjectList.class);
+    when(projectOperation.list()).thenReturn(projectList);
+
+    when(projectList.getItems()).thenReturn(projects);
+  }
+
+  private void throwOnTryToGetProjectsList(Throwable e) throws Exception {
+    when(projectOperation.list()).thenThrow(e);
+  }
+
+  private Project createProject(String name, String displayName, String description, String phase) {
+    return createProject(name, displayName, description, phase, emptyMap());
+  }
+
+  private Project createProject(
+      String name,
+      String displayName,
+      String description,
+      String phase,
+      Map<String, String> extraAnnotations) {
+    Map<String, String> annotations = new HashMap<>();
+    if (displayName != null) {
+      annotations.put(PROJECT_DISPLAY_NAME_ANNOTATION, displayName);
+    }
+    if (description != null) {
+      annotations.put(PROJECT_DESCRIPTION_ANNOTATION, description);
+    }
+    if (extraAnnotations != null) {
+      annotations.putAll(extraAnnotations);
+    }
+
+    return new ProjectBuilder()
+        .withNewMetadata()
+        .withName(name)
+        .withAnnotations(annotations)
+        .endMetadata()
+        .withNewStatus()
+        .withNewPhase(phase)
+        .endStatus()
+        .build();
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -1,269 +1,269 @@
-/*
- * Copyright (c) 2012-2018 Red Hat, Inc.
- * This program and the accompanying materials are made
- * available under the terms of the Eclipse Public License 2.0
- * which is available at https://www.eclipse.org/legal/epl-2.0/
- *
- * SPDX-License-Identifier: EPL-2.0
- *
- * Contributors:
- *   Red Hat, Inc. - initial API and implementation
- */
-package org.eclipse.che.workspace.infrastructure.openshift.project;
-
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-
-import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
-import io.fabric8.kubernetes.client.dsl.MixedOperation;
-import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-import io.fabric8.kubernetes.client.dsl.Resource;
-import io.fabric8.openshift.api.model.DoneableProjectRequest;
-import io.fabric8.openshift.api.model.Project;
-import io.fabric8.openshift.api.model.ProjectBuilder;
-import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
-import io.fabric8.openshift.client.OpenShiftClient;
-import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
-import java.util.concurrent.Executor;
-import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
-import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
-import org.mockito.Mock;
-import org.mockito.testng.MockitoTestNGListener;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Listeners;
-import org.testng.annotations.Test;
-
-/**
- * Tests {@link OpenShiftProject}
- *
- * @author Sergii Leshchenko
- */
-@Listeners(MockitoTestNGListener.class)
-public class OpenShiftProjectTest {
-
-  public static final String PROJECT_NAME = "testProject";
-  public static final String WORKSPACE_ID = "workspace123";
-
-  @Mock private KubernetesDeployments deployments;
-  @Mock private KubernetesServices services;
-  @Mock private OpenShiftRoutes routes;
-  @Mock private KubernetesPersistentVolumeClaims pvcs;
-  @Mock private KubernetesIngresses ingresses;
-  @Mock private KubernetesSecrets secrets;
-  @Mock private KubernetesConfigsMaps configsMaps;
-  @Mock private OpenShiftClientFactory clientFactory;
-  @Mock private Executor executor;
-  @Mock private OpenShiftClient openShiftClient;
-  @Mock private KubernetesClient kubernetesClient;
-  @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
-
-  private OpenShiftProject openShiftProject;
-
-  @BeforeMethod
-  public void setUp() throws Exception {
-    lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
-    lenient().when(clientFactory.createOC()).thenReturn(openShiftClient);
-    lenient().when(clientFactory.createOC(anyString())).thenReturn(openShiftClient);
-    lenient().when(openShiftClient.adapt(OpenShiftClient.class)).thenReturn(openShiftClient);
-
-    final MixedOperation mixedOperation = mock(MixedOperation.class);
-    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-    lenient().doReturn(mixedOperation).when(kubernetesClient).serviceAccounts();
-    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-    lenient().when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
-    lenient().when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
-
-    openShiftProject =
-        new OpenShiftProject(
-            clientFactory,
-            WORKSPACE_ID,
-            PROJECT_NAME,
-            deployments,
-            services,
-            routes,
-            pvcs,
-            ingresses,
-            secrets,
-            configsMaps);
-  }
-
-  @Test
-  public void testOpenShiftProjectPreparingWhenProjectExists() throws Exception {
-    // given
-    MetadataNested projectMeta = prepareProjectRequest();
-
-    prepareProject(PROJECT_NAME);
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-
-    // when
-    project.prepare(true);
-
-    // then
-    verify(projectMeta, never()).withName(PROJECT_NAME);
-  }
-
-  @Test
-  public void testOpenShiftProjectPreparingWhenProjectDoesNotExist() throws Exception {
-    // given
-    MetadataNested projectMetadata = prepareProjectRequest();
-
-    Resource resource = prepareProjectResource(PROJECT_NAME);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-
-    // when
-    openShiftProject.prepare(true);
-
-    // then
-    verify(projectMetadata).withName(PROJECT_NAME);
-  }
-
-  @Test(expectedExceptions = InfrastructureException.class)
-  public void throwsExceptionIfNamespaceDoesntExistAndNotAllowedToCreateIt() throws Exception {
-    // given
-    Resource resource = prepareProjectResource(PROJECT_NAME);
-    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-
-    // when
-    project.prepare(false);
-
-    // then
-    // exception is thrown
-  }
-
-  @Test
-  public void testOpenShiftProjectCleaningUp() throws Exception {
-    // when
-    openShiftProject.cleanUp();
-
-    verify(routes).delete();
-    verify(services).delete();
-    verify(deployments).delete();
-    verify(secrets).delete();
-    verify(configsMaps).delete();
-  }
-
-  @Test
-  public void testOpenShiftProjectCleaningUpIfExceptionsOccurs() throws Exception {
-    doThrow(new InfrastructureException("err1.")).when(services).delete();
-    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
-
-    InfrastructureException error = null;
-    // when
-    try {
-      openShiftProject.cleanUp();
-
-    } catch (InfrastructureException e) {
-      error = e;
-    }
-
-    // then
-    assertNotNull(error);
-    String message = error.getMessage();
-    assertEquals(message, "Error(s) occurs while cleaning up the namespace. err1. err2.");
-    verify(routes).delete();
-  }
-
-  @Test
-  public void testDeletesExistingProject() throws Exception {
-    // given
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-    Resource resource = prepareProjectResource(PROJECT_NAME);
-
-    // when
-    project.delete();
-
-    // then
-    verify(resource).delete();
-  }
-
-  @Test
-  public void testDoesntFailIfDeletedProjectDoesntExist() throws Exception {
-    // given
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-    Resource resource = prepareProjectResource(PROJECT_NAME);
-    when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
-    when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
-
-    // when
-    project.delete();
-
-    // then
-    verify(resource).delete();
-    // and no exception is thrown
-  }
-
-  @Test
-  public void testDoesntFailIfDeletedProjectIsBeingDeleted() throws Exception {
-    // given
-    OpenShiftProject project =
-        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-    Resource resource = prepareProjectResource(PROJECT_NAME);
-    when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
-
-    // when
-    project.delete();
-
-    // then
-    verify(resource).delete();
-    // and no exception is thrown
-  }
-
-  private MetadataNested prepareProjectRequest() {
-    ProjectRequestOperation projectRequestOperation = mock(ProjectRequestOperation.class);
-    DoneableProjectRequest projectRequest = mock(DoneableProjectRequest.class);
-    MetadataNested metadataNested = mock(MetadataNested.class);
-
-    doReturn(projectRequestOperation).when(openShiftClient).projectrequests();
-    doReturn(projectRequest).when(projectRequestOperation).createNew();
-    doReturn(metadataNested).when(projectRequest).withNewMetadata();
-    doReturn(metadataNested).when(metadataNested).withName(anyString());
-    doReturn(projectRequest).when(metadataNested).endMetadata();
-    return metadataNested;
-  }
-
-  private Resource prepareProjectResource(String projectName) {
-    Resource projectResource = mock(Resource.class);
-
-    NonNamespaceOperation projectOperation = mock(NonNamespaceOperation.class);
-    doReturn(projectResource).when(projectOperation).withName(projectName);
-    doReturn(projectOperation).when(openShiftClient).projects();
-
-    when(projectResource.get())
-        .thenReturn(
-            new ProjectBuilder().withNewMetadata().withName(projectName).endMetadata().build());
-
-    openShiftClient.projects().withName(projectName).get();
-    return projectResource;
-  }
-
-  private Project prepareProject(String projectName) {
-    Project project = mock(Project.class);
-    Resource projectResource = prepareProjectResource(projectName);
-    doReturn(project).when(projectResource).get();
-    return project;
-  }
-}
+///*
+// * Copyright (c) 2012-2018 Red Hat, Inc.
+// * This program and the accompanying materials are made
+// * available under the terms of the Eclipse Public License 2.0
+// * which is available at https://www.eclipse.org/legal/epl-2.0/
+// *
+// * SPDX-License-Identifier: EPL-2.0
+// *
+// * Contributors:
+// *   Red Hat, Inc. - initial API and implementation
+// */
+//package org.eclipse.che.workspace.infrastructure.openshift.project;
+//
+//import static org.mockito.ArgumentMatchers.anyString;
+//import static org.mockito.Mockito.doReturn;
+//import static org.mockito.Mockito.doThrow;
+//import static org.mockito.Mockito.lenient;
+//import static org.mockito.Mockito.mock;
+//import static org.mockito.Mockito.never;
+//import static org.mockito.Mockito.verify;
+//import static org.mockito.Mockito.when;
+//import static org.testng.Assert.assertEquals;
+//import static org.testng.Assert.assertNotNull;
+//
+//import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
+//import io.fabric8.kubernetes.api.model.ServiceAccount;
+//import io.fabric8.kubernetes.client.KubernetesClient;
+//import io.fabric8.kubernetes.client.KubernetesClientException;
+//import io.fabric8.kubernetes.client.dsl.MixedOperation;
+//import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+//import io.fabric8.kubernetes.client.dsl.Resource;
+//import io.fabric8.openshift.api.model.DoneableProjectRequest;
+//import io.fabric8.openshift.api.model.Project;
+//import io.fabric8.openshift.api.model.ProjectBuilder;
+//import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
+//import io.fabric8.openshift.client.OpenShiftClient;
+//import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
+//import java.util.concurrent.Executor;
+//import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
+//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
+//import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+//import org.mockito.Mock;
+//import org.mockito.testng.MockitoTestNGListener;
+//import org.testng.annotations.BeforeMethod;
+//import org.testng.annotations.Listeners;
+//import org.testng.annotations.Test;
+//
+///**
+// * Tests {@link OpenShiftProject}
+// *
+// * @author Sergii Leshchenko
+// */
+//@Listeners(MockitoTestNGListener.class)
+//public class OpenShiftProjectTest {
+//
+//  public static final String PROJECT_NAME = "testProject";
+//  public static final String WORKSPACE_ID = "workspace123";
+//
+//  @Mock private KubernetesDeployments deployments;
+//  @Mock private KubernetesServices services;
+//  @Mock private OpenShiftRoutes routes;
+//  @Mock private KubernetesPersistentVolumeClaims pvcs;
+//  @Mock private KubernetesIngresses ingresses;
+//  @Mock private KubernetesSecrets secrets;
+//  @Mock private KubernetesConfigsMaps configsMaps;
+//  @Mock private OpenShiftClientFactory clientFactory;
+//  @Mock private Executor executor;
+//  @Mock private OpenShiftClient openShiftClient;
+//  @Mock private KubernetesClient kubernetesClient;
+//  @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
+//
+//  private OpenShiftProject openShiftProject;
+//
+//  @BeforeMethod
+//  public void setUp() throws Exception {
+//    lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
+//    lenient().when(clientFactory.createOC()).thenReturn(openShiftClient);
+//    lenient().when(clientFactory.createOC(anyString())).thenReturn(openShiftClient);
+//    lenient().when(openShiftClient.adapt(OpenShiftClient.class)).thenReturn(openShiftClient);
+//
+//    final MixedOperation mixedOperation = mock(MixedOperation.class);
+//    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
+//    lenient().doReturn(mixedOperation).when(kubernetesClient).serviceAccounts();
+//    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
+//    lenient().when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
+//    lenient().when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
+//
+//    openShiftProject =
+//        new OpenShiftProject(
+//            clientFactory,
+//            WORKSPACE_ID,
+//            PROJECT_NAME,
+//            deployments,
+//            services,
+//            routes,
+//            pvcs,
+//            ingresses,
+//            secrets,
+//            configsMaps);
+//  }
+//
+//  @Test
+//  public void testOpenShiftProjectPreparingWhenProjectExists() throws Exception {
+//    // given
+//    MetadataNested projectMeta = prepareProjectRequest();
+//
+//    prepareProject(PROJECT_NAME);
+//    OpenShiftProject project =
+//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+//
+//    // when
+//    project.prepare(true);
+//
+//    // then
+//    verify(projectMeta, never()).withName(PROJECT_NAME);
+//  }
+//
+//  @Test
+//  public void testOpenShiftProjectPreparingWhenProjectDoesNotExist() throws Exception {
+//    // given
+//    MetadataNested projectMetadata = prepareProjectRequest();
+//
+//    Resource resource = prepareProjectResource(PROJECT_NAME);
+//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+//    OpenShiftProject project =
+//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+//
+//    // when
+//    openShiftProject.prepare(true);
+//
+//    // then
+//    verify(projectMetadata).withName(PROJECT_NAME);
+//  }
+//
+//  @Test(expectedExceptions = InfrastructureException.class)
+//  public void throwsExceptionIfNamespaceDoesntExistAndNotAllowedToCreateIt() throws Exception {
+//    // given
+//    Resource resource = prepareProjectResource(PROJECT_NAME);
+//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+//    OpenShiftProject project =
+//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+//
+//    // when
+//    project.prepare(false);
+//
+//    // then
+//    // exception is thrown
+//  }
+//
+//  @Test
+//  public void testOpenShiftProjectCleaningUp() throws Exception {
+//    // when
+//    openShiftProject.cleanUp();
+//
+//    verify(routes).delete();
+//    verify(services).delete();
+//    verify(deployments).delete();
+//    verify(secrets).delete();
+//    verify(configsMaps).delete();
+//  }
+//
+//  @Test
+//  public void testOpenShiftProjectCleaningUpIfExceptionsOccurs() throws Exception {
+//    doThrow(new InfrastructureException("err1.")).when(services).delete();
+//    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
+//
+//    InfrastructureException error = null;
+//    // when
+//    try {
+//      openShiftProject.cleanUp();
+//
+//    } catch (InfrastructureException e) {
+//      error = e;
+//    }
+//
+//    // then
+//    assertNotNull(error);
+//    String message = error.getMessage();
+//    assertEquals(message, "Error(s) occurs while cleaning up the namespace. err1. err2.");
+//    verify(routes).delete();
+//  }
+//
+//  @Test
+//  public void testDeletesExistingProject() throws Exception {
+//    // given
+//    OpenShiftProject project =
+//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+//    Resource resource = prepareProjectResource(PROJECT_NAME);
+//
+//    // when
+//    project.delete();
+//
+//    // then
+//    verify(resource).delete();
+//  }
+//
+//  @Test
+//  public void testDoesntFailIfDeletedProjectDoesntExist() throws Exception {
+//    // given
+//    OpenShiftProject project =
+//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+//    Resource resource = prepareProjectResource(PROJECT_NAME);
+//    when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
+//    when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
+//
+//    // when
+//    project.delete();
+//
+//    // then
+//    verify(resource).delete();
+//    // and no exception is thrown
+//  }
+//
+//  @Test
+//  public void testDoesntFailIfDeletedProjectIsBeingDeleted() throws Exception {
+//    // given
+//    OpenShiftProject project =
+//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+//    Resource resource = prepareProjectResource(PROJECT_NAME);
+//    when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
+//
+//    // when
+//    project.delete();
+//
+//    // then
+//    verify(resource).delete();
+//    // and no exception is thrown
+//  }
+//
+//  private MetadataNested prepareProjectRequest() {
+//    ProjectRequestOperation projectRequestOperation = mock(ProjectRequestOperation.class);
+//    DoneableProjectRequest projectRequest = mock(DoneableProjectRequest.class);
+//    MetadataNested metadataNested = mock(MetadataNested.class);
+//
+//    doReturn(projectRequestOperation).when(openShiftClient).projectrequests();
+//    doReturn(projectRequest).when(projectRequestOperation).createNew();
+//    doReturn(metadataNested).when(projectRequest).withNewMetadata();
+//    doReturn(metadataNested).when(metadataNested).withName(anyString());
+//    doReturn(projectRequest).when(metadataNested).endMetadata();
+//    return metadataNested;
+//  }
+//
+//  private Resource prepareProjectResource(String projectName) {
+//    Resource projectResource = mock(Resource.class);
+//
+//    NonNamespaceOperation projectOperation = mock(NonNamespaceOperation.class);
+//    doReturn(projectResource).when(projectOperation).withName(projectName);
+//    doReturn(projectOperation).when(openShiftClient).projects();
+//
+//    when(projectResource.get())
+//        .thenReturn(
+//            new ProjectBuilder().withNewMetadata().withName(projectName).endMetadata().build());
+//
+//    openShiftClient.projects().withName(projectName).get();
+//    return projectResource;
+//  }
+//
+//  private Project prepareProject(String projectName) {
+//    Project project = mock(Project.class);
+//    Resource projectResource = prepareProjectResource(projectName);
+//    doReturn(project).when(projectResource).get();
+//    return project;
+//  }
+//}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -1,270 +1,289 @@
-/// *
-// * Copyright (c) 2012-2018 Red Hat, Inc.
-// * This program and the accompanying materials are made
-// * available under the terms of the Eclipse Public License 2.0
-// * which is available at https://www.eclipse.org/legal/epl-2.0/
-// *
-// * SPDX-License-Identifier: EPL-2.0
-// *
-// * Contributors:
-// *   Red Hat, Inc. - initial API and implementation
-// */
-// package org.eclipse.che.workspace.infrastructure.openshift.project;
-//
-// import static org.mockito.ArgumentMatchers.anyString;
-// import static org.mockito.Mockito.doReturn;
-// import static org.mockito.Mockito.doThrow;
-// import static org.mockito.Mockito.lenient;
-// import static org.mockito.Mockito.mock;
-// import static org.mockito.Mockito.never;
-// import static org.mockito.Mockito.verify;
-// import static org.mockito.Mockito.when;
-// import static org.testng.Assert.assertEquals;
-// import static org.testng.Assert.assertNotNull;
-//
-// import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-// import io.fabric8.kubernetes.api.model.ServiceAccount;
-// import io.fabric8.kubernetes.client.KubernetesClient;
-// import io.fabric8.kubernetes.client.KubernetesClientException;
-// import io.fabric8.kubernetes.client.dsl.MixedOperation;
-// import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-// import io.fabric8.kubernetes.client.dsl.Resource;
-// import io.fabric8.openshift.api.model.DoneableProjectRequest;
-// import io.fabric8.openshift.api.model.Project;
-// import io.fabric8.openshift.api.model.ProjectBuilder;
-// import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
-// import io.fabric8.openshift.client.OpenShiftClient;
-// import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
-// import java.util.concurrent.Executor;
-// import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
-// import
-// org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
-// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
-// import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
-// import org.mockito.Mock;
-// import org.mockito.testng.MockitoTestNGListener;
-// import org.testng.annotations.BeforeMethod;
-// import org.testng.annotations.Listeners;
-// import org.testng.annotations.Test;
-//
-/// **
-// * Tests {@link OpenShiftProject}
-// *
-// * @author Sergii Leshchenko
-// */
-// @Listeners(MockitoTestNGListener.class)
-// public class OpenShiftProjectTest {
-//
-//  public static final String PROJECT_NAME = "testProject";
-//  public static final String WORKSPACE_ID = "workspace123";
-//
-//  @Mock private KubernetesDeployments deployments;
-//  @Mock private KubernetesServices services;
-//  @Mock private OpenShiftRoutes routes;
-//  @Mock private KubernetesPersistentVolumeClaims pvcs;
-//  @Mock private KubernetesIngresses ingresses;
-//  @Mock private KubernetesSecrets secrets;
-//  @Mock private KubernetesConfigsMaps configsMaps;
-//  @Mock private OpenShiftClientFactory clientFactory;
-//  @Mock private Executor executor;
-//  @Mock private OpenShiftClient openShiftClient;
-//  @Mock private KubernetesClient kubernetesClient;
-//  @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
-//
-//  private OpenShiftProject openShiftProject;
-//
-//  @BeforeMethod
-//  public void setUp() throws Exception {
-//    lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
-//    lenient().when(clientFactory.createOC()).thenReturn(openShiftClient);
-//    lenient().when(clientFactory.createOC(anyString())).thenReturn(openShiftClient);
-//    lenient().when(openShiftClient.adapt(OpenShiftClient.class)).thenReturn(openShiftClient);
-//
-//    final MixedOperation mixedOperation = mock(MixedOperation.class);
-//    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
-//    lenient().doReturn(mixedOperation).when(kubernetesClient).serviceAccounts();
-//    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
-//    lenient().when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
-//    lenient().when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
-//
-//    openShiftProject =
-//        new OpenShiftProject(
-//            clientFactory,
-//            WORKSPACE_ID,
-//            PROJECT_NAME,
-//            deployments,
-//            services,
-//            routes,
-//            pvcs,
-//            ingresses,
-//            secrets,
-//            configsMaps);
-//  }
-//
-//  @Test
-//  public void testOpenShiftProjectPreparingWhenProjectExists() throws Exception {
-//    // given
-//    MetadataNested projectMeta = prepareProjectRequest();
-//
-//    prepareProject(PROJECT_NAME);
-//    OpenShiftProject project =
-//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-//
-//    // when
-//    project.prepare(true);
-//
-//    // then
-//    verify(projectMeta, never()).withName(PROJECT_NAME);
-//  }
-//
-//  @Test
-//  public void testOpenShiftProjectPreparingWhenProjectDoesNotExist() throws Exception {
-//    // given
-//    MetadataNested projectMetadata = prepareProjectRequest();
-//
-//    Resource resource = prepareProjectResource(PROJECT_NAME);
-//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-//    OpenShiftProject project =
-//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-//
-//    // when
-//    openShiftProject.prepare(true);
-//
-//    // then
-//    verify(projectMetadata).withName(PROJECT_NAME);
-//  }
-//
-//  @Test(expectedExceptions = InfrastructureException.class)
-//  public void throwsExceptionIfNamespaceDoesntExistAndNotAllowedToCreateIt() throws Exception {
-//    // given
-//    Resource resource = prepareProjectResource(PROJECT_NAME);
-//    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
-//    OpenShiftProject project =
-//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-//
-//    // when
-//    project.prepare(false);
-//
-//    // then
-//    // exception is thrown
-//  }
-//
-//  @Test
-//  public void testOpenShiftProjectCleaningUp() throws Exception {
-//    // when
-//    openShiftProject.cleanUp();
-//
-//    verify(routes).delete();
-//    verify(services).delete();
-//    verify(deployments).delete();
-//    verify(secrets).delete();
-//    verify(configsMaps).delete();
-//  }
-//
-//  @Test
-//  public void testOpenShiftProjectCleaningUpIfExceptionsOccurs() throws Exception {
-//    doThrow(new InfrastructureException("err1.")).when(services).delete();
-//    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
-//
-//    InfrastructureException error = null;
-//    // when
-//    try {
-//      openShiftProject.cleanUp();
-//
-//    } catch (InfrastructureException e) {
-//      error = e;
-//    }
-//
-//    // then
-//    assertNotNull(error);
-//    String message = error.getMessage();
-//    assertEquals(message, "Error(s) occurs while cleaning up the namespace. err1. err2.");
-//    verify(routes).delete();
-//  }
-//
-//  @Test
-//  public void testDeletesExistingProject() throws Exception {
-//    // given
-//    OpenShiftProject project =
-//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-//    Resource resource = prepareProjectResource(PROJECT_NAME);
-//
-//    // when
-//    project.delete();
-//
-//    // then
-//    verify(resource).delete();
-//  }
-//
-//  @Test
-//  public void testDoesntFailIfDeletedProjectDoesntExist() throws Exception {
-//    // given
-//    OpenShiftProject project =
-//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-//    Resource resource = prepareProjectResource(PROJECT_NAME);
-//    when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
-//    when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
-//
-//    // when
-//    project.delete();
-//
-//    // then
-//    verify(resource).delete();
-//    // and no exception is thrown
-//  }
-//
-//  @Test
-//  public void testDoesntFailIfDeletedProjectIsBeingDeleted() throws Exception {
-//    // given
-//    OpenShiftProject project =
-//        new OpenShiftProject(clientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
-//    Resource resource = prepareProjectResource(PROJECT_NAME);
-//    when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
-//
-//    // when
-//    project.delete();
-//
-//    // then
-//    verify(resource).delete();
-//    // and no exception is thrown
-//  }
-//
-//  private MetadataNested prepareProjectRequest() {
-//    ProjectRequestOperation projectRequestOperation = mock(ProjectRequestOperation.class);
-//    DoneableProjectRequest projectRequest = mock(DoneableProjectRequest.class);
-//    MetadataNested metadataNested = mock(MetadataNested.class);
-//
-//    doReturn(projectRequestOperation).when(openShiftClient).projectrequests();
-//    doReturn(projectRequest).when(projectRequestOperation).createNew();
-//    doReturn(metadataNested).when(projectRequest).withNewMetadata();
-//    doReturn(metadataNested).when(metadataNested).withName(anyString());
-//    doReturn(projectRequest).when(metadataNested).endMetadata();
-//    return metadataNested;
-//  }
-//
-//  private Resource prepareProjectResource(String projectName) {
-//    Resource projectResource = mock(Resource.class);
-//
-//    NonNamespaceOperation projectOperation = mock(NonNamespaceOperation.class);
-//    doReturn(projectResource).when(projectOperation).withName(projectName);
-//    doReturn(projectOperation).when(openShiftClient).projects();
-//
-//    when(projectResource.get())
-//        .thenReturn(
-//            new ProjectBuilder().withNewMetadata().withName(projectName).endMetadata().build());
-//
-//    openShiftClient.projects().withName(projectName).get();
-//    return projectResource;
-//  }
-//
-//  private Project prepareProject(String projectName) {
-//    Project project = mock(Project.class);
-//    Resource projectResource = prepareProjectResource(projectName);
-//    doReturn(project).when(projectResource).get();
-//    return project;
-//  }
-// }
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.openshift.project;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
+import io.fabric8.kubernetes.api.model.Namespace;
+import io.fabric8.kubernetes.api.model.NamespaceBuilder;
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+import io.fabric8.openshift.api.model.DoneableProjectRequest;
+import io.fabric8.openshift.api.model.Project;
+import io.fabric8.openshift.api.model.ProjectBuilder;
+import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
+import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
+import java.util.concurrent.Executor;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.workspace.infrastructure.kubernetes.CheServerKubernetesClientFactory;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
+import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
+import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+/**
+ * Tests {@link OpenShiftProject}
+ *
+ * @author Sergii Leshchenko
+ */
+@Listeners(MockitoTestNGListener.class)
+public class OpenShiftProjectTest {
+
+  public static final String PROJECT_NAME = "testProject";
+  public static final String WORKSPACE_ID = "workspace123";
+
+  @Mock private KubernetesDeployments deployments;
+  @Mock private KubernetesServices services;
+  @Mock private OpenShiftRoutes routes;
+  @Mock private KubernetesPersistentVolumeClaims pvcs;
+  @Mock private KubernetesIngresses ingresses;
+  @Mock private KubernetesSecrets secrets;
+  @Mock private KubernetesConfigsMaps configsMaps;
+  @Mock private OpenShiftClientFactory clientFactory;
+  @Mock private CheServerKubernetesClientFactory cheClientFactory;
+  @Mock private Executor executor;
+  @Mock private OpenShiftClient openShiftClient;
+  @Mock private KubernetesClient kubernetesClient;
+  @Mock private Resource<ServiceAccount, DoneableServiceAccount> serviceAccountResource;
+
+  private OpenShiftProject openShiftProject;
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    lenient().when(clientFactory.create(anyString())).thenReturn(kubernetesClient);
+    lenient().when(clientFactory.createOC()).thenReturn(openShiftClient);
+    lenient().when(clientFactory.createOC(anyString())).thenReturn(openShiftClient);
+    lenient().when(openShiftClient.adapt(OpenShiftClient.class)).thenReturn(openShiftClient);
+
+    final MixedOperation mixedOperation = mock(MixedOperation.class);
+    final NonNamespaceOperation namespaceOperation = mock(NonNamespaceOperation.class);
+    lenient().doReturn(mixedOperation).when(kubernetesClient).serviceAccounts();
+    lenient().when(mixedOperation.inNamespace(anyString())).thenReturn(namespaceOperation);
+    lenient().when(namespaceOperation.withName(anyString())).thenReturn(serviceAccountResource);
+    lenient().when(serviceAccountResource.get()).thenReturn(mock(ServiceAccount.class));
+
+    openShiftProject =
+        new OpenShiftProject(
+            clientFactory,
+            cheClientFactory,
+            WORKSPACE_ID,
+            PROJECT_NAME,
+            deployments,
+            services,
+            routes,
+            pvcs,
+            ingresses,
+            secrets,
+            configsMaps);
+  }
+
+  @Test
+  public void testOpenShiftProjectPreparingWhenProjectExists() throws Exception {
+    // given
+    MetadataNested projectMeta = prepareProjectRequest();
+    prepareNamespaceGet(PROJECT_NAME);
+
+    prepareProject(PROJECT_NAME);
+    OpenShiftProject project =
+        new OpenShiftProject(clientFactory, cheClientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+
+    // when
+    project.prepare(true);
+
+    // then
+    verify(projectMeta, never()).withName(PROJECT_NAME);
+  }
+
+  @Test
+  public void testOpenShiftProjectPreparingWhenProjectDoesNotExist() throws Exception {
+    // given
+    MetadataNested projectMetadata = prepareProjectRequest();
+    prepareNamespaceGet(PROJECT_NAME);
+
+    Resource resource = prepareProjectResource(PROJECT_NAME);
+    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+    OpenShiftProject project =
+        new OpenShiftProject(clientFactory, cheClientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+
+    // when
+    openShiftProject.prepare(true);
+
+    // then
+    verify(projectMetadata).withName(PROJECT_NAME);
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwsExceptionIfNamespaceDoesntExistAndNotAllowedToCreateIt() throws Exception {
+    // given
+    Resource resource = prepareProjectResource(PROJECT_NAME);
+    doThrow(new KubernetesClientException("error", 403, null)).when(resource).get();
+    OpenShiftProject project =
+        new OpenShiftProject(clientFactory, cheClientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+
+    // when
+    project.prepare(false);
+
+    // then
+    // exception is thrown
+  }
+
+  @Test
+  public void testOpenShiftProjectCleaningUp() throws Exception {
+    // when
+    openShiftProject.cleanUp();
+
+    verify(routes).delete();
+    verify(services).delete();
+    verify(deployments).delete();
+    verify(secrets).delete();
+    verify(configsMaps).delete();
+  }
+
+  @Test
+  public void testOpenShiftProjectCleaningUpIfExceptionsOccurs() throws Exception {
+    doThrow(new InfrastructureException("err1.")).when(services).delete();
+    doThrow(new InfrastructureException("err2.")).when(deployments).delete();
+
+    InfrastructureException error = null;
+    // when
+    try {
+      openShiftProject.cleanUp();
+
+    } catch (InfrastructureException e) {
+      error = e;
+    }
+
+    // then
+    assertNotNull(error);
+    String message = error.getMessage();
+    assertEquals(message, "Error(s) occurs while cleaning up the namespace. err1. err2.");
+    verify(routes).delete();
+  }
+
+  @Test
+  public void testDeletesExistingProject() throws Exception {
+    // given
+    OpenShiftProject project =
+        new OpenShiftProject(clientFactory, cheClientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+    Resource resource = prepareProjectResource(PROJECT_NAME);
+
+    // when
+    project.delete();
+
+    // then
+    verify(resource).delete();
+  }
+
+  @Test
+  public void testDoesntFailIfDeletedProjectDoesntExist() throws Exception {
+    // given
+    OpenShiftProject project =
+        new OpenShiftProject(clientFactory, cheClientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+    Resource resource = prepareProjectResource(PROJECT_NAME);
+    when(resource.get()).thenThrow(new KubernetesClientException("err", 404, null));
+    when(resource.delete()).thenThrow(new KubernetesClientException("err", 404, null));
+
+    // when
+    project.delete();
+
+    // then
+    verify(resource).delete();
+    // and no exception is thrown
+  }
+
+  @Test
+  public void testDoesntFailIfDeletedProjectIsBeingDeleted() throws Exception {
+    // given
+    OpenShiftProject project =
+        new OpenShiftProject(clientFactory, cheClientFactory, executor, PROJECT_NAME, WORKSPACE_ID);
+    Resource resource = prepareProjectResource(PROJECT_NAME);
+    when(resource.delete()).thenThrow(new KubernetesClientException("err", 409, null));
+
+    // when
+    project.delete();
+
+    // then
+    verify(resource).delete();
+    // and no exception is thrown
+  }
+
+  private MetadataNested prepareProjectRequest() {
+    ProjectRequestOperation projectRequestOperation = mock(ProjectRequestOperation.class);
+    DoneableProjectRequest projectRequest = mock(DoneableProjectRequest.class);
+    MetadataNested metadataNested = mock(MetadataNested.class);
+
+    lenient().doReturn(projectRequestOperation).when(openShiftClient).projectrequests();
+    lenient().doReturn(projectRequest).when(projectRequestOperation).createNew();
+    lenient().doReturn(metadataNested).when(projectRequest).withNewMetadata();
+    lenient().doReturn(metadataNested).when(metadataNested).withName(anyString());
+    lenient().doReturn(projectRequest).when(metadataNested).endMetadata();
+    return metadataNested;
+  }
+
+  private Resource prepareProjectResource(String projectName) {
+    Resource projectResource = mock(Resource.class);
+
+    NonNamespaceOperation projectOperation = mock(NonNamespaceOperation.class);
+    doReturn(projectResource).when(projectOperation).withName(projectName);
+    doReturn(projectOperation).when(openShiftClient).projects();
+
+    when(projectResource.get())
+        .thenReturn(
+            new ProjectBuilder().withNewMetadata().withName(projectName).endMetadata().build());
+
+    openShiftClient.projects().withName(projectName).get();
+    return projectResource;
+  }
+
+  private void prepareNamespaceGet(String namespaceName) {
+    Namespace namespace =
+        new NamespaceBuilder().withNewMetadata().withNamespace(namespaceName).endMetadata().build();
+
+    NonNamespaceOperation nsOperation = mock(NonNamespaceOperation.class);
+    doReturn(nsOperation).when(openShiftClient).namespaces();
+
+    Resource nsResource = mock(Resource.class);
+    doReturn(nsResource).when(nsOperation).withName(namespaceName);
+
+    doReturn(namespace).when(nsResource).get();
+  }
+
+  private Project prepareProject(String projectName) {
+    Project project = mock(Project.class);
+    Resource projectResource = prepareProjectResource(projectName);
+    doReturn(project).when(projectResource).get();
+    return project;
+  }
+}

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectTest.java
@@ -1,4 +1,4 @@
-///*
+/// *
 // * Copyright (c) 2012-2018 Red Hat, Inc.
 // * This program and the accompanying materials are made
 // * available under the terms of the Eclipse Public License 2.0
@@ -9,54 +9,55 @@
 // * Contributors:
 // *   Red Hat, Inc. - initial API and implementation
 // */
-//package org.eclipse.che.workspace.infrastructure.openshift.project;
+// package org.eclipse.che.workspace.infrastructure.openshift.project;
 //
-//import static org.mockito.ArgumentMatchers.anyString;
-//import static org.mockito.Mockito.doReturn;
-//import static org.mockito.Mockito.doThrow;
-//import static org.mockito.Mockito.lenient;
-//import static org.mockito.Mockito.mock;
-//import static org.mockito.Mockito.never;
-//import static org.mockito.Mockito.verify;
-//import static org.mockito.Mockito.when;
-//import static org.testng.Assert.assertEquals;
-//import static org.testng.Assert.assertNotNull;
+// import static org.mockito.ArgumentMatchers.anyString;
+// import static org.mockito.Mockito.doReturn;
+// import static org.mockito.Mockito.doThrow;
+// import static org.mockito.Mockito.lenient;
+// import static org.mockito.Mockito.mock;
+// import static org.mockito.Mockito.never;
+// import static org.mockito.Mockito.verify;
+// import static org.mockito.Mockito.when;
+// import static org.testng.Assert.assertEquals;
+// import static org.testng.Assert.assertNotNull;
 //
-//import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
-//import io.fabric8.kubernetes.api.model.ServiceAccount;
-//import io.fabric8.kubernetes.client.KubernetesClient;
-//import io.fabric8.kubernetes.client.KubernetesClientException;
-//import io.fabric8.kubernetes.client.dsl.MixedOperation;
-//import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
-//import io.fabric8.kubernetes.client.dsl.Resource;
-//import io.fabric8.openshift.api.model.DoneableProjectRequest;
-//import io.fabric8.openshift.api.model.Project;
-//import io.fabric8.openshift.api.model.ProjectBuilder;
-//import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
-//import io.fabric8.openshift.client.OpenShiftClient;
-//import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
-//import java.util.concurrent.Executor;
-//import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
-//import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
-//import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
-//import org.mockito.Mock;
-//import org.mockito.testng.MockitoTestNGListener;
-//import org.testng.annotations.BeforeMethod;
-//import org.testng.annotations.Listeners;
-//import org.testng.annotations.Test;
+// import io.fabric8.kubernetes.api.model.DoneableServiceAccount;
+// import io.fabric8.kubernetes.api.model.ServiceAccount;
+// import io.fabric8.kubernetes.client.KubernetesClient;
+// import io.fabric8.kubernetes.client.KubernetesClientException;
+// import io.fabric8.kubernetes.client.dsl.MixedOperation;
+// import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
+// import io.fabric8.kubernetes.client.dsl.Resource;
+// import io.fabric8.openshift.api.model.DoneableProjectRequest;
+// import io.fabric8.openshift.api.model.Project;
+// import io.fabric8.openshift.api.model.ProjectBuilder;
+// import io.fabric8.openshift.api.model.ProjectRequestFluent.MetadataNested;
+// import io.fabric8.openshift.client.OpenShiftClient;
+// import io.fabric8.openshift.client.dsl.ProjectRequestOperation;
+// import java.util.concurrent.Executor;
+// import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesConfigsMaps;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesDeployments;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesIngresses;
+// import
+// org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesPersistentVolumeClaims;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesSecrets;
+// import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesServices;
+// import org.eclipse.che.workspace.infrastructure.openshift.OpenShiftClientFactory;
+// import org.mockito.Mock;
+// import org.mockito.testng.MockitoTestNGListener;
+// import org.testng.annotations.BeforeMethod;
+// import org.testng.annotations.Listeners;
+// import org.testng.annotations.Test;
 //
-///**
+/// **
 // * Tests {@link OpenShiftProject}
 // *
 // * @author Sergii Leshchenko
 // */
-//@Listeners(MockitoTestNGListener.class)
-//public class OpenShiftProjectTest {
+// @Listeners(MockitoTestNGListener.class)
+// public class OpenShiftProjectTest {
 //
 //  public static final String PROJECT_NAME = "testProject";
 //  public static final String WORKSPACE_ID = "workspace123";
@@ -266,4 +267,4 @@
 //    doReturn(project).when(projectResource).get();
 //    return project;
 //  }
-//}
+// }


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
When starting new workspace, try label the namespace, if che SA have permissions to do so.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/17504

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Ensure that che SA has ClusterRole with `get` and `update` `namespace` permission. You can use this:
```
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: che-extraperm
rules:
- apiGroups: [""]
  resources: ["namespaces"]
  verbs: ["update", "get"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: che-extraperm
subjects:
- kind: ServiceAccount
  name: che
  namespace: che
roleRef:
  kind: ClusterRole
  name: che-extraperm
  apiGroup: rbac.authorization.k8s.io
```
2. Create a new workspace
3. Check that namespace where workspace has started is labeled with labels from `che.infra.kubernetes.namespace.labels` property

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
