### PR TITLE
Fix error message when workspace has invalid async storage config

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/AsyncStorageProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/AsyncStorageProvisioner.java
@@ -17,6 +17,7 @@ import static java.lang.String.format;
 import static java.lang.String.valueOf;
 import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.workspace.shared.Constants.ASYNC_PERSIST_ATTRIBUTE;
+import static org.eclipse.che.api.workspace.shared.Constants.PERSIST_VOLUMES_ATTRIBUTE;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_DEPLOYMENT_NAME_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Constants.CHE_USER_ID_LABEL;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_SSH_KEYS;
@@ -169,7 +170,7 @@ public class AsyncStorageProvisioner {
       String message =
           format(
               "Workspace configuration not valid: Asynchronous storage available only if '%s' attribute set to false",
-              ASYNC_PERSIST_ATTRIBUTE);
+              PERSIST_VOLUMES_ATTRIBUTE);
       LOG.warn(message);
       k8sEnv.addWarning(new WarningImpl(4200, message));
       throw new InfrastructureException(message);

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/AsyncStorageProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/AsyncStorageProvisionerTest.java
@@ -122,7 +122,10 @@ public class AsyncStorageProvisionerTest {
     sshPair = new SshPairImpl(USER, "internal", SSH_KEY_NAME, "", "");
   }
 
-  @Test(expectedExceptions = InfrastructureException.class)
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only for 'common' PVC strategy.*")
   public void shouldThrowExceptionIfNotCommonStrategy() throws Exception {
     AsyncStorageProvisioner asyncStorageProvisioner =
         new AsyncStorageProvisioner(
@@ -142,7 +145,10 @@ public class AsyncStorageProvisionerTest {
     verifyNoMoreInteractions(identity);
   }
 
-  @Test(expectedExceptions = InfrastructureException.class)
+  @Test(
+      expectedExceptions = InfrastructureException.class,
+      expectedExceptionsMessageRegExp =
+          "Workspace configuration not valid: Asynchronous storage available only if 'persistVolumes' attribute set to false")
   public void shouldThrowExceptionIfAsyncStorageForNotEphemeralWorkspace() throws Exception {
     Map attributes = new HashMap<>(2);
     attributes.put(ASYNC_PERSIST_ATTRIBUTE, "true");


### PR DESCRIPTION
### What does this PR do?
Fix error message when workspace is started with

```yaml
attributes:
  asyncPersist: 'true'
```

to correctly mention that persistVolumes: 'false' is required for
asyncPersist: 'true'


### What issues does this PR fix or reference?
fixes https://github.com/eclipse/che/issues/19016

### How to test this PR?
Start a workspace with devfile
```yaml
apiVersion: 1.0.0
metadata:
  name: react-akqw0
attributes:
  asyncPersist: 'true'
components:
  - mountSources: true
    endpoints:
      - name: nodejs
        port: 4100
    memoryLimit: 512Mi
    type: dockerimage
    image: 'quay.io/eclipse/che-nodejs8-centos:nightly'
    alias: nodejs
```
error message should be
> Workspace configuration not valid: Asynchronous storage available only if 'persistVolumes' attribute set to false

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [N/A] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [N/A] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [N/A] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [N/A] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
