### PR TITLE
[Typescript] Delete SSH key added to github account automatically by GitPublishBranch typescript test(7.38.x branch)) 

### DIFF
--- a/tests/e2e/utils/VCS/github/GitHubUtil.ts
+++ b/tests/e2e/utils/VCS/github/GitHubUtil.ts
@@ -73,6 +73,25 @@ export class GitHubUtil {
     }
   }
 
+  async deletePublicSshKeyByName(authToken: string, keyName: string) {
+    const gitHubApiSshURL: string = GitHubUtil.GITHUB_API_ENTRIPOINT_URL + 'user/keys';
+    const authHeader = { headers: { 'Authorization': 'token ' + authToken, 'Content-Type': 'application/json' } };
+    try {
+      const response = await axios.get(gitHubApiSshURL, authHeader);
+      const stringified = JSON.stringify(response.data);
+      const arrayOfPublicKeys = JSON.parse(stringified);
+      for (let entry of arrayOfPublicKeys) {
+        if (entry.title === keyName) {
+          this.removePublicSshKey(authToken, entry.id);
+          break;
+        }
+      }
+    } catch (error) {
+      console.error('Cannot delete the ' + keyName + ' public key from the GitHub account');
+      console.error(error);
+      throw error;
+    }
+  }
 
   async removeAllPublicSshKeys(authToken: string) {
     try {


### PR DESCRIPTION
### What does this PR do?
We need to delete SSH key added to github account by GitPublishBranch typescript test after test is finished.

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-2513


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
