### PR TITLE
Adding k8s tolerations to workspace pods

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -686,8 +686,9 @@ che.infra.kubernetes.async.storage.image=quay.io/eclipse/che-workspace-data-sync
 # key=value pairs, e.g:  disktype=ssd,cpu=xlarge,foo=bar
 che.workspace.pod.node_selector=NULL
 
-# Optionally configures tolerations for workspace pod. Format is a JSON string:
-che.workspace.pod.tolerations=NULL
+# Optionally configures tolerations for workspace pod. Format is a JSON array.
+# Consult kubernetes official documentation on tolerations for JSON schema.
+che.workspace.pod.tolerations_json=NULL
 
 # The timeout for the Asynchronous Storage Pod shutdown after stopping the last used workspace.
 # Value less or equal to 0 interpreted as disabling shutdown ability.

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -686,6 +686,9 @@ che.infra.kubernetes.async.storage.image=quay.io/eclipse/che-workspace-data-sync
 # key=value pairs, e.g:  disktype=ssd,cpu=xlarge,foo=bar
 che.workspace.pod.node_selector=NULL
 
+# Optionally configures tolerations for workspace pod. Format is a JSON string:
+che.workspace.pod.tolerations=NULL
+
 # The timeout for the Asynchronous Storage Pod shutdown after stopping the last used workspace.
 # Value less or equal to 0 interpreted as disabling shutdown ability.
 che.infra.kubernetes.async.storage.shutdown_timeout_min=120

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -686,8 +686,10 @@ che.infra.kubernetes.async.storage.image=quay.io/eclipse/che-workspace-data-sync
 # key=value pairs, e.g:  disktype=ssd,cpu=xlarge,foo=bar
 che.workspace.pod.node_selector=NULL
 
-# Optionally configures tolerations for workspace pod. Format is a JSON array.
-# Consult kubernetes official documentation on tolerations for JSON schema.
+# Optionally configures tolerations for workspace pod. Format is a string representing a JSON Array of taint tolerations, 
+# or `NULL` to disable it. The objects contained in the array have to follow this 
+# link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.20/#toleration-v1-core[spec]. 
+# Example: [{"effect":"NoExecute","key":"aNodeTaint","operator":"Equal","value":"aValue"}]
 che.workspace.pod.tolerations_json=NULL
 
 # The timeout for the Asynchronous Storage Pod shutdown after stopping the last used workspace.

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -154,3 +154,6 @@ data:
 {{- if .Values.cheServerSecureExposerJwtProxyImage }}
   CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: {{ .Values.cheServerSecureExposerJwtProxyImage | quote }}
 {{- end }}
+{{- if .Values.che.workspace.tolerations }}
+  CHE_WORKSPACE_POD_TOLERATIONS: {{ .Values.che.workspace.tolerations | toJson | quote }}
+{{- end }}

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -154,6 +154,6 @@ data:
 {{- if .Values.cheServerSecureExposerJwtProxyImage }}
   CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: {{ .Values.cheServerSecureExposerJwtProxyImage | quote }}
 {{- end }}
-{{- if .Values.che.workspace.tolerations }}
-  CHE_WORKSPACE_POD_TOLERATIONS__JSON: {{ .Values.che.workspace.tolerations | toJson | quote }}
+{{- if .Values.cheWorkspacePodTolerations }}
+  CHE_WORKSPACE_POD_TOLERATIONS__JSON: {{ .Values.cheWorkspacePodTolerations | toJson | quote }}
 {{- end }}

--- a/deploy/kubernetes/helm/che/templates/configmap.yaml
+++ b/deploy/kubernetes/helm/che/templates/configmap.yaml
@@ -155,5 +155,5 @@ data:
   CHE_SERVER_SECURE__EXPOSER_JWTPROXY_IMAGE: {{ .Values.cheServerSecureExposerJwtProxyImage | quote }}
 {{- end }}
 {{- if .Values.che.workspace.tolerations }}
