### PR TITLE
feat(vscode-extensions): Add vscode-commons as default plug-in

### DIFF
--- a/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
+++ b/assembly/assembly-wsmaster-war/src/main/webapp/WEB-INF/classes/che/che.properties
@@ -723,7 +723,7 @@ che.cors.allow_credentials=false
 # which does not contain any {prod-short}-specific workspace descriptor
 # Multiple plugins must be comma-separated, for example:
 # `pluginFooPublisher/pluginFooName/pluginFooVersion,pluginBarPublisher/pluginBarName/pluginBarVersion`
-che.factory.default_plugins=NULL
+che.factory.default_plugins=redhat/vscode-commons/latest
 
 # Devfile filenames to look on repository-based factories (for example GitHub).
 # Factory will try to locate those files in the order they enumerated in the property.


### PR DESCRIPTION
### What does this PR do?
New extensions may require this one and we can only have one instance running at a time
che-server with plugin-broker are not handling dependencies so we need to add it as default plug-in
for devWorkspaces, the resolver will handle dependencies and then will be able to load only one instance of vscode-commons


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/19361


### How to test this PR?
you shouldn't notice problem by default.
Then, you can enable an extension requiring vscode-commons and see that it's working (for now none of them are on the plug-in registry as we were waiting to have the commons extension being deployed)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
Change-Id: I69154dd97b837214c04fdd3e9e42d89a03c542d3
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
