### PR TITLE
Gh18948 devfile v2 validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,9 +84,9 @@
         <io.opentracing.web-servlet-filter.version>0.4.0</io.opentracing.web-servlet-filter.version>
         <io.prometheus.simpleclient.version>0.7.0</io.prometheus.simpleclient.version>
         <io.swagger.version>1.5.9</io.swagger.version>
+        <jakarta.json.version>2.0.0</jakarta.json.version>
         <javax.annotation.version>1.2</javax.annotation.version>
         <javax.inject.version>1</javax.inject.version>
-        <javax.json.version>1.1.4</javax.json.version>
         <javax.mail.version>1.4.4</javax.mail.version>
         <javax.servlet.version>3.1.0</javax.servlet.version>
         <javax.validation.version>1.1.0.Final</javax.validation.version>
@@ -112,7 +112,7 @@
         <org.jgroups.kubernetes.version>1.0.13.Final</org.jgroups.kubernetes.version>
         <org.jgroups.version>4.1.9.Final</org.jgroups.version>
         <org.kohsuke.github-api.version>1.90</org.kohsuke.github-api.version>
-        <org.leadpony.justify.version>0.14.0</org.leadpony.justify.version>
+        <org.leadpony.justify.version>3.1.0</org.leadpony.justify.version>
         <org.mockito.mockito-testng.version>0.1.1</org.mockito.mockito-testng.version>
         <org.mockito.version>2.21.0</org.mockito.version>
         <org.postgresql.version>42.2.2</org.postgresql.version>
@@ -1293,8 +1293,8 @@
             </dependency>
             <dependency>
                 <groupId>org.glassfish</groupId>
