### PR TITLE
Do not mount ssh keys as secrets if the name is not a valid Kubernetes config map key name

### DIFF
--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
@@ -68,5 +68,9 @@ public final class Warnings {
       NOT_ABLE_TO_PROVISION_WORKSPACE_DEPLOYMENT_LABELS_OR_ANNOTATIONS_MESSAGE =
           "Not able to provision workspace %s deployment labels or annotations because of invalid configuration. Reason: '%s'";
 
+  public static final int SSH_KEYS_WILL_NOT_BE_MOUNTED = 4300;
+  public static final String SSH_KEYS_WILL_NOT_BE_MOUNTED_MESSAGE =
+      "Ssh keys %s has invalid names and can't be mounted to workspace %s.";
+
   private Warnings() {}
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/Warnings.java
@@ -70,7 +70,7 @@ public final class Warnings {
 
   public static final int SSH_KEYS_WILL_NOT_BE_MOUNTED = 4300;
   public static final String SSH_KEYS_WILL_NOT_BE_MOUNTED_MESSAGE =
-      "Ssh keys %s has invalid names and can't be mounted to workspace %s.";
+      "Ssh keys %s have invalid names and can't be mounted to workspace %s.";
 
   private Warnings() {}
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtil.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtil.java
@@ -36,6 +36,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 
 /**
@@ -46,6 +47,9 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 public class KubernetesObjectUtil {
 
   private static final String STORAGE_PARAM = "storage";
+  private static final String VALID_CONFIG_MAP_KEY_NAME = "[-._a-zA-Z0-9]+";
+  private static final Pattern VALID_CONFIG_MAP_KEY_NAME_PATTERN =
+      Pattern.compile(VALID_CONFIG_MAP_KEY_NAME);
 
   /** Checks if the specified object has the specified label. */
   public static boolean isLabeled(HasMetadata source, String key, String value) {
@@ -252,5 +256,10 @@ public class KubernetesObjectUtil {
     return annotations
         .getOrDefault(CREATE_IN_CHE_INSTALLATION_NAMESPACE, FALSE.toString())
         .equals(TRUE.toString());
+  }
+
+  /** Checks the provided name is a valid kubernetes config map key name */
+  public static boolean isValidConfigMapKeyName(String configMapKeyName) {
+    return VALID_CONFIG_MAP_KEY_NAME_PATTERN.matcher(configMapKeyName).matches();
   }
 }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
@@ -120,11 +120,12 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
     List<SshPairImpl> vcsSshPairs = getVcsSshPairs(k8sEnv, identity);
     List<SshPairImpl> systemSshPairs = getSystemSshPairs(k8sEnv, identity);
 
-    List<SshPairImpl> all = new ArrayList<>(vcsSshPairs);
-    all.addAll(systemSshPairs);
+    List<SshPairImpl> allSshPairs = new ArrayList<>(vcsSshPairs);
+    allSshPairs.addAll(systemSshPairs);
 
     List<String> invalidSshKeyNames =
-        all.stream()
+        allSshPairs
+            .stream()
             .filter(keyPair -> !isValidSshKeyPair(keyPair))
             .map(SshPairImpl::getName)
             .collect(toList());
@@ -141,7 +142,9 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
     }
 
     doProvisionSshKeys(
-        all.stream().filter(this::isValidSshKeyPair).collect(toList()), k8sEnv, workspaceId);
+        allSshPairs.stream().filter(this::isValidSshKeyPair).collect(toList()),
+        k8sEnv,
+        workspaceId);
     doProvisionVcsSshConfig(
         vcsSshPairs.stream().filter(this::isValidSshKeyPair).collect(toList()),
         k8sEnv,

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
@@ -14,6 +14,7 @@ package org.eclipse.che.workspace.infrastructure.kubernetes.provision;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_SSH_KEYS;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_SSH_KEYS_MESSAGE;
@@ -39,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
 import org.eclipse.che.api.core.ConflictException;
@@ -123,17 +123,17 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
     List<SshPairImpl> all = new ArrayList<>(vcsSshPairs);
     all.addAll(systemSshPairs);
 
-    List<String> invalidSshKeys =
+    List<String> invalidSshKeyNames =
         all.stream()
             .filter(keyPair -> !isValidSshKeyPair(keyPair))
             .map(SshPairImpl::getName)
-            .collect(Collectors.toList());
+            .collect(toList());
 
-    if (!invalidSshKeys.isEmpty()) {
+    if (!invalidSshKeyNames.isEmpty()) {
       String message =
           format(
               Warnings.SSH_KEYS_WILL_NOT_BE_MOUNTED_MESSAGE,
-              invalidSshKeys.toString(),
+              invalidSshKeyNames.toString(),
               identity.getWorkspaceId());
       LOG.warn(message);
       k8sEnv.addWarning(new WarningImpl(Warnings.SSH_KEYS_WILL_NOT_BE_MOUNTED, message));
@@ -141,11 +141,9 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
     }
 
     doProvisionSshKeys(
-        all.stream().filter(this::isValidSshKeyPair).collect(Collectors.toList()),
-        k8sEnv,
-        workspaceId);
+        all.stream().filter(this::isValidSshKeyPair).collect(toList()), k8sEnv, workspaceId);
     doProvisionVcsSshConfig(
-        vcsSshPairs.stream().filter(this::isValidSshKeyPair).collect(Collectors.toList()),
+        vcsSshPairs.stream().filter(this::isValidSshKeyPair).collect(toList()),
         k8sEnv,
         workspaceId);
   }

