### PR TITLE
Make all configmaps unique in same namespace

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -489,6 +489,9 @@ che.infra.kubernetes.trusted_ca.src_configmap=NULL
 # Holds the copy of che.infra.kubernetes.trusted_ca.src_configmap but in a workspace namespace.
 # Content of this config map is mounted into all workspace containers including plugin brokers.
 # Do not change the config map name unless it conflicts with the already existing config map.
+# Note that the resulting config map name can be adjusted eventually to make it unique in k8s namespace.
+# The original name would be stored in `che.original_name` label.
+
 che.infra.kubernetes.trusted_ca.dest_configmap=ca-certs
 
 # Configures path on workspace containers where the CA bundle should be mount.

--- a/infrastructures/kubernetes/pom.xml
+++ b/infrastructures/kubernetes/pom.xml
@@ -257,11 +257,6 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
             <artifactId>mockito-testng</artifactId>
             <scope>test</scope>
         </dependency>

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
@@ -167,7 +167,6 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
       // 3 stage - add Kubernetes env items
       LOG.debug("Provisioning environment items for workspace '{}'", workspaceId);
       restartPolicyRewriter.provision(k8sEnv, identity);
-      uniqueNamesProvisioner.provision(k8sEnv, identity);
       resourceLimitRequestProvisioner.provision(k8sEnv, identity);
       nodeSelectorProvisioner.provision(k8sEnv, identity);
       externalServerTlsProvisioner.provision(k8sEnv, identity);
@@ -183,6 +182,7 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
       gitConfigProvisioner.provision(k8sEnv, identity);
       gatewayRouterProvisioner.provision(k8sEnv, identity);
       trustedCAProvisioner.provision(k8sEnv, identity);
