### PR TITLE
Work around error highlighting and run application failures in Happy path tests

### DIFF
--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -372,6 +372,7 @@ EOL"""
                        -e TS_SELENIUM_PASSWORD="admin" \\
                        -e TEST_SUITE="${e2eTestToRun}" ${e2eTestParameters} \\
                        -e NODE_TLS_REJECT_UNAUTHORIZED=0 \\
+                       -e TS_SELENIUM_LOG_LEVEL="TRACE" \\
                        -v ${WORKSPACE}/tests/e2e:/tmp/e2e:Z \\
                        quay.io/eclipse/che-e2e:${cheE2eImageTag}
                 """

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -244,10 +244,6 @@ pipeline {
 
                             docker pull ${cheImageRepo}:${mutableCheImageTag}
                             docker pull docker.io/traefik:v2.2.8
-
-                            # temporary for issue https://github.com/eclipse/che/issues/19004
-                            docker pull maxura/che-theia-endpoint-runtime-binary:695
-                            docker pull maxura/che-theia:695
                         """
                     }
 

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -242,11 +242,12 @@ pipeline {
                             eval \$(minikube docker-env)
                             docker login -u maxura -p ${maxura_docker_password}
 
-                            docker pull mariolet/petclinic:d2831f9b
-                            docker pull centos/postgresql-96-centos7:9.6
-                            docker pull centos/mysql-57-centos7
                             docker pull ${cheImageRepo}:${mutableCheImageTag}
                             docker pull docker.io/traefik:v2.2.8
+
+                            # temporary for issue https://github.com/eclipse/che/issues/19004
+                            docker pull maxura/che-theia-endpoint-runtime-binary:695
+                            docker pull maxura/che-theia:695
                         """
                     }
 
@@ -423,8 +424,11 @@ EOL"""
                 mkdir -p $LOGS_AND_CONFIGS/workspace-logs
                 WORKSPACE_NAMESPACE_NAME=admin-che
                 export WS_POD=\$(kubectl get pod --namespace=\$WORKSPACE_NAMESPACE_NAME | grep ".workspace-" | awk '{print \$1}')
-                for c in \$(kubectl get pod --namespace=\$WORKSPACE_NAMESPACE_NAME \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do \\
-                    kubectl logs \$(kubectl get pod --namespace=\$WORKSPACE_NAMESPACE_NAME | grep ".workspace-" | awk '{print \$1}') "\${c}" --namespace=\$WORKSPACE_NAMESPACE_NAME > $LOGS_AND_CONFIGS/workspace-logs/"\${c}".container.log || true; \\
+                for c in \$(kubectl get pod --namespace=\$WORKSPACE_NAMESPACE_NAME \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do
+                    CONTAINER_LOGS_DIR=$LOGS_AND_CONFIGS/workspace-logs/"\${c}"
+                    mkdir \$CONTAINER_LOGS_DIR
+                    kubectl logs \$WS_POD "\${c}" --namespace=\$WORKSPACE_NAMESPACE_NAME > \${CONTAINER_LOGS_DIR}.container.log || true;
+                    kubectl cp \$WORKSPACE_NAMESPACE_NAME/\$WS_POD:/workspace-logs \$CONTAINER_LOGS_DIR -c "\${c}" || true;
                 done
                 kubectl describe pod --namespace=\$WORKSPACE_NAMESPACE_NAME \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
 

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -428,7 +428,7 @@ EOL"""
                     CONTAINER_LOGS_DIR=$LOGS_AND_CONFIGS/workspace-logs/"\${c}"
                     mkdir \$CONTAINER_LOGS_DIR
                     kubectl logs \$WS_POD "\${c}" --namespace=\$WORKSPACE_NAMESPACE_NAME > \${CONTAINER_LOGS_DIR}.container.log || true;
