### PR TITLE
[Selenium] Disable chectl telemetry in centos.ci test jobs 

### DIFF
--- a/tests/.infra/centos-ci/functional_tests_utils.sh
+++ b/tests/.infra/centos-ci/functional_tests_utils.sh
@@ -271,7 +271,7 @@ function getOpenshiftLogs() {
 
 function deployCheIntoCluster() {
   echo "======== Start to install CHE ========"
-  if chectl server:deploy --listr-renderer=verbose -a operator -p minishift --k8spodreadytimeout=600000 --k8spodwaittimeout=600000 --k8spoddownloadimagetimeout=600000 $1 --chenamespace=eclipse-che; then
+  if chectl server:deploy --telemetry=off --listr-renderer=verbose -a operator -p minishift --k8spodreadytimeout=600000 --k8spodwaittimeout=600000 --k8spoddownloadimagetimeout=600000 $1 --chenamespace=eclipse-che; then
     echo "Started successfully"
     oc get checluster -o yaml
   else


### PR DESCRIPTION
### What does this PR do?
After merging che-incubator/chectl#1052 chectl requires confirmation to collect anonymous data usage of cli via prompt. To avoid prompt confirmation exist a flag to avoid prompt: --telemetry=on/off