### PR TITLE
Update make-release.sh to install npm dependencies

### DIFF
--- a/make-release.sh
+++ b/make-release.sh
@@ -162,7 +162,7 @@ pushd tests/e2e >/dev/null || exit
 # update devworkspace generator version
 jq ".\"dependencies\".\"@eclipse-che/che-devworkspace-generator\" = \"${VERSION}\"" package.json > package.json.update
 mv package.json.update package.json
-npm install
+npm i -g prettier
 npm --no-git-tag-version version --allow-same-version "${VERSION}"
 npm run prettier
 popd >/dev/null || exit

--- a/make-release.sh
+++ b/make-release.sh
@@ -162,6 +162,7 @@ pushd tests/e2e >/dev/null || exit
 # update devworkspace generator version
 jq ".\"dependencies\".\"@eclipse-che/che-devworkspace-generator\" = \"${VERSION}\"" package.json > package.json.update
 mv package.json.update package.json
+npm install
 npm --no-git-tag-version version --allow-same-version "${VERSION}"
 npm run prettier
 popd >/dev/null || exit


### PR DESCRIPTION
npm run prettier is called but prettier is never installed

### What does this PR do?
Fix release pipeline by running `npm install -g prettier` so `npm run prettier` can be run

### What issues does this PR fix or reference?


### How to test this PR?

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
