### PR TITLE
chore(release): Set correct versions in issue template

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -33,7 +33,6 @@ sed_in_place() {
   fi
 }
 
-
 # Update the issue template with released version and add current latest as previous item
 update_issue_template() {
   local -r currentReleaseVersion=$1
@@ -57,7 +56,6 @@ update_issue_template() {
   # Now check if we have the previous version in the template
   # if not, need to add it
   if ! grep -q "\"${versionXY}\"" "${templateFile}" ; then
-
     # add the version just after the current next version
     # really want \'$'\n'
     # shellcheck disable=SC1003


### PR DESCRIPTION
### What does this PR do?
When doing a release, update issue template with the versions we're tagging

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
#20054 

### How to test this PR?
Extract code to a separate file and run for example
```bash
VERSION="7.35.0"
ISSUE_TEMPLATE_FILE=".github/ISSUE_TEMPLATE/bug_report.yml"
update_issue_template "7.35.0" ".github/ISSUE_TEMPLATE/bug_report.yml"
```

it will update `.github/ISSUE_TEMPLATE/bug_report.yml` file


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.


Change-Id: Iebccac1611befbae19fe9b9c326b6ced918c818f
Signed-off-by: Florent Benoit <fbenoit@redhat.com>
