### PR TITLE
fix: redact headers, cookies, url params in har file

### DIFF
--- a/tests/e2e/utils/CheReporter.ts
+++ b/tests/e2e/utils/CheReporter.ts
@@ -181,11 +181,7 @@ class CheReporter extends mocha.reporters.Spec {
 			const networkLogsEntries: logging.Entry[] = await this.driverHelper.getDriver().manage().logs().get('performance');
 			const events: any[] = networkLogsEntries.map((entry): any[] => JSON.parse(entry.message).message);
 			const har: any = chromeHar.harFromMessages(events, { includeTextFromResponseBody: true });
-			try {
-				this.maskHarContent(har);
-			} catch (e) {
-				console.log(e);
-			}
+			this.maskHarContent(har);
 
 			const networkLogsStream: WriteStream = fs.createWriteStream(harFileName);
 			networkLogsStream.write(Buffer.from(JSON.stringify(har)), (): void => {

--- a/tests/e2e/utils/CheReporter.ts
+++ b/tests/e2e/utils/CheReporter.ts
@@ -181,10 +181,46 @@ class CheReporter extends mocha.reporters.Spec {
 			const networkLogsEntries: logging.Entry[] = await this.driverHelper.getDriver().manage().logs().get('performance');
 			const events: any[] = networkLogsEntries.map((entry): any[] => JSON.parse(entry.message).message);
 			const har: any = chromeHar.harFromMessages(events, { includeTextFromResponseBody: true });
+			try {
+				this.maskHarContent(har);
+			} catch (e) {
+				console.log(e);
+			}
+
 			const networkLogsStream: WriteStream = fs.createWriteStream(harFileName);
 			networkLogsStream.write(Buffer.from(JSON.stringify(har)), (): void => {
 				networkLogsStream.end();
 			});
+		});
+	}
+
+	maskHarContent(har: any): void {
+		har.log?.entries?.forEach((entry: any): void => {
+			let text: string | undefined = entry.request?.postData?.text;
+			if (text) {
+				text = StringUtil.updateUrlQueryValue(text, 'csrf', '<REDACTED>');
+				text = StringUtil.updateUrlQueryValue(text, 'username', '<REDACTED>');
+				entry.request.postData.text = StringUtil.updateUrlQueryValue(text, 'password', '<REDACTED>');
+			}
+
+			const cookies: any = entry.request?.cookies;
+			if (cookies) {
+				cookies.forEach((cookie: any): void => {
+					if (cookie.name?.startsWith('_oauth_proxy')) {
+						cookie.value = '<REDACTED>';
+					}
+				});
+			}
+
+			const headers: any = entry.request?.headers;
+			if (headers) {
+				headers.forEach((header: any): void => {
+					if (header.name?.toLowerCase() === 'cookie') {
+						header.value = StringUtil.updateCookieValue(header.value, '_oauth_proxy', '<REDACTED>');
+						header.value = StringUtil.updateCookieValue(header.value, '_oauth_proxy_csrf', '<REDACTED>');
+					}
+				});
+			}
 		});
 	}
 }

--- a/tests/e2e/utils/CheReporter.ts
+++ b/tests/e2e/utils/CheReporter.ts
@@ -181,7 +181,7 @@ class CheReporter extends mocha.reporters.Spec {
 			const networkLogsEntries: logging.Entry[] = await this.driverHelper.getDriver().manage().logs().get('performance');
 			const events: any[] = networkLogsEntries.map((entry): any[] => JSON.parse(entry.message).message);
 			const har: any = chromeHar.harFromMessages(events, { includeTextFromResponseBody: true });
-			this.maskHarContent(har);
+			this.redactHarContent(har);
 
 			const networkLogsStream: WriteStream = fs.createWriteStream(harFileName);
 			networkLogsStream.write(Buffer.from(JSON.stringify(har)), (): void => {
@@ -190,7 +190,7 @@ class CheReporter extends mocha.reporters.Spec {
 		});
 	}
 
-	maskHarContent(har: any): void {
+	redactHarContent(har: any): void {
 		har.log?.entries?.forEach((entry: any): void => {
 			let text: string | undefined = entry.request?.postData?.text;
 			if (text) {

--- a/tests/e2e/utils/StringUtil.ts
+++ b/tests/e2e/utils/StringUtil.ts
@@ -59,4 +59,32 @@ export class StringUtil {
 
 		return command.replace(/[{}]/g, '').replace(/(?<!")\${?[a-zA-Z0-9_+\-\s]+\b}?/gm, '"$&"');
 	}
+
+	/**
+	 * replaces the cookie value of the specified cookie
+	 * @param cookie cookie names and values, seperated with ;
+	 * @param name name of cookie to replace its value for
+	 * @param replaceStr the new value of the cookie
+	 * @return updated cookie string with the cookie value replaced
+	 */
+	static updateCookieValue(cookie: string, name: string, replaceStr: string): string {
+		Logger.trace();
+
+		const regex: RegExp = new RegExp(`(${name})=[^;]+`, 'g');
+		return cookie.replace(regex, `$1=${replaceStr}`);
+	}
+
+	/**
+	 * replaces the query value of the specified query
+	 * @param queryString query string (ie. query=value&query2=value2)
+	 * @param name name of the query to replace
+	 * @param replaceStr new query value
+	 * @returns updated queryString with the query value replaced
+	 */
+	static updateUrlQueryValue(queryString: string, name: string, replaceStr: string): string {
+		Logger.trace();
+
+		const regex: RegExp = new RegExp(`(${name})=[^&]+`, 'g');
+		return queryString.replace(regex, `$1=${replaceStr}`);
+	}
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Extension to the https://github.com/eclipse/che/pull/22526 feature, that redacts auth headers, cookies, and params from har files.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. On an OpenShift cluster, install Eclipse Che
2. Checkout this PR, cd to `tests/e2e`
3. Run the following to set the necessary environment variables:
```
export TS_SELENIUM_BASE_URL=<CHE_URL>
export TS_SELENIUM_OCP_USERNAME=<USERNAME>
export TS_SELENIUM_OCP_PASSWORD=<PASSWORD>
export TS_SELENIUM_VALUE_OPENSHIFT_OAUTH=true
``` 
4. Run `npm ci`
5. Apply the following patch to guarantee that one of the smoke tests fail:
```
git apply <<EOF
diff --git a/tests/e2e/specs/SmokeTest.spec.ts b/tests/e2e/specs/SmokeTest.spec.ts
index 4a5f08bf76..709371a396 100644
--- a/tests/e2e/specs/SmokeTest.spec.ts
+++ b/tests/e2e/specs/SmokeTest.spec.ts
@@ -46,6 +46,7 @@ suite('The SmokeTest userstory', function (): void {
 		test('Check a project folder has been created', async function (): Promise<void> {
 			const projectName: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_PROJECT_NAME || StringUtil.getProjectNameFromGitUrl(factoryUrl);
 			projectSection = (await new SideBarView().getContent().getSections())[0]; // get the (WORKSPACE) section from the sidebar - contains project content
+			expect(false).to.be.true;
 			expect(await projectSection.findItem(projectName)).not.eqls(undefined);
 		});
 		test('Check the project files was imported', async function (): Promise<void> {
EOF
```
6. Run the smoke tests
```
export USERSTORY=SmokeTest && npm run test
```
7. The test should fail and a `.har` file should be available in `tests/e2e/report/<test-name>/`
8. Verify that the har file does not contain authentication headers, cookies, url params

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
