### PR TITLE
Hotfix fix cookie policy approval

### DIFF
--- a/tests/e2e/pageobjects/login/openshift/OcpRedHatLoginPage.ts
+++ b/tests/e2e/pageobjects/login/openshift/OcpRedHatLoginPage.ts
@@ -40,6 +40,12 @@ export class OcpRedHatLoginPage implements ICheLoginPage {
 		);
 		await this.ocpLogin.waitAndClickOnLoginProviderTitle();
 		await this.redHatLogin.waitRedHatLoginWelcomePage();
+		try {
+			await this.redHatLogin.waitAndConfirmCookiePolicy();
+		} catch (err) {
+			Logger.warn('Cookie confirmation dialog not present, continuing...');
+			Logger.warn(`${err}`);
+		}
 		await this.redHatLogin.enterUserNameRedHat();
 		await this.redHatLogin.clickNextButton();
 		await this.redHatLogin.enterPasswordRedHat();

--- a/tests/e2e/pageobjects/login/openshift/RedHatLoginPage.ts
+++ b/tests/e2e/pageobjects/login/openshift/RedHatLoginPage.ts
@@ -22,6 +22,8 @@ export class RedHatLoginPage {
 	private static readonly PASSWORD_INPUT: By = By.id('password');
 	private static readonly NEXT_BUTTON: By = By.id('login-show-step2');
 	private static readonly LOGIN_BUTTON: By = By.id('rh-password-verification-submit-button');
+	private static readonly COOKIE_DIALOG_IFRAME: By = By.xpath('//div[@class="truste_box_overlay"]//iframe[@class="truste_popframe"]');
+	private static readonly COOKIE_DIALOG_BUTTON: By = By.xpath('//div[@class="pdynamicbutton"]//a[@class="call"]');
 
 	constructor(
 		@inject(CLASSES.DriverHelper)
@@ -32,6 +34,18 @@ export class RedHatLoginPage {
 		Logger.debug();
 
 		await this.driverHelper.waitVisibility(RedHatLoginPage.USERNAME_INPUT, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+	}
+
+	async waitAndConfirmCookiePolicy(): Promise<void> {
+		Logger.debug();
+
+		await this.driverHelper.waitVisibility(RedHatLoginPage.COOKIE_DIALOG_IFRAME, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+		await this.driverHelper
+			.getDriver()
+			.switchTo()
+			.frame(await this.driverHelper.getDriver().findElement(RedHatLoginPage.COOKIE_DIALOG_IFRAME));
+		await this.driverHelper.waitAndClick(RedHatLoginPage.COOKIE_DIALOG_BUTTON, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+		await this.driverHelper.refreshPage();
 	}
 
 	async enterPasswordRedHat(): Promise<void> {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Adds a new check for cookie policy approval

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
N/A

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
hotfix

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
set variables and run `npm run test`

### Test Log
```
  The SmokeTest userstory
    Create workspace from factory:https://github.com/che-incubator/quarkus-api-example.git
          ? BrowserTabsUtil.navigateTo - https://devspaces.apps.sandbox-stage.gb17.p1.openshiftapps.com
          ? OcpRedHatLoginPage.login
          ? OcpLoginPage.waitAndClickOnLoginProviderTitle
          ? RedHatLoginPage.waitRedHatLoginWelcomePage
          ? RedHatLoginPage.waitAndConfirmCookiePolicy
          ? RedHatLoginPage.enterUserNameRedHat
          ? RedHatLoginPage.clickNextButton
          ? RedHatLoginPage.enterPasswordRedHat
          ? RedHatLoginPage.clickOnLoginButton
          ? RedHatLoginPage.waitDisappearanceRedHatLoginWelcomePage
          ? BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
          ? Dashboard.waitStartingPageLoaderDisappearance
      ? Login (24756ms)
          ? Dashboard.waitPage
          ? WorkspaceHandlingTests.createAndOpenWorkspaceFromGitRepository - fetching user kubernetes namespace, storing auth token by getting workspaces API URL.
          ? ApiUrlResolver.obtainUserNamespace
(node:196798) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
          ? ApiUrlResolver.obtainUserNamespace - kubeapi success: osio-ci-devsandbox-periodic-stg-dev
          ? Dashboard.clickCreateWorkspaceButton
          ? CreateWorkspace.waitPage
          ? CreateWorkspace.waitTitleContains - text: "Create Workspace"
          ? BrowserTabsUtil.getCurrentWindowHandle
          ? CreateWorkspace.importFromGitUsingUI - factoryUrl: "https://github.com/che-incubator/quarkus-api-example.git"
          ? BrowserTabsUtil.waitAndSwitchToAnotherWindow
          ? BrowserTabsUtil.getAllWindowHandles
          ? BrowserTabsUtil.getAllWindowHandles
          ? BrowserTabsUtil.switchToWindow
      ? Create and open new workspace from factory:https://github.com/che-incubator/quarkus-api-example.git (1130ms)
      ? WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: quarkus-api-example-00xq
      ? Obtain workspace name from workspace loader page (16207ms)
          ? registerRunningWorkspace - with workspaceName:quarkus-api-example-00xq
      ? Register running workspace
          ? ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
          ? ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 46915 seconds.
      ? Wait workspace readiness (46917ms)
          ? Function.getProjectNameFromGitUrl - https://github.com/che-incubator/quarkus-api-example.git
          ? Function.getProjectNameFromGitUrl - quarkus-api-example
          ? Function.getProjectNameFromGitUrl - https://github.com/che-incubator/quarkus-api-example.git
          ? Function.getProjectNameFromGitUrl - quarkus-api-example
      ? Check a project folder has been created (225ms)
          ? projectSection.findItem: find devfile.yaml
      ? Check the project files was imported (79ms)
          ? Dashboard.openDashboard
          ? Dashboard.waitPage
          ? Dashboard.stopWorkspaceByUI - "quarkus-api-example-00xq"
          ? Dashboard.clickWorkspacesButton
          ? Workspaces.waitPage
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-00xq"
          ? Workspaces.waitWorkspaceWithRunningStatus - "quarkus-api-example-00xq"
          ? Workspaces.stopWorkspaceByActionsButton
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-00xq"
          ? Workspaces.openActionsPopup - for the 'quarkus-api-example-00xq' list item
          ? Workspaces.clickActionsButton - of the 'quarkus-api-example-00xq' list item
          ? Workspaces.waitActionsPopup - of the 'quarkus-api-example-00xq' list item
          ? Workspaces.clickActionsStopWorkspaceButton - for the 'quarkus-api-example-00xq' list item
          ? Workspaces.waitWorkspaceWithStoppedStatus - "quarkus-api-example-00xq"
          ? BrowserTabsUtil.getAllWindowHandles
          ? BrowserTabsUtil.getCurrentWindowHandle
          ? BrowserTabsUtil.switchToWindow
          ? BrowserTabsUtil.switchToWindow
      ? Stop the workspace (4815ms)
          ? Dashboard.openDashboard
          ? Dashboard.waitPage
          ? Dashboard.deleteStoppedWorkspaceByUI - "quarkus-api-example-00xq"
          ? Dashboard.clickWorkspacesButton
          ? Workspaces.waitPage
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-00xq"
          ? Workspaces.deleteWorkspaceByActionsButton
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-00xq"
          ? Workspaces.openActionsPopup - for the 'quarkus-api-example-00xq' list item
          ? Workspaces.clickActionsButton - of the 'quarkus-api-example-00xq' list item
          ? Workspaces.waitActionsPopup - of the 'quarkus-api-example-00xq' list item
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //tr[td//a[text()='quarkus-api-example-00xq']]//button[@aria-label='Actions' and @aria-expanded='true'])
  Wait timed out after 1068ms
          ? Dashboard.openDashboard
          ? Dashboard.waitPage
          ? Dashboard.deleteStoppedWorkspaceByUI - "quarkus-api-example-00xq"
          ? Dashboard.clickWorkspacesButton
          ? Workspaces.waitPage
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-00xq"
          ? Workspaces.deleteWorkspaceByActionsButton
          ? Workspaces.waitWorkspaceListItem - "quarkus-api-example-00xq"
          ? Workspaces.openActionsPopup - for the 'quarkus-api-example-00xq' list item
          ? Workspaces.clickActionsButton - of the 'quarkus-api-example-00xq' list item
          ? Workspaces.waitActionsPopup - of the 'quarkus-api-example-00xq' list item
          ? Workspaces.clickActionsDeleteButton - for the 'quarkus-api-example-00xq' list item
          ? Workspaces.waitDeleteWorkspaceConfirmationWindow
          ? Workspaces.clickToDeleteConfirmationCheckbox
          ? Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton
          ? Workspaces.waitPage
          ? Workspaces.waitWorkspaceListItemAbsence - "quarkus-api-example-00xq"
      ? Delete the workspace (5910ms)
          ? Dashboard.logout
          ? Dashboard.openDashboard
          ? Dashboard.waitPage
      ? Logout (4049ms)

      ? Context.stopTheDriver - Chrome driver session stopped.

  10 passing (2m)
  ```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
