### PR TITLE
Adapts Che to new dashboard next image

### DIFF
--- a/deploy/kubernetes/helm/che/templates/ingress.yaml
+++ b/deploy/kubernetes/helm/che/templates/ingress.yaml
@@ -37,19 +37,11 @@ spec:
   - http:
 {{- end }}
       paths:
+      - path: /
+        backend:
+          servicePort: 8080
 {{- if and (eq .Values.global.serverStrategy "single-host") (eq .Values.global.singleHostExposure "gateway") }}
-        - path: /
-          backend:
-            serviceName: che-gateway
-            servicePort: 8080
+          serviceName: che-gateway
 {{- else }}
-        - path: /
-          backend:
-            serviceName: che-host
-            servicePort: 8080
-        # The path rule for Che Dashboard next hosted by Che Server. It should be removed after https://github.com/eclipse/che/issues/17647 is fixed
-        - path: /dashboard/next
-          backend:
-            serviceName: che-host
-            servicePort: 8080
+          serviceName: che-host
 {{- end }}

--- a/deploy/kubernetes/helm/che/templates/traefik-gateway-configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/traefik-gateway-configmap.yaml
@@ -24,11 +24,6 @@ data:
           rule: "PathPrefix(`/`)"
           service: che
           priority: 1
-        # The path rule for Che Dashboard next hosted by Che Server. It should be removed after https://github.com/eclipse/che/issues/17647 is fixed
-        dashboard-next:
-          rule: "PathPrefix(`/dashboard/next`)"
-          service: che
-          priority: 20
       services:
         che:
           loadBalancer:

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -114,7 +114,7 @@ che:
   logLevel: "INFO"
 
 dashboard:
-  image: quay.io/eclipse/che-dashboard:next
+  image: quay.io/eclipse/che-dashboard:next-react
   imagePullPolicy: "Always"
   memoryRequest: 16Mi
   memoryLimit: 256Mi

--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -9,14 +9,14 @@
 # Variables in `COPY --from=` is not supported see https://github.com/moby/moby/issues/34482
 # this is workaround to handle that.
 ARG CHE_DASHBOARD_ORGANIZATION=quay.io/eclipse
-ARG CHE_DASHBOARD_NEXT_ORGANIZATION=quay.io/che-incubator
+ARG CHE_DASHBOARD_NEXT_ORGANIZATION=quay.io/eclipse
 ARG CHE_DASHBOARD_VERSION=next
-ARG CHE_DASHBOARD_NEXT_VERSION=next
+ARG CHE_DASHBOARD_NEXT_VERSION=next-react
 ARG CHE_WORKSPACE_LOADER_ORGANIZATION=quay.io/eclipse
 ARG CHE_WORKSPACE_LOADER_VERSION=next
 
 FROM ${CHE_DASHBOARD_ORGANIZATION}/che-dashboard:${CHE_DASHBOARD_VERSION} as che_dashboard_base
-FROM ${CHE_DASHBOARD_NEXT_ORGANIZATION}/che-dashboard-next:${CHE_DASHBOARD_NEXT_VERSION} as che_dashboard_next
+FROM ${CHE_DASHBOARD_NEXT_ORGANIZATION}/che-dashboard:${CHE_DASHBOARD_NEXT_VERSION} as che_dashboard_next
 FROM ${CHE_WORKSPACE_LOADER_ORGANIZATION}/che-workspace-loader:${CHE_WORKSPACE_LOADER_VERSION} as che_workspace_loader_base
 
 FROM adoptopenjdk/openjdk11:jre-11.0.8_10
@@ -28,7 +28,7 @@ ENTRYPOINT ["/entrypoint.sh"]
 RUN mkdir /logs /data && \
     chmod 0777 /logs /data
 COPY --from=che_dashboard_base /usr/local/apache2/htdocs/dashboard /home/user/eclipse-che/tomcat/webapps/dashboard
-COPY --from=che_dashboard_next /usr/local/apache2/htdocs/dashboard /home/user/eclipse-che/tomcat/webapps/dashboard/next
+COPY --from=che_dashboard_next /usr/local/apache2/htdocs/dashboard/next /home/user/eclipse-che/tomcat/webapps/dashboard/next
 COPY --from=che_workspace_loader_base /usr/local/apache2/htdocs/workspace-loader/ /home/user/eclipse-che/tomcat/webapps/workspace-loader
 ADD eclipse-che /home/user/eclipse-che
 RUN find /home/user -type d -exec chmod 777 {} \;


### PR DESCRIPTION
### What does this PR do?
This PR adapts Che to new dashboard next image which includes the existing dashboard, that's done in https://github.com/che-incubator/che-dashboard-next/pull/71
So, Che Server as previously copies resources from Dashboard + Dashboard Next resources.
Helm chart now serves the dashboard next from a separate deployment.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
It's a kind of prerequisites for https://github.com/eclipse/che/issues/17647


### How to test this PR?
For Che Server image testing, just run Che in any way and check that dashboard and dashboard next are available.

For helm chart, see more:
<details>
<summary>helm chart tested configurations</summary>

SingleUser Single host
```
export CHART_DIR=/home/sleshche/projects/che/deploy/kubernetes/helm/che
helm upgrade --install che \
  --force \
  --namespace che \
  --set global.cheDomain=$(minikube ip).nip.io \
  --set global.ingressDomain=$(minikube ip).nip.io \
  --set cheImage=sleshchenko/che-server:no-dashboards \
  --set global.serverStrategy=single-host \
  --set global.tls.useSelfSignedCerts=true \
  -f ${CHART_DIR}/values/tls.yaml \
  ${CHART_DIR}
```
Multiuser Single host gateway
```
export CHART_DIR=/home/sleshche/projects/che/deploy/kubernetes/helm/che
helm upgrade --install che \
  --force \
  --namespace che \
  --set global.cheDomain=$(minikube ip).nip.io \
  --set global.ingressDomain=$(minikube ip).nip.io \
  --set cheImage=sleshchenko/che-server:no-dashboards \
  --set global.tls.useSelfSignedCerts=true \
  --set global.serverStrategy=single-host \
  --set cheSinglehostGateway.deploy=true \
  --set global.singleHostExposure=gateway \
  -f ${CHART_DIR}/values/tls.yaml \
  -f ${CHART_DIR}/values/multi-user.yaml \
  ${CHART_DIR}
```
Multiuser Multihost
```
export CHART_DIR=/home/sleshche/projects/che/deploy/kubernetes/helm/che
helm upgrade --install che \
  --force \
  --namespace che \
  --set global.cheDomain=$(minikube ip).nip.io \
  --set global.ingressDomain=$(minikube ip).nip.io \
  --set cheImage=sleshchenko/che-server:no-dashboards \
  --set global.serverStrategy=multi-host \
  --set global.tls.useSelfSignedCerts=true \
  -f ${CHART_DIR}/values/tls.yaml \
  -f ${CHART_DIR}/values/multi-user.yaml \
  ${CHART_DIR}
```

</details>


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
