### PR TITLE
Added new dependency, switched ffmpeg to use libvpx-vp8 instead

### DIFF
--- a/tests/e2e/build/dockerfiles/Dockerfile
+++ b/tests/e2e/build/dockerfiles/Dockerfile
@@ -5,11 +5,10 @@ ENV DISPLAY=':20'
 USER root
 
 RUN apt-get update && apt-get install && \
-    apt-get install -y ftp && \
+    apt-get install -y ftp x11vnc ffmpeg libvpx6 && \
     curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash - && \
     apt-get install -y nodejs && \
     npm install -g typescript && \
-    apt-get install x11vnc ffmpeg -y && \
     node -v
 
 COPY --chown=0:0 build/dockerfiles/entrypoint.sh /tmp/

--- a/tests/e2e/build/dockerfiles/entrypoint.sh
+++ b/tests/e2e/build/dockerfiles/entrypoint.sh
@@ -98,7 +98,7 @@ else
   if [ "${SCREEN_RECORDING}" == "true" ]; then
     echo "Starting ffmpeg recording..."
     mkdir -p /tmp/ffmpeg_report
-    nohup ffmpeg -y -video_size 1920x1080 -framerate 24 -f x11grab -i :20.0 /tmp/ffmpeg_report/output.mp4 2> /tmp/ffmpeg_report/ffmpeg_err.txt > /tmp/ffmpeg_report/ffmpeg_std.txt & 
+    nohup ffmpeg -y -video_size 1920x1080 -framerate 30 -f x11grab -i :20.0 -c:a libvpx /tmp/ffmpeg_report/output.webm 2> /tmp/ffmpeg_report/ffmpeg_err.txt > /tmp/ffmpeg_report/ffmpeg_std.txt &
     ffmpeg_pid=$!
     trap kill_ffmpeg 2 15
   fi


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Switches test image to use libvpx-vp8 for recording and encoding screencasting

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
N/A
This PR fixes the issue of incompatibility between downstream and upstream jobs. The recording on downstream utilizes webm libvpx-vp8 recording format to fix the mimetype error when trying to playback the recording in a browser from jenkins artifacts. Also the size is more optimal and framerate is increased slightly.

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
