### PR TITLE
Backporting workspace name handler and workspace deletion fix

### DIFF
--- a/tests/e2e/TestConstants.ts
+++ b/tests/e2e/TestConstants.ts
@@ -181,6 +181,16 @@ export const TestConstants = {
     TS_SELENIUM_LOG_LEVEL: process.env.TS_SELENIUM_LOG_LEVEL || 'INFO',
 
     /**
+     * Enable Axios request interceptor, false by default
+     */
+    TS_SELENIUM_REQUEST_INTERCEPTOR: process.env.TS_SELENIUM_REQUEST_INTERCEPTOR === 'true',
+
+    /**
+     * Enable Axios response interceptor, false by default
+     */
+     TS_SELENIUM_RESPONSE_INTERCEPTOR: process.env.TS_SELENIUM_RESPONSE_INTERCEPTOR === 'true',
+
+    /**
      * Running test suite - possible variants can be found in package.json scripts part.
      */
     TEST_SUITE: process.env.TEST_SUITE || 'test-happy-path',

--- a/tests/e2e/driver/CheReporter.ts
+++ b/tests/e2e/driver/CheReporter.ts
@@ -33,6 +33,14 @@ let testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil
 let preferencesHandler: PreferencesHandler = e2eContainer.get(CLASSES.PreferencesHandler);
 
 class CheReporter extends mocha.reporters.Spec {
+
+  private static latestWorkspace: string;
+
+  public static registerRunningWorkspace(workspaceName: string) {
+    Logger.debug(`CheReporter.registerRunningWorkspace {${workspaceName}}`);
+    CheReporter.latestWorkspace = workspaceName;
+  }
+
   constructor(runner: mocha.Runner, options: mocha.MochaOptions) {
     super(runner, options);
 
@@ -70,8 +78,10 @@ class CheReporter extends mocha.reporters.Spec {
       console.log(launchInformation);
 
       rm.sync(TestConstants.TS_SELENIUM_REPORT_FOLDER);
-      if (TestConstants.TS_SELENIUM_LOG_LEVEL === 'TRACE') {
+      if (TestConstants.TS_SELENIUM_REQUEST_INTERCEPTOR) {
         CheApiRequestHandler.enableRequestInteceptor();
+      }
+      if (TestConstants.TS_SELENIUM_RESPONSE_INTERCEPTOR) {
         CheApiRequestHandler.enableResponseInterceptor();
       }
       await preferencesHandler.setConfirmExit(AskForConfirmationType.never);
@@ -175,8 +185,8 @@ class CheReporter extends mocha.reporters.Spec {
 
       // stop and remove running workspace
       if (TestConstants.DELETE_WORKSPACE_ON_FAILED_TEST) {
-        console.log('Property DELETE_WORKSPACE_ON_FAILED_TEST se to true - trying to stop and delete running workspace.');
-        testWorkspaceUtil.cleanUpAllWorkspaces();
+        Logger.warn('Property DELETE_WORKSPACE_ON_FAILED_TEST se to true - trying to stop and delete running workspace.');
+        await testWorkspaceUtil.cleanUpRunningWorkspace(CheReporter.latestWorkspace);
       }
 
     });

--- a/tests/e2e/index.ts
+++ b/tests/e2e/index.ts
@@ -55,7 +55,7 @@ export * from './pageobjects/login/SingleUserLoginPage';
 export * from './pageobjects/login/UpdateAccountInformationPage';
 export * from './pageobjects/openshift/CheLoginPage';
 export * from './pageobjects/openshift/OcpLoginPage';
-export * from './testsLibrary/LanguageServerTests';
 export * from './testsLibrary/CodeExecutionTests';
+export * from './testsLibrary/LanguageServerTests';
 export * from './testsLibrary/ProjectAndFileTests';
 export * from './testsLibrary/WorkspaceHandlingTests';

--- a/tests/e2e/inversify.config.ts
+++ b/tests/e2e/inversify.config.ts
@@ -63,6 +63,7 @@ import { LanguageServerTests } from './testsLibrary/LanguageServerTests';
 import { CodeExecutionTests } from './testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from './testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from './testsLibrary/WorkspaceHandlingTests';
+import { WorkspaceNameHandler } from './utils/WorkspaceNameHandler';
 
 const e2eContainer: Container = new Container({ defaultScope: 'Transient' });
 
@@ -122,5 +123,6 @@ e2eContainer.bind<LanguageServerTests>(CLASSES.LanguageServerTests).to(LanguageS
 e2eContainer.bind<CodeExecutionTests>(CLASSES.CodeExecutionTests).to(CodeExecutionTests);
 e2eContainer.bind<ProjectAndFileTests>(CLASSES.ProjectAndFileTests).to(ProjectAndFileTests);
 e2eContainer.bind<WorkspaceHandlingTests>(CLASSES.WorkspaceHandlingTests).to(WorkspaceHandlingTests);
+e2eContainer.bind<WorkspaceNameHandler>(CLASSES.WorkspaceNameHandler).to(WorkspaceNameHandler);
 
 export { e2eContainer };

--- a/tests/e2e/inversify.types.ts
+++ b/tests/e2e/inversify.types.ts
@@ -16,8 +16,6 @@ const TYPES = {
     WorkspaceUtil: Symbol.for('WorkspaceUtil'),
     IAuthorizationHeaderHandler: Symbol.for('IAuthorizationHeaderHandler'),
     ITokenHandler: Symbol.for('ITokenHandler')
-
-
 };
 
 const CLASSES = {
@@ -59,7 +57,8 @@ const CLASSES = {
     LanguageServerTests: 'LanguageServerTests',
     CodeExecutionTests: 'CodeExecutionTests',
     ProjectAndFileTests: 'ProjectAndFileTests',
-    WorkspaceHandlingTests: 'WorkspaceHandlingTests'
+    WorkspaceHandlingTests: 'WorkspaceHandlingTests',
+    WorkspaceNameHandler: 'WorkspaceNameHandler'
 };
 
 export { TYPES, CLASSES };

--- a/tests/e2e/pageobjects/dashboard/Dashboard.ts
+++ b/tests/e2e/pageobjects/dashboard/Dashboard.ts
@@ -22,6 +22,7 @@ export class Dashboard {
     private static readonly WORKSPACES_BUTTON_XPATH: string = `//div[@id='page-sidebar']//a[contains(text(), 'Workspaces (')]`;
     private static readonly CREATE_WORKSPACE_BUTTON_XPATH: string = `//div[@id='page-sidebar']//a[text()='Create Workspace']`;
     private static readonly LOADER_PAGE_CSS: string = '.main-page-loader';
+    private static readonly WORKSPACE_STARTING_PAGE_CSS: string = '.ide-loader-page';
 
     constructor(@inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,
         @inject(CLASSES.Workspaces) private readonly workspaces: Workspaces) { }
@@ -109,6 +110,12 @@ export class Dashboard {
         Logger.debug('Dashboard.waitDisappearanceNavigationMenu');
 
         await this.driverHelper.waitDisappearance(By.id('chenavmenu'), timeout);
+    }
+
+    async waitWorkspaceStartingPage(timeout: number = TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT) {
+        Logger.debug(`Dashboard.waitWorkspaceStartingPage`);
+
+        await this.driverHelper.waitPresence(By.css(Dashboard.WORKSPACE_STARTING_PAGE_CSS), timeout);
     }
 
 }

--- a/tests/e2e/tests/devfiles/CSlashCPlusPlus.spec.ts
+++ b/tests/e2e/tests/devfiles/CSlashCPlusPlus.spec.ts
@@ -9,12 +9,13 @@
  **********************************************************************/
 import 'reflect-metadata';
 import { e2eContainer } from '../../inversify.config';
-import { Editor, CLASSES } from '../..';
-import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
+import { CLASSES } from '../../inversify.types';
+import { Editor } from '../../pageobjects/ide/Editor';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -28,10 +29,17 @@ const tabTitle: string = 'hello.cpp';
 const buildTaskName: string = 'build';
 const runTaskName: string = 'run';
 const stack: string = 'C/C++';
+let workspaceName: string;
 
 suite(`${stack} test`, async () => {
     suite(`Create ${stack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(stack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName);
     });
 
@@ -54,11 +62,6 @@ suite(`${stack} test`, async () => {
     });
 
     suite('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/DevfileSmoke.spec.ts
+++ b/tests/e2e/tests/devfiles/DevfileSmoke.spec.ts
@@ -8,29 +8,33 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import 'reflect-metadata';
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
+import CheReporter from '../../driver/CheReporter';
 import { e2eContainer } from '../../inversify.config';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
+
 const workspaceSampleName: string = 'console-java-simple';
 const workspaceRootFolderName: string = 'src';
-const stack : string = 'Java Maven';
+const stack: string = 'Java Maven';
+let workspaceName: string;
 
 suite(`${stack} test`, async () => {
     suite (`Create ${stack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(stack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/DotNetCore.spec.ts
+++ b/tests/e2e/tests/devfiles/DotNetCore.spec.ts
@@ -8,12 +8,14 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import 'reflect-metadata';
-import { WorkspaceNameHandler, Editor, CLASSES } from '../..';
+import { CLASSES } from '../../inversify.types';
 import { e2eContainer } from '../../inversify.config';
+import { Editor } from '../../pageobjects/ide/Editor';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -30,10 +32,17 @@ const updateDependenciesTaskName: string = 'update dependencies';
 const buildTaskName: string = 'build';
 const runTaskName: string = 'run';
 const runTaskNameExpectedString: string = 'Process 5000-tcp is now listening on port 5000. Open it ?';
+let workspaceName: string;
 
 suite(`Test ${stack}`, async () => {
     suite (`Create ${stack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(stack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName);
     });
 
@@ -65,11 +74,6 @@ suite(`Test ${stack}`, async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/Go.spec.ts
+++ b/tests/e2e/tests/devfiles/Go.spec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import { e2eContainer } from  '../../inversify.config';
 import 'reflect-metadata';
 import { Logger } from '../../utils/Logger';
@@ -16,6 +16,7 @@ import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -33,6 +34,7 @@ const taskRunServer: string = '1.1 Run outyet';
 const taskStopServer: string = '1.2 Stop outyet';
 const taskTestOutyet: string = '1.3 Test outyet';
 const notificationText: string = 'Process 8080-tcp is now listening on port 8080. Open it ?';
+let workspaceName: string;
 
 suite(`${workspaceStack} test`, async () => {
 
@@ -42,6 +44,12 @@ suite(`${workspaceStack} test`, async () => {
             await preferencesHandler.setUseGoLanaguageServer();
         });
         workspaceHandlingTests.createAndOpenWorkspace(workspaceStack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -68,11 +76,6 @@ suite(`${workspaceStack} test`, async () => {
     });
 
     suite('Stop and remove workspace', async() => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/JavaMaven.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaMaven.spec.ts
@@ -8,12 +8,13 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import 'reflect-metadata';
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { e2eContainer } from '../../inversify.config';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -27,10 +28,17 @@ const tabTitle: string = 'HelloWorld.java';
 const codeNavigationClassName: string = 'String.class';
 const stack : string = 'Java Maven';
 const taskName: string = 'maven build';
+let workspaceName: string;
 
 suite(`${stack} test`, async () => {
     suite (`Create ${stack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(stack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -51,12 +59,7 @@ suite(`${stack} test`, async () => {
         commonLanguageServerTests.goToImplementations(tabTitle, 9, 10, codeNavigationClassName, 30_000); // extended timout to give LS enough time to start
     });
 
-    suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
+    suite('Stopping and deleting the workspace', async () => {
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
@@ -8,12 +8,13 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import 'reflect-metadata';
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { e2eContainer } from '../../inversify.config';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -29,10 +30,17 @@ const codeNavigationClassName: string = 'SpringApplication.class';
 const buildTaskName: string = 'maven build';
 const runTaskName: string = 'run webapp';
 const runTaskExpectedDialogue: string = 'Process 8080-tcp is now listening on port 8080. Open it ?';
+let workspaceName: string;
 
 suite(`${stack} test`, async () => {
     suite(`Create ${stack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(stack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -59,11 +67,6 @@ suite(`${stack} test`, async () => {
     });
 
     suite('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/JavaVertx.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaVertx.spec.ts
@@ -8,12 +8,13 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import 'reflect-metadata';
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { e2eContainer } from '../../inversify.config';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -27,10 +28,17 @@ const tabTitle: string = 'HttpApplication.java';
 const codeNavigationClassName: string = 'RouterImpl.class';
 const buildTaskName: string = 'maven build';
 const stack: string = 'Java Vert.x';
+let workspaceName: string;
 
 suite(`${stack} test`, async () => {
     suite (`Create ${stack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(stack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -52,11 +60,6 @@ suite(`${stack} test`, async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/NodeJS.spec.ts
+++ b/tests/e2e/tests/devfiles/NodeJS.spec.ts
@@ -7,13 +7,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import 'reflect-metadata';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { e2eContainer } from '../../inversify.config';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -29,11 +30,18 @@ const fileName: string = `app.js`;
 const taskDownloadDependencies: string = 'download dependencies';
 const taskRunWebApp: string = 'run the web app';
 const taskExpectedDialogText: string = 'Process nodejs is now listening on port 3000. Open it ?';
+let workspaceName: string;
 
 suite(`${workspaceStack} test`, async () => {
 
     suite(`Create ${workspaceStack}`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(workspaceStack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -59,11 +67,6 @@ suite(`${workspaceStack} test`, async () => {
     });
 
     suite('Stop and remove workspace', async() => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/PHPSimple.spec.ts
+++ b/tests/e2e/tests/devfiles/PHPSimple.spec.ts
@@ -9,11 +9,13 @@
  **********************************************************************/
 import 'reflect-metadata';
 import { e2eContainer } from '../../inversify.config';
-import { WorkspaceNameHandler, Editor, CLASSES } from '../..';
+import { CLASSES } from '../../inversify.types';
+import { Editor } from '../../pageobjects/ide/Editor';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -28,10 +30,17 @@ const tabTitle: string = 'index.php';
 const depTaskName: string = 'Configure Apache Web Server DocumentRoot';
 const buildTaskName: string = 'Start Apache Web Server';
 const stack: string = 'PHP Simple';
+let workspaceName: string;
 
 suite(`${stack} test`, async () => {
     suite (`Create ${stack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(stack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName);
     });
 
@@ -57,11 +66,6 @@ suite(`${stack} test`, async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/Python.spec.ts
+++ b/tests/e2e/tests/devfiles/Python.spec.ts
@@ -7,13 +7,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import 'reflect-metadata';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { e2eContainer } from '../../inversify.config';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -26,11 +27,18 @@ const workspaceSampleName: string = 'python-hello-world';
 const taskRunName: string = 'run';
 const fileFolderPath: string = `${workspaceSampleName}`;
 const fileName: string = `hello-world.py`;
+let workspaceName: string;
 
 suite(`${workspaceStack} test`, async () => {
 
     suite(`Create ${workspaceStack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(workspaceStack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName);
     });
 
@@ -52,11 +60,6 @@ suite(`${workspaceStack} test`, async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/PythonDjango.spec.ts
+++ b/tests/e2e/tests/devfiles/PythonDjango.spec.ts
@@ -7,12 +7,13 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import 'reflect-metadata';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { e2eContainer } from '../../inversify.config';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -27,11 +28,18 @@ const taskInstallDependencies: string = 'install dependencies';
 const taskMigrate: string = 'migrate';
 const taskRunServer: string = 'run server';
 const taskExpectedDialogText: string = 'Process django is now listening on port 7000. Open it ?';
+let workspaceName: string;
 
 suite(`${workspaceStack} test`, async () => {
 
     suite(`Create ${workspaceStack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(workspaceStack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -55,11 +63,6 @@ suite(`${workspaceStack} test`, async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/Quarkus.spec.ts
+++ b/tests/e2e/tests/devfiles/Quarkus.spec.ts
@@ -7,13 +7,14 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import 'reflect-metadata';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { e2eContainer } from '../../inversify.config';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -29,10 +30,17 @@ const fileName: string = `GreetingService.java`;
 const taskPackage: string = 'Package';
 const taskPackageNative: string = 'Package Native';
 const taskStartNative: string = 'Start Native';
+let workspaceName: string;
 
 suite(`${workspaceStack} test`, async () => {
     suite(`Create ${workspaceStack}`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(workspaceStack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -64,11 +72,6 @@ suite(`${workspaceStack} test`, async () => {
     });
 
     suite('Stop and remove workspace', async() => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/devfiles/Scala.spec.ts
+++ b/tests/e2e/tests/devfiles/Scala.spec.ts
@@ -8,12 +8,13 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import 'reflect-metadata';
-import { CLASSES, WorkspaceNameHandler } from '../..';
+import { CLASSES } from '../../inversify.types';
 import { LanguageServerTests } from '../../testsLibrary/LanguageServerTests';
 import { e2eContainer } from '../../inversify.config';
 import { CodeExecutionTests } from '../../testsLibrary/CodeExecutionTests';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -28,11 +29,18 @@ const compileTaskkName: string = 'sbt compile';
 const runTaskName: string = 'sbt run';
 const testTaskName: string = 'sbt test';
 const stack: string = 'Scala';
+let workspaceName: string;
 
 // skipping scala to enable pre-release suite to be easily used for updates until https://github.com/eclipse/che/issues/18662 is fixed
 suite.skip(`${stack} test`, async () => {
     suite (`Create ${stack} workspace`, async () => {
         workspaceHandlingTests.createAndOpenWorkspace(stack);
+
+        test('Register running workspace', async () => {
+            workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -58,11 +66,6 @@ suite.skip(`${stack} test`, async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/e2e/DirectUrlFactoryWithKeepDirectoryTest.spec.ts
+++ b/tests/e2e/tests/e2e/DirectUrlFactoryWithKeepDirectoryTest.spec.ts
@@ -11,32 +11,42 @@
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
-import { DriverHelper } from '../../utils/DriverHelper';
-import { WorkspaceNameHandler } from '../..';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
+
+const factoryUrl : string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=https://github.com/che-samples/console-java-simple/tree/master/src`;
+const workspaceSampleName: string = 'console-java-simple';
+const workspaceRootFolderName: string = 'src';
+const fileName: string = 'pom.xml';
+const fileFolderPath: string = `${workspaceSampleName}/${workspaceRootFolderName}/main/java/org/eclipse/che/examples`;
+const tabTitle: string = 'HelloWorld.java';
+let workspaceName: string;
 
 // the suite expect user to be logged in
 suite('Workspace creation via factory url', async () => {
-
-    let factoryUrl : string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=https://github.com/che-samples/console-java-simple/tree/master/src`;
-    const workspaceSampleName: string = 'console-java-simple';
-    const workspaceRootFolderName: string = 'src';
-    const fileName: string = 'pom.xml';
-    const fileFolderPath: string = `${workspaceSampleName}/${workspaceRootFolderName}/main/java/org/eclipse/che/examples`;
-    const tabTitle: string = 'HelloWorld.java';
-
     suite('Open factory URL', async () => {
         test(`Navigating to factory URL`, async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
     });
 
     suite('Wait workspace readyness', async () => {
+        test('Register running workspace', async () => {
+            await dashboard.waitWorkspaceStartingPage();
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -48,10 +58,6 @@ suite('Workspace creation via factory url', async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup( async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
         test (`Stop workspace`, async () => {
             await workspaceHandlingTests.stopWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/e2e/DirectUrlFactoryWithRootFolderTest.spec.ts
+++ b/tests/e2e/tests/e2e/DirectUrlFactoryWithRootFolderTest.spec.ts
@@ -11,31 +11,41 @@
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
-import { DriverHelper } from '../../utils/DriverHelper';
-import { WorkspaceNameHandler } from '../..';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
+
+const factoryUrl : string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=https://github.com/che-samples/console-java-simple`;
+const workspaceSampleName: string = 'console-java-simple';
+const workspaceRootFolderName: string = 'src';
+const fileFolderPath: string = `${workspaceSampleName}/${workspaceRootFolderName}/main/java/org/eclipse/che/examples`;
+const tabTitle: string = 'HelloWorld.java';
+let workspaceName: string;
 
 // the suite expect user to be logged in
 suite('Workspace creation via factory url', async () => {
-
-    let factoryUrl : string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=https://github.com/che-samples/console-java-simple`;
-    const workspaceSampleName: string = 'console-java-simple';
-    const workspaceRootFolderName: string = 'src';
-    const fileFolderPath: string = `${workspaceSampleName}/${workspaceRootFolderName}/main/java/org/eclipse/che/examples`;
-    const tabTitle: string = 'HelloWorld.java';
-
     suite('Open factory URL', async () => {
         test(`Navigating to factory URL`, async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
     });
 
     suite('Wait workspace readyness', async () => {
+        test('Register running workspace', async () => {
+            await dashboard.waitWorkspaceStartingPage();
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -46,10 +56,6 @@ suite('Workspace creation via factory url', async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup( async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
         test (`Stop workspace`, async () => {
             await workspaceHandlingTests.stopWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/e2e/DirectUrlFactoryWithSpecificBranchTest.spec.ts
+++ b/tests/e2e/tests/e2e/DirectUrlFactoryWithSpecificBranchTest.spec.ts
@@ -11,14 +11,20 @@
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
-import { DriverHelper } from '../../utils/DriverHelper';
-import { WorkspaceNameHandler } from '../..';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
+
+let workspaceName: string;
 
 // the suite expect user to be logged in
 suite('Workspace creation via factory url', async () => {
@@ -31,11 +37,17 @@ suite('Workspace creation via factory url', async () => {
 
     suite('Open factory URL', async () => {
         test(`Navigating to factory URL`, async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
     });
 
     suite('Wait workspace readyness', async () => {
+        test('Register running workspace', async () => {
+            await dashboard.waitWorkspaceStartingPage();
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
@@ -45,10 +57,6 @@ suite('Workspace creation via factory url', async () => {
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup( async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
         test (`Stop workspace`, async () => {
             await workspaceHandlingTests.stopWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/e2e/FactoryUrl.spec.ts
+++ b/tests/e2e/tests/e2e/FactoryUrl.spec.ts
@@ -11,37 +11,43 @@
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { TestConstants } from '../../TestConstants';
-import { DriverHelper } from '../../utils/DriverHelper';
-import { WorkspaceNameHandler } from '../..';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
+
+const factoryUrl : string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=https://raw.githubusercontent.com/eclipse/che-devfile-registry/master/devfiles/java-maven/devfile.yaml`;
+const workspaceSampleName: string = 'console-java-simple';
+const workspaceRootFolderName: string = 'src';
+let workspaceName: string;
 
 // the suite expect user to be logged in
 suite('Workspace creation via factory url', async () => {
-
-    let factoryUrl : string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=https://raw.githubusercontent.com/eclipse/che-devfile-registry/master/devfiles/java-maven/devfile.yaml`;
-    const workspaceSampleName: string = 'console-java-simple';
-    const workspaceRootFolderName: string = 'src';
-
     suite('Open factory URL', async () => {
         test(`Navigating to factory URL`, async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
     });
 
     suite('Wait workspace readyness', async () => {
+        test('Register running workspace', async () => {
+            await dashboard.waitWorkspaceStartingPage();
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 
     suite ('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup( async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
         test (`Stop worksapce`, async () => {
             await workspaceHandlingTests.stopWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/e2e/GitPublishBranch.spec.ts
+++ b/tests/e2e/tests/e2e/GitPublishBranch.spec.ts
@@ -22,8 +22,11 @@ import { TestWorkspaceUtil } from '../../utils/workspace/TestWorkspaceUtil';
 import { TopMenu } from '../../pageobjects/ide/TopMenu';
 import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 import { By } from 'selenium-webdriver';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const quickOpenContainer: QuickOpenContainer = e2eContainer.get(CLASSES.QuickOpenContainer);
 const editor: Editor = e2eContainer.get(CLASSES.Editor);
@@ -32,16 +35,15 @@ const loginPage: ICheLoginPage = e2eContainer.get<ICheLoginPage>(TYPES.CheLogin)
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const gitPlugin: GitPlugin = e2eContainer.get(CLASSES.GitPlugin);
 const testWorkspaceUtils: TestWorkspaceUtil = e2eContainer.get<TestWorkspaceUtil>(TYPES.WorkspaceUtil);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
+const workspacePrefixUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/dashboard/#/ide/${TestConstants.TS_SELENIUM_USERNAME}/`;
+const wsNameGitPublishBranch = workspaceNameHandler.generateWorkspaceName('checkGitPublishBranch-', 5);
+const changedFile = 'README.md';
+const branchName = workspaceNameHandler.generateWorkspaceName('checkGitPublishBranch', 5);
+const file = `https://github.com/${TestConstants.TS_GITHUB_TEST_REPO}/blob/${branchName}/README.md`;
 
 suite('Publish branch in git extension', async () => {
-    const workspacePrefixUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/dashboard/#/ide/${TestConstants.TS_SELENIUM_USERNAME}/`;
-    const wsNameGitPublishBranch = WorkspaceNameHandler.generateWorkspaceName('checkGitPublishBranch-', 5);
-    const changedFile = 'README.md';
-    const branchName = WorkspaceNameHandler.generateWorkspaceName('checkGitPublishBranch', 5);
-    const file = `https://github.com/${TestConstants.TS_GITHUB_TEST_REPO}/blob/${branchName}/README.md`;
-
-
     suiteSetup(async function () {
         const wsConfig = await testWorkspaceUtils.getBaseDevfile();
         wsConfig.metadata!.name = wsNameGitPublishBranch;
@@ -49,8 +51,9 @@ suite('Publish branch in git extension', async () => {
     });
 
     test('Login into workspace', async () => {
-        await driverHelper.navigateToUrl(workspacePrefixUrl + wsNameGitPublishBranch);
+        await browserTabsUtil.navigateTo(workspacePrefixUrl + wsNameGitPublishBranch);
         await loginPage.login();
+        CheReporter.registerRunningWorkspace(wsNameGitPublishBranch);
         await ide.waitWorkspaceAndIde();
         await projectTree.openProjectTreeContainer();
         await driverHelper.wait(15000);
@@ -79,7 +82,7 @@ suite('Publish branch in git extension', async () => {
         await gitPlugin.waitDataIsSynchronized();
         await testWorkspaceUtils.cleanUpAllWorkspaces();
 
-        await driverHelper.navigateToUrl(file);
+        await browserTabsUtil.navigateTo(file);
         await driverHelper.waitVisibility(By.xpath(readmeFileContentXpath));
     });
 

--- a/tests/e2e/tests/e2e/GitSsh.spec.ts
+++ b/tests/e2e/tests/e2e/GitSsh.spec.ts
@@ -28,6 +28,7 @@ import { TimeoutConstants } from '../../TimeoutConstants';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 import { By } from 'selenium-webdriver';
+import CheReporter from '../../driver/CheReporter';
 
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
@@ -42,14 +43,14 @@ const gitPlugin: GitPlugin = e2eContainer.get(CLASSES.GitPlugin);
 const testWorkspaceUtils: TestWorkspaceUtil = e2eContainer.get<TestWorkspaceUtil>(TYPES.WorkspaceUtil);
 const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
 const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
+const workspacePrefixUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/dashboard/#/ide/${TestConstants.TS_SELENIUM_USERNAME}/`;
+const wsNameCheckGeneratingKeys = 'checkGeneratingSsh';
+const wsNameCheckPropagatingKeys = 'checkPropagatingSsh';
+const committedFile = 'README.md';
 
 suite('Git with ssh workflow', async () => {
-    const workspacePrefixUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/dashboard/#/ide/${TestConstants.TS_SELENIUM_USERNAME}/`;
-    const wsNameCheckGeneratingKeys = 'checkGeneratingSsh';
-    const wsNameCheckPropagatingKeys = 'checkPropagatingSsh';
-    const committedFile = 'README.md';
-
     suiteSetup(async function () {
         const wsConfig = await testWorkspaceUtils.getBaseDevfile();
         wsConfig.metadata!.name = wsNameCheckGeneratingKeys;
@@ -62,6 +63,7 @@ suite('Git with ssh workflow', async () => {
         await dashboard.openDashboard();
         await dashboard.waitPage();
         await browserTabsUtil.navigateTo(workspacePrefixUrl + wsNameCheckGeneratingKeys);
+        CheReporter.registerRunningWorkspace(wsNameCheckGeneratingKeys);
         await ide.waitWorkspaceAndIde();
         await projectTree.openProjectTreeContainer();
         await driverHelper.wait(TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
@@ -76,7 +78,7 @@ suite('Git with ssh workflow', async () => {
     });
 
     test('Add a SSH key to GitHub side and clone by ssh link', async () => {
-        const sshName: string = WorkspaceNameHandler.generateWorkspaceName('test-SSH-', 5);
+        const sshName: string = workspaceNameHandler.generateWorkspaceName('test-SSH-', 5);
         const publicSshKey = await cheGitAPI.getPublicSSHKey();
         await gitHubUtils.addPublicSshKeyToUserAccount(TestConstants.TS_GITHUB_TEST_REPO_ACCESS_TOKEN, sshName, publicSshKey);
         await cloneTestRepo();
@@ -114,6 +116,7 @@ suite('Git with ssh workflow', async () => {
         await testWorkspaceUtils.createWsFromDevFile(data);
         await dashboard.openDashboard();
         await browserTabsUtil.navigateTo(workspacePrefixUrl + wsNameCheckPropagatingKeys);
+        CheReporter.registerRunningWorkspace(wsNameCheckPropagatingKeys);
         await ide.waitWorkspaceAndIde();
         await projectTree.openProjectTreeContainer();
         await driverHelper.wait(TimeoutConstants.TS_SELENIUM_LOAD_PAGE_TIMEOUT);

--- a/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
+++ b/tests/e2e/tests/e2e/OpenshiftConnector.spec.ts
@@ -25,6 +25,7 @@ import { PreferencesHandler, TerminalRendererType } from '../../utils/Preference
 import { TestWorkspaceUtil } from '../../utils/workspace/TestWorkspaceUtil';
 import { TimeoutConstants } from '../../TimeoutConstants';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import CheReporter from '../../driver/CheReporter';
 
 
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
@@ -76,6 +77,7 @@ suite('Openshift connector user story', async () => {
   test('Login into workspace and open plugin', async () => {
     await dashboard.openDashboard();
     await browserTabsUtil.navigateTo(workspacePrefixUrl + wsName);
+    CheReporter.registerRunningWorkspace(wsName);
     await ide.waitWorkspaceAndIde();
     await projectTree.openProjectTreeContainer();
     await projectTree.waitProjectImported(projectName, 'index.js');

--- a/tests/e2e/tests/e2e_happy_path/DevWorkspaceHappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/DevWorkspaceHappyPath.spec.ts
@@ -10,12 +10,15 @@
 
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
-import { DriverHelper } from '../../utils/DriverHelper';
-import { TestConstants } from '../..';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
+import { TestConstants } from '../../TestConstants';
 
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 // this test checks only workspace created from "web-nodejs-sample" https://github.com/devfile/devworkspace-operator/blob/main/samples/flattened_theia-next.yaml.
 suite('Workspace creation via factory url', async () => {
@@ -26,11 +29,15 @@ suite('Workspace creation via factory url', async () => {
 
     suite('Open factory URL', async () => {
         test(`Navigating to factory URL`, async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
     });
 
     suite('Wait workspace readiness', async () => {
+        test('Register running workspace', async () => {
+            CheReporter.registerRunningWorkspace(await workspaceNameHandler.getNameFromUrl());
+        });
+
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
     });
 

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -29,9 +29,12 @@ import { TimeoutConstants } from '../../TimeoutConstants';
 import { Logger } from '../../utils/Logger';
 import { RightToolBar } from '../../pageobjects/ide/RightToolBar';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import CheReporter from '../../driver/CheReporter';
 
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const topMenu: TopMenu = e2eContainer.get(CLASSES.TopMenu);
@@ -72,6 +75,10 @@ suite('Validation of workspace start', async () => {
         await dashboard.clickWorkspacesButton();
         await workspaces.waitPage();
         await workspaces.clickOpenButton(workspaceName);
+    });
+
+    test('Register running workspace', async () => {
+        CheReporter.registerRunningWorkspace(workspaceName);
     });
 
     projectAndFileTests.waitWorkspaceReadiness(projectName, workspaceRootFolderName);
@@ -115,7 +122,7 @@ suite('Language server validation', async () => {
             await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT);
         } catch (err) {
             Logger.debug('Workaround for the https://github.com/eclipse/che/issues/18974.');
-            await driverHelper.reloadPage();
+            await browserTabsUtil.refreshPage();
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde();
             await editor.waitErrorInLine(30, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT * 2);

--- a/tests/e2e/tests/intelij/IntelijOpenWorkspace.spec.ts
+++ b/tests/e2e/tests/intelij/IntelijOpenWorkspace.spec.ts
@@ -14,18 +14,28 @@ import { CLASSES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { TestConstants } from '../../TestConstants';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
+import CheReporter from '../../driver/CheReporter';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
+
 const dashboardUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}`;
 
 suite('The "IntelijOpenWorkspace" userstory', async () => {
     suite('Open workspace', async () => {
         test('Open workspace', async () => {
-            await driverHelper.navigateToUrl(`${dashboardUrl}/dashboard/#/ide/admin/java-11-intellij`);
+            await browserTabsUtil.navigateTo(`${dashboardUrl}/dashboard/#/ide/admin/java-11-intellij`);
         });
 
         test('Wait workspace', async () => {
+            await dashboard.waitWorkspaceStartingPage();
+            CheReporter.registerRunningWorkspace(await workspaceNameHandler.getNameFromUrl());
             await ide.waitAndSwitchToIdeFrame();
             await waitIntelijWorkspace();
         });

--- a/tests/e2e/tests/load_test/LoadTest.spec.ts
+++ b/tests/e2e/tests/load_test/LoadTest.spec.ts
@@ -12,16 +12,20 @@ import { e2eContainer } from '../../inversify.config';
 import { CLASSES, TYPES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
 import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { ICheLoginPage } from '../../pageobjects/login/ICheLoginPage';
 import { TestWorkspaceUtil } from '../../utils/workspace/TestWorkspaceUtil';
 import { TestConstants, WorkspaceNameHandler } from '../..';
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const cheLoginPage: ICheLoginPage = e2eContainer.get<ICheLoginPage>(TYPES.CheLogin);
 const testWorkspaceUtils: TestWorkspaceUtil = e2eContainer.get<TestWorkspaceUtil>(TYPES.WorkspaceUtil);
-const workspaceName: string = WorkspaceNameHandler.generateWorkspaceName('wksp-test-', 5);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
+
+const workspaceName: string = workspaceNameHandler.generateWorkspaceName('wksp-test-', 5);
 const workspacePrefixUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/dashboard/#/ide/${TestConstants.TS_SELENIUM_USERNAME}/`;
 
 suite('Load test suite', async () => {
@@ -35,12 +39,12 @@ suite('Load test suite', async () => {
     });
 
     test('Login into workspace and open tree container', async () => {
-        await driverHelper.navigateToUrl(workspacePrefixUrl + workspaceName);
+        await browserTabsUtil.navigateTo(workspacePrefixUrl + workspaceName);
         await cheLoginPage.login();
     });
 
-
     test('Wait loading workspace and get time', async () => {
+        CheReporter.registerRunningWorkspace(workspaceName);
         await ide.waitWorkspaceAndIde();
         await projectTree.openProjectTreeContainer();
     });

--- a/tests/e2e/tests/plugins/JavaPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/JavaPlugin.spec.ts
@@ -7,9 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { WorkspaceNameHandler } from '../..';
 import 'reflect-metadata';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
@@ -20,13 +18,17 @@ import { Key } from 'selenium-webdriver';
 import { Editor } from '../../pageobjects/ide/Editor';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const editor: Editor = e2eContainer.get(CLASSES.Editor);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/devfiles/plugins/Java11PluginTest.yaml';
 const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
@@ -36,16 +38,21 @@ const subRootFolder: string = 'src';
 
 const fileFolderPath: string = `${sampleName}/src/main/java/org/eclipse/che/examples`;
 const tabTitle: string = 'HelloWorld.java';
+let workspaceName: string;
 
 suite(`The 'JavaPlugin' test`, async () => {
     suite('Create workspace', async () => {
         test('Create workspace using factory', async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
 
         test('Wait until created workspace is started', async () => {
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
+
             await projectTree.openProjectTreeContainer();
             await projectTree.waitProjectImported(sampleName, subRootFolder);
         });
@@ -86,11 +93,6 @@ suite(`The 'JavaPlugin' test`, async () => {
     });
 
     suite('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remove workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/plugins/PhpPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/PhpPlugin.spec.ts
@@ -7,7 +7,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { WorkspaceNameHandler } from '../..';
 import 'reflect-metadata';
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
@@ -21,6 +20,8 @@ import { TopMenu } from '../../pageobjects/ide/TopMenu';
 import { DebugView } from '../../pageobjects/ide/DebugView';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
@@ -29,6 +30,7 @@ const editor: Editor = e2eContainer.get(CLASSES.Editor);
 const topMenu: TopMenu = e2eContainer.get(CLASSES.TopMenu);
 const debugView: DebugView = e2eContainer.get(CLASSES.DebugView);
 const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/devfiles/plugins/PhpPluginTest.yaml';
 const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
@@ -37,6 +39,7 @@ const subRootFolder: string = 'README.md';
 
 const fileFolderPath: string = `${projectName}`;
 const tabTitle: string = 'index.php';
+let workspaceName: string;
 
 suite(`The 'PhpPlugin' tests`, async () => {
     suite('Create workspace', async () => {
@@ -45,8 +48,12 @@ suite(`The 'PhpPlugin' tests`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
+
             await projectTree.openProjectTreeContainer();
             await projectTree.waitProjectImported(projectName, subRootFolder);
         });
@@ -95,11 +102,6 @@ suite(`The 'PhpPlugin' tests`, async () => {
 
     suite('Stopping and deleting the workspace', async () => {
         test(`Stop and remove workspace`, async () => {
-            let workspaceName = 'not defined';
-            suiteSetup(async () => {
-                workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-            });
-
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });
     });

--- a/tests/e2e/tests/plugins/PythonPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/PythonPlugin.spec.ts
@@ -7,9 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { WorkspaceNameHandler } from '../..';
 import 'reflect-metadata';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
@@ -19,12 +17,16 @@ import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
 import { Key } from 'selenium-webdriver';
 import { Editor } from '../../pageobjects/ide/Editor';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const editor: Editor = e2eContainer.get(CLASSES.Editor);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/devfiles/plugins/PythonPluginTest.yaml';
 const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
@@ -33,16 +35,21 @@ const subRootFile: string = 'README.md';
 
 const fileFolderPath: string = `${sampleName}`;
 const tabTitle: string = 'hello-world.py';
+let workspaceName: string;
 
 suite(`The 'PythonPlugin' test`, async () => {
     suite('Create workspace', async () => {
         test('Create workspace using factory', async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
 
         test('Wait until created workspace is started', async () => {
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
+
             await projectTree.openProjectTreeContainer();
             await projectTree.waitProjectImported(sampleName, subRootFile);
         });
@@ -71,11 +78,6 @@ suite(`The 'PythonPlugin' test`, async () => {
     });
 
     suite('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remove workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/plugins/VscodeKubernetesPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeKubernetesPlugin.spec.ts
@@ -7,9 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { WorkspaceNameHandler } from '../..';
 import 'reflect-metadata';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
@@ -19,19 +17,24 @@ import { PreferencesHandler } from '../../utils/PreferencesHandler';
 import { KubernetesPlugin } from '../../pageobjects/ide/plugins/KubernetesPlugin';
 import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const preferencesHandler: PreferencesHandler = e2eContainer.get(CLASSES.PreferencesHandler);
 const kubernetesPlugin: KubernetesPlugin = e2eContainer.get(CLASSES.KubernetesPlugin);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/devfiles/plugins/VscodeKubernetesPlugin.yaml';
 const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
 const sampleName: string = 'nodejs-web-app';
 const subRootFolder: string = 'app';
 const vsKubernetesConfig = { 'vs-kubernetes.kubeconfig': '/projects/nodejs-web-app/config' };
+let workspaceName: string;
 
 suite(`The 'VscodeKubernetesPlugin' test`, async () => {
     suite('Create workspace', async () => {
@@ -40,12 +43,16 @@ suite(`The 'VscodeKubernetesPlugin' test`, async () => {
         });
 
         test('Create workspace using factory', async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
 
         test('Wait until created workspace is started', async () => {
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
+
             await projectTree.openProjectTreeContainer();
             await projectTree.waitProjectImported(sampleName, subRootFolder);
         });
@@ -62,11 +69,6 @@ suite(`The 'VscodeKubernetesPlugin' test`, async () => {
     });
 
     suite('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/plugins/VscodeShellcheckPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeShellcheckPlugin.spec.ts
@@ -7,9 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { WorkspaceNameHandler } from '../..';
 import 'reflect-metadata';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
@@ -20,13 +18,17 @@ import { Editor } from '../../pageobjects/ide/Editor';
 import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
 import { Key } from 'selenium-webdriver';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const preferencesHandler: PreferencesHandler = e2eContainer.get(CLASSES.PreferencesHandler);
 const editor: Editor = e2eContainer.get(CLASSES.Editor);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/devfiles/plugins/VscodeShellcheckPlugin.yaml';
 const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
@@ -34,6 +36,7 @@ const sampleName: string = 'nodejs-web-app';
 const subRootFolder: string = 'app';
 const pathToFile: string = `${sampleName}`;
 const fileName: string = 'test.sh';
+let workspaceName: string;
 
 // skipped until issue: https://github.com/eclipse/che/issues/19376 resolved
 suite.skip(`The 'VscodeShellcheckPlugin' test`, async () => {
@@ -46,12 +49,16 @@ suite.skip(`The 'VscodeShellcheckPlugin' test`, async () => {
         });
 
         test('Create workspace using factory', async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
 
         test('Wait until created workspace is started', async () => {
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
+
             await projectTree.openProjectTreeContainer();
             await projectTree.waitProjectImported(sampleName, subRootFolder);
         });
@@ -86,11 +93,6 @@ suite.skip(`The 'VscodeShellcheckPlugin' test`, async () => {
     });
 
     suite('Stopping and deleting the workspace', async () => {
-        let workspaceName = 'not defined';
-        suiteSetup(async () => {
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
-        });
-
         test(`Stop and remowe workspace`, async () => {
             await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });

--- a/tests/e2e/tests/plugins/VscodeValePlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeValePlugin.spec.ts
@@ -10,44 +10,45 @@
 
 import { Key } from 'selenium-webdriver';
 import { e2eContainer } from '../../inversify.config';
-import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { CLASSES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
 import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
 import { Editor } from '../../pageobjects/ide/Editor';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { TestConstants } from '../../TestConstants';
 import { TimeoutConstants } from '../../TimeoutConstants';
 import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
 import { Terminal } from '../../pageobjects/ide/Terminal';
-
-const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const editor: Editor = e2eContainer.get(CLASSES.Editor);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const terminal: Terminal = e2eContainer.get(CLASSES.Terminal);
-
-let workspaceName: string = '';
+const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/devfiles/plugins/VscodeValePlugin.yaml';
 const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
 const projectName: string = 'che-docs';
 const pathToFile: string = `${projectName}/modules/administration-guide/partials`;
 const docFileName: string = 'assembly_authenticating-users.adoc';
+let workspaceName: string = '';
 
 suite('The "VscodeValePlugin" userstory', async () => {
     suite('Create workspace', async () => {
         test('Create workspace using factory', async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
 
         test('Wait until created workspace is started', async () => {
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
-
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
         });
     });
 
@@ -75,9 +76,9 @@ suite('The "VscodeValePlugin" userstory', async () => {
 
     });
 
-    suite('Delete workspace', async () => {
-        test('Delete workspace', async () => {
-            await dashboard.stopAndRemoveWorkspaceByUI(workspaceName);
+    suite('Stopping and deleting the workspace', async () => {
+        test(`Stop and remowe workspace`, async () => {
+            await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });
     });
 });

--- a/tests/e2e/tests/plugins/VscodeXmlPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeXmlPlugin.spec.ts
@@ -11,41 +11,42 @@
 import { Key } from 'selenium-webdriver';
 import { e2eContainer } from '../../inversify.config';
 import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
-import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { Ide } from '../../pageobjects/ide/Ide';
 import { CLASSES } from '../../inversify.types';
 import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
 import { Editor } from '../../pageobjects/ide/Editor';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { TestConstants } from '../../TestConstants';
 import { TimeoutConstants } from '../../TimeoutConstants';
-
-const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const editor: Editor = e2eContainer.get(CLASSES.Editor);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
-
-let workspaceName: string = '';
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/devfiles/plugins/VscodeXmlPlugin.yaml';
 const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
 const projectName: string = 'nodejs-web-app';
 const pathToFile: string = `${projectName}`;
 const xmlFileName: string = 'hello.xml';
+let workspaceName: string = '';
 
 suite('The "VscodeXmlPlugin" userstory', async () => {
     suite('Create workspace', async () => {
         test('Create workspace using factory', async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
 
         test('Wait until created workspace is started', async () => {
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
-
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
         });
     });
 
@@ -103,9 +104,9 @@ suite('The "VscodeXmlPlugin" userstory', async () => {
 
     });
 
-    suite('Delete workspace', async () => {
-        test('Delete workspace', async () => {
-            await dashboard.stopAndRemoveWorkspaceByUI(workspaceName);
+    suite('Stopping and deleting the workspace', async () => {
+        test(`Stop and remowe workspace`, async () => {
+            await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });
     });
 });

--- a/tests/e2e/tests/plugins/VscodeYamlPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeYamlPlugin.spec.ts
@@ -10,26 +10,25 @@
 
 import { Key } from 'selenium-webdriver';
 import { e2eContainer } from '../../inversify.config';
-import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { CLASSES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
 import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
 import { Editor } from '../../pageobjects/ide/Editor';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { PreferencesHandler } from '../../utils/PreferencesHandler';
 import { TestConstants } from '../../TestConstants';
 import { TimeoutConstants } from '../../TimeoutConstants';
 import { WorkspaceNameHandler } from '../../utils/WorkspaceNameHandler';
-
-const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
+import CheReporter from '../../driver/CheReporter';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
 const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const editor: Editor = e2eContainer.get(CLASSES.Editor);
-const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const preferencesHandler: PreferencesHandler = e2eContainer.get(CLASSES.PreferencesHandler);
-
-let workspaceName: string = '';
+const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
 
 const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/master/tests/e2e/files/devfiles/plugins/VscodeYamlPlugin.yaml';
 const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
@@ -37,6 +36,7 @@ const projectName: string = 'nodejs-web-app';
 const pathToFile: string = `${projectName}`;
 const yamlFileName: string = 'routes.yaml';
 const yamlSchema = { 'https://raw.githubusercontent.com/apache/camel-k-runtime/camel-k-runtime-parent-1.5.0/camel-k-loader-yaml/camel-k-loader-yaml/src/generated/resources/camel-yaml-dsl.json': '*.yaml' };
+let workspaceName: string = '';
 
 suite('The "VscodeYamlPlugin" userstory', async () => {
     suite('Create workspace', async () => {
@@ -45,14 +45,15 @@ suite('The "VscodeYamlPlugin" userstory', async () => {
         });
 
         test('Create workspace using factory', async () => {
-            await driverHelper.navigateToUrl(factoryUrl);
+            await browserTabsUtil.navigateTo(factoryUrl);
         });
 
         test('Wait until created workspace is started', async () => {
+            workspaceName = await workspaceNameHandler.getNameFromUrl();
+            CheReporter.registerRunningWorkspace(workspaceName);
+
             await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
-
-            workspaceName = await WorkspaceNameHandler.getNameFromUrl();
         });
     });
 
@@ -100,9 +101,9 @@ suite('The "VscodeYamlPlugin" userstory', async () => {
 
     });
 
-    suite('Delete workspace', async () => {
-        test('Delete workspace', async () => {
-            await dashboard.stopAndRemoveWorkspaceByUI(workspaceName);
+    suite('Stopping and deleting the workspace', async () => {
+        test(`Stop and remowe workspace`, async () => {
+            await workspaceHandlingTests.stopAndRemoveWorkspace(workspaceName);
         });
     });
 });

--- a/tests/e2e/testsLibrary/WorkspaceHandlingTests.ts
+++ b/tests/e2e/testsLibrary/WorkspaceHandlingTests.ts
@@ -14,14 +14,22 @@ import { CLASSES } from '../inversify.types';
 import { Dashboard } from '../pageobjects/dashboard/Dashboard';
 import { CreateWorkspace } from '../pageobjects/dashboard/CreateWorkspace';
 import { Workspaces } from '../pageobjects/dashboard/Workspaces';
+import { WorkspaceNameHandler } from '../utils/WorkspaceNameHandler';
 
 @injectable()
 export class WorkspaceHandlingTests {
 
+    private static workspaceName: string = 'undefined';
+
+    public static getWorkspaceName(): string {
+        return WorkspaceHandlingTests.workspaceName;
+    }
+
     constructor(
         @inject(CLASSES.Dashboard) private readonly dashboard: Dashboard,
         @inject(CLASSES.CreateWorkspace) private readonly createWorkspace: CreateWorkspace,
-        @inject(CLASSES.Workspaces) private readonly workspaces: Workspaces) {}
+        @inject(CLASSES.Workspaces) private readonly workspaces: Workspaces,
+        @inject(CLASSES.WorkspaceNameHandler) private readonly workspaceNameHandler: WorkspaceNameHandler) {}
 
     public createAndOpenWorkspace(stack: string) {
         test(`Open 'New Workspace' page`, async () => {
@@ -29,6 +37,8 @@ export class WorkspaceHandlingTests {
             await this.dashboard.clickCreateWorkspaceButton();
             await this.createWorkspace.waitPage();
             await this.createWorkspace.clickOnSample(stack);
+            await this.dashboard.waitWorkspaceStartingPage();
+            WorkspaceHandlingTests.workspaceName = await this.workspaceNameHandler.getNameFromUrl();
         });
     }
 

--- a/tests/e2e/utils/WorkspaceNameHandler.ts
+++ b/tests/e2e/utils/WorkspaceNameHandler.ts
@@ -8,17 +8,21 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { DriverHelper } from './DriverHelper';
-import { e2eContainer } from '../inversify.config';
 import { CLASSES } from '../inversify.types';
-let driverHelper : DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+import { inject, injectable } from 'inversify';
+import { BrowserTabsUtil } from './BrowserTabsUtil';
+import { Logger } from './Logger';
 
+@injectable()
 export class WorkspaceNameHandler {
 
-    public static generateWorkspaceName(prefix: string, randomLength: number): string {
+    constructor(@inject(CLASSES.BrowserTabsUtil) private readonly browserTabsUtil: BrowserTabsUtil) {}
+
+    public generateWorkspaceName(prefix: string, randomLength: number): string {
         const possibleCharacters: string = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
         const possibleCharactersLength: number = possibleCharacters.length;
         let randomPart: string = '';
+        Logger.debug('WorkspaceNameHandler.generateWorkspaceName');
 
         for (let i = 0; i < randomLength; i++) {
             let currentRandomIndex: number = Math.floor(Math.random() * Math.floor(possibleCharactersLength));
@@ -29,12 +33,16 @@ export class WorkspaceNameHandler {
         return prefix + randomPart;
     }
 
-    public static async getNameFromUrl() : Promise<string> {
-        let url : string = await driverHelper.getCurrentUrl();
-        url = url.split('?')[0];
-        let splittedUrl = url.split(`/`);
-        let wsname : string = splittedUrl[splittedUrl.length - 1];
-        return wsname;
-    }
+    public async getNameFromUrl(): Promise<string> {
+        let workspaceUrl: string = await this.browserTabsUtil.getCurrentUrl();
+        Logger.debug(`WorkspaceNameHandler.fromWorkspaceUrl  workspaceUrl: ${workspaceUrl}`);
 
+        const workspaceUrlParts: string[] = workspaceUrl.split('/');
+        const workspaceNameQueryString: string = workspaceUrlParts[workspaceUrlParts.length - 1];
+        const workspaceName: string = workspaceNameQueryString.split('?')[0];
+
+        Logger.debug(`workspaceName: ${workspaceName}`);
+
+        return workspaceName;
+    }
 }

--- a/tests/e2e/utils/workspace/ITestWorkspaceUtil.ts
+++ b/tests/e2e/utils/workspace/ITestWorkspaceUtil.ts
@@ -13,11 +13,12 @@ import { che } from '@eclipse-che/api';
 
 export interface ITestWorkspaceUtil {
     cleanUpAllWorkspaces() : void;
+    cleanUpRunningWorkspace(workspaceName: string) : void;
     waitWorkspaceStatus(namespace: string, workspaceName: string, expectedWorkspaceStatus: WorkspaceStatus) : void;
     waitPluginAdding(namespace: string, workspaceName: string, pluginId: string) : void;
     removeWorkspaceById(id: string) : void;
     stopWorkspaceById(id: string) : void;
-    getIdOfRunningWorkspace(namespace: string): Promise<string>;
+    getIdOfRunningWorkspace(workspaceName: string): Promise<string>;
     getIdOfRunningWorkspaces(): Promise<Array<string>>;
     createWsFromDevFile(customTemplate: che.workspace.devfile.Devfile): void;
     getBaseDevfile(): Promise<che.workspace.devfile.Devfile>;

--- a/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
+++ b/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
@@ -207,6 +207,26 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
 
     }
 
+    public async cleanUpRunningWorkspace(workspaceName: string) {
+        if (workspaceName === undefined || workspaceName.length === 0) {
+          Logger.warn(`Could nod delete workspace because workspaceName is undefined or empty`);
+          return;
+        }
+
+        Logger.debug(`TestWorkspaceUtil.cleanUpRunningWorkspace ${workspaceName}`);
+        const workspaceID: string = await this.getIdOfRunningWorkspace(workspaceName);
+
+        if (workspaceID === undefined || workspaceID.length === 0) {
+          Logger.error(`Could nod delete workspace with name ${workspaceName} because workspaceID is undefined or empty`);
+          return;
+        }
+
+        Logger.trace(`TestWorkspaceUtil.cleanUpRunningWorkspace Stopping workspace:${workspaceName} with ID:${workspaceID}`);
+        await this.stopWorkspaceById(workspaceID);
+        Logger.trace(`TestWorkspaceUtil.cleanUpRunningWorkspace Deleting workspace ${workspaceName}`);
+        await this.removeWorkspaceById(workspaceID);
+    }
+
     async createWsFromDevFile(customTemplate: che.workspace.devfile.Devfile) {
         Logger.debug('TestWorkspaceUtil.createWsFromDevFile');
 


### PR DESCRIPTION
* Fixing linter errors

Signed-off-by: Tibor Dancs <tdancs@redhat.com>

* Added on.fail workspace deletion logic that only removes a single workspace to allow running the tests in parallel

Signed-off-by: Tibor Dancs <tdancs@redhat.com>

* Refactored WorkspaceNameHandler logic and associated test classes

Signed-off-by: Tibor Dancs <tdancs@redhat.com>

* Added option to separately toggle Request and Response interceptors, false by default

Signed-off-by: Tibor Dancs <tdancs@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