-                    kubectl cp \$WORKSPACE_NAMESPACE_NAME/\$WS_POD:/workspace-logs \$CONTAINER_LOGS_DIR -c "\${c}" || true;
+                    kubectl cp \$WORKSPACE_NAMESPACE_NAME/\$WS_POD:/workspace_logs \$CONTAINER_LOGS_DIR -c "\${c}" || true;
                 done
                 kubectl describe pod --namespace=\$WORKSPACE_NAMESPACE_NAME \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
 

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -398,6 +398,7 @@ EOL"""
                 mkdir -p $LOGS_AND_CONFIGS/kubectl
                 kubectl --namespace=eclipse-che get events > $LOGS_AND_CONFIGS/kubectl/events.txt || true
                 kubectl --namespace=eclipse-che get events -o json > $LOGS_AND_CONFIGS/kubectl/events.json || true
+                kubectl get pods -A >$LOGS_AND_CONFIGS/kubectl/pods.txt || true
 
                 mkdir -p $LOGS_AND_CONFIGS/che-config
 
@@ -416,13 +417,15 @@ EOL"""
                 for pod in \$PODS ; do \
                     kubectl logs --namespace=eclipse-che "\${pod}" --namespace=eclipse-che > $LOGS_AND_CONFIGS/che-logs/"\${pod}".pod.log || true; \
                 done
+                kubectl describe pod --namespace=eclipse-che \$WS_POD > $LOGS_AND_CONFIGS/che-config/eclipse-che-pod-description.txt || true
 
                 mkdir -p $LOGS_AND_CONFIGS/workspace-logs
