### PR TITLE
Refactoring test codebase accordind to recomendations

### DIFF
--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -15,6 +15,7 @@ import { CLASSES } from '../configs/inversify.types';
 import { Logger } from '../utils/Logger';
 import { TIMEOUT_CONSTANTS } from '../constants/TIMEOUT_CONSTANTS';
 import { CheCodeLocatorLoader } from '../pageobjects/ide/CheCodeLocatorLoader';
+import { Workbench } from 'monaco-page-objects';
 
 @injectable()
 export class ProjectAndFileTests {
@@ -43,7 +44,8 @@ export class ProjectAndFileTests {
 
 	async performTrustAuthorDialog(): Promise<void> {
 		Logger.debug();
-
+		// sometimes the trust dialog does not appear at first time, for avoiding this problem we send click event for activating
+		await new Workbench().click();
 		await this.driverHelper.waitAndClick(
 			this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.button,
 			TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT

--- a/tests/e2e/utils/ShellExecutor.ts
+++ b/tests/e2e/utils/ShellExecutor.ts
@@ -10,6 +10,7 @@
 import { exec, ShellString } from 'shelljs';
 import { Logger } from './Logger';
 import { injectable } from 'inversify';
+import { assert } from 'chai';
 
 @injectable()
 export class ShellExecutor {
@@ -24,5 +25,13 @@ export class ShellExecutor {
 	executeCommand(command: string): ShellString {
 		Logger.debug(command);
 		return exec(command);
+	}
+	executeArbitraryShellScript(command: string): string {
+		Logger.debug(command);
+		const output: ShellString = this.executeCommand(command);
+		if (output.stderr.length > 0) {
+			assert.fail(output.stderr);
+		}
+		return output.stdout;
 	}
 }


### PR DESCRIPTION

### What does this PR do?
Apple changes according to the comments in the https://github.com/eclipse/che/pull/22506 and https://github.com/eclipse/che/issues/22538

### Screenshot/screencast of this PR
```
> @eclipse-che/che-e2e@7.75.0-SNAPSHOT parent
> ./configs/sh-scripts/initDefaultValues.sh npm run lint && npm run tsc && export USERSTORY=WorkspaceWithParent && mocha --config dist/configs/mocharc.js

Initialized default values

TS_SELENIUM_VALUE_TLS_SUPPORT =       
TS_SELENIUM_VALUE_OPENSHIFT_OAUTH =   true
TS_OCP_LOGIN_PAGE_PROVIDER_TITLE =    htpasswd
E2E_OCP_CLUSTER_VERSION =             4.x
TS_SELENIUM_LOG_LEVEL =               DEBUG
TS_SELENIUM_OCP_USERNAME =            admin
TS_SELENIUM_W3C_CHROME_OPTION =       true
NODE_TLS_REJECT_UNAUTHORIZED =        0
TS_SELENIUM_EDITOR =                  che-code

> @eclipse-che/che-e2e@7.75.0-SNAPSHOT tsc
> rm -rf ./dist && ./configs/sh-scripts/generateIndex.sh && tsc -p .

Generating index.ts file...
Warning: Cannot find any files matching pattern "dist/specs/WorkspaceWithParent.spec.js"
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - login to the "OC" client.
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.isUserLoggedIn - oc
          ▼ ShellExecutor.executeCommand - oc whoami && oc whoami --show-server=true
admin
https://api.ocp412-mmusiie.crw-qe.com:6443
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - user already logged

################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://devspaces.apps.ocp412-mmusiie.crw-qe.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: admin
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: true
      TS_SELENIUM_LOG_LEVEL: DEBUG
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java 11 with Lombok,Java 11 with Quarkus,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DRIRECTORY is not set
      USERSTORY: WorkspaceWithParent

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


  Workspace using a parent test suite
          ▼ BrowserTabsUtil.navigateTo - https://devspaces.apps.ocp412-mmusiie.crw-qe.com
          ▼ RegularUserOcpCheLoginPage.login
          ▼ OcpLoginPage.isIdentityProviderLinkVisible
          ▼ OcpLoginPage.waitAndClickOnLoginProviderTitle
          ▼ OcpLoginPage.waitOpenShiftLoginWelcomePage
          ▼ OcpLoginPage.enterUserNameOpenShift - "admin"
          ▼ OcpLoginPage.enterPasswordOpenShift
          ▼ OcpLoginPage.clickOnLoginButton
          ▼ OcpLoginPage.waitDisappearanceOpenShiftLoginWelcomePage
          ▼ OcpLoginPage.isAuthorizeOpenShiftIdentityProviderPageVisible
          ▼ BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
          ▼ Dashboard.waitStartingPageLoaderDisappearance
    ✔ Login (16067ms)
          ▼ Dashboard.waitPage
          ▼ BrowserTabsUtil.navigateTo - https://devspaces.apps.ocp412-mmusiie.crw-qe.com/dashboard/#https://github.com/testsfactory/parentDevfile
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: sample-using-parent
          ▼ registerRunningWorkspace - with workspaceName:sample-using-parent
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 27059 seconds.
          ▼ ProjectAndFileTests.performTrustAuthorDialog
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1065ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1123ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1014ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1105ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1088ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1107ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1123ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1119ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1127ms
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1123ms
  [ERROR] DriverHelper.waitAndClick - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1123ms
      • ProjectAndFileTests.performTrustAuthorDialog - Second welcome content dialog box was not shown
    ✔ Create a workspace using a parent (43857ms)
    ✔ Check cloning of the test project (521ms)
    ✔ Check devfile VS Code tasks  (4182ms)
          ▼ ShellExecutor.executeCommand - oc get pods --selector=controller.devfile.io/devworkspace_name=sample-using-parent --output jsonpath='{.items[0].metadata.name}'
workspacede8cd0d29bf24afd-59b7448fdf-xskc5          ▼ ShellExecutor.executeCommand - oc get pod workspacede8cd0d29bf24afd-59b7448fdf-xskc5 --output jsonpath='{.spec.containers[*].name}'
tools che-gateway          ▼ ShellExecutor.executeCommand - oc get pod workspacede8cd0d29bf24afd-59b7448fdf-xskc5 --output jsonpath='{.spec.initContainers[].name}'
che-code-injector    ✔ Check expected containers in the parent POD (2901ms)
          ▼ ShellExecutor.executeCommand - oc exec -i workspacede8cd0d29bf24afd-59b7448fdf-xskc5 -c tools -- sh -c env
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13132_TCP_PROTO=tcp
NVM_DIR=/home/user/.nvm
SECONDS_OF_DW_RUN_BEFORE_IDLING=-1
WORKSPACE94E2203639AD4489_SERVICE_PORT_13133_TCP_ADDR=172.30.16.161
HTTPD_DATA_ORIG_PATH=/var/www
PHP_SYSCONF_PATH=/etc
WORKSPACE94E2203639AD4489_SERVICE_SERVICE_HOST=172.30.16.161
NODEJS_HOME_16=/home/user/.nvm/versions/node/v16.14.0
DEVWORKSPACE_CREATOR=4965fa71-5122-4e46-ad9e-158d00970365
HTTPD_DATA_PATH=/var/www
NODEJS_HOME_14=/home/user/.nvm/versions/node/v14.19.0
NODEJS_HOME_12=/home/user/.nvm/versions/node/v12.22.10
HOSTNAME=workspacede8cd0d29bf24afd-59b7448fdf-xskc5
WORKSPACE94E2203639AD4489_SERVICE_SERVICE_PORT=3030
WORKSPACE94E2203639AD4489_SERVICE_PORT_13133_TCP=tcp://172.30.16.161:13133
WORKSPACE94E2203639AD4489_SERVICE_SERVICE_PORT_CODE_REDIRECT_2=13132
WORKSPACE94E2203639AD4489_SERVICE_SERVICE_PORT_CODE_REDIRECT_3=13133
WORKSPACE94E2203639AD4489_SERVICE_SERVICE_PORT_CODE_REDIRECT_1=13131
SDKMAN_CANDIDATES_API=https://api.sdkman.io/2
KUBECONFIG=/home/user/.kube/config
MAVEN_HOME=/home/user/.sdkman/candidates/maven/current
RUSTUP_HOME=/home/user/.rustup
WORKSPACE94E2203639AD4489_SERVICE_PORT_13131_TCP_PORT=13131
CHE_PLUGIN_REGISTRY_INTERNAL_URL=http://plugin-registry.devspaces.svc:8080/v3
JAVA_HOME=/home/user/.sdkman/candidates/java/current
KUBEDOCK_VERSION=0.13.0
DEVWORKSPACE_NAME=sample-using-parent
PHP_HTTPD_CONF_FILE=php.conf
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_3030_TCP_ADDR=172.30.132.18
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13132_TCP=tcp://172.30.132.18:13132
KAMEL_VERSION=1.11.0
HTTPD_VAR_RUN=/var/run/httpd
NODEJS_14_VERSION=14.19.0
CHE_PLUGIN_REGISTRY_URL=https://devspaces.apps.ocp412-mmusiie.crw-qe.com/plugin-registry/v3
WORKSPACEDE8CD0D29BF24AFD_SERVICE_SERVICE_PORT_CODE_REDIRECT_3=13133
WORKSPACEDE8CD0D29BF24AFD_SERVICE_SERVICE_PORT=3030
WORKSPACEDE8CD0D29BF24AFD_SERVICE_SERVICE_PORT_CODE_REDIRECT_2=13132
WORKSPACEDE8CD0D29BF24AFD_SERVICE_SERVICE_PORT_CODE_REDIRECT_1=13131
KUBERNETES_PORT_443_TCP_PROTO=tcp
WORKSPACE94E2203639AD4489_SERVICE_SERVICE_PORT_NODEJS=3000
WORKSPACE94E2203639AD4489_SERVICE_PORT_3030_TCP=tcp://172.30.16.161:3030
KUBERNETES_PORT_443_TCP_ADDR=172.30.0.1
container=oci
CHE_DASHBOARD_URL=https://devspaces.apps.ocp412-mmusiie.crw-qe.com
WORKSPACE94E2203639AD4489_SERVICE_PORT_13133_TCP_PROTO=tcp
WORKSPACE94E2203639AD4489_SERVICE_PORT_13133_TCP_PORT=13133
KUBERNETES_PORT=tcp://172.30.0.1:443
GRADLE_HOME=/home/user/.sdkman/candidates/gradle/current
DEVWORKSPACE_METADATA=/devworkspace-metadata
PWD=/projects
SECONDS_OF_DW_INACTIVITY_BEFORE_IDLING=1800
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13133_TCP=tcp://172.30.132.18:13133
DEVFILE_ENV_VAR=true
HOME=/home/user
OPENVSX_REGISTRY_URL=
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_3030_TCP_PROTO=tcp
HTTPD_VAR_PATH=/var
JAVA_HOME_8=/home/user/.sdkman/candidates/java/8.0.332-tem
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_3030_TCP_PORT=3030
KUBERNETES_SERVICE_PORT_HTTPS=443
WORKSPACE94E2203639AD4489_SERVICE_PORT_13132_TCP=tcp://172.30.16.161:13132
DEVWORKSPACE_NAMESPACE=admin-devspaces
WORKSPACE94E2203639AD4489_SERVICE_PORT_13131_TCP_ADDR=172.30.16.161
LOMBOK_VERSION=1.18.18
OC_VERSION=4.6
KUBERNETES_PORT_443_TCP_PORT=443
NODEJS_VERSION=16.14.0
WORKSPACE94E2203639AD4489_SERVICE_PORT_3030_TCP_ADDR=172.30.16.161
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13133_TCP_PORT=13133
WORKSPACE94E2203639AD4489_SERVICE_PORT_3000_TCP=tcp://172.30.16.161:3000
PROJECT_SOURCE=/projects/parentdevfile
BUILDAH_ISOLATION=chroot
WORKSPACEDE8CD0D29BF24AFD_SERVICE_SERVICE_PORT_WS_ROUTE=3030
WORKSPACEDE8CD0D29BF24AFD_SERVICE_SERVICE_HOST=172.30.132.18
CARGO_HOME=/home/user/.cargo
SDKMAN_DIR=/home/user/.sdkman
WORKSPACE94E2203639AD4489_SERVICE_PORT_13132_TCP_PROTO=tcp
KUBERNETES_PORT_443_TCP=tcp://172.30.0.1:443
HTTPD_MODULES_CONF_D_PATH=/etc/httpd/conf.modules.d
WORKSPACE94E2203639AD4489_SERVICE_PORT=tcp://172.30.16.161:3030
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_3030_TCP=tcp://172.30.132.18:3030
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13131_TCP_PORT=13131
CLUSTER_CONSOLE_URL=https://console-openshift-console.apps.ocp412-mmusiie.crw-qe.com
TERM=xterm
WORKSPACE94E2203639AD4489_SERVICE_PORT_13132_TCP_ADDR=172.30.16.161
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT=tcp://172.30.132.18:3030
GRAALVM_HOME=/home/user/.sdkman/candidates/java/22.1.0.0.r17-mandrel
WORKSPACE94E2203639AD4489_SERVICE_PORT_13131_TCP_PROTO=tcp
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13133_TCP_PROTO=tcp
PARENT_ENV_VAR=true
NSS_SDB_USE_CACHE=no
SDKMAN_CANDIDATES_DIR=/home/user/.sdkman/candidates
_BUILDAH_STARTED_IN_USERNS=
PHP_VERSION=7.4
CLUSTER_CONSOLE_TITLE=OpenShift console
WORKSPACE94E2203639AD4489_SERVICE_PORT_3030_TCP_PORT=3030
WORKSPACE94E2203639AD4489_SERVICE_PORT_3000_TCP_PORT=3000
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13131_TCP_ADDR=172.30.132.18
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13131_TCP_PROTO=tcp
SHLVL=1
WORKSPACE94E2203639AD4489_SERVICE_PORT_3000_TCP_ADDR=172.30.16.161
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13132_TCP_ADDR=172.30.132.18
KUBERNETES_SERVICE_PORT=443
WORKSPACE94E2203639AD4489_SERVICE_PORT_3000_TCP_PROTO=tcp
WORKSPACE94E2203639AD4489_SERVICE_SERVICE_PORT_WS_ROUTE=3030
JAVA_HOME_17=/home/user/.sdkman/candidates/java/17.0.3-tem
JAVA_HOME_11=/home/user/.sdkman/candidates/java/11.0.15-tem
DEVWORKSPACE_FLATTENED_DEVFILE=/devworkspace-metadata/flattened.devworkspace.yaml
DEVWORKSPACE_ORIGINAL_DEVFILE=/devworkspace-metadata/original.devworkspace.yaml
NODEJS_12_VERSION=12.22.10
DOTNET_RPM_VERSION=6.0
GOBIN=/home/user/go/bin/
PROJECTS_ROOT=/projects
DEVWORKSPACE_ID=workspacede8cd0d29bf24afd
WORKSPACE94E2203639AD4489_SERVICE_PORT_13131_TCP=tcp://172.30.16.161:13131
PATH=/home/user/.cargo/bin:/home/user/go/bin/:/home/user/.local/bin:/home/user/.nvm/versions/node/v16.14.0/bin:/home/user/.local/share/coursier/bin:/home/user/.sdkman/candidates/gradle/current/bin:/home/user/.sdkman/candidates/java/current/bin:/home/user/.sdkman/candidates/maven/current/bin:/home/user/.krew/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HTTPD_MAIN_CONF_PATH=/etc/httpd/conf
SDKMAN_VERSION=5.13.0
DEVWORKSPACE_IDLE_TIMEOUT=15m
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13132_TCP_PORT=13132
WORKSPACE94E2203639AD4489_SERVICE_PORT_3030_TCP_PROTO=tcp
PHP_DEFAULT_INCLUDE_PATH=/usr/share/pear
KUBERNETES_SERVICE_HOST=172.30.0.1
SDKMAN_PLATFORM=linuxx64
WORKSPACE94E2203639AD4489_SERVICE_PORT_13132_TCP_PORT=13132
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13133_TCP_ADDR=172.30.132.18
DEVWORKSPACE_COMPONENT_NAME=tools
HTTPD_MAIN_CONF_D_PATH=/etc/httpd/conf.d
WORKSPACEDE8CD0D29BF24AFD_SERVICE_PORT_13131_TCP=tcp://172.30.132.18:13131
_=/usr/bin/env
    ✔ Check expected environment variables (1767ms)
          ▼ Dashboard.logout
          ▼ Dashboard.openDashboard
          ▼ Dashboard.waitPage
    ✔ Logout (8766ms)

      • Context.stopTheDriver - Chrome driver session stopped.

  7 passing (1m)


Process finished with exit code 0
```


### What issues does this PR fix or reference?
[<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)](https://github.com/eclipse/che/issues/22538)
-->


### How to test this PR?
Set up all env vars and run with npm or yarn as usual


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