+      uniqueNamesProvisioner.provision(k8sEnv, identity);
       LOG.debug("Provisioning Kubernetes environment done for workspace '{}'", workspaceId);
     }
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GitConfigProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GitConfigProvisioner.java
@@ -52,7 +52,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 @Singleton
 public class GitConfigProvisioner implements ConfigurationProvisioner<KubernetesEnvironment> {
 
-  public static final String GIT_CONFIG_MAP_NAME_SUFFIX = "-gitconfig";
+  public static final String GIT_CONFIG_MAP_NAME = "gitconfig";
 
   private static final String GIT_BASE_CONFIG_PATH = "/etc/";
   public static final String GIT_CONFIG = "gitconfig";
@@ -132,12 +132,7 @@ public class GitConfigProvisioner implements ConfigurationProvisioner<Kubernetes
   private void prepareAndProvisionGitConfiguration(
       String name, String email, KubernetesEnvironment k8sEnv, RuntimeIdentity identity) {
     prepareGitConfigurationContent(name, email)
-        .ifPresent(
-            content -> {
-              String configMapName = identity.getWorkspaceId() + GIT_CONFIG_MAP_NAME_SUFFIX;
-
-              doProvisionGitConfiguration(configMapName, content, k8sEnv);
-            });
+        .ifPresent(content -> doProvisionGitConfiguration(GIT_CONFIG_MAP_NAME, content, k8sEnv));
   }
 
   private String getStringValueOrNull(Map<String, Object> map, String key) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesTrustedCAProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesTrustedCAProvisioner.java
@@ -23,7 +23,6 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
@@ -113,26 +112,21 @@ public class KubernetesTrustedCAProvisioner implements TrustedCAProvisioner {
     }
 
     KubernetesNamespace namespace = namespaceFactory.getOrCreate(runtimeID);
-    Optional<ConfigMap> existing = namespace.configMaps().get(configMapName);
-    if (existing.isEmpty()
-        || !(existing.get().getData() == allCaCertsConfigMap.getData()
-            || existing.get().getData().equals(allCaCertsConfigMap.getData()))) {
-      // create or renew map
-      k8sEnv
-          .getConfigMaps()
-          .put(
-              configMapName,
-              new ConfigMapBuilder()
-                  .withMetadata(
-                      new ObjectMetaBuilder()
-                          .withName(configMapName)
-                          .withAnnotations(allCaCertsConfigMap.getMetadata().getAnnotations())
-                          .withLabels(configMapLabelKeyValue)
-                          .build())
-                  .withApiVersion(allCaCertsConfigMap.getApiVersion())
-                  .withData(allCaCertsConfigMap.getData())
-                  .build());
-    }
+
+    k8sEnv
+        .getConfigMaps()
+        .put(
+            configMapName,
+            new ConfigMapBuilder()
+                .withMetadata(
+                    new ObjectMetaBuilder()
+                        .withName(configMapName)
+                        .withAnnotations(allCaCertsConfigMap.getMetadata().getAnnotations())
+                        .withLabels(configMapLabelKeyValue)
+                        .build())
+                .withApiVersion(allCaCertsConfigMap.getApiVersion())
+                .withData(allCaCertsConfigMap.getData())
+                .build());
 
     for (PodData pod : k8sEnv.getPodsData().values()) {
       if (pod.getRole() == PodRole.DEPLOYMENT) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesTrustedCAProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/KubernetesTrustedCAProvisioner.java
@@ -34,7 +34,6 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.CheInstal
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodRole;
-import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespace;
 import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesNamespaceFactory;
 
 /**
@@ -110,8 +109,6 @@ public class KubernetesTrustedCAProvisioner implements TrustedCAProvisioner {
     if (allCaCertsConfigMap == null) {
       return;
     }
-
-    KubernetesNamespace namespace = namespaceFactory.getOrCreate(runtimeID);
 
     k8sEnv
         .getConfigMaps()

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
@@ -84,7 +84,7 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
   private static final String SSH_CONFIG = "ssh_config";
   private static final String SSH_CONFIG_PATH = SSH_BASE_CONFIG_PATH + SSH_CONFIG;
 
-  private static final String SSH_CONFIG_MAP_NAME_SUFFIX = "-sshconfigmap";
+  private static final String SSH_CONFIG_MAP_NAME = "sshconfigmap";
   private static final String SSH_SECRET_NAME_SUFFIX = "-sshprivatekeys";
 
   private static final String SSH_SECRET_TYPE = "opaque";
@@ -250,7 +250,7 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
       sshConfigData.append(buildConfig(sshPair.getName()));
     }
 
-    String sshConfigMapName = wsId + SSH_CONFIG_MAP_NAME_SUFFIX;
+    String sshConfigMapName = SSH_CONFIG_MAP_NAME;
 
     Map<String, String> sshConfig = new HashMap<>();
     sshConfig.put(SSH_CONFIG, sshConfigData.toString());

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
@@ -250,14 +250,12 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
       sshConfigData.append(buildConfig(sshPair.getName()));
     }
 
-    String sshConfigMapName = SSH_CONFIG_MAP_NAME;
-
     Map<String, String> sshConfig = new HashMap<>();
     sshConfig.put(SSH_CONFIG, sshConfigData.toString());
     ConfigMap configMap =
         new ConfigMapBuilder()
             .withNewMetadata()
-            .withName(sshConfigMapName)
+            .withName(SSH_CONFIG_MAP_NAME)
             .endMetadata()
             .withData(sshConfig)
             .build();
@@ -267,7 +265,9 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
         .getPodsData()
         .values()
         .forEach(
-            p -> mountConfigFile(p.getSpec(), sshConfigMapName, p.getRole() != PodRole.INJECTABLE));
+            p ->
+                mountConfigFile(
+                    p.getSpec(), SSH_CONFIG_MAP_NAME, p.getRole() != PodRole.INJECTABLE));
   }
 
   private void mountConfigFile(PodSpec podSpec, String sshConfigMapName, boolean addVolume) {

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisioner.java
@@ -39,7 +39,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
- * Makes names of Kubernetes pods and ingresses, config maps unique whole namespace by {@link
+ * Makes names of Kubernetes pods, ingresses and config maps unique whole namespace by {@link
  * Names}.
  *
  * <p>Original names will be stored in {@link Constants#CHE_ORIGINAL_NAME_LABEL} label of renamed

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/UniqueNamesProvisioner.java
@@ -39,7 +39,8 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment.PodData;
 
 /**
- * Makes names of Kubernetes pods and ingresses unique whole namespace by {@link Names}.
+ * Makes names of Kubernetes pods and ingresses, config maps unique whole namespace by {@link
+ * Names}.
  *
  * <p>Original names will be stored in {@link Constants#CHE_ORIGINAL_NAME_LABEL} label of renamed
  * object.

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/GitCredentialStorageFileSecretApplier.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/GitCredentialStorageFileSecretApplier.java
@@ -64,10 +64,7 @@ public class GitCredentialStorageFileSecretApplier extends FileSecretApplier {
               keys.size()));
     }
     Path gitSecretFilePath = Paths.get(secretMountPath, keys.iterator().next());
-    ConfigMap gitConfigMap =
-        env.getConfigMaps()
-            .get(
-                runtimeIdentity.getWorkspaceId() + GitConfigProvisioner.GIT_CONFIG_MAP_NAME_SUFFIX);
+    ConfigMap gitConfigMap = env.getConfigMaps().get(GitConfigProvisioner.GIT_CONFIG_MAP_NAME);
     if (gitConfigMap != null) {
       Map<String, String> gitConfigMapData = gitConfigMap.getData();
       String gitConfig = gitConfigMapData.get(GitConfigProvisioner.GIT_CONFIG);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisionerTest.java
@@ -153,7 +153,7 @@ public class KubernetesEnvironmentProvisionerTest {
     provisionOrder.verify(envVarsProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verify(volumesStrategy).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verify(restartPolicyRewriter).provision(eq(k8sEnv), eq(runtimeIdentity));
-    provisionOrder.verify(uniqueNamesProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
+
     provisionOrder.verify(ramLimitProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verify(nodeSelectorProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder
@@ -170,6 +170,7 @@ public class KubernetesEnvironmentProvisionerTest {
     provisionOrder.verify(gitConfigProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verify(gatewayRouterProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verify(trustedCAProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
+    provisionOrder.verify(uniqueNamesProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verifyNoMoreInteractions();
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GitConfigProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/GitConfigProvisionerTest.java
@@ -205,9 +205,9 @@ public class GitConfigProvisionerTest {
     assertEquals(mount.getSubPath(), "gitconfig");
 
     assertEquals(k8sEnv.getConfigMaps().size(), 1);
-    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+    assertTrue(k8sEnv.getConfigMaps().containsKey("gitconfig"));
 
-    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("gitconfig");
 
     assertEquals(configMap.getData().size(), 1);
     assertTrue(configMap.getData().containsKey("gitconfig"));
@@ -257,9 +257,9 @@ public class GitConfigProvisionerTest {
     assertEquals(mount.getSubPath(), "gitconfig");
 
     assertEquals(k8sEnv.getConfigMaps().size(), 1);
-    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+    assertTrue(k8sEnv.getConfigMaps().containsKey("gitconfig"));
 
-    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("gitconfig");
 
     assertEquals(configMap.getData().size(), 1);
     assertTrue(configMap.getData().containsKey("gitconfig"));
@@ -309,9 +309,9 @@ public class GitConfigProvisionerTest {
     assertEquals(mount.getSubPath(), "gitconfig");
 
     assertEquals(k8sEnv.getConfigMaps().size(), 1);
-    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+    assertTrue(k8sEnv.getConfigMaps().containsKey("gitconfig"));
 
-    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("gitconfig");
 
     assertEquals(configMap.getData().size(), 1);
     assertTrue(configMap.getData().containsKey("gitconfig"));
@@ -354,9 +354,9 @@ public class GitConfigProvisionerTest {
     assertEquals(mount.getSubPath(), "gitconfig");
 
     assertEquals(k8sEnv.getConfigMaps().size(), 1);
-    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+    assertTrue(k8sEnv.getConfigMaps().containsKey("gitconfig"));
 
-    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("gitconfig");
 
     assertEquals(configMap.getData().size(), 1);
     assertTrue(configMap.getData().containsKey("gitconfig"));
@@ -402,9 +402,9 @@ public class GitConfigProvisionerTest {
     assertEquals(mount.getSubPath(), "gitconfig");
 
     assertEquals(k8sEnv.getConfigMaps().size(), 1);
-    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+    assertTrue(k8sEnv.getConfigMaps().containsKey("gitconfig"));
 
-    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("gitconfig");
 
     assertEquals(configMap.getData().size(), 1);
     assertTrue(configMap.getData().containsKey("gitconfig"));
@@ -420,8 +420,6 @@ public class GitConfigProvisionerTest {
     when(vcsSslCertificateProvisioner.isConfigured()).thenReturn(true);
     when(vcsSslCertificateProvisioner.getGitServerHost()).thenReturn("https://localhost");
     when(vcsSslCertificateProvisioner.getCertPath()).thenReturn("/some/path");
-
-    when(runtimeIdentity.getWorkspaceId()).thenReturn("wksp");
 
     ObjectMeta podMeta = new ObjectMetaBuilder().withName("wksp").build();
     when(pod.getMetadata()).thenReturn(podMeta);
@@ -450,9 +448,9 @@ public class GitConfigProvisionerTest {
     assertEquals(mount.getSubPath(), "gitconfig");
 
     assertEquals(k8sEnv.getConfigMaps().size(), 1);
-    assertTrue(k8sEnv.getConfigMaps().containsKey("wksp-gitconfig"));
+    assertTrue(k8sEnv.getConfigMaps().containsKey("gitconfig"));
 
-    ConfigMap configMap = k8sEnv.getConfigMaps().get("wksp-gitconfig");
+    ConfigMap configMap = k8sEnv.getConfigMaps().get("gitconfig");
 
     assertEquals(configMap.getData().size(), 1);
     assertTrue(configMap.getData().containsKey("gitconfig"));
@@ -471,7 +469,6 @@ public class GitConfigProvisionerTest {
         singletonMap(
             "theia-user-preferences", "{\"git.user.name\":\"user\",\"git.user.email\":\"email\"}");
     when(preferenceManager.find(eq("id"), eq("theia-user-preferences"))).thenReturn(preferences);
-    when(runtimeIdentity.getWorkspaceId()).thenReturn("wksp");
 
     Pod pod =
         new PodBuilder()

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeySecretProvisionerTest.java
@@ -144,9 +144,9 @@ public class SshKeySecretProvisionerTest {
 
     Map<String, ConfigMap> configMaps = k8sEnv.getConfigMaps();
     assertNotNull(configMaps);
-    assertTrue(configMaps.containsKey("wksp-sshconfigmap"));
+    assertTrue(configMaps.containsKey("sshconfigmap"));
 
-    ConfigMap sshConfigMap = configMaps.get("wksp-sshconfigmap");
+    ConfigMap sshConfigMap = configMaps.get("sshconfigmap");
     assertNotNull(sshConfigMap);
 
     Map<String, String> mapData = sshConfigMap.getData();

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/GitCredentialStorageFileSecretApplierTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/secret/GitCredentialStorageFileSecretApplierTest.java
@@ -13,6 +13,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.GitConfigProvisioner.GIT_CONFIG_MAP_NAME;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.FileSecretApplier.ANNOTATION_MOUNT_PATH;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.KubernetesSecretApplier.ANNOTATION_AUTOMOUNT;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.SecretAsContainerResourceProvisioner.ANNOTATION_MOUNT_AS;
@@ -64,7 +65,7 @@ public class GitCredentialStorageFileSecretApplierTest {
     when(environment.getPodsData()).thenReturn(singletonMap("pod1", podData));
     when(podData.getRole()).thenReturn(KubernetesEnvironment.PodRole.DEPLOYMENT);
     when(podData.getSpec()).thenReturn(podSpec);
-    when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-1234598");
+    lenient().when(runtimeIdentity.getWorkspaceId()).thenReturn("ws-1234598");
   }
 
   @Test(
@@ -124,10 +125,7 @@ public class GitCredentialStorageFileSecretApplierTest {
         new ConfigMapBuilder()
             .withData(ImmutableMap.of(GitConfigProvisioner.GIT_CONFIG, GIT_CONFIG_CONTENT))
             .build();
-    when(environment.getConfigMaps())
-        .thenReturn(
-            ImmutableMap.of(
-                "ws-1234598" + GitConfigProvisioner.GIT_CONFIG_MAP_NAME_SUFFIX, configMap));
+    when(environment.getConfigMaps()).thenReturn(ImmutableMap.of(GIT_CONFIG_MAP_NAME, configMap));
     // when
     secretApplier.applySecret(environment, runtimeIdentity, secret);
     // then
@@ -172,10 +170,7 @@ public class GitCredentialStorageFileSecretApplierTest {
                     GIT_CONFIG_CONTENT
                         + "[credential]\n\thelper = store --file /home/user/.git/credentials\n"))
             .build();
-    when(environment.getConfigMaps())
-        .thenReturn(
-            ImmutableMap.of(
-                "ws-1234598" + GitConfigProvisioner.GIT_CONFIG_MAP_NAME_SUFFIX, configMap));
+    when(environment.getConfigMaps()).thenReturn(ImmutableMap.of(GIT_CONFIG_MAP_NAME, configMap));
     // when
     secretApplier.applySecret(environment, runtimeIdentity, secret);
   }

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -163,7 +163,6 @@ public class OpenShiftEnvironmentProvisioner
 
     // 3 stage - add OpenShift env items
     restartPolicyRewriter.provision(osEnv, identity);
-    uniqueNamesProvisioner.provision(osEnv, identity);
     routeTlsProvisioner.provision(osEnv, identity);
     resourceLimitRequestProvisioner.provision(osEnv, identity);
     nodeSelectorProvisioner.provision(osEnv, identity);
@@ -179,6 +178,7 @@ public class OpenShiftEnvironmentProvisioner
     gatewayRouterProvisioner.provision(osEnv, identity);
     deploymentMetadataProvisioner.provision(osEnv, identity);
     trustedCAProvisioner.provision(osEnv, identity);
+    uniqueNamesProvisioner.provision(osEnv, identity);
     LOG.debug(
         "Provisioning OpenShift environment done for workspace '{}'", identity.getWorkspaceId());
   }

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -150,7 +150,6 @@ public class OpenShiftEnvironmentProvisionerTest {
     provisionOrder.verify(envVarsProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(volumesStrategy).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(restartPolicyRewriter).provision(eq(osEnv), eq(runtimeIdentity));
-    provisionOrder.verify(uniqueNamesProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(tlsRouteProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(ramLimitProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(nodeSelectorProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
@@ -167,6 +166,7 @@ public class OpenShiftEnvironmentProvisionerTest {
     provisionOrder.verify(gatewayRouterProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(deploymentMetadataProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(trustedCAProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
+    provisionOrder.verify(uniqueNamesProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verifyNoMoreInteractions();
   }
 }


### PR DESCRIPTION
Signed-off-by: Sergii Kabashniuk <skabashniuk@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Make all configmaps unique in the same namespace.
1. Removed any workspace id prefix.
2. Put `UniqueNamesProvisioner` to the end of the list of provisioners. After that, all config maps renamed and have the name `wsid.originalname`

### Screenshot/screencast of this PR
Before the change. Openshift.
<img width="987" alt="Знімок екрана 2020-12-15 о 09 56 18" src="https://user-images.githubusercontent.com/1614429/102225754-3e1b9400-3ef0-11eb-87b8-cef81cedc54b.png">
After the change Openshift
<img width="1003" alt="Знімок екрана 2020-12-15 о 10 07 04" src="https://user-images.githubusercontent.com/1614429/102225798-45db3880-3ef0-11eb-8874-70c0107b89c0.png">
After the change Minikube
<img width="1181" alt="Знімок екрана 2020-12-15 о 14 07 45" src="https://user-images.githubusercontent.com/1614429/102225825-4e337380-3ef0-11eb-987a-a9b549cdbee1.png">
<img width="784" alt="Знімок екрана 2020-12-15 о 14 07 35" src="https://user-images.githubusercontent.com/1614429/102225836-51c6fa80-3ef0-11eb-9d2c-8a424adf473c.png">



### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/18536


### How to test this PR?
1. Deploy che server image `quay.io/skabashn/che-server:che18536'
2. Create two workspaces. Start them.
3. All config maps have to have different names.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
