### PR TITLE
Fix for 7.69.0 Release

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -76,7 +76,7 @@ bump_version () {
 
   pushd tests/e2e >/dev/null || exit
   npm --no-git-tag-version version --allow-same-version "${NEXT_VERSION}"
-  sed_in_place -r -e "/@eclipse-che\/api|@eclipse-che\/workspace-client|@eclipse-che\/workspace-telemetry-client/!s/(\"@eclipse-che\/..*\": )(\".*\")/\1\"$VERSION\"/" package.json
+  sed_in_place -r -e "/@eclipse-che\/api|@eclipse-che\/workspace-client|@eclipse-che\/workspace-telemetry-client|@eclipse-che\/che-devworkspace-generator/!s/(\"@eclipse-che\/..*\": )(\".*\")/\1\"$VERSION\"/" package.json
   popd  >/dev/null || exit
 
   COMMIT_MSG="chore: Bump to ${NEXT_VERSION} in ${BUMP_BRANCH}"

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -17,7 +17,7 @@
   "author": "Ihor Okhrimenko (iokhrime@redhat.com)",
   "license": "ISC",
   "devDependencies": {
-    "@eclipse-che/che-devworkspace-generator": "7.68.0",
+    "@eclipse-che/che-devworkspace-generator": "next",
     "@types/chai": "^4.3.4",
     "@types/clone-deep": "^4.0.1",
     "@types/mocha": "5.2.6",


### PR DESCRIPTION
Add devworkspace-generator to a sed that I missed originally and reset the version in the package.json to next since devsworkspace-generator still has non-standard versions.
