### PR TITLE
Sync java version between CI and che-server image and set to java 11.0.11_9

### DIFF
--- a/.github/workflows/build-pr-check.yml
+++ b/.github/workflows/build-pr-check.yml
@@ -26,8 +26,9 @@ jobs:
        restore-keys: |
         ${{ runner.os }}-maven-      
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'adopt'
+        java-version: '11.0.11+9'
     - name: Build with Maven
       run: mvn -B clean install -U -Pintegration

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -27,9 +27,10 @@ jobs:
        restore-keys: |
         ${{ runner.os }}-maven-      
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: 11
+        distribution: 'adopt'
+        java-version: '11.0.11+9'
     - name: Login to docker.io
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,11 +78,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.6
-      - uses: actions/setup-java@v1
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
         with:
-          java-version: '11.0.7'
-          java-package: jdk
-          architecture: x64 
+          distribution: 'adopt'
+          java-version: '11.0.11+9'
       - name: Set up environment
         run: |
           sudo apt-get update -y || true

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -12,9 +12,10 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          distribution: 'adopt'
+          java-version: '11.0.11+9'
       - name: Cache SonarCloud packages
         uses: actions/cache@v1
         with:

--- a/dockerfiles/che/Dockerfile
+++ b/dockerfiles/che/Dockerfile
@@ -13,7 +13,7 @@ ARG CHE_DASHBOARD_VERSION=next
 
 FROM ${CHE_DASHBOARD_ORGANIZATION}/che-dashboard:${CHE_DASHBOARD_VERSION} as che_dashboard_base
 
-FROM docker.io/adoptopenjdk/openjdk11:jre-11.0.8_10
+FROM docker.io/adoptopenjdk/openjdk11:jre-11.0.11_9
 ENV LANG=C.UTF-8
 RUN echo "%root ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && rm -rf /tmp/*
 EXPOSE 8000 8080


### PR DESCRIPTION
### What does this PR do?
Sync java version between CI and che-server image and set to java 11.0.11_9

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
During the investigation of https://github.com/eclipse/che/issues/19641 I've noticed that our CI is using a different version from Che-server. Even though that is not mandatory. I think it's better to keep them in sync. This pr.
 - Sync version between CI and che-server image
 - Uses latest java for che-server image.



### How to test this PR?
 - Deploy che-serve image `quay.io/skabashn/che-server:syncjava`
 - Start new workspace
  
  
  ### PR Checklist
  
  [As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)
  
  - [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
  - [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
  - [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
  - [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
  - [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
  - [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
  - [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
  - [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
