### PR TITLE
fix(async-pv): Avoid to use latest as tag as it may change a lot

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -677,7 +677,7 @@ che.workspace.provision.secret.labels=app.kubernetes.io/part-of=che.eclipse.org,
 che.workspace.devfile.async.storage.plugin=eclipse/che-async-pv-plugin/nightly
 
 # Docker image for the Che async storage
-che.infra.kubernetes.async.storage.image=quay.io/eclipse/che-workspace-data-sync-storage:latest
+che.infra.kubernetes.async.storage.image=quay.io/eclipse/che-workspace-data-sync-storage:0.0.1
 
 # Optionally configures node selector for workspace pod. Format is comma-separated
 # key=value pairs, e.g:  disktype=ssd,cpu=xlarge,foo=bar


### PR DESCRIPTION

### What does this PR do?
Following discussion of https://github.com/eclipse/che/pull/18612, avoid to use `:latest` as tag and then replace it by the same image (for now) but with `:0.0.1` tag

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/pull/18612


### How to test this PR?
Use async PV, it should work
Notice that the image digests are the same on quay.io
![image](https://user-images.githubusercontent.com/436777/102487914-8f9c5e00-406b-11eb-9e16-6395e0ca3666.png)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: Id8db376588ea0dad12af6b68e8ba4e27be6004af
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
