### PR TITLE
chore: Split launch.sh into two independent scripts

### DIFF
--- a/tests/devworkspace-happy-path/launch.sh
+++ b/tests/devworkspace-happy-path/launch.sh
@@ -20,138 +20,16 @@ set -u
 START=$(date +%s.%N)
 SCRIPT_DIR=$(dirname $(readlink -f "$0"))
 
-export WORKDIR="${WORKDIR:-${SCRIPT_DIR}/workdir}"
 export CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"
-export E2E_TEST_IMAGE="${E2E_TEST_IMAGE:-quay.io/eclipse/che-e2e:next}"
 export HAPPY_PATH_POD_NAME=happy-path-che
-export HAPPY_PATH_TEST_PROJECT='https://github.com/che-samples/java-spring-petclinic/tree/devfilev2'
-export HAPPY_PATH_SUITE="${HAPPY_PATH_SUITE:-test-all-devfiles}"
-export HAPPY_PATH_USERSTORY="${HAPPY_PATH_USERSTORY:-EmptyWorkspace}"
 
-rm -rf ${WORKDIR}
-mkdir -p ${WORKDIR}
+source "${SCRIPT_DIR}/common.sh"
 
-# Create cluster-admin user inside of OpenShift cluster and login
-function provisionOpenShiftOAuthUser() {
-  echo "[INFO] Testing if Che User exists."
-  KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
-  TMP_KUBECONFIG="$WORKDIR/kubeconfig"
-  cp "$KUBECONFIG" "$TMP_KUBECONFIG"
-
-  if oc login -u che-user -p user --kubeconfig $TMP_KUBECONFIG; then
-    echo "[INFO] Che User already exists. Using it"
-    return 0
-  fi
-  echo "[INFO] Che User does not exist. Setting up htpasswd oauth for it."
-  oc delete secret dev-htpasswd-secret -n openshift-config || true
-  oc create secret generic dev-htpasswd-secret --from-file=htpasswd="$SCRIPT_DIR/resources/users.htpasswd" -n openshift-config
-
-  if [[ $(oc get oauth cluster --ignore-not-found) == "" ]]; then
-    echo "[INFO] Creating a new OAuth Cluster since it's not found."
-    oc apply -f ${SCRIPT_DIR}/resources/cluster-oauth.yaml
-  # CustomResources don't support strategic merge. So, we need to merge or add array item depending on the object state
-  elif [[ $(oc get oauth/cluster -o=json | jq -e 'select (.spec.identityProviders == null)') ]]; then
-    # there are no identity providers. We can do merge and set the whole .spec.identityProviders field
-    echo "[INFO] No identity providers found, provisioning Che one."
-    oc patch oauth/cluster --type=merge -p "$(cat $SCRIPT_DIR/resources/cluster-oauth-patch.json)"
-  elif [[ ! $(oc get oauth/cluster -o=json | jq -e '.spec.identityProviders[]?.name? | select ( . == ("dev-htpasswd"))') ]]; then
-    # there are some identity providers. We should do add patch not to override existing identity providers
-    echo "[INFO] OAuth Cluster is found but dev-htpasswd provider missing. Provisioning it."
-    oc patch oauth/cluster --type=json -p '[{
-      "op": "add",
-      "path": "/spec/identityProviders/0",
-      "value": {
-        "name":"dev-htpasswd",
-        "mappingMethod":"add",
-        "type":"HTPasswd",
-        "htpasswd": {
-          "fileData":{"name":"dev-htpasswd-secret"}
-        }
-      }
-    }]'
-
-  else
-    echo "[INFO] dev-htpasswd oauth provider is found. Using it"
-  fi
-
-  echo "[INFO] rollout oauth-openshift pods for applying OAuth configuration"
-  # apply just added identity providers, we need to rollout deployment for make sure
-  # that new IDP item will appear in the IDP table
-  # https://github.com/eclipse/che/issues/20822
-
-  oc rollout status -n openshift-authentication deployment/oauth-openshift
-  echo -e "[INFO] Waiting for htpasswd auth to be working up to 5 minutes"
-  CURRENT_TIME=$(date +%s)
-  ENDTIME=$(($CURRENT_TIME + 300))
-  while [ $(date +%s) -lt $ENDTIME ]; do
-      if oc login -u happypath-dev -p dev --kubeconfig $TMP_KUBECONFIG; then
-          return 0
-      fi
-      sleep 10
-  done
-  echo "[ERROR] Che htpasswd changes are not affected after timeout."
-  exit 1
-}
-
-startHappyPathTest() {
-  oc delete pod happy-path-che -n eclipse-che --grace-period=30 --ignore-not-found
-  # patch happy-path-che.yaml
-  ECLIPSE_CHE_URL=http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
-  TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_TEST_PROJECT}"
-  HAPPY_PATH_POD_FILE=${SCRIPT_DIR}/resources/pod-che-happy-path.yaml
-  cp $HAPPY_PATH_POD_FILE ${WORKDIR}/e2e-pod.yaml
-  sed -i "s@HAPPY_PATH_SUITE@${HAPPY_PATH_SUITE}@g" ${WORKDIR}/e2e-pod.yaml
-  sed -i "s@HAPPY_PATH_USERSTORY@${HAPPY_PATH_USERSTORY}@g" ${WORKDIR}/e2e-pod.yaml
-  sed -i "s@CHE_URL@${ECLIPSE_CHE_URL}@g" ${WORKDIR}/e2e-pod.yaml
-  sed -i "s@WORKSPACE_ROUTE@${TS_SELENIUM_DEVWORKSPACE_URL}@g" ${WORKDIR}/e2e-pod.yaml
-  sed -i "s@CHE-NAMESPACE@${CHE_NAMESPACE}@g" ${WORKDIR}/e2e-pod.yaml
-  sed -i "s|image: .*|image: ${E2E_TEST_IMAGE}|g" ${WORKDIR}/e2e-pod.yaml
-  echo "[INFO] Applying the following patched Che Happy Path Pod:"
-  cat ${WORKDIR}/e2e-pod.yaml
-  echo "[INFO] --------------------------------------------------"
-  oc apply -f ${WORKDIR}/e2e-pod.yaml
-  # wait for the pod to start
-  n=0
-  while [ $n -le 120 ]
-  do
-    PHASE=$(oc get pod -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} \
-        --template='{{ .status.phase }}')
-    if [[ ${PHASE} == "Running" ]]; then
-      echo "[INFO] Happy-path test started successfully."
-      return
-    fi
-
-    sleep 5
-    n=$(( n+1 ))
-  done
-
-  echo "[ERROR] Failed to start happy-path test."
-  exit 1
-}
-
-provisionOpenShiftOAuthUser
-
-source "${SCRIPT_DIR}"/common.sh
 # Catch the finish of the job and write logs in artifacts.
 trap 'collectLogs $?' EXIT SIGINT
 
