### PR TITLE
Add delay for stabilizing git + ssh test on Jenkins

### DIFF
--- a/tests/.infra/crw-ci/nightly/k8s/multi-host/Jenkinsfile
+++ b/tests/.infra/crw-ci/nightly/k8s/multi-host/Jenkinsfile
@@ -148,7 +148,7 @@ pipeline {
                                                             value: false),
 
                                                     string(name: 'e2eTestParameters',
-                                                            value: "-e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
+                                                            value: "-e TS_SELENIUM_LOAD_PAGE_TIMEOUT=30000 -e TS_GITHUB_TEST_REPO_ACCESS_TOKEN=$github_oauth_token  -e TS_GITHUB_TEST_REPO=chepullreq4/Spoon-Knife -e NODE_TLS_REJECT_UNAUTHORIZED=0"),
 
                                                     string(name: 'chectlPackageUrl',
                                                             value: ''),


### PR DESCRIPTION
### What does this PR do?
* Rewrite default timeout for Loading CHE page. The default timeout sometimes is mot enough for loading CHE page. It increase timeout to 30 sec. It should stabilize CHE loading page