### PR TITLE
Adapt tests to multi-root workspaces related changes

### DIFF
--- a/tests/e2e/pageobjects/ide/ProjectTree.ts
+++ b/tests/e2e/pageobjects/ide/ProjectTree.ts
@@ -323,7 +323,8 @@ export class ProjectTree {
     }
 
     private async getExpandIconCssLocator(itemPath: string): Promise<string> {
-        const entry: string = await this.getWorkspacePathEntry();
+        const items: Array<string> = itemPath.split('/');
+        const entry: string = items.length > 1 ? await this.getWorkspacePathEntry() : '';
         return `div[data-node-id='${entry}/projects/${itemPath}']`;
     }
 

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -270,7 +270,7 @@ suite('Validation of debug functionality', async () => {
         await topMenu.selectOption('View', 'Debug');
         await ide.waitLeftToolbarButton(LeftToolbarButton.Debug);
         await debugView.clickOnDebugConfigurationDropDown();
-        await debugView.clickOnDebugConfigurationItem('Debug (Attach) - Remote');
+        await debugView.clickOnDebugConfigurationItem('Debug (Attach) - Remote (petclinic)');
         await debugView.clickOnRunDebugButton();
 
         try {


### PR DESCRIPTION
Signed-off-by: Roman Nikitenko <rnikiten@redhat.com>

The changes should be merged together with https://github.com/eclipse/che-theia/pull/1053
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
We are going to turn on the multi-root mode by default within https://github.com/eclipse/che-theia/pull/1053.  
The current changes adapt Happy Path tests to multi-root workspaces related changes.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/19390

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
The Happy Path tests should pass for the https://github.com/eclipse/che-theia/pull/1053.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