-startHappyPathTest
-
-echo "[INFO] Waiting until happy path pod finished"
-oc logs -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test -f
-# just to sleep
-sleep 3
-
-echo "[INFO] Downloading test report."
-mkdir ${ARTIFACT_DIR}/e2e
-oc rsync -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME}:/tmp/e2e/report/ ${ARTIFACT_DIR}/e2e -c download-reports
-oc exec -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c download-reports -- touch /tmp/done
-EXIT_CODE=$(oc logs -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test | grep EXIT_CODE)
-if [[ ${EXIT_CODE} != "+ EXIT_CODE=0" ]]; then
-    echo "[ERROR] Happy-path test failed. Check report at ${ARTIFACT_DIR}. Or happy path pod in eclipse-che namespace"
-    exit 1
-fi
-echo "[INFO] Happy-path test succeed."
+. "${SCRIPT_DIR}/provision-openshift-oauth-user.sh"
+. "${SCRIPT_DIR}/start-happypath-tests.sh"
 
 END=$(date +%s.%N)
 echo "[INFO] Happy-path execution took $(echo "$END - $START" | bc) seconds."

--- a/tests/devworkspace-happy-path/provision-openshift-oauth-user.sh
+++ b/tests/devworkspace-happy-path/provision-openshift-oauth-user.sh
@@ -15,7 +15,7 @@ set -o pipefail
 # error on unset variables
 set -u
 # uncomment to print each command before executing it
-set -x
+# set -x
 
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 WORKDIR_KUBE="${WORKDIR:-${SCRIPT_DIR}/workdir/.kube}"

--- a/tests/devworkspace-happy-path/provision-openshift-oauth-user.sh
+++ b/tests/devworkspace-happy-path/provision-openshift-oauth-user.sh
@@ -15,7 +15,7 @@ set -o pipefail
 # error on unset variables
 set -u
 # uncomment to print each command before executing it
-# set -x
+set -x
 
 SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 WORKDIR_KUBE="${WORKDIR:-${SCRIPT_DIR}/workdir/.kube}"

--- a/tests/devworkspace-happy-path/provision-openshift-oauth-user.sh
+++ b/tests/devworkspace-happy-path/provision-openshift-oauth-user.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2023 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# uncomment to print each command before executing it
+# set -x
+
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+WORKDIR_KUBE="${WORKDIR:-${SCRIPT_DIR}/workdir/.kube}"
+
+rm -rf "${WORKDIR_KUBE}" && mkdir -p "${WORKDIR_KUBE}"
+
+# Create cluster-admin user inside of OpenShift cluster and login
+function run() {
+  echo "[INFO] Testing if Che User exists."
+  KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
+  TMP_KUBECONFIG="$WORKDIR_KUBE/kubeconfig"
+  cp "$KUBECONFIG" "$TMP_KUBECONFIG"
+
+  if oc login -u che-user -p user --kubeconfig "${TMP_KUBECONFIG}"; then
+    echo "[INFO] Che User already exists. Using it"
+    return 0
+  fi
+  echo "[INFO] Che User does not exist. Setting up htpasswd oauth for it."
+  oc delete secret dev-htpasswd-secret -n openshift-config || true
+  oc create secret generic dev-htpasswd-secret --from-file=htpasswd="$SCRIPT_DIR/resources/users.htpasswd" -n openshift-config
+
+  if [[ $(oc get oauth cluster --ignore-not-found) == "" ]]; then
+    echo "[INFO] Creating a new OAuth Cluster since it's not found."
+    oc apply -f ${SCRIPT_DIR}/resources/cluster-oauth.yaml
+  # CustomResources don't support strategic merge. So, we need to merge or add array item depending on the object state
+  elif [[ $(oc get oauth/cluster -o=json | jq -e 'select (.spec.identityProviders == null)') ]]; then
+    # there are no identity providers. We can do merge and set the whole .spec.identityProviders field
+    echo "[INFO] No identity providers found, provisioning Che one."
+    oc patch oauth/cluster --type=merge -p "$(cat $SCRIPT_DIR/resources/cluster-oauth-patch.json)"
+  elif [[ ! $(oc get oauth/cluster -o=json | jq -e '.spec.identityProviders[]?.name? | select ( . == ("dev-htpasswd"))') ]]; then
+    # there are some identity providers. We should do add patch not to override existing identity providers
+    echo "[INFO] OAuth Cluster is found but dev-htpasswd provider missing. Provisioning it."
+    oc patch oauth/cluster --type=json -p '[{
+      "op": "add",
+      "path": "/spec/identityProviders/0",
+      "value": {
+        "name":"dev-htpasswd",
+        "mappingMethod":"add",
+        "type":"HTPasswd",
+        "htpasswd": {
+          "fileData":{"name":"dev-htpasswd-secret"}
+        }
+      }
+    }]'
+
+  else
+    echo "[INFO] dev-htpasswd oauth provider is found. Using it"
+  fi
+
+  echo "[INFO] rollout oauth-openshift pods for applying OAuth configuration"
+  # apply just added identity providers, we need to rollout deployment for make sure
+  # that new IDP item will appear in the IDP table
+  # https://github.com/eclipse/che/issues/20822
+
+  oc rollout status -n openshift-authentication deployment/oauth-openshift
+  echo -e "[INFO] Waiting for htpasswd auth to be working up to 5 minutes"
+  CURRENT_TIME=$(date +%s)
+  ENDTIME=$(($CURRENT_TIME + 300))
+  while [ $(date +%s) -lt $ENDTIME ]; do
+      if oc login -u happypath-dev -p dev --kubeconfig $TMP_KUBECONFIG; then
+          return 0
+      fi
+      sleep 10
+  done
+  echo "[ERROR] Che htpasswd changes are not affected after timeout."
+  exit 1
+}
+
+run

