### PR TITLE
Fix workspace stopping with new Dashboard - backport to 7.28

### DIFF
--- a/tests/e2e/pageobjects/dashboard/Workspaces.ts
+++ b/tests/e2e/pageobjects/dashboard/Workspaces.ts
@@ -163,7 +163,7 @@ export class Workspaces {
     }
 
     private getWorkspaceListItemLocator(workspaceName: string): string {
-        return `//table[@aria-label='Workspaces List Table']//tbody//tr[//a[text()='${workspaceName}']]`;
+        return `//tr[td/span/a[text()='${workspaceName}']]`;
     }
 
     private getWorkspaceStatusLocator(workspaceName: string, workspaceStatus: WorkspaceStatusUI): By {
@@ -171,7 +171,7 @@ export class Workspaces {
     }
 
     private getActionsLocator(workspaceName: string): By {
-        return By.xpath(`${this.getWorkspaceListItemLocator(workspaceName)}//button[@aria-label='Actions']`);
+        return By.xpath(`${this.getWorkspaceListItemLocator(workspaceName)}/td/div/button[@aria-label='Actions']`);
     }
 
     private getExpandedActionsLocator(workspaceName: string): By {


### PR DESCRIPTION
### What does this PR do?
Fix issue with workspace stopping in a test where there are multiple workspaces in the list.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19477

### How to test this PR?
Run test changes against Che 7.28.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
