### PR TITLE
Fix exception if no data in certs config map

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesTrustedCAProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesTrustedCAProvisioner.java
@@ -114,7 +114,9 @@ public class KubernetesTrustedCAProvisioner implements TrustedCAProvisioner {
 
     KubernetesNamespace namespace = namespaceFactory.getOrCreate(runtimeID);
     Optional<ConfigMap> existing = namespace.configMaps().get(configMapName);
-    if (existing.isEmpty() || !existing.get().getData().equals(allCaCertsConfigMap.getData())) {
+    if (existing.isEmpty()
+        || !(existing.get().getData() == allCaCertsConfigMap.getData()
+            || existing.get().getData().equals(allCaCertsConfigMap.getData()))) {
       // create or renew map
       k8sEnv
           .getConfigMaps()


### PR DESCRIPTION
### What does this PR do?
Provides fix for inability to start second workspace for the user

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
Failure to start second workspace for the user cause by exception:

<details>

```
2020-12-03 07:46:49,827[aceSharedPool-1]  [WARN ] [.i.k.KubernetesInternalRuntime 257]  - Failed to start Kubernetes runtime of workspace workspacem1wn6pmb06ltlsrn.
java.lang.NullPointerException: null
	at org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesTrustedCAProvisioner.provision(KubernetesTrustedCAProvisioner.java:117)
	at org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironmentProvisioner$KubernetesEnvironmentProvisionerImpl.provision(KubernetesEnvironmentProvisioner.java:185)
	at org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.PluginBrokerManager.getTooling(PluginBrokerManager.java:118)
	at org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.SidecarToolingProvisioner.provision(SidecarToolingProvisioner.java:90)
	at org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime.provisionWorkspace(KubernetesInternalRuntime.java:288)
	at org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime.internalStart(KubernetesInternalRuntime.java:204)
	at org.eclipse.che.api.workspace.server.spi.InternalRuntime.start(InternalRuntime.java:141)
	at org.eclipse.che.api.workspace.server.WorkspaceRuntimes$StartRuntimeTask.run(WorkspaceRuntimes.java:969)
	at org.eclipse.che.commons.lang.concurrent.CopyThreadLocalRunnable.run(CopyThreadLocalRunnable.java:38)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
	at io.micrometer.core.instrument.internal.TimedRunnable.run(TimedRunnable.java:44)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at org.eclipse.che.commons.observability.CountedThreadFactory.lambda$newThread$0(CountedThreadFactory.java:75)
	at java.base/java.lang.Thread.run(Unknown Source)
2020-12-03 07:46:49,903[aceSharedPool-1]  [INFO ] [o.e.c.a.w.s.WorkspaceRuntimes 995]   - Workspace 'admin:golang-omt8y' with id 'workspacem1wn6pmb06ltlsrn' start failed
2020-12-03 07:46:49,903[aceSharedPool-1]  [ERROR] [o.e.c.a.w.s.WorkspaceRuntimes 1005]  - An exception occurred.
org.eclipse.che.api.workspace.server.spi.InternalInfrastructureException: An exception occurred.
	at org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime.wrapAndRethrow(KubernetesInternalRuntime.java:966)
	at org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime.internalStart(KubernetesInternalRuntime.java:277)
	at org.eclipse.che.api.workspace.server.spi.InternalRuntime.start(InternalRuntime.java:141)
	at org.eclipse.che.api.workspace.server.WorkspaceRuntimes$StartRuntimeTask.run(WorkspaceRuntimes.java:969)
	at org.eclipse.che.commons.lang.concurrent.CopyThreadLocalRunnable.run(CopyThreadLocalRunnable.java:38)
	at java.base/java.util.concurrent.CompletableFuture$AsyncRun.run(Unknown Source)
	at io.micrometer.core.instrument.internal.TimedRunnable.run(TimedRunnable.java:44)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
	at org.eclipse.che.commons.observability.CountedThreadFactory.lambda$newThread$0(CountedThreadFactory.java:75)
	at java.base/java.lang.Thread.run(Unknown Source)
Caused by: java.lang.NullPointerException: null
	at org.eclipse.che.workspace.infrastructure.kubernetes.provision.KubernetesTrustedCAProvisioner.provision(KubernetesTrustedCAProvisioner.java:117)
	at org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesEnvironmentProvisioner$KubernetesEnvironmentProvisionerImpl.provision(KubernetesEnvironmentProvisioner.java:185)
	at org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.PluginBrokerManager.getTooling(PluginBrokerManager.java:118)
	at org.eclipse.che.workspace.infrastructure.kubernetes.wsplugins.SidecarToolingProvisioner.provision(SidecarToolingProvisioner.java:90)
	at org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime.provisionWorkspace(KubernetesInternalRuntime.java:288)
	at org.eclipse.che.workspace.infrastructure.kubernetes.KubernetesInternalRuntime.internalStart(KubernetesInternalRuntime.java:204)
	... 9 common frames omitted
```

</details>

### How to test this PR?
Start two workspaces simultaniously


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