--- a/tests/devworkspace-happy-path/provision-openshift-oauth-user.sh
+++ b/tests/devworkspace-happy-path/provision-openshift-oauth-user.sh
@@ -17,7 +17,7 @@ set -u
 # uncomment to print each command before executing it
 # set -x
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 WORKDIR_KUBE="${WORKDIR:-${SCRIPT_DIR}/workdir/.kube}"
 
 rm -rf "${WORKDIR_KUBE}" && mkdir -p "${WORKDIR_KUBE}"

--- a/tests/devworkspace-happy-path/start-happypath-tests.sh
+++ b/tests/devworkspace-happy-path/start-happypath-tests.sh
@@ -33,11 +33,7 @@ run() {
   oc create namespace "${CHE_NAMESPACE}" || true
   oc delete pod happy-path-che -n "${CHE_NAMESPACE}" --grace-period=30 --ignore-not-found
   # patch happy-path-che.yaml
-  set +u
-    if [[ -z "${ECLIPSE_CHE_URL}" ]]; then
-      ECLIPSE_CHE_URL=http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
-    fi
-  set -u
+  ECLIPSE_CHE_URL=${ECLIPSE_CHE_URL:-http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')}
   TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_TEST_PROJECT}"
   HAPPY_PATH_POD_FILE=${SCRIPT_DIR}/resources/pod-che-happy-path.yaml
   cp $HAPPY_PATH_POD_FILE ${WORKDIR}/e2e-pod.yaml

--- a/tests/devworkspace-happy-path/start-happypath-tests.sh
+++ b/tests/devworkspace-happy-path/start-happypath-tests.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Copyright (c) 2012-2023 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+# exit immediately when a command fails
+set -e
+# only exit with zero if all commands of the pipeline exit successfully
+set -o pipefail
+# error on unset variables
+set -u
+# uncomment to print each command before executing it
+# set -x
+
+SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+
+export WORKDIR="${WORKDIR:-${SCRIPT_DIR}/workdir/e2e}"
+export CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"
+export E2E_TEST_IMAGE="${E2E_TEST_IMAGE:-quay.io/eclipse/che-e2e:next}"
+export HAPPY_PATH_POD_NAME=happy-path-che
+export HAPPY_PATH_TEST_PROJECT='https://github.com/che-samples/java-spring-petclinic/tree/devfilev2'
+export HAPPY_PATH_SUITE="${HAPPY_PATH_SUITE:-test-all-devfiles}"
+export HAPPY_PATH_USERSTORY="${HAPPY_PATH_USERSTORY:-EmptyWorkspace}"
+
+rm -rf "${WORKDIR}" && mkdir -p "${WORKDIR}"
+
+run() {
+  oc create namespace "${CHE_NAMESPACE}" || true
+  oc delete pod happy-path-che -n "${CHE_NAMESPACE}" --grace-period=30 --ignore-not-found
+  # patch happy-path-che.yaml
+  if [[ -z "${ECLIPSE_CHE_URL}" ]]; then
+    ECLIPSE_CHE_URL=http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
+  fi
+  TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_TEST_PROJECT}"
+  HAPPY_PATH_POD_FILE=${SCRIPT_DIR}/resources/pod-che-happy-path.yaml
+  cp $HAPPY_PATH_POD_FILE ${WORKDIR}/e2e-pod.yaml
+  sed -i "s@HAPPY_PATH_SUITE@${HAPPY_PATH_SUITE}@g" ${WORKDIR}/e2e-pod.yaml
+  sed -i "s@HAPPY_PATH_USERSTORY@${HAPPY_PATH_USERSTORY}@g" ${WORKDIR}/e2e-pod.yaml
+  sed -i "s@CHE_URL@${ECLIPSE_CHE_URL}@g" ${WORKDIR}/e2e-pod.yaml
+  sed -i "s@WORKSPACE_ROUTE@${TS_SELENIUM_DEVWORKSPACE_URL}@g" ${WORKDIR}/e2e-pod.yaml
+  sed -i "s@CHE-NAMESPACE@${CHE_NAMESPACE}@g" ${WORKDIR}/e2e-pod.yaml
+  sed -i "s|image: .*|image: ${E2E_TEST_IMAGE}|g" ${WORKDIR}/e2e-pod.yaml
+  echo "[INFO] Applying the following patched Che Happy Path Pod:"
+  cat ${WORKDIR}/e2e-pod.yaml
+  echo "[INFO] --------------------------------------------------"
+  oc apply -f ${WORKDIR}/e2e-pod.yaml
+  # wait for the pod to start
+  n=0
+  while [ $n -le 120 ]
+  do
+    PHASE=$(oc get pod -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} \
+        --template='{{ .status.phase }}')
+    if [[ ${PHASE} == "Running" ]]; then
+      echo "[INFO] Happy-path test started successfully."
+      return
+    fi
+
+    sleep 5
+    n=$(( n+1 ))
+  done
+
+  echo "[ERROR] Failed to start happy-path test."
+  exit 1
+}
+
+run
+
+echo "[INFO] Waiting until happy path pod finished"
+oc logs -n ${CHE_NAMESPACE} ${HAPPY_PATH_POD_NAME} -c happy-path-test -f
+# just to sleep
+sleep 3
+
+echo "[INFO] Downloading test report."
+mkdir "${ARTIFACT_DIR}/e2e"
+oc rsync -n "${CHE_NAMESPACE}" ${HAPPY_PATH_POD_NAME}:/tmp/e2e/report/" ${ARTIFACT_DIR}/e2e" -c download-reports
+oc exec -n "${CHE_NAMESPACE}" ${HAPPY_PATH_POD_NAME} -c download-reports -- touch /tmp/done
+
+EXIT_CODE=$(oc logs -n "${CHE_NAMESPACE}" ${HAPPY_PATH_POD_NAME} -c happy-path-test | grep EXIT_CODE)
+if [[ ${EXIT_CODE} != "+ EXIT_CODE=0" ]]; then
+    echo "[ERROR] Happy-path test failed. Check report at ${ARTIFACT_DIR}. Or happy path pod in eclipse-che namespace"
+    exit 1
+fi
+echo "[INFO] Happy-path test succeed."

