### PR TITLE
Updated plugin scripts to fetch the workspace name from url

### DIFF
--- a/tests/e2e/tests/plugins/GitHubPullRequestPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/GitHubPullRequestPlugin.spec.ts
@@ -77,10 +77,10 @@ suite(`The 'GitHubPullRequestPlugin' test`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
 

--- a/tests/e2e/tests/plugins/InstallPluginUsingUI.spec.ts
+++ b/tests/e2e/tests/plugins/InstallPluginUsingUI.spec.ts
@@ -42,10 +42,10 @@ suite(`The 'InstallPluginUsingUI' test`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
 
             await projectTree.openProjectTreeContainer();

--- a/tests/e2e/tests/plugins/JavaPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/JavaPlugin.spec.ts
@@ -48,10 +48,10 @@ suite(`The 'JavaPlugin' test`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
 

--- a/tests/e2e/tests/plugins/PhpPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/PhpPlugin.spec.ts
@@ -49,10 +49,10 @@ suite(`The 'PhpPlugin' tests`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
 

--- a/tests/e2e/tests/plugins/PythonPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/PythonPlugin.spec.ts
@@ -45,10 +45,10 @@ suite(`The 'PythonPlugin' test`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
 

--- a/tests/e2e/tests/plugins/TypescriptPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/TypescriptPlugin.spec.ts
@@ -57,10 +57,10 @@ suite(`The 'TypescriptPlugin and Node-debug' tests`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
 

--- a/tests/e2e/tests/plugins/VscodeKubernetesPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeKubernetesPlugin.spec.ts
@@ -47,10 +47,10 @@ suite(`The 'VscodeKubernetesPlugin' test`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
 

--- a/tests/e2e/tests/plugins/VscodeShellcheckPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeShellcheckPlugin.spec.ts
@@ -53,10 +53,10 @@ suite(`The 'VscodeShellcheckPlugin' test`, async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
 

--- a/tests/e2e/tests/plugins/VscodeValePlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeValePlugin.spec.ts
@@ -45,10 +45,10 @@ suite('The "VscodeValePlugin" userstory', async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
         });

--- a/tests/e2e/tests/plugins/VscodeXmlPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeXmlPlugin.spec.ts
@@ -43,10 +43,10 @@ suite('The "VscodeXmlPlugin" userstory', async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
         });

--- a/tests/e2e/tests/plugins/VscodeYamlPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/VscodeYamlPlugin.spec.ts
@@ -47,10 +47,10 @@ suite('The "VscodeYamlPlugin" userstory', async () => {
         });
 
         test('Wait until created workspace is started', async () => {
+            await ide.waitAndSwitchToIdeFrame();
             workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
         });


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This pr helps to fetch the workspace name from url after browser navigated to Ide. So that deletion of the workspace works fine.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Due to this pr, script deletes the workspace

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Download the latest [chectl](https://github.com/che-incubator/chectl/tags) or update existing one
2. Install the Minikube
3. Install the VirtualBox
4. Deploy Che (perform commands)

```
minikube start --vm-driver=virtualbox --cpus 4 --memory 13000
minikube addons enable ingress
chectl server:deploy --listr-renderer=verbose --debug --multiuser --platform=minikube
```

5. set the below environmental variables
```
- export TS_SELENIUM_BASE_URL=\<Che-URL\>
- export USERSTORY=\<test-you-want-to-run\>
- export TS_SELENIUM_VALUE_OPENSHIFT_OAUTH="true"
- export TS_SELENIUM_OCP_USERNAME=\<cluster-username\>
- export TS_SELENIUM_OCP_PASSWORD=\<cluster-password\> 
```
6. export the plugins related user stories
`export USERSTORY=<spec file name present in che/tests/e2e/tests/plugins folder>`

7. Execute the command to run the test scripts
`npm run test-plugin`


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
