### PR TITLE
fix: property 'spec' does not exist on type 'Object' in api tests.

### DIFF
--- a/tests/e2e/specs/api/ContainerOverridesAPI.spec.ts
+++ b/tests/e2e/specs/api/ContainerOverridesAPI.spec.ts
@@ -23,7 +23,7 @@ suite(`Test defining container overrides via attribute.`, async function (): Pro
     });
 
     test('Check that fields are overridden in the Deployment for DewWorkspace', function (): void {
-       const devWorkspaceFullYamlOutput: Object = YAML.parse(kubernetesCommandLineToolsExecutor.getDevWorkspaceYamlConfiguration());
+       const devWorkspaceFullYamlOutput: any = YAML.parse(kubernetesCommandLineToolsExecutor.getDevWorkspaceYamlConfiguration());
        expect(devWorkspaceFullYamlOutput.spec.template.components[0].attributes['container-overrides']).eqls({
            resources: {
                limits: {

--- a/tests/e2e/specs/api/PodOverridesAPI.spec.ts
+++ b/tests/e2e/specs/api/PodOverridesAPI.spec.ts
@@ -23,7 +23,7 @@ suite(`Test defining pod overrides via attribute.`, async function (): Promise<v
     });
 
     test('Check that fields are overridden in the Deployment for DewWorkspace', function (): void {
-       const devWorkspaceFullYamlOutput: Object = YAML.parse(kubernetesCommandLineToolsExecutor.getDevWorkspaceYamlConfiguration());
+       const devWorkspaceFullYamlOutput: any = YAML.parse(kubernetesCommandLineToolsExecutor.getDevWorkspaceYamlConfiguration());
        expect(devWorkspaceFullYamlOutput.spec.template.attributes['pod-overrides']).eqls({
            metadata: {
                annotations: {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
fix Object to any type in constant created with YAML.parse()

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

N/A
### What issues does this PR fix or reference?
https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/7980/console
```
 Generating index.ts file...
 specs/api/ContainerOverridesAPI.spec.ts(27,42): error TS2339: Property 'spec' does not exist on type 'Object'.
 specs/api/PodOverridesAPI.spec.ts(27,42): error TS2339: Property 'spec' does not exist on type 'Object'.
```

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
export USERSTORY=PodOverridesAPI && npm run driver-less-test
export USERSTORY=ContainerOverridesAPI && npm run driver-less-test

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
