### PR TITLE
Prevent infinite loop of build.sh script for building nightly images

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -45,10 +45,8 @@ jobs:
     - name: Build with Maven
       run: mvn -B clean install -U -Pintegration
     - name: Build docker images
-      run: |
-        cd dockerfiles
-        ./build.sh 
-        cd ..
+      run:
+          ./dockerfiles/build.sh
     - name: Push docker images
       run: |
         docker push quay.io/eclipse/endpoint-watcher:nightly

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -10,8 +10,9 @@
 name: build-nightly
 
 on:
+  workflow_dispatch:
   schedule:
-    - cron: "0 0 * * *"
+  - cron: "0 0 * * *"
 
 jobs:
   build:
@@ -45,7 +46,9 @@ jobs:
       run: mvn -B clean install -U -Pintegration
     - name: Build docker images
       run: |
-        ./dockerfiles/build.sh 
+        cd dockerfiles
+        ./build.sh 
+        cd ..
     - name: Push docker images
       run: |
         docker push quay.io/eclipse/endpoint-watcher:nightly

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -12,7 +12,6 @@
 base_dir=$(cd "$(dirname "$0")"; pwd)
 . "${base_dir}"/build.include
 
-. ./build.include
 init "$@"
 
 DIRECTORIES_PROCESSED=""
@@ -46,7 +45,7 @@ build_directory() {
 
 build_all() {
   # loop on all directories and call build.sh script if present
-  for directory in */ ; do
+  for directory in ${base_dir}/*/ ; do
     if [ -e ${directory}/build.sh ] ; then
       build_directory ${directory}
     else
@@ -59,7 +58,7 @@ build_custom() {
   echo "directories are $ARGS and options $OPTIONS"
   # loop on provided directories by the user
    for directory in $(echo ${ARGS}); do
-     build_directory "${directory}/" ${OPTIONS}
+     build_directory "${base_dir}/${directory}/" ${OPTIONS}
    done
 
 }

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -9,6 +9,8 @@
 #
 # See: https://sipb.mit.edu/doc/safe-shell/
 
+set -e
+
 . ./build.include
 init "$@"
 

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -9,7 +9,8 @@
 #
 # See: https://sipb.mit.edu/doc/safe-shell/
 
-set -e
+base_dir=$(cd "$(dirname "$0")"; pwd)
+. "${base_dir}"/build.include
 
 . ./build.include
 init "$@"


### PR DESCRIPTION
Signed-off-by: Mykhailo Kuznietsov <mkuznets@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Execution of script `./dockerfiles/build.sh` has caused an infinite loop when running nightly build of Che. It happened, because script didn't fail on error, when it tried to import script by relative path, and then went on to invoke `build.sh` recursivelly.

As a workaround, "set -e" will prevent this infinite loop.
Also add manual workflow trigger to restart the job in this PR


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
