### PR TITLE
CRW-4864 Make 'Check the project files were imported' test in Che test framework not use view section name

### DIFF
--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -31,7 +31,7 @@
 				"allure-mocha": "^2.4.0",
 				"axios": "^0.25.0",
 				"chai": "^4.3.4",
-				"chromedriver": "^114.0.2",
+				"chromedriver": "^117.0.3",
 				"clone-deep": "^4.0.1",
 				"eslint": "^8.45.0",
 				"eslint-config-prettier": "^8.10.0",
@@ -1646,9 +1646,9 @@
 			}
 		},
 		"node_modules/chromedriver": {
-			"version": "114.0.3",
-			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-114.0.3.tgz",
-			"integrity": "sha512-Qy5kqsAUrCDwpovM5pIWFkb3X3IgJLoorigwFEDgC1boL094svny3N7yw06marJHAuyX4CE/hhd25RarIcKvKg==",
+			"version": "117.0.3",
+			"resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-117.0.3.tgz",
+			"integrity": "sha512-c2rk2eGK5zZFBJMdviUlAJfQEBuPNIKfal4+rTFVYAmrWbMPYAqPozB+rIkc1lDP/Ryw44lPiqKglrI01ILhTQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
@@ -1664,7 +1664,7 @@
 				"chromedriver": "bin/chromedriver"
 			},
 			"engines": {
-				"node": ">=16"
+				"node": ">=18"
 			}
 		},
 		"node_modules/chromedriver/node_modules/axios": {

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -38,7 +38,7 @@
 		"@typescript-eslint/parser": "^6.1.0",
 		"axios": "^0.25.0",
 		"chai": "^4.3.4",
-		"chromedriver": "^114.0.2",
+		"chromedriver": "^117.0.3",
 		"clone-deep": "^4.0.1",
 		"eslint": "^8.45.0",
 		"eslint-config-prettier": "^8.10.0",

--- a/tests/e2e/pageobjects/dashboard/Dashboard.ts
+++ b/tests/e2e/pageobjects/dashboard/Dashboard.ts
@@ -163,7 +163,7 @@ export class Dashboard {
 		await this.driverHelper.waitAndClick(Dashboard.ABOUT_DIALOG_WINDOW_CLOSE_BUTTON);
 	}
 
-	async waitExistingWorkspaceFoundAlert(timeout: number = TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT): Promise<void> {
+	async waitExistingWorkspaceFoundAlert(timeout: number = TIMEOUT_CONSTANTS.TS_WAIT_LOADER_PRESENCE_TIMEOUT): Promise<void> {
 		Logger.debug();
 
 		await this.driverHelper.waitVisibility(Dashboard.EXISTING_WORKSPACE_FOUND_ALERT, timeout);

--- a/tests/e2e/specs/SmokeTest.spec.ts
+++ b/tests/e2e/specs/SmokeTest.spec.ts
@@ -7,13 +7,12 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { SideBarView, ViewItem, ViewSection } from 'monaco-page-objects';
+import { ViewSection } from 'monaco-page-objects';
 import { ProjectAndFileTests } from '../tests-library/ProjectAndFileTests';
 import { CLASSES } from '../configs/inversify.types';
 import { e2eContainer } from '../configs/inversify.config';
 import { WorkspaceHandlingTests } from '../tests-library/WorkspaceHandlingTests';
 import { registerRunningWorkspace } from './MochaHooks';
-import { Logger } from '../utils/Logger';
 import { LoginTests } from '../tests-library/LoginTests';
 import { StringUtil } from '../utils/StringUtil';
 import { FACTORY_TEST_CONSTANTS } from '../constants/FACTORY_TEST_CONSTANTS';
@@ -45,15 +44,15 @@ suite('The SmokeTest userstory', function (): void {
 		});
 		test('Check a project folder has been created', async function (): Promise<void> {
 			const projectName: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_PROJECT_NAME || StringUtil.getProjectNameFromGitUrl(factoryUrl);
-			projectSection = (await new SideBarView().getContent().getSections())[0]; // get the (WORKSPACE) section from the sidebar - contains project content
-			expect(await projectSection.findItem(projectName)).not.eqls(undefined);
+			projectSection = await projectAndFileTests.getProjectViewSession();
+			expect(await projectAndFileTests.getProjectTreeItem(projectSection, projectName), 'Project folder was not imported').not
+				.undefined;
 		});
 		test('Check the project files was imported', async function (): Promise<void> {
-			Logger.debug(`projectSection.findItem: find ${BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME}`);
-			const isFileImported: ViewItem | undefined = await projectSection.findItem(
-				BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME
-			);
-			expect(isFileImported).not.eqls(undefined);
+			expect(
+				await projectAndFileTests.getProjectTreeItem(projectSection, BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME),
+				'Project files were not imported'
+			).not.undefined;
 		});
 		test('Stop the workspace', async function (): Promise<void> {
 			await workspaceHandlingTests.stopWorkspace(WorkspaceHandlingTests.getWorkspaceName());

--- a/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
+++ b/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
@@ -74,8 +74,9 @@ for (const sample of samples) {
 		});
 
 		test('Check the project files were imported', async function (): Promise<void> {
-			const [projectSection]: ViewSection[] = await new SideBarView().getContent().getSections();
-			expect(await projectSection.findItem(pathToExtensionsListFileName), 'Files not imported').not.undefined;
+			projectSection = await projectAndFileTests.getProjectViewSession();
+			expect(await projectAndFileTests.getProjectTreeItem(projectSection, pathToExtensionsListFileName), 'Files not imported').not
+				.undefined;
 		});
 
 		test('Accept the project as a trusted one', async function (): Promise<void> {
@@ -83,11 +84,8 @@ for (const sample of samples) {
 		});
 
 		test(`Get recommended extensions list from ${extensionsListFileName}`, async function (): Promise<void> {
-			Logger.debug('projectSection.findItem(item))?.select(): expand .vscode folder and open extensions.json.');
-			[projectSection] = await new SideBarView().getContent().getSections();
-			await (await projectSection.findItem(pathToExtensionsListFileName))?.select();
-			await driverHelper.waitVisibility(webCheCodeLocators.DefaultTreeItem.ctor(extensionsListFileName));
-			await (await projectSection.findItem(extensionsListFileName))?.select();
+			await (await projectAndFileTests.getProjectTreeItem(projectSection, pathToExtensionsListFileName))?.select();
+			await (await projectAndFileTests.getProjectTreeItem(projectSection, extensionsListFileName, 3))?.select();
 			Logger.debug(`EditorView().openEditor(${extensionsListFileName})`);
 			const editor: TextEditor = (await new EditorView().openEditor(extensionsListFileName)) as TextEditor;
 			await driverHelper.waitVisibility(webCheCodeLocators.Editor.inputArea);
@@ -185,7 +183,7 @@ for (const sample of samples) {
 				const isInstalled: boolean = (await itemWithRightNameAndPublisher?.isInstalled()) as boolean;
 
 				Logger.debug(`itemWithRightNameAndPublisher?.isInstalled(): ${isInstalled}.`);
-				expect(isInstalled, `Extension ${extension.name} not installed`).is.true;
+				expect(isInstalled, `Extension ${extension.name} not installed`).to.be.true;
 
 				Logger.debug('itemWithRightNameAndPublisher.manage(): get context menu.');
 				const extensionManageMenu: ContextMenu = await (itemWithRightNameAndPublisher as ExtensionsViewItem).manage();

--- a/tests/e2e/specs/devconsole-intergration/DevConsoleIntegration.spec.ts
+++ b/tests/e2e/specs/devconsole-intergration/DevConsoleIntegration.spec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 
-import { SideBarView, ViewItem, ViewSection } from 'monaco-page-objects';
+import { ViewSection } from 'monaco-page-objects';
 import { registerRunningWorkspace } from '../MochaHooks';
 import { LoginTests } from '../../tests-library/LoginTests';
 import { e2eContainer } from '../../configs/inversify.config';
@@ -88,9 +88,15 @@ suite('DevConsole Integration', function (): void {
 
 	test('Check if project and files imported', async function (): Promise<void> {
 		const applicationSourceProjectName: string = StringUtil.getProjectNameFromGitUrl(gitImportRepo);
-		const projectSection: ViewSection = await new SideBarView().getContent().getSection(applicationSourceProjectName);
-		const isFileImported: ViewItem | undefined = await projectSection.findItem(BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME);
-		expect(isFileImported).not.eqls(undefined);
+		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
+		expect(
+			await projectAndFileTests.getProjectTreeItem(projectSection, applicationSourceProjectName),
+			'Project folder was not imported'
+		).not.undefined;
+		expect(
+			await projectAndFileTests.getProjectTreeItem(projectSection, BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME),
+			'Project files were not imported'
+		).not.undefined;
 	});
 
 	test('Stop and delete the workspace by API', async function (): Promise<void> {

--- a/tests/e2e/specs/factory/Factory.spec.ts
+++ b/tests/e2e/specs/factory/Factory.spec.ts
@@ -17,11 +17,9 @@ import {
 	EditorView,
 	Locators,
 	NewScmView,
-	SideBarView,
 	SingleScmProvider,
 	TextEditor,
 	ViewControl,
-	ViewItem,
 	ViewSection
 } from 'monaco-page-objects';
 import { expect } from 'chai';
@@ -92,18 +90,18 @@ suite(
 		test('Check if a project folder has been created', async function (): Promise<void> {
 			testRepoProjectName = StringUtil.getProjectNameFromGitUrl(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL);
 			Logger.debug(`new SideBarView().getContent().getSection: get ${testRepoProjectName}`);
-			projectSection = await new SideBarView().getContent().getSection(testRepoProjectName);
-		});
-
-		test('Check if the project files were imported', async function (): Promise<void> {
-			const label: string = BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME;
-			Logger.debug(`projectSection.findItem: find ${label}`);
-			const isFileImported: ViewItem | undefined = await projectSection.findItem(label);
-			expect(isFileImported).not.eqls(undefined);
+			projectSection = await projectAndFileTests.getProjectViewSession();
+			expect(await projectAndFileTests.getProjectTreeItem(projectSection, testRepoProjectName), 'Project folder was not imported').not
+				.undefined;
 		});
 
 		test('Accept the project as a trusted one', async function (): Promise<void> {
 			await projectAndFileTests.performTrustAuthorDialog();
+		});
+
+		test('Check if the project files were imported', async function (): Promise<void> {
+			const label: string = BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME;
+			expect(await projectAndFileTests.getProjectTreeItem(projectSection, label), 'Project files were not imported').not.undefined;
 		});
 
 		test('Make changes to the file', async function (): Promise<void> {
@@ -186,7 +184,7 @@ suite(
 				webCheCodeLocators.ScmView.actionConstructor(commitChangesButtonLabel),
 				'aria-disabled'
 			);
-			expect(isCommitButtonDisabled).eql('true');
+			expect(isCommitButtonDisabled).to.be.true;
 		});
 
 		test('Stop the workspace', async function (): Promise<void> {

--- a/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
+++ b/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
@@ -18,11 +18,9 @@ import {
 	Locators,
 	ModalDialog,
 	NewScmView,
-	SideBarView,
 	SingleScmProvider,
 	TextEditor,
 	ViewControl,
-	ViewItem,
 	ViewSection
 } from 'monaco-page-objects';
 import { expect } from 'chai';
@@ -116,8 +114,9 @@ suite(
 
 			test('Check if a project folder has been created', async function (): Promise<void> {
 				testRepoProjectName = StringUtil.getProjectNameFromGitUrl(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL);
-				Logger.debug(`new SideBarView().getContent().getSection: get ${testRepoProjectName}`);
-				projectSection = await new SideBarView().getContent().getSection(testRepoProjectName);
+				projectSection = await projectAndFileTests.getProjectViewSession();
+				expect(await projectAndFileTests.getProjectTreeItem(projectSection, testRepoProjectName), 'Project folder was not imported')
+					.not.undefined;
 			});
 
 			test('Accept the project as a trusted one', async function (): Promise<void> {
@@ -125,10 +124,8 @@ suite(
 			});
 
 			test('Check if the project files were imported', async function (): Promise<void> {
-				Logger.debug(`projectSection.findItem: find ${label}`);
-				const isFileImported: ViewItem | undefined = await projectSection.findItem(label);
-				// projectSection.findItem(label) can return undefined but test will goes on
-				expect(isFileImported).not.eqls(undefined);
+				expect(await projectAndFileTests.getProjectTreeItem(projectSection, label), 'Project files were not imported').not
+					.undefined;
 			});
 
 			test('Make changes to the file', async function (): Promise<void> {
@@ -243,7 +240,7 @@ suite(
 					webCheCodeLocators.ScmView.actionConstructor(commitChangesButtonLabel),
 					'aria-disabled'
 				);
-				expect(isCommitButtonDisabled).eql('true');
+				expect(isCommitButtonDisabled).to.be.true;
 			});
 
 			test('Stop the workspace', async function (): Promise<void> {

--- a/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
+++ b/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
@@ -18,11 +18,9 @@ import {
 	Locators,
 	ModalDialog,
 	NewScmView,
-	SideBarView,
 	SingleScmProvider,
 	TextEditor,
 	ViewControl,
-	ViewItem,
 	ViewSection
 } from 'monaco-page-objects';
 import { expect } from 'chai';
@@ -99,8 +97,9 @@ suite(
 
 		test('Check if a project folder has been created', async function (): Promise<void> {
 			testRepoProjectName = StringUtil.getProjectNameFromGitUrl(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL);
-			Logger.debug(`new SideBarView().getContent().getSection: get ${testRepoProjectName}`);
-			projectSection = await new SideBarView().getContent().getSection(testRepoProjectName);
+			projectSection = await projectAndFileTests.getProjectViewSession();
+			expect(await projectAndFileTests.getProjectTreeItem(projectSection, testRepoProjectName), 'Project folder was not imported').not
+				.undefined;
 		});
 
 		test('Accept the project as a trusted one', async function (): Promise<void> {
@@ -116,15 +115,12 @@ suite(
 			});
 
 			test('Check that project files were not imported', async function (): Promise<void> {
-				const isFileImported: ViewItem | undefined = await projectSection.findItem(label);
-				expect(isFileImported).eqls(undefined);
+				expect(await projectAndFileTests.getProjectTreeItem(projectSection, label), 'Project files were found').to.be.undefined;
 			});
 		} else {
 			test('Check if the project files were imported', async function (): Promise<void> {
-				Logger.debug(`projectSection.findItem: find ${label}`);
-				const isFileImported: ViewItem | undefined = await projectSection.findItem(label);
-				// projectSection.findItem(label) can return undefined but test will goes on
-				expect(isFileImported).not.eqls(undefined);
+				expect(await projectAndFileTests.getProjectTreeItem(projectSection, label), 'Project files were not imported').not
+					.undefined;
 			});
 
 			test('Make changes to the file', async function (): Promise<void> {
@@ -231,7 +227,7 @@ suite(
 					webCheCodeLocators.ScmView.actionConstructor(commitChangesButtonLabel),
 					'aria-disabled'
 				);
-				expect(isCommitButtonDisabled).eql('true');
+				expect(isCommitButtonDisabled).to.be.true;
 			});
 		}
 

--- a/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistedName.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CreateWorkspaceWithExistedName.spec.ts
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
 import { e2eContainer } from '../../configs/inversify.config';
-import { ViewSection, SideBarView, ViewItem } from 'monaco-page-objects';
+import { ViewSection } from 'monaco-page-objects';
 import { CLASSES } from '../../configs/inversify.types';
 import { expect } from 'chai';
 import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
@@ -42,9 +42,12 @@ suite('"Start workspace with existed workspace name" test', function (): void {
 
 	test('Wait workspace readiness and project folder has been created', async function (): Promise<void> {
 		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
-		projectSection = await new SideBarView().getContent().getSection(projectName);
-		const isFileImported: ViewItem | undefined = await projectSection.findItem(BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME);
-		expect(isFileImported).not.eqls(undefined);
+		projectSection = await projectAndFileTests.getProjectViewSession();
+		expect(await projectAndFileTests.getProjectTreeItem(projectSection, projectName), 'Project folder was not imported').not.undefined;
+		expect(
+			await projectAndFileTests.getProjectTreeItem(projectSection, BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME),
+			'Project files were not imported'
+		).not.undefined;
 	});
 
 	test('Stop created workspace', async function (): Promise<void> {
@@ -65,9 +68,12 @@ suite('"Start workspace with existed workspace name" test', function (): void {
 
 	test('Wait the second workspace readiness and project folder has been created', async function (): Promise<void> {
 		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
-		projectSection = await new SideBarView().getContent().getSection(projectName);
-		const isFileImported: ViewItem | undefined = await projectSection.findItem(BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME);
-		expect(isFileImported).not.eqls(undefined);
+		projectSection = await projectAndFileTests.getProjectViewSession();
+		expect(await projectAndFileTests.getProjectTreeItem(projectSection, projectName), 'Project folder was not imported').not.undefined;
+		expect(
+			await projectAndFileTests.getProjectTreeItem(projectSection, BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME),
+			'Project files were not imported'
+		).not.undefined;
 	});
 
 	test(`Stop all created ${stackName} workspaces`, async function (): Promise<void> {

--- a/tests/e2e/specs/miscellaneous/KubedockPodmanTest.spec.ts
+++ b/tests/e2e/specs/miscellaneous/KubedockPodmanTest.spec.ts
@@ -7,7 +7,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  **********************************************************************/
-import { SideBarView, ViewSection } from 'monaco-page-objects';
+import { ViewSection } from 'monaco-page-objects';
 import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
 import { CLASSES } from '../../configs/inversify.types';
 import { e2eContainer } from '../../configs/inversify.config';
@@ -66,8 +66,8 @@ suite('Check possibility to manage containers within a workspace with kubedock a
 	});
 
 	test('Check the project files were imported', async function (): Promise<void> {
-		const [projectSection]: ViewSection[] = await new SideBarView().getContent().getSections();
-		expect(await projectSection.findItem('Dockerfile'), 'Files not imported').not.undefined;
+		const projectSection: ViewSection = await projectAndFileTests.getProjectViewSession();
+		expect(await projectAndFileTests.getProjectTreeItem(projectSection, 'Dockerfile'), 'Files not imported').not.undefined;
 	});
 
 	test('Create and check container runs using kubedock and podman', function (): void {

--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -64,6 +64,11 @@ export class ProjectAndFileTests {
 		}
 	}
 
+	/**
+	 * find an ViewSection with project tree.
+	 * @returns Promise resolving to ViewSection object
+	 */
+
 	async getProjectViewSession(): Promise<ViewSection> {
 		Logger.debug();
 
@@ -77,8 +82,17 @@ export class ProjectAndFileTests {
 		return projectSection;
 	}
 
-	async getProjectTreeItem(projectSection: ViewSection, item: string, itemLevel: number = 2): Promise<ViewItem | undefined> {
-		Logger.debug(`${item}`);
+	/**
+	 * find an item in this view section by label. Does not perform recursive search through the whole tree.
+	 * Does however scroll through all the expanded content. Will find items beyond the current scroll range.
+	 * @param projectSection ViewSection with project tree files.
+	 * @param label Label of the item to search for.
+	 * @param itemLevel Shows how deep the algorithm should look into expanded folders to find item,
+	 * default - 2 means first level is project directory and files inside it is the second level, unlimited 0
+	 * @returns Promise resolving to ViewItem object is such item exists, undefined otherwise
+	 */
+	async getProjectTreeItem(projectSection: ViewSection, label: string, itemLevel: number = 2): Promise<ViewItem | undefined> {
+		Logger.debug(`${label}`);
 
 		let projectTreeItem: ViewItem | undefined;
 		await this.driverHelper.waitVisibility(
@@ -87,11 +101,11 @@ export class ProjectAndFileTests {
 		);
 
 		try {
-			projectTreeItem = await projectSection.findItem(item, itemLevel);
+			projectTreeItem = await projectSection.findItem(label, itemLevel);
 			if (!projectTreeItem) {
 				try {
 					await projectSection.collapse();
-					projectTreeItem = await projectSection.findItem(item, itemLevel);
+					projectTreeItem = await projectSection.findItem(label, itemLevel);
 				} catch (e) {
 					Logger.warn(JSON.stringify(e));
 				}


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Closes test issue [Make 'Check the project files were imported' test in Che test framework not use view section name](https://issues.redhat.com/browse/CRW-4864)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->

https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/12418/

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
[CRW-4864](https://issues.redhat.com/browse/CRW-4864)

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
export USERSTORY=Quarkus && npm run test

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
