### PR TITLE
Fix project import failures on che-dashboard prcheck

### DIFF
--- a/tests/e2e/constants/MONACO_CONSTANTS.ts
+++ b/tests/e2e/constants/MONACO_CONSTANTS.ts
@@ -21,5 +21,5 @@ export const MONACO_CONSTANTS: {
 	 * https://github.com/redhat-developer/vscode-extension-tester/tree/master/locators/lib ,
 	 * "1.73.0" by default.
 	 */
-	TS_SELENIUM_MONACO_PAGE_OBJECTS_USE_VERSION: process.env.TS_SELENIUM_MONACO_PAGE_OBJECTS_USE_VERSION || '1.73.0'
+	TS_SELENIUM_MONACO_PAGE_OBJECTS_USE_VERSION: process.env.TS_SELENIUM_MONACO_PAGE_OBJECTS_USE_VERSION || '1.76.0'
 };

--- a/tests/e2e/pageobjects/dashboard/Workspaces.ts
+++ b/tests/e2e/pageobjects/dashboard/Workspaces.ts
@@ -229,7 +229,7 @@ export class Workspaces {
 	}
 
 	private getActionsPopupButtonLocator(workspaceName: string, buttonText: string): By {
-		return By.xpath(`${this.getWorkspaceListItemLocator(workspaceName).value}//li//button[text()='${buttonText}']`);
+		return By.xpath(`${this.getWorkspaceListItemLocator(workspaceName).value}//button[text()='${buttonText}']`);
 	}
 
 	private getOpenButtonLocator(workspaceName: string): By {

--- a/tests/e2e/specs/SmokeTest.spec.ts
+++ b/tests/e2e/specs/SmokeTest.spec.ts
@@ -45,8 +45,8 @@ suite('The SmokeTest userstory', function (): void {
 		});
 		test('Check a project folder has been created', async function (): Promise<void> {
 			const projectName: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_PROJECT_NAME || StringUtil.getProjectNameFromGitUrl(factoryUrl);
-			projectSection = await new SideBarView().getContent().getSection(projectName);
-			Logger.debug(`new SideBarView().getContent().getSection: get ${projectName}`);
+			projectSection = (await new SideBarView().getContent().getSections())[0]; // get the (WORKSPACE) section from the sidebar - contains project content
+			expect(await projectSection.findItem(projectName)).not.eqls(undefined);
 		});
 		test('Check the project files was imported', async function (): Promise<void> {
 			Logger.debug(`projectSection.findItem: find ${BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME}`);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* fixes project import check
* simplifies dashboard workspace context button locator (test was failing on dogfooding because `li` segment had `@role=none`
* updates vscode-extension-tester-locators version

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse/che/issues/22450

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.

### Test Run Logs
```
[tdancs@fedora e2e]$ USERSTORY='SmokeTest' MOCHA_DIRECTORY='.' npm run test

> @eclipse-che/che-e2e@7.73.0-SNAPSHOT test
> ./configs/sh-scripts/initDefaultValues.sh npm run lint && npm run tsc && export USERSTORY=$USERSTORY && mocha --config dist/configs/mocharc.js

Initialized default values

TS_SELENIUM_VALUE_TLS_SUPPORT =       
TS_SELENIUM_VALUE_OPENSHIFT_OAUTH =   true
TS_OCP_LOGIN_PAGE_PROVIDER_TITLE =    github-app-sre
E2E_OCP_CLUSTER_VERSION =             4.x
TS_SELENIUM_LOG_LEVEL =               TRACE
TS_SELENIUM_OCP_USERNAME =            ScrewTSW
TS_SELENIUM_W3C_CHROME_OPTION =       true
NODE_TLS_REJECT_UNAUTHORIZED =        0
TS_SELENIUM_EDITOR =                  che-code

> @eclipse-che/che-e2e@7.73.0-SNAPSHOT tsc
> rm -rf ./dist && ./configs/sh-scripts/generateIndex.sh && tsc -p .

Generating index.ts file...

################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: ScrewTSW
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: true
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express

      MOCHA_DIRECTORY: .
      USERSTORY: SmokeTest

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


            ? DriverHelper.getDriver
  The SmokeTest userstory
    Create workspace from factory:https://github.com/che-incubator/quarkus-api-example.git
            ? DriverHelper.getDriver
          ? BrowserTabsUtil.navigateTo - https://che-dogfooding.apps.che-dev.x6e0.p1.openshiftapps.com
            ? DriverHelper.getDriver
          ? RegularUserOcpCheLoginPage.login
          ? RegularUserOcpCheLoginPage.login - wait for LogInWithOpenShift page and click button
            ? DriverHelper.waitPresence - By(xpath, //div[@class="panel-login"])
            ? DriverHelper.waitAndClick - By(xpath, //div[@class="panel-login"]/div[contains(@class, 'panel-content')]/form/button)
            ? DriverHelper.waitVisibility - By(xpath, //div[@class="panel-login"]/div[contains(@class, 'panel-content')]/form/button)
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? OcpLoginPage.isIdentityProviderLinkVisible
            ? DriverHelper.waitVisibilityBoolean - By(xpath, //a[text()="github-app-sre"])
            ? DriverHelper.isVisible - By(xpath, //a[text()="github-app-sre"])
          ? OcpLoginPage.clickOnLoginProviderTitle
            ? DriverHelper.waitAndClick - By(xpath, //a[text()="github-app-sre"])
            ? DriverHelper.waitVisibility - By(xpath, //a[text()="github-app-sre"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? OcpLoginPage.isAuthorizeOpenShiftIdentityProviderPageVisible
            ? DriverHelper.isVisible - By(xpath, //h1[text()="Authorize Access"])
            ? BrowserTabsUtil.maximize
          ? BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
            ? DriverHelper.getDriver
          ? Dashboard.waitStartingPageLoaderDisappearance
            ? DriverHelper.waitDisappearance - By(css selector, .main-page-loader)
            ? DriverHelper.waitDisappearanceBoolean - By(css selector, .main-page-loader)
            ? DriverHelper.isVisible - By(css selector, .main-page-loader)
            ? DriverHelper.wait - (1000 milliseconds)
      ? Login (5509ms)
          ? Dashboard.waitPage
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? WorkspaceHandlingTests.createAndOpenWorkspaceFromGitRepository - fetching user kubernetes namespace, storing auth token by getting workspaces API URL.
          ? ApiUrlResolver.obtainUserNamespace
            ? ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ? DriverHelper.getDriver
(node:452253) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
          ? ApiUrlResolver.obtainUserNamespace - kubeapi success: screwtsw-che-xmlol7
          ? Dashboard.clickCreateWorkspaceButton
            ? DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? CreateWorkspace.waitPage
          ? CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ? DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? BrowserTabsUtil.getCurrentWindowHandle
            ? DriverHelper.getDriver
          ? CreateWorkspace.importFromGitUsingUI - factoryUrl: "https://github.com/che-incubator/quarkus-api-example.git"
            ? DriverHelper.waitVisibility - By(xpath, //input[@id="git-repo-url"])
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? DriverHelper.type - By(xpath, //input[@id="git-repo-url"]) text: https://github.com/che-incubator/quarkus-api-example.git??
            ? DriverHelper.waitVisibility - By(xpath, //input[@id="git-repo-url"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ? DriverHelper.waitUntilTrue
          ? BrowserTabsUtil.getAllWindowHandles
            ? DriverHelper.getDriver
          ? BrowserTabsUtil.getAllWindowHandles
            ? DriverHelper.getDriver
          ? BrowserTabsUtil.switchToWindow
            ? DriverHelper.getDriver
      ? Create and open new workspace from factory:https://github.com/che-incubator/quarkus-api-example.git (15447ms)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.getDriver
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace quarkus-api-example-pft9
            ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():quarkus-api-example-pft9
      ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: quarkus-api-example-pft9
      ? Obtain workspace name from workspace loader page (10585ms)
          ? Object.registerRunningWorkspace - with workspaceName:quarkus-api-example-pft9
      ? Register running workspace
          ? ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ? DriverHelper.getDriver
          ? ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 41942 seconds.
      ? Wait workspace readiness (41947ms)
          ? Function.getProjectNameFromGitUrl - https://github.com/che-incubator/quarkus-api-example.git
          ? Function.getProjectNameFromGitUrl - quarkus-api-example
          ? Function.getProjectNameFromGitUrl - https://github.com/che-incubator/quarkus-api-example.git
          ? Function.getProjectNameFromGitUrl - quarkus-api-example
      ? Check a project folder has been created (310ms)
          ? projectSection.findItem: find devfile.yaml
      ? Check the project files was imported (142ms)
          ? Dashboard.openDashboard
            ? DriverHelper.getDriver
          ? Dashboard.waitPage
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Dashboard.stopWorkspaceByUI - "quarkus-api-example-pft9"
          ? Dashboard.clickWorkspacesButton
            ? DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitPage
            ? DriverHelper.waitVisibility - By(xpath, //button[text()="Add Workspace"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-pft9"
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitWorkspaceWithRunningStatus - "quarkus-api-example-pft9"
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]//span[@data-testid='workspace-status-indicator']//*[local-name()='svg' and @fill='green'])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.stopWorkspaceByActionsButton - Workspaces.stopWorkspaceByActionsButton
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-pft9"
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.openActionsPopup - for the 'quarkus-api-example-pft9' list item
          ? Workspaces.clickActionsButton - of the 'quarkus-api-example-pft9' list item
            ? DriverHelper.waitAndClick - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]/td/div/button[@aria-label='Actions'])
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]/td/div/button[@aria-label='Actions'])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitActionsPopup - of the 'quarkus-api-example-pft9' list item
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]//button[@aria-label='Actions' and @aria-expanded='true'])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.clickActionsStopWorkspaceButton - for the 'quarkus-api-example-pft9' list item
            ? DriverHelper.waitAndClick - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]//button[text()='Stop Workspace'])
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]//button[text()='Stop Workspace'])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitWorkspaceWithStoppedStatus - "quarkus-api-example-pft9"
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]//span[@data-testid='workspace-status-indicator']//*[local-name()='svg' and @fill='grey'])
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? BrowserTabsUtil.closeAllTabsExceptCurrent
          ? BrowserTabsUtil.getAllWindowHandles
            ? DriverHelper.getDriver
          ? BrowserTabsUtil.getCurrentWindowHandle
            ? DriverHelper.getDriver
          ? BrowserTabsUtil.switchToWindow
            ? DriverHelper.getDriver
            ? DriverHelper.getDriver
          ? BrowserTabsUtil.switchToWindow
            ? DriverHelper.getDriver
      ? Stop the workspace (4800ms)
          ? Dashboard.openDashboard
            ? DriverHelper.getDriver
          ? Dashboard.waitPage
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Dashboard.deleteStoppedWorkspaceByUI - "quarkus-api-example-pft9"
          ? Dashboard.clickWorkspacesButton
            ? DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitPage
            ? DriverHelper.waitVisibility - By(xpath, //button[text()="Add Workspace"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-pft9"
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.deleteWorkspaceByActionsButton - Workspaces.deleteWorkspaceByActionsButton
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-pft9"
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.openActionsPopup - for the 'quarkus-api-example-pft9' list item
          ? Workspaces.clickActionsButton - of the 'quarkus-api-example-pft9' list item
            ? DriverHelper.waitAndClick - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]/td/div/button[@aria-label='Actions'])
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]/td/div/button[@aria-label='Actions'])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitActionsPopup - of the 'quarkus-api-example-pft9' list item
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]//button[@aria-label='Actions' and @aria-expanded='true'])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.clickActionsDeleteButton - for the 'quarkus-api-example-pft9' list item
            ? DriverHelper.waitAndClick - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]//button[text()='Delete Workspace'])
            ? DriverHelper.waitVisibility - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']]//button[text()='Delete Workspace'])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitDeleteWorkspaceConfirmationWindow
            ? DriverHelper.waitVisibility - By(xpath, //div[@aria-label="Delete workspaces confirmation window"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.clickToDeleteConfirmationCheckbox - Workspaces.clickToDeleteConfirmationCheckbox
            ? DriverHelper.waitAndClick - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ? DriverHelper.waitVisibility - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton - Workspaces.waitEnabledConfirmationWindowDeleteButton
            ? DriverHelper.waitAndClick - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ? DriverHelper.waitVisibility - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitPage
            ? DriverHelper.waitVisibility - By(xpath, //button[text()="Add Workspace"])
            ? DriverHelper.waitVisibility - element is located and is visible.
          ? Workspaces.waitWorkspaceListItemAbsence - Workspaces.waitWorkspaceListItemAbsence "quarkus-api-example-pft9"
            ? DriverHelper.waitDisappearance - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']])
            ? DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']])
            ? DriverHelper.isVisible - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']])
            ? DriverHelper.wait - (1000 milliseconds)
            ? DriverHelper.isVisible - By(xpath, //tr[td/span/a[text()='quarkus-api-example-pft9']])
      ? Delete the workspace (6050ms)
          ? Dashboard.logout
          ? Dashboard.openDashboard
            ? DriverHelper.getDriver
          ? Dashboard.waitPage
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #19, retrying with 1000ms timeout
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
  Wait timed out after 1065ms
          ? Dashboard.logout
          ? Dashboard.openDashboard
            ? DriverHelper.getDriver
          ? Dashboard.waitPage
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ? DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? DriverHelper.waitAndClick - By(xpath, //header//button/span[text()!=""]//parent::button)
            ? DriverHelper.waitVisibility - By(xpath, //header//button/span[text()!=""]//parent::button)
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? DriverHelper.waitAndClick - By(xpath, //button[text()="Logout"])
            ? DriverHelper.waitVisibility - By(xpath, //button[text()="Logout"])
            ? DriverHelper.waitVisibility - element is located and is visible.
            ? DriverHelper.waitDisappearance - By(xpath, //header//button/span[text()!=""]//parent::button)
            ? DriverHelper.waitDisappearanceBoolean - By(xpath, //header//button/span[text()!=""]//parent::button)
            ? DriverHelper.isVisible - By(xpath, //header//button/span[text()!=""]//parent::button)
      ? Logout (4321ms)

            ? DriverHelper.getDriver
      ? Context.stopTheDriver - Chrome driver session stopped.

  10 passing (2m)

            ? DriverHelper.wait - (5000 milliseconds)
            ? DriverHelper.getDriver
```