### PR TITLE
Import all certificates from propagated bundle

### DIFF
--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -324,14 +324,57 @@ add_che_cert_to_truststore() {
 }
 
 add_public_cert_to_truststore() {
+  chmod 644 $JAVA_TRUST_STORE || true
+
+  JAVA_TRUST_STORE=/home/user/cacerts
+  DEFAULT_JAVA_TRUST_STOREPASS="changeit"
+
   CUSTOM_PUBLIC_CERTIFICATES="/public-certs"
   if [[ -d "$CUSTOM_PUBLIC_CERTIFICATES" && -n "$(find $CUSTOM_PUBLIC_CERTIFICATES -type f)" ]]; then
     FILES="$CUSTOM_PUBLIC_CERTIFICATES/*"
     for cert in $FILES
     do
-      add_cert_to_truststore "$(<$cert)" "HOSTDOMAIN-$(basename $cert)"
+      jks_import_ca_bundle $cert $JAVA_TRUST_STORE $DEFAULT_JAVA_TRUST_STOREPASS
     done
   fi
+
+  chmod 444 $JAVA_TRUST_STORE
+}
+
+function jks_import_ca_bundle {
+  CA_FILE=$1
+  KEYSTORE_PATH=$2
+  KEYSTORE_PASSWORD=$3
+
+  if [ ! -f $CA_FILE ]; then
+    # CA bundle file doesn't exist, skip it
+    echo "Failed to import CA certificates from ${CA_FILE}. File doesn't exist"
+    return
+  fi
+
+  bundle_name=$(basename $CA_FILE)
+  cert_index=0
+  tmp_file=/tmp/cert.pem
+  is_cert=false
+  while IFS= read -r line; do
+    if [ "$line" == "-----BEGIN CERTIFICATE-----" ]; then
+      # Start copying a new certificate
+      is_cert=true
+      cert_index=$((cert_index+1))
+      # Reset destination file and add header line
+      echo $line > ${tmp_file}
+    elif [ "$line" == "-----END CERTIFICATE-----" ]; then
+      # End of the certificate is reached, add it to trust store
+      is_cert=false
+      echo $line >> ${tmp_file}
+      keytool -importcert -alias "${bundle_name}_${cert_index}" -keystore $KEYSTORE_PATH -file $tmp_file -storepass $KEYSTORE_PASSWORD -noprompt
+    elif [ "$is_cert" == true ]; then
+      # In the middle of a certificate, copy line to target file
+      echo $line >> ${tmp_file}
+    fi
+  done < "$CA_FILE"
+  # Clean up
+  rm -f $tmp_file
 }
 
 get_che_data_from_host() {

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -353,6 +353,7 @@ function jks_import_ca_bundle {
   fi
 
   bundle_name=$(basename $CA_FILE)
+  certs_imported=0
   cert_index=0
   tmp_file=/tmp/cert.pem
   is_cert=false
@@ -367,12 +368,14 @@ function jks_import_ca_bundle {
       # End of the certificate is reached, add it to trust store
       is_cert=false
       echo $line >> ${tmp_file}
-      keytool -importcert -alias "${bundle_name}_${cert_index}" -keystore $KEYSTORE_PATH -file $tmp_file -storepass $KEYSTORE_PASSWORD -noprompt
+      keytool -importcert -alias "${bundle_name}_${cert_index}" -keystore $KEYSTORE_PATH -file $tmp_file -storepass $KEYSTORE_PASSWORD -noprompt && \
+      certs_imported=$((certs_imported+1))
     elif [ "$is_cert" == true ]; then
       # In the middle of a certificate, copy line to target file
       echo $line >> ${tmp_file}
     fi
   done < "$CA_FILE"
+  echo "Imported ${certs_imported} certificates from ${CA_FILE}"
   # Clean up
   rm -f $tmp_file
 }

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -324,10 +324,10 @@ add_che_cert_to_truststore() {
 }
 
 add_public_cert_to_truststore() {
-  chmod 644 $JAVA_TRUST_STORE || true
-
   JAVA_TRUST_STORE=/home/user/cacerts
   DEFAULT_JAVA_TRUST_STOREPASS="changeit"
+
+  chmod 644 $JAVA_TRUST_STORE || true
 
   CUSTOM_PUBLIC_CERTIFICATES="/public-certs"
   if [[ -d "$CUSTOM_PUBLIC_CERTIFICATES" && -n "$(find $CUSTOM_PUBLIC_CERTIFICATES -type f)" ]]; then

--- a/dockerfiles/che/entrypoint.sh
+++ b/dockerfiles/che/entrypoint.sh
@@ -306,11 +306,10 @@ add_cert_to_truststore() {
   echo "$1" > $SELF_SIGNED_CERT
 
   # make sure that owner has permissions to write and other groups have permissions to read
-  # note that this might not work when running as anyuid OpenShift user, which is why we're forcing a true if it fails
-  chmod 644 $JAVA_TRUST_STORE || true
+  chmod 644 $JAVA_TRUST_STORE
 
   echo yes | keytool -keystore $JAVA_TRUST_STORE -importcert -alias "$2" -file $SELF_SIGNED_CERT -storepass $DEFAULT_JAVA_TRUST_STOREPASS > /dev/null
-  # allow only read by all groups
+  # return back read only permissions for keystore
   chmod 444 $JAVA_TRUST_STORE
   if [[ "$JAVA_OPTS" != *"-Djavax.net.ssl.trustStore"* && "$JAVA_OPTS" != *"-Djavax.net.ssl.trustStorePassword"* ]]; then
     export JAVA_OPTS="${JAVA_OPTS} -Djavax.net.ssl.trustStore=$JAVA_TRUST_STORE -Djavax.net.ssl.trustStorePassword=$DEFAULT_JAVA_TRUST_STOREPASS"
@@ -327,7 +326,7 @@ add_public_cert_to_truststore() {
   JAVA_TRUST_STORE=/home/user/cacerts
   DEFAULT_JAVA_TRUST_STOREPASS="changeit"
 
-  chmod 644 $JAVA_TRUST_STORE || true
+  chmod 644 $JAVA_TRUST_STORE
 
   CUSTOM_PUBLIC_CERTIFICATES="/public-certs"
   if [[ -d "$CUSTOM_PUBLIC_CERTIFICATES" && -n "$(find $CUSTOM_PUBLIC_CERTIFICATES -type f)" ]]; then

--- a/dockerfiles/che/rhel.Dockerfile
+++ b/dockerfiles/che/rhel.Dockerfile
@@ -17,9 +17,7 @@ ENV JAVA_HOME=/usr/lib/jvm/jre
 RUN microdnf install java-11-openjdk-headless tar gzip shadow-utils findutils && \
     microdnf update -y gnutls && \
     microdnf -y clean all && rm -rf /var/cache/yum && echo "Installed Packages" && rpm -qa | sort -V && echo "End Of Installed Packages" && \
-    adduser -G root user && mkdir -p /home/user/codeready && \
-    # copy cacert to home dir - see file references in entrypoint.sh
-    cp /etc/pki/ca-trust/extracted/java/cacerts /home/user/cacerts
+    adduser -G root user && mkdir -p /home/user/codeready
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
@@ -32,8 +30,6 @@ RUN mkdir /logs /data && \
     chown -R user /home/user && \
     chmod -R g+rwX /home/user && \
     find /home/user -type d -exec chmod 777 {} \; && \
-    # set group write permission so that entrypoint.sh can update permissions once file is updated w/ new cert
-    chmod g+w /home/user/cacerts && \
     java -version && echo -n "Server startup script in: " && \
     find /home/user/codeready -name catalina.sh | grep -z /home/user/codeready/tomcat/bin/catalina.sh
 

--- a/dockerfiles/keycloak/kc_realm_user.sh
+++ b/dockerfiles/keycloak/kc_realm_user.sh
@@ -8,6 +8,42 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
+function jks_import_ca_bundle {
+  CA_FILE=$1
+  KEYSTORE_PATH=$2
+  KEYSTORE_PASSWORD=$3
+
+  if [ ! -f $CA_FILE ]; then
+    # CA bundle file doesn't exist, skip it
+    echo "Failed to import CA certificates from ${CA_FILE}. File doesn't exist"
+    return
+  fi
+
+  bundle_name=$(basename $CA_FILE)
+  cert_index=0
+  tmp_file=/tmp/cert.pem
+  is_cert=false
+  while IFS= read -r line; do
+    if [ "$line" == "-----BEGIN CERTIFICATE-----" ]; then
+      # Start copying a new certificate
+      is_cert=true
+      cert_index=$((cert_index+1))
+      # Reset destination file and add header line
+      echo $line > ${tmp_file}
+    elif [ "$line" == "-----END CERTIFICATE-----" ]; then
+      # End of the certificate is reached, add it to trust store
+      is_cert=false
+      echo $line >> ${tmp_file}
+      keytool -importcert -alias "${bundle_name}_${cert_index}" -keystore $KEYSTORE_PATH -file $tmp_file -storepass $KEYSTORE_PASSWORD -noprompt
+    elif [ "$is_cert" == true ]; then
+      # In the middle of a certificate, copy line to target file
+      echo $line >> ${tmp_file}
+    fi
+  done < "$CA_FILE"
+  # Clean up
+  rm -f $tmp_file
+}
+
 echo "Configuring Keycloak by modifying realm and user templates..."
 
 cat /scripts/che-users-0.json.erb | \
@@ -41,7 +77,7 @@ CUSTOM_CERTS_DIR=/public-certs
 # Check for additional CA certificates propagated to Keycloak
 if [[ -d $CUSTOM_CERTS_DIR && -n $(find ${CUSTOM_CERTS_DIR} -type f) ]]; then
     for certfile in ${CUSTOM_CERTS_DIR}/* ; do
-        keytool -importcert -alias CERT_$(basename $certfile) -keystore $KEYSTORE_PATH -file $certfile -storepass $TRUST_STORE_PASSWORD  -noprompt;
+        jks_import_ca_bundle $certfile $KEYSTORE_PATH $TRUST_STORE_PASSWORD
     done
 fi
 

--- a/dockerfiles/keycloak/kc_realm_user.sh
+++ b/dockerfiles/keycloak/kc_realm_user.sh
@@ -20,6 +20,7 @@ function jks_import_ca_bundle {
   fi
 
   bundle_name=$(basename $CA_FILE)
+  certs_imported=0
   cert_index=0
   tmp_file=/tmp/cert.pem
   is_cert=false
@@ -34,12 +35,14 @@ function jks_import_ca_bundle {
       # End of the certificate is reached, add it to trust store
       is_cert=false
       echo $line >> ${tmp_file}
-      keytool -importcert -alias "${bundle_name}_${cert_index}" -keystore $KEYSTORE_PATH -file $tmp_file -storepass $KEYSTORE_PASSWORD -noprompt
+      keytool -importcert -alias "${bundle_name}_${cert_index}" -keystore $KEYSTORE_PATH -file $tmp_file -storepass $KEYSTORE_PASSWORD -noprompt && \
+      certs_imported=$((certs_imported+1))
     elif [ "$is_cert" == true ]; then
       # In the middle of a certificate, copy line to target file
       echo $line >> ${tmp_file}
     fi
   done < "$CA_FILE"
+  echo "Imported ${certs_imported} certificates from ${CA_FILE}"
   # Clean up
   rm -f $tmp_file
 }

--- a/dockerfiles/keycloak/kc_realm_user.sh
+++ b/dockerfiles/keycloak/kc_realm_user.sh
@@ -13,13 +13,13 @@ function jks_import_ca_bundle {
   KEYSTORE_PATH=$2
   KEYSTORE_PASSWORD=$3
 
-  if [ ! -f $CA_FILE ]; then
+  if [ ! -f "$CA_FILE" ]; then
     # CA bundle file doesn't exist, skip it
     echo "Failed to import CA certificates from ${CA_FILE}. File doesn't exist"
     return
   fi
 
-  bundle_name=$(basename $CA_FILE)
+  bundle_name=$(basename "$CA_FILE")
   certs_imported=0
   cert_index=0
   tmp_file=/tmp/cert.pem
@@ -30,16 +30,16 @@ function jks_import_ca_bundle {
       is_cert=true
       cert_index=$((cert_index+1))
       # Reset destination file and add header line
-      echo $line > ${tmp_file}
+      echo "$line" > ${tmp_file}
     elif [ "$line" == "-----END CERTIFICATE-----" ]; then
       # End of the certificate is reached, add it to trust store
       is_cert=false
-      echo $line >> ${tmp_file}
-      keytool -importcert -alias "${bundle_name}_${cert_index}" -keystore $KEYSTORE_PATH -file $tmp_file -storepass $KEYSTORE_PASSWORD -noprompt && \
+      echo "$line" >> ${tmp_file}
+      keytool -importcert -alias "${bundle_name}_${cert_index}" -keystore "$KEYSTORE_PATH" -file $tmp_file -storepass "$KEYSTORE_PASSWORD" -noprompt && \
       certs_imported=$((certs_imported+1))
     elif [ "$is_cert" == true ]; then
       # In the middle of a certificate, copy line to target file
-      echo $line >> ${tmp_file}
+      echo "$line" >> ${tmp_file}
     fi
   done < "$CA_FILE"
   echo "Imported ${certs_imported} certificates from ${CA_FILE}"
@@ -78,9 +78,9 @@ TRUST_STORE_PASSWORD=${TRUSTPASS:-openshift}
 CUSTOM_CERTS_DIR=/public-certs
 
 # Check for additional CA certificates propagated to Keycloak
-if [[ -d $CUSTOM_CERTS_DIR && -n $(find ${CUSTOM_CERTS_DIR} -type f) ]]; then
+if [[ -d $CUSTOM_CERTS_DIR && -n $(find "${CUSTOM_CERTS_DIR}" -type f) ]]; then
     for certfile in ${CUSTOM_CERTS_DIR}/* ; do
-        jks_import_ca_bundle $certfile $KEYSTORE_PATH $TRUST_STORE_PASSWORD
+        jks_import_ca_bundle "$certfile" "$KEYSTORE_PATH" "$TRUST_STORE_PASSWORD"
     done
 fi
 


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

### What does this PR do?
Makes it possible to import several CA certificates from a single file into Che server's java trust store.

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
* https://github.com/eclipse/che/issues/18339
* https://issues.redhat.com/projects/CRW-1413 - must remove patches from https://github.com/redhat-developer/codeready-workspaces/blob/crw-2.6-rhel-8/Jenkinsfile#L382-L399
* https://issues.redhat.com/browse/CRW-1381

### How to test this PR?
1. Create a *.pem file that contains several root CA certificates
1.1. Generate a few root CA certificates:
```sh
OPENSSL_CNF='/etc/pki/tls/openssl.cnf'
if [ ! -f $OPENSSL_CNF ]; then
    OPENSSL_CNF='/etc/ssl/openssl.cnf'
fi

for ((i=1;i<=4;i++)); do
  openssl genrsa -out ${i}.key 4096
  openssl req -batch -new -x509 -nodes -key ${i}.key -sha256 -subj /CN="TestCA${i}" -days 1024 -reqexts SAN -extensions SAN -config <(cat ${OPENSSL_CNF} <(printf '[SAN]\nbasicConstraints=critical, CA:TRUE\nkeyUsage=keyCertSign, cRLSign, digitalSignature')) -outform PEM -out ${i}.crt
```
1.2. Join them into a single bundle:
```sh
$ cat *.crt > bundle.pem
```
2. Create a configmap with single data field which contains the *.pem file:
```sh
$ kubectl create configmap custom-ca --from-file=bundle.pem -n che
```
3. Add the configmap as trusted for Che:
```sh
$ kubectl label configmap custom-ca app.kubernetes.io/part-of=che.eclipse.org -n che && kubectl label configmap custom-ca app.kubernetes.io/component=ca-bundle -n che
```
4. Check that all CA certs are added into Che server's trust store
4.1. Exec into Che server's container and go to `/home/user` directory
4.2. Make sure that the certs are imported into `cacerts` keystore:
```sh
$ keytool -list  -keystore cacerts -storepass changeit | grep bundle
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
