### PR TITLE
Eliminate lint errors; fix build of quay.io/eclipse/che-e2e

### DIFF
--- a/tests/e2e/build/dockerfiles/Dockerfile
+++ b/tests/e2e/build/dockerfiles/Dockerfile
@@ -6,10 +6,11 @@ USER root
 
 RUN apt-get update && apt-get install && \
     apt-get install -y ftp && \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \
     apt-get install -y nodejs && \
-    apt-get install -y npm && \
     npm install -g typescript && \
-    apt-get install x11vnc ffmpeg -y
+    apt-get install x11vnc ffmpeg -y && \
+    node -v
 
 COPY --chown=0:0 build/dockerfiles/entrypoint.sh /tmp/
 

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eclipse-che/che-e2e",
-  "version": "7.58.0-SNAPSHOT",
+  "version": "7.58.1-SNAPSHOT",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/tests/e2e/tslint.json
+++ b/tests/e2e/tslint.json
@@ -96,10 +96,10 @@
     "typedef": [
       true,
       // "call-signature",
-      "member-variable-declaration",
+      // "member-variable-declaration",
       "parameter",
       "property-declaration",
-      "variable-declaration"
+      // "variable-declaration"
     ],
     "typedef-whitespace": [
       true,


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- Fix build of quay.io/eclipse/che-e2e by setting up node.js 16.x in che-e2e image
- Restore 7.58.1-SNAPSHOT version
- Eliminate lint errors after switch to tslint = 6.1.3+

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21904


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
