### PR TITLE
Fixed logic errors regarding obtaining the preview widget URL

### DIFF
--- a/tests/e2e/testsLibrary/CodeExecutionTests.ts
+++ b/tests/e2e/testsLibrary/CodeExecutionTests.ts
@@ -104,8 +104,8 @@ export class CodeExecutionTests {
         test(`Run command '${taskName}' expecting notification`, async () => {
             await this.topMenu.runTask(taskName);
             await this.ide.waitNotification(notificationText, timeout);
-            CodeExecutionTests.lastApplicationUrl = await this.ide.getApplicationUrlFromNotification(notificationText, timeout);
             await this.ide.clickOnNotificationButton(notificationText, buttonText);
+            CodeExecutionTests.lastApplicationUrl = await this.previewWidget.getUrl();
         });
     }
 
@@ -114,7 +114,6 @@ export class CodeExecutionTests {
             await this.topMenu.runTask(taskName);
             await this.ide.waitNotification(notificationText, timeout);
             await this.ide.clickOnNotificationButton(notificationText, 'Open In Preview');
-            await this.previewWidget.waitAndSwitchToWidgetFrame();
             CodeExecutionTests.lastApplicationUrl = await this.previewWidget.getUrl();
         });
     }
@@ -123,8 +122,8 @@ export class CodeExecutionTests {
         test(`Run command '${taskName}' expecting notification with unexposed port`, async () => {
             await this.topMenu.runTask(taskName);
             await this.ide.waitNotificationAndConfirm(notificationText, timeout);
-            CodeExecutionTests.lastApplicationUrl = await this.ide.getApplicationUrlFromNotification(portOpenText, timeout);
             await this.ide.waitNotificationAndOpenLink(portOpenText, timeout);
+            CodeExecutionTests.lastApplicationUrl = await this.previewWidget.getUrl();
         });
     }
 


### PR DESCRIPTION
Signed-off-by: Tibor Dancs <tdancs@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
There was an errorneous call for ide.switchToWidgedFrame before attempting to get URL from the widget element that caused the tests to fail.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
hotfix

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
