### PR TITLE
Eliminate lint errors; fix build of quay.io/eclipse/che-e2e

### DIFF
--- a/tests/e2e/build/dockerfiles/Dockerfile
+++ b/tests/e2e/build/dockerfiles/Dockerfile
@@ -6,10 +6,11 @@ USER root
 
 RUN apt-get update && apt-get install && \
     apt-get install -y ftp && \
+    curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \
     apt-get install -y nodejs && \
-    apt-get install -y npm && \
     npm install -g typescript && \
-    apt-get install x11vnc ffmpeg -y
+    apt-get install x11vnc ffmpeg -y && \
+    node -v
 
 COPY --chown=0:0 build/dockerfiles/entrypoint.sh /tmp/
 

--- a/tests/e2e/tslint.json
+++ b/tests/e2e/tslint.json
@@ -96,10 +96,10 @@
     "typedef": [
       true,
       // "call-signature",
-      "member-variable-declaration",
+      // "member-variable-declaration",
       "parameter",
-      "property-declaration",
-      "variable-declaration"
+      "property-declaration"
+      // "variable-declaration"
     ],
     "typedef-whitespace": [
       true,


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- Fixes build of quay.io/eclipse/che-e2e by setting up node.js 16.x in che-e2e image
- Eliminates lint errors after switch to tslint = 6.1.3+

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
#### che-e2e image build output
```
$ podman build -t quay.io/eclipse/che-e2e:next -f build/dockerfiles/Dockerfile .
STEP 1/14: FROM selenium/standalone-chrome:107.0
STEP 2/14: ENV DISPLAY=':20'
--> Using cache 7fda43084b37166b069b86bc81fc03e63adf36e6c81ff62a1c257e9296303b80
--> 7fda43084b3
STEP 3/14: USER root
--> Using cache 21608ab8bb58f62a32a590ce2484f4772f31abf684e14b023718bb622f287d63
--> 21608ab8bb5
STEP 4/14: RUN apt-get update && apt-get install &&     apt-get install -y ftp &&     curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - &&     apt-get install -y nodejs &&     npm install -g typescript &&     apt-get install x11vnc ffmpeg -y &&     node -v
--> Using cache 9044d8327b9231d6612b055786a87fb7396ef50324d21829cd7248902b0c1a31
--> 9044d8327b9
STEP 5/14: COPY --chown=0:0 build/dockerfiles/entrypoint.sh /tmp/
--> Using cache a6ffb42c1d5b5c32f42411d4b3ce6d7d331250b4dac7aeb1d18568bbb686f6b6
--> a6ffb42c1d5
STEP 6/14: RUN mkdir /tmp/e2e &&     chmod -R 777 /tmp/e2e
--> Using cache e1995f6485ddb873b5a4d082a316e0c0ad7424806b45493a5d5f8a3f7aa38b4c
--> e1995f6485d
STEP 7/14: RUN sed -i "s/nodaemon=true/nodaemon=false/" /etc/supervisord.conf
--> Using cache 06fd7f3679b3630f9e289417b8a6960cda6b1b2c4ed5cff8bf9c220151c4cd45
--> 06fd7f3679b
STEP 8/14: COPY package.json package-lock.json /tmp/e2e/
--> 4b119a6c5d1
STEP 9/14: RUN cd /tmp/e2e &&     npm --silent i
--> f240fac08f8
STEP 10/14: COPY . /tmp/e2e
--> cb63daccd3c
STEP 11/14: WORKDIR /tmp/e2e
--> 421cc891e93
STEP 12/14: EXPOSE 5920
--> 9892217e2fd
STEP 13/14: RUN chgrp -R 0 /tmp &&     chmod -R g+rwX /tmp
--> 69c0f5c62db
STEP 14/14: ENTRYPOINT [ "/tmp/entrypoint.sh" ]
COMMIT quay.io/eclipse/che-e2e:next
--> ed807be553d
Successfully tagged quay.io/eclipse/che-e2e:next
ed807be553d1cc615c833d701704ade700a23908c65d72a8d6e0a02d252d6586
```

#### **lint** output
```
$ npm run lint

> @eclipse-che/che-e2e@7.59.0-SNAPSHOT lint /home/ndp/projects/che/tests/e2e
> tslint --fix -p .

no-unused-variable is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.
no-use-before-declare is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.

```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21904

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