-  CHE_WORKSPACE_POD_TOLERATIONS: {{ .Values.che.workspace.tolerations | toJson | quote }}
+  CHE_WORKSPACE_POD_TOLERATIONS__JSON: {{ .Values.che.workspace.tolerations | toJson | quote }}
 {{- end }}

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -119,6 +119,11 @@ che:
 #    pluginBroker:
 #      waitTimeoutMin: "3"
 #    pluginRegistryUrl: "https://che-plugin-registry.openshift.io/v3"
+#    tolerations:
+#      - key: "a.node.taint"
+#        operator: "Equal"
+#        value: "aValue"
+#        effect: "NoExecute"
   disableProbes: false
   logLevel: "INFO"
 

--- a/deploy/kubernetes/helm/che/values.yaml
+++ b/deploy/kubernetes/helm/che/values.yaml
@@ -16,6 +16,11 @@
 cheWorkspaceHttpProxy: ""
 cheWorkspaceHttpsProxy: ""
 cheWorkspaceNoProxy: ""
+#cheWorkspacePodTolerations:
+#  - key: "a.node.taint"
+#    operator: "Equal"
+#    value: "aValue"
+#    effect: "NoExecute"
 cheImage: quay.io/eclipse/che-server:nightly
 cheImagePullPolicy: Always
 cheKeycloakRealm: "che"
@@ -119,11 +124,6 @@ che:
 #    pluginBroker:
 #      waitTimeoutMin: "3"
 #    pluginRegistryUrl: "https://che-plugin-registry.openshift.io/v3"
-#    tolerations:
-#      - key: "a.node.taint"
-#        operator: "Equal"
-#        value: "aValue"
-#        effect: "NoExecute"
   disableProbes: false
   logLevel: "INFO"
 

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisioner.java
@@ -36,6 +36,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAcco
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SshKeysProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TlsProvisionerProvider;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TolerationsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
@@ -78,6 +79,7 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
     private final ImagePullSecretProvisioner imagePullSecretProvisioner;
     private final ProxySettingsProvisioner proxySettingsProvisioner;
     private final NodeSelectorProvisioner nodeSelectorProvisioner;
+    private final TolerationsProvisioner tolerationsProvisioner;
     private final AsyncStorageProvisioner asyncStorageProvisioner;
     private final AsyncStoragePodInterceptor asyncStoragePodInterceptor;
     private final ServiceAccountProvisioner serviceAccountProvisioner;
@@ -105,6 +107,7 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
         ImagePullSecretProvisioner imagePullSecretProvisioner,
         ProxySettingsProvisioner proxySettingsProvisioner,
         NodeSelectorProvisioner nodeSelectorProvisioner,
+        TolerationsProvisioner tolerationsProvisioner,
         AsyncStorageProvisioner asyncStorageProvisioner,
         AsyncStoragePodInterceptor asyncStoragePodInterceptor,
         ServiceAccountProvisioner serviceAccountProvisioner,
@@ -129,6 +132,7 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
       this.imagePullSecretProvisioner = imagePullSecretProvisioner;
       this.proxySettingsProvisioner = proxySettingsProvisioner;
       this.nodeSelectorProvisioner = nodeSelectorProvisioner;
+      this.tolerationsProvisioner = tolerationsProvisioner;
       this.asyncStorageProvisioner = asyncStorageProvisioner;
       this.asyncStoragePodInterceptor = asyncStoragePodInterceptor;
       this.serviceAccountProvisioner = serviceAccountProvisioner;
@@ -169,6 +173,7 @@ public interface KubernetesEnvironmentProvisioner<T extends KubernetesEnvironmen
       restartPolicyRewriter.provision(k8sEnv, identity);
       resourceLimitRequestProvisioner.provision(k8sEnv, identity);
       nodeSelectorProvisioner.provision(k8sEnv, identity);
