### PR TITLE
Adding support for Keycloak admin secret and endpoint-watcher image configuration

### DIFF
--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -67,9 +67,9 @@ spec:
               key: KEYCLOAK_PASSWORD
 {{- else }}
         - name: KEYCLOAK_USER
-          value: {{ .Values.keycloakAdminUserName }}
+          value: {{ .Values.keycloakAdminUserName | default "admin" }}
         - name: KEYCLOAK_PASSWORD
-          value: {{ .Values.keycloakAdminUserPassword }}
+          value: {{ required "keycloakAdminUserPassword cannot be empty" (.Values.keycloakAdminUserPassword | trim) }}
 {{- end }}
         - name: CHE_HOST
           value: {{ template "cheHost" . }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       initContainers:
       - name: wait-for-postgres
-        image: quay.io/eclipse/che-endpoint-watcher:nightly
+        image: {{ .Values.global.endpointWatcher.image }}
         env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -54,10 +54,23 @@ spec:
           value: keycloak
         - name: DB_PASSWORD
           value: keycloak
+{{- if .Values.keycloakAdminUserSecret }}
+        - name: KEYCLOAK_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.keycloakAdminUserSecret }}
+              key: KEYCLOAK_USER
+        - name: KEYCLOAK_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.keycloakAdminUserSecret }}
+              key: KEYCLOAK_PASSWORD
+{{- else }}
         - name: KEYCLOAK_USER
           value: {{ .Values.keycloakAdminUserName }}
         - name: KEYCLOAK_PASSWORD
           value: {{ .Values.keycloakAdminUserPassword }}
+{{- end }}
         - name: CHE_HOST
           value: {{ template "cheHost" . }}
         - name: ROUTING_SUFFIX

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/templates/deployment.yaml
@@ -54,17 +54,17 @@ spec:
           value: keycloak
         - name: DB_PASSWORD
           value: keycloak
-{{- if .Values.keycloakAdminUserSecret }}
+{{- if .Values.keycloakCredentialsSecret }}
         - name: KEYCLOAK_USER
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.keycloakAdminUserSecret }}
-              key: KEYCLOAK_USER
+              name: {{ .Values.keycloakCredentialsSecret }}
+              key: user
         - name: KEYCLOAK_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ .Values.keycloakAdminUserSecret }}
-              key: KEYCLOAK_PASSWORD
+              name: {{ .Values.keycloakCredentialsSecret }}
+              key: password
 {{- else }}
         - name: KEYCLOAK_USER
           value: {{ .Values.keycloakAdminUserName | default "admin" }}

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
@@ -28,7 +28,7 @@ image: quay.io/eclipse/che-keycloak:nightly
 requireAdminPasswordChange: true
 keycloakAdminUserName: admin
 keycloakAdminUserPassword: admin
-# Or use a secret with keys 'KEYCLOAK_USER' and 'KEYCLOAK_PASSWORD'
+# Or use a secret with keys 'user' and 'password'
 #keycloakCredentialsSecret: che-identity-secret
 
 deploymentStrategy: RollingUpdate

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
@@ -29,6 +29,6 @@ requireAdminPasswordChange: true
 keycloakAdminUserName: admin
 keycloakAdminUserPassword: admin
 # Or use a secret with keys 'KEYCLOAK_USER' and 'KEYCLOAK_PASSWORD'
-#keycloakAdminUserSecret: keycloak-admin-secret
+#keycloakCredentialsSecret: che-identity-secret
 
 deploymentStrategy: RollingUpdate

--- a/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
+++ b/deploy/kubernetes/helm/che/custom-charts/che-keycloak/values.yaml
@@ -17,9 +17,18 @@ global:
   tls:
     ## Name of the config-map with public certificates to add to Java trust store of the Keycloak
     serverTrustStoreConfigMapName: ""
+  # Image used by endpoint watcher (postgres)
+  endpointWatcher:
+    image: quay.io/eclipse/che-endpoint-watcher:nightly
 
 image: quay.io/eclipse/che-keycloak:nightly
+
+## Admin credentials configuration
+# Manually define them in clear
 requireAdminPasswordChange: true
 keycloakAdminUserName: admin
 keycloakAdminUserPassword: admin
+# Or use a secret with keys 'KEYCLOAK_USER' and 'KEYCLOAK_PASSWORD'
+#keycloakAdminUserSecret: keycloak-admin-secret
+
 deploymentStrategy: RollingUpdate

--- a/deploy/kubernetes/helm/che/templates/deployment.yaml
+++ b/deploy/kubernetes/helm/che/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       initContainers:
 {{- if .Values.global.multiuser }}
       - name: wait-for-postgres
-        image: quay.io/eclipse/che-endpoint-watcher:nightly
+        image: {{ .Values.global.endpointWatcher.image }}
         env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -45,7 +45,7 @@ spec:
 #wait for keycloak if in multiuser mode and .Values.customOidcProvider was not defined
 {{- if (and .Values.global.multiuser (not .Values.customOidcProvider)) }}
       - name: wait-for-keycloak
-        image: quay.io/eclipse/che-endpoint-watcher:nightly
+        image: {{ .Values.global.endpointWatcher.image }}
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -44,6 +44,9 @@ global:
   singleHostGatewayLabels: app=che,component=che-gateway-config
   # Public hostname of the installed Che server. If value is omitted then it will be automatically set.
   cheHost: ""
+  # Image used by endpoint watchers
+  endpointWatcher:
+    image: quay.io/eclipse/che-endpoint-watcher:nightly
 
   ## Allows to enable and configure TLS
   tls:


### PR DESCRIPTION
### What does this PR do?
Currently the only supported ways of configuring the `admin` user of Keycloak are:

1. Set its username and password via helm values
2. Leave the default `admin`:`admin` and mark them as `to be changed` at first login.

This PR is introducing a new way to inject the username and password using a Kubernetes secret, which make this more secure than passing values in the clear in helm values.  It is adding this new way and keeping the other ones also.  To create a secret recognized by the chart, you would do the following:
```
kubectl --namespace ${NAMESPACE} create secret generic keycloak-admin-secret \
    --from-literal=user=admin \
    --from-literal=password=XXXXXX
```
and then in your values.yaml:
```
che-keycloak:
  keycloakCredentialsSecret: "keycloak-admin-secret"
  #requireAdminPasswordChange: true
  #keycloakAdminUserName: admin
  #keycloakAdminUserPassword: admin
```

The PR also adds a new global value to configure `quay.io/eclipse/che-endpoint-watcher:nightly` image to something else, which is useful if you are using Che's helm charts from the repository and not from `chectl`.  Otherwise, you cannot change the image and you are stuck with the nighlty build.

### How to test this PR?
In order to test this, you can create a Che deployment using its helm chart.  You could also modify `chectl` to create a Kubernetes secret with the random password it generates and then `--set che-keycloak.keycloakCredentialsSecret=keycloak-admin-secret`.  In my opinion, modifying `chectl` in this regard would be a good idea.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
