### PR TITLE
Remove iframe code in automation testing

### DIFF
--- a/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
+++ b/tests/e2e/pageobjects/dashboard/workspace-details/WorkspaceDetails.ts
@@ -85,7 +85,7 @@ export class WorkspaceDetails {
         Logger.debug(`WorkspaceDetails.openWorkspace "${namespace}/${workspaceName}"`);
 
         await this.clickOnOpenButton(timeout);
-        await this.driverHelper.waitVisibility(By.css(Ide.ACTIVATED_IDE_IFRAME_CSS), TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT);
+        await this.driverHelper.waitVisibility(By.css(Ide.THEIA_EDITOR_CSS), TimeoutConstants.TS_COMMON_DASHBOARD_WAIT_TIMEOUT);
         await this.testWorkspaceUtil.waitWorkspaceStatus(namespace, workspaceName, WorkspaceStatus.STARTING);
     }
 

--- a/tests/e2e/pageobjects/ide/Ide.ts
+++ b/tests/e2e/pageobjects/ide/Ide.ts
@@ -29,7 +29,7 @@ export enum LeftToolbarButton {
 export class Ide {
     public static readonly EXPLORER_BUTTON_ID: string = 'shell-tab-explorer-view-container';
     public static readonly SELECTED_EXPLORER_BUTTON_CSS: string = 'li#shell-tab-explorer-view-container.theia-mod-active';
-    public static readonly ACTIVATED_IDE_IFRAME_CSS: string = '#ide-iframe-window[aria-hidden=\'false\']';
+    public static readonly THEIA_EDITOR_CSS: string = '#theia-main-content-panel';
     public static readonly SELECTED_GIT_BUTTON_XPATH: string = '(//ul[@class=\'p-TabBar-content\']//li[@title=\'Git\' and contains(@class, \'p-mod-current\')])[1]';
     private static readonly TOP_MENU_PANEL_CSS: string = '#theia-app-shell #theia-top-panel .p-MenuBar-content';
     private static readonly LEFT_CONTENT_PANEL_CSS: string = '#theia-left-content-panel';
@@ -41,6 +41,10 @@ export class Ide {
         @inject(CLASSES.NotificationCenter) private readonly notificationCenter: NotificationCenter
     ) { }
 
+    /**
+     * @deprecated Method deprecated. Iframe is not available, Replace it with waitForEditor() or waitIde() method incase for conditional wait
+     * @see Ide.waitForEditor()
+     */
     async waitAndSwitchToIdeFrame(timeout: number = TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
         Logger.debug('Ide.waitAndSwitchToIdeFrame');
         try {
@@ -68,6 +72,16 @@ export class Ide {
             }
 
             Logger.error(`Switching to IDE frame failed.`);
+            throw err;
+        }
+    }
+
+    async waitForEditor(timeout: number = TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
+        Logger.debug('Ide.waitForEditor');
+        try {
+            await this.driverHelper.waitVisibility(By.css(Ide.THEIA_EDITOR_CSS), timeout);
+        } catch (err) {
+            Logger.warn(`Editor is not displayed even after ${timeout} milliseconds.`);
             throw err;
         }
     }
@@ -166,11 +180,11 @@ export class Ide {
 
         Logger.debug('Ide.waitWorkspaceAndIde');
 
-        await this.waitAndSwitchToIdeFrame(timeout);
+        await this.waitForEditor(timeout);
         await this.waitIde(timeout);
     }
 
-    async waitIde(timeout: number = TimeoutConstants.TS_IDE_LOAD_TIMEOUT) {
+    async waitIde(timeout: number = TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT) {
         Logger.debug('Ide.waitIde');
 
         const mainIdeParts: Array<By> = [By.css(Ide.TOP_MENU_PANEL_CSS), By.css(Ide.LEFT_CONTENT_PANEL_CSS), By.id(Ide.EXPLORER_BUTTON_ID)];

--- a/tests/e2e/pageobjects/ide/PreviewWidget.ts
+++ b/tests/e2e/pageobjects/ide/PreviewWidget.ts
@@ -76,6 +76,9 @@ export class PreviewWidget {
         }, timeout);
     }
 
+    /**
+     * @deprecated Method deprecated. Iframe is not available anymore
+     */
     async waitAndSwitchToWidgetFrame() {
         Logger.debug('PreviewWidget.waitAndSwitchToWidgetFrame');
 
@@ -98,8 +101,6 @@ export class PreviewWidget {
         await this.driverHelper.getDriver().wait(async () => {
             const isApplicationTitleVisible: boolean = await this.driverHelper.isVisible(contentLocator);
             if (isApplicationTitleVisible) {
-                await this.driverHelper.getDriver().switchTo().defaultContent();
-                await this.ide.waitAndSwitchToIdeFrame();
                 return true;
             }
 
@@ -125,6 +126,9 @@ export class PreviewWidget {
         await this.driverHelper.waitAndClick(PreviewWidget.WIDGET_REFRESH_BUTTON_LOCATOR);
     }
 
+    /**
+     * @deprecated Method deprecated. Iframe is not available.
+     */
     async switchBackToIdeFrame() {
         Logger.debug('PreviewWidget.switchBackToIdeFrame');
 

--- a/tests/e2e/pageobjects/ide/ProjectTree.ts
+++ b/tests/e2e/pageobjects/ide/ProjectTree.ts
@@ -240,8 +240,7 @@ export class ProjectTree {
             if (!isProjectFolderVisible) {
                 Logger.trace(`ProjectTree.waitProjectImported project not located, reloading page.`);
                 await this.browserTabsUtil.refreshPage();
-                await this.ide.waitAndSwitchToIdeFrame();
-                await this.ide.waitIde();
+                await this.ide.waitWorkspaceAndIde();
                 await this.openProjectTreeContainer();
                 continue;
             }
@@ -256,8 +255,7 @@ export class ProjectTree {
             if (!isRootSubItemVisible) {
                 Logger.trace(`ProjectTree.waitProjectImported sub-items not found, reloading page.`);
                 await this.browserTabsUtil.refreshPage();
-                await this.ide.waitAndSwitchToIdeFrame();
-                await this.ide.waitIde();
+                await this.ide.waitWorkspaceAndIde();
                 await this.openProjectTreeContainer();
                 continue;
             }
@@ -284,8 +282,7 @@ export class ProjectTree {
                 Logger.trace(`ProjectTree.waitProjectImportedNoSubfolder project not located, reloading page.`);
                 await this.browserTabsUtil.refreshPage();
                 await this.driverHelper.wait(triesPolling);
-                await this.ide.waitAndSwitchToIdeFrame();
-                await this.ide.waitIde();
+                await this.ide.waitWorkspaceAndIde();
                 await this.openProjectTreeContainer();
                 continue;
             }

--- a/tests/e2e/tests/e2e_happy_path/DevWorkspaceHappyPath.spec.ts
+++ b/tests/e2e/tests/e2e_happy_path/DevWorkspaceHappyPath.spec.ts
@@ -116,7 +116,6 @@ suite('Language server validation', async () => {
         } catch (err) {
             Logger.debug('Workaround for the https://github.com/eclipse/che/issues/18974.');
             await browserTabsUtil.refreshPage();
-            await ide.waitAndSwitchToIdeFrame();
             await ide.waitIde();
             await editor.waitErrorInLine(30, javaFileName, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT * 2);
         }

--- a/tests/e2e/tests/plugins/JavaPlugin.spec.ts
+++ b/tests/e2e/tests/plugins/JavaPlugin.spec.ts
@@ -7,14 +7,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { WorkspaceNameHandler } from '../..';
 import 'reflect-metadata';
 import { e2eContainer } from '../../inversify.config';
 import { CLASSES } from '../../inversify.types';
 import { Ide } from '../../pageobjects/ide/Ide';
 import { TimeoutConstants } from '../../TimeoutConstants';
 import { TestConstants } from '../../TestConstants';
-import { ProjectTree } from '../../pageobjects/ide/ProjectTree';
 import { Key } from 'selenium-webdriver';
 import { Editor } from '../../pageobjects/ide/Editor';
 import { ProjectAndFileTests } from '../../testsLibrary/ProjectAndFileTests';
@@ -22,24 +20,24 @@ import { WorkspaceHandlingTests } from '../../testsLibrary/WorkspaceHandlingTest
 import { Logger } from '../../utils/Logger';
 import CheReporter from '../../driver/CheReporter';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { PreferencesHandler } from '../../utils/PreferencesHandler';
 
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
 const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
 const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const ide: Ide = e2eContainer.get(CLASSES.Ide);
-const projectTree: ProjectTree = e2eContainer.get(CLASSES.ProjectTree);
 const editor: Editor = e2eContainer.get(CLASSES.Editor);
-const workspaceNameHandler: WorkspaceNameHandler = e2eContainer.get(CLASSES.WorkspaceNameHandler);
+const preferencesHandler: PreferencesHandler = e2eContainer.get(CLASSES.PreferencesHandler);
 
-const devfileUrl: string = 'https://raw.githubusercontent.com/eclipse/che/main/tests/e2e/files/devfiles/plugins/Java11PluginTest.yaml';
-const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devfileUrl}`;
+const devFileUrl: string = 'https://github.com/che-samples/java-guestbook/tree/devfilev2';
+const factoryUrl: string = `${TestConstants.TS_SELENIUM_BASE_URL}/f?url=${devFileUrl}`;
 const codeNavigationClassName: string = 'String.class';
-const sampleName: string = 'console-java-simple';
-const subRootFolder: string = 'src';
+const projectName: string = 'java-guestbook';
+const subRootFolder: string = 'backend';
 
-const fileFolderPath: string = `${sampleName}/src/main/java/org/eclipse/che/examples`;
-const tabTitle: string = 'HelloWorld.java';
-let workspaceName: string;
+const fileFolderPath: string = `${projectName}/backend/src/main/java/cloudcode/guestbook/backend`;
+const tabTitle: string = 'GuestBookEntry.java';
+let workspaceName: string = 'java-guestbook';
 
 suite(`The 'JavaPlugin' test`, async () => {
     suite('Create workspace', async () => {
@@ -47,16 +45,12 @@ suite(`The 'JavaPlugin' test`, async () => {
             await browserTabsUtil.navigateTo(factoryUrl);
         });
 
+        projectAndFileTests.waitWorkspaceReadiness(projectName, subRootFolder);
+
         test('Wait until created workspace is started', async () => {
-            await ide.waitAndSwitchToIdeFrame();
-            workspaceName = await workspaceNameHandler.getNameFromUrl();
             CheReporter.registerRunningWorkspace(workspaceName);
 
-            await ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
-            await ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);
-
-            await projectTree.openProjectTreeContainer();
-            await projectTree.waitProjectImported(sampleName, subRootFolder);
+            await preferencesHandler.setPreferenceUsingUI('application.confirmExit', 'never');
         });
     });
 
@@ -66,28 +60,28 @@ suite(`The 'JavaPlugin' test`, async () => {
     });
 
     suite('Language server validation', async () => {
-        test('Wait until Java LS is initialised', async () => {
+        test('Wait until Java LS is initialized', async () => {
             await ide.checkLsInitializationStart('Activating');
             await ide.waitStatusBarTextAbsence('Activating', 900_000);
         });
 
         test('Autocomplete', async () => {
-            await editor.moveCursorToLineAndChar(tabTitle, 10, 20);
+            await editor.moveCursorToLineAndChar(tabTitle, 15, 1);
             await editor.pressControlSpaceCombination(tabTitle);
             await editor.waitSuggestionContainer();
-            await editor.waitSuggestion(tabTitle, 'close() : void');
+            await editor.waitSuggestion(tabTitle, 'clone() : Object');
         });
 
         test('Error highlighting', async () => {
             const textForErrorDisplaying: string = '$';
-            await editor.type(tabTitle, textForErrorDisplaying, 10);
-            await editor.waitErrorInLine(10, tabTitle, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT);
+            await editor.type(tabTitle, textForErrorDisplaying, 15);
+            await editor.waitErrorInLine(15, tabTitle, TimeoutConstants.TS_ERROR_HIGHLIGHTING_TIMEOUT);
             await editor.performKeyCombination(tabTitle, Key.chord(Key.BACK_SPACE));
-            await editor.waitErrorInLineDisappearance(10, tabTitle);
+            await editor.waitErrorInLineDisappearance(15, tabTitle);
         });
 
-        test('Codenavigation', async () => {
-            await editor.moveCursorToLineAndChar(tabTitle, 9, 12);
+        test('CodeNavigation', async () => {
+            await editor.moveCursorToLineAndChar(tabTitle, 9, 14);
             await editor.performKeyCombination(tabTitle, Key.chord(Key.CONTROL, Key.F12));
             await editor.waitEditorAvailable(codeNavigationClassName, 60_000);
         });

--- a/tests/e2e/testsLibrary/CodeExecutionTests.ts
+++ b/tests/e2e/testsLibrary/CodeExecutionTests.ts
@@ -140,8 +140,7 @@ export class CodeExecutionTests {
                 // https://issues.redhat.com/browse/CRW-2175
                 if (err instanceof error.TimeoutError) {
                     Logger.warn(`CodeExecutionTests.verifyRunningApplication application not located, probably blocked by preloader or content not available. Retrying.`);
-                    await this.driverHelper.getDriver().switchTo().defaultContent();
-                    await this.ide.waitAndSwitchToIdeFrame();
+                    await this.ide.waitIde();
                     await this.previewWidget.refreshPage();
                     await this.previewWidget.waitContentAvailable(locator, applicationCheckTimeout, polling);
                 }

--- a/tests/e2e/testsLibrary/LanguageServerTests.ts
+++ b/tests/e2e/testsLibrary/LanguageServerTests.ts
@@ -19,7 +19,6 @@ import { DebugView } from '../pageobjects/ide/DebugView';
 import { Key, error } from 'selenium-webdriver';
 import { Logger } from '../utils/Logger';
 import { BrowserTabsUtil } from '../utils/BrowserTabsUtil';
-import { DriverHelper } from '../utils/DriverHelper';
 
 @injectable()
 export class LanguageServerTests {
@@ -29,8 +28,7 @@ export class LanguageServerTests {
         @inject(CLASSES.Ide) private readonly ide: Ide,
         @inject(CLASSES.TopMenu) private readonly topMenu: TopMenu,
         @inject(CLASSES.DebugView) private readonly debugView: DebugView,
-        @inject(CLASSES.BrowserTabsUtil) private readonly browserTabsUtil: BrowserTabsUtil,
-        @inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper) { }
+        @inject(CLASSES.BrowserTabsUtil) private readonly browserTabsUtil: BrowserTabsUtil) { }
 
     public errorHighlighting(openedTab: string, textToWrite: string, line: number) {
         test('Error highlighting', async () => {
@@ -164,9 +162,7 @@ export class LanguageServerTests {
             } catch (err) {
                 // debug config is probably missing, refresh IDE and try again https://github.com/eclipse/che/issues/19887
                 await this.browserTabsUtil.refreshPage();
-                await this.driverHelper.wait(TimeoutConstants.TS_IDE_LOAD_TIMEOUT);
-                await this.ide.waitAndSwitchToIdeFrame();
-                await this.driverHelper.wait(TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+                await this.ide.waitIde();
                 await this.debugView.clickOnRunDebugButton();
             }
         });
@@ -187,9 +183,7 @@ export class LanguageServerTests {
             } catch (err) {
                 // debug config is probably missing, refresh IDE and try again https://github.com/eclipse/che/issues/19887
                 await this.browserTabsUtil.refreshPage();
-                await this.driverHelper.wait(TimeoutConstants.TS_IDE_LOAD_TIMEOUT);
-                await this.ide.waitAndSwitchToIdeFrame();
-                await this.driverHelper.wait(TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM);
+                await this.ide.waitIde();
                 await this.debugView.clickOnDebugConfigurationDropDown();
                 await this.debugView.clickOnDebugConfigurationItem(configurationName);
                 await this.debugView.clickOnRunDebugButton();

--- a/tests/e2e/testsLibrary/ProjectAndFileTests.ts
+++ b/tests/e2e/testsLibrary/ProjectAndFileTests.ts
@@ -48,7 +48,6 @@ export class ProjectAndFileTests {
 
     public waitWorkspaceReadinessNoSubfolder(sampleName : string, checkNotification: boolean = true) {
         test('Wait for workspace readiness', async () => {
-            await this.ide.waitAndSwitchToIdeFrame();
             await this.ide.waitIde(TimeoutConstants.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
             if (checkNotification) {
                 await this.ide.waitNotificationAndClickOnButton('Do you trust the authors of', 'Yes, I trust', 60_000);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
#21255 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Removed iframe code from javaPlugin, pythonPlugin and DevWorkSpaceHappyPath sepc files and deprecated the iframe related functions. 

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
**Test Platform used**: minikube
**Execution Commands:**
```
export TS_SELENIUM_BASE_URL=https://192.168.59.179.nip.io
export TS_SELENIUM_USERNAME=che@eclipse.org
export TS_SELENIUM_PASSWORD=admin
export TS_SELENIUM_LOG_LEVEL=DEBUG
export USERSTORY=JavaPlugin or PythonPlugin
npm run test-plugin
-------------------------------------------------------------------
For DevWorkspaceHappyPath Spec file Execution
--------------------------------------------------------------------
export TS_SELENIUM_BASE_URL=https://192.168.59.179.nip.io
export TS_SELENIUM_USERNAME=che@eclipse.org
export TS_SELENIUM_PASSWORD=admin
export TS_SELENIUM_DEVWORKSPACE_URL=https://192.168.59.179.nip.io/#https://github.com/che-samples/java-spring-petclinic/tree/devfilev2
export TS_SELENIUM_LOG_LEVEL=DEBUG
npm run test-devworkspace-happy-path
```

**Execution Logs**: 
[PythonPlugin_ExecLogs.txt](https://github.com/eclipse/che/files/8260014/PythonPlugin_ExecLogs.txt)
[JavaPlugin_ExecLogs.txt](https://github.com/eclipse/che/files/8260126/JavaPlugin_ExecLogs.txt)
[DevWorkspace_HappyPath_ExecLogs.txt](https://github.com/eclipse/che/files/8260840/DevWorkspace_HappyPath_ExecLogs.txt)

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
