### PR TITLE
fix container cpu resource conversion

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/Containers.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/Containers.java
@@ -128,7 +128,7 @@ public class Containers {
         && resources.getLimits() != null
         && (quantity = resources.getLimits().get("cpu")) != null
         && quantity.getAmount() != null) {
-      return KubernetesSize.toCores(quantity.getAmount());
+      return KubernetesSize.toCores(quantity);
     }
     return 0;
   }
@@ -174,7 +174,7 @@ public class Containers {
         && resources.getRequests() != null
         && (quantity = resources.getRequests().get("cpu")) != null
         && quantity.getAmount() != null) {
-      return KubernetesSize.toCores(quantity.getAmount());
+      return KubernetesSize.toCores(quantity);
     }
     return 0;
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/KubernetesSize.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/KubernetesSize.java
@@ -157,12 +157,12 @@ public class KubernetesSize {
   }
 
   /**
-   * Converts CPU resource in {@link Quantity} to cores.
+   * Converts CPU resource from {@link Quantity} object to cores.
    *
    * <p>see {@link KubernetesSize#toCores(String)} for conversion rules
    *
    * @param quantity to convert
-   * @return value in full cores
+   * @return value in cores
    */
   public static float toCores(Quantity quantity) {
     return toCores(quantity.getAmount() + quantity.getFormat());

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/KubernetesSize.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/KubernetesSize.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.che.workspace.infrastructure.kubernetes.util;
 
+import io.fabric8.kubernetes.api.model.Quantity;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -153,5 +154,17 @@ public class KubernetesSize {
       }
     }
     throw new IllegalArgumentException("Invalid Kubernetes CPU size format provided: " + cpuString);
+  }
+
+  /**
+   * Converts CPU resource in {@link Quantity} to cores.
+   *
+   * <p>see {@link KubernetesSize#toCores(String)} for conversion rules
+   *
+   * @param quantity to convert
+   * @return value in full cores
+   */
+  public static float toCores(Quantity quantity) {
+    return toCores(quantity.getAmount() + quantity.getFormat());
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/ContainersTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/ContainersTest.java
@@ -288,4 +288,13 @@ public class ContainersTest {
       {"155m", "155", "m", null},
     };
   }
+
+  @Test
+  public void testReturnContainerCPULimitAndRequestConvertedToFullCores() {
+    when(resource.getLimits()).thenReturn(ImmutableMap.of("cpu", new Quantity("1000", "m")));
+    when(resource.getRequests()).thenReturn(ImmutableMap.of("cpu", new Quantity("30", "m")));
+
+    assertEquals(Containers.getCpuLimit(container), 1);
+    assertEquals(Containers.getCpuRequest(container), 0.03, 0.000000001);
+  }
 }


### PR DESCRIPTION
Signed-off-by: Michal Vala <mvala@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix conversion of CPU resource into full cores for plugins.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/18484


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
```
metadata:
  name: test-cpulimit22qho
attributes:
  persistVolumes: 'false'
components:
  - type: cheEditor
    reference: >-
      https://gist.githubusercontent.com/sparkoo/cb5105fa1f01f29bf73eb238f6ae622f/raw/090062b9eca6a25ef5226d566ef9626d8a2ca012/theia_meta.yaml
    alias: che-theia
apiVersion: 1.0.0
```
This devfile should now work and theia container should have 
```     
  cpuLimit: "1"
  cpuRequest: "0.03"
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
