### PR TITLE
Mask sensitive test data in DriverHelper.ts 

### DIFF
--- a/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpLoginPage.ts
@@ -78,7 +78,7 @@ export class OcpLoginPage {
     }
 
     async enterPasswordOpenShift(passw: string) {
-        Logger.debug(`OcpLoginPage.enterPasswordOpenShift "${passw}"`);
+        Logger.debug(`OcpLoginPage.enterPasswordOpenShift"`);
 
         await this.driverHelper.enterValue(By.id('inputPassword'), passw);
     }

--- a/tests/e2e/utils/DriverHelper.ts
+++ b/tests/e2e/utils/DriverHelper.ts
@@ -408,7 +408,11 @@ export class DriverHelper {
         const polling: number = TestConstants.TS_SELENIUM_DEFAULT_POLLING;
         const attempts: number = Math.ceil(timeout / polling);
 
-        Logger.trace(`DriverHelper.type ${elementLocator} text: ${text}`);
+        if (elementLocator.toString().toLocaleLowerCase().includes('password')) {
+            Logger.trace(`DriverHelper.type ${elementLocator} text: ***`);
+        } else {
+            Logger.trace(`DriverHelper.type ${elementLocator} text: ${text}`);
+        }
 
         for (let i = 0; i < attempts; i++) {
             let element: WebElement;
@@ -573,7 +577,11 @@ export class DriverHelper {
     }
 
     public async enterValue(elementLocator: By, text: string, timeout: number = TimeoutConstants.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM) {
-        Logger.trace(`DriverHelper.enterValue ${elementLocator} text: ${text}`);
+        if (elementLocator.toString().toLocaleLowerCase().includes('password')) {
+            Logger.trace(`DriverHelper.enterValue ${elementLocator} text: ***`);
+        } else {
+            Logger.trace(`DriverHelper.enterValue ${elementLocator} text: ${text}`);
+        }
 
         await this.waitVisibility(elementLocator, timeout);
         await this.clear(elementLocator);


### PR DESCRIPTION
Signed-off-by: Dmytro Nochevnov <dnochevn@redhat.com>

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Mask password text in test output logs, e.g. https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/6315/console :
```
   ▼ OcpLoginPage.enterPasswordOpenShift"

           ▼ OcpLoginPage.enterPasswordOpenShift"
             ‣ DriverHelper.enterValue By(css selector, *[id="inputPassword"]) text: ***
             ‣ DriverHelper.waitVisibility By(css selector, *[id="inputPassword"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
             ‣ DriverHelper.clear By(css selector, *[id="inputPassword"])
             ‣ DriverHelper.waitVisibility By(css selector, *[id="inputPassword"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
             ‣ DriverHelper.waitAttributeValue By(css selector, *[id="inputPassword"])
             ‣ DriverHelper.waitAndGetElementAttribute By(css selector, *[id="inputPassword"]) attribute: 'value'
             ‣ DriverHelper.waitVisibility By(css selector, *[id="inputPassword"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
             ‣ DriverHelper.type By(css selector, *[id="inputPassword"]) text: ***
             ‣ DriverHelper.waitVisibility By(css selector, *[id="inputPassword"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
             ‣ DriverHelper.waitAttributeValue By(css selector, *[id="inputPassword"])
             ‣ DriverHelper.waitAndGetElementAttribute By(css selector, *[id="inputPassword"]) attribute: 'value'
             ‣ DriverHelper.waitVisibility By(css selector, *[id="inputPassword"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
...
           ▼ OauthPage.enterPassword
             ‣ DriverHelper.enterValue By(css selector, *[id="user_password"]) text: ***
             ‣ DriverHelper.waitVisibility By(css selector, *[id="user_password"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
             ‣ DriverHelper.clear By(css selector, *[id="user_password"])
             ‣ DriverHelper.waitVisibility By(css selector, *[id="user_password"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
             ‣ DriverHelper.waitAttributeValue By(css selector, *[id="user_password"])
             ‣ DriverHelper.waitAndGetElementAttribute By(css selector, *[id="user_password"]) attribute: 'value'
             ‣ DriverHelper.waitVisibility By(css selector, *[id="user_password"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
             ‣ DriverHelper.type By(css selector, *[id="user_password"]) text: ***
             ‣ DriverHelper.waitVisibility By(css selector, *[id="user_password"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
             ‣ DriverHelper.waitAttributeValue By(css selector, *[id="user_password"])
             ‣ DriverHelper.waitAndGetElementAttribute By(css selector, *[id="user_password"]) attribute: 'value'
             ‣ DriverHelper.waitVisibility By(css selector, *[id="user_password"])
             ‣ DriverHelper.waitVisibility - Element is located and is visible.
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
