### PR TITLE
[Selenium] Update 'happy-path' files to run 'Happy-path' E2E test on Che 'single-host' 

### DIFF
--- a/tests/e2e/files/happy-path/happy-path-workspace.yaml
+++ b/tests/e2e/files/happy-path/happy-path-workspace.yaml
@@ -32,6 +32,13 @@ components:
       - name: MAVEN_CONFIG
         value: /home/user/.m2
     memoryLimit: 1500Mi
+    endpoints:
+      - name: '8080-tcp'
+        port: 8080
+      - name: 'debug'
+        port: 5005
+        attributes:
+          public: 'false'
     mountSources: true
   - type: chePlugin
     id: redhat/java/latest

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -30,6 +30,7 @@ import { TimeoutConstants } from '../../TimeoutConstants';
 import { Logger } from '../../utils/Logger';
 import { RightToolBar } from '../../pageobjects/ide/RightToolBar';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
@@ -59,6 +60,7 @@ const codeNavigationClassName: string = 'SpringApplication.class';
 const pathToYamlFolder: string = projectName;
 const yamlFileName: string = 'devfile.yaml';
 const loginPage: ICheLoginPage = e2eContainer.get<ICheLoginPage>(TYPES.CheLogin);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 
 const SpringAppLocators = {
     springTitleLocator: By.xpath('//div[@class=\'container-fluid\']//h2[text()=\'Welcome\']'),
@@ -70,7 +72,7 @@ const SpringAppLocators = {
 
 suite('Login', async () => {
     test('Login', async () => {
-        await driverHelper.navigateToUrl(TestConstants.TS_SELENIUM_BASE_URL);
+        await browserTabsUtil.navigateTo(TestConstants.TS_SELENIUM_BASE_URL);
         await loginPage.login();
     });
 });
@@ -125,7 +127,7 @@ suite('Language server validation', async () => {
             await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT);
         } catch (err) {
             Logger.debug('Workaround for the https://github.com/eclipse/che/issues/18974.');
-            await driverHelper.reloadPage();
+            await browserTabsUtil.refreshPage();
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde();
             await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT * 2);
@@ -166,7 +168,7 @@ suite('Language server validation', async () => {
 });
 
 suite('Validation of workspace build and run', async () => {
-    let applicationUrl: string = '';
+    // let applicationUrl: string = '';
 
     test('Build application', async () => {
         let buildTaskName: string = 'build-file-output';
@@ -176,14 +178,17 @@ suite('Validation of workspace build and run', async () => {
 
     test('Run application', async () => {
         await topMenu.runTask('run');
-        await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 120_000);
-        applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 120_000);
-        await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 120_000);
+        // await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 120_000);
+        // applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 120_000);
+        // await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 120_000);
+        await ide.waitNotification('Process 8080-tcp is now listening on port 8080. Open it ?', 120_000);
+        await driverHelper.wait(TimeoutConstants.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT);
+        await ide.clickOnNotificationButton('Process 8080-tcp is now listening on port 8080. Open it ?', 'Open In Preview');
     });
 
     test('Check the running application', async () => {
-        await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
-        await previewWidget.waitContentAvailable(SpringAppLocators.springTitleLocator, 60_000, 10_000);
+        // await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
+        await previewWidget.waitContentAvailable(SpringAppLocators.springTitleLocator, 60_000, 20_000);
     });
 
     test('Close preview widget', async () => {
@@ -201,7 +206,7 @@ suite('Validation of workspace build and run', async () => {
 });
 
 suite('Display source code changes in the running application', async () => {
-    let applicationUrl: string = '';
+    // let applicationUrl: string = '';
 
     test('Change source code', async () => {
         await projectTree.expandPathAndOpenFile(pathToChangedJavaFileFolder, changedJavaFileName);
@@ -216,21 +221,23 @@ suite('Display source code changes in the running application', async () => {
 
     test('Build application with changes', async () => {
         let buildTaskName: string = 'build';
-
         await topMenu.runTask('build');
         await terminal.waitIconSuccess(buildTaskName, 250_000);
     });
 
     test('Run application with changes', async () => {
         await topMenu.runTask('run-with-changes');
-        await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 120_000);
-        applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 120_000);
-        await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 120_000);
+        // await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 120_000);
+        // applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 120_000);
+        // await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 120_000);
+        await ide.waitNotification('Process 8080-tcp is now listening on port 8080. Open it ?', 120_000);
+        await driverHelper.wait(TimeoutConstants.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT);
+        await ide.clickOnNotificationButton('Process 8080-tcp is now listening on port 8080. Open it ?', 'Open In Preview');
     });
 
     test('Check changes are displayed', async () => {
-        await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
-        await previewWidget.waitContentAvailable(SpringAppLocators.springTitleLocator, 60_000, 10_000);
+        // await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
+        await previewWidget.waitContentAvailable(SpringAppLocators.springTitleLocator, 60_000, 20_000);
         await checkErrorMessageInApplicationController();
     });
 
@@ -247,17 +254,20 @@ suite('Display source code changes in the running application', async () => {
 });
 
 suite('Validation of debug functionality', async () => {
-    let applicationUrl: string = '';
+    // let applicationUrl: string = '';
 
     test('Launch debug', async () => {
         await topMenu.runTask('run-debug');
-        await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 180_000);
-        applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 180_000);
-        await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 180_000);
+        // await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 180_000);
+        // applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 180_000);
+        // await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 180_000);
+        await ide.waitNotification('Process 8080-tcp is now listening on port 8080. Open it ?', 180_000);
+        await driverHelper.wait(TimeoutConstants.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT);
+        await ide.clickOnNotificationButton('Process 8080-tcp is now listening on port 8080. Open it ?', 'Open In Preview');
     });
 
     test('Check content of the launched application', async () => {
-        await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
+        // await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
         await previewWidget.waitAndSwitchToWidgetFrame();
         await previewWidget.waitAndClick(SpringAppLocators.springHomeButtonLocator);
         await driverHelper.getDriver().switchTo().defaultContent();

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -168,8 +168,6 @@ suite('Language server validation', async () => {
 });
 
 suite('Validation of workspace build and run', async () => {
-    // let applicationUrl: string = '';
-
     test('Build application', async () => {
         let buildTaskName: string = 'build-file-output';
         await topMenu.runTask('build-file-output');
@@ -178,23 +176,18 @@ suite('Validation of workspace build and run', async () => {
 
     test('Run application', async () => {
         await topMenu.runTask('run');
-        // await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 120_000);
-        // applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 120_000);
-        // await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 120_000);
         await ide.waitNotification('Process 8080-tcp is now listening on port 8080. Open it ?', 120_000);
         await driverHelper.wait(TimeoutConstants.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT);
         await ide.clickOnNotificationButton('Process 8080-tcp is now listening on port 8080. Open it ?', 'Open In Preview');
     });
 
     test('Check the running application', async () => {
-        // await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
-        await previewWidget.waitContentAvailable(SpringAppLocators.springTitleLocator, 60_000, 20_000);
+        await previewWidget.waitContentAvailable(SpringAppLocators.springTitleLocator, 60_000, 10_000);
     });
 
     test('Close preview widget', async () => {
         await rightToolBar.clickOnToolIcon('Preview');
         await previewWidget.waitPreviewWidgetAbsence();
-
     });
 
     test('Close the terminal running tasks', async () => {
@@ -206,8 +199,6 @@ suite('Validation of workspace build and run', async () => {
 });
 
 suite('Display source code changes in the running application', async () => {
-    // let applicationUrl: string = '';
-
     test('Change source code', async () => {
         await projectTree.expandPathAndOpenFile(pathToChangedJavaFileFolder, changedJavaFileName);
         await editor.waitEditorAvailable(changedJavaFileName);
@@ -227,17 +218,13 @@ suite('Display source code changes in the running application', async () => {
 
     test('Run application with changes', async () => {
         await topMenu.runTask('run-with-changes');
-        // await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 120_000);
-        // applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 120_000);
-        // await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 120_000);
         await ide.waitNotification('Process 8080-tcp is now listening on port 8080. Open it ?', 120_000);
         await driverHelper.wait(TimeoutConstants.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT);
         await ide.clickOnNotificationButton('Process 8080-tcp is now listening on port 8080. Open it ?', 'Open In Preview');
     });
 
     test('Check changes are displayed', async () => {
-        // await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
-        await previewWidget.waitContentAvailable(SpringAppLocators.springTitleLocator, 60_000, 20_000);
+        await previewWidget.waitContentAvailable(SpringAppLocators.springTitleLocator, 60_000, 10_000);
         await checkErrorMessageInApplicationController();
     });
 
@@ -254,20 +241,14 @@ suite('Display source code changes in the running application', async () => {
 });
 
 suite('Validation of debug functionality', async () => {
-    // let applicationUrl: string = '';
-
     test('Launch debug', async () => {
         await topMenu.runTask('run-debug');
-        // await ide.waitNotificationAndConfirm('A new process is now listening on port 8080', 180_000);
-        // applicationUrl = await ide.getApplicationUrlFromNotification('Redirect is now enabled on port 8080', 180_000);
-        // await ide.waitNotificationAndOpenLink('Redirect is now enabled on port 8080', 180_000);
         await ide.waitNotification('Process 8080-tcp is now listening on port 8080. Open it ?', 180_000);
         await driverHelper.wait(TimeoutConstants.TS_SELENIUM_PREVIEW_WIDGET_DEFAULT_TIMEOUT);
         await ide.clickOnNotificationButton('Process 8080-tcp is now listening on port 8080. Open it ?', 'Open In Preview');
     });
 
     test('Check content of the launched application', async () => {
-        // await previewWidget.waitApplicationOpened(applicationUrl, 60_000);
         await previewWidget.waitAndSwitchToWidgetFrame();
         await previewWidget.waitAndClick(SpringAppLocators.springHomeButtonLocator);
         await driverHelper.getDriver().switchTo().defaultContent();


### PR DESCRIPTION
### What does this PR do?
* Updates  the 'happy-path-workspace.yaml' to avoid the failed run demo application in Che 'single-host'
* Updates 'Happy-path' E2E test according to the changes related to run demo application
* Refactored code

### Screenshot/screencast of this PR
**`multi-host / single-host`** 
![image](https://user-images.githubusercontent.com/5408906/118124499-58559180-b3fe-11eb-8a4e-ae417b7b20bf.png)




### What issues does this PR fix or reference?
#18765

### How to test this PR?
There were launched jobs with these changes to check 'Happy-path' E2E test on Che 'single-host ->
https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/Che/job/e2e/job/minikube/job/basic/job/eclipse-che/1167/
https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/Che/job/e2e/job/minikube/job/basic/job/eclipse-che/1170/

### Reviewers
@dmytro-ndp 
@SkorikSergey 
