### PR TITLE
fix(e2e): Handle properly the exit code in case ffmpeg is not called

### DIFF
--- a/dockerfiles/e2e/entrypoint.sh
+++ b/dockerfiles/e2e/entrypoint.sh
@@ -8,7 +8,6 @@ kill_ffmpeg(){
   wait "$ffmpeg_pid"
   mkdir -p /tmp/e2e/report/
   cp /tmp/ffmpeg_report/* /tmp/e2e/report/
-  exit $EXIT_CODE
 }
 
 set -x
@@ -110,4 +109,5 @@ else
   if [ "${SCREEN_RECORDING}" == "true" ]; then
     kill_ffmpeg
   fi
+  exit $EXIT_CODE
 fi


### PR DESCRIPTION
### What does this PR do?
in case of error and if video is not recorded, we may exit without error

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
if I run e2e tests and there is an error but without video recording, exit code is not handled as it was handled by kill_ffmpeg function

### How to test this PR?
Disable video and use invalid e2e test

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

Change-Id: Ifea088d349a89a656dbf2b9cd2a488938542b18e
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
