### PR TITLE
[Test] Improve WebTerminalTest e2e test to check more test steps

### DIFF
--- a/tests/e2e/pageobjects/openshift/OcpMainPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpMainPage.ts
@@ -89,7 +89,7 @@ export class OcpMainPage {
 
 		await this.waitOpenMainPage();
 		await this.driverHelper.waitAndClick(OcpMainPage.WEB_TERMINAL_BUTTON);
-		await this.driverHelper.waitPresence(OcpMainPage.WEB_TERMINAL_PAGE, TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
+		await this.driverHelper.waitPresence(OcpMainPage.WEB_TERMINAL_PAGE, TIMEOUT_CONSTANTS.TS_WAIT_LOADER_ABSENCE_TIMEOUT);
 	}
 
 	async typeToWebTerminal(text: string): Promise<void> {

--- a/tests/e2e/specs/web-terminal/WebTerminalTest.spec.ts
+++ b/tests/e2e/specs/web-terminal/WebTerminalTest.spec.ts
@@ -12,15 +12,44 @@ import { e2eContainer } from '../../configs/inversify.config';
 import { LoginTests } from '../../tests-library/LoginTests';
 import { OcpMainPage } from '../../pageobjects/openshift/OcpMainPage';
 import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesCommandLineToolsExecutor';
+import { ShellExecutor } from '../../utils/ShellExecutor';
+import { expect } from 'chai';
 
 suite(`Login to Openshift console and start WebTerminal ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 	const ocpMainPage: OcpMainPage = e2eContainer.get(CLASSES.OcpMainPage);
+	const kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor = e2eContainer.get(
+		CLASSES.KubernetesCommandLineToolsExecutor
+	);
+	const shellExecutor: ShellExecutor = e2eContainer.get(CLASSES.ShellExecutor);
+
+	suiteSetup(function (): void {
+		kubernetesCommandLineToolsExecutor.loginToOcp('admin');
+		shellExecutor.executeCommand('oc project openshift-operators');
+	});
 
 	loginTests.loginIntoOcpConsole();
 
 	test('Open Web Terminal', async function (): Promise<void> {
 		await ocpMainPage.waitOpenMainPage();
 		await ocpMainPage.openWebTerminal();
+	});
+
+	test('Check username is correct', async function (): Promise<void> {
+		const userUid = shellExecutor.executeCommand('oc get user $(oc whoami) -o jsonpath={.metadata.uid}').replace(/\n/g, '');
+
+		// label selector for Web Terminal workspaces owned by the currently-logged in user
+		const labelSelector = 'console.openshift.io/terminal=true,controller.devfile.io/creator=' + userUid;
+		// namespace of this users web terminal
+		const namespace = shellExecutor.executeCommand(`oc get dw -A -l ${labelSelector} -o jsonpath='{.items[0].metadata.namespace}'`);
+		// devWorkspace ID for this users web terminal
+		const termDwId = shellExecutor.executeCommand(`oc get dw -A -l ${labelSelector} -o jsonpath='{.items[0].status.devworkspaceId}'`);
+		// use oc exec to run oc whoami inside this user's terminal
+		const user = shellExecutor
+			.executeCommand(`oc exec -n ${namespace} deploy/${termDwId} -c web-terminal-tooling -- oc whoami`)
+			.replace(/\n/g, '');
+		// above should output current user's username:
+		expect(user).to.equal(shellExecutor.executeCommand('oc whoami').replace(/\n/g, ''));
 	});
 });


### PR DESCRIPTION
### What does this PR do?
For now WebTerminalTest test checks only web terminal starting page. We need to add checking step 4 from [Test intergration with DWO](https://gist.github.com/amisevsk/1bdfa7b063e4c1a0cb420314a9c14ae6#4-test-intergration-with-wto) document.

### What issues does this PR fix or reference?
Eclipse Che issue -  https://github.com/eclipse/che/issues/22563


### How to test this PR?
1. Install WebTerminal on Openshift from Operator Hub
2. Start WebTerminalTest test.

Test logs
```          ▼ OcpMainPage.openWebTerminal
          ▼ OcpMainPage.waitOpenMainPage
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="page-main-header"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-quickstart-id="qs-masthead-cloudshell"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-quickstart-id="qs-masthead-cloudshell"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitPresence - By(xpath, //*[@class="xterm-helper-textarea"])
            ‣ DriverHelper.waitPresence - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #5, retrying with 1000ms timeout
    ✔ Open Web Terminal
          ▼ ShellExecutor.executeCommand - oc get user $(oc whoami) -o jsonpath={.metadata.uid}
7a7e552e-28b7-49cf-b6c4-bfc790dbf114          ▼ ShellExecutor.executeCommand - oc get dw -A -l console.openshift.io/terminal=true,controller.devfile.io/creator=7a7e552e-28b7-49cf-b6c4-bfc790dbf114 -o jsonpath='{.items[0].metadata.namespace}'
openshift-terminal          ▼ ShellExecutor.executeCommand - oc get dw -A -l console.openshift.io/terminal=true,controller.devfile.io/creator=7a7e552e-28b7-49cf-b6c4-bfc790dbf114 -o jsonpath='{.items[0].status.devworkspaceId}'
workspace761cd28d480443be          ▼ ShellExecutor.executeCommand - oc exec -n openshift-terminal deploy/workspace761cd28d480443be -c web-terminal-tooling -- oc whoami
admin
          ▼ ShellExecutor.executeCommand - oc whoami
admin
    ✔ Check username is correct

            ‣ Context.deleteAllWorkspacesOnFinish - Property DELETE_WORKSPACE_ON_FAILED_TEST is true - trying to stop and delete all running workspace after test run with API.
          ▼ TestWorkspaceUtil.stopAndDeleteAllRunningWorkspaces
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
            ‣ Context.deleteAllWorkspacesOnFinish - Running workspaces not found
            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.quit
            ‣ DriverHelper.getDriver

  2 passing (33s)
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
