### PR TITLE
feat(machine-exec): Remove default machine-exec component as it is provided by che-theia meta/devfile now

### DIFF
--- a/.ci/set_tag_version_images.sh
+++ b/.ci/set_tag_version_images.sh
@@ -17,9 +17,7 @@ sed_in_place() {
 # only use /latest plugins so updates are smoother (old plugins are deleted from registries with each new release)
 plugin_version="latest"
 sed_in_place -r -e "s#che.factory.default_editor=eclipse/che-theia/.*#che.factory.default_editor=eclipse/che-theia/$plugin_version#g" ../assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
-sed_in_place -r -e "s#che.factory.default_plugins=eclipse/che-machine-exec-plugin/.*#che.factory.default_plugins=eclipse/che-machine-exec-plugin/$plugin_version#g" ../assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
 sed_in_place -r -e "s#che.workspace.devfile.default_editor=eclipse/che-theia/.*#che.workspace.devfile.default_editor=eclipse/che-theia/$plugin_version#g" ../assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
-sed_in_place -r -e "s#che.workspace.devfile.default_editor.plugins=eclipse/che-machine-exec-plugin/.*#che.workspace.devfile.default_editor.plugins=eclipse/che-machine-exec-plugin/$plugin_version#g" ../assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
 
 # use actual image tags, so a new container is used after each update
 image_version="$1"

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -743,7 +743,7 @@ che.factory.default_editor=eclipse/che-theia/next
 # which doesn't contain any Che-specific workspace descriptor.
 # Multiple plugins must be comma-separated, for example:
 # pluginFooPublisher/pluginFooName/pluginFooVersion,pluginBarPublisher/pluginBarName/pluginBarVersion
-che.factory.default_plugins=eclipse/che-machine-exec-plugin/nightly
+che.factory.default_plugins=NULL
 
 # Devfile filenames to look on repository-based factories (like GitHub etc).
 # Factory will try to locate those files in the order they enumerated in the property.
@@ -763,7 +763,7 @@ che.workspace.devfile.default_editor=eclipse/che-theia/next
 # Format is comma-separated `pluginPublisher/pluginName/pluginVersion` values, and URLs. For example:
 # eclipse/che-theia-exec-plugin/0.0.1,eclipse/che-theia-terminal-plugin/0.0.1,https://cdn.pluginregistry.com/vi-mode/meta.yaml
 # If the plugin is a URL, the plugin's meta.yaml is retrieved from that URL.
-che.workspace.devfile.default_editor.plugins=eclipse/che-machine-exec-plugin/nightly
+che.workspace.devfile.default_editor.plugins=NULL
 
 # Defines comma-separated list of labels for selecting secrets from a user namespace,
 # which will be mount into workspace containers as a files or env variables.

--- a/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
+++ b/multiuser/integration-tests/che-multiuser-cascade-removal/src/test/java/org/eclipse/che/multiuser/integration/jpa/cascaderemoval/JpaEntitiesCascadeRemovalTest.java
@@ -302,9 +302,9 @@ public class JpaEntitiesCascadeRemovalTest {
                 bindConstant()
                     .annotatedWith(Names.named("che.websocket.endpoint"))
                     .to("che.websocket.endpoint");
-                bind(String[].class)
+                bind(String.class)
                     .annotatedWith(Names.named("che.workspace.devfile.default_editor.plugins"))
-                    .toInstance(new String[] {"default/plugin/0.0.1"});
+                    .toInstance("default/plugin/0.0.1");
                 bind(String.class)
                     .annotatedWith(Names.named("che.workspace.devfile.async.storage.plugin"))
                     .toInstance("");

--- a/wsmaster/che-core-api-factory/pom.xml
+++ b/wsmaster/che-core-api-factory/pom.xml
@@ -92,6 +92,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.che.core</groupId>
+            <artifactId>che-core-commons-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.che.core</groupId>
             <artifactId>che-core-commons-lang</artifactId>
         </dependency>
         <dependency>

--- a/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
+++ b/wsmaster/che-core-api-factory/src/main/java/org/eclipse/che/api/factory/server/urlfactory/URLFactoryBuilder.java
@@ -48,6 +48,7 @@ import org.eclipse.che.api.workspace.server.model.impl.devfile.MetadataImpl;
 import org.eclipse.che.api.workspace.shared.dto.WorkspaceConfigDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.DevfileDto;
 import org.eclipse.che.api.workspace.shared.dto.devfile.MetadataDto;
+import org.eclipse.che.commons.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +72,7 @@ public class URLFactoryBuilder {
   @Inject
   public URLFactoryBuilder(
       @Named("che.factory.default_editor") String defaultCheEditor,
-      @Named("che.factory.default_plugins") String defaultChePlugins,
+      @Nullable @Named("che.factory.default_plugins") String defaultChePlugins,
       DevfileParser devfileParser,
       DevfileVersionDetector devfileVersionDetector) {
     this.defaultCheEditor = defaultCheEditor;
@@ -221,7 +222,9 @@ public class URLFactoryBuilder {
 
     Map<String, String> attributes = new HashMap<>();
     attributes.put(WORKSPACE_TOOLING_EDITOR_ATTRIBUTE, defaultCheEditor);
-    attributes.put(WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE, defaultChePlugins);
+    if (!isNullOrEmpty(defaultChePlugins)) {
+      attributes.put(WORKSPACE_TOOLING_PLUGINS_ATTRIBUTE, defaultChePlugins);
+    }
 
     // workspace configuration using the environment
     return newDto(WorkspaceConfigDto.class).withName(name).withAttributes(attributes);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/WorkspaceService.java
@@ -137,7 +137,7 @@ public class WorkspaceService extends Service {
       @Named(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES) String availableStorageTypes,
       @Named(CHE_WORKSPACE_STORAGE_PREFERRED_TYPE) String preferredStorageType,
       @Named(CHE_FACTORY_DEFAULT_EDITOR_PROPERTY) String defaultEditor,
-      @Named(CHE_FACTORY_DEFAULT_PLUGINS_PROPERTY) String defaultPlugins,
+      @Named(CHE_FACTORY_DEFAULT_PLUGINS_PROPERTY) @Nullable String defaultPlugins,
       @Named(CHE_DEVWORKSPACES_ENABLED_PROPERTY) boolean cheDevWorkspacesEnabled) {
     this.apiEndpoint = apiEndpoint;
     this.cheWorkspaceAutoStart = cheWorkspaceAutoStart;
@@ -464,7 +464,9 @@ public class WorkspaceService extends Service {
       settings.put("cheWorkspaceDevfileRegistryInternalUrl", devfileRegistryInternalUrl);
     }
 
-    settings.put(CHE_FACTORY_DEFAULT_PLUGINS_PROPERTY, defaultPlugins);
+    if (defaultPlugins != null) {
+      settings.put(CHE_FACTORY_DEFAULT_PLUGINS_PROPERTY, defaultPlugins);
+    }
     settings.put(CHE_FACTORY_DEFAULT_EDITOR_PROPERTY, defaultEditor);
     settings.put(CHE_WORKSPACE_STORAGE_AVAILABLE_TYPES, availableStorageTypes);
     settings.put(CHE_WORKSPACE_STORAGE_PREFERRED_TYPE, preferredStorageType);

--- a/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/DefaultEditorProvisioner.java
+++ b/wsmaster/che-core-api-workspace/src/main/java/org/eclipse/che/api/workspace/server/devfile/convert/DefaultEditorProvisioner.java
@@ -34,6 +34,7 @@ import org.eclipse.che.api.workspace.server.model.impl.devfile.DevfileImpl;
 import org.eclipse.che.api.workspace.server.spi.InfrastructureException;
 import org.eclipse.che.api.workspace.server.wsplugins.PluginFQNParser;
 import org.eclipse.che.api.workspace.server.wsplugins.model.ExtendedPluginFQN;
+import org.eclipse.che.commons.annotation.Nullable;
 
 /**
  * Provision default editor if there is no any another editor and default plugins for it.
@@ -52,7 +53,7 @@ public class DefaultEditorProvisioner {
   @Inject
   public DefaultEditorProvisioner(
       @Named("che.workspace.devfile.default_editor") String defaultEditorRef,
-      @Named("che.workspace.devfile.default_editor.plugins") String[] defaultPluginsRefs,
+      @Named("che.workspace.devfile.default_editor.plugins") @Nullable String defaultPluginsRefs,
       @Named("che.workspace.devfile.async.storage.plugin") String asyncStoragePluginRef,
       ComponentFQNParser componentFQNParser,
       PluginFQNParser pluginFQNParser)
@@ -66,8 +67,10 @@ public class DefaultEditorProvisioner {
             ? null
             : componentFQNParser.getPluginPublisherAndName(this.defaultEditorRef);
     Map<String, String> map = new HashMap<>();
-    for (String defaultPluginsRef : defaultPluginsRefs) {
-      map.put(componentFQNParser.getPluginPublisherAndName(defaultPluginsRef), defaultPluginsRef);
+    if (!isNullOrEmpty(defaultPluginsRefs)) {
+      for (String defaultPluginsRef : defaultPluginsRefs.split(",")) {
+        map.put(componentFQNParser.getPluginPublisherAndName(defaultPluginsRef), defaultPluginsRef);
+      }
     }
     this.defaultPluginsToRefs = map;
   }

--- a/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/DefaultEditorProvisionerTest.java
+++ b/wsmaster/che-core-api-workspace/src/test/java/org/eclipse/che/api/workspace/server/devfile/convert/DefaultEditorProvisionerTest.java
@@ -71,7 +71,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            null, new String[] {}, ASYNC_STORAGE_PLUGIN_REF, fqnParser, pluginFQNParser);
+            null, "", ASYNC_STORAGE_PLUGIN_REF, fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
 
     // when
@@ -87,7 +87,7 @@ public class DefaultEditorProvisionerTest {
     provisioner =
         new DefaultEditorProvisioner(
             EDITOR_REF,
-            new String[] {TERMINAL_PLUGIN_REF, COMMAND_PLUGIN_REF},
+            TERMINAL_PLUGIN_REF + "," + COMMAND_PLUGIN_REF,
             "",
             fqnParser,
             pluginFQNParser);
@@ -110,7 +110,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl defaultEditorWithDifferentVersion =
@@ -136,7 +136,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl defaultEditorWithDifferentVersion =
@@ -163,7 +163,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl editorWithNameSimilarToDefault =
@@ -187,7 +187,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     devfile.getAttributes().put(EDITOR_FREE_DEVFILE_ATTRIBUTE, "true");
@@ -207,7 +207,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, "", fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl pluginWithNameSimilarToDefault =
@@ -230,8 +230,7 @@ public class DefaultEditorProvisionerTest {
   public void shouldNotProvisionDefaultEditorOrDefaultPluginsIfDevfileAlreadyHasNonDefaultEditor()
       throws Exception {
     // given
-    provisioner =
-        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, "", fqnParser, pluginFQNParser);
+    provisioner = new DefaultEditorProvisioner(EDITOR_REF, "", "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl nonDefaultEditor =
         new ComponentImpl(EDITOR_COMPONENT_TYPE, "anypublisher/anyname/v" + EDITOR_VERSION);
@@ -250,8 +249,7 @@ public class DefaultEditorProvisionerTest {
   public void shouldNotProvisionDefaultEditorIfDevfileAlreadyContainsSuchButWithDifferentVersion()
       throws Exception {
     // given
-    provisioner =
-        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, "", fqnParser, pluginFQNParser);
+    provisioner = new DefaultEditorProvisioner(EDITOR_REF, "", "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl myTheiaEditor =
         new ComponentImpl(
@@ -271,8 +269,7 @@ public class DefaultEditorProvisionerTest {
   public void shouldNotProvisionDefaultEditorIfDevfileAlreadyContainsSuchByReference()
       throws Exception {
     // given
-    provisioner =
-        new DefaultEditorProvisioner(EDITOR_REF, new String[] {}, "", fqnParser, pluginFQNParser);
+    provisioner = new DefaultEditorProvisioner(EDITOR_REF, "", "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl myTheiaEditor =
         new ComponentImpl(
@@ -307,7 +304,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl myTerminal =
         new ComponentImpl(
@@ -330,7 +327,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF, new String[] {TERMINAL_PLUGIN_REF}, "", fqnParser, pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     String meta =
         "apiVersion: v2\n"
@@ -365,11 +362,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF,
-            new String[] {EDITOR_PUBLISHER + "/" + "my-plugin/v2.0"},
-            "",
-            fqnParser,
-            pluginFQNParser);
+            EDITOR_REF, EDITOR_PUBLISHER + "/" + "my-plugin/v2.0", "", fqnParser, pluginFQNParser);
     DevfileImpl devfile = new DevfileImpl();
     ComponentImpl myPlugin =
         new ComponentImpl(
@@ -396,7 +389,7 @@ public class DefaultEditorProvisionerTest {
     provisioner =
         new DefaultEditorProvisioner(
             EDITOR_REF,
-            new String[] {EDITOR_PUBLISHER + "/" + "my-plugin/v2.0", referencePluginRef},
+            EDITOR_PUBLISHER + "/" + "my-plugin/v2.0" + "," + referencePluginRef,
             "",
             fqnParser,
             pluginFQNParser);
@@ -430,11 +423,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF,
-            new String[] {TERMINAL_PLUGIN_REF},
-            ASYNC_STORAGE_PLUGIN_REF,
-            fqnParser,
-            pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, ASYNC_STORAGE_PLUGIN_REF, fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     devfile.setAttributes(ImmutableMap.of(Constants.ASYNC_PERSIST_ATTRIBUTE, "true"));
@@ -454,11 +443,7 @@ public class DefaultEditorProvisionerTest {
     // given
     provisioner =
         new DefaultEditorProvisioner(
-            EDITOR_REF,
-            new String[] {TERMINAL_PLUGIN_REF},
-            ASYNC_STORAGE_PLUGIN_REF,
-            fqnParser,
-            pluginFQNParser);
+            EDITOR_REF, TERMINAL_PLUGIN_REF, ASYNC_STORAGE_PLUGIN_REF, fqnParser, pluginFQNParser);
 
     DevfileImpl devfile = new DevfileImpl();
     devfile.setAttributes(


### PR DESCRIPTION
### What does this PR do?
remove default plug-in when starting workspaces
Only components requiring machine-exec should include it in their definition (like che-theia)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19215


### How to test this PR?
Happy path should be successful (also you can check there is only one machine-exec component starting in a given che-theia workspace and no che-machine-exec component if another editor is picked-up)

note: che-theia image is not yet published so it should fail happy path right now
After relaunching the test (once che-theia image is published) it should work :-)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: I98ca453e305db71f9e947b9611a42df80b7d6776
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
