### PR TITLE
Precreated namespace backport

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -298,7 +298,7 @@ che.infra.kubernetes.namespace.default=<username>-che
 
 # List of labels to find Namespaces/Projects that are used for Che Workspaces.
 # They are used to find prepared Namespaces/Projects for users in combination with `che.infra.kubernetes.namespace.annotations`.
-che.infra.kubernetes.namespace.labels=app.kubernetes.io/part-of=che.eclipse.org,app.kubernetes.io/component=workspace
+che.infra.kubernetes.namespace.labels=app.kubernetes.io/part-of=che.eclipse.org,app.kubernetes.io/component=workspaces-namespace
 
 # List of annotations to find Namespaces/Projects prepared for Che users workspaces.
 # Only Namespaces/Projects matching the `che.infra.kubernetes.namespace.labels` will be matched against these annotations.

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -296,10 +296,16 @@ che.infra.kubernetes.namespace.creation_allowed=true
 # Is used by OpenShift infra as well to specify Project
 che.infra.kubernetes.namespace.default=<username>-che
 
-# List of labels to find Namespaces/Projects prepared for Che users.
-# Namespaces labeled with these, will be preferentially offered to users when creating a workspace.
-# It's possible to use `<username>` placeholder to specify the namespace to concrete user.
-che.infra.kubernetes.namespace.labels=app.kubernetes.io/part-of=che.eclipse.org,app.kubernetes.io/component=workspace,che.eclipse.org/username=<username>
+# List of labels to find Namespaces/Projects that are used for Che Workspaces.
+# They are used to find prepared Namespaces/Projects for users in combination with `che.infra.kubernetes.namespace.annotations`.
+che.infra.kubernetes.namespace.labels=app.kubernetes.io/part-of=che.eclipse.org,app.kubernetes.io/component=workspace
+
+# List of annotations to find Namespaces/Projects prepared for Che users workspaces.
+# Only Namespaces/Projects matching the `che.infra.kubernetes.namespace.labels` will be matched against these annotations.
+# Namespaces/Projects that matches both `che.infra.kubernetes.namespace.labels` and `che.infra.kubernetes.namespace.annotations`
+# will be preferentially used for User's workspaces.
+# It's possible to use `<username>` placeholder to specify the Namespace/Project to concrete user.
+che.infra.kubernetes.namespace.annotations=che.eclipse.org/username=<username>
 
 # Defines if a user is able to specify Kubernetes namespace (or OpenShift project) different from the default.
 # It's NOT RECOMMENDED to configured true without OAuth configured. This property is also used by the OpenShift infra.

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -296,6 +296,11 @@ che.infra.kubernetes.namespace.creation_allowed=true
 # Is used by OpenShift infra as well to specify Project
 che.infra.kubernetes.namespace.default=<username>-che
 