+      tolerationsProvisioner.provision(k8sEnv, identity);
       externalServerTlsProvisioner.provision(k8sEnv, identity);
       securityContextProvisioner.provision(k8sEnv, identity);
       podTerminationGracePeriodProvisioner.provision(k8sEnv, identity);

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
@@ -151,6 +151,8 @@ public class PodMerger {
 
       // if there are entries with such keys then values will be overridden
       baseSpec.getAdditionalProperties().putAll(podData.getSpec().getAdditionalProperties());
+      // add tolerations to baseSpec if any
+      baseSpec.getTolerations().addAll(podData.getSpec().getTolerations());
     }
 
     Map<String, String> matchLabels = new HashMap<>();

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/NodeSelectorProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/NodeSelectorProvisioner.java
@@ -21,14 +21,11 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Provisions node selector into workspace pod spec. */
 public class NodeSelectorProvisioner implements ConfigurationProvisioner {
 
   private final Map<String, String> nodeSelectorAttributes;
-  private static final Logger LOG = LoggerFactory.getLogger(NodeSelectorProvisioner.class);
 
   @Inject
   public NodeSelectorProvisioner(
@@ -46,14 +43,7 @@ public class NodeSelectorProvisioner implements ConfigurationProvisioner {
       k8sEnv
           .getPodsData()
           .values()
-          .forEach(
-              d -> {
-                LOG.info(
-                    "CHKPNT: adding nodeSelector to pod {}/{}",
-                    d.getMetadata().getNamespace(),
-                    d.getMetadata().getName());
-                d.getSpec().setNodeSelector(nodeSelectorAttributes);
-              });
+          .forEach(d -> d.getSpec().setNodeSelector(nodeSelectorAttributes));
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/NodeSelectorProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/NodeSelectorProvisioner.java
@@ -21,11 +21,14 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Provisions node selector into workspace pod spec. */
 public class NodeSelectorProvisioner implements ConfigurationProvisioner {
 
   private final Map<String, String> nodeSelectorAttributes;
+  private static final Logger LOG = LoggerFactory.getLogger(NodeSelectorProvisioner.class);
 
   @Inject
   public NodeSelectorProvisioner(
@@ -43,7 +46,14 @@ public class NodeSelectorProvisioner implements ConfigurationProvisioner {
       k8sEnv
           .getPodsData()
           .values()
-          .forEach(d -> d.getSpec().setNodeSelector(nodeSelectorAttributes));
+          .forEach(
+              d -> {
+                LOG.info(
+                    "CHKPNT: adding nodeSelector to pod {}/{}",
+                    d.getMetadata().getNamespace(),
+                    d.getMetadata().getName());
+                d.getSpec().setNodeSelector(nodeSelectorAttributes);
+              });
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
@@ -24,20 +24,16 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Provisions tolerations into workspace pod spec. */
 public class TolerationsProvisioner implements ConfigurationProvisioner {
 
   private final List<Toleration> tolerations;
-  private static final Logger LOG = LoggerFactory.getLogger(TolerationsProvisioner.class);
 
   @Inject
   public TolerationsProvisioner(
       @Nullable @Named("che.workspace.pod.tolerations") String tolerationsProperty)
       throws JsonProcessingException {
-    LOG.info("CHKPNT: TolerationsProvisioner created with {}", tolerationsProperty);
     ObjectMapper jsonMapper = new ObjectMapper();
     this.tolerations =
         tolerationsProperty != null
@@ -49,23 +45,7 @@ public class TolerationsProvisioner implements ConfigurationProvisioner {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     if (!tolerations.isEmpty()) {
-      k8sEnv
-          .getPodsData()
-          .values()
-          .forEach(
-              d -> {
-                LOG.info(
-                    "CHKPNT: adding tolerations '[{}] {} {} {}' to pod {}/{}",
-                    tolerations.get(0).getEffect(),
-                    tolerations.get(0).getKey(),
-                    tolerations.get(0).getOperator(),
-                    tolerations.get(0).getValue(),
-                    d.getMetadata().getNamespace(),
-                    d.getMetadata().getName());
-                d.getSpec().setTolerations(tolerations);
-              });
-    } else {
-      LOG.info("CHKPNT: No tolerations available");
+      k8sEnv.getPodsData().values().forEach(d -> d.getSpec().setTolerations(tolerations));
     }
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
@@ -23,6 +23,7 @@ import javax.inject.Named;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 
 /** Provisions tolerations into workspace pod spec. */
@@ -32,15 +33,18 @@ public class TolerationsProvisioner implements ConfigurationProvisioner {
 
   @Inject
   public TolerationsProvisioner(
-      @Nullable @Named("che.workspace.pod.tolerations") String tolerationsProperty)
-      throws
-          JsonProcessingException { // TODO: What kind of exception should I throw here?  Code the
-    // appropriate unit test.
-    ObjectMapper jsonMapper = new ObjectMapper();
-    this.tolerations =
-        tolerationsProperty != null
-            ? jsonMapper.readValue(tolerationsProperty, new TypeReference<List<Toleration>>() {})
-            : emptyList();
+      @Nullable @Named("che.workspace.pod.tolerations_json") String tolerationsProperty)
+      throws ConfigurationException {
+    try {
+      ObjectMapper jsonMapper = new ObjectMapper();
+      this.tolerations =
+          tolerationsProperty != null
+              ? jsonMapper.readValue(tolerationsProperty, new TypeReference<List<Toleration>>() {})
+              : emptyList();
+    } catch (JsonProcessingException e) {
+      throw new ConfigurationException(
+          "che.workspace.pod.tolerations_json contains an invalid JSON string", e);
+    }
   }
 
   @Override

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
@@ -33,7 +33,9 @@ public class TolerationsProvisioner implements ConfigurationProvisioner {
   @Inject
   public TolerationsProvisioner(
       @Nullable @Named("che.workspace.pod.tolerations") String tolerationsProperty)
-      throws JsonProcessingException {
+      throws
+          JsonProcessingException { // TODO: What kind of exception should I throw here?  Code the
+    // appropriate unit test.
     ObjectMapper jsonMapper = new ObjectMapper();
     this.tolerations =
         tolerationsProperty != null

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
@@ -24,16 +24,19 @@ import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.slf4j.Logger;
 
 /** Provisions tolerations into workspace pod spec. */
 public class TolerationsProvisioner implements ConfigurationProvisioner {
 
   private final List<Toleration> tolerations;
+  private static final Logger LOG = LoggerFactory.getLogger(TolerationsProvisioner.class);
 
   @Inject
   public TolerationsProvisioner(
       @Nullable @Named("che.workspace.pod.tolerations") String tolerationsProperty)
       throws JsonProcessingException {
+    LOG.info("ERLADOU: TolerationsProvisioner created with {}", tolerationsProperty);
     ObjectMapper jsonMapper = new ObjectMapper();
     this.tolerations =
         tolerationsProperty != null

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
+
+import static java.util.Collections.emptyList;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.Toleration;
+import java.util.List;
+import javax.inject.Inject;
+import javax.inject.Named;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
+import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+
+/** Provisions tolerations into workspace pod spec. */
+public class TolerationsProvisioner implements ConfigurationProvisioner {
+
+  private final List<Toleration> tolerations;
+
+  @Inject
+  public TolerationsProvisioner(
+      @Nullable @Named("che.workspace.pod.tolerations") String tolerationsProperty)
+      throws JsonProcessingException {
+    ObjectMapper jsonMapper = new ObjectMapper();
+    this.tolerations =
+        tolerationsProperty != null
+            ? jsonMapper.readValue(tolerationsProperty, new TypeReference<List<Toleration>>() {})
+            : emptyList();
+  }
+
+  @Override
+  public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
+      throws InfrastructureException {
+    if (!tolerations.isEmpty()) {
+      k8sEnv.getPodsData().values().forEach(d -> d.getSpec().setTolerations(tolerations));
+    }
+  }
+}

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisioner.java
@@ -25,6 +25,7 @@ import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.commons.annotation.Nullable;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Provisions tolerations into workspace pod spec. */
 public class TolerationsProvisioner implements ConfigurationProvisioner {
@@ -36,7 +37,7 @@ public class TolerationsProvisioner implements ConfigurationProvisioner {
   public TolerationsProvisioner(
       @Nullable @Named("che.workspace.pod.tolerations") String tolerationsProperty)
       throws JsonProcessingException {
-    LOG.info("ERLADOU: TolerationsProvisioner created with {}", tolerationsProperty);
+    LOG.info("CHKPNT: TolerationsProvisioner created with {}", tolerationsProperty);
     ObjectMapper jsonMapper = new ObjectMapper();
     this.tolerations =
         tolerationsProperty != null
@@ -48,7 +49,23 @@ public class TolerationsProvisioner implements ConfigurationProvisioner {
   public void provision(KubernetesEnvironment k8sEnv, RuntimeIdentity identity)
       throws InfrastructureException {
     if (!tolerations.isEmpty()) {
-      k8sEnv.getPodsData().values().forEach(d -> d.getSpec().setTolerations(tolerations));
+      k8sEnv
+          .getPodsData()
+          .values()
+          .forEach(
+              d -> {
+                LOG.info(
+                    "CHKPNT: adding tolerations '[{}] {} {} {}' to pod {}/{}",
+                    tolerations.get(0).getEffect(),
+                    tolerations.get(0).getKey(),
+                    tolerations.get(0).getOperator(),
+                    tolerations.get(0).getValue(),
+                    d.getMetadata().getNamespace(),
+                    d.getMetadata().getName());
+                d.getSpec().setTolerations(tolerations);
+              });
+    } else {
+      LOG.info("CHKPNT: No tolerations available");
     }
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/KubernetesEnvironmentProvisionerTest.java
@@ -35,6 +35,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAcco
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SshKeysProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TlsProvisionerProvider;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TolerationsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
@@ -84,6 +85,7 @@ public class KubernetesEnvironmentProvisionerTest {
   @Mock private PreviewUrlExposer previewUrlExposer;
   @Mock private VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
   @Mock private NodeSelectorProvisioner nodeSelectorProvisioner;
+  @Mock private TolerationsProvisioner tolerationsProvisioner;
   @Mock private KubernetesTrustedCAProvisioner trustedCAProvisioner;
   @Mock private GatewayRouterProvisioner gatewayRouterProvisioner;
 
@@ -111,6 +113,7 @@ public class KubernetesEnvironmentProvisionerTest {
             imagePullSecretProvisioner,
             proxySettingsProvisioner,
             nodeSelectorProvisioner,
+            tolerationsProvisioner,
             asyncStorageProvisioner,
             asyncStoragePodObserver,
             serviceAccountProvisioner,
@@ -131,6 +134,7 @@ public class KubernetesEnvironmentProvisionerTest {
             restartPolicyRewriter,
             ramLimitProvisioner,
             nodeSelectorProvisioner,
+            tolerationsProvisioner,
             securityContextProvisioner,
             podTerminationGracePeriodProvisioner,
             externalServerIngressTlsProvisioner,
@@ -156,6 +160,7 @@ public class KubernetesEnvironmentProvisionerTest {
 
     provisionOrder.verify(ramLimitProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder.verify(nodeSelectorProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
+    provisionOrder.verify(tolerationsProvisioner).provision(eq(k8sEnv), eq(runtimeIdentity));
     provisionOrder
         .verify(externalServerIngressTlsProvisioner)
         .provision(eq(k8sEnv), eq(runtimeIdentity));

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
@@ -122,7 +122,6 @@ public class PodMergerTest {
             .build();
     podSpec1.setAdditionalProperty("add1", 1L);
     PodData podData1 = new PodData(podSpec1, new ObjectMetaBuilder().build());
-    System.out.println("#tolerations for pod1: " + podData1.getSpec().getTolerations().size());
 
     PodSpec podSpec2 =
         new PodSpecBuilder()
@@ -134,15 +133,12 @@ public class PodMergerTest {
             .build();
     podSpec2.setAdditionalProperty("add2", 2L);
     PodData podData2 = new PodData(podSpec2, new ObjectMetaBuilder().build());
-    System.out.println("#tolerations for pod2: " + podData2.getSpec().getTolerations().size());
 
     // when
     Deployment merged = podMerger.merge(Arrays.asList(podData1, podData2));
 
     // then
     PodTemplateSpec podTemplate = merged.getSpec().getTemplate();
-    System.out.println(
-        "#tolerations for merged pod: " + podTemplate.getSpec().getTolerations().size());
     verifyContainsAllFrom(podTemplate.getSpec(), podData1.getSpec());
     verifyContainsAllFrom(podTemplate.getSpec(), podData2.getSpec());
   }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisionerTest.java
@@ -46,11 +46,11 @@ public class TolerationsProvisionerTest {
     // given
     k8sEnv.addPod(createPod("pod"));
     k8sEnv.addPod(createPod("pod2"));
-    Toleration t = new Toleration("NoExecute", "scylladev.node.taint", "Equal", 0L, "logging");
-    ObjectMapper m = new ObjectMapper();
-    String json = m.writeValueAsString(Collections.singletonList(t));
+    Toleration expectedToleration =
+        new Toleration("NoExecute", "a.node.taint", "Equal", 0L, "aValue");
+    ObjectMapper objMapper = new ObjectMapper();
+    String json = objMapper.writeValueAsString(Collections.singletonList(expectedToleration));
     provisioner = new TolerationsProvisioner(json);
-    // "[{\"effect\":\"NoExecute\",\"key\":\"scylladev.node.taint\",\"operator\":\"Equal\",\"value\":\"logging\"}]");
 
     // when
     provisioner.provision(k8sEnv, runtimeId);
@@ -58,20 +58,12 @@ public class TolerationsProvisionerTest {
     // then
     for (Pod pod : k8sEnv.getPodsCopy().values()) {
       assertEquals(pod.getSpec().getTolerations().size(), 1);
-      assertEquals(pod.getSpec().getTolerations().get(0).getEffect(), t.getEffect());
-      assertEquals(pod.getSpec().getTolerations().get(0).getKey(), t.getKey());
-      assertEquals(pod.getSpec().getTolerations().get(0).getOperator(), t.getOperator());
-      assertEquals(
-          pod.getSpec().getTolerations().get(0).getTolerationSeconds(), t.getTolerationSeconds());
-      assertEquals(pod.getSpec().getTolerations().get(0).getValue(), t.getValue());
-      assertEquals(
-          pod.getSpec().getTolerations().get(0).getAdditionalProperties(),
-          t.getAdditionalProperties());
+      assertEquals(pod.getSpec().getTolerations().get(0), expectedToleration);
     }
   }
 
   @Test
-  public void shouldOmitEmptySelector() throws Exception {
+  public void shouldOmitEmptyTolerations() throws Exception {
     // given
     k8sEnv.addPod(createPod("pod"));
     k8sEnv.addPod(createPod("pod2"));

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisionerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.Toleration;
+import java.util.Collections;
+import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
+import org.mockito.Mock;
+import org.mockito.testng.MockitoTestNGListener;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(MockitoTestNGListener.class)
+public class TolerationsProvisionerTest {
+
+  @Mock private RuntimeIdentity runtimeId;
+  private KubernetesEnvironment k8sEnv;
+
+  private TolerationsProvisioner provisioner;
+
+  @BeforeMethod
+  public void setUp() {
+    k8sEnv = KubernetesEnvironment.builder().build();
+  }
+
+  @Test
+  public void shouldAddTolerationsIntoAllPods() throws Exception {
+    // given
+    k8sEnv.addPod(createPod("pod"));
+    k8sEnv.addPod(createPod("pod2"));
+    Toleration t = new Toleration("NoExecute", "scylladev.node.taint", "Equal", 0L, "logging");
+    ObjectMapper m = new ObjectMapper();
+    String json = m.writeValueAsString(Collections.singletonList(t));
+    provisioner = new TolerationsProvisioner(json);
+    // "[{\"effect\":\"NoExecute\",\"key\":\"scylladev.node.taint\",\"operator\":\"Equal\",\"value\":\"logging\"}]");
+
+    // when
+    provisioner.provision(k8sEnv, runtimeId);
+
+    // then
+    for (Pod pod : k8sEnv.getPodsCopy().values()) {
+      assertEquals(pod.getSpec().getTolerations().size(), 1);
+      assertEquals(pod.getSpec().getTolerations().get(0).getEffect(), t.getEffect());
+      assertEquals(pod.getSpec().getTolerations().get(0).getKey(), t.getKey());
+      assertEquals(pod.getSpec().getTolerations().get(0).getOperator(), t.getOperator());
+      assertEquals(
+          pod.getSpec().getTolerations().get(0).getTolerationSeconds(), t.getTolerationSeconds());
+      assertEquals(pod.getSpec().getTolerations().get(0).getValue(), t.getValue());
+      assertEquals(
+          pod.getSpec().getTolerations().get(0).getAdditionalProperties(),
+          t.getAdditionalProperties());
+    }
+  }
+
+  @Test
+  public void shouldOmitEmptySelector() throws Exception {
+    // given
+    k8sEnv.addPod(createPod("pod"));
+    k8sEnv.addPod(createPod("pod2"));
+
+    provisioner = new TolerationsProvisioner(null);
+
+    // when
+    provisioner.provision(k8sEnv, runtimeId);
+
+    // then
+    for (Pod pod : k8sEnv.getPodsCopy().values()) {
+      assertTrue(pod.getSpec().getTolerations().isEmpty());
+    }
+  }
+
+  private Pod createPod(String podName) {
+    return new PodBuilder()
+        .withNewMetadata()
+        .withName(podName)
+        .endMetadata()
+        .withNewSpec()
+        .withTolerations()
+        .withInitContainers(new ContainerBuilder().build())
+        .withContainers(new ContainerBuilder().build(), new ContainerBuilder().build())
+        .endSpec()
+        .build();
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/TolerationsProvisionerTest.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Toleration;
 import java.util.Collections;
 import org.eclipse.che.api.core.model.workspace.runtime.RuntimeIdentity;
+import org.eclipse.che.inject.ConfigurationException;
 import org.eclipse.che.workspace.infrastructure.kubernetes.environment.KubernetesEnvironment;
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
@@ -77,6 +78,12 @@ public class TolerationsProvisionerTest {
     for (Pod pod : k8sEnv.getPodsCopy().values()) {
       assertTrue(pod.getSpec().getTolerations().isEmpty());
     }
+  }
+
+  @Test(expectedExceptions = ConfigurationException.class)
+  public void shouldFailOnInvalidTolerationsJson() throws Exception {
+    // given
+    provisioner = new TolerationsProvisioner("an invalid json string");
   }
 
   private Pod createPod(String podName) {

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisioner.java
@@ -35,6 +35,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAcco
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SshKeysProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TlsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TlsProvisionerProvider;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TolerationsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.UniqueNamesProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
@@ -75,6 +76,7 @@ public class OpenShiftEnvironmentProvisioner
   private final ImagePullSecretProvisioner imagePullSecretProvisioner;
   private final ProxySettingsProvisioner proxySettingsProvisioner;
   private final NodeSelectorProvisioner nodeSelectorProvisioner;
+  private final TolerationsProvisioner tolerationsProvisioner;
   private final AsyncStoragePodInterceptor asyncStoragePodInterceptor;
   private final ServiceAccountProvisioner serviceAccountProvisioner;
   private final AsyncStorageProvisioner asyncStorageProvisioner;
@@ -102,6 +104,7 @@ public class OpenShiftEnvironmentProvisioner
       ImagePullSecretProvisioner imagePullSecretProvisioner,
       ProxySettingsProvisioner proxySettingsProvisioner,
       NodeSelectorProvisioner nodeSelectorProvisioner,
+      TolerationsProvisioner tolerationsProvisioner,
       AsyncStorageProvisioner asyncStorageProvisioner,
       AsyncStoragePodInterceptor asyncStoragePodInterceptor,
       ServiceAccountProvisioner serviceAccountProvisioner,
@@ -126,6 +129,7 @@ public class OpenShiftEnvironmentProvisioner
     this.imagePullSecretProvisioner = imagePullSecretProvisioner;
     this.proxySettingsProvisioner = proxySettingsProvisioner;
     this.nodeSelectorProvisioner = nodeSelectorProvisioner;
+    this.tolerationsProvisioner = tolerationsProvisioner;
     this.asyncStorageProvisioner = asyncStorageProvisioner;
     this.asyncStoragePodInterceptor = asyncStoragePodInterceptor;
     this.serviceAccountProvisioner = serviceAccountProvisioner;
@@ -166,6 +170,7 @@ public class OpenShiftEnvironmentProvisioner
     routeTlsProvisioner.provision(osEnv, identity);
     resourceLimitRequestProvisioner.provision(osEnv, identity);
     nodeSelectorProvisioner.provision(osEnv, identity);
+    tolerationsProvisioner.provision(osEnv, identity);
     podTerminationGracePeriodProvisioner.provision(osEnv, identity);
     imagePullSecretProvisioner.provision(osEnv, identity);
     proxySettingsProvisioner.provision(osEnv, identity);

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/OpenShiftEnvironmentProvisionerTest.java
@@ -31,6 +31,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ProxySettin
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.ServiceAccountProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.SshKeysProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TlsProvisionerProvider;
+import org.eclipse.che.workspace.infrastructure.kubernetes.provision.TolerationsProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.VcsSslCertificateProvisioner;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.env.EnvVarsConverter;
 import org.eclipse.che.workspace.infrastructure.kubernetes.provision.limits.ram.ContainerResourceProvisioner;
@@ -79,6 +80,7 @@ public class OpenShiftEnvironmentProvisionerTest {
   @Mock private OpenShiftPreviewUrlExposer previewUrlEndpointsProvisioner;
   @Mock private VcsSslCertificateProvisioner vcsSslCertificateProvisioner;
   @Mock private NodeSelectorProvisioner nodeSelectorProvisioner;
+  @Mock private TolerationsProvisioner tolerationsProvisioner;
   @Mock private GatewayRouterProvisioner gatewayRouterProvisioner;
   @Mock private DeploymentMetadataProvisioner deploymentMetadataProvisioner;
   @Mock private OpenshiftTrustedCAProvisioner trustedCAProvisioner;
@@ -105,6 +107,7 @@ public class OpenShiftEnvironmentProvisionerTest {
             imagePullSecretProvisioner,
             proxySettingsProvisioner,
             nodeSelectorProvisioner,
+            tolerationsProvisioner,
             asyncStorageProvisioner,
             asyncStoragePodObserver,
             serviceAccountProvisioner,
@@ -127,6 +130,7 @@ public class OpenShiftEnvironmentProvisionerTest {
             restartPolicyRewriter,
             ramLimitProvisioner,
             nodeSelectorProvisioner,
+            tolerationsProvisioner,
             podTerminationGracePeriodProvisioner,
             imagePullSecretProvisioner,
             proxySettingsProvisioner,
@@ -153,6 +157,7 @@ public class OpenShiftEnvironmentProvisionerTest {
     provisionOrder.verify(tlsRouteProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(ramLimitProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder.verify(nodeSelectorProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
+    provisionOrder.verify(tolerationsProvisioner).provision(eq(osEnv), eq(runtimeIdentity));
     provisionOrder
         .verify(podTerminationGracePeriodProvisioner)
         .provision(eq(osEnv), eq(runtimeIdentity));


### PR DESCRIPTION
### What does this PR do?
This PR is adding support for k8s tolerations for workspace pods.  Taints and tolerations can be used for many things, but here is why I need those:

_Node selectors & labels_: when setting a selector on a pod, it is good to look for nodes with those labels.  But it won't prevent pods without that selector to be executed on that node.

_Taints and tolerations_: if you set a taint on a node, only pods that are tolerating that taint can be executed.  The taint will protect the node from unwanted pods.

In my setup, I use a dedicated node pool in my k8s cluster for user workspace pods.  Only Che workspace pods will be executed there and nothing else.  I make that pool grow and shrink as my number of users increases or decreases.  I also use Azure SpotVMs (to lower cost) and those have a taint set by Microsoft.  So I need my pods to tolerate the SpotVM taint because otherwise, they are never scheduled to run on those.

Here is the [associated doc PR](https://github.com/eclipse/che-docs/pull/1780).

### Screenshot/screencast of this PR
In order to use tolerations, you can add them to the helm value (for now, planning to add Operator support later):
```yaml
cheWorkspacePodTolerations:
  - key: "a.node.taint"
    operator: "Equal"
    value: "aValue"
    effect: "NoExecute"
```
Helm will convert the YAML into a JSON string, which is then passed as a property to Che.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/13319

### How to test this PR?
You will need to use the helm installer since I didn't add Operator support.  In order to see the toleration in action, you will also need to add a taint on your k8s node.  See [documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/).

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
