### PR TITLE
Add cleanup for keys

### DIFF
--- a/tests/e2e/tests/e2e/GitSsh.spec.ts
+++ b/tests/e2e/tests/e2e/GitSsh.spec.ts
@@ -112,6 +112,8 @@ suite('Git with ssh workflow', async () => {
 suite('Cleanup', async () => {
     test('Remove test workspace', async () => {
         await testWorkspaceUtils.cleanUpAllWorkspaces();
+        await gitHubUtils.removeAllPublicSshKeys(TestConstants.TS_GITHUB_TEST_REPO_ACCESS_TOKEN);
+
     });
 });
 


### PR DESCRIPTION

### What does this PR do?
After each running of **GitSsh.spec.ts** on github test repo side we add a ssh key. We need to remove it after test.