### PR TITLE
Enable to customize `ingress.class`

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/templates/ingress.yaml
@@ -14,7 +14,7 @@ kind: Ingress
 metadata:
   name: devfile-registry
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class | quote }}
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout: "3600"
 {{- if .Values.global.tls.enabled }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-devfile-registry/values.yaml
@@ -7,6 +7,10 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+global:
+  ingress:
+    class: "nginx"
+
 cheDevfileRegistry:
   image: quay.io/eclipse/che-devfile-registry:nightly
   imagePullPolicy: Always

--- a/deploy/kubernetes/helm/che/custom-charts/che-jaeger/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-jaeger/templates/ingress.yaml
@@ -15,7 +15,7 @@ kind: Ingress
 metadata:
   name: jaeger-query
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class | quote }}
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout: "3600"
 {{- if .Values.global.tls.enabled }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-jaeger/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-jaeger/values.yaml
@@ -11,4 +11,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  ingress:
+    class: "nginx"
+
 image: jaegertracing/all-in-one:latest

--- a/deploy/kubernetes/helm/che/custom-charts/che-jaeger/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-jaeger/values.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-# Default values for postgres.
+# Default values for Jaegar
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/ingress.yaml
@@ -14,7 +14,7 @@ kind: Ingress
 metadata:
   name: keycloak-ingress
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class | quote }}
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout: "3600"
 {{- if .Values.global.tls.enabled }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
@@ -11,6 +11,10 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+global:
+  ingress:
+    class: "nginx"
+
 image: quay.io/eclipse/che-keycloak:nightly
 requireAdminPasswordChange: true
 keycloakAdminUserName: admin

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-# Default values for postgres.
+# Default values for Keycloak
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/templates/ingress.yaml
@@ -14,7 +14,7 @@ kind: Ingress
 metadata:
   name: plugin-registry
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class | quote }}
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout: "3600"
 {{- if .Values.global.tls.enabled }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-plugin-registry/values.yaml
@@ -7,6 +7,10 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+global:
+  ingress:
+    class: "nginx"
+
 chePluginRegistry:
   image: quay.io/eclipse/che-plugin-registry:nightly
   imagePullPolicy: Always

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -75,9 +75,9 @@ data:
   JAVA_OPTS: "-XX:MaxRAMPercentage=85.0 "
   CHE_WORKSPACE_AUTO_START: "false"
 {{- if .Values.global.tls.enabled }}
-  CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"kubernetes.io/ingress.class": "nginx", "kubernetes.io/tls-acme": "true", "{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/rewrite-target": "/$1","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/ssl-redirect": "true","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout": "3600","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout": "3600"}'
+  CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"kubernetes.io/ingress.class": {{ .Values.global.ingress.class | quote }}, "kubernetes.io/tls-acme": "true", "{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/rewrite-target": "/$1","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/ssl-redirect": "true","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout": "3600","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout": "3600"}'
 {{- else }}
-  CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"kubernetes.io/ingress.class": "nginx", "{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/rewrite-target": "/$1","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/ssl-redirect": "false","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout": "3600","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout": "3600"}'
+  CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"kubernetes.io/ingress.class": {{ .Values.global.ingress.class | quote }}, "{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/rewrite-target": "/$1","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/ssl-redirect": "false","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout": "3600","{{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout": "3600"}'
 {{- end }}
   CHE_INFRA_KUBERNETES_INGRESS_PATH__TRANSFORM: '%s(.*)'
   CHE_INFRA_KUBERNETES_SERVER__STRATEGY: {{ .Values.global.serverStrategy }}

--- a/deploy/kubernetes/helm/che/templates/dashboard-ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/dashboard-ingress.yaml
@@ -16,7 +16,7 @@ kind: Ingress
 metadata:
   name: che-dashboard-ingress
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class | quote }}
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout: "3600"
 {{- if and .Values.global.tls .Values.global.tls.enabled }}

--- a/deploy/kubernetes/helm/che/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/ingress.yaml
@@ -12,7 +12,7 @@ kind: Ingress
 metadata:
   name: che-ingress
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class | quote }}
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout: "3600"
 {{- if and .Values.global.tls .Values.global.tls.enabled }}

--- a/deploy/kubernetes/helm/che/templates/metrics-ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/metrics-ingress.yaml
@@ -22,7 +22,7 @@ kind: Ingress
 metadata:
   name: che-metrics-ingress
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    kubernetes.io/ingress.class: {{ .Values.global.ingress.class | quote }}
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-read-timeout: "3600"
     {{ .Values.global.ingressAnnotationsPrefix }}ingress.kubernetes.io/proxy-connect-timeout: "3600"
 {{- if and .Values.global.tls .Values.global.tls.enabled }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -32,6 +32,8 @@ global:
   #  default (if empty) is true
   #cheDedicatedKeycloak: false
   ingressDomain: 192.168.99.100.nip.io
+  ingress:
+    class: "nginx"
   # See --annotations-prefix flag (https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/cli-arguments.md)
   ingressAnnotationsPrefix: "nginx."
   # options: default-host, single-host, multi-host


### PR DESCRIPTION
### What does this PR do?

Enables to specify `ingress.class` on deployments by Helm.

### What issues does this PR fix or reference?

#18253 

(And some wrong comments are fixed.)

### How to test this PR?

Runs them by hand.

```
cd /deploy/kubernetes/helm/che
helm dependency update
helm template che . --values values.yaml --set tracingEnabled=true,metricsEnabled=true | grep ingress.class
```

The result should be:

```
  CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"kubernetes.io/ingress.class": "nginx", "nginx.ingress.kubernetes.io/rewrite-target": "/$1","nginx.ingress.kubernetes.io/ssl-redirect": "false","nginx.ingress.kubernetes.io/proxy-connect-timeout": "3600","nginx.ingress.kubernetes.io/proxy-read-timeout": "3600"}'
    kubernetes.io/ingress.class: "nginx"
    kubernetes.io/ingress.class: "nginx"
    kubernetes.io/ingress.class: "nginx"
    kubernetes.io/ingress.class: "nginx"
```

Then, reruns with value `global.ingress.class=traefik` like this.

```
helm template che . --values values.yaml --set tracingEnabled=true,metricsEnabled=true,global.ingress.class=traefik | grep ingress.class
```

All `kubernetes.io/ingress.class: "nginx"` in the result  should be replaced to `kubernetes.io/ingress.class: "traefik"`:

```
  CHE_INFRA_KUBERNETES_INGRESS_ANNOTATIONS__JSON: '{"kubernetes.io/ingress.class": "traefik", "nginx.ingress.kubernetes.io/rewrite-target": "/$1","nginx.ingress.kubernetes.io/ssl-redirect": "false","nginx.ingress.kubernetes.io/proxy-connect-timeout": "3600","nginx.ingress.kubernetes.io/proxy-read-timeout": "3600"}'
    kubernetes.io/ingress.class: "traefik"
    kubernetes.io/ingress.class: "traefik"
    kubernetes.io/ingress.class: "traefik"
    kubernetes.io/ingress.class: "traefik"
```

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