-                <artifactId>javax.json</artifactId>
-                <version>${javax.json.version}</version>
+                <artifactId>jakarta.json</artifactId>
+                <version>${jakarta.json.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>

--- a/wsmaster/che-core-api-workspace/pom.xml
+++ b/wsmaster/che-core-api-workspace/pom.xml
@@ -128,15 +128,15 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
         </dependency>
         <dependency>
             <groupId>org.leadpony.justify</groupId>
             <artifactId>justify</artifactId>
             <exclusions>
                 <exclusion>
-                    <artifactId>javax.json-api</artifactId>
-                    <groupId>javax.json</groupId>
+                    <artifactId>jakarta.json-api</artifactId>
+                    <groupId>jakarta.json</groupId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/DevfileParser.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/DevfileParser.java
@@ -105,6 +105,7 @@ public class DevfileParser {
   public JsonNode parseYamlRaw(String yaml) throws DevfileFormatException {
     try {
       JsonNode devfileJson = yamlMapper.readTree(yaml);
+      schemaValidator.validate(devfileJson);
       if (devfileJson == null) {
         throw new DevfileFormatException("Unable to parse Devfile - provided source is empty");
       }

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidator.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidator.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.SUPPORTED_V
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.json.JsonReader;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.ArrayList;
@@ -24,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import javax.json.JsonReader;
 import org.eclipse.che.api.workspace.server.devfile.DevfileVersionDetector;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileException;
 import org.eclipse.che.api.workspace.server.devfile.exception.DevfileFormatException;

--- a/wsmaster/che-core-api-workspace/src/main/resources/schema/2.0.0/devfile.json
+++ b/wsmaster/che-core-api-workspace/src/main/resources/schema/2.0.0/devfile.json
@@ -1,8 +1,3374 @@
 {
-  "description": "This is a temporary dummy structure for devfile 2.0.0.",
+  "description": "Devfile describes the structure of a cloud-native workspace and development environment.",
   "type": "object",
   "title": "Devfile schema - Version 2.0.0",
   "required": [
     "schemaVersion"
-  ]
+  ],
+  "properties": {
+    "commands": {
+      "description": "Predefined, ready-to-use, workspace-related commands",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "oneOf": [
+          {
+            "required": [
+              "exec"
+            ]
+          },
+          {
+            "required": [
+              "apply"
+            ]
+          },
+          {
+            "required": [
+              "vscodeTask"
+            ]
+          },
+          {
+            "required": [
+              "vscodeLaunch"
+            ]
+          },
+          {
+            "required": [
+              "composite"
+            ]
+          }
+        ],
+        "properties": {
+          "apply": {
+            "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+            "type": "object",
+            "required": [
+              "component"
+            ],
+            "properties": {
+              "component": {
+                "description": "Describes component that will be applied",
+                "type": "string"
+              },
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "label": {
+                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "attributes": {
+            "description": "Map of implementation-dependant free-form YAML attributes.",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "composite": {
+            "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
+            "type": "object",
+            "properties": {
+              "commands": {
+                "description": "The commands that comprise this composite command",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "label": {
+                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                "type": "string"
+              },
+              "parallel": {
+                "description": "Indicates if the sub-commands should be executed concurrently",
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "exec": {
+            "description": "CLI Command executed in an existing component container",
+            "type": "object",
+            "required": [
+              "commandLine",
+              "component"
+            ],
+            "properties": {
+              "commandLine": {
+                "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "type": "string"
+              },
+              "component": {
+                "description": "Describes component to which given action relates",
+                "type": "string"
+              },
+              "env": {
+                "description": "Optional list of environment variables that have to be set before running the command",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "hotReloadCapable": {
+                "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                "type": "boolean"
+              },
+              "label": {
+                "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                "type": "string"
+              },
+              "workingDir": {
+                "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "id": {
+            "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          "vscodeLaunch": {
+            "description": "Command providing the definition of a VsCode launch action",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
+                ]
+              },
+              {
+                "required": [
+                  "inlined"
+                ]
+              }
+            ],
+            "properties": {
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "inlined": {
+                "description": "Inlined content of the VsCode configuration",
+                "type": "string"
+              },
+              "uri": {
+                "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "vscodeTask": {
+            "description": "Command providing the definition of a VsCode Task",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
+                ]
+              },
+              {
+                "required": [
+                  "inlined"
+                ]
+              }
+            ],
+            "properties": {
+              "group": {
+                "description": "Defines the group this command is part of",
+                "type": "object",
+                "required": [
+                  "kind"
+                ],
+                "properties": {
+                  "isDefault": {
+                    "description": "Identifies the default command for a given group kind",
+                    "type": "boolean"
+                  },
+                  "kind": {
+                    "description": "Kind of group the command is part of",
+                    "type": "string",
+                    "enum": [
+                      "build",
+                      "run",
+                      "test",
+                      "debug"
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              },
+              "inlined": {
+                "description": "Inlined content of the VsCode configuration",
+                "type": "string"
+              },
+              "uri": {
+                "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "components": {
+      "description": "List of the workspace components, such as editor and plugins, user-provided containers, or other types of components",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "oneOf": [
+          {
+            "required": [
+              "container"
+            ]
+          },
+          {
+            "required": [
+              "kubernetes"
+            ]
+          },
+          {
+            "required": [
+              "openshift"
+            ]
+          },
+          {
+            "required": [
+              "volume"
+            ]
+          },
+          {
+            "required": [
+              "plugin"
+            ]
+          }
+        ],
+        "properties": {
+          "attributes": {
+            "description": "Map of implementation-dependant free-form YAML attributes.",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "container": {
+            "description": "Allows adding and configuring workspace-related containers",
+            "type": "object",
+            "required": [
+              "image"
+            ],
+            "properties": {
+              "args": {
+                "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "command": {
+                "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "dedicatedPod": {
+                "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                "type": "boolean"
+              },
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "targetPort"
+                  ],
+                  "properties": {
+                    "attributes": {
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "exposure": {
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                      "type": "string",
+                      "default": "public",
+                      "enum": [
+                        "public",
+                        "internal",
+                        "none"
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                    },
+                    "path": {
+                      "description": "Path of the endpoint URL",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "default": "http",
+                      "enum": [
+                        "http",
+                        "https",
+                        "ws",
+                        "wss",
+                        "tcp",
+                        "udp"
+                      ]
+                    },
+                    "secure": {
+                      "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                      "type": "boolean"
+                    },
+                    "targetPort": {
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "env": {
+                "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "value"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "image": {
+                "type": "string"
+              },
+              "memoryLimit": {
+                "type": "string"
+              },
+              "mountSources": {
+                "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                "type": "boolean"
+              },
+              "sourceMapping": {
+                "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
+                "type": "string",
+                "default": "/projects"
+              },
+              "volumeMounts": {
+                "description": "List of volumes mounts that should be mounted is this container.",
+                "type": "array",
+                "items": {
+                  "description": "Volume that should be mounted to a component container",
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "properties": {
+                    "name": {
+                      "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                    },
+                    "path": {
+                      "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "kubernetes": {
+            "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
+                ]
+              },
+              {
+                "required": [
+                  "inlined"
+                ]
+              }
+            ],
+            "properties": {
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "targetPort"
+                  ],
+                  "properties": {
+                    "attributes": {
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "exposure": {
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                      "type": "string",
+                      "default": "public",
+                      "enum": [
+                        "public",
+                        "internal",
+                        "none"
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                    },
+                    "path": {
+                      "description": "Path of the endpoint URL",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "default": "http",
+                      "enum": [
+                        "http",
+                        "https",
+                        "ws",
+                        "wss",
+                        "tcp",
+                        "udp"
+                      ]
+                    },
+                    "secure": {
+                      "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                      "type": "boolean"
+                    },
+                    "targetPort": {
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "inlined": {
+                "description": "Inlined manifest",
+                "type": "string"
+              },
+              "uri": {
+                "description": "Location in a file fetched from a uri.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "name": {
+            "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          "openshift": {
+            "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
+                ]
+              },
+              {
+                "required": [
+                  "inlined"
+                ]
+              }
+            ],
+            "properties": {
+              "endpoints": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name",
+                    "targetPort"
+                  ],
+                  "properties": {
+                    "attributes": {
+                      "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "exposure": {
+                      "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                      "type": "string",
+                      "default": "public",
+                      "enum": [
+                        "public",
+                        "internal",
+                        "none"
+                      ]
+                    },
+                    "name": {
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                    },
+                    "path": {
+                      "description": "Path of the endpoint URL",
+                      "type": "string"
+                    },
+                    "protocol": {
+                      "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                      "type": "string",
+                      "default": "http",
+                      "enum": [
+                        "http",
+                        "https",
+                        "ws",
+                        "wss",
+                        "tcp",
+                        "udp"
+                      ]
+                    },
+                    "secure": {
+                      "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                      "type": "boolean"
+                    },
+                    "targetPort": {
+                      "type": "integer"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "inlined": {
+                "description": "Inlined manifest",
+                "type": "string"
+              },
+              "uri": {
+                "description": "Location in a file fetched from a uri.",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "plugin": {
+            "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+            "type": "object",
+            "oneOf": [
+              {
+                "required": [
+                  "uri"
+                ]
+              },
+              {
+                "required": [
+                  "id"
+                ]
+              },
+              {
+                "required": [
+                  "kubernetes"
+                ]
+              }
+            ],
+            "properties": {
+              "commands": {
+                "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "id"
+                  ],
+                  "oneOf": [
+                    {
+                      "required": [
+                        "exec"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "apply"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "vscodeTask"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "vscodeLaunch"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "composite"
+                      ]
+                    }
+                  ],
+                  "properties": {
+                    "apply": {
+                      "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                      "type": "object",
+                      "properties": {
+                        "component": {
+                          "description": "Describes component that will be applied",
+                          "type": "string"
+                        },
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "label": {
+                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "attributes": {
+                      "description": "Map of implementation-dependant free-form YAML attributes.",
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "composite": {
+                      "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
+                      "type": "object",
+                      "properties": {
+                        "commands": {
+                          "description": "The commands that comprise this composite command",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "label": {
+                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                          "type": "string"
+                        },
+                        "parallel": {
+                          "description": "Indicates if the sub-commands should be executed concurrently",
+                          "type": "boolean"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "exec": {
+                      "description": "CLI Command executed in an existing component container",
+                      "type": "object",
+                      "properties": {
+                        "commandLine": {
+                          "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "type": "string"
+                        },
+                        "component": {
+                          "description": "Describes component to which given action relates",
+                          "type": "string"
+                        },
+                        "env": {
+                          "description": "Optional list of environment variables that have to be set before running the command",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "hotReloadCapable": {
+                          "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                          "type": "boolean"
+                        },
+                        "label": {
+                          "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                          "type": "string"
+                        },
+                        "workingDir": {
+                          "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "id": {
+                      "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                    },
+                    "vscodeLaunch": {
+                      "description": "Command providing the definition of a VsCode launch action",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "inlined"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "inlined": {
+                          "description": "Inlined content of the VsCode configuration",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "vscodeTask": {
+                      "description": "Command providing the definition of a VsCode Task",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "inlined"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "group": {
+                          "description": "Defines the group this command is part of",
+                          "type": "object",
+                          "properties": {
+                            "isDefault": {
+                              "description": "Identifies the default command for a given group kind",
+                              "type": "boolean"
+                            },
+                            "kind": {
+                              "description": "Kind of group the command is part of",
+                              "type": "string",
+                              "enum": [
+                                "build",
+                                "run",
+                                "test",
+                                "debug"
+                              ]
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "inlined": {
+                          "description": "Inlined content of the VsCode configuration",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "components": {
+                "description": "Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "name"
+                  ],
+                  "oneOf": [
+                    {
+                      "required": [
+                        "container"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "kubernetes"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "openshift"
+                      ]
+                    },
+                    {
+                      "required": [
+                        "volume"
+                      ]
+                    }
+                  ],
+                  "properties": {
+                    "attributes": {
+                      "description": "Map of implementation-dependant free-form YAML attributes.",
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "container": {
+                      "description": "Allows adding and configuring workspace-related containers",
+                      "type": "object",
+                      "properties": {
+                        "args": {
+                          "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "command": {
+                          "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        },
+                        "dedicatedPod": {
+                          "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                          "type": "boolean"
+                        },
+                        "endpoints": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "attributes": {
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "additionalProperties": true
+                              },
+                              "exposure": {
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                                "type": "string",
+                                "enum": [
+                                  "public",
+                                  "internal",
+                                  "none"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                              },
+                              "path": {
+                                "description": "Path of the endpoint URL",
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "enum": [
+                                  "http",
+                                  "https",
+                                  "ws",
+                                  "wss",
+                                  "tcp",
+                                  "udp"
+                                ]
+                              },
+                              "secure": {
+                                "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                                "type": "boolean"
+                              },
+                              "targetPort": {
+                                "type": "integer"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "env": {
+                          "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "value": {
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "image": {
+                          "type": "string"
+                        },
+                        "memoryLimit": {
+                          "type": "string"
+                        },
+                        "mountSources": {
+                          "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                          "type": "boolean"
+                        },
+                        "sourceMapping": {
+                          "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
+                          "type": "string"
+                        },
+                        "volumeMounts": {
+                          "description": "List of volumes mounts that should be mounted is this container.",
+                          "type": "array",
+                          "items": {
+                            "description": "Volume that should be mounted to a component container",
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "name": {
+                                "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                              },
+                              "path": {
+                                "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
+                                "type": "string"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "kubernetes": {
+                      "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "inlined"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "endpoints": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "attributes": {
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "additionalProperties": true
+                              },
+                              "exposure": {
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                                "type": "string",
+                                "enum": [
+                                  "public",
+                                  "internal",
+                                  "none"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                              },
+                              "path": {
+                                "description": "Path of the endpoint URL",
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "enum": [
+                                  "http",
+                                  "https",
+                                  "ws",
+                                  "wss",
+                                  "tcp",
+                                  "udp"
+                                ]
+                              },
+                              "secure": {
+                                "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                                "type": "boolean"
+                              },
+                              "targetPort": {
+                                "type": "integer"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "inlined": {
+                          "description": "Inlined manifest",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "Location in a file fetched from a uri.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "name": {
+                      "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
+                      "type": "string",
+                      "maxLength": 63,
+                      "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                    },
+                    "openshift": {
+                      "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+                      "type": "object",
+                      "oneOf": [
+                        {
+                          "required": [
+                            "uri"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "inlined"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "endpoints": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "required": [
+                              "name"
+                            ],
+                            "properties": {
+                              "attributes": {
+                                "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                "type": "object",
+                                "additionalProperties": true
+                              },
+                              "exposure": {
+                                "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                                "type": "string",
+                                "enum": [
+                                  "public",
+                                  "internal",
+                                  "none"
+                                ]
+                              },
+                              "name": {
+                                "type": "string",
+                                "maxLength": 63,
+                                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                              },
+                              "path": {
+                                "description": "Path of the endpoint URL",
+                                "type": "string"
+                              },
+                              "protocol": {
+                                "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                "type": "string",
+                                "enum": [
+                                  "http",
+                                  "https",
+                                  "ws",
+                                  "wss",
+                                  "tcp",
+                                  "udp"
+                                ]
+                              },
+                              "secure": {
+                                "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                                "type": "boolean"
+                              },
+                              "targetPort": {
+                                "type": "integer"
+                              }
+                            },
+                            "additionalProperties": false
+                          }
+                        },
+                        "inlined": {
+                          "description": "Inlined manifest",
+                          "type": "string"
+                        },
+                        "uri": {
+                          "description": "Location in a file fetched from a uri.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "volume": {
+                      "description": "Allows specifying the definition of a volume shared by several other components",
+                      "type": "object",
+                      "properties": {
+                        "size": {
+                          "description": "Size of the volume",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "id": {
+                "description": "Id in a registry that contains a Devfile yaml file",
+                "type": "string"
+              },
+              "kubernetes": {
+                "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "namespace": {
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "registryUrl": {
+                "type": "string"
+              },
+              "uri": {
+                "description": "Uri of a Devfile yaml file",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          },
+          "volume": {
+            "description": "Allows specifying the definition of a volume shared by several other components",
+            "type": "object",
+            "properties": {
+              "size": {
+                "description": "Size of the volume",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "events": {
+      "description": "Bindings of commands to events. Each command is referred-to by its name.",
+      "type": "object",
+      "properties": {
+        "postStart": {
+          "description": "IDs of commands that should be executed after the workspace is completely started. In the case of Che-Theia, these commands should be executed after all plugins and extensions have started, including project cloning. This means that those commands are not triggered until the user opens the IDE in his browser.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "postStop": {
+          "description": "IDs of commands that should be executed after stopping the workspace.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "preStart": {
+          "description": "IDs of commands that should be executed before the workspace start. Kubernetes-wise, these commands would typically be executed in init containers of the workspace POD.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "preStop": {
+          "description": "IDs of commands that should be executed before stopping the workspace.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "description": "Optional metadata",
+      "type": "object",
+      "properties": {
+        "attributes": {
+          "description": "Map of implementation-dependant free-form YAML attributes.",
+          "type": "object",
+          "additionalProperties": true
+        },
+        "description": {
+          "description": "Optional devfile description",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "Optional devfile display name",
+          "type": "string"
+        },
+        "globalMemoryLimit": {
+          "description": "Optional devfile global memory limit",
+          "type": "string"
+        },
+        "icon": {
+          "description": "Optional devfile icon",
+          "type": "string"
+        },
+        "name": {
+          "description": "Optional devfile name",
+          "type": "string"
+        },
+        "tags": {
+          "description": "Optional devfile tags",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "description": "Optional semver-compatible version",
+          "type": "string",
+          "pattern": "^([0-9]+)\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+        }
+      },
+      "additionalProperties": true
+    },
+    "parent": {
+      "description": "Parent workspace template",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "uri"
+          ]
+        },
+        {
+          "required": [
+            "id"
+          ]
+        },
+        {
+          "required": [
+            "kubernetes"
+          ]
+        }
+      ],
+      "properties": {
+        "commands": {
+          "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "oneOf": [
+              {
+                "required": [
+                  "exec"
+                ]
+              },
+              {
+                "required": [
+                  "apply"
+                ]
+              },
+              {
+                "required": [
+                  "vscodeTask"
+                ]
+              },
+              {
+                "required": [
+                  "vscodeLaunch"
+                ]
+              },
+              {
+                "required": [
+                  "composite"
+                ]
+              }
+            ],
+            "properties": {
+              "apply": {
+                "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                "type": "object",
+                "properties": {
+                  "component": {
+                    "description": "Describes component that will be applied",
+                    "type": "string"
+                  },
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "label": {
+                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "attributes": {
+                "description": "Map of implementation-dependant free-form YAML attributes.",
+                "type": "object",
+                "additionalProperties": true
+              },
+              "composite": {
+                "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
+                "type": "object",
+                "properties": {
+                  "commands": {
+                    "description": "The commands that comprise this composite command",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "label": {
+                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                    "type": "string"
+                  },
+                  "parallel": {
+                    "description": "Indicates if the sub-commands should be executed concurrently",
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "exec": {
+                "description": "CLI Command executed in an existing component container",
+                "type": "object",
+                "properties": {
+                  "commandLine": {
+                    "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "type": "string"
+                  },
+                  "component": {
+                    "description": "Describes component to which given action relates",
+                    "type": "string"
+                  },
+                  "env": {
+                    "description": "Optional list of environment variables that have to be set before running the command",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "hotReloadCapable": {
+                    "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                    "type": "boolean"
+                  },
+                  "label": {
+                    "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                    "type": "string"
+                  },
+                  "workingDir": {
+                    "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "id": {
+                "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              },
+              "vscodeLaunch": {
+                "description": "Command providing the definition of a VsCode launch action",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "inlined"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "inlined": {
+                    "description": "Inlined content of the VsCode configuration",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "vscodeTask": {
+                "description": "Command providing the definition of a VsCode Task",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "inlined"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "group": {
+                    "description": "Defines the group this command is part of",
+                    "type": "object",
+                    "properties": {
+                      "isDefault": {
+                        "description": "Identifies the default command for a given group kind",
+                        "type": "boolean"
+                      },
+                      "kind": {
+                        "description": "Kind of group the command is part of",
+                        "type": "string",
+                        "enum": [
+                          "build",
+                          "run",
+                          "test",
+                          "debug"
+                        ]
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "inlined": {
+                    "description": "Inlined content of the VsCode configuration",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "components": {
+          "description": "Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "oneOf": [
+              {
+                "required": [
+                  "container"
+                ]
+              },
+              {
+                "required": [
+                  "kubernetes"
+                ]
+              },
+              {
+                "required": [
+                  "openshift"
+                ]
+              },
+              {
+                "required": [
+                  "volume"
+                ]
+              },
+              {
+                "required": [
+                  "plugin"
+                ]
+              }
+            ],
+            "properties": {
+              "attributes": {
+                "description": "Map of implementation-dependant free-form YAML attributes.",
+                "type": "object",
+                "additionalProperties": true
+              },
+              "container": {
+                "description": "Allows adding and configuring workspace-related containers",
+                "type": "object",
+                "properties": {
+                  "args": {
+                    "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "command": {
+                    "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "dedicatedPod": {
+                    "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                    "type": "boolean"
+                  },
+                  "endpoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "exposure": {
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                          "type": "string",
+                          "enum": [
+                            "public",
+                            "internal",
+                            "none"
+                          ]
+                        },
+                        "name": {
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                        },
+                        "path": {
+                          "description": "Path of the endpoint URL",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "https",
+                            "ws",
+                            "wss",
+                            "tcp",
+                            "udp"
+                          ]
+                        },
+                        "secure": {
+                          "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                          "type": "boolean"
+                        },
+                        "targetPort": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "env": {
+                    "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "name": {
+                          "type": "string"
+                        },
+                        "value": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "image": {
+                    "type": "string"
+                  },
+                  "memoryLimit": {
+                    "type": "string"
+                  },
+                  "mountSources": {
+                    "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                    "type": "boolean"
+                  },
+                  "sourceMapping": {
+                    "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
+                    "type": "string"
+                  },
+                  "volumeMounts": {
+                    "description": "List of volumes mounts that should be mounted is this container.",
+                    "type": "array",
+                    "items": {
+                      "description": "Volume that should be mounted to a component container",
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "name": {
+                          "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                        },
+                        "path": {
+                          "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "kubernetes": {
+                "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "inlined"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "endpoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "exposure": {
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                          "type": "string",
+                          "enum": [
+                            "public",
+                            "internal",
+                            "none"
+                          ]
+                        },
+                        "name": {
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                        },
+                        "path": {
+                          "description": "Path of the endpoint URL",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "https",
+                            "ws",
+                            "wss",
+                            "tcp",
+                            "udp"
+                          ]
+                        },
+                        "secure": {
+                          "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                          "type": "boolean"
+                        },
+                        "targetPort": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "inlined": {
+                    "description": "Inlined manifest",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Location in a file fetched from a uri.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              },
+              "openshift": {
+                "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "inlined"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "endpoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "exposure": {
+                          "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                          "type": "string",
+                          "enum": [
+                            "public",
+                            "internal",
+                            "none"
+                          ]
+                        },
+                        "name": {
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                        },
+                        "path": {
+                          "description": "Path of the endpoint URL",
+                          "type": "string"
+                        },
+                        "protocol": {
+                          "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                          "type": "string",
+                          "enum": [
+                            "http",
+                            "https",
+                            "ws",
+                            "wss",
+                            "tcp",
+                            "udp"
+                          ]
+                        },
+                        "secure": {
+                          "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                          "type": "boolean"
+                        },
+                        "targetPort": {
+                          "type": "integer"
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "inlined": {
+                    "description": "Inlined manifest",
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Location in a file fetched from a uri.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "plugin": {
+                "description": "Allows importing a plugin.\n\nPlugins are mainly imported devfiles that contribute components, commands and events as a consistent single unit. They are defined in either YAML files following the devfile syntax, or as `DevWorkspaceTemplate` Kubernetes Custom Resources",
+                "type": "object",
+                "oneOf": [
+                  {
+                    "required": [
+                      "uri"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "id"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "kubernetes"
+                    ]
+                  }
+                ],
+                "properties": {
+                  "commands": {
+                    "description": "Overrides of commands encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "id"
+                      ],
+                      "oneOf": [
+                        {
+                          "required": [
+                            "exec"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "apply"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "vscodeTask"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "vscodeLaunch"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "composite"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "apply": {
+                          "description": "Command that consists in applying a given component definition, typically bound to a workspace event.\n\nFor example, when an `apply` command is bound to a `preStart` event, and references a `container` component, it will start the container as a K8S initContainer in the workspace POD, unless the component has its `dedicatedPod` field set to `true`.\n\nWhen no `apply` command exist for a given component, it is assumed the component will be applied at workspace start by default.",
+                          "type": "object",
+                          "properties": {
+                            "component": {
+                              "description": "Describes component that will be applied",
+                              "type": "string"
+                            },
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "label": {
+                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "attributes": {
+                          "description": "Map of implementation-dependant free-form YAML attributes.",
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "composite": {
+                          "description": "Composite command that allows executing several sub-commands either sequentially or concurrently",
+                          "type": "object",
+                          "properties": {
+                            "commands": {
+                              "description": "The commands that comprise this composite command",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "label": {
+                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                              "type": "string"
+                            },
+                            "parallel": {
+                              "description": "Indicates if the sub-commands should be executed concurrently",
+                              "type": "boolean"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "exec": {
+                          "description": "CLI Command executed in an existing component container",
+                          "type": "object",
+                          "properties": {
+                            "commandLine": {
+                              "description": "The actual command-line string\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "type": "string"
+                            },
+                            "component": {
+                              "description": "Describes component to which given action relates",
+                              "type": "string"
+                            },
+                            "env": {
+                              "description": "Optional list of environment variables that have to be set before running the command",
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "hotReloadCapable": {
+                              "description": "Whether the command is capable to reload itself when source code changes. If set to `true` the command won't be restarted and it is expected to handle file changes on its own.\n\nDefault value is `false`",
+                              "type": "boolean"
+                            },
+                            "label": {
+                              "description": "Optional label that provides a label for this command to be used in Editor UI menus for example",
+                              "type": "string"
+                            },
+                            "workingDir": {
+                              "description": "Working directory where the command should be executed\n\nSpecial variables that can be used:\n\n - `$PROJECTS_ROOT`: A path where projects sources are mounted as defined by container component's sourceMapping.\n\n - `$PROJECT_SOURCE`: A path to a project source ($PROJECTS_ROOT/\u003cproject-name\u003e). If there are multiple projects, this will point to the directory of the first one.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "id": {
+                          "description": "Mandatory identifier that allows referencing this command in composite commands, from a parent, or in events.",
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                        },
+                        "vscodeLaunch": {
+                          "description": "Command providing the definition of a VsCode launch action",
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "required": [
+                                "uri"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "inlined"
+                              ]
+                            }
+                          ],
+                          "properties": {
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "inlined": {
+                              "description": "Inlined content of the VsCode configuration",
+                              "type": "string"
+                            },
+                            "uri": {
+                              "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "vscodeTask": {
+                          "description": "Command providing the definition of a VsCode Task",
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "required": [
+                                "uri"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "inlined"
+                              ]
+                            }
+                          ],
+                          "properties": {
+                            "group": {
+                              "description": "Defines the group this command is part of",
+                              "type": "object",
+                              "properties": {
+                                "isDefault": {
+                                  "description": "Identifies the default command for a given group kind",
+                                  "type": "boolean"
+                                },
+                                "kind": {
+                                  "description": "Kind of group the command is part of",
+                                  "type": "string",
+                                  "enum": [
+                                    "build",
+                                    "run",
+                                    "test",
+                                    "debug"
+                                  ]
+                                }
+                              },
+                              "additionalProperties": false
+                            },
+                            "inlined": {
+                              "description": "Inlined content of the VsCode configuration",
+                              "type": "string"
+                            },
+                            "uri": {
+                              "description": "Location as an absolute of relative URI the VsCode configuration will be fetched from",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "components": {
+                    "description": "Overrides of components encapsulated in a parent devfile or a plugin. Overriding is done according to K8S strategic merge patch standard rules.",
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "required": [
+                        "name"
+                      ],
+                      "oneOf": [
+                        {
+                          "required": [
+                            "container"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "kubernetes"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "openshift"
+                          ]
+                        },
+                        {
+                          "required": [
+                            "volume"
+                          ]
+                        }
+                      ],
+                      "properties": {
+                        "attributes": {
+                          "description": "Map of implementation-dependant free-form YAML attributes.",
+                          "type": "object",
+                          "additionalProperties": true
+                        },
+                        "container": {
+                          "description": "Allows adding and configuring workspace-related containers",
+                          "type": "object",
+                          "properties": {
+                            "args": {
+                              "description": "The arguments to supply to the command running the dockerimage component. The arguments are supplied either to the default command provided in the image or to the overridden command.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "command": {
+                              "description": "The command to run in the dockerimage component instead of the default one provided in the image.\n\nDefaults to an empty array, meaning use whatever is defined in the image.",
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            },
+                            "dedicatedPod": {
+                              "description": "Specify if a container should run in its own separated pod, instead of running as part of the main development environment pod.\n\nDefault value is `false`",
+                              "type": "boolean"
+                            },
+                            "endpoints": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "attributes": {
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  },
+                                  "exposure": {
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                                    "type": "string",
+                                    "enum": [
+                                      "public",
+                                      "internal",
+                                      "none"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                                  },
+                                  "path": {
+                                    "description": "Path of the endpoint URL",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "enum": [
+                                      "http",
+                                      "https",
+                                      "ws",
+                                      "wss",
+                                      "tcp",
+                                      "udp"
+                                    ]
+                                  },
+                                  "secure": {
+                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                                    "type": "boolean"
+                                  },
+                                  "targetPort": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "env": {
+                              "description": "Environment variables used in this container.\n\nThe following variables are reserved and cannot be overridden via env:\n\n - `$PROJECTS_ROOT`\n\n - `$PROJECT_SOURCE`",
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "type": "string"
+                                  },
+                                  "value": {
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "image": {
+                              "type": "string"
+                            },
+                            "memoryLimit": {
+                              "type": "string"
+                            },
+                            "mountSources": {
+                              "description": "Toggles whether or not the project source code should be mounted in the component.\n\nDefaults to true for all component types except plugins and components that set `dedicatedPod` to true.",
+                              "type": "boolean"
+                            },
+                            "sourceMapping": {
+                              "description": "Optional specification of the path in the container where project sources should be transferred/mounted when `mountSources` is `true`. When omitted, the default value of /projects is used.",
+                              "type": "string"
+                            },
+                            "volumeMounts": {
+                              "description": "List of volumes mounts that should be mounted is this container.",
+                              "type": "array",
+                              "items": {
+                                "description": "Volume that should be mounted to a component container",
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "name": {
+                                    "description": "The volume mount name is the name of an existing `Volume` component. If several containers mount the same volume name then they will reuse the same volume and will be able to access to the same files.",
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                                  },
+                                  "path": {
+                                    "description": "The path in the component container where the volume should be mounted. If not path is mentioned, default path is the is `/\u003cname\u003e`.",
+                                    "type": "string"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "kubernetes": {
+                          "description": "Allows importing into the workspace the Kubernetes resources defined in a given manifest. For example this allows reusing the Kubernetes definitions used to deploy some runtime components in production.",
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "required": [
+                                "uri"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "inlined"
+                              ]
+                            }
+                          ],
+                          "properties": {
+                            "endpoints": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "attributes": {
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  },
+                                  "exposure": {
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                                    "type": "string",
+                                    "enum": [
+                                      "public",
+                                      "internal",
+                                      "none"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                                  },
+                                  "path": {
+                                    "description": "Path of the endpoint URL",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "enum": [
+                                      "http",
+                                      "https",
+                                      "ws",
+                                      "wss",
+                                      "tcp",
+                                      "udp"
+                                    ]
+                                  },
+                                  "secure": {
+                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                                    "type": "boolean"
+                                  },
+                                  "targetPort": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "inlined": {
+                              "description": "Inlined manifest",
+                              "type": "string"
+                            },
+                            "uri": {
+                              "description": "Location in a file fetched from a uri.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "name": {
+                          "description": "Mandatory name that allows referencing the component from other elements (such as commands) or from an external devfile that may reference this component through a parent or a plugin.",
+                          "type": "string",
+                          "maxLength": 63,
+                          "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                        },
+                        "openshift": {
+                          "description": "Allows importing into the workspace the OpenShift resources defined in a given manifest. For example this allows reusing the OpenShift definitions used to deploy some runtime components in production.",
+                          "type": "object",
+                          "oneOf": [
+                            {
+                              "required": [
+                                "uri"
+                              ]
+                            },
+                            {
+                              "required": [
+                                "inlined"
+                              ]
+                            }
+                          ],
+                          "properties": {
+                            "endpoints": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "required": [
+                                  "name"
+                                ],
+                                "properties": {
+                                  "attributes": {
+                                    "description": "Map of implementation-dependant string-based free-form attributes.\n\nExamples of Che-specific attributes:\n- cookiesAuthEnabled: \"true\" / \"false\",\n- type: \"terminal\" / \"ide\" / \"ide-dev\",",
+                                    "type": "object",
+                                    "additionalProperties": true
+                                  },
+                                  "exposure": {
+                                    "description": "Describes how the endpoint should be exposed on the network.\n- `public` means that the endpoint will be exposed on the public network, typically through a K8S ingress or an OpenShift route.\n- `internal` means that the endpoint will be exposed internally outside of the main workspace POD, typically by K8S services, to be consumed by other elements running on the same cloud internal network.\n- `none` means that the endpoint will not be exposed and will only be accessible inside the main workspace POD, on a local address.\n\nDefault value is `public`",
+                                    "type": "string",
+                                    "enum": [
+                                      "public",
+                                      "internal",
+                                      "none"
+                                    ]
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "maxLength": 63,
+                                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                                  },
+                                  "path": {
+                                    "description": "Path of the endpoint URL",
+                                    "type": "string"
+                                  },
+                                  "protocol": {
+                                    "description": "Describes the application and transport protocols of the traffic that will go through this endpoint.\n- `http`: Endpoint will have `http` traffic, typically on a TCP connection. It will be automaticaly promoted to `https` when the `secure` field is set to `true`.\n- `https`: Endpoint will have `https` traffic, typically on a TCP connection.\n- `ws`: Endpoint will have `ws` traffic, typically on a TCP connection. It will be automaticaly promoted to `wss` when the `secure` field is set to `true`.\n- `wss`: Endpoint will have `wss` traffic, typically on a TCP connection.\n- `tcp`: Endpoint will have traffic on a TCP connection, without specifying an application protocol.\n- `udp`: Endpoint will have traffic on an UDP connection, without specifying an application protocol.\n\nDefault value is `http`",
+                                    "type": "string",
+                                    "enum": [
+                                      "http",
+                                      "https",
+                                      "ws",
+                                      "wss",
+                                      "tcp",
+                                      "udp"
+                                    ]
+                                  },
+                                  "secure": {
+                                    "description": "Describes whether the endpoint should be secured and protected by some authentication process. This requires a protocol of `https` or `wss`.",
+                                    "type": "boolean"
+                                  },
+                                  "targetPort": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "additionalProperties": false
+                              }
+                            },
+                            "inlined": {
+                              "description": "Inlined manifest",
+                              "type": "string"
+                            },
+                            "uri": {
+                              "description": "Location in a file fetched from a uri.",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        },
+                        "volume": {
+                          "description": "Allows specifying the definition of a volume shared by several other components",
+                          "type": "object",
+                          "properties": {
+                            "size": {
+                              "description": "Size of the volume",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "id": {
+                    "description": "Id in a registry that contains a Devfile yaml file",
+                    "type": "string"
+                  },
+                  "kubernetes": {
+                    "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "namespace": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "registryUrl": {
+                    "type": "string"
+                  },
+                  "uri": {
+                    "description": "Uri of a Devfile yaml file",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "volume": {
+                "description": "Allows specifying the definition of a volume shared by several other components",
+                "type": "object",
+                "properties": {
+                  "size": {
+                    "description": "Size of the volume",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "id": {
+          "description": "Id in a registry that contains a Devfile yaml file",
+          "type": "string"
+        },
+        "kubernetes": {
+          "description": "Reference to a Kubernetes CRD of type DevWorkspaceTemplate",
+          "type": "object",
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "namespace": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "projects": {
+          "description": "Overrides of projects encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "oneOf": [
+              {
+                "required": [
+                  "git"
+                ]
+              },
+              {
+                "required": [
+                  "github"
+                ]
+              },
+              {
+                "required": [
+                  "zip"
+                ]
+              }
+            ],
+            "properties": {
+              "attributes": {
+                "description": "Map of implementation-dependant free-form YAML attributes.",
+                "type": "object",
+                "additionalProperties": true
+              },
+              "clonePath": {
+                "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
+                "type": "string"
+              },
+              "git": {
+                "description": "Project's Git source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                    "type": "object",
+                    "properties": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "github": {
+                "description": "Project's GitHub source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                    "type": "object",
+                    "properties": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Project name",
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              },
+              "sparseCheckoutDirs": {
+                "description": "Populate the project sparsely with selected directories.",
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "zip": {
+                "description": "Project's Zip source",
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "registryUrl": {
+          "type": "string"
+        },
+        "starterProjects": {
+          "description": "Overrides of starterProjects encapsulated in a parent devfile. Overriding is done according to K8S strategic merge patch standard rules.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "oneOf": [
+              {
+                "required": [
+                  "git"
+                ]
+              },
+              {
+                "required": [
+                  "github"
+                ]
+              },
+              {
+                "required": [
+                  "zip"
+                ]
+              }
+            ],
+            "properties": {
+              "attributes": {
+                "description": "Map of implementation-dependant free-form YAML attributes.",
+                "type": "object",
+                "additionalProperties": true
+              },
+              "description": {
+                "description": "Description of a starter project",
+                "type": "string"
+              },
+              "git": {
+                "description": "Project's Git source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                    "type": "object",
+                    "properties": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "github": {
+                "description": "Project's GitHub source",
+                "type": "object",
+                "properties": {
+                  "checkoutFrom": {
+                    "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                    "type": "object",
+                    "properties": {
+                      "remote": {
+                        "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                        "type": "string"
+                      },
+                      "revision": {
+                        "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false
+                  },
+                  "remotes": {
+                    "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "additionalProperties": false
+              },
+              "name": {
+                "description": "Project name",
+                "type": "string",
+                "maxLength": 63,
+                "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+              },
+              "subDir": {
+                "description": "Sub-directory from a starter project to be used as root for starter project.",
+                "type": "string"
+              },
+              "zip": {
+                "description": "Project's Zip source",
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "uri": {
+          "description": "Uri of a Devfile yaml file",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "projects": {
+      "description": "Projects worked on in the workspace, containing names and sources locations",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "oneOf": [
+          {
+            "required": [
+              "git"
+            ]
+          },
+          {
+            "required": [
+              "github"
+            ]
+          },
+          {
+            "required": [
+              "zip"
+            ]
+          }
+        ],
+        "properties": {
+          "attributes": {
+            "description": "Map of implementation-dependant free-form YAML attributes.",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "clonePath": {
+            "description": "Path relative to the root of the projects to which this project should be cloned into. This is a unix-style relative path (i.e. uses forward slashes). The path is invalid if it is absolute or tries to escape the project root through the usage of '..'. If not specified, defaults to the project name.",
+            "type": "string"
+          },
+          "git": {
+            "description": "Project's Git source",
+            "type": "object",
+            "required": [
+              "remotes"
+            ],
+            "properties": {
+              "checkoutFrom": {
+                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                "type": "object",
+                "properties": {
+                  "remote": {
+                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "remotes": {
+                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "github": {
+            "description": "Project's GitHub source",
+            "type": "object",
+            "required": [
+              "remotes"
+            ],
+            "properties": {
+              "checkoutFrom": {
+                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                "type": "object",
+                "properties": {
+                  "remote": {
+                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "remotes": {
+                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "name": {
+            "description": "Project name",
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          "sparseCheckoutDirs": {
+            "description": "Populate the project sparsely with selected directories.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "zip": {
+            "description": "Project's Zip source",
+            "type": "object",
+            "properties": {
+              "location": {
+                "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "schemaVersion": {
+      "description": "Devfile schema version",
+      "type": "string",
+      "pattern": "^([2-9])\\.([0-9]+)\\.([0-9]+)(\\-[0-9a-z-]+(\\.[0-9a-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+    },
+    "starterProjects": {
+      "description": "StarterProjects is a project that can be used as a starting point when bootstrapping new projects",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "oneOf": [
+          {
+            "required": [
+              "git"
+            ]
+          },
+          {
+            "required": [
+              "github"
+            ]
+          },
+          {
+            "required": [
+              "zip"
+            ]
+          }
+        ],
+        "properties": {
+          "attributes": {
+            "description": "Map of implementation-dependant free-form YAML attributes.",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "description": {
+            "description": "Description of a starter project",
+            "type": "string"
+          },
+          "git": {
+            "description": "Project's Git source",
+            "type": "object",
+            "required": [
+              "remotes"
+            ],
+            "properties": {
+              "checkoutFrom": {
+                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                "type": "object",
+                "properties": {
+                  "remote": {
+                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "remotes": {
+                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "github": {
+            "description": "Project's GitHub source",
+            "type": "object",
+            "required": [
+              "remotes"
+            ],
+            "properties": {
+              "checkoutFrom": {
+                "description": "Defines from what the project should be checked out. Required if there are more than one remote configured",
+                "type": "object",
+                "properties": {
+                  "remote": {
+                    "description": "The remote name should be used as init. Required if there are more than one remote configured",
+                    "type": "string"
+                  },
+                  "revision": {
+                    "description": "The revision to checkout from. Should be branch name, tag or commit id. Default branch is used if missing or specified revision is not found.",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "remotes": {
+                "description": "The remotes map which should be initialized in the git project. Must have at least one remote configured",
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "name": {
+            "description": "Project name",
+            "type": "string",
+            "maxLength": 63,
+            "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+          },
+          "subDir": {
+            "description": "Sub-directory from a starter project to be used as root for starter project.",
+            "type": "string"
+          },
+          "zip": {
+            "description": "Project's Zip source",
+            "type": "object",
+            "properties": {
+              "location": {
+                "description": "Zip project's source location address. Should be file path of the archive, e.g. file://$FILE_PATH",
+                "type": "string"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
 }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/DevfileParserTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/DevfileParserTest.java
@@ -81,6 +81,28 @@ public class DevfileParserTest {
   }
 
   @Test
+  public void testParseRaw() throws DevfileFormatException {
+    JsonNode parsed = devfileParser.parseYamlRaw(DEVFILE_YAML_CONTENT);
+
+    assertEquals(parsed, devfileJsonNode);
+    verify(schemaValidator).validate(eq(devfileJsonNode));
+  }
+
+  @Test(expectedExceptions = DevfileFormatException.class)
+  public void testParseRawThrowsExceptionWhenNothinParsed()
+      throws DevfileFormatException, JsonProcessingException {
+    when(yamlMapper.readTree(DEVFILE_YAML_CONTENT)).thenReturn(null);
+    devfileParser.parseYamlRaw(DEVFILE_YAML_CONTENT);
+  }
+
+  @Test(expectedExceptions = DevfileFormatException.class)
+  public void testParseRawThrowsDevfilExceptionWhenJsonParsingFails()
+      throws JsonProcessingException, DevfileFormatException {
+    when(yamlMapper.readTree(DEVFILE_YAML_CONTENT)).thenThrow(JsonProcessingException.class);
+    devfileParser.parseYamlRaw(DEVFILE_YAML_CONTENT);
+  }
+
+  @Test
   public void testInitializingDevfileMapsAfterParsing() throws Exception {
     // given
     CommandImpl command = new CommandImpl();

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
@@ -78,9 +78,12 @@ public class DevfileSchemaValidatorTest {
       {"devfile/devfile_name_and_generatename.yaml"},
       {"devfile/devfile_with_sparse_checkout_dir.yaml"},
       {"devfile/devfile_name_and_generatename.yaml"},
-      {"devfile/devfile_v2_just_schemaVersion.yaml"},
       {"command/devfile_command_with_preview_url.yaml"},
       {"command/devfile_command_with_preview_url_only_port.yaml"},
+      {"devfile/devfile_v2_just_schemaVersion.yaml"},
+      {"devfile/devfile_v2_sample-devfile.yaml"},
+      {"devfile/devfile_v2_simple-devfile.yaml"},
+      {"devfile/devfile_v2_spring-boot-http-booster-devfile.yaml"}
     };
   }
 

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/validator/DevfileSchemaValidatorTest.java
@@ -192,7 +192,7 @@ public class DevfileSchemaValidatorTest {
       },
       {
         "editor_plugin_component/devfile_editor_component_without_version.yaml",
-        "(/components/0/id):The string value must match the pattern \"[a-z0-9_\\-.]+/[a-z0-9_\\-.]+/[a-z0-9_\\-.]+$\"."
+        "(/components/0/id):The string value must match the pattern \"[a-z0-9_\\-.]+/[a-z0-9_\\-.]+/[a-z0-9_\\-.]+\\z\"."
       },
       {
         "editor_plugin_component/devfile_editor_plugins_components_with_invalid_memory_limit.yaml",
@@ -200,11 +200,11 @@ public class DevfileSchemaValidatorTest {
       },
       {
         "editor_plugin_component/devfile_editor_component_with_multiple_colons_in_id.yaml",
-        "(/components/0/id):The string value must match the pattern \"[a-z0-9_\\-.]+/[a-z0-9_\\-.]+/[a-z0-9_\\-.]+$\"."
+        "(/components/0/id):The string value must match the pattern \"[a-z0-9_\\-.]+/[a-z0-9_\\-.]+/[a-z0-9_\\-.]+\\z\"."
       },
       {
         "editor_plugin_component/devfile_editor_component_with_registry_in_id.yaml",
-        "(/components/0/id):The string value must match the pattern \"[a-z0-9_\\-.]+/[a-z0-9_\\-.]+/[a-z0-9_\\-.]+$\"."
+        "(/components/0/id):The string value must match the pattern \"[a-z0-9_\\-.]+/[a-z0-9_\\-.]+/[a-z0-9_\\-.]+\\z\"."
       },
       {
         "editor_plugin_component/devfile_editor_component_with_bad_registry.yaml",

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_sample-devfile.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_sample-devfile.yaml
@@ -1,0 +1,42 @@
+schemaVersion: "2.0.0"
+metadata:
+  name: "devfile example"
+  version: "1.0.0"
+projects:
+  - name: "my-project"
+    git:
+      remotes:
+        origin: "https://github.com/devfile/api"
+      checkoutFrom:
+        revision: "master"
+        remote: origin
+components:
+  - name: editor
+    attributes:
+      kjkh: "128M"
+      kjhkjh:
+        "": ""
+    plugin:
+      id: eclipse/che-theia/latest
+  - name: "ownplugin"
+    plugin:
+      id: acme/newPlugin/latest
+      registryUrl: "https://acme.com/registry/"
+  - name: "myplugin"
+    plugin:
+      uri: "https://github.com/johndoe/che-plugins/blob/master/cool-plugin/0.0.1/meta.yaml"
+  - name: "mycontainer"
+    container:
+      image: "busybox"
+      memoryLimit: "128M"
+      mountSources: true
+      endpoints:
+        - name: term-websockets
+          exposure: public
+          protocol: ws
+          attributes:
+            type: terminal
+          targetPort: 4000
+  - name: "production"
+    kubernetes:
+      uri: "https://somewhere/production-environment.yaml"

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_sample-devfile.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_sample-devfile.yaml
@@ -1,3 +1,15 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 schemaVersion: "2.0.0"
 metadata:
   name: "devfile example"

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_simple-devfile.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_simple-devfile.yaml
@@ -1,3 +1,15 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 schemaVersion: "2.0.0"
 metadata:
   name: "myDevfile"

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_simple-devfile.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_simple-devfile.yaml
@@ -1,0 +1,55 @@
+schemaVersion: "2.0.0"
+metadata:
+  name: "myDevfile"
+  version: "0.0.1"
+projects:
+  - name: "devworkspace-spec"
+    git:
+      remotes:
+        origin: "https://github.com/devfile/api"
+commands:
+  - id: buildschema
+    exec:
+      label: Build the schema
+      commandLine: "./buildSchema.sh"
+      component: build-tools
+      group:
+        kind: build
+        isDefault: true
+  - id: opendevfile
+    vscodeTask:
+      inlined:
+        json        
+  - id: build-schema-and-open-devfile
+    composite:
+      label: Build schema and open devfile
+      commands:
+        - buildschema
+        - opendevfile
+      parallel: false
+  - id: helloworld
+    exec:
+      env:
+        - name: "USER"
+          value: "John Doe"
+      commandLine: 'echo "Hello ${USER}"'
+      component: build-tools
+events:
+  postStart:
+    - "build-schema-and-open-devfile"
+components:
+  - name: yaml-support
+    plugin:
+      id: redhat/vscode-yaml/latest
+  - name: go-support
+    plugin:
+      id: ms-vscode/go/latest
+  - name: editor
+    plugin:
+      id: eclipse/che-theia/latest
+      registryUrl: "external-registry-url"
+  - name: "build-tools"
+    container:
+      image: some container image with required build tools
+      mountSources: true
+      sourceMapping: /home/src

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_spring-boot-http-booster-devfile.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_spring-boot-http-booster-devfile.yaml
@@ -1,0 +1,106 @@
+schemaVersion: 2.0.0
+metadata:
+  name: spring-boot-http-booster
+  attributes:
+    type: workspace
+projects:
+  - name: spring-boot-http-booster
+    git:
+      remotes:
+        origin: https://github.com/snowdrop/spring-boot-http-booster
+      checkoutFrom:
+        revision: master
+components:
+  - name: java-support
+    plugin:
+      id: redhat/java8/latest
+      components:
+        - name: vscode-java            
+          container:
+            memoryLimit: 2Gi
+        - name: m2
+          volume:
+            size: 2G
+  - name: dependency-analytics
+    plugin:
+      id: redhat/dependency-analytics/latest
+  - name: maven-tooling
+    container:
+      image: registry.redhat.io/codeready-workspaces/stacks-java-rhel8:2.1
+      mountSources: true
+      memoryLimit: 768Mi
+      env:
+        - name: JAVA_OPTS
+          value: >-
+            -XX:MaxRAMPercentage=50.0 -XX:+UseParallelGC -XX:MinHeapFreeRatio=10
+            -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4
+            -XX:AdaptiveSizePolicyWeight=90 -Dsun.zip.disableMemoryMapping=true
+            -Xms20m -Djava.security.egd=file:/dev/./urandom -Duser.home=/home/jboss
+        - name: MAVEN_OPTS
+          value: $(JAVA_OPTS)
+      endpoints:
+        - name: tcp-8080
+          targetPort: 8080
+          exposure: public
+      volumeMounts:
+        - name: m2
+          path: /home/jboss/.m2
+commands:
+  - id: build 
+    exec:
+      component: maven
+      commandLine: mvn -Duser.home=${HOME} -DskipTests clean install
+      workingDir: '${PROJECTS_ROOT}/spring-boot-http-booster'
+      env:
+        - name: MAVEN_OPTS
+          value: "-Xmx200m"
+  - id: debug-remote-java-application
+    vscodeLaunch:
+      inlined: |
+        {
+          "version": "0.2.0",
+          "configurations": [
+            {
+              "type": "java",
+              "name": "Debug (Attach) - Remote",
+              "request": "attach",
+              "hostName": "localhost",
+              "port": 8000
+            }]
+          }
+  - id: run
+    exec:
+      component: maven
+      commandLine: 'mvn -Duser.home=${HOME} spring-boot:run'
+      workingDir: '${PROJECTS_ROOT}/spring-boot-http-booster'
+      env:
+        - name: MAVEN_OPTS
+          value: "-Xmx200m"
+  - id: debug
+    exec:
+      component: maven
+      commandLine: >-
+        mvn  -Duser.home=${HOME} spring-boot:run -Drun.jvmArguments="-Xdebug
+        -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000"
+      workingDir: '${PROJECTS_ROOT}/spring-boot-http-booster'
+  - id: test
+    exec:
+      component: maven
+      commandLine: 'mvn -Duser.home=${HOME} verify'
+      workingDir: '${PROJECTS_ROOT}/spring-boot-http-booster'
+      env:
+        - name: MAVEN_OPTS
+          value: "-Xmx200m"
+  - id: dependency-analysis
+    exec:
+      component: maven
+      workingDir: '${PROJECTS_ROOT}/spring-boot-http-booster'
+      commandLine: >-
+        ${HOME}/stack-analysis.sh -f
+        ${PROJECTS_ROOT}/spring-boot-http-booster/pom.xml -p
+        ${PROJECTS_ROOT}/spring-boot-http-booster
+  - id: deploy-to-openshift 
+    exec:
+      component: maven
+      commandLine: 'mvn fabric8:deploy -Popenshift -DskipTests'
+      workingDir: '${PROJECTS_ROOT}/spring-boot-http-booster'

--- a/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_spring-boot-http-booster-devfile.yaml
+++ b/wsmaster/che-core-api-workspace/src/test/resources/devfile/schema_test/devfile/devfile_v2_spring-boot-http-booster-devfile.yaml
@@ -1,3 +1,15 @@
+#
+# Copyright (c) 2012-2018 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 schemaVersion: 2.0.0
 metadata:
   name: spring-boot-http-booster


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
adds devfile v2 validation. The update justify library PR is prerequisite for this one https://github.com/eclipse/che/pull/19010

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/18948


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
che-server image: `quay.io/mvala/che-server:gh18948-devfileV2Validation`

#### some valid devfiles/repos:
 - https://github.com/sparkoo/spring-petclinic
 - https://raw.githubusercontent.com/sparkoo/spring-petclinic/main/devfile.yaml
 - something from devfile v2 samples https://github.com/devfile/api/tree/master/samples/devfiles

#### some invalid devfiles/repos:
 - https://raw.githubusercontent.com/sparkoo/spring-petclinic/163f77f37155347c621205b1a356e4791c3ddc2d/devfile.yaml
 - https://github.com/sparkoo/spring-petclinic/tree/163f77f37155347c621205b1a356e4791c3ddc2d

#### steps
1. deploy che with che-server image `quay.io/mvala/che-server:gh18948-devfileV2Validation`
2. send request to che-server `/factory/resolve`
```
curl -k -X POST --header 'Content-Type: application/json' --header 'Accept: application/json' -d '{"url":"<devfile/repo-url>"}' 'https://<che-server-url>/api/factory/resolver'

# replace `<devfile/repo-url>` with actual devfile or repository with devfile (see some example links above)
# replace `<che-server-url>` with url to your che instance
```
3. see either response with the devfile content, or validation error message


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
