### PR TITLE
Fix - accepting GitHub factories may ignore devfile.yaml in repository.

### DIFF
--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
@@ -15,6 +15,9 @@ import static org.eclipse.che.api.factory.shared.Constants.CURRENT_VERSION;
 import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -27,7 +30,9 @@ import org.eclipse.che.api.factory.server.DefaultFactoryParameterResolver;
 import org.eclipse.che.api.factory.server.urlfactory.ProjectConfigDtoMerger;
 import org.eclipse.che.api.factory.server.urlfactory.URLFactoryBuilder;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
+import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
+import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.ProjectDto;
 
@@ -93,7 +98,7 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
         urlFactoryBuilder
             .createFactoryFromDevfile(
                 githubUrl,
-                fileName -> urlFetcher.fetch(githubUrl.rawFileLocation(fileName)),
+                new GithubFileContentProvider(githubUrl),
                 extractOverrideParams(factoryParameters))
             .orElseGet(() -> newDto(FactoryDto.class).withV(CURRENT_VERSION).withSource("repo"));
 
@@ -134,5 +139,32 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
           });
     }
     return factory;
+  }
+
+  /** Github specific file content provider. */
+  private class GithubFileContentProvider implements FileContentProvider {
+
+    private final GithubUrl githubUrl;
+
+    private GithubFileContentProvider(GithubUrl githubUrl) {
+      this.githubUrl = githubUrl;
+    }
+
+    @Override
+    public String fetchContent(String fileURL) throws IOException, DevfileException {
+      {
+        String requestURL;
+        try {
+          if (new URI(fileURL).isAbsolute()) {
+            requestURL = fileURL;
+          } else {
+            requestURL = githubUrl.rawFileLocation(fileURL);
+          }
+        } catch (URISyntaxException e) {
+          throw new DevfileException(e.getMessage(), e);
+        }
+        return urlFetcher.fetch(requestURL);
+      }
+    }
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFactoryParametersResolver.java
@@ -15,9 +15,6 @@ import static org.eclipse.che.api.factory.shared.Constants.CURRENT_VERSION;
 import static org.eclipse.che.api.factory.shared.Constants.URL_PARAMETER_NAME;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -30,9 +27,7 @@ import org.eclipse.che.api.factory.server.DefaultFactoryParameterResolver;
 import org.eclipse.che.api.factory.server.urlfactory.ProjectConfigDtoMerger;
 import org.eclipse.che.api.factory.server.urlfactory.URLFactoryBuilder;
 import org.eclipse.che.api.factory.shared.dto.FactoryDto;
-import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
 import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
-import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.shared.dto.ProjectConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.ProjectDto;
 
@@ -98,7 +93,7 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
         urlFactoryBuilder
             .createFactoryFromDevfile(
                 githubUrl,
-                new GithubFileContentProvider(githubUrl),
+                new GithubFileContentProvider(githubUrl, urlFetcher),
                 extractOverrideParams(factoryParameters))
             .orElseGet(() -> newDto(FactoryDto.class).withV(CURRENT_VERSION).withSource("repo"));
 
@@ -139,32 +134,5 @@ public class GithubFactoryParametersResolver extends DefaultFactoryParameterReso
           });
     }
     return factory;
