### PR TITLE
Fix NodeSelector passing through PodMerger

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMerger.java
@@ -149,6 +149,9 @@ public class PodMerger {
           mergeServiceAccountName(
               baseSpec.getServiceAccountName(), podData.getSpec().getServiceAccountName()));
 
+      baseSpec.setNodeSelector(
+          mergeNodeSelector(baseSpec.getNodeSelector(), podData.getSpec().getNodeSelector()));
+
       // if there are entries with such keys then values will be overridden
       baseSpec.getAdditionalProperties().putAll(podData.getSpec().getAdditionalProperties());
     }
@@ -202,5 +205,17 @@ public class PodMerger {
     } else {
       throw new ValidationException(String.format(errorMessageTemplate, a, b));
     }
+  }
+
+  private Map<String, String> mergeNodeSelector(
+      @Nullable Map<String, String> base, @Nullable Map<String, String> nodeSelector) {
+    Map<String, String> mergedMap = base;
+    if (nodeSelector != null && !nodeSelector.isEmpty()) {
+      if (mergedMap == null) {
+        mergedMap = new HashMap<>();
+      }
+      mergedMap.putAll(nodeSelector);
+    }
+    return mergedMap;
   }
 }

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/environment/PodMergerTest.java
@@ -116,6 +116,7 @@ public class PodMergerTest {
             .withContainers(new ContainerBuilder().withName("c1").build())
             .withInitContainers(new ContainerBuilder().withName("initC1").build())
             .withVolumes(new VolumeBuilder().withName("v1").build())
+            .withNodeSelector(Map.of("foo1", "bar1"))
             .withImagePullSecrets(new LocalObjectReferenceBuilder().withName("secret1").build())
             .build();
     podSpec1.setAdditionalProperty("add1", 1L);
@@ -126,6 +127,7 @@ public class PodMergerTest {
             .withContainers(new ContainerBuilder().withName("c2").build())
             .withInitContainers(new ContainerBuilder().withName("initC2").build())
             .withVolumes(new VolumeBuilder().withName("v2").build())
+            .withNodeSelector(Map.of("foo2", "bar2"))
             .withImagePullSecrets(new LocalObjectReferenceBuilder().withName("secret2").build())
             .build();
     podSpec2.setAdditionalProperty("add2", 2L);
@@ -439,6 +441,8 @@ public class PodMergerTest {
     assertTrue(source.getInitContainers().containsAll(toCheck.getInitContainers()));
     assertTrue(source.getVolumes().containsAll(toCheck.getVolumes()));
     assertTrue(source.getImagePullSecrets().containsAll(toCheck.getImagePullSecrets()));
+    assertTrue(
+        source.getNodeSelector().entrySet().containsAll(toCheck.getNodeSelector().entrySet()));
     assertTrue(
         source
             .getAdditionalProperties()


### PR DESCRIPTION
### What does this PR do?
NodeSelector passing is missing in PodMerger, resulting in NodeSelector not applied for main deployment.
This PR fixes the situation.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18697

### How to test this PR?
Set some selector using `CHE_WORKSPACE_POD_NODE__SELECTOR`
Make sure selector is applied to deployment:

![image](https://user-images.githubusercontent.com/1651062/103012346-22456d00-4544-11eb-82b7-9e6f5c365c54.png)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
