### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/contributing-repositories-check.yml
+++ b/.github/workflows/contributing-repositories-check.yml
@@ -18,6 +18,9 @@ on:
   pull_request:
     paths:
       - '.repositories.yaml'
+permissions:
+  contents: read
+
 jobs:
   check-contributing-up-to-date:
     runs-on: ubuntu-latest

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -19,6 +19,9 @@ on:
     - 'tests/e2e/**'
     - '.github/workflows/typescript-publish.yml'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