--- a/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
+++ b/infrastructures/kubernetes/src/main/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeysProvisioner.java
@@ -17,6 +17,7 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toMap;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_SSH_KEYS;
 import static org.eclipse.che.workspace.infrastructure.kubernetes.Warnings.NOT_ABLE_TO_PROVISION_SSH_KEYS_MESSAGE;
+import static org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesObjectUtil.isValidConfigMapKeyName;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
@@ -187,6 +188,7 @@ public class SshKeysProvisioner implements ConfigurationProvisioner<KubernetesEn
         sshPairs
             .stream()
             .filter(sshPair -> !isNullOrEmpty(sshPair.getPrivateKey()))
+            .filter(sshPair -> isValidConfigMapKeyName(sshPair.getName()))
             .collect(
                 toMap(
                     SshPairImpl::getName,

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtilTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/namespace/KubernetesObjectUtilTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2012-2018 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.che.workspace.infrastructure.kubernetes.namespace;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class KubernetesObjectUtilTest {
+  @Test(dataProvider = "testNames")
+  public void shouldTestisValidConfigMapKeyName(String nameToTest, boolean isValid) {
+    assertEquals(KubernetesObjectUtil.isValidConfigMapKeyName(nameToTest), isValid);
+  }
+
+  @DataProvider
+  public static Object[][] testNames() {
+    return new Object[][] {
+      new Object[] {"foo.bar", true},
+      new Object[] {"https://foo.bar", false},
+      new Object[] {"_fef_123-ah_*zz**", false},
+      new Object[] {"_fef_123-ah_z.z", true},
+      new Object[] {"a-b#-hello", false},
+      new Object[] {"a---------b", true},
+      new Object[] {"--ab--", true}
+    };
+  }
+}

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeySecretProvisionerTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -43,6 +44,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.environment.Kubernete
 import org.mockito.Mock;
 import org.mockito.testng.MockitoTestNGListener;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
@@ -72,15 +74,15 @@ public class SshKeySecretProvisionerTest {
 
   @BeforeMethod
   public void setup() {
-    when(runtimeIdentity.getOwnerId()).thenReturn(someUser);
-    when(runtimeIdentity.getWorkspaceId()).thenReturn("wksp");
+    lenient().when(runtimeIdentity.getOwnerId()).thenReturn(someUser);
+    lenient().when(runtimeIdentity.getWorkspaceId()).thenReturn("wksp");
     k8sEnv = KubernetesEnvironment.builder().build();
     ObjectMeta podMeta = new ObjectMetaBuilder().withName("wksp").build();
-    when(pod.getMetadata()).thenReturn(podMeta);
-    when(pod.getSpec()).thenReturn(podSpec);
-    when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
-    when(podSpec.getContainers()).thenReturn(Collections.singletonList(container));
-    when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
+    lenient().when(pod.getMetadata()).thenReturn(podMeta);
+    lenient().when(pod.getSpec()).thenReturn(podSpec);
+    lenient().when(podSpec.getVolumes()).thenReturn(new ArrayList<>());
+    lenient().when(podSpec.getContainers()).thenReturn(Collections.singletonList(container));
+    lenient().when(container.getVolumeMounts()).thenReturn(new ArrayList<>());
     k8sEnv.addPod(pod);
     sshKeysProvisioner = new SshKeysProvisioner(sshManager);
   }
@@ -98,13 +100,13 @@ public class SshKeySecretProvisionerTest {
     assertEquals(k8sEnv.getSecrets().size(), 1);
   }
 
-  @Test
-  public void shuldNotMountKeysWithInvalidKeyNames() throws Exception {
+  @Test(dataProvider = "invalidNames")
+  public void shuldNotMountKeysWithInvalidKeyNames(String invalidName) throws Exception {
     // given
     when(sshManager.getPairs(someUser, "vcs"))
         .thenReturn(
             ImmutableList.of(
-                new SshPairImpl(someUser, "vcs", "http://blah.blah", "public", "private"),
+                new SshPairImpl(someUser, "vcs", invalidName, "public", "private"),
                 new SshPairImpl(someUser, "vcs", "gothub.mk", "public", "private"),
                 new SshPairImpl(someUser, "vcs", "boombaket.barabaket.com", "public", "private")));
     // when
@@ -115,6 +117,43 @@ public class SshKeySecretProvisionerTest {
     assertEquals(secret.getData().size(), 2);
     assertTrue(secret.getData().containsKey("gothub.mk"));
     assertTrue(secret.getData().containsKey("boombaket.barabaket.com"));
+    assertFalse(secret.getData().containsKey(invalidName));
+  }
+
+  @Test(dataProvider = "invalidNames")
+  public void shouldIgnoreInvalidKeyNames(String invalidName) throws Exception {
+    assertFalse(
+        sshKeysProvisioner.isValidSshKeyPair(
+            new SshPairImpl(someUser, "vcs", invalidName, "public", "private")));
+  }
+
+  @Test(dataProvider = "validNames")
+  public void shouldAcceptValidKeyNames(String validName) throws Exception {
+    assertTrue(
+        sshKeysProvisioner.isValidSshKeyPair(
+            new SshPairImpl(someUser, "vcs", validName, "public", "private")));
+  }
+
+  @DataProvider
+  public static Object[][] invalidNames() {
+    return new Object[][] {
+      new Object[] {"https://foo.bar"},
+      new Object[] {"_fef_123-ah_*zz**"},
+      new Object[] {"_fef_123-ah_z.z"},
+      new Object[] {"a-b#-hello"},
+      new Object[] {"--ab--"}
+    };
+  }
+
+  @DataProvider
+  public static Object[][] validNames() {
+    return new Object[][] {
+      new Object[] {"foo.bar"},
+      new Object[] {"fef-123-ahzz"},
+      new Object[] {"fef0123-ahz.z"},
+      new Object[] {"a-b.hello"},
+      new Object[] {"a--a----------b"}
+    };
   }
 
   @Test

--- a/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeySecretProvisionerTest.java
+++ b/infrastructures/kubernetes/src/test/java/org/eclipse/che/workspace/infrastructure/kubernetes/provision/SshKeySecretProvisionerTest.java
@@ -99,6 +99,25 @@ public class SshKeySecretProvisionerTest {
   }
 
   @Test
+  public void shuldNotMountKeysWithInvalidKeyNames() throws Exception {
+    // given
+    when(sshManager.getPairs(someUser, "vcs"))
+        .thenReturn(
+            ImmutableList.of(
+                new SshPairImpl(someUser, "vcs", "http://blah.blah", "public", "private"),
+                new SshPairImpl(someUser, "vcs", "gothub.mk", "public", "private"),
+                new SshPairImpl(someUser, "vcs", "boombaket.barabaket.com", "public", "private")));
+    // when
+    sshKeysProvisioner.provision(k8sEnv, runtimeIdentity);
+    // then
+    Secret secret = k8sEnv.getSecrets().get("wksp-sshprivatekeys");
+    assertNotNull(secret);
+    assertEquals(secret.getData().size(), 2);
+    assertTrue(secret.getData().containsKey("gothub.mk"));
+    assertTrue(secret.getData().containsKey("boombaket.barabaket.com"));
+  }
+
+  @Test
   public void addSshKeysConfigInPod() throws Exception {
     String keyName1 = UUID.randomUUID().toString();
     String keyName2 = "default-" + UUID.randomUUID().toString();


### PR DESCRIPTION
### What does this PR do?
Do not mount ssh keys as secrets if the name is not a valid Kubernetes config map key name

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
Fixes https://github.com/eclipse/che/issues/19024


### How to test this PR?
-  deploy nightly. 
- create invalid ssh key
```bash
curl $CHE_SERVER_URL/api/ssh \
-H 'Authorization: Bearer '${KEYCLOAK_TOKEN} \
-H "Accept: application/json" \
-H "Content-Type:application/json" \
--data @<(cat <<EOF
  {
    "name": "http://github.com",
    "service": "vcs",
    "publicKey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCFs7ZasKC9XyaX02tYbW/8dWNdoce6hv48uK2Hgfqex+rYT+aV5lqCdVVKfzWQcF3gsM1i9Ee6w+Rr4HQ++QZtE4w2huT82uVcfLy/0Axyh6ZMyVTFpchykl8v93hQo1YaTgsUrokPQp/3gLLfcP9PNBOZn071HJK/zMIcyAjfzS8bCxQtMdI7aZd7ohb4ZiiymsFvoOInjDPKokr1E+GdfAIp4o+g6FZAA4cM7hW0EExzXMBtDEtw4sexiSrZWN6uTbFUVxVtoyKCh3Fyaumj6zVXRHCf+TqUGwURDGooO2RS5K0gzbX6uKSVn9P6uEQdb0f/cPurhX2cb1hRZyHH ",
    "privateKey": "-----BEGIN RSA PRIVATE KEY-----\nMIIEogIBAAKCAQEAhbO2WrCgvV8ml9NrWG1v/HVjXaHHuob+PLith4H6nsfq2E/m\nleZagnVVSn81kHBd4LDNYvRHusPka+B0PvkGbROMNobk/NrlXHy8v9AMcoemTMlU\nxaXIcpJfL/d4UKNWGk4LFK6JD0Kf94Cy33D/TzQTmZ9O9RySv8zCHMgI380vGwsU\nLTHSO2mXe6IW+GYosprBb6DiJ4wzyqJK9RPhnXwCKeKPoOhWQAOHDO4VtBBMc1zA\nbQxLcOLHsYkq2Vjerk2xVFcVbaMigodxcmrpo+s1V0Rwn/k6lBsFEQxqKDtkUuSt\nIM21+riklZ/T+rhEHW9H/3D7q4V9nG9YUWchxwIDAQABAoIBADs7+l9Ff4FGpYeA\nQD+mBIY5z7MM2Lr30a0/OIofeNRdx9rb01G4A4Nmzkm6ABYk4kKIsgXUKe9BmHJ+\nt6GqnEE49ta1fr/Tjughz1G/r7QSCwhb7jW+lAbGeGt83Q4Ev0HaL6iTBt/+6XYy\ny4yYuFPzw3c9EDMh3JYi9iDgMqZLzdLx3Luh+ChrCx34iDzEZtIcwPkvrcrUwgCY\nG01tRyn0xDmjlDlJKy+++FxTsBXjpZajMMgOprHI9RzdygdcS0kHB2e7FXjlNJIK\nWXXJrtHrdYb16PYEM9ksdwew8tywSsARD+OuzMkjIFcLo6IiCBx55Ab3Zl/+v/wS\n6YdoyjkCgYEA6b6qkZmbDKJqwA7q8f7+D55K4UlB8tWssSNM0avBMlReoijw4Bwq\nBfzlVvnARTJ+mOEAJu7H+cMTuv3DrAPInYJWYTS1PVga4a+AHITiTzbDesSENPKJ\n8i1XRy1BLH2Ql4dNLNYymwP6K2dwKi9MpKDhf83wK8iJY6QKWuZK4rsCgYEAkm6W\nNUYkvoFhxY+4xhMnwWqvwlTdm6tBIg+X4khf3F+W+gp8WdYunFyrBRk32DK/fhFo\nMvDvrbcWWCZ/mHs9Z6Vj6FCh6a7TlMJtUl6nXDVt/LJWklA89zhySf1c/SpDwKIw\nZ61AqnFKodM0TcYvo6BDL6uYsbPo9cT72fHrKmUCgYAoKPYtZfLZzN4CeY2sXl9Q\nV6YN5wRJsKSnGqWMMLJU72IDAn3AQ5aEyNquguKiAPb3VVEtX0FEjFvLeOYxm8TQ\nKyCkOuYY0BZuSDT+sWYgrgwP/8unPTSuQ1QHiqLz/e7l2f1MgtDXCWvmITOIS/Aj\nKPEVgFCPdTkFwZ112LNtGQKBgH5VhqaD0+PAgHgQXVwW3q/Subyxt1g80j7usR17\nT6kzl3A2Z76iOSiSEsKdVT7j2a6MmheJI1/+m/qFjIQjn4CygpXGK0sPmF+5ttPf\n8ght2Gyx+FrXeyHXw1LukrGhKz8hLx3jrezfPYKMU43eNO+4rv6Lz3tROuX/g0Iv\no7K5AoGAOrUD0BvS/BEQ1lmqUmVfvDYMuIzv8VoxecBRPBb4Zw1ojDNAQNNUytwK\nLPDikxj60S5WL2IpN/Db51i/EQCQXLDj52fv0sKdiFiEXbGjhS2kaea6yTkhXyn5\nBxnQYhyVtTTRw8bhbXwePL19dEEfuvRprNXgUOo53yWzORZKh9k=\n-----END RSA PRIVATE KEY-----\n",
    "service": "vcs"
  }
EOF
)
```
- try to start workspace It should fail.

![Знімок екрана 2021-02-10 о 15 37 10](https://user-images.githubusercontent.com/1614429/107517319-47ef0a00-6bb6-11eb-9450-4c760daf1697.png)
- Deploy new che-server image `quay.io/skabashn/che-server:che19024`
- Try to start the workspace again. It should start successfully.
- To delete invalid key use .
```bash
curl  -X DELETE -s $CHE_SERVER_URL'/api/ssh/vcs?name=http%3A%2F%2Fgithub.com'  -H 'Accept: application/json, text/plain'  -H 'Authorization: Bearer '${KEYCLOAK_TOKEN} 
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
