### PR TITLE
Remove rhopp from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,7 +5,7 @@
 dockerfiles/** @benoitf @nickboldt
 
 # e2e tests
-tests/e2e/** @musienko-maxim @rhopp @nickboldt @ScrewTSW @dmytro-ndp
+tests/e2e/** @musienko-maxim @nickboldt @ScrewTSW @dmytro-ndp
 
 # devworkspace happy path test
 tests/devworkspace-happy-path/** @musienko-maxim


### PR DESCRIPTION
### What does this PR do?
Removes rhopp from CODEOWNERS. Mainly to reduce github noise - I'm not doing any PR reviews, but I still am assigned as a reviewer automatically because of this which results in lot of notification/mails traffic.
