### PR TITLE
Fix NPE for ENV-s that not contain value, but only valueFrom.

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/EnvVars.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/EnvVars.java
@@ -14,6 +14,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.util;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -92,6 +93,9 @@ public class EnvVars {
    */
   public static Set<String> extractReferencedVariables(EnvVar var) {
     String val = var.getValue();
+    if (val == null) {
+      return Collections.emptySet();
+    }
 
     Matcher matcher = REFERENCE_PATTERN.matcher(val);
 

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/EnvVarsTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/util/EnvVarsTest.java
@@ -16,11 +16,14 @@ import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.util.EnvVars.extractReferencedVariables;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarSource;
+import io.fabric8.kubernetes.api.model.EnvVarSourceBuilder;
 import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.SecretKeySelectorBuilder;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -74,6 +77,26 @@ public class EnvVarsTest {
 
     // then
     assertEquals(refs, new HashSet<>(Arrays.asList("b", "c")));
+  }
+
+  @Test
+  public void shouldReturnEmptySetOnEnvContainingValueFrom() throws Exception {
+    // given
+    EnvVar envVar = var("a", null);
+    envVar.setValueFrom(
+        new EnvVarSourceBuilder()
+            .withSecretKeyRef(
+                new SecretKeySelectorBuilder()
+                    .withName("secret_name")
+                    .withKey("secret_key")
+                    .build())
+            .build());
+
+    // when
+    Set<String> refs = extractReferencedVariables(envVar);
+
+    // then
+    assertTrue(refs.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
### What does this PR do?
FIxes NPE when accepting factory with devfile containing K8S/Openshift recipe with ENV variable with specified `valueFrom`.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/18508

### How to test this PR?
Create devfile with K8S/openshift component contains the following ENV declaration:
```
- name: MYSQL_PASSWORD
        valueFrom: 
          secretKeyRef:
            key: database-password
            name: postgresql-customers
```
Before PR - failing win an NPE
After PR - working

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
