### PR TITLE
Hostname configuration of workspace routes

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -538,8 +538,11 @@ che.infra.openshift.trusted_ca.dest_configmap_labels=config.openshift.io/inject-
 # Additional labels to add into every Route created by Che server
 # to allow clear identification.
 che.infra.openshift.route.labels=NULL
+
 # The hostname that should be used as a suffix for the workspace routes.
 # For example host=open.che.org then the route will look like routed3qrtkptr0.open.che.org
+# It has to be a valid DNS name.
+# It's recommend to keep the length of this property less then 47 characters.
 che.infra.openshift.route.host.domain_suffix=NULL
 
 ### Experimental properties

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -540,7 +540,7 @@ che.infra.openshift.trusted_ca.dest_configmap_labels=config.openshift.io/inject-
 che.infra.openshift.route.labels=NULL
 # The hostname that should be used as a suffix for the workspace routes.
 # For example host=open.che.org then the route will look like routed3qrtkptr0.open.che.org
-che.infra.openshift.route.host=NULL
+che.infra.openshift.route.host.domain_suffix=NULL
 
 ### Experimental properties
 

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -538,6 +538,9 @@ che.infra.openshift.trusted_ca.dest_configmap_labels=config.openshift.io/inject-
 # Additional labels to add into every Route created by Che server
 # to allow clear identification.
 che.infra.openshift.route.labels=NULL
+# The hostname that should be used as a suffix for the workspace routes.
+# For example host=open.che.org then the route will look like routed3qrtkptr0.open.che.org
+che.infra.openshift.route.host=NULL
 
 ### Experimental properties
 

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -542,7 +542,6 @@ che.infra.openshift.route.labels=NULL
 # The hostname that should be used as a suffix for the workspace routes.
 # For example host=open.che.org then the route will look like routed3qrtk.open.che.org
 # It has to be a valid DNS name.
-# It's recommend to keep the length of this property less then 51 characters.
 che.infra.openshift.route.host.domain_suffix=NULL
 
 ### Experimental properties

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -540,9 +540,9 @@ che.infra.openshift.trusted_ca.dest_configmap_labels=config.openshift.io/inject-
 che.infra.openshift.route.labels=NULL
 
 # The hostname that should be used as a suffix for the workspace routes.
-# For example host=open.che.org then the route will look like routed3qrtkptr0.open.che.org
+# For example host=open.che.org then the route will look like routed3qrtk.open.che.org
 # It has to be a valid DNS name.
-# It's recommend to keep the length of this property less then 47 characters.
+# It's recommend to keep the length of this property less then 51 characters.
 che.infra.openshift.route.host.domain_suffix=NULL
 
 ### Experimental properties

--- a/infrastructures/openshift/pom.xml
+++ b/infrastructures/openshift/pom.xml
@@ -96,6 +96,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-lang</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-tracing</artifactId>
         </dependency>
         <dependency>

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerExposer.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerExposer.java
@@ -26,6 +26,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 import org.eclipse.che.api.core.model.workspace.config.ServerConfig;
 import org.eclipse.che.commons.annotation.Nullable;
+import org.eclipse.che.commons.lang.NameGenerator;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Annotations;
 import org.eclipse.che.workspace.infrastructure.kubernetes.Names;
 import org.eclipse.che.workspace.infrastructure.kubernetes.server.external.ExternalServerExposer;
