### PR TITLE
Fixed error message incorrectly listing available editors on nonexisting `USERSTORY` in initDevFileTests

### DIFF
--- a/tests/e2e/initDevfileTests.sh
+++ b/tests/e2e/initDevfileTests.sh
@@ -23,9 +23,13 @@ launchSingleUserstory(){
 checkUserstoryName(){
     local checkedName="$(ls tests/devfiles/${TS_SELENIUM_EDITOR} | grep ${USERSTORY}.spec.ts)";
 
-    if [ -z "$TS_SELENIUM_EDITOR" ]; then
+    if [ -z "$TS_SELENIUM_EDITOR" ] || [ ! -d "tests/devfiles/${TS_SELENIUM_EDITOR}" ]; then
         echo ""
-        echo "Variable TS_SELENIUM_EDITOR is unset."
+        if [ -z "$TS_SELENIUM_EDITOR" ]; then
+          echo "Variable TS_SELENIUM_EDITOR is unset."
+        elif [ ! -d "tests/devfiles/${TS_SELENIUM_EDITOR}" ]; then
+          echo "Variable \"${TS_SELENIUM_EDITOR}\" is not a valid directory."
+        fi
         echo ""
         echo "Available values are:"
         echo ""
@@ -39,9 +43,9 @@ checkUserstoryName(){
 
     if [ -z "$checkedName" ]; then
         echo ""
-        echo "Current value USERSTORY=\"${USERSTORY}\" doesn't match to any existed test:"
+        echo "Current value USERSTORY=\"${USERSTORY}\" doesn't match to any of existing tests:"
         echo ""
-        echo "$(ls tests/devfiles | sed -e 's/.spec.ts/ /g')"
+        echo "$(ls "tests/devfiles/${TS_SELENIUM_EDITOR}" | sed -e 's/.spec.ts//g')"
         echo ""
         echo "Please choose one of the tests above, or unset the \"USERSTORY\" variable for launching all of them."
         echo ""


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes incorrect error messages on nonexisting `USERSTORY` in `initDevFileTests.sh`. Now showing available user stories of given editor instead of available editors. Also showing whether the `TS_SELENIUM_EDITOR` option exists.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
n/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
#22018

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
-->  

  - Test platform: CodeReady Container
  - Install method: chectl

  1. Build Che
  2. Move to test/e2e
  2. Set TS_SELENIUM_EDITOR to che-code
  4. Don't set USERSTORY variable
  5. Run test-all-devfiles script


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)