### PR TITLE
/devfile version parameter to provide concrete schema version

### DIFF
--- a/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/IoUtil.java
+++ b/core/commons/che-core-commons-lang/src/main/java/org/eclipse/che/commons/lang/IoUtil.java
@@ -17,6 +17,7 @@ import static java.nio.file.FileVisitResult.TERMINATE;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
@@ -137,7 +138,7 @@ public class IoUtil {
             ? new FileInputStream(resourceFile)
             : Thread.currentThread().getContextClassLoader().getResourceAsStream(resource);
     if (is == null) {
-      throw new IOException(String.format("Resource %s is not found", resource));
+      throw new FileNotFoundException(String.format("Resource %s is not found", resource));
     }
     return is;
   }

--- a/multiuser/permission/che-multiuser-permission-devfile/src/test/java/org/eclipse/che/multiuser/permission/devfile/server/filters/UserDevfilePermissionsFilterTest.java
+++ b/multiuser/permission/che-multiuser-permission-devfile/src/test/java/org/eclipse/che/multiuser/permission/devfile/server/filters/UserDevfilePermissionsFilterTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.che.multiuser.permission.devfile.server.filters;
 
 import static com.jayway.restassured.RestAssured.given;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
 import static org.everrest.assured.JettyHttpServer.SECURE_PATH;
@@ -138,9 +139,10 @@ public class UserDevfilePermissionsFilterTest {
 
   @Test
   public void shouldNotCheckAnyPermissionOnDevfileSchema()
-      throws BadRequestException, ForbiddenException, NotFoundException, ServerException {
+      throws NotFoundException, ServerException {
     // given
-    Mockito.when(devfileService.getSchema()).thenReturn(javax.ws.rs.core.Response.ok().build());
+    Mockito.when(devfileService.getSchema(CURRENT_API_VERSION))
+        .thenReturn(javax.ws.rs.core.Response.ok().build());
     // when
     final Response response =
         given()

--- a/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileServiceTest.java
+++ b/wsmaster/che-core-api-devfile/src/test/java/org/eclipse/che/api/devfile/server/DevfileServiceTest.java
@@ -19,6 +19,7 @@ import static org.eclipse.che.api.devfile.server.TestObjectGenerator.TEST_ACCOUN
 import static org.eclipse.che.api.devfile.server.TestObjectGenerator.TEST_SUBJECT;
 import static org.eclipse.che.api.devfile.server.TestObjectGenerator.USER_DEVFILE_ID;
 import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API_VERSION;
+import static org.eclipse.che.api.workspace.server.devfile.Constants.SUPPORTED_VERSIONS;
 import static org.eclipse.che.dto.server.DtoFactory.newDto;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_NAME;
 import static org.everrest.assured.JettyHttpServer.ADMIN_USER_PASSWORD;
@@ -125,6 +126,41 @@ public class DevfileServiceTest {
     assertEquals(response.getStatusCode(), 200);
     assertEquals(
         response.getBody().asString(), schemaProvider.getSchemaContent(CURRENT_API_VERSION));
+  }
+
+  @Test
+  public void shouldReturn404WhenSchemaNotFound() {
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/devfile?version=1.2.3.4.5");
+
+    assertEquals(response.getStatusCode(), 404);
+  }
+
+  @Test(dataProvider = "schemaVersions")
+  public void shouldRetrieveSchemaVersion(String version) throws Exception {
+    final Response response =
+        given()
+            .auth()
+            .basic(ADMIN_USER_NAME, ADMIN_USER_PASSWORD)
+            .when()
+            .get(SECURE_PATH + "/devfile?version=" + version);
+
+    assertEquals(response.getStatusCode(), 200);
+    assertEquals(response.getBody().asString(), schemaProvider.getSchemaContent(version));
+  }
+
+  @DataProvider
+  public static Object[][] schemaVersions() {
+    Object[][] versions = new Object[SUPPORTED_VERSIONS.size()][];
+    for (int i = 0; i < SUPPORTED_VERSIONS.size(); i++) {
+      versions[i] = new Object[] {SUPPORTED_VERSIONS.get(i)};
+    }
+
+    return versions;
   }
 
   @BeforeMethod

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProvider.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProvider.java
@@ -17,6 +17,7 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.SUPPORTED_V
 import static org.eclipse.che.commons.lang.IoUtil.getResource;
 import static org.eclipse.che.commons.lang.IoUtil.readAndCloseQuietly;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.ref.SoftReference;
@@ -28,7 +29,7 @@ import javax.inject.Singleton;
 @Singleton
 public class DevfileSchemaProvider {
 
-  private Map<String, SoftReference<String>> schemas = new HashMap<>();
+  private final Map<String, SoftReference<String>> schemas = new HashMap<>();
 
   public String getSchemaContent(String version) throws IOException {
     if (schemas.containsKey(version)) {
@@ -50,6 +51,11 @@ public class DevfileSchemaProvider {
   private String loadFile(String version) throws IOException {
     try {
       return readAndCloseQuietly(getResource(SCHEMAS_LOCATION + version + "/" + SCHEMA_FILENAME));
+    } catch (FileNotFoundException e) {
+      throw new FileNotFoundException(
+          String.format(
+              "Unable to find schema for devfile version '%s'. Supported versions are '%s'.",
+              version, SUPPORTED_VERSIONS));
     } catch (IOException ioe) {
       throw new IOException(
           String.format(

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProviderTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/schema/DevfileSchemaProviderTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.che.api.workspace.server.devfile.Constants.CURRENT_API
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 import org.testng.annotations.Test;
@@ -47,7 +48,7 @@ public class DevfileSchemaProviderTest {
             .contains("This schema describes the structure of the devfile object"));
   }
 
-  @Test(expectedExceptions = IOException.class)
+  @Test(expectedExceptions = FileNotFoundException.class)
   public void shouldThrowExceptionWhenInvalidVersionRequested() throws IOException {
     devfileSchemaProvider.getSchemaContent("this_is_clearly_not_a_valid_schema_version");
   }


### PR DESCRIPTION
### What does this PR do?
Adds `version` parameter on `/devfile` method of che-server REST API. This method returns devfile schema so now it would be possible to ask for a schema for exact version. The default is still `1.0.0`. If schema was not found, return 404.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19023


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

test image `quay.io/mvala/che-server:gh19023-devfileV2Schema`

1. deploy che with che-server image ^^
2. call `/devfile` REST API method with or without `version` parameter

request examples. you might need to add a token or use swagger:
 - valid 200, should return 1.0.0 schema
   - `curl -X GET --header 'Accept: application/json' 'https://<che-url>/api/devfile'`
 - valid 200 1.0.0 schema
   - `curl -X GET --header 'Accept: application/json' 'https://<che-url>/api/devfile?version=1.0.0'`
 - valid 200 2.0.0 schema (now there is only dummy schema in master, waiting for https://github.com/eclipse/che/pull/19012)
   - `curl -X GET --header 'Accept: application/json' 'https://<che-url>/api/devfile?version=2.0.0'`
 - invalid 404
   - `curl -X GET --header 'Accept: application/json' 'https://<che-url>/api/devfile?version=1.1.1'`


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