+# List of labels to find Namespaces/Projects prepared for Che users.
+# Namespaces labeled with these, will be preferentially offered to users when creating a workspace.
+# It's possible to use `<username>` placeholder to specify the namespace to concrete user.
+che.infra.kubernetes.namespace.labels=app.kubernetes.io/part-of=che.eclipse.org,app.kubernetes.io/component=workspace,che.eclipse.org/username=<username>
+
 # Defines if a user is able to specify Kubernetes namespace (or OpenShift project) different from the default.
 # It's NOT RECOMMENDED to configured true without OAuth configured. This property is also used by the OpenShift infra.
 che.infra.kubernetes.namespace.allow_user_defined=false

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespace.java
@@ -336,6 +336,9 @@ public class KubernetesNamespace {
     } catch (KubernetesClientException e) {
       if (e.getCode() == 403) {
         // namespace is foreign or doesn't exist
+        LOG.warn(
+            "Trying to get namespace '{}', but failed because the lack of permissions.",
+            namespaceName);
         return null;
       } else {
         throw new KubernetesInfrastructureException(e);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -27,6 +27,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import java.util.ArrayList;
@@ -92,6 +93,7 @@ public class KubernetesNamespaceFactory {
   private final String defaultNamespaceName;
   private final boolean allowUserDefinedNamespaces;
   protected final Map<String, String> namespaceLabels;
+  protected final Map<String, String> namespaceAnnotations;
 
   private final String legacyNamespaceName;
   private final String serviceAccountName;
@@ -112,6 +114,7 @@ public class KubernetesNamespaceFactory {
           boolean allowUserDefinedNamespaces,
       @Named("che.infra.kubernetes.namespace.creation_allowed") boolean namespaceCreationAllowed,
       @Named("che.infra.kubernetes.namespace.labels") String namespaceLabels,
+      @Named("che.infra.kubernetes.namespace.annotations") String namespaceAnnotations,
       KubernetesClientFactory clientFactory,
       UserManager userManager,
       PreferenceManager preferenceManager,
@@ -128,10 +131,15 @@ public class KubernetesNamespaceFactory {
     this.sharedPool = sharedPool;
 
     //noinspection UnstableApiUsage
+    Splitter.MapSplitter csvMapSplitter = Splitter.on(",").withKeyValueSeparator("=");
+    //noinspection UnstableApiUsage
     this.namespaceLabels =
-        isNullOrEmpty(namespaceLabels)
+        isNullOrEmpty(namespaceLabels) ? emptyMap() : csvMapSplitter.split(namespaceLabels);
+    //noinspection UnstableApiUsage
+    this.namespaceAnnotations =
+        isNullOrEmpty(namespaceAnnotations)
             ? emptyMap()
-            : Splitter.on(",").withKeyValueSeparator("=").split(namespaceLabels);
+            : csvMapSplitter.split(namespaceAnnotations);
 
     if (isNullOrEmpty(defaultNamespaceName)) {
       throw new ConfigurationException("che.infra.kubernetes.namespace.default must be configured");
@@ -182,7 +190,7 @@ public class KubernetesNamespaceFactory {
     if (!namespaceName.equals(defaultNamespace)) {
       try {
         List<KubernetesNamespaceMeta> labeledNamespaces =
-            findLabeledNamespaces(
+            findPreparedNamespaces(
                 new NamespaceResolutionContext(EnvironmentContext.getCurrent().getSubject()));
         if (labeledNamespaces.stream().noneMatch(n -> n.getName().equals(namespaceName))) {
           throw new ValidationException(
@@ -202,7 +210,7 @@ public class KubernetesNamespaceFactory {
       NamespaceResolutionContext resolutionCtx =
           new NamespaceResolutionContext(EnvironmentContext.getCurrent().getSubject());
 
-      List<KubernetesNamespaceMeta> labeledNamespaces = findLabeledNamespaces(resolutionCtx);
+      List<KubernetesNamespaceMeta> labeledNamespaces = findPreparedNamespaces(resolutionCtx);
       if (!labeledNamespaces.isEmpty()) {
         return labeledNamespaces;
       } else {
@@ -512,7 +520,7 @@ public class KubernetesNamespaceFactory {
    */
   private Optional<String> findFirstLabeledNamespace(NamespaceResolutionContext resolutionCtx)
       throws InfrastructureException {
-    List<KubernetesNamespaceMeta> labeledNamespaces = findLabeledNamespaces(resolutionCtx);
+    List<KubernetesNamespaceMeta> labeledNamespaces = findPreparedNamespaces(resolutionCtx);
     if (!labeledNamespaces.isEmpty()) {
       String foundNamespace =
           labeledNamespaces
@@ -591,33 +599,36 @@ public class KubernetesNamespaceFactory {
 
   /**
    * Finds all namespaces that matches the labels configured in
-   * `che.infra.kubernetes.namespace.labels` property. Makes sure that placeholder in the property
-   * are correctly evaluated.
+   * `che.infra.kubernetes.namespace.labels` and annotations in
+   * `che.infra.kubernetes.namespace.annotations` properties. Makes sure that placeholder in the
+   * annotations property are correctly evaluated.
    *
    * <p>If used ServiceAccount does not have permissions to list the namespaces, returns the empty
    * list.
    *
-   * @return namespaces that matches the configured labels
+   * @return namespaces that matches the configured labels and annotations
    * @throws InfrastructureException in case of any Kubernetes request failure
    */
-  protected List<KubernetesNamespaceMeta> findLabeledNamespaces(
+  protected List<KubernetesNamespaceMeta> findPreparedNamespaces(
       NamespaceResolutionContext namespaceCtx) throws InfrastructureException {
-    Map<String, String> labels = evaluateLabelsPlaceholders(namespaceCtx);
     try {
-      return clientFactory
-          .create()
-          .namespaces()
-          .withLabels(labels)
-          .list()
-          .getItems()
-          .stream()
-          .map(this::asNamespaceMeta)
-          .collect(Collectors.toList());
+      List<Namespace> workspaceNamespaces =
+          clientFactory.create().namespaces().withLabels(namespaceLabels).list().getItems();
+      if (!workspaceNamespaces.isEmpty()) {
+        Map<String, String> evaluatedAnnotations = evaluateAnnotationPlaceholders(namespaceCtx);
+        return workspaceNamespaces
+            .stream()
+            .filter(p -> matchesAnnotations(p, evaluatedAnnotations))
+            .map(this::asNamespaceMeta)
+            .collect(Collectors.toList());
+      } else {
+        return emptyList();
+      }
     } catch (KubernetesClientException kce) {
       if (kce.getCode() == 403) {
         LOG.warn(
             "Trying to fetch namespaces with labels '{}', but failed for lack of permissions. Cause: '{}'",
-            labels,
+            namespaceLabels,
             kce.getMessage());
         return emptyList();
       } else {
@@ -630,20 +641,36 @@ public class KubernetesNamespaceFactory {
   }
 
   /**
-   * Evaluate placeholder in `che.infra.kubernetes.namespace.labels` property with given {@link
+   * Evaluate placeholder in `che.infra.kubernetes.namespace.annotations` property with given {@link
    * NamespaceResolutionContext}.
    *
    * @return evaluated labels
    */
-  protected Map<String, String> evaluateLabelsPlaceholders(
+  protected Map<String, String> evaluateAnnotationPlaceholders(
       NamespaceResolutionContext namespaceCtx) {
-    Map<String, String> evaluatedLabels = new HashMap<>();
-    for (String labelName : namespaceLabels.keySet()) {
-      String evaluatedLabelValue =
-          namespaceLabels.get(labelName).replace(USERNAME_PLACEHOLDER, namespaceCtx.getUserName());
-      evaluatedLabels.put(labelName, evaluatedLabelValue);
+    Map<String, String> evaluatedAnnotations = new HashMap<>();
+    for (String annotationName : namespaceAnnotations.keySet()) {
+      String evaluatedAnnotationValue =
+          namespaceAnnotations
+              .get(annotationName)
+              .replace(USERNAME_PLACEHOLDER, namespaceCtx.getUserName());
+      evaluatedAnnotations.put(annotationName, evaluatedAnnotationValue);
     }
-    return evaluatedLabels;
+    return evaluatedAnnotations;
+  }
+
+  /**
+   * Checks if given `object` contains all given `annotations` with exact values.
+   *
+   * @param object to check
+   * @param annotations that given `object` has to contain
+   * @return true if `object` contains all `annotations`. False otherwise.
+   */
+  protected boolean matchesAnnotations(HasMetadata object, Map<String, String> annotations) {
+    if (object.getMetadata().getAnnotations() == null) {
+      return false;
+    }
+    return object.getMetadata().getAnnotations().entrySet().containsAll(annotations.entrySet());
   }
 
   public void deleteIfManaged(Workspace workspace) throws InfrastructureException {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactory.java
@@ -545,20 +545,6 @@ public class KubernetesNamespaceFactory {
   }
 
   /**
-   * Finds namespace name stored in User's preferences and ensures it is still valid.
-   *
-   * @return user's stored namespace if exists
-   */
-  private Optional<String> findStoredNamespace(NamespaceResolutionContext resolutionCtx) {
-    Optional<Pair<String, String>> storedNamespace = getPreferencesNamespaceName(resolutionCtx);
-    if (storedNamespace.isPresent() && isStoredTemplateValid(storedNamespace.get().second)) {
-      return Optional.of(storedNamespace.get().first);
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  /**
    * Constructs the namespace name from `che.infra.kubernetes.namespace.default` property. Ensures
    * that all placeholders are evaluated and final namespace name is in valid format.
    *

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -96,8 +96,10 @@ public class KubernetesNamespaceFactoryTest {
 
   private static final String USER_ID = "userid";
   private static final String USER_NAME = "username";
-  private static final String NAMESPACE_LABEL_NAME = "che-username";
-  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=<username>";
+  private static final String NAMESPACE_LABEL_NAME = "component";
+  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
+  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
+  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
 
   @Mock private KubernetesSharedPool pool;
   @Mock private KubernetesClientFactory clientFactory;
@@ -160,6 +162,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -181,6 +184,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -230,6 +234,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -251,6 +256,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -258,13 +264,14 @@ public class KubernetesNamespaceFactoryTest {
   }
 
   @Test
-  public void shouldReturnLabeledNamespacesWhenFound() throws InfrastructureException {
+  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
     // given
     List<Namespace> namespaces =
         Arrays.asList(
             new NamespaceBuilder()
                 .withNewMetadata()
                 .withName("ns1")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
                 .endMetadata()
                 .withNewStatus()
                 .withNewPhase("Active")
@@ -273,6 +280,16 @@ public class KubernetesNamespaceFactoryTest {
             new NamespaceBuilder()
                 .withNewMetadata()
                 .withName("ns2")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build(),
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns3")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user"))
                 .endMetadata()
                 .withNewStatus()
                 .withNewPhase("Active")
@@ -289,6 +306,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -300,7 +318,7 @@ public class KubernetesNamespaceFactoryTest {
 
     // then
     assertEquals(availableNamespaces.size(), 2);
-    verify(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, "jondoe"));
+    verify(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, "workspace"));
     assertEquals(availableNamespaces.get(0).getName(), "ns1");
     assertEquals(availableNamespaces.get(1).getName(), "ns2");
   }
@@ -331,6 +349,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -360,6 +379,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -393,6 +413,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -420,6 +441,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -450,6 +472,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -475,6 +498,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -509,6 +533,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -544,6 +569,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -573,6 +599,7 @@ public class KubernetesNamespaceFactoryTest {
                 false,
                 true,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -604,6 +631,7 @@ public class KubernetesNamespaceFactoryTest {
                 true,
                 false,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -636,6 +664,7 @@ public class KubernetesNamespaceFactoryTest {
                 false,
                 true,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -672,6 +701,7 @@ public class KubernetesNamespaceFactoryTest {
                 false,
                 true,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -739,6 +769,7 @@ public class KubernetesNamespaceFactoryTest {
                 false,
                 true,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -794,6 +825,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -812,6 +844,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -834,6 +867,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -860,6 +894,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -889,6 +924,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -919,6 +955,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -949,6 +986,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -979,6 +1017,7 @@ public class KubernetesNamespaceFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -1005,6 +1044,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -1033,6 +1073,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -1051,12 +1092,13 @@ public class KubernetesNamespaceFactoryTest {
   }
 
   @Test
-  public void testEvalNamespaceNameWhenLabeledNamespacesFound() throws InfrastructureException {
+  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
     List<Namespace> namespaces =
         Arrays.asList(
             new NamespaceBuilder()
                 .withNewMetadata()
                 .withName("ns1")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
                 .endMetadata()
                 .withNewStatus()
                 .withNewPhase("Active")
@@ -1065,6 +1107,7 @@ public class KubernetesNamespaceFactoryTest {
             new NamespaceBuilder()
                 .withNewMetadata()
                 .withName("ns2")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
                 .endMetadata()
                 .withNewStatus()
                 .withNewPhase("Active")
@@ -1081,6 +1124,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -1091,6 +1135,41 @@ public class KubernetesNamespaceFactoryTest {
             new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
 
     assertEquals(namespace, "ns1");
+  }
+
+  @Test
+  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
+    List<Namespace> namespaces =
+        singletonList(
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns1")
+                .withAnnotations(Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe"))
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build());
+    doReturn(namespaces).when(namespaceList).getItems();
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            "try_placeholder_here=<username>",
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+    namespaceFactory.list();
+
+    verify(namespaceOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
   }
 
   @Test(dataProvider = "invalidUsernames")
@@ -1104,6 +1183,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -1122,6 +1202,7 @@ public class KubernetesNamespaceFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -18,9 +18,11 @@ import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.Kub
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory.NAMESPACE_TEMPLATE_ATTRIBUTE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -38,15 +40,20 @@ import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.api.model.NamespaceBuilder;
 import io.fabric8.kubernetes.api.model.NamespaceList;
 import io.fabric8.kubernetes.api.model.ServiceAccountList;
+import io.fabric8.kubernetes.api.model.Status;
 import io.fabric8.kubernetes.api.model.rbac.Role;
 import io.fabric8.kubernetes.api.model.rbac.RoleBindingList;
 import io.fabric8.kubernetes.api.model.rbac.RoleList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,6 +96,8 @@ public class KubernetesNamespaceFactoryTest {
 
   private static final String USER_ID = "userid";
   private static final String USER_NAME = "username";
+  private static final String NAMESPACE_LABEL_NAME = "che-username";
+  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=<username>";
 
   @Mock private KubernetesSharedPool pool;
   @Mock private KubernetesClientFactory clientFactory;
@@ -107,6 +116,12 @@ public class KubernetesNamespaceFactoryTest {
 
   private KubernetesNamespaceFactory namespaceFactory;
 
+  @Mock
+  private FilterWatchListDeletable<Namespace, NamespaceList, Boolean, Watch, Watcher<Namespace>>
+      namespaceListResource;
+
+  @Mock private NamespaceList namespaceList;
+
   @BeforeMethod
   public void setUp() throws Exception {
     serverMock = new KubernetesServer(true, true);
@@ -114,8 +129,13 @@ public class KubernetesNamespaceFactoryTest {
     k8sClient = spy(serverMock.getClient());
     lenient().when(clientFactory.create()).thenReturn(k8sClient);
     lenient().when(k8sClient.namespaces()).thenReturn(namespaceOperation);
+
     lenient().when(namespaceOperation.withName(any())).thenReturn(namespaceResource);
     lenient().when(namespaceResource.get()).thenReturn(mock(Namespace.class));
+
+    lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(anyMap());
+    lenient().when(namespaceListResource.list()).thenReturn(namespaceList);
+    lenient().when(namespaceList.getItems()).thenReturn(Collections.emptyList());
 
     lenient()
         .when(userManager.getById(USER_ID))
@@ -139,6 +159,7 @@ public class KubernetesNamespaceFactoryTest {
             "defaultNs",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -159,6 +180,7 @@ public class KubernetesNamespaceFactoryTest {
             "defaultNs",
             true,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -207,6 +229,7 @@ public class KubernetesNamespaceFactoryTest {
             "defaultNs",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -218,7 +241,7 @@ public class KubernetesNamespaceFactoryTest {
   @Test(
       expectedExceptions = ConfigurationException.class,
       expectedExceptionsMessageRegExp = "che.infra.kubernetes.namespace.default must be configured")
-  public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() throws Exception {
+  public void shouldThrowExceptionIfNoDefaultNamespaceIsConfigured() {
     namespaceFactory =
         new KubernetesNamespaceFactory(
             "predefined",
@@ -227,10 +250,125 @@ public class KubernetesNamespaceFactoryTest {
             null,
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
             pool);
+  }
+
+  @Test
+  public void shouldReturnLabeledNamespacesWhenFound() throws InfrastructureException {
+    // given
+    List<Namespace> namespaces =
+        Arrays.asList(
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns1")
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build(),
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns2")
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build());
+    doReturn(namespaces).when(namespaceList).getItems();
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+
+    // when
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+
+    // then
+    assertEquals(availableNamespaces.size(), 2);
+    verify(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, "jondoe"));
+    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+    assertEquals(availableNamespaces.get(1).getName(), "ns2");
+  }
+
+  @Test
+  public void shouldNotThrowAnExceptionWhenNotAllowedToListNamespaces() throws Exception {
+    // given
+    Namespace ns =
+        new NamespaceBuilder()
+            .withNewMetadata()
+            .withName("ns1")
+            .endMetadata()
+            .withNewStatus()
+            .withNewPhase("Active")
+            .endStatus()
+            .build();
+    doThrow(new KubernetesClientException("Not allowed.", 403, new Status()))
+        .when(namespaceList)
+        .getItems();
+    prepareNamespaceToBeFoundByName("che-default", ns);
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+
+    // when
+    List<KubernetesNamespaceMeta> availableNamespaces = namespaceFactory.list();
+
+    // then
+    assertEquals(availableNamespaces.get(0).getName(), "ns1");
+  }
+
+  @Test(expectedExceptions = InfrastructureException.class)
+  public void throwAnExceptionWhenErrorListingNamespaces() throws Exception {
+    // given
+    doThrow(new KubernetesClientException("Not allowed.", 500, new Status()))
+        .when(namespaceList)
+        .getItems();
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "predefined",
+            "",
+            "",
+            "che-default",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    // when
+    namespaceFactory.list();
+
+    // then throw
   }
 
   @Test
@@ -254,6 +392,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-default",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -280,6 +419,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-default",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -309,6 +449,7 @@ public class KubernetesNamespaceFactoryTest {
             "che",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -333,6 +474,7 @@ public class KubernetesNamespaceFactoryTest {
             "default",
             true,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -366,6 +508,7 @@ public class KubernetesNamespaceFactoryTest {
             "default",
             true,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -400,6 +543,7 @@ public class KubernetesNamespaceFactoryTest {
             "default_ns",
             true,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -428,6 +572,7 @@ public class KubernetesNamespaceFactoryTest {
                 "new-default",
                 false,
                 true,
+                NAMESPACE_LABELS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -458,6 +603,7 @@ public class KubernetesNamespaceFactoryTest {
                 "new-default",
                 true,
                 false,
+                NAMESPACE_LABELS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -489,6 +635,7 @@ public class KubernetesNamespaceFactoryTest {
                 "<workspaceid>",
                 false,
                 true,
+                NAMESPACE_LABELS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -524,6 +671,7 @@ public class KubernetesNamespaceFactoryTest {
                 "<workspaceid>",
                 false,
                 true,
+                NAMESPACE_LABELS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -590,6 +738,7 @@ public class KubernetesNamespaceFactoryTest {
                 "<workspaceid>",
                 false,
                 true,
+                NAMESPACE_LABELS,
                 clientFactory,
                 userManager,
                 preferenceManager,
@@ -644,6 +793,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -661,6 +811,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -682,6 +833,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -707,6 +859,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             true,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -735,6 +888,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>-<username>",
             true,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -764,6 +918,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>-<username>",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -793,6 +948,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<workspaceid>-<username>",
             true,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -822,6 +978,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             true,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -847,6 +1004,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -874,6 +1032,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -891,6 +1050,49 @@ public class KubernetesNamespaceFactoryTest {
     assertEquals(namespace, "<userid>");
   }
 
+  @Test
+  public void testEvalNamespaceNameWhenLabeledNamespacesFound() throws InfrastructureException {
+    List<Namespace> namespaces =
+        Arrays.asList(
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns1")
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build(),
+            new NamespaceBuilder()
+                .withNewMetadata()
+                .withName("ns2")
+                .endMetadata()
+                .withNewStatus()
+                .withNewPhase("Active")
+                .endStatus()
+                .build());
+    doReturn(namespaces).when(namespaceList).getItems();
+
+    namespaceFactory =
+        new KubernetesNamespaceFactory(
+            "legacy",
+            "",
+            "",
+            "defaultNs",
+            false,
+            true,
+            NAMESPACE_LABELS,
+            clientFactory,
+            userManager,
+            preferenceManager,
+            pool);
+
+    String namespace =
+        namespaceFactory.evaluateNamespaceName(
+            new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
+
+    assertEquals(namespace, "ns1");
+  }
+
   @Test(dataProvider = "invalidUsernames")
   public void normalizeTest(String raw, String expected) {
     namespaceFactory =
@@ -901,6 +1103,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -918,6 +1121,7 @@ public class KubernetesNamespaceFactoryTest {
             "che-<userid>",
             false,
             true,
+            NAMESPACE_LABELS,
             clientFactory,
             userManager,
             preferenceManager,
@@ -940,6 +1144,12 @@ public class KubernetesNamespaceFactoryTest {
       new Object[] {"a---------b", "a-b"},
       new Object[] {"--ab--", "ab"}
     };
+  }
+
+  private void prepareNamespaceToBeFoundByLabel(String username, List<Namespace> namespaces) {
+    //
+    // lenient().doReturn(namespaceListResource).when(namespaceOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, username));
+    doReturn(namespaceList).when(namespaceListResource).list();
   }
 
   private void prepareNamespaceToBeFoundByName(String name, Namespace namespace) throws Exception {

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesNamespaceFactoryTest.java
@@ -210,6 +210,8 @@ public class KubernetesNamespaceFactoryTest {
             "defaultNs",
             false,
             true,
+            NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             userManager,
             preferenceManager,

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProject.java
@@ -208,6 +208,9 @@ public class OpenShiftProject extends KubernetesNamespace {
     } catch (KubernetesClientException e) {
       if (e.getCode() == 403) {
         // project is foreign or doesn't exist
+        LOG.warn(
+            "Trying to get namespace '{}', but failed because the lack of permissions.",
+            projectName);
         return null;
       } else {
         throw new KubernetesInfrastructureException(e);

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactory.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.openshift.project;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta.PHASE_ATTRIBUTE;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -32,6 +33,7 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.user.server.PreferenceManager;
 import org.eclipse.che.api.user.server.UserManager;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.api.workspace.server.spi.NamespaceResolutionContext;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.server.impls.KubernetesNamespaceMetaImpl;
 import org.eclipse.che.workspace.infrastructure.kubernetes.api.shared.KubernetesNamespaceMeta;
@@ -67,6 +69,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
       @Named("che.infra.kubernetes.namespace.allow_user_defined")
           boolean allowUserDefinedNamespaces,
       @Named("che.infra.kubernetes.namespace.creation_allowed") boolean namespaceCreationAllowed,
+      @Named("che.infra.kubernetes.namespace.labels") String projectLabels,
       OpenShiftClientFactory clientFactory,
       OpenShiftClientConfigFactory clientConfigFactory,
       OpenShiftStopWorkspaceRoleProvisioner stopWorkspaceRoleProvisioner,
@@ -82,6 +85,7 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
         defaultNamespaceName,
         allowUserDefinedNamespaces,
         namespaceCreationAllowed,
+        projectLabels,
         clientFactory,
         userManager,
         preferenceManager,
@@ -182,6 +186,34 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
     }
   }
 
+  protected List<KubernetesNamespaceMeta> findLabeledNamespaces(
+      NamespaceResolutionContext namespaceCtx) throws InfrastructureException {
+    Map<String, String> labels = evaluateLabelsPlaceholders(namespaceCtx);
+    try {
+      return clientFactory
+          .createOC()
+          .projects()
+          .withLabels(labels)
+          .list()
+          .getItems()
+          .stream()
+          .map(this::asNamespaceMeta)
+          .collect(Collectors.toList());
+    } catch (KubernetesClientException kce) {
+      if (kce.getCode() == 403) {
+        LOG.warn(
+            "Trying to fetch projects with labels '{}', but failed for lack of permissions. Cause: '{}'",
+            labels,
+            kce.getMessage());
+        return emptyList();
+      } else {
+        throw new InfrastructureException(
+            "Error occurred when tried to list all available projects. Cause: " + kce.getMessage(),
+            kce);
+      }
+    }
+  }
+
   @Override
   protected List<KubernetesNamespaceMeta> fetchNamespaces() throws InfrastructureException {
     try {
@@ -194,8 +226,16 @@ public class OpenShiftProjectFactory extends KubernetesNamespaceFactory {
           .map(this::asNamespaceMeta)
           .collect(Collectors.toList());
     } catch (KubernetesClientException e) {
-      throw new InfrastructureException(
-          "Error occurred when tried to list all available projects. Cause: " + e.getMessage(), e);
+      if (e.getCode() == 403) {
+        LOG.warn(
+            "Trying to fetch all namespaces, but failed for lack of permissions. Cause: {}",
+            e.getMessage());
+        return emptyList();
+      } else {
+        throw new InfrastructureException(
+            "Error occurred when tried to list all available projects. Cause: " + e.getMessage(),
+            e);
+      }
     }
   }
 

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/project/OpenShiftProjectFactoryTest.java
@@ -87,8 +87,10 @@ public class OpenShiftProjectFactoryTest {
   private static final String USER_NAME = "username";
   private static final String NO_OAUTH_IDENTITY_PROVIDER = null;
   private static final String OAUTH_IDENTITY_PROVIDER = "openshift-v4";
-  private static final String NAMESPACE_LABEL_NAME = "for-user";
-  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=<username>";
+  private static final String NAMESPACE_LABEL_NAME = "component";
+  private static final String NAMESPACE_LABELS = NAMESPACE_LABEL_NAME + "=workspace";
+  private static final String NAMESPACE_ANNOTATION_NAME = "owner";
+  private static final String NAMESPACE_ANNOTATIONS = NAMESPACE_ANNOTATION_NAME + "=<username>";
 
   @Mock private OpenShiftClientConfigFactory configFactory;
   @Mock private OpenShiftClientFactory clientFactory;
@@ -150,6 +152,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -174,6 +177,7 @@ public class OpenShiftProjectFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -201,6 +205,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -227,6 +232,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -237,12 +243,20 @@ public class OpenShiftProjectFactoryTest {
   }
 
   @Test
-  public void shouldReturnLabeledNamespacesWhenFound() throws InfrastructureException {
+  public void shouldReturnPreparedNamespacesWhenFound() throws InfrastructureException {
     // given
     List<Project> projects =
         Arrays.asList(
-            createProject("ns1", "project1", "desc1", "Active"),
-            createProject("ns2", "project2", "desc2", "Active"));
+            createProject(
+                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
+            createProject(
+                "ns3",
+                "project3",
+                "desc3",
+                "Active",
+                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
+            createProject(
+                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
     doReturn(projects).when(projectList).getItems();
 
     projectFactory =
@@ -254,6 +268,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -268,7 +283,6 @@ public class OpenShiftProjectFactoryTest {
 
     // then
     assertEquals(availableNamespaces.size(), 2);
-    verify(projectOperation).withLabels(Map.of(NAMESPACE_LABEL_NAME, "jondoe"));
     assertEquals(availableNamespaces.get(0).getName(), "ns1");
     assertEquals(availableNamespaces.get(1).getName(), "ns2");
   }
@@ -291,6 +305,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -323,6 +338,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -365,6 +381,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -401,6 +418,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -437,6 +455,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -465,6 +484,7 @@ public class OpenShiftProjectFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -509,6 +529,7 @@ public class OpenShiftProjectFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -548,6 +569,7 @@ public class OpenShiftProjectFactoryTest {
             true,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -579,6 +601,7 @@ public class OpenShiftProjectFactoryTest {
                 false,
                 true,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 configFactory,
                 stopWorkspaceRoleProvisioner,
@@ -614,6 +637,7 @@ public class OpenShiftProjectFactoryTest {
                 false,
                 true,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 configFactory,
                 stopWorkspaceRoleProvisioner,
@@ -651,6 +675,7 @@ public class OpenShiftProjectFactoryTest {
                 false,
                 true,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 configFactory,
                 stopWorkspaceRoleProvisioner,
@@ -690,6 +715,7 @@ public class OpenShiftProjectFactoryTest {
                 false,
                 true,
                 NAMESPACE_LABELS,
+                NAMESPACE_ANNOTATIONS,
                 clientFactory,
                 configFactory,
                 stopWorkspaceRoleProvisioner,
@@ -717,11 +743,19 @@ public class OpenShiftProjectFactoryTest {
   }
 
   @Test
-  public void testEvalNamespaceNameWhenLabeledNamespacesFound() throws InfrastructureException {
+  public void testEvalNamespaceNameWhenPreparedNamespacesFound() throws InfrastructureException {
     List<Project> projects =
         Arrays.asList(
-            createProject("ns1", "project1", "desc1", "Active"),
-            createProject("ns2", "project2", "desc2", "Active"));
+            createProject(
+                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")),
+            createProject(
+                "ns3",
+                "project3",
+                "desc3",
+                "Active",
+                Map.of(NAMESPACE_ANNOTATION_NAME, "some_other_user")),
+            createProject(
+                "ns2", "project2", "desc2", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
     doReturn(projects).when(projectList).getItems();
 
     projectFactory =
@@ -733,6 +767,7 @@ public class OpenShiftProjectFactoryTest {
             false,
             true,
             NAMESPACE_LABELS,
+            NAMESPACE_ANNOTATIONS,
             clientFactory,
             configFactory,
             stopWorkspaceRoleProvisioner,
@@ -746,6 +781,37 @@ public class OpenShiftProjectFactoryTest {
             new NamespaceResolutionContext("workspace123", "user123", "jondoe"));
 
     assertEquals(namespace, "ns1");
+  }
+
+  @Test
+  public void testUsernamePlaceholderInLabelsIsNotEvaluated() throws InfrastructureException {
+    List<Project> projects =
+        singletonList(
+            createProject(
+                "ns1", "project1", "desc1", "Active", Map.of(NAMESPACE_ANNOTATION_NAME, "jondoe")));
+    doReturn(projects).when(projectList).getItems();
+
+    projectFactory =
+        new OpenShiftProjectFactory(
+            "predefined",
+            "",
+            null,
+            "che-default",
+            false,
+            true,
+            "try_placeholder_here=<username>",
+            NAMESPACE_ANNOTATIONS,
+            clientFactory,
+            configFactory,
+            stopWorkspaceRoleProvisioner,
+            userManager,
+            preferenceManager,
+            pool,
+            NO_OAUTH_IDENTITY_PROVIDER);
+    EnvironmentContext.getCurrent().setSubject(new SubjectImpl("jondoe", "123", null, false));
+    projectFactory.list();
+
+    verify(projectOperation).withLabels(Map.of("try_placeholder_here", "<username>"));
   }
 
   private void prepareNamespaceToBeFoundByName(String name, Project project) throws Exception {
@@ -778,12 +844,24 @@ public class OpenShiftProjectFactoryTest {
   }
 
   private Project createProject(String name, String displayName, String description, String phase) {
+    return createProject(name, displayName, description, phase, emptyMap());
+  }
+
+  private Project createProject(
+      String name,
+      String displayName,
+      String description,
+      String phase,
+      Map<String, String> extraAnnotations) {
     Map<String, String> annotations = new HashMap<>();
     if (displayName != null) {
       annotations.put(PROJECT_DISPLAY_NAME_ANNOTATION, displayName);
     }
     if (description != null) {
       annotations.put(PROJECT_DESCRIPTION_ANNOTATION, description);
+    }
+    if (extraAnnotations != null) {
+      annotations.putAll(extraAnnotations);
     }
 
     return new ProjectBuilder()


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Allows admins to prepare namespace for users using labels and annotations.

Backport of precreated namespaces

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/17842 backport to 7.20.x


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. prepare namespace with
```
labels:
  app.kubernetes.io/part-of: che.eclipse.org
  app.kubernetes.io/component: workspaces-namespace
annotations:
  che.eclipse.org/username: <username> # replace <username> with real user that should use this namespace
```
2. assign admin ClusterRole for user in the namespace
2. start workspace with the user
2. workspace will start in created namesapce


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