--- a/tests/devworkspace-happy-path/start-happypath-tests.sh
+++ b/tests/devworkspace-happy-path/start-happypath-tests.sh
@@ -17,7 +17,7 @@ set -u
 # uncomment to print each command before executing it
 # set -x
 
-SCRIPT_DIR=$(dirname $(readlink -f "$0"))
+SCRIPT_DIR=$(cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
 export WORKDIR="${WORKDIR:-${SCRIPT_DIR}/workdir/e2e}"
 export CHE_NAMESPACE="${CHE_NAMESPACE:-eclipse-che}"

--- a/tests/devworkspace-happy-path/start-happypath-tests.sh
+++ b/tests/devworkspace-happy-path/start-happypath-tests.sh
@@ -33,9 +33,11 @@ run() {
   oc create namespace "${CHE_NAMESPACE}" || true
   oc delete pod happy-path-che -n "${CHE_NAMESPACE}" --grace-period=30 --ignore-not-found
   # patch happy-path-che.yaml
-  if [[ -z "${ECLIPSE_CHE_URL}" ]]; then
-    ECLIPSE_CHE_URL=http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
-  fi
+  set +u
+    if [[ -z "${ECLIPSE_CHE_URL}" ]]; then
+      ECLIPSE_CHE_URL=http://$(oc get route -n "${CHE_NAMESPACE}" che -o jsonpath='{.status.ingress[0].host}')
+    fi
+  set -u
   TS_SELENIUM_DEVWORKSPACE_URL="${ECLIPSE_CHE_URL}/#${HAPPY_PATH_TEST_PROJECT}"
   HAPPY_PATH_POD_FILE=${SCRIPT_DIR}/resources/pod-che-happy-path.yaml
   cp $HAPPY_PATH_POD_FILE ${WORKDIR}/e2e-pod.yaml


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This PR splits `launch.sh` into two independent scripts: 
* `provision-openshift-oauth-user.sh`
* `start-happypath-tests.sh`
The main idea is to adapt HappyPath tests to run into disconnected environment. 
It will be possible into two steps:
1. Run `provision-openshift-oauth-user.sh` against disconnected cluster
2. Run `start-happypath-tests.sh` against microk8s cluster which have access to the internet

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/21445

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
N/A

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
