### PR TITLE
[Selenium] Stabilize java selenium tests from factory package

### DIFF
--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromDevfileUrl.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/CreateFactoryFromDevfileUrl.java
@@ -72,7 +72,6 @@ public class CreateFactoryFromDevfileUrl {
     theiaIde.waitAllNotificationsClosed();
 
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaIde.waitNotificationDisappearance(
         "Che Workspace: Finished importing projects.", UPDATING_PROJECT_TIMEOUT_SEC);
     theiaIde.waitAllNotificationsClosed();

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithKeepDirectoryTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithKeepDirectoryTest.java
@@ -81,7 +81,6 @@ public class DirectUrlFactoryWithKeepDirectoryTest {
     theiaIde.waitAllNotificationsClosed();
 
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaIde.waitNotificationDisappearance(
         "Che Workspace: Finished importing projects.", UPDATING_PROJECT_TIMEOUT_SEC);
     theiaIde.waitAllNotificationsClosed();

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolderTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithRootFolderTest.java
@@ -103,7 +103,6 @@ public class DirectUrlFactoryWithRootFolderTest {
     theiaIde.waitAllNotificationsClosed();
 
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaProjectTree.waitItem(repositoryName);
     theiaIde.waitNotificationDisappearance(
         "Che Workspace: Finished importing projects.", UPDATING_PROJECT_TIMEOUT_SEC);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/factory/DirectUrlFactoryWithSpecificBranchTest.java
@@ -99,7 +99,6 @@ public class DirectUrlFactoryWithSpecificBranchTest {
     theiaIde.waitAllNotificationsClosed();
 
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaProjectTree.waitItem(repositoryName);
     theiaIde.waitNotificationDisappearance(
         "Che Workspace: Finished importing projects.", UPDATING_PROJECT_TIMEOUT_SEC);

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithEditorTest.java
@@ -62,7 +62,6 @@ public class RollingUpdateStrategyWithEditorTest {
   @Test
   public void shouldUpdateMasterByRollingStrategyWithAccessibleEditorInProcess() throws Exception {
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaProjectTree.waitProjectAreaOpened();
     theiaProjectTree.waitItem(CONSOLE_JAVA_SIMPLE);
     theiaIde.waitAllNotificationsClosed();

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/hotupdate/rolling/RollingUpdateStrategyWithStartedWorkspaceTest.java
@@ -67,7 +67,6 @@ public class RollingUpdateStrategyWithStartedWorkspaceTest {
   @Test
   public void startStopWorkspaceFunctionsShouldBeAvailableDuringRollingUpdate() throws Exception {
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaProjectTree.waitProjectAreaOpened();
     theiaProjectTree.waitItem(CONSOLE_JAVA_SIMPLE);
     theiaIde.waitAllNotificationsClosed();

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRefreshTest.java
@@ -58,7 +58,6 @@ public class ProjectStateAfterRefreshTest {
   @Test
   public void checkRestoreStateOfProjectAfterRefreshTest() {
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaProjectTree.waitProjectAreaOpened();
     theiaProjectTree.waitItem(CONSOLE_JAVA_SIMPLE);
     theiaIde.waitAllNotificationsClosed();

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterRenameWorkspaceTest.java
@@ -65,7 +65,6 @@ public class ProjectStateAfterRenameWorkspaceTest {
   @Test
   public void checkProjectAfterRenameWs() {
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaProjectTree.waitProjectAreaOpened();
     theiaProjectTree.waitItem(CONSOLE_JAVA_SIMPLE);
     theiaIde.waitAllNotificationsClosed();

--- a/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterWorkspaceRestartTest.java
+++ b/tests/legacy-e2e/che-selenium-test/src/test/java/org/eclipse/che/selenium/workspaces/ProjectStateAfterWorkspaceRestartTest.java
@@ -65,7 +65,6 @@ public class ProjectStateAfterWorkspaceRestartTest {
   @Test
   public void checkProjectAfterStopStartWs() {
     theiaProjectTree.waitFilesTab();
-    theiaProjectTree.clickOnFilesTab();
     theiaProjectTree.waitProjectAreaOpened();
     theiaProjectTree.waitItem(CONSOLE_JAVA_SIMPLE);
     theiaIde.waitAllNotificationsClosed();


### PR DESCRIPTION
### What does this PR do?
Update java tests to not open Project tab after Theia IDE is ready to work. For now it is opened by default.


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18333