### PR TITLE
Restore defaults of `che.factory.default_editor` property

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -740,6 +740,9 @@ che.factory.default_plugins=NULL
 che.factory.default_devfile_filenames=devfile.yaml,.devfile.yaml
 
 ### Devfile defaults
+# Editor that will be used for factories which are created from remote git repository
+# which doesn't contain any Che-specific workspace descriptor.
+che.factory.default_editor=eclipse/che-theia/next
 
 # Default Editor that should be provisioned into Devfile if there is no specified Editor
 # Format is `editorPublisher/editorName/editorVersion` value.

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -741,7 +741,7 @@ che.factory.default_devfile_filenames=devfile.yaml,.devfile.yaml
 
 ### Devfile defaults
 # Editor that will be used for factories that are created from a remote Git repository
-# which doesn't contain any {prod-short}-specific workspace descriptor.
+# which does not contain any {prod-short}-specific workspace descriptor.
 che.factory.default_editor=eclipse/che-theia/next
 
 # Default Editor that should be provisioned into Devfile if there is no specified Editor

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -741,7 +741,7 @@ che.factory.default_devfile_filenames=devfile.yaml,.devfile.yaml
 
 ### Devfile defaults
 # Editor that will be used for factories which are created from remote git repository
-# which doesn't contain any Che-specific workspace descriptor.
+# which doesn't contain any {prod-short}-specific workspace descriptor.
 che.factory.default_editor=eclipse/che-theia/next
 
 # Default Editor that should be provisioned into Devfile if there is no specified Editor

--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -740,7 +740,7 @@ che.factory.default_plugins=NULL
 che.factory.default_devfile_filenames=devfile.yaml,.devfile.yaml
 
 ### Devfile defaults
-# Editor that will be used for factories which are created from remote git repository
+# Editor that will be used for factories that are created from a remote Git repository
 # which doesn't contain any {prod-short}-specific workspace descriptor.
 che.factory.default_editor=eclipse/che-theia/next
 


### PR DESCRIPTION
### What does this PR do?
Restore defaults of `che.factory.default_editor` property removed in  https://github.com/eclipse/che/pull/19263
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Знімок екрана 2021-04-15 о 10 10 07](https://user-images.githubusercontent.com/1614429/114829664-0821ea00-9dd4-11eb-85e1-d1a92676506c.png)

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19599


### How to test this PR?
- Deploy che server image `quay.io/skabashn/che-server:che19599`
- Start che-server
- Start new workspace

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
