### PR TITLE
[Selenium] Increase number of timeout to stabilize 'OpenshiftConnector' e2e test

### DIFF
--- a/tests/e2e/TimeoutConstants.ts
+++ b/tests/e2e/TimeoutConstants.ts
@@ -78,9 +78,9 @@ export const TimeoutConstants = {
     // -------------------------------------------- PROJECT TREE --------------------------------------------
 
     /**
-     * Wait for IDE showing project tree tab, "20 000" by default.
+     * Wait for IDE showing project tree tab, "60 000" by default.
      */
-    TS_PROJECT_TREE_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 20_000,
+    TS_PROJECT_TREE_TIMEOUT: Number(process.env.TS_OPEN_PROJECT_TREE_TIMEOUT) || 60_000,
 
     /**
      * Click on item timeout (project tree), "10 000" by default.


### PR DESCRIPTION
### What does this PR do?
* Increase the timeout od waiting project explorer to stabilize 'OpenshiftConnector' E2E test


### Screenshot/screencast of this PR
* Some launches of test on 'ci.centos' show instability of test when wait project explorer:
```
     TimeoutError: Exceeded maximum visibility checkings attempts for 'By(xpath, //div[@id='theia-left-content-panel']//ul[@class='p-TabBar-content']//li[@title[contains(.,'Explorer')] and contains(@id, 'shell-tab')])' element, timeouted after 20000
      at DriverHelper.waitVisibility (/tmp/e2e/utils/DriverHelper.ts:152:15)
      at process._tickCallback (internal/process/next_tick.js:68:7)
 ```
![ci-centos-os-plugun-test](https://user-images.githubusercontent.com/5408906/109631073-4b8b0680-7b4e-11eb-8314-41dcd721d100.png)


### What issues does this PR fix or reference?
#19002