### PR TITLE
enhancement: initial state for dashboard configurability proposal

### DIFF
--- a/enhancement/dashboard-configurability/dashboard-configurability.md
+++ b/enhancement/dashboard-configurability/dashboard-configurability.md
@@ -2,9 +2,9 @@
 
 ## Motivation
 
-Dashboard has [product.json](https://github.com/eclipse-che/che-dashboard#branding) configuration file which can be overridden on container build phase and which would some dashboard appearance stuff like Product Title, Product icon.
+Dashboard has [product.json](https://github.com/eclipse-che/che-dashboard#branding) configuration file which can be overridden on container build phase and which would override some dashboard appearance stuff like Product Title, Product icon.
 
-But apart from that there is some settings which an Admin would like to override on the CheCluster level without rebuilding container, like warning.
+In addition from that, there are some settings which an Admin would like to override on the CheCluster level without rebuilding container, like warning.
 
 The potential user of this would be at least Hosted Che, which sometime needs to inform users about upcoming upgrade.
 

--- a/enhancement/dashboard-configurability/dashboard-configurability.md
+++ b/enhancement/dashboard-configurability/dashboard-configurability.md
@@ -1,0 +1,76 @@
+# Dashboard Configurability Proposal
+
+## Motivation
+
+Dashboard has [product.json](https://github.com/eclipse-che/che-dashboard#branding) configuration file which can be overridden on container build phase and which would some dashboard appearance stuff like Product Title, Product icon.
+
+But apart from that there is some settings which an Admin would like to override on the CheCluster level without rebuilding container, like warning.
+
+The potential user of this would be at least Hosted Che, which sometime needs to inform users about upcoming upgrade.
+
+## Alternatives
+
+There are multiple options to achieve the same goals:
+
+### JSON vs YAML
+
+According to the latest trends, every configuration file is in yaml format, since it's easier to read and write for admins. It may be a good time to move from JSON to YAML format. It may makes sense to do backward compatible solution where we support both (old JSON with new YAML) but maybe it's good enough to break the stuff and request dependencies to adapt to a new way.
+
+### CheCluster vs ConfigMap
+
+We're able to define it on CheCluster level in two way:
+
+- define detailed model on CheCluster CRD level which would be backward compatible in terms of Kubernetes API and easier to discover/configure. But it would require changes on Che Operator side each time when Dashboard configuration is changed:
+
+```yaml
+spec:
+  dashboard:
+    productTitle: "Eclipse Che powered by ME"
+    applications:
+      - group: "Apps"
+        title: "My App"
+        url: "https://example-app.com
+```
+
+- define the ability to define inclined yaml file content on CheCluster CR level. It would not be 100% safe to use in terms of backward compatibility and letting users know about their mistakes, but it would allows define once on Che Operator side, expose link on documentation and then fully support on Dashboard/docs sides:
+
+```yaml
+spec:
+  dashboard:
+    config: |
+        productTitle: "Eclipse Che powered by ME"
+        applications:
+        - group: "Apps"
+            title: "My App"
+            url: "https://example-app.com
+```
+
+- define an ability to configure dashboard with help of standalone configmap mounted with Che Operator mechanism:
+
+```yaml
+CHE_NAMESPACE="eclipse-che"
+cat <<EOF | kubectl apply -f -
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: che-dashboard-custom-config
+  namespace: eclipse-che
+  labels:
+    app.kubernetes.io/component: che-dashboard-configmap
+    app.kubernetes.io/part-of: che.eclipse.org
+  annotations:
+    che.eclipse.org/mount-as: file
+    che.eclipse.org/mount-path: /config/product.yaml
+data:
+  config: |
+    productTitle: "Eclipse Che powered by ME"
+    applications:
+    - group: "Apps"
+        title: "My App"
+        url: "https://example-app.com
+EOF
+```
+
+TODOs:
+
+- clearly describe pros and cons each of the way;

--- a/enhancement/dashboard-configurability/dashboard-configurability.md
+++ b/enhancement/dashboard-configurability/dashboard-configurability.md
@@ -18,9 +18,9 @@ According to the latest trends, every configuration file is in yaml format, sinc
 
 ### CheCluster vs ConfigMap
 
-We're able to define it on CheCluster level in two way:
+#### 1. Part of CheCluster on model level
 
-- define detailed model on CheCluster CRD level which would be backward compatible in terms of Kubernetes API and easier to discover/configure. But it would require changes on Che Operator side each time when Dashboard configuration is changed:
+Define detailed model on CheCluster CRD level:
 
 ```yaml
 spec:
@@ -32,7 +32,20 @@ spec:
         url: "https://example-app.com
 ```
 
-- define the ability to define inclined yaml file content on CheCluster CR level. It would not be 100% safe to use in terms of backward compatibility and letting users know about their mistakes, but it would allows define once on Che Operator side, expose link on documentation and then fully support on Dashboard/docs sides:
+**Pros:**
+
+- self-documenting on CheCluster CRD level;
+- backward compatible in terms of K8s API;
+- admin configuration is validated by K8s API;
+
+**Cons:**
+
+- each dashboard configuration change would require changes and build on CheOperator side;
+- controversial: CheCluster CRD grows with component specific configuration;
+
+#### 2. Part of CheCluster as field with inlined content
+
+Define the ability to define inclined yaml file content on CheCluster CR level. 
 
 ```yaml
 spec:
@@ -45,7 +58,19 @@ spec:
             url: "https://example-app.com
 ```
 
-- define an ability to configure dashboard with help of standalone configmap mounted with Che Operator mechanism:
+**Pros:**
+
+- is defined in Che Operator side once;
+- controversial: CheCluster is kept for more deployment configuration than component-specific behavior;
+
+**Cons:**
+
+- ideally, this way needs a separate versioned piece of documentation;
+- backward compatibility and content validation is done later on dashboard component side and it may be late lifecycle phase to report that;
+
+#### 3. Separated ConfigMap
+
+Define an ability to configure dashboard with help of standalone configmap mounted with Che Operator mechanism:
 
 ```yaml
 CHE_NAMESPACE="eclipse-che"
@@ -71,6 +96,12 @@ data:
 EOF
 ```
 
-TODOs:
+**Pros:**
 
-- clearly describe pros and cons each of the way;
+- that's the cheapest way to get it working since nothing should be done on Dashboard side if we go with JSON, or only YAML to JSON conversion should be done;
+
+**Cons:**
+
+- not easy to discover such an ability;
+- the format is described separately from configuration;
+- no validation available;


### PR DESCRIPTION
### What does this PR do?
This PR proposes different alternatives for the dashboard configurability without the need to rebuild dashboard container.
See the changes for details. No decision made yet.
IMHO:
- the first is the best for user experience;
- the second is a bit easier for developers, since they can drop or rework stuff without leaving ballast in CRD(with CRD you can't remove but just deprecate), but it's not 100% safe;


### What issues does this PR fix or reference?
This enhancement is the result of https://github.com/eclipse/che/issues/15778