### PR TITLE
Never show exit confirmation popup in DevfileSmoke test

### DIFF
--- a/tests/e2e/tests/devfiles/CSlashCPlusPlus.spec.ts
+++ b/tests/e2e/tests/devfiles/CSlashCPlusPlus.spec.ts
@@ -40,7 +40,7 @@ suite(`${stack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName);
+        projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/DevfileSmoke.spec.ts
+++ b/tests/e2e/tests/devfiles/DevfileSmoke.spec.ts
@@ -11,10 +11,12 @@ import 'reflect-metadata';
 import { CLASSES } from '../../inversify.types';
 import CheReporter from '../../driver/CheReporter';
 import { e2eContainer } from '../../inversify.config';
+import { PreferencesHandler } from '../../utils/PreferencesHandler';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
 import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTests';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+const preferencesHandler: PreferencesHandler = e2eContainer.get(CLASSES.PreferencesHandler);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
 
 const workspaceSampleName: string = 'console-java-simple';
@@ -32,6 +34,10 @@ suite(`${stack} test`, async () => {
         });
 
         projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+
+        test('Set application.confirmExit user preferences to "never"', async () => {
+            await preferencesHandler.setPreferenceUsingUI('application.confirmExit', 'never');
+        });
     });
 
     suite ('Stopping and deleting the workspace', async () => {

--- a/tests/e2e/tests/devfiles/DevfileSmoke.spec.ts
+++ b/tests/e2e/tests/devfiles/DevfileSmoke.spec.ts
@@ -33,7 +33,7 @@ suite(`${stack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName, false);
 
         test('Set application.confirmExit user preferences to "never"', async () => {
             await preferencesHandler.setPreferenceUsingUI('application.confirmExit', 'never');

--- a/tests/e2e/tests/devfiles/DotNetCore.spec.ts
+++ b/tests/e2e/tests/devfiles/DotNetCore.spec.ts
@@ -43,7 +43,7 @@ suite(`Test ${stack}`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName);
+        projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/Go.spec.ts
+++ b/tests/e2e/tests/devfiles/Go.spec.ts
@@ -50,7 +50,7 @@ suite(`${workspaceStack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceSubfolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceSubfolderName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/JavaMaven.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaMaven.spec.ts
@@ -39,7 +39,7 @@ suite(`${stack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaSpringBoot.spec.ts
@@ -41,7 +41,7 @@ suite(`${stack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/JavaVertx.spec.ts
+++ b/tests/e2e/tests/devfiles/JavaVertx.spec.ts
@@ -39,7 +39,7 @@ suite(`${stack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/NodeJS.spec.ts
+++ b/tests/e2e/tests/devfiles/NodeJS.spec.ts
@@ -42,7 +42,7 @@ suite(`${workspaceStack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/PHPSimple.spec.ts
+++ b/tests/e2e/tests/devfiles/PHPSimple.spec.ts
@@ -41,7 +41,7 @@ suite(`${stack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName);
+        projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/Python.spec.ts
+++ b/tests/e2e/tests/devfiles/Python.spec.ts
@@ -39,7 +39,7 @@ suite(`${workspaceStack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName);
+        projectAndFileTests.waitWorkspaceReadinessNoSubfolder(workspaceSampleName, false);
     });
 
     suite('Test opening file', async () => {

--- a/tests/e2e/tests/devfiles/PythonDjango.spec.ts
+++ b/tests/e2e/tests/devfiles/PythonDjango.spec.ts
@@ -41,7 +41,7 @@ suite(`${workspaceStack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName, false);
     });
 
     suite('Install dependencies', async () => {

--- a/tests/e2e/tests/devfiles/Quarkus.spec.ts
+++ b/tests/e2e/tests/devfiles/Quarkus.spec.ts
@@ -41,7 +41,7 @@ suite(`${workspaceStack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName, false);
     });
 
     suite(`Test opening the file`, async () => {

--- a/tests/e2e/tests/devfiles/Scala.spec.ts
+++ b/tests/e2e/tests/devfiles/Scala.spec.ts
@@ -41,7 +41,7 @@ suite.skip(`${stack} test`, async () => {
             CheReporter.registerRunningWorkspace(workspaceName);
         });
 
-        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName);
+        projectAndFileTests.waitWorkspaceReadiness(workspaceSampleName, workspaceRootFolderName, false);
     });
 
     suite('Test opening file', async () => {


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
1. It is setting up test user preferences through UI to never show exit confirmation popup in DevfileSmoke test.
It's not possible to set preferences just after installation of Eclipse Che, before workspace is created and started

2. It fix workspace readiness verification to ignore absence of "`Do you trust the authors of`" popup, which is not needed in case workspace project is taking from zip-file.

"DevfileSmoke.spec.ts" test has passed successfully in build https://main-jenkins-csb-crwqe.apps.ocp4.prod.psi.redhat.com/job/Che/job/e2e/job/minikube/job/basic/job/che-server/797/

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

### What issues does this PR fix or reference?
#20533, #20548 

### How to test this PR?
Run tests/e2e/tests/devfiles/DevfileSmoke.spec.ts test.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