@@ -99,14 +100,17 @@ import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftE
 public class RouteServerExposer implements ExternalServerExposer<OpenShiftEnvironment> {
 
   private final Map<String, String> labels;
+  private final String host;
 
   @Inject
   public RouteServerExposer(
-      @Nullable @Named("che.infra.openshift.route.labels") String labelsProperty) {
+      @Nullable @Named("che.infra.openshift.route.labels") String labelsProperty,
+      @Nullable @Named("che.infra.openshift.route.host") String host) {
     this.labels =
         labelsProperty != null
             ? Splitter.on(",").withKeyValueSeparator("=").split(labelsProperty)
             : emptyMap();
+    this.host = host;
   }
 
   @Override
@@ -124,6 +128,7 @@ public class RouteServerExposer implements ExternalServerExposer<OpenShiftEnviro
             .withTargetPort(servicePort.getName())
             .withServers(externalServers)
             .withLabels(labels)
+            .withHost(host != null ? NameGenerator.generate("route", "." + host, 10) : null)
             .withTo(serviceName)
             .build();
     env.getRoutes().put(commonRoute.getMetadata().getName(), commonRoute);
@@ -132,6 +137,7 @@ public class RouteServerExposer implements ExternalServerExposer<OpenShiftEnviro
   private static class RouteBuilder {
 
     private String name;
+    private String host;
     private String serviceName;
     private IntOrString targetPort;
     private Map<String, ServerConfig> servers;
@@ -145,6 +151,11 @@ public class RouteServerExposer implements ExternalServerExposer<OpenShiftEnviro
 
     private RouteBuilder withTo(String serviceName) {
       this.serviceName = serviceName;
+      return this;
+    }
+
+    private RouteBuilder withHost(String host) {
+      this.host = host;
       return this;
     }
 
@@ -189,6 +200,7 @@ public class RouteServerExposer implements ExternalServerExposer<OpenShiftEnviro
           .withLabels(labels)
           .endMetadata()
           .withNewSpec()
+          .withHost(host)
           .withNewTo()
           .withName(serviceName)
           .endTo()

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerExposer.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerExposer.java
@@ -130,7 +130,7 @@ public class RouteServerExposer implements ExternalServerExposer<OpenShiftEnviro
             .withLabels(labels)
             .withHost(
                 domainSuffix != null
-                    ? NameGenerator.generate("route", "." + domainSuffix, 10)
+                    ? NameGenerator.generate("route", "." + domainSuffix, 6)
                     : null)
             .withTo(serviceName)
             .build();

--- a/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerExposer.java
+++ b/infrastructures/openshift/src/main/java/org/eclipse/che/workspace/infrastructure/openshift/server/RouteServerExposer.java
@@ -100,17 +100,17 @@ import org.eclipse.che.workspace.infrastructure.openshift.environment.OpenShiftE
 public class RouteServerExposer implements ExternalServerExposer<OpenShiftEnvironment> {
 
   private final Map<String, String> labels;
-  private final String host;
+  private final String domainSuffix;
 
   @Inject
   public RouteServerExposer(
       @Nullable @Named("che.infra.openshift.route.labels") String labelsProperty,
-      @Nullable @Named("che.infra.openshift.route.host") String host) {
+      @Nullable @Named("che.infra.openshift.route.host.domain_suffix") String domainSuffix) {
     this.labels =
         labelsProperty != null
             ? Splitter.on(",").withKeyValueSeparator("=").split(labelsProperty)
             : emptyMap();
-    this.host = host;
+    this.domainSuffix = domainSuffix;
   }
 
   @Override
@@ -128,7 +128,10 @@ public class RouteServerExposer implements ExternalServerExposer<OpenShiftEnviro
             .withTargetPort(servicePort.getName())
             .withServers(externalServers)
             .withLabels(labels)
-            .withHost(host != null ? NameGenerator.generate("route", "." + host, 10) : null)
+            .withHost(
+                domainSuffix != null
+                    ? NameGenerator.generate("route", "." + domainSuffix, 10)
+                    : null)
             .withTo(serviceName)
             .build();
     env.getRoutes().put(commonRoute.getMetadata().getName(), commonRoute);

--- a/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftPreviewUrlExposerTest.java
+++ b/infrastructures/openshift/src/test/java/org/eclipse/che/workspace/infrastructure/openshift/server/OpenShiftPreviewUrlExposerTest.java
@@ -43,7 +43,7 @@ public class OpenShiftPreviewUrlExposerTest {
 
   @BeforeMethod
   public void setUp() {
-    RouteServerExposer externalServerExposer = new RouteServerExposer("a=b");
+    RouteServerExposer externalServerExposer = new RouteServerExposer("a=b", null);
     previewUrlEndpointsProvisioner = new OpenShiftPreviewUrlExposer(externalServerExposer);
   }
 


### PR DESCRIPTION
### What does this PR do?
Hostname configuration of workspace routes

### Screenshot/screencast of this PR
<img width="1680" alt="Знімок екрана 2021-02-24 о 16 44 52" src="https://user-images.githubusercontent.com/1614429/109144431-d4c6c580-7769-11eb-9f3c-9f8df4247f8b.png">



### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-1466


### How to test this PR?
Setup keys
```
CLUSTER_HOST=$(oc get route/console --namespace=openshift-console -o=jsonpath={'.status.ingress[0].routerCanonicalHostname'})
echo 'Cluster host:'$CLUSTER_HOST

DOMAIN=$CLUSTER_HOST
DNS_ENTRIES=DNS:${DOMAIN},DNS:*.${DOMAIN},DNS:*.sharded.${DOMAIN}
CHE_CA_CN='Local Eclipse Che Signer'
CHE_CA_KEY_FILE='ca.key'
CHE_CA_CERT_FILE='ca.crt'
CHE_SERVER_ORG='Local Eclipse Che'
CHE_SERVER_KEY_FILE='domain.key'
CHE_SERVER_CERT_REQUEST_FILE='domain.csr'
CHE_SERVER_CERT_FILE='domain.crt'
# Figure out openssl configuration file location
OPENSSL_CNF='/etc/pki/tls/openssl.cnf'
if [ ! -f $OPENSSL_CNF ]; then
    OPENSSL_CNF='/etc/ssl/openssl.cnf'
fi
openssl genrsa -out $CHE_CA_KEY_FILE 4096
openssl req -new -x509 -nodes -key $CHE_CA_KEY_FILE -sha256 \
            -subj /CN="${CHE_CA_CN}" \
            -days 1024 \
            -reqexts SAN -extensions SAN \
            -config <(cat ${OPENSSL_CNF} <(printf '[SAN]\nbasicConstraints=critical, CA:TRUE\nkeyUsage=keyCertSign, cRLSign, digitalSignature')) \
            -outform PEM -out $CHE_CA_CERT_FILE
openssl genrsa -out $CHE_SERVER_KEY_FILE 2048
openssl req -new -sha256 -key $CHE_SERVER_KEY_FILE \
            -subj "/O=${CHE_SERVER_ORG}/CN=${DOMAIN}" \
            -reqexts SAN \
            -config <(cat $OPENSSL_CNF <(printf "\n[SAN]\nsubjectAltName=${DNS_ENTRIES}\nbasicConstraints=critical, CA:FALSE\nkeyUsage=digitalSignature, keyEncipherment, keyAgreement, dataEncipherment\nextendedKeyUsage=serverAuth")) \
            -outform PEM -out $CHE_SERVER_CERT_REQUEST_FILE
openssl x509 -req -in $CHE_SERVER_CERT_REQUEST_FILE -CA $CHE_CA_CERT_FILE -CAkey $CHE_CA_KEY_FILE -CAcreateserial \
             -days 365 \
             -sha256 \
             -extfile <(printf "subjectAltName=${DNS_ENTRIES}\nbasicConstraints=critical, CA:FALSE\nkeyUsage=digitalSignature, keyEncipherment, keyAgreement, dataEncipherment\nextendedKeyUsage=serverAuth") \
             -outform PEM -out $CHE_SERVER_CERT_FILE

oc create configmap custom-ca --from-file=ca-bundle.crt=ca.crt  -n openshift-config
oc patch proxy/cluster     --type=merge      --patch='{"spec":{"trustedCA":{"name":"custom-ca"}}}'
cat domain.crt ca.crt > openshift.crt
oc create secret tls certificate      --cert=openshift.crt      --key=domain.key      -n openshift-ingress
oc patch ingresscontroller.operator default      --type=merge -p      '{"spec":{"defaultCertificate": {"name": "certificate"}}}' -n openshift-ingress-operator
```
Patch routes and setup che
```
CLUSTER_HOST=$(oc get route/console --namespace=openshift-console -o=jsonpath={'.status.ingress[0].routerCanonicalHostname'})
echo 'Cluster host:'$CLUSTER_HOST

oc label route/console type=default -n openshift-console
oc label route/oauth-openshift type=default -n openshift-authentication
oc label route/default-route type=default -n  openshift-image-registry
oc patch ingresscontroller/default --patch "{\"spec\":{\"routeSelector\":{\"matchLabels\": {\"type\": \"default\"}}}}" --type=merge -n openshift-ingress-operator

oc apply -f - <<EOF
apiVersion: operator.openshift.io/v1
kind: IngressController
metadata:
  name: sharded
  namespace: openshift-ingress-operator
spec:
  domain: sharded.$CLUSTER_HOST
  defaultCertificate:
    name: certificate
  replicas: 2
  routeSelector:
    matchLabels:
      type: sharded
EOF

cat > cr-patch.yaml<<EOF
spec:
  server:
    devfileRegistryRoute:
      labels: type=sharded
      domain: sharded.$CLUSTER_HOST
    pluginRegistryRoute:
      labels: type=sharded
      domain: sharded.$CLUSTER_HOST
    cheServerRoute:
      labels: type=sharded
      domain: sharded.$CLUSTER_HOST
  auth:
    identityProviderRoute:
      labels: type=sharded
      domain: sharded.$CLUSTER_HOST
EOF
chectl server:deploy --platform openshift --installer operator --che-operator-cr-patch-yaml cr-patch.yaml



```
deploy che-server image : `quay.io/skabashn/che-server:CRW-1466`

Setup Che
```
che.infra.openshift.route.labels=type=sharded
che.infra.openshift.route.host.domain_suffix=sharded.apps.cluster-devtools-<>.example.opentlc.com

```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
