### PR TITLE
Fix error messaging 7.46.x cherry-pick

### DIFF
--- a/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
+++ b/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
@@ -57,7 +57,8 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
 
         if (!expectedStatus) {
             let waitTime = this.attempts * this.polling;
-            throw new error.TimeoutError(`The workspace was not stopped in ${waitTime} ms. Currnet status is: ${workspaceStatus}`);
+            Logger.error(`TestWorkspaceUtil.waitWorkspaceStatus is out of attempts. Expected status ${expectedStatus} not reached. Current status: ${workspaceStatus}`);
+            throw new Error(`The workspace was not stopped in ${waitTime} ms. Currnet status is: ${workspaceStatus}`);
         }
     }
 
@@ -116,7 +117,8 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
 
         if (!deleteWorkspaceStatus) {
             let waitTime = this.attempts * this.polling;
-            throw new error.TimeoutError(`The workspace was not stopped in ${waitTime} ms.`);
+            Logger.error(`TestWorkspaceUtil.deleteWorkspaceByName is out of attempts. Workspace was not yet deleted.`);
+            throw new Error(`The workspace was not stopped in ${waitTime} ms.`);
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Tibor Dancs <tdancs@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Changes type of error in TestWorkspaceUtil.ts
* Adds extra error login on failure

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Ad-hoc

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
