### PR TITLE
[Typescript] Check that settings.json content is valid

### DIFF
--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -26,7 +26,7 @@
     "tsc": "tsc -p .",
     "init-mocha-opts": "tsc && mocha --config mocha-single-devfile.json --spec dist/tests/login/Login.spec.js",
     "test-plugin": "./initPluginTest.sh",
-    "test-plugin-ci": "export TS_DELETE_PLUGINS_TEST_WORKSPACE=false && npm run init-mocha-opts -- --spec dist/tests/plugins/${USERSTORY}.spec.js",
+    "test-plugin-ci": "export TS_DELETE_PLUGINS_TEST_WORKSPACE=true && npm run init-mocha-opts -- --spec dist/tests/plugins/${USERSTORY}.spec.js",
     "test-all-plugins": "tsc && mocha --config mocha-all-plugins.json"
   },
   "author": "Ihor Okhrimenko (iokhrime@redhat.com)",

--- a/tests/e2e/utils/PreferencesHandler.ts
+++ b/tests/e2e/utils/PreferencesHandler.ts
@@ -47,6 +47,9 @@ export class PreferencesHandler {
         await this.quickOpenContainer.typeAndSelectSuggestion('Preferences:', 'Preferences: Open Preferences (JSON)');
 
         let editorText: string = await this.editor.getEditorVisibleText(tabTitle);
+        if (!editorText) {
+            editorText = '{}';
+        }
         let preferences = JSON.parse(editorText);
         preferences[property] = value;
 


### PR DESCRIPTION
### What does this PR do?
We are using `setPreferenceUsingUI` function in our tests to set preferences by UI(open settings.json file and change content). It works well when settings.json file has any content. But without content it tries to parse empty string.

Also set **TS_DELETE_PLUGINS_TEST_WORKSPACE** property to true to delete workspace after test is finished. Because it gets to much resources when all 11 plugin tests started.

### What issues does this PR fix or reference?
https://github.com/eclipse/che/issues/21201

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
