### PR TITLE
feat(skip-recording): Allow to skip ffmpeg recording if VIDEO_RECORDING=false env var is given

### DIFF
--- a/dockerfiles/e2e/README.md
+++ b/dockerfiles/e2e/README.md
@@ -38,6 +38,13 @@ Happy Path test suite will be run by default when executing a docker run command
 docker run --shm-size=256m -e TEST_SUITE=test-happy-path -e TS_SELENIUM_BASE_URL=$URL eclipse/che-e2e:nightly
 ```
 
+### Video recording
+ffmpeg will record the screen and produce mp4 file. Disable the recording by specifying `VIDEO_RECORDING=false` env parameter.
+
+```
+docker run ... -e VIDEO_RECORDING=false ... eclipse/che-e2e:nightly
+```
+
 ### Debugging
 #### Running own code
 If you have done some changes locally and you want to test them, you can mount your code directly to the Docker. If you do so, your mounted code will be executed instead of the code that is already in an image.
@@ -48,3 +55,4 @@ docker run --shm-size=256m -v /full/path/to/your/e2e:/tmp/e2e:Z -e TS_SELENIUM_B
 
 #### Watching Chrome
 If you want to see what is going on in chrome inside a docker, you can use VNC. When running a docker, you can see API where you can connect. This API is on the first line of output and can look like that: ` You can watch locally using VNC with IP: 172.17.0.2 `. Then you can easily join VNC using this API: ` 172.17.0.2:0 `.
+

--- a/dockerfiles/e2e/entrypoint.sh
+++ b/dockerfiles/e2e/entrypoint.sh
@@ -95,13 +95,19 @@ End_script
   
   echo "Files sent to load-tests-ftp-service."
 else
-  mkdir -p /tmp/ffmpeg_report
-  nohup ffmpeg -y -video_size 1920x1080 -framerate 24 -f x11grab -i :20.0 /tmp/ffmpeg_report/output.mp4 2> /tmp/ffmpeg_report/ffmpeg_err.txt > /tmp/ffmpeg_report/ffmpeg_std.txt & 
-  ffmpeg_pid=$!
-  trap kill_ffmpeg 2 15
+  SCREEN_RECORDING=${VIDEO_RECORDING:-true}
+  if [ "${SCREEN_RECORDING}" == "true" ]; then
+    echo "Starting ffmpeg recording..."
+    mkdir -p /tmp/ffmpeg_report
+    nohup ffmpeg -y -video_size 1920x1080 -framerate 24 -f x11grab -i :20.0 /tmp/ffmpeg_report/output.mp4 2> /tmp/ffmpeg_report/ffmpeg_err.txt > /tmp/ffmpeg_report/ffmpeg_std.txt & 
+    ffmpeg_pid=$!
+    trap kill_ffmpeg 2 15
+  fi
 
   echo "Running TEST_SUITE: $TEST_SUITE with user: $TS_SELENIUM_USERNAME"
   npm run $TEST_SUITE
   EXIT_CODE=$?
-  kill_ffmpeg
+  if [ "${SCREEN_RECORDING}" == "true" ]; then
+    kill_ffmpeg
+  fi
 fi


### PR DESCRIPTION
### What does this PR do?
Allow to skip ffmpeg recording when running happy path tests

On some configuration with few cpu cores, ffmpeg is eating almost all the cpu available, thus having a way to disable it allow to spare CPU

### Screenshot/screencast of this PR
N/A


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18653

### How to test this PR?
```bash
$ docker run ... -e VIDEO_RECORDING=false  ... quay.io/eclipse/che-e2e:nightly
```
note that without providing the variable it's as it is now (ffmpeg is on)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: Ia26d4b8baa8e77e0010ca8030ee262f3d7528dd4
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
