### PR TITLE
Removed SCM user name from git credential secret name

### DIFF
--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
@@ -59,7 +59,7 @@ public class KubernetesGitCredentialManager implements GitCredentialManager {
           "app.kubernetes.io/part-of", "che.eclipse.org",
           "app.kubernetes.io/component", "workspace-secret");
 
-  private static final Map<String, String> ANNOTATIONS =
+  public static final Map<String, String> DEFAULT_SECRET_ANNOTATIONS =
       ImmutableMap.of(
           ANNOTATION_AUTOMOUNT,
           "true",
@@ -116,7 +116,7 @@ public class KubernetesGitCredentialManager implements GitCredentialManager {
       Secret secret =
           existing.orElseGet(
               () -> {
-                Map<String, String> annotations = new HashMap<>(ANNOTATIONS);
+                Map<String, String> annotations = new HashMap<>(DEFAULT_SECRET_ANNOTATIONS);
                 annotations.put(ANNOTATION_SCM_URL, personalAccessToken.getScmProviderUrl());
                 annotations.put(ANNOTATION_SCM_USERNAME, personalAccessToken.getScmUserName());
                 annotations.put(ANNOTATION_CHE_USERID, personalAccessToken.getCheUserId());

--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
@@ -49,7 +49,7 @@ import org.eclipse.che.workspace.infrastructure.kubernetes.namespace.KubernetesN
  */
 @Singleton
 public class KubernetesGitCredentialManager implements GitCredentialManager {
-  public static final String NAME_PATTERN = "%s-git-credentials-secret-";
+  public static final String NAME_PATTERN = "git-credentials-secret-";
   public static final String ANNOTATION_SCM_URL = "che.eclipse.org/scm-url";
   public static final String ANNOTATION_SCM_USERNAME = "che.eclipse.org/scm-username";
   public static final String ANNOTATION_CHE_USERID = "che.eclipse.org/che-userid";
@@ -122,10 +122,7 @@ public class KubernetesGitCredentialManager implements GitCredentialManager {
                 annotations.put(ANNOTATION_CHE_USERID, personalAccessToken.getCheUserId());
                 ObjectMeta meta =
                     new ObjectMetaBuilder()
-                        .withName(
-                            NameGenerator.generate(
-                                String.format(NAME_PATTERN, personalAccessToken.getScmUserName()),
-                                5))
+                        .withName(NameGenerator.generate(NAME_PATTERN, 5))
                         .withAnnotations(annotations)
                         .withLabels(LABELS)
                         .build();

--- a/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
+++ b/infrastructures/infrastructure-factory/src/main/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManager.java
@@ -59,7 +59,7 @@ public class KubernetesGitCredentialManager implements GitCredentialManager {
           "app.kubernetes.io/part-of", "che.eclipse.org",
           "app.kubernetes.io/component", "workspace-secret");
 
-  public static final Map<String, String> DEFAULT_SECRET_ANNOTATIONS =
+  static final Map<String, String> DEFAULT_SECRET_ANNOTATIONS =
       ImmutableMap.of(
           ANNOTATION_AUTOMOUNT,
           "true",

--- a/infrastructures/infrastructure-factory/src/test/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManagerTest.java
+++ b/infrastructures/infrastructure-factory/src/test/java/org/eclipse/che/api/factory/server/scm/kubernetes/KubernetesGitCredentialManagerTest.java
@@ -16,8 +16,8 @@ import static java.util.Collections.singletonList;
 import static org.eclipse.che.api.factory.server.scm.kubernetes.KubernetesGitCredentialManager.ANNOTATION_CHE_USERID;
 import static org.eclipse.che.api.factory.server.scm.kubernetes.KubernetesGitCredentialManager.ANNOTATION_SCM_URL;
 import static org.eclipse.che.api.factory.server.scm.kubernetes.KubernetesGitCredentialManager.ANNOTATION_SCM_USERNAME;
+import static org.eclipse.che.api.factory.server.scm.kubernetes.KubernetesGitCredentialManager.DEFAULT_SECRET_ANNOTATIONS;
 import static org.eclipse.che.api.factory.server.scm.kubernetes.KubernetesGitCredentialManager.NAME_PATTERN;
-import static org.eclipse.che.workspace.infrastructure.kubernetes.provision.secret.KubernetesSecretAnnotationNames.ANNOTATION_GIT_CREDENTIALS;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -136,10 +136,10 @@ public class KubernetesGitCredentialManagerTest {
             "tid-23434",
             "token123");
 
-    Map<String, String> annotations = new HashMap<>();
+    Map<String, String> annotations = new HashMap<>(DEFAULT_SECRET_ANNOTATIONS);
+
     annotations.put(ANNOTATION_SCM_URL, token.getScmProviderUrl());
     annotations.put(ANNOTATION_SCM_USERNAME, token.getScmUserName());
-    annotations.put(ANNOTATION_GIT_CREDENTIALS, "true");
     annotations.put(ANNOTATION_CHE_USERID, token.getCheUserId());
     ObjectMeta objectMeta =
         new ObjectMetaBuilder()


### PR DESCRIPTION


### What does this PR do?
Removed SCM user name from git credential secret name

### Screenshot/screencast of this PR
<img width="1240" alt="Знімок екрана 2021-04-30 о 14 00 35" src="https://user-images.githubusercontent.com/1614429/116686432-76fa6800-a9bc-11eb-936e-ce4c59fa60cc.png">

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
 - Deploy che-server image `quay.io/skabashn/che-server:che19700`
 - Enable integration Gitlab or Bitbucket
 - Create a user with characters that are not allowed as k8s namespace name characters.
 - Run factory to a private repo

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
