### PR TITLE
CRW-4557 Fixes workspace deleting by API in MochaHooks.ts after test run.

### DIFF
--- a/tests/e2e/specs/MochaHooks.ts
+++ b/tests/e2e/specs/MochaHooks.ts
@@ -56,14 +56,18 @@ exports.mochaHooks = {
             }
         },
     ],
-    afterAll: [
+    afterEach: [
         // stop and remove running workspace
-        async () => {
-            if (BaseTestConstants.DELETE_WORKSPACE_ON_FAILED_TEST) {
-                Logger.info('Property DELETE_WORKSPACE_ON_FAILED_TEST is true - trying to stop and delete running workspace with API.');
-                await testWorkspaceUtil.stopAndDeleteWorkspaceByName(latestWorkspace);
+        async function (this: Mocha.Context): Promise<void> {
+            if (this.currentTest?.state === 'failed') {
+                if (BaseTestConstants.DELETE_WORKSPACE_ON_FAILED_TEST) {
+                    Logger.info('Property DELETE_WORKSPACE_ON_FAILED_TEST is true - trying to stop and delete running workspace with API.');
+                    await testWorkspaceUtil.stopAndDeleteWorkspaceByName(latestWorkspace);
+                }
             }
         },
+    ],
+    afterAll: [
         async function stopTheDriver(): Promise<void> {
             if (!BaseTestConstants.TS_DEBUG_MODE && ChromeDriverConstants.TS_USE_WEB_DRIVER_FOR_TEST) {
                 await driverHelper.getDriver().quit();

--- a/tests/e2e/specs/MochaHooks.ts
+++ b/tests/e2e/specs/MochaHooks.ts
@@ -51,7 +51,7 @@ exports.mochaHooks = {
         async function prolongTimeoutConstantsInDebugMode(): Promise<void> {
             if (BaseTestConstants.TS_DEBUG_MODE) {
                 for (let [timeout, seconds] of Object.entries(TimeoutConstants)) {
-                    Object.defineProperty(TimeoutConstants, timeout, {value: seconds as number * 100});
+                    Object.defineProperty(TimeoutConstants, timeout, { value: seconds as number * 100 });
                 }
             }
         },
@@ -61,7 +61,7 @@ exports.mochaHooks = {
         async () => {
             if (BaseTestConstants.DELETE_WORKSPACE_ON_FAILED_TEST) {
                 Logger.info('Property DELETE_WORKSPACE_ON_FAILED_TEST is true - trying to stop and delete running workspace with API.');
-                testWorkspaceUtil.stopAndDeleteWorkspaceByName(latestWorkspace);
+                await testWorkspaceUtil.stopAndDeleteWorkspaceByName(latestWorkspace);
             }
         },
         async function stopTheDriver(): Promise<void> {

--- a/tests/e2e/specs/factory/Factory.spec.ts
+++ b/tests/e2e/specs/factory/Factory.spec.ts
@@ -187,15 +187,14 @@ suite(`Create a workspace via launching a factory from the ${FactoryTestConstant
         expect(isCommitButtonDisabled).eql('true');
     });
 
-    test(`Stop and remove the workspace`, async function (): Promise<void> {
-        await workspaceHandlingTests.stopAndRemoveWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+    test('Stop the workspace', async function (): Promise<void> {
+        await workspaceHandlingTests.stopWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+        await browserTabsUtil.closeAllTabsExceptCurrent();
+    });
+
+    test('Delete the workspace', async function (): Promise<void> {
+        await workspaceHandlingTests.removeWorkspace(WorkspaceHandlingTests.getWorkspaceName());
     });
 
     loginTests.logoutFromChe();
-
-    suiteTeardown('Close the browser', async function (): Promise<void> {
-        if (!BaseTestConstants.TS_DEBUG_MODE) {
-            await driverHelper.getDriver().close();
-        }
-    });
 });

--- a/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
+++ b/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
@@ -42,7 +42,7 @@ import { TimeoutConstants } from '../../constants/TimeoutConstants';
 import { LoginTests } from '../../tests-library/LoginTests';
 import { OAuthConstants } from '../../constants/OAuthConstants';
 import { BaseTestConstants } from '../../constants/BaseTestConstants';
-import { FactoryTestConstants } from '../../constants/FactoryTestConstants';
+import { FactoryTestConstants, GitProviderType } from '../../constants/FactoryTestConstants';
 
 const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
@@ -217,13 +217,12 @@ suite(`Create a workspace via launching a factory from the ${FactoryTestConstant
         });
 
         test('Insert git credentials which were asked after push', async function (): Promise<void> {
-            await driverHelper.waitVisibility(webCheCodeLocators.ScmView.more);
-
             try {
-                await driverHelper.waitVisibility(webCheCodeLocators.Input.inputBox);
+                await driverHelper.waitVisibility(webCheCodeLocators.InputBox.message);
             } catch (e) {
                 Logger.info(`Workspace did not ask credentials before push - ${e};
-                Known issue for github.com - https://issues.redhat.com/browse/CRW-4066`);
+                Known issue for github.com - https://issues.redhat.com/browse/CRW-4066, please check if not other git provider. `);
+                expect(FactoryTestConstants.TS_SELENIUM_FACTORY_GIT_PROVIDER).eqls(GitProviderType.GITHUB);
             }
             const input: InputBox = new InputBox();
             await input.setText(OAuthConstants.TS_SELENIUM_GIT_PROVIDER_USERNAME);
@@ -248,15 +247,14 @@ suite(`Create a workspace via launching a factory from the ${FactoryTestConstant
         });
     }
 
-    test(`Stop and remove the workspace`, async function (): Promise<void> {
-        await workspaceHandlingTests.stopAndRemoveWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+    test('Stop the workspace', async function (): Promise<void> {
+        await workspaceHandlingTests.stopWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+        await browserTabsUtil.closeAllTabsExceptCurrent();
+    });
+
+    test('Delete the workspace', async function (): Promise<void> {
+        await workspaceHandlingTests.removeWorkspace(WorkspaceHandlingTests.getWorkspaceName());
     });
 
     loginTests.logoutFromChe();
-
-    suiteTeardown('Close the browser', async function (): Promise<void> {
-        if (!BaseTestConstants.TS_DEBUG_MODE) {
-            await driverHelper.getDriver().close();
-        }
-    });
 });

--- a/tests/e2e/utils/CheReporter.ts
+++ b/tests/e2e/utils/CheReporter.ts
@@ -8,13 +8,12 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import * as mocha from 'mocha';
-import { TYPES, CLASSES } from '../configs/inversify.types';
+import { CLASSES } from '../configs/inversify.types';
 import * as fs from 'fs';
 import * as rm from 'rimraf';
 import { logging } from 'selenium-webdriver';
 import { DriverHelper } from './DriverHelper';
 import { ScreenCatcher } from './ScreenCatcher';
-import { ITestWorkspaceUtil } from './workspace/ITestWorkspaceUtil';
 import { TimeoutConstants } from '../constants/TimeoutConstants';
 import { Logger } from './Logger';
 import { e2eContainer } from '../configs/inversify.config';
@@ -30,11 +29,8 @@ const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 const screenCatcher: ScreenCatcher = e2eContainer.get(CLASSES.ScreenCatcher);
 let methodIndex: number = 0;
 let deleteScreencast: boolean = true;
-let testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
 
 class CheReporter extends mocha.reporters.Spec {
-
-  private static latestWorkspace: string = '';
 
   constructor(runner: mocha.Runner, options: mocha.MochaOptions) {
     super(runner, options);
@@ -181,12 +177,6 @@ class CheReporter extends mocha.reporters.Spec {
       const browserLogsStream: WriteStream = fs.createWriteStream(browserLogsFileName);
       browserLogsStream.write(Buffer.from(browserLogs));
       browserLogsStream.end();
-
-      // stop and remove running workspace
-      if (BaseTestConstants.DELETE_WORKSPACE_ON_FAILED_TEST) {
-        Logger.warn('Property DELETE_WORKSPACE_ON_FAILED_TEST se to true - trying to stop and delete running workspace.');
-        await testWorkspaceUtil.stopAndDeleteWorkspaceByName(CheReporter.latestWorkspace);
-      }
 
     });
   }

--- a/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
+++ b/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
@@ -23,8 +23,8 @@ import { TimeoutConstants } from '../../constants/TimeoutConstants';
 
 @injectable()
 export class TestWorkspaceUtil implements ITestWorkspaceUtil {
-    readonly attempts: number = TimeoutConstants.TS_SELENIUM_DEFAULT_ATTEMPTS;
     readonly polling: number = TimeoutConstants.TS_SELENIUM_DEFAULT_POLLING;
+    readonly attempts: number = TimeoutConstants.TS_DASHBOARD_WORKSPACE_STOP_TIMEOUT / this.polling;
 
     constructor(
         @inject(CLASSES.DriverHelper) private readonly driverHelper: DriverHelper,

--- a/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
+++ b/tests/e2e/utils/workspace/TestWorkspaceUtil.ts
@@ -61,7 +61,7 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
     }
 
     async stopWorkspaceByName(workspaceName: string): Promise<void> {
-        Logger.debug('TestWorkspaceUtil.stopWorkspaceByName');
+        Logger.debug(`TestWorkspaceUtil.stopWorkspaceByName: ${workspaceName}`);
 
         const stopWorkspaceApiUrl: string = await this.apiUrlResolver.getWorkspaceApiUrl(workspaceName);
         let stopWorkspaceResponse: AxiosResponse;
@@ -69,7 +69,7 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
         try {
             stopWorkspaceResponse = await this.processRequestHandler.patch(stopWorkspaceApiUrl, [{'op': 'replace', 'path': '/spec/started', 'value': false}]);
         } catch (err) {
-            console.log(`Stop workspace call failed. URL used: ${stopWorkspaceApiUrl}`);
+            Logger.error(`Stop workspace call failed. URL used: ${stopWorkspaceApiUrl}`);
             throw err;
         }
 
@@ -78,11 +78,12 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
         }
 
         await this.waitWorkspaceStatus(workspaceName, WorkspaceStatus.STOPPED);
+        Logger.debug(`TestWorkspaceUtil.stopWorkspaceByName: ${workspaceName} stopped successfully`);
     }
 
     // delete a workspace without stopping phase (similar with force deleting)
     async deleteWorkspaceByName(workspaceName: string): Promise<void> {
-        Logger.debug(`TestWorkspaceUtil.deleteWorkspaceByName ${workspaceName}` );
+        Logger.debug(`TestWorkspaceUtil.deleteWorkspaceByName: ${workspaceName}` );
 
         const deleteWorkspaceApiUrl: string = await this.apiUrlResolver.getWorkspaceApiUrl(workspaceName);
         let deleteWorkspaceResponse: AxiosResponse;
@@ -108,6 +109,7 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
             } catch (error) {
                 if (axios.isAxiosError(error) && error.response?.status === 404) {
                     deleteWorkspaceStatus = true;
+                    Logger.debug(`TestWorkspaceUtil.stopWorkspaceByName: ${workspaceName} deleted successfully`);
                     break;
                 }
             }
@@ -115,7 +117,7 @@ export class TestWorkspaceUtil implements ITestWorkspaceUtil {
 
         if (!deleteWorkspaceStatus) {
             let waitTime: number = this.attempts * this.polling;
-            throw new error.TimeoutError(`The workspace was not stopped in ${waitTime} ms.`);
+            throw new error.TimeoutError(`The workspace was not deleted in ${waitTime} ms.`);
         }
     }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes workspace deleting by API in MochaHooks.ts aftef test:
- added missed `await` (browser have been closed before delete by API was finished);
- test('Stop and remove the workspace') relapsed with two separate ones to improve test stability (if deleting of workspace will fail by timeout, rerun will try to stop it again and failed).
- added new expected error into NoSetupRepoFactory.spec
- removed test hooks from custom reporter
- improved logs
- prolong workspace deleting timeout

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
 • Property DELETE_WORKSPACE_ON_FAILED_TEST is true - trying to stop and delete running workspace with API.
          ▼ TestWorkspaceUtil.stopAndDeleteWorkspaceByName
          ▼ TestWorkspaceUtil.stopWorkspaceByName: empty-fn4r
          ▼ ApiUrlResolver.obtainUserNamespace 
          ▼ ApiUrlResolver.obtainUserNamespace kubeapi success: admin-devspaces
          ▼ TestWorkspaceUtil.waitWorkspaceStatus
          ▼ ApiUrlResolver.obtainUserNamespace admin-devspaces
          ▼ TestWorkspaceUtil.stopWorkspaceByName: empty-fn4r stopped successfully
          ▼ TestWorkspaceUtil.deleteWorkspaceByName: empty-fn4r
          ▼ ApiUrlResolver.obtainUserNamespace admin-devspaces
          ▼ TestWorkspaceUtil.stopWorkspaceByName: empty-fn4r deleted successfully
      • Chrome driver session stopped.

  5 passing (1m)
  1 failing
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-4557

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

Checked locally with run of two tests one by one (in first added `except(process.env.THIS_SHOULD_FAIL).eqls("false")` to make it failed). Workspaces were deleted in both cases. 
test script:
```
  export USERSTORY="Factory"
  echo $USERSTORY
  export THIS_SHOULD_FAIL="true"
  echo $THIS_SHOULD_FAIL
  npm run test
  export USERSTORY="Factory"
  echo $USERSTORY
  export THIS_SHOULD_FAIL="false"
  echo $THIS_SHOULD_FAIL
  npm run test
```
[log.txt](https://github.com/eclipse/che/files/11915513/log.txt)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