-  }
-
-  /** Github specific file content provider. */
-  private class GithubFileContentProvider implements FileContentProvider {
-
-    private final GithubUrl githubUrl;
-
-    private GithubFileContentProvider(GithubUrl githubUrl) {
-      this.githubUrl = githubUrl;
-    }
-
-    @Override
-    public String fetchContent(String fileURL) throws IOException, DevfileException {
-      {
-        String requestURL;
-        try {
-          if (new URI(fileURL).isAbsolute()) {
-            requestURL = fileURL;
-          } else {
-            requestURL = githubUrl.rawFileLocation(fileURL);
-          }
-        } catch (URISyntaxException e) {
-          throw new DevfileException(e.getMessage(), e);
-        }
-        return urlFetcher.fetch(requestURL);
-      }
-    }
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFileContentProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server.github;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
+import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
+import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
+
+/** Github specific file content provider. */
+class GithubFileContentProvider implements FileContentProvider {
+
+  private final GithubUrl githubUrl;
+  private URLFetcher urlFetcher;
+
+  GithubFileContentProvider(GithubUrl githubUrl, URLFetcher urlFetcher) {
+    this.githubUrl = githubUrl;
+    this.urlFetcher = urlFetcher;
+  }
+
+  @Override
+  public String fetchContent(String fileURL) throws IOException, DevfileException {
+    {
+      String requestURL;
+      try {
+        if (new URI(fileURL).isAbsolute()) {
+          requestURL = fileURL;
+        } else {
+          requestURL = githubUrl.rawFileLocation(fileURL);
+        }
+      } catch (URISyntaxException e) {
+        throw new DevfileException(e.getMessage(), e);
+      }
+      return urlFetcher.fetch(requestURL);
+    }
+  }
+}

--- a/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFileContentProvider.java
+++ b/wsmaster/che-core-api-factory-github/src/main/java/org/eclipse/che/api/factory/server/github/GithubFileContentProvider.java
@@ -22,7 +22,7 @@ import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 class GithubFileContentProvider implements FileContentProvider {
 
   private final GithubUrl githubUrl;
-  private URLFetcher urlFetcher;
+  private final URLFetcher urlFetcher;
 
   GithubFileContentProvider(GithubUrl githubUrl, URLFetcher urlFetcher) {
     this.githubUrl = githubUrl;
@@ -31,18 +31,16 @@ class GithubFileContentProvider implements FileContentProvider {
 
   @Override
   public String fetchContent(String fileURL) throws IOException, DevfileException {
-    {
-      String requestURL;
-      try {
-        if (new URI(fileURL).isAbsolute()) {
-          requestURL = fileURL;
-        } else {
-          requestURL = githubUrl.rawFileLocation(fileURL);
-        }
-      } catch (URISyntaxException e) {
-        throw new DevfileException(e.getMessage(), e);
+    String requestURL;
+    try {
+      if (new URI(fileURL).isAbsolute()) {
+        requestURL = fileURL;
+      } else {
+        requestURL = githubUrl.rawFileLocation(fileURL);
       }
-      return urlFetcher.fetch(requestURL);
+    } catch (URISyntaxException e) {
+      throw new DevfileException(e.getMessage(), e);
     }
+    return urlFetcher.fetch(requestURL);
   }
 }

--- a/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFileContentProviderTest.java
+++ b/wsmaster/che-core-api-factory-github/src/test/java/org/eclipse/che/api/factory/server/github/GithubFileContentProviderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.api.factory.server.github;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import org.eclipse.che.api.workspace.server.devfile.FileContentProvider;
+import org.eclipse.che.api.workspace.server.devfile.URLFetcher;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+public class GithubFileContentProviderTest {
+
+  @Test
+  public void shouldExpandRelativePaths() throws Exception {
+    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
+    GithubUrl githubUrl = new GithubUrl().withUsername("eclipse").withRepository("che");
+    FileContentProvider fileContentProvider = new GithubFileContentProvider(githubUrl, urlFetcher);
+    fileContentProvider.fetchContent("devfile.yaml");
+    verify(urlFetcher).fetch(eq("https://raw.githubusercontent.com/eclipse/che/HEAD/devfile.yaml"));
+  }
+
+  @Test
+  public void shouldPreserveAbsolutePaths() throws Exception {
+    URLFetcher urlFetcher = Mockito.mock(URLFetcher.class);
+    GithubUrl githubUrl = new GithubUrl().withUsername("eclipse").withRepository("che");
+    FileContentProvider fileContentProvider = new GithubFileContentProvider(githubUrl, urlFetcher);
+    String url = "https://raw.githubusercontent.com/foo/bar/devfile.yaml";
+    fileContentProvider.fetchContent(url);
+    verify(urlFetcher).fetch(eq(url));
+  }
+}


### PR DESCRIPTION
### What does this PR do?
When added support for Bitbucket, we're accidentally broken the search of devfile in the repository for GitHub.
This PR fixes the situation.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Current master ignores devfile in the repository and always apply default params. Atfer PR, actual devfile is applied.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
