### PR TITLE
Fixing error message if editor variable not set

### DIFF
--- a/tests/e2e/initDevfileTests.sh
+++ b/tests/e2e/initDevfileTests.sh
@@ -23,6 +23,16 @@ launchSingleUserstory(){
 checkUserstoryName(){
     local checkedName="$(ls tests/devfiles/${TS_SELENIUM_EDITOR} | grep ${USERSTORY}.spec.ts)";
 
+    if [ -z "${TS_SELENIUM_EDITOR}"]; then
+        echo ""
+        echo "Variable TS_SELENIUM_EDITOR is unset."
+        echo ""
+        echo "Please assign the variable to a correct editor value."
+        echo ""
+
+        exit 1
+    fi
+
     if [ -z "$checkedName" ]; then
         echo ""
         echo "Current value USERSTORY=\"${USERSTORY}\" doesn't match to any existed test:"

--- a/tests/e2e/initDevfileTests.sh
+++ b/tests/e2e/initDevfileTests.sh
@@ -23,9 +23,13 @@ launchSingleUserstory(){
 checkUserstoryName(){
     local checkedName="$(ls tests/devfiles/${TS_SELENIUM_EDITOR} | grep ${USERSTORY}.spec.ts)";
 
-    if [ -z "$TS_SELENIUM_EDITOR"]; then
+    if [ -z "$TS_SELENIUM_EDITOR" ]; then
         echo ""
         echo "Variable TS_SELENIUM_EDITOR is unset."
+        echo ""
+        echo "Available values are:"
+        echo ""
+        ls tests/devfiles/ | xargs -n1 echo
         echo ""
         echo "Please assign the variable to a correct editor value."
         echo ""

--- a/tests/e2e/initDevfileTests.sh
+++ b/tests/e2e/initDevfileTests.sh
@@ -23,7 +23,7 @@ launchSingleUserstory(){
 checkUserstoryName(){
     local checkedName="$(ls tests/devfiles/${TS_SELENIUM_EDITOR} | grep ${USERSTORY}.spec.ts)";
 
-    if [ -z "${TS_SELENIUM_EDITOR}"]; then
+    if [ -z "$TS_SELENIUM_EDITOR"]; then
         echo ""
         echo "Variable TS_SELENIUM_EDITOR is unset."
         echo ""


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes error message on running `test-all-devfiles` in che/tests/e2e when `TS_SELENIUM_EDITOR` is unset.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![image](https://user-images.githubusercontent.com/44302901/220653641-2aeb6da3-f75f-4399-b97a-c93b1dd7ffdb.png)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->#22018


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Test platform: CodeReady Container
- Install method: chectl
1. Build Che
2. Move to test/e2e 
3. Don't set TS_SELENIUM_EDITOR variable
4. Run `test-all-devfiles` script


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
