### PR TITLE
[Selenium] fix Editor view-lines locator

### DIFF
--- a/tests/e2e/pageobjects/ide/Editor.ts
+++ b/tests/e2e/pageobjects/ide/Editor.ts
@@ -240,7 +240,7 @@ export class Editor {
     async getEditorVisibleText(tabTitle: string): Promise<string> {
         Logger.debug(`Editor.getEditorVisibleText "${tabTitle}"`);
 
-        const editorBodyLocator: By = By.xpath(`//div[contains(@data-uri, \'${tabTitle}')]//div[@class=\'view-lines\']`);
+        const editorBodyLocator: By = By.xpath(`//div[contains(@data-uri, \'${tabTitle}')]//div[contains(@class,\'view-lines\')]`);
         // const editorBodyLocator: By = By.xpath('//div[@class=\'view-lines\']');
         const editorText: string = await this.driverHelper.waitAndGetText(editorBodyLocator);
         return editorText;


### PR DESCRIPTION
### What does this PR do?
Fix locator in **Editor** page object that check expected text in opened file. It will fix `GitSsh` typescript test failing.