### PR TITLE
fix(async-pv): There is only one tag of the image which is latest so there should not be any nightly plug-in

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -674,7 +674,7 @@ che.workspace.provision.secret.labels=app.kubernetes.io/part-of=che.eclipse.org,
 
 # Plugin is added in case async storage feature will be enabled in workspace config
 # and supported by environment
-che.workspace.devfile.async.storage.plugin=eclipse/che-async-pv-plugin/nightly
+che.workspace.devfile.async.storage.plugin=eclipse/che-async-pv-plugin/latest
 
 # Docker image for the Che async storage
 che.infra.kubernetes.async.storage.image=quay.io/eclipse/che-workspace-data-sync-storage:latest


### PR DESCRIPTION
### What does this PR do?
Use latest instead of nightly as there is no "nightly/next" versio of this component.
https://quay.io/repository/eclipse/che-sidecar-workspace-data-sync?tag=latest&tab=tags


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
When automating meta.yaml generation in plug-in registry, I noticed that

### How to test this PR?
Use async-pv mode.
BTW latest always exists.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
