### PR TITLE
generate changelog and include in GH release 

### DIFF
--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -23,13 +23,23 @@ jobs:
       - uses: actions/checkout@v2
         with: 
           fetch-depth: 0
+      - name: Set up GH checkout and tokens
+        run: |
+          git config --global user.name "Mykhailo Kuznietsov"
+          git config --global user.email "mkuznets@redhat.com"
+          git config --global push.default matching
+          export GITHUB_TOKEN=${{ secrets.CHE_BOT_GITHUB_TOKEN }}
+          export CHE_BOT_GITHUB_TOKEN=${{ secrets.CHE_BOT_GITHUB_TOKEN }}
       - name: Create changelog
         id: generate-release-changelog
         # wrapper for https://github.com/github-changelog-generator/github-changelog-generator
         uses: heinrichreimer/github-changelog-generator-action@v2.2
         env:
           GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}
-          CHANGELOG_GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }} 
+          CHANGELOG_GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}
+          # TODO: Do we need to set these env vars too?
+          # INPUT_TOKEN
+          # ACTIONS_RUNTIME_TOKEN
         with:
           repo: eclipse/che 
           # output: CHANGELOG-next.md

--- a/.github/workflows/release-changelog.yml
+++ b/.github/workflows/release-changelog.yml
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+name: Release changelog
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version that is going to be released. Should be in format 7.y.z'
+        required: true
+        default: ''
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with: 
+          fetch-depth: 0
+      - name: Create changelog
+        id: generate-release-changelog
+        # wrapper for https://github.com/github-changelog-generator/github-changelog-generator
+        uses: heinrichreimer/github-changelog-generator-action@v2.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}
+          CHANGELOG_GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }} 
+        with:
+          repo: eclipse/che 
+          # output: CHANGELOG-next.md
+          dateFormat: "%Y-%m-%d"
+          onlyLastTag: "true"
+          stripHeaders: "true"
+          stripGeneratorNotice: "true"
+          maxIssues: 200
+          verbose: true
+          releaseBranch: master # TODO: change to main
+          dueTag: ${{ github.event.inputs.version }} # all issues up to the current release tag
+          filterByMilestone: false # this requires that we get good at setting milestone when something is actually DONE rather than when we think it'll be done
+          pullRequests: false # only include issues, not PRs, since PRs span multiple repos and are too noisy to include
+          issuesWoLabels: false # no labels? no logged change
+          issues: true
+          issueLineLabels: "ALL"
+          compareLink: true
+          unreleased: true # show unreleased, but closed items
+          addSections: '{"sprint/current-sprint":{"prefix":"**Issues in Current Sprint:**","labels":["sprint/current-sprint"]}, "new&noteworthy":{"prefix":"**New and Noteworthy Issues:**","labels":["new&noteworthy"]}}'
+          excludeTags: '' # comma,delimited,list,of,tags
+          # includeLabels: ''
+          excludeLabels: "kind/release"
+          enhancementLabel: "Enhancements, Epics, and UX"
+          enhancementLabels: "kind/enhancement,kind/epic,kind/ux"
+          bugsLabel: "Bugs fixed"
+          bugLabels: "kind/bug"
+          token: ${{ secrets.CHE_BOT_GITHUB_TOKEN }} 
+      - name: Create GH Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }} 
+        with:
+          tag_name: ${{ github.event.inputs.version}}
+          release_name: Eclipse Che ${{ github.event.inputs.version}}
+          body: ${{ steps.generate-release-changelog.outputs.changelog }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
### What does this PR do?

generate changelog and include in GH release

Change-Id: I9dba0e8b2c8e5b7eb687ff454ea75556bfdb06c1
Signed-off-by: nickboldt <nboldt@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
N/A (or see commit message above for issue number)

### How to test this PR?

I tried testing this from https://github.com/eclipse/che/actions/workflows/release.yml via the create-gh-release-when-releasing branch but it never accepted the CHE_BOT token so was always rate limited. Hoping that's because it was from a topic branch rather than master branch. 

If we merge this, we can validate that theory, then we can call this action from che-release so that it fires only when the release is done (after chectl?), rather than when che server is done. 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.