### PR TITLE
fixing testFullTitle constant for CSlashCPlusPlus dir title

### DIFF
--- a/tests/e2e/driver/CheReporter.ts
+++ b/tests/e2e/driver/CheReporter.ts
@@ -136,7 +136,7 @@ class CheReporter extends mocha.reporters.Spec {
       // raise flag for keeping the screencast
       deleteScreencast = false;
 
-      const testFullTitle: string = test.fullTitle().replace(/\s/g, '_');
+      const testFullTitle: string = test.fullTitle().replace(/[^a-z0-9\+]/gi, '_');
       const testTitle: string = test.title.replace(/\s/g, '_');
 
       const testReportDirPath: string = `${TestConstants.TS_SELENIUM_REPORT_FOLDER}/${testFullTitle}`;


### PR DESCRIPTION
Signed-off-by: Viktoryia Bahdanovich <vbahdano@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixing a regular expression for saving tests directories with logs in report folder

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![Screenshot_20210818_124034](https://user-images.githubusercontent.com/57172594/129891668-5c2fbbff-00e3-4fee-9c72-7fe69a04cd30.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
 #18904 

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
* Go into Eclipse repository che/tests/e2e
* Run npm i and verify that all packages install without errors
* Run tsc and verify that no errors are present
* Export following variables:
  * TS_SELENIUM_BASE_URL
  * TS_SELENIUM_MULTIUSER=true
  * NODE_TLS_REJECT_UNAUTHORIZED=0
  * TS_SELENIUM_LOG_LEVEL="DEBUG"
  * TS_SELENIUM_USERNAME
  * TS_SELENIUM_PASSWORD
  * Set timeouts for starting a workspace to few seconds, so the test will fail quicker:
      * export TS_SELENIUM_START_WORKSPACE_TIMEOUT=3600
      * export TS_IDE_LOAD_TIMEOUT=2000
* Run `USERSTORY="CSlashCPlusPlus" npm run test-all-devfiles`
Test will fail, after that the artifacts are expected to be saved.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
