### PR TITLE
[Test] Add test that revokes OAuth access from Dashboard

### DIFF
--- a/tests/e2e/configs/inversify.types.ts
+++ b/tests/e2e/configs/inversify.types.ts
@@ -49,7 +49,8 @@ const CLASSES: any = {
 	ShellExecutor: 'ShellExecutor',
 	ContainerTerminal: 'ContainerTerminal',
 	UserPreferences: 'UserPreferences',
-	WebTerminalPage: 'WebTerminalPage'
+	WebTerminalPage: 'WebTerminalPage',
+	RevokeOauthPage: 'RevokeOauthPage'
 };
 
 const EXTERNAL_CLASSES: any = {

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -13,15 +13,7 @@ import { CLASSES } from '../../configs/inversify.types';
 import { By } from 'selenium-webdriver';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { Logger } from '../../utils/Logger';
-
-enum GitServices {
-	GITHUB = 'github',
-	GITLAB = 'gitlab',
-	BITBUCKET_SERVER_OAUTH1 = 'bitbucket-server-oauth1',
-	BITBUCKET_SERVER_OAUTH2 = 'bitbucket-server-oauth2',
-	BITBUCKET_CLOUD_OAUTH2 = 'bitbucket-org',
-	AZURE_DEVOPS = 'azure-devops'
-}
+import { GitProviderType } from '../../constants/FACTORY_TEST_CONSTANTS';
 
 @injectable()
 export class UserPreferences {
@@ -122,12 +114,12 @@ export class UserPreferences {
 
 	getServiceConfig(service: string): string {
 		const gitService: { [key: string]: string } = {
-			[GitServices.GITHUB]: 'GitHub',
-			[GitServices.GITLAB]: 'GitLab',
-			[GitServices.AZURE_DEVOPS]: 'Microsoft Azure DevOps',
-			[GitServices.BITBUCKET_CLOUD_OAUTH2]: 'Bitbucket Cloud',
-			[GitServices.BITBUCKET_SERVER_OAUTH1]: 'Bitbucket Server',
-			[GitServices.BITBUCKET_SERVER_OAUTH2]: 'Bitbucket Server'
+			[GitProviderType.GITHUB]: 'GitHub',
+			[GitProviderType.GITLAB]: 'GitLab',
+			[GitProviderType.AZURE_DEVOPS]: 'Microsoft Azure DevOps',
+			[GitProviderType.BITBUCKET_CLOUD_OAUTH2]: 'Bitbucket Cloud',
+			[GitProviderType.BITBUCKET_SERVER_OAUTH1]: 'Bitbucket Server',
+			[GitProviderType.BITBUCKET_SERVER_OAUTH2]: 'Bitbucket Server'
 		};
 
 		return gitService[service];

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -14,13 +14,14 @@ import { By } from 'selenium-webdriver';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { Logger } from '../../utils/Logger';
 
-enum GitService {
-	github = 'github',
-	gitlab='gitlab',
-	'azure-devops'='azure-devops',
-	'bitbucket-server-oauth1'='bitbucket-server-oauth1',
-	'bitbucket-server-oauth2'='bitbucket-server-oauth2'
-  }
+enum GitServices {
+	GITHUB = 'github',
+	GITLAB = 'gitlab',
+	BITBUCKET_SERVER_OAUTH1 = 'bitbucket-server-oauth1',
+	BITBUCKET_SERVER_OAUTH2 = 'bitbucket-server-oauth2',
+	BITBUCKET_CLOUD_OAUTH2 = 'bitbucket-org',
+	AZURE_DEVOPS = 'azure-devops'
+}
 
 @injectable()
 export class UserPreferences {
@@ -119,15 +120,16 @@ export class UserPreferences {
 		await this.driverHelper.waitVisibility(UserPreferences.ADD_NEW_SSH_KEY_BUTTON);
 	}
 
-    async getServiceConfig(service: string): Promise<string> {
-    	const gitService: { [key: string]: string } = {
-			[GitService.github]: 'GitHub',
-			[GitService.gitlab]: 'GitLab',
-			[GitService['azure-devops']]: 'Microsoft Azure DevOps',
-			[GitService['bitbucket-server-oauth1']]: 'Bitbucket Server',
-			[GitService['bitbucket-server-oauth2']]: 'Bitbucket Server'
+	getServiceConfig(service: string): string {
+		const gitService: { [key: string]: string } = {
+			[GitServices.GITHUB]: 'GitHub',
+			[GitServices.GITLAB]: 'GitLab',
+			[GitServices.AZURE_DEVOPS]: 'Microsoft Azure DevOps',
+			[GitServices.BITBUCKET_CLOUD_OAUTH2]: 'Bitbucket Cloud',
+			[GitServices.BITBUCKET_SERVER_OAUTH1]: 'Bitbucket Server',
+			[GitServices.BITBUCKET_SERVER_OAUTH2]: 'Bitbucket Server'
 		};
-	  
+
 		return gitService[service];
 	}
 

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -21,7 +21,9 @@ export class UserPreferences {
 	private static readonly USER_PREFERENCES_PAGE: By = By.xpath('//h1[text()="User Preferences"]');
 
 	private static readonly CONTAINER_REGISTRIES_TAB: By = By.xpath('//button[text()="Container Registries"]');
+
 	private static readonly GIT_SERVICES_TAB: By = By.xpath('//button[text()="Git Services"]');
+	private static readonly GIT_SERVICES_REVOKE_BUTTON: By = By.xpath('//button[text()="Revoke"]');
 
 	private static readonly PAT_TAB: By = By.xpath('//button[text()="Personal Access Tokens"]');
 	private static readonly ADD_NEW_PAT_BUTTON: By = By.xpath('//button[text()="Add Personal Access Token"]');
@@ -30,6 +32,10 @@ export class UserPreferences {
 
 	private static readonly SSH_KEY_TAB: By = By.xpath('//button[text()="SSH Keys"]');
 	private static readonly ADD_NEW_SSH_KEY_BUTTON: By = By.xpath('//button[text()="Add SSH Key"]');
+
+	private static readonly CONFIRMATION_WINDOW: By = By.xpath('//span[text()="Revoke Git Services"]');
+	private static readonly DELETE_CONFIRMATION_CHECKBOX: By = By.xpath('//input[@data-testid="warning-info-checkbox"]');
+	private static readonly DELETE_ITEM_BUTTON_ENABLED: By = By.xpath('//button[@data-testid="revoke-button" and not(@disabled)]');
 
 	constructor(
 		@inject(CLASSES.DriverHelper)
@@ -67,6 +73,24 @@ export class UserPreferences {
 		await this.driverHelper.waitAndClick(UserPreferences.GIT_SERVICES_TAB);
 	}
 
+	async revokeGitService(servicesName: string): Promise<void> {
+		Logger.debug();
+
+		await this.selectListItem(servicesName);
+		await this.driverHelper.waitAndClick(UserPreferences.GIT_SERVICES_REVOKE_BUTTON);
+
+		await this.driverHelper.waitVisibility(UserPreferences.CONFIRMATION_WINDOW);
+		await this.driverHelper.waitAndClick(UserPreferences.DELETE_CONFIRMATION_CHECKBOX);
+		await this.driverHelper.waitAndClick(UserPreferences.DELETE_ITEM_BUTTON_ENABLED);
+		await this.driverHelper.waitDisappearance(this.getServicesListItemLocator(servicesName));
+	}
+
+	async selectListItem(servicesName: string): Promise<void> {
+		Logger.debug(`of the '${servicesName}' list item`);
+
+		await this.driverHelper.waitAndClick(this.getServicesListItemLocator(servicesName));
+	}
+
 	async openPatTab(): Promise<void> {
 		Logger.debug();
 
@@ -85,5 +109,9 @@ export class UserPreferences {
 
 		await this.driverHelper.waitAndClick(UserPreferences.SSH_KEY_TAB);
 		await this.driverHelper.waitVisibility(UserPreferences.ADD_NEW_SSH_KEY_BUTTON);
+	}
+
+	private getServicesListItemLocator(servicesName: string): By {
+		return By.xpath(`//tr[td[text()='${servicesName}']]//input`);
 	}
 }

--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -14,6 +14,14 @@ import { By } from 'selenium-webdriver';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { Logger } from '../../utils/Logger';
 
+enum GitService {
+	github = 'github',
+	gitlab='gitlab',
+	'azure-devops'='azure-devops',
+	'bitbucket-server-oauth1'='bitbucket-server-oauth1',
+	'bitbucket-server-oauth2'='bitbucket-server-oauth2'
+  }
+
 @injectable()
 export class UserPreferences {
 	private static readonly USER_SETTINGS_DROPDOWN: By = By.xpath('//header//button/span[text()!=""]//parent::button');
@@ -109,6 +117,18 @@ export class UserPreferences {
 
 		await this.driverHelper.waitAndClick(UserPreferences.SSH_KEY_TAB);
 		await this.driverHelper.waitVisibility(UserPreferences.ADD_NEW_SSH_KEY_BUTTON);
+	}
+
+    async getServiceConfig(service: string): Promise<string> {
+    	const gitService: { [key: string]: string } = {
+			[GitService.github]: 'GitHub',
+			[GitService.gitlab]: 'GitLab',
+			[GitService['azure-devops']]: 'Microsoft Azure DevOps',
+			[GitService['bitbucket-server-oauth1']]: 'Bitbucket Server',
+			[GitService['bitbucket-server-oauth2']]: 'Bitbucket Server'
+		};
+	  
+		return gitService[service];
 	}
 
 	private getServicesListItemLocator(servicesName: string): By {

--- a/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
+++ b/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
@@ -1,5 +1,5 @@
 /** *******************************************************************
- * copyright (c) 2020-2023 Red Hat, Inc.
+ * copyright (c) 2020-2024 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -24,5 +24,8 @@ suite(`"Check User Preferences page" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT
 	test('Check user preferences page', async function (): Promise<void> {
 		await userPreferences.openUserPreferencesPage();
 		await userPreferences.checkTabsAvailability();
+
+		await userPreferences.openGitServicesTab();
+		await userPreferences.revokeGitService('GitHub');
 	});
 });

--- a/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
+++ b/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
@@ -10,10 +10,9 @@
 import { e2eContainer } from '../../configs/inversify.config';
 import { CLASSES } from '../../configs/inversify.types';
 import { LoginTests } from '../../tests-library/LoginTests';
-import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { UserPreferences } from '../../pageobjects/dashboard/UserPreferences';
 
-suite(`"Check User Preferences page" test ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+suite(`"Revoke OAuth" test`, function (): void {
 	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 	const userPreferences: UserPreferences = e2eContainer.get(CLASSES.UserPreferences);
 

--- a/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
+++ b/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
@@ -13,7 +13,7 @@ import { LoginTests } from '../../tests-library/LoginTests';
 import { UserPreferences } from '../../pageobjects/dashboard/UserPreferences';
 import { FACTORY_TEST_CONSTANTS } from '../../constants/FACTORY_TEST_CONSTANTS';
 
-suite(`"Revoke OAuth" test`, function (): void {
+suite('"Revoke OAuth" test', function (): void {
 	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 	const userPreferences: UserPreferences = e2eContainer.get(CLASSES.UserPreferences);
 	const gitService: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER || 'github';
@@ -27,8 +27,8 @@ suite(`"Revoke OAuth" test`, function (): void {
 		await userPreferences.checkTabsAvailability();
 
 		await userPreferences.openGitServicesTab();
-		
-		const selectedService: string = await userPreferences.getServiceConfig(gitService);
+
+		const selectedService: string = userPreferences.getServiceConfig(gitService);
 		await userPreferences.revokeGitService(selectedService);
 	});
 });

--- a/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
+++ b/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
@@ -11,20 +11,24 @@ import { e2eContainer } from '../../configs/inversify.config';
 import { CLASSES } from '../../configs/inversify.types';
 import { LoginTests } from '../../tests-library/LoginTests';
 import { UserPreferences } from '../../pageobjects/dashboard/UserPreferences';
+import { FACTORY_TEST_CONSTANTS } from '../../constants/FACTORY_TEST_CONSTANTS';
 
 suite(`"Revoke OAuth" test`, function (): void {
 	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 	const userPreferences: UserPreferences = e2eContainer.get(CLASSES.UserPreferences);
+	const gitService: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER || 'github';
 
 	suiteSetup('Login', async function (): Promise<void> {
 		await loginTests.loginIntoChe();
 	});
 
-	test('Check user preferences page', async function (): Promise<void> {
+	test('Revoke OAuth test', async function (): Promise<void> {
 		await userPreferences.openUserPreferencesPage();
 		await userPreferences.checkTabsAvailability();
 
 		await userPreferences.openGitServicesTab();
-		await userPreferences.revokeGitService('GitHub');
+		
+		const selectedService: string = await userPreferences.getServiceConfig(gitService);
+		await userPreferences.revokeGitService(selectedService);
 	});
 });

--- a/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
+++ b/tests/e2e/specs/miscellaneous/RevokeOauth.spec.ts
@@ -24,8 +24,6 @@ suite('"Revoke OAuth" test', function (): void {
 
 	test('Revoke OAuth test', async function (): Promise<void> {
 		await userPreferences.openUserPreferencesPage();
-		await userPreferences.checkTabsAvailability();
-
 		await userPreferences.openGitServicesTab();
 
 		const selectedService: string = userPreferences.getServiceConfig(gitService);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
This test automate revoke OAuth access from User Preferences page.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-4841


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

<code>
        ▼ UserPreferences.openUserPreferencesPage
            ‣ DriverHelper.waitAndClick - By(xpath, //header//button/span[text()!=""]//parent::button)
            ‣ DriverHelper.waitVisibility - By(xpath, //header//button/span[text()!=""]//parent::button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="User Preferences"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="User Preferences"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[text()="User Preferences"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ UserPreferences.openGitServicesTab
            ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="Git Services"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Git Services"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ UserPreferences.revokeGitService
          ▼ UserPreferences.selectListItem - of the 'GitHub' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="Revoke"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Revoke"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //span[text()="Revoke Git Services"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="warning-info-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="warning-info-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="revoke-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="revoke-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitDisappearance - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.isVisible - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(xpath, //tr[td[text()='GitHub']]//input)
    ✔ Revoke OAuth test
</code>





[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
