### PR TITLE
Removing the RedHat che specific header from the multiuser.properties

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/multiuser.properties
@@ -129,9 +129,7 @@ che.keycloak.realm=che
 
 # Keycloak client id in che.keycloak.realm that is used by dashboard, ide and cli to authenticate users
 che.keycloak.client_id=che-public
-
-### RedHat Che specific configuration
-
+        
 # URL to access OSO oauth tokens
 che.keycloak.oso.endpoint=NULL
 


### PR DESCRIPTION
Backporting https://github.com/eclipse/che/pull/18902 to 7.24.x