### PR TITLE
🔨 Fix e2e docker image (log output & crooked screencast)

### DIFF
--- a/dockerfiles/e2e/Dockerfile
+++ b/dockerfiles/e2e/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome:86.0
+FROM selenium/standalone-chrome:3.141.59-20201119
 
 ENV DISPLAY=':20'
 

--- a/dockerfiles/e2e/entrypoint.sh
+++ b/dockerfiles/e2e/entrypoint.sh
@@ -26,7 +26,7 @@ fi
 
 # Launch display mode and VNC server
 export DISPLAY=':20'
-Xvfb :20 -screen 0 1920x1080x16 > /dev/null 2>&1 &
+Xvfb :20 -screen 0 1920x1080x24 > /dev/null 2>&1 &
 x11vnc -display :20 -N -forever > /dev/null 2>&1 &
 echo ''
 echo '#######################'

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -371,7 +371,7 @@ EOL"""
                        -e TEST_SUITE="${e2eTestToRun}" ${e2eTestParameters} \\
                        -e NODE_TLS_REJECT_UNAUTHORIZED=0 \\
                        -v ${WORKSPACE}/tests/e2e:/tmp/e2e:Z \\
-                       quay.io/eclipse/che-e2e:${cheE2eImageTag}
+                       quay.io/fbenoit/che-e2e:rhoppv1
                 """
             }
         }

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -371,7 +371,7 @@ EOL"""
                        -e TEST_SUITE="${e2eTestToRun}" ${e2eTestParameters} \\
                        -e NODE_TLS_REJECT_UNAUTHORIZED=0 \\
                        -v ${WORKSPACE}/tests/e2e:/tmp/e2e:Z \\
-                       quay.io/fbenoit/che-e2e:rhoppv1
+                       quay.io/eclipse/che-e2e:${cheE2eImageTag}
                 """
             }
         }


### PR DESCRIPTION
### What does this PR do?
Fixes #18602 and #18433

### Screenshot/screencast of this PR
Here's screenshot from the recording showing #18433 is fixed
![image](https://user-images.githubusercontent.com/1215011/102503103-acdb2780-407f-11eb-9ca9-2b78653b1ae8.png)
Here's log output of run showing the logging is "fixed" (#18602 ):
https://pastebin.com/p8geHDhh




### What issues does this PR fix or reference?
This PR updates base image for e2e testing image to use selenium chrome image containing latest (87) chrome. 
It also changes screen color depth of xvfb (the low screen color depth was causing the crooked screencast from #18433 )
The base image is now based on selenium grid 3, instead of selenium grid 4. This is a quick workaround for #18602 until we cind better solution how to disable the openlogging output of selenium server

### How to test this PR?
Run the test, see the log output & screencast ;-)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