-                export WS_POD=\$(kubectl get pod --namespace=eclipse-che | grep ".workspace-" | awk '{print \$1}')
-                for c in \$(kubectl get pod --namespace=eclipse-che \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do \\
-                    kubectl logs \$(kubectl get pod --namespace=eclipse-che | grep ".workspace-" | awk '{print \$1}') "\${c}" --namespace=eclipse-che > $LOGS_AND_CONFIGS/workspace-logs/"\${c}".container.log || true; \\
+                WORKSPACE_NAMESPACE_NAME=admin-che
+                export WS_POD=\$(kubectl get pod --namespace=\$WORKSPACE_NAMESPACE_NAME | grep ".workspace-" | awk '{print \$1}')
+                for c in \$(kubectl get pod --namespace=\$WORKSPACE_NAMESPACE_NAME \$WS_POD -o jsonpath="{.spec.containers[*].name}") ; do \\
+                    kubectl logs \$(kubectl get pod --namespace=\$WORKSPACE_NAMESPACE_NAME | grep ".workspace-" | awk '{print \$1}') "\${c}" --namespace=\$WORKSPACE_NAMESPACE_NAME > $LOGS_AND_CONFIGS/workspace-logs/"\${c}".container.log || true; \\
                 done
-                kubectl describe pod --namespace=eclipse-che \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
+                kubectl describe pod --namespace=\$WORKSPACE_NAMESPACE_NAME \$WS_POD > $LOGS_AND_CONFIGS/che-config/workspace-pod-description.txt || true
 
                 mkdir -p $LOGS_AND_CONFIGS/docker
                 docker image ls > $LOGS_AND_CONFIGS/docker/images.txt || true

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -70,9 +70,9 @@ export const TimeoutConstants = {
     TS_SUGGESTION_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 30_000,
 
     /**
-     * Timeout for error highlighting presence, "30 000" by default
+     * Timeout for error highlighting presence, "120 000" by default
      */
-    TS_ERROR_HIGHLIGHTING_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 90_000,
+    TS_ERROR_HIGHLIGHTING_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 120_000,
 
 
     // -------------------------------------------- PROJECT TREE --------------------------------------------

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -70,9 +70,9 @@ export const TimeoutConstants = {
     TS_SUGGESTION_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 30_000,
 
     /**
-     * Timeout for error highlighting presence, "10 000" by default
+     * Timeout for error highlighting presence, "30 000" by default
      */
-    TS_ERROR_HIGHLIGHTING_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 20_000,
+    TS_ERROR_HIGHLIGHTING_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 90_000,
 
 
     // -------------------------------------------- PROJECT TREE --------------------------------------------
@@ -130,7 +130,7 @@ export const TimeoutConstants = {
     /**
      * Timeout for debugger to connect, "30 000" by default
      */
-    TS_DEBUGGER_CONNECTION_TIMEOUT: Number(process.env.TS_DEBUGGER_CONNECTION_TIMEOUT) || 30_000,
+    TS_DEBUGGER_CONNECTION_TIMEOUT: Number(process.env.TS_DEBUGGER_CONNECTION_TIMEOUT) || 60_000,
 
     /**
      * Timeout for context menu manipulation, "10 000" by default

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -72,7 +72,7 @@ export const TimeoutConstants = {
     /**
      * Timeout for error highlighting presence, "120 000" by default
      */
-    TS_ERROR_HIGHLIGHTING_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 120_000,
+    TS_ERROR_HIGHLIGHTING_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 90_000,
 
 
     // -------------------------------------------- PROJECT TREE --------------------------------------------

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -65,9 +65,9 @@ export const TimeoutConstants = {
     TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT: Number(process.env.TS_SELENIUM_LANGUAGE_SERVER_START_TIMEOUT) || 180_000,
 
     /**
-     * Timeout for suggestion invoking, "30 000" by default.
+     * Timeout for suggestion invoking, "60 000" by default.
      */
-    TS_SUGGESTION_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 30_000,
+    TS_SUGGESTION_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 60_000,
 
     /**
      * Timeout for error highlighting presence, "90 000" by default

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -70,7 +70,7 @@ export const TimeoutConstants = {
     TS_SUGGESTION_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 30_000,
 
     /**
-     * Timeout for error highlighting presence, "120 000" by default
+     * Timeout for error highlighting presence, "90 000" by default
      */
     TS_ERROR_HIGHLIGHTING_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 90_000,
 

--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -128,7 +128,7 @@ export const TimeoutConstants = {
     TS_NOTIFICATION_CENTER_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 10_000,
 
     /**
-     * Timeout for debugger to connect, "30 000" by default
+     * Timeout for debugger to connect, "60 000" by default
      */
     TS_DEBUGGER_CONNECTION_TIMEOUT: Number(process.env.TS_DEBUGGER_CONNECTION_TIMEOUT) || 60_000,
 

--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -52,7 +52,7 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: cd /projects/petclinic && mvn package | tee /workspace_logs/build-output.log && tail -n 40 tee /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build-output.txt
+        command: cd /projects/petclinic && mvn package | tee /workspace_logs/build-output.log && tail -n 40 /workspace_logs/build-output.log | grep 'BUILD SUCCESS' > /projects/petclinic/result-build-output.txt
   - name: run
     actions:
       - type: exec

--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -9,8 +9,7 @@ projects:
       location: "https://github.com/spring-projects/spring-petclinic.git"
 components:
   - type: cheEditor
-    alias: che-theia
-    reference: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-695/che_theia_meta.yaml
+    id: eclipse/che-theia/next
     memoryLimit: 512Mi
   - type: kubernetes
     alias: petclinic-web

--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -46,30 +46,30 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: mvn clean package | tee build.txt && tail -n 40 /projects/petclinic/build.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build.txt
+        command: mvn clean package | tee /workspace_logs/build.log && tail -n 40 /projects/petclinic/build.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build.txt
         workdir: /projects/petclinic
   - name: build-file-output
     actions:
       - type: exec
         component: maven-container
-        command: cd /projects/petclinic && mvn package | tee build-output.txt && tail -n 40 /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build-output.txt
+        command: cd /projects/petclinic && mvn package | tee /workspace_logs/build-output.log && tail -n 40 tee /projects/petclinic/build-output.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build-output.txt
   - name: run
     actions:
       - type: exec
         component: maven-container
-        command: java -jar spring-petclinic-2.4.2.jar --spring.profiles.active=mysql
+        command: java -jar spring-petclinic-2.4.2.jar --spring.profiles.active=mysql | tee /workspace_logs/run.log
         workdir: /projects/petclinic/target
   - name: run-with-changes
     actions:
       - type: exec
         component: maven-container
-        command: java -jar spring-petclinic-2.4.2.jar --spring.profiles.active=mysql
+        command: java -jar spring-petclinic-2.4.2.jar --spring.profiles.active=mysql | tee /workspace_logs/run-with-changes.log
         workdir: /projects/petclinic/target
   - name: run-debug
     actions:
       - type: exec
         component: maven-container
-        command: java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 spring-petclinic-2.4.2.jar --spring.profiles.active=mysql
+        command: java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 spring-petclinic-2.4.2.jar --spring.profiles.active=mysql | tee /workspace_logs/run-debug.log
         workdir: /projects/petclinic/target
   - name: Debug remote java application
     actions:

--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -9,7 +9,8 @@ projects:
       location: "https://github.com/spring-projects/spring-petclinic.git"
 components:
   - type: cheEditor
-    id: eclipse/che-theia/next
+    alias: che-theia
+    reference: https://raw.githubusercontent.com/chepullreq4/pr-check-files/master/che-theia/pr-695/che_theia_meta.yaml
     memoryLimit: 512Mi
   - type: kubernetes
     alias: petclinic-web

--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -46,7 +46,7 @@ commands:
     actions:
       - type: exec
         component: maven-container
-        command: mvn clean package | tee /workspace_logs/build.log && tail -n 40 /projects/petclinic/build.txt | grep 'BUILD SUCCESS' > /projects/petclinic/result-build.txt
+        command: mvn clean package | tee /workspace_logs/build.log && tail -n 40 /workspace_logs/build.log | grep 'BUILD SUCCESS' > /projects/petclinic/result-build.txt
         workdir: /projects/petclinic
   - name: build-file-output
     actions:

--- a/tests/e2e/pageobjects/ide/DebugView.ts
+++ b/tests/e2e/pageobjects/ide/DebugView.ts
@@ -11,7 +11,7 @@ import { inject, injectable } from 'inversify';
 import { CLASSES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { By, Key, WebElement } from 'selenium-webdriver';
+import { By, Key, WebElement, error } from 'selenium-webdriver';
 import { Ide } from './Ide';
 import { Logger } from '../../utils/Logger';
 import { TimeoutConstants } from '../../TimeoutConstants';
@@ -56,12 +56,19 @@ export class DebugView {
 
             const threadsTreeLocator = `//div[contains(@class, 'theia-debug-thread')]`;
 
-            const threadElements: WebElement[] = await this.driverHelper.waitAllPresence(By.xpath(threadsTreeLocator));
-            if (threadElements.length > 1) {
-                return true;
+            try {
+                const threadElements: WebElement[] = await this.driverHelper.waitAllPresence(By.xpath(threadsTreeLocator));
+                if (threadElements.length > 1) {
+                    return true;
+                }
+        
+            } catch (err) {
+                if (!(err instanceof error.TimeoutError)) {
+                    throw err;
+                }
+                
+                return await this.driverHelper.wait(TestConstants.TS_SELENIUM_DEFAULT_POLLING);
             }
-
-            await this.driverHelper.wait(TestConstants.TS_SELENIUM_DEFAULT_POLLING);
         }, timeout);
     }
 

--- a/tests/e2e/pageobjects/ide/DebugView.ts
+++ b/tests/e2e/pageobjects/ide/DebugView.ts
@@ -9,6 +9,7 @@
  **********************************************************************/
 import { inject, injectable } from 'inversify';
 import { CLASSES } from '../../inversify.types';
+import { TestConstants } from '../../TestConstants';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { By, Key, WebElement } from 'selenium-webdriver';
 import { Ide } from './Ide';
@@ -59,7 +60,8 @@ export class DebugView {
             if (threadElements.length > 1) {
                 return true;
             }
-            return false;
+
+            await this.driverHelper.wait(TestConstants.TS_SELENIUM_DEFAULT_POLLING);
         }, timeout);
     }
 

--- a/tests/e2e/pageobjects/ide/Ide.ts
+++ b/tests/e2e/pageobjects/ide/Ide.ts
@@ -114,7 +114,7 @@ export class Ide {
     async waitNotificationAndOpenLink(notificationText: string, timeout: number) {
         Logger.debug(`Ide.waitNotificationAndOpenLink "${notificationText}"`);
         await this.waitNotification(notificationText, timeout);
-        await this.waitApllicationIsReady(await this.getApplicationUrlFromNotification(notificationText), timeout);
+        // await this.waitApllicationIsReady(await this.getApplicationUrlFromNotification(notificationText), timeout);  // workaround https://github.com/eclipse/che/issues/19085
         await this.waitNotificationAndClickOnButton(notificationText, 'Open Link', timeout);
     }
 

--- a/tests/e2e/pageobjects/ide/Ide.ts
+++ b/tests/e2e/pageobjects/ide/Ide.ts
@@ -114,7 +114,6 @@ export class Ide {
     async waitNotificationAndOpenLink(notificationText: string, timeout: number) {
         Logger.debug(`Ide.waitNotificationAndOpenLink "${notificationText}"`);
         await this.waitNotification(notificationText, timeout);
-        // await this.waitApllicationIsReady(await this.getApplicationUrlFromNotification(notificationText), timeout);  // workaround https://github.com/eclipse/che/issues/19085
         await this.waitNotificationAndClickOnButton(notificationText, 'Open Link', timeout);
     }
 

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -115,18 +115,18 @@ suite('Language server validation', async () => {
     });
 
     test('Error highlighting', async () => {
+        await driverHelper.getDriver().sleep(TimeoutConstants.TS_SUGGESTION_TIMEOUT);   // workaround https://github.com/eclipse/che/issues/19004
+        
         const textForErrorDisplaying: string = '$';
-
         await editor.type(javaFileName, textForErrorDisplaying, 30);
 
         try {
             await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT);
         } catch (err) {
-            Logger.debug('Workaround for the https://github.com/eclipse/che/issues/18974 issue.');
+            Logger.debug('Workaround for the https://github.com/eclipse/che/issues/18974.');
             await driverHelper.reloadPage();
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde();
-            await editor.type(javaFileName, Key.chord(Key.END), 30);
             await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT * 2);
         }
 

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -126,8 +126,7 @@ suite('Language server validation', async () => {
             await driverHelper.reloadPage();
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde();
-            await projectTree.expandPathAndOpenFile(pathToJavaFolder, javaFileName);
-            await editor.selectTab(javaFileName);
+            await editor.type(javaFileName, Key.chord(Key.END), 30);
             await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT * 2);
         }
 

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -115,22 +115,23 @@ suite('Language server validation', async () => {
     });
 
     test('Error highlighting', async () => {
-        const textForErrorDisplaying: string = '$#%@#';
+        const textForErrorDisplaying: string = '$';
 
         await editor.type(javaFileName, textForErrorDisplaying, 30);
 
         try {
-            await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT * 3);
+            await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT);
         } catch (err) {
             Logger.debug('Workaround for the https://github.com/eclipse/che/issues/18974 issue.');
-            await (await driverHelper.getDriver()).navigate().refresh();
-
+            await driverHelper.reloadPage();
             await ide.waitAndSwitchToIdeFrame();
+            await ide.waitIde();
+            await projectTree.expandPathAndOpenFile(pathToJavaFolder, javaFileName);
             await editor.selectTab(javaFileName);
-            await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT * 3);
+            await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT * 2);
         }
 
-        await editor.performKeyCombination(javaFileName, Key.chord(Key.BACK_SPACE, Key.BACK_SPACE, Key.BACK_SPACE, Key.BACK_SPACE, Key.BACK_SPACE));
+        await editor.performKeyCombination(javaFileName, Key.chord(Key.BACK_SPACE));
         await editor.waitErrorInLineDisappearance(30);
     });
 
@@ -170,10 +171,6 @@ suite('Validation of workspace build and run', async () => {
     test('Build application', async () => {
         let buildTaskName: string = 'build-file-output';
         await topMenu.runTask('build-file-output');
-
-        // workaround for issue: https://github.com/eclipse/che/issues/14771
-
-        // await projectTree.expandPathAndOpenFileInAssociatedWorkspace(projectName, 'build-output.txt');
         await terminal.waitIconSuccess(buildTaskName, 250_000);
     });
 


### PR DESCRIPTION
### What does this PR do?

Change list:
- workaround of Happy path tests failure on check "Error highlighting" ability;
- removes redundant verification in 'Validation of workspace build and run' step;
- fixes pr-check Jenkins file: restores grabbing of workspace logs; doesn't pre-pull outdated docker images;
- saves build, run and debug logs of Happy path test application;
- sets `TS_SELENIUM_LOG_LEVEL="TRACE"` when run Happy path tests in PR check.

### What issues does this PR fix or reference?
#19004, #19085

### How to test this PR?
Run Happy path tests against PR https://github.com/eclipse/che-theia/pull/695

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
