### PR TITLE
Temporarily disabling Scala:sbt test to allow more stable pre-release suite

### DIFF
--- a/tests/e2e/tests/devfiles/Scala.spec.ts
+++ b/tests/e2e/tests/devfiles/Scala.spec.ts
@@ -23,7 +23,8 @@ const runTaskName: string = 'sbt run';
 const testTaskName: string = 'sbt test';
 const stack: string = 'Scala';
 
-suite(`${stack} test`, async () => {
+// skipping scala to enable pre-release suite to be easily used for updates until https://github.com/eclipse/che/issues/18662 is fixed
+suite.skip(`${stack} test`, async () => {
     suite (`Create ${stack} workspace`, async () => {
         workspaceHandling.createAndOpenWorkspace(stack);
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);


### PR DESCRIPTION
### What does this PR do?
* Skips scala:sbt test suite until #18662 is fixed

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
#18662

### How to test this PR?
* Go into Eclipse repository che/tests/e2e
* Run `npm i` and verify that all packages install without errors
* Run `tsc` and verify that no errors are present
* Export following variables:
  * `TS_SELENIUM_BASE_URL`
  * `TS_SELENIUM_MULTIUSER=true`
  * `NODE_TLS_REJECT_UNAUTHORIZED=0`
  * `TS_SELENIUM_LOG_LEVEL="TRACE"`
  * `TS_SELENIUM_USERNAME`
  * `TS_SELENIUM_PASSWORD`
* Run `npm run test-java-vertx` to execute the smoke test devfile and verify that the tests are working correctly or run entire suite using `npm run test-all-devfiles`
* Tests should pass without a failure

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
