### PR TITLE
Fixing JavaSpringBoot timeouts

### DIFF
--- a/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
@@ -50,7 +50,7 @@ suite(`${stack} test`, async () => {
     });
 
     suite('Validation of workspace build', async () => {
-        codeExecutionTests.runTask(buildTaskName, 420_000);
+        codeExecutionTests.runTask(buildTaskName, 720_000);
         codeExecutionTests.closeTerminal(buildTaskName);
     });
 

--- a/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/HappyPath.spec.ts
@@ -243,9 +243,9 @@ suite('Validation of debug functionality', async () => {
         await editor.selectTab(weclomeControllerJavaFileName);
         await topMenu.selectOption('View', 'Debug');
         await ide.waitLeftToolbarButton(LeftToolbarButton.Debug);
-    })
-    
-    test('Choose debug configuration', async ()=> {
+    });
+
+    test('Choose debug configuration', async () => {
         // workaround to the https://github.com/eclipse/che/issues/19887
         await debugView.clickOnDebugConfigurationDropDown();
         await debugView.clickOnDebugConfigurationItem('Add Configuration...');
@@ -256,19 +256,19 @@ suite('Validation of debug functionality', async () => {
 
     test('Run debug', async () => {
         await debugView.clickOnRunDebugButton();
-        await waitDebugToConnect()
+        await waitDebugToConnect();
     });
 
-    test('Activate breakpoint', async ()=> {
+    test('Activate breakpoint', async () => {
         await editor.selectTab(weclomeControllerJavaFileName);
         await editor.activateBreakpoint(weclomeControllerJavaFileName, 27);
     });
-    
-    test('Check debugger stop at the breakpoint', async ()=> {
+
+    test('Check debugger stop at the breakpoint', async () => {
         await previewWidget.refreshPage();
         await waitStoppedBreakpoint(27);
     });
-        
+
 });
 
 async function checkErrorMessageInApplicationController() {
@@ -313,7 +313,7 @@ async function checkJavaPathCompletion() {
     }
 }
 
-async function waitDebugToConnect(){
+async function waitDebugToConnect() {
     try {
         await debugView.waitForDebuggerToConnect();
     } catch (err) {
@@ -324,7 +324,7 @@ async function waitDebugToConnect(){
     }
 }
 
-async function waitStoppedBreakpoint(lineNumber: number){
+async function waitStoppedBreakpoint(lineNumber: number) {
     try {
         await editor.waitStoppedDebugBreakpoint(weclomeControllerJavaFileName, lineNumber);
     } catch (err) {

--- a/tests/e2e/tests/plugins/TypescriptPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/TypescriptPlugin.spec.ts
@@ -15,7 +15,7 @@ import { Ide, LeftToolbarButton } from '../../pageobjects/ide/Ide';
 import { TimeoutConstants } from '../../TimeoutConstants';
 import { TestConstants } from '../../TestConstants';
 import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
-import { Key, By, error } from 'selenium-webdriver';
+import { Key, By } from 'selenium-webdriver';
 import { Editor } from '../../pageobjects/ide/Editor';
 import { TopMenu } from '../../pageobjects/ide/TopMenu';
 import { DebugView } from '../../pageobjects/ide/DebugView';
@@ -137,7 +137,7 @@ suite(`The 'TypescriptPlugin and Node-debug' tests`, async () => {
             // workaround for the issue: https://github.com/eclipse/che/issues/20067
             await debugView.clickOnDebugConfigurationDropDown();
             await debugView.clickOnDebugConfigurationItem('Add Configuration...');
-            
+
             await debugView.clickOnDebugConfigurationDropDown();
             await debugView.clickOnDebugConfigurationItem('Attach to Remote (nodejs-web-app)');
             await debugView.clickOnRunDebugButton();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Fixes TimeOut value for running 'maven build' task
* Fixes linter issues

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
#20130 

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
* Go into Eclipse repository che/tests/e2e
* Run npm i and verify that all packages install without errors
* Run tsc and verify that no errors are present
* Export following variables:
  * TS_SELENIUM_BASE_URL
  * TS_SELENIUM_MULTIUSER=true
  * NODE_TLS_REJECT_UNAUTHORIZED=0
  * TS_SELENIUM_LOG_LEVEL="DEBUG"
  * TS_SELENIUM_USERNAME
  * TS_SELENIUM_PASSWORD
* Run `USERSTORY="JavaSpringBoot" npm run test-all-devfiles`
* Test should pass with imported project.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
