### PR TITLE
Disable broken repo from Che Happy path tests pipeline

### DIFF
--- a/tests/.infra/crw-ci/dashboard-next/pr-check/Jenkinsfile
+++ b/tests/.infra/crw-ci/dashboard-next/pr-check/Jenkinsfile
@@ -141,12 +141,17 @@ pipeline {
                     steps {
                         echo "Install dependencies needed for build of Eclipse Che"
                         sh """
-                            sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686 || true
-
                             # workaround https://github.com/eclipse/che/issues/19093
-                            sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686 || true
-                            sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686 || true
-                            sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686
+                            for i in {1..12} 
+                            do
+                                echo "-- ITERATION \$i --"
+                                sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686 \\
+                                    --disablerepo=rhel-7-server-extras-os-rpms,rhel-7-server-ose-3.4-os-rpms,rhel-7-server-optional-os-rpms || true
+                            done
+                            
+                            sudo yum list installed | grep "glibc.i686"
+                            sudo yum list installed | grep "fontconfig.i686"
+                            sudo yum list installed | grep "libstdc++-devel.i686"
                         """
 
                         echo "Build branch ${ghprbSourceBranch} of upstream projects"

--- a/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
+++ b/tests/.infra/crw-ci/pr-check/k8s/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
     stages {
         stage("Setup environment") {
             steps {
-                script { 
+                script {
                     if (cheImageTag == null || cheImageTag == '') {
                         mutableCheImageTag = ghprbPullId
                     } else {
@@ -162,12 +162,17 @@ pipeline {
                     steps {
                         echo "Install dependencies needed for build of Eclipse Che"
                         sh """
-                            sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686 || true
-
                             # workaround https://github.com/eclipse/che/issues/19093
-                            sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686 || true
-                            sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686 || true
-                            sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686
+                            for i in {1..12} 
+                            do
+                                echo "-- ITERATION \$i --"
+                                sudo yum install -y glibc.i686 libfontconfig.so.1 libstdc++-devel.i686 \\
+                                    --disablerepo=rhel-7-server-extras-os-rpms,rhel-7-server-ose-3.4-os-rpms,rhel-7-server-optional-os-rpms || true
+                            done
+                            
+                            sudo yum list installed | grep "glibc.i686"
+                            sudo yum list installed | grep "fontconfig.i686"
+                            sudo yum list installed | grep "libstdc++-devel.i686"
                         """
 
                         echo "Build branch ${ghprbSourceBranch} of upstream projects"


### PR DESCRIPTION
### What does this PR do?
PR disables broken Centos 7 repos from Che Happy path tests pipeline when run it on CRW Jenkins CI.

- Eclipse Che repo happy path tests report: https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/Multiuser-Che-PR-check-E2E-Happy-path-tests-against-k8s/detail/Multiuser-Che-PR-check-E2E-Happy-path-tests-against-k8s/4684/

- Eclipse Che Dashboard repo happy path tests report: https://codeready-workspaces-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/blue/organizations/jenkins/dashboard-next-happy-path/detail/dashboard-next-happy-path/445

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
#19093 


### How to test this PR?
Run PR Happy path tests.


### PR Checklist
- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
