### PR TITLE
Gh17540 memory request dockerimage

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplier.java
@@ -172,6 +172,7 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
         buildDeployment(
             machineName,
             dockerimageComponent.getImage(),
+            dockerimageComponent.getMemoryRequest(),
             dockerimageComponent.getMemoryLimit(),
             dockerimageComponent.getCpuRequest(),
             dockerimageComponent.getCpuLimit(),
@@ -190,6 +191,7 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
   private Deployment buildDeployment(
       String name,
       String image,
+      String memoryRequest,
       String memoryLimit,
       String cpuRequest,
       String cpuLimit,
@@ -207,6 +209,9 @@ public class DockerimageComponentToWorkspaceApplier implements ComponentToWorksp
             .build();
 
     Containers.addRamLimit(container, memoryLimit);
+    if (!isNullOrEmpty(memoryRequest)) {
+      Containers.addRamRequest(container, memoryRequest);
+    }
     if (!isNullOrEmpty(cpuRequest)) {
       Containers.addCpuRequest(container, KubernetesSize.toCores(cpuRequest));
     }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
@@ -276,7 +276,6 @@ public class DockerimageComponentToWorkspaceApplierTest {
     Quantity memoryRequest = container.getResources().getRequests().get("memory");
     assertEquals(memoryRequest.getAmount(), "128");
     assertEquals(memoryRequest.getFormat(), "M");
-
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/devfile/DockerimageComponentToWorkspaceApplierTest.java
@@ -243,13 +243,14 @@ public class DockerimageComponentToWorkspaceApplierTest {
   }
 
   @Test
-  public void shouldProvisionContainerWithMemoryLimitSpecified() throws Exception {
+  public void shouldProvisionContainerWithMemoryResourcesSpecified() throws Exception {
     // given
     ComponentImpl dockerimageComponent = new ComponentImpl();
     dockerimageComponent.setAlias("jdk");
     dockerimageComponent.setType(DOCKERIMAGE_COMPONENT_TYPE);
     dockerimageComponent.setImage("eclipse/ubuntu_jdk8:latest");
     dockerimageComponent.setMemoryLimit("1G");
+    dockerimageComponent.setMemoryRequest("128M");
 
     // when
     dockerimageComponentApplier.apply(workspaceConfig, dockerimageComponent, null);
@@ -271,6 +272,11 @@ public class DockerimageComponentToWorkspaceApplierTest {
     Quantity memoryLimit = container.getResources().getLimits().get("memory");
     assertEquals(memoryLimit.getAmount(), "1");
     assertEquals(memoryLimit.getFormat(), "G");
+
+    Quantity memoryRequest = container.getResources().getRequests().get("memory");
+    assertEquals(memoryRequest.getAmount(), "128");
+    assertEquals(memoryRequest.getFormat(), "M");
+
   }
 
   @Test

--- a/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
+++ b/wsmaster/che-core-api-workspace/src/main/resources/schema/1.0.0/devfile.json
@@ -247,46 +247,10 @@
                     "examples": [
                       "https://che-plugin-registry.openshift.io/v3/"
                     ]
-                  },
-                  "memoryLimit": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "integer",
-                        "exclusiveMinimum": 0
-                      }
-                    ],
-                    "description": "Describes memory limit for the component. You can express memory as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki",
-                    "examples": [
-                      "128974848",
-                      "129e6",
-                      "129M",
-                      "123Mi"
-                    ]
-                  },
-                  "memoryRequest": {
-                      "anyOf": [
-                        {
-                          "type": "string"
-                        },
-                        {
-                          "type": "integer",
-                          "exclusiveMinimum": 0
-                        }
-                      ],
-                      "description": "Describes memory request for the component. You can express memory as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki",
-                      "examples": [
-                        "128974848",
-                        "129e6",
-                        "129M",
-                        "123Mi"
-                      ]
-                    }
                   }
                 }
-              },
+              }
+            },
             {
               "if": {
                 "properties": {
@@ -349,7 +313,7 @@
                       "{\"java.home\": \"/home/user/jdk11\", \"java.jdt.ls.vmargs\": \"-Xmx1G\"}"
                     ],
                     "additionalProperties": {
-                      "anyOf" : [
+                      "anyOf": [
                         {
                           "type": [
                             "boolean",
@@ -500,24 +464,8 @@
                   "automountWorkspaceSecrets": {},
                   "volumes": {},
                   "endpoints": {},
-                  "memoryLimit": {
-                    "anyOf": [
-                      {
-                        "type": "string"
-                      },
-                      {
-                        "type": "integer",
-                        "exclusiveMinimum": 0
-                      }
-                    ],
-                    "description": "Describes memory limit for the component. You can express memory as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki",
-                    "examples": [
-                      "128974848",
-                      "129e6",
-                      "129M",
-                      "123Mi"
-                    ]
-                  },
+                  "memoryLimit": {},
+                  "memoryRequest": {},
                   "image": {
                     "type": "string",
                     "description": "Specifies the docker image that should be used for component",
@@ -581,6 +529,42 @@
             "type": "boolean",
             "description": "Describes whether projects sources should be mount to the component. `CHE_PROJECTS_ROOT` environment variable should contains a path where projects sources are mount",
             "default": "false"
+          },
+          "memoryLimit": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            ],
+            "description": "Describes memory limit for the component. You can express memory as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki",
+            "examples": [
+              "128974848",
+              "129e6",
+              "129M",
+              "123Mi"
+            ]
+          },
+          "memoryRequest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0
+              }
+            ],
+            "description": "Describes memory request for the component. You can express memory as a plain integer or as a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki",
+            "examples": [
+              "128974848",
+              "129e6",
+              "129M",
+              "123Mi"
+            ]
           },
           "cpuLimit": {
             "anyOf": [

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/dockerimage_component/devfile_dockerimage_component.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/dockerimage_component/devfile_dockerimage_component.yaml
@@ -32,6 +32,7 @@ components:
           public: 'true'
           discoverable: 'false'
     memoryLimit: 1536M
+    memoryRequest: 512M
     cpuLimit: 1.5
     cpuRequest: 750m
     command: ['/bin/sh']


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds support for `memoryRequest` for dockerimage components.

docs PR: https://github.com/eclipse/che-docs/pull/1734


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/17540


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

che-server image: `quay.io/mvala/che-server:gh17540-memoryRequestDockerimage`

```
apiVersion: 1.0.0
metadata:
  generateName: memreq
attributes:
  persistVolumes: 'false'
components:
  - memoryLimit: 2Gi
    type: dockerimage
    image: 'quay.io/eclipse/che-golang-1.14:nightly'
    alias: go-cli
    memoryRequest: 1Gi
```
1. add `memoryRequest` to some dockerimage component in the devfile
1. check that the value is properly set in workspace pod container



### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
