### PR TITLE
Add user story for testing WTO under regular user

### DIFF
--- a/tests/e2e/specs/web-terminal/WebTerminalUnderRegularUser.spec.ts
+++ b/tests/e2e/specs/web-terminal/WebTerminalUnderRegularUser.spec.ts
@@ -15,11 +15,16 @@ import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesCommandLineToolsExecutor';
 import { ShellExecutor } from '../../utils/ShellExecutor';
 import { DriverHelper } from '../../utils/DriverHelper';
-import { WebTerminalPage } from '../../pageobjects/webterminal/WebTerminalPage';
+import { TimeUnits, WebTerminalPage } from '../../pageobjects/webterminal/WebTerminalPage';
 import { expect } from 'chai';
 import YAML from 'yaml';
+import { afterEach } from 'mocha';
+import { By } from 'selenium-webdriver';
 
-suite(`Login to Openshift console and start WebTerminal ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+suite(`Login to Openshift console and check WebTerminal ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+	const webTerminalToolContainerName: string = 'web-terminal-tooling';
+	const testProjectName: string = 'wto-under-regular-user-test';
+	const fileForVerificationTerminalCommands: string = 'result.txt';
 	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 	const ocpMainPage: OcpMainPage = e2eContainer.get(CLASSES.OcpMainPage);
 	const webTerminal: WebTerminalPage = e2eContainer.get(CLASSES.WebTerminalPage);
@@ -27,30 +32,35 @@ suite(`Login to Openshift console and start WebTerminal ${BASE_TEST_CONSTANTS.TE
 	const kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor = e2eContainer.get(
 		CLASSES.KubernetesCommandLineToolsExecutor
 	);
-	const defaultWTOProjectNameForAdmin: string = 'openshift-terminal';
+
 	const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
-	const webTerminalToolContainerName: string = 'web-terminal-tooling';
-	const fileForVerificationTerminalCommands: string = 'result.txt';
 
 	suiteSetup(function (): void {
-		kubernetesCommandLineToolsExecutor.loginToOcp('admin');
+		kubernetesCommandLineToolsExecutor.loginToOcp();
 	});
 
 	suiteTeardown(function (): void {
-		shellExecutor.executeArbitraryShellScript(`oc delete dw --all -n ${defaultWTOProjectNameForAdmin}`);
+		kubernetesCommandLineToolsExecutor.deleteProject(testProjectName);
 	});
+
+	afterEach(function (): void {
+		try {
+			shellExecutor.executeArbitraryShellScript(`oc delete dw --all -n ${testProjectName}`);
+		} catch (e) {
+			console.log(`cannot delete the  ${testProjectName} under regular user:`, e);
+		}
+	});
+
 	loginTests.loginIntoOcpConsole();
-	test('Open Web Terminal after first installation', async function (): Promise<void> {
+
+	test('Open WebTerminal after first installation', async function (): Promise<void> {
 		await ocpMainPage.waitOpenMainPage();
 		await driverHelper.refreshPage();
 		await webTerminal.clickOnWebTerminalIcon();
 	});
-	test('Verify first started WTO widget and disabled state Project field under admin user', async function (): Promise<void> {
-		await webTerminal.waitTerminalWidget();
-		expect(await webTerminal.waitDisabledProjectFieldAndGetProjectName()).equal(defaultWTOProjectNameForAdmin);
-	});
-	test('Check starting Web Terminal under admin', async function (): Promise<void> {
-		kubernetesCommandLineToolsExecutor.namespace = await webTerminal.getAdminProjectName();
+
+	test('Check WebTerminal with creating new Openshift Project', async function (): Promise<void> {
+		kubernetesCommandLineToolsExecutor.namespace = testProjectName;
 		await webTerminal.clickOnStartWebTerminalButton();
 		await webTerminal.waitTerminalIsStarted();
 		await webTerminal.typeAndEnterIntoWebTerminal(`oc whoami > ${fileForVerificationTerminalCommands}`);
@@ -63,31 +73,18 @@ suite(`Login to Openshift console and start WebTerminal ${BASE_TEST_CONSTANTS.TE
 			`cat /home/user/${fileForVerificationTerminalCommands}`,
 			webTerminalToolContainerName
 		);
-		expect(commandResult).contains('admin');
-	});
-	test('Verify help command under admin user', async function (): Promise<void> {
-		const helpCommandExpectedResult: string =
-			'oc         \\d+\\.\\d+\\.\\d+          OpenShift CLI\n' +
-			'kubectl    \\d+\\.\\d+\\.\\d+          Kubernetes CLI\n' +
-			'kustomize  \\d+\\.\\d+\\.\\d+           Kustomize CLI \\(built-in to kubectl\\)\n' +
-			'helm       \\d+\\.\\d+\\.\\d+          Helm CLI\n' +
-			'kn         \\d+\\.\\d+\\.\\d+           KNative CLI\n' +
-			'tkn        \\d+\\.\\d+\\.\\d+          Tekton CLI\n' +
-			'subctl     \\d+\\.\\d+\\.\\d+          Submariner CLI\n' +
-			'odo        \\d+\\.\\d+\\.\\d+          Red Hat OpenShift Developer CLI\n' +
-			'virtctl    \\d+\\.\\d+\\.\\d+          KubeVirt CLI\n' +
-			'jq         \\d+\\.\\d+             jq';
-
-		await webTerminal.typeAndEnterIntoWebTerminal(`help > ${fileForVerificationTerminalCommands}`);
-		const commandResult: string = kubernetesCommandLineToolsExecutor.execInContainerCommand(
-			`cat /home/user/${fileForVerificationTerminalCommands}`,
-			webTerminalToolContainerName
-		);
-		expect(commandResult).to.match(new RegExp(helpCommandExpectedResult));
+		const currentUserName: string = await driverHelper.waitAndGetText(By.css('span[data-test="username"]'));
+		expect(commandResult).contains(currentUserName);
 	});
 
-	test('Verify help command under admin user', async function (): Promise<void> {
-		await webTerminal.typeAndEnterIntoWebTerminal('wtoctl set timeout 30s');
+	test('Check running WebTerminal in the existed Project with custom timeout', async function (): Promise<void> {
+		await webTerminal.findAndSelectProject(testProjectName);
+		await webTerminal.clickOnTimeoutButton();
+		await webTerminal.clickOnTimeUnitDropDown();
+		await webTerminal.selectTimeUnit(TimeUnits.Seconds);
+		await webTerminal.setTimeoutByEntering(20);
+		await webTerminal.clickOnStartWebTerminalButton();
+		await webTerminal.waitTerminalIsStarted();
 		await webTerminal.waitTerminalInactivity();
 	});
 });

--- a/tests/e2e/specs/web-terminal/WebTerminalUnderRegularUser.spec.ts
+++ b/tests/e2e/specs/web-terminal/WebTerminalUnderRegularUser.spec.ts
@@ -61,6 +61,7 @@ suite(`Login to Openshift console and check WebTerminal ${BASE_TEST_CONSTANTS.TE
 
 	test('Check WebTerminal with creating new Openshift Project', async function (): Promise<void> {
 		kubernetesCommandLineToolsExecutor.namespace = testProjectName;
+		await webTerminal.typeProjectName(testProjectName);
 		await webTerminal.clickOnStartWebTerminalButton();
 		await webTerminal.waitTerminalIsStarted();
 		await webTerminal.typeAndEnterIntoWebTerminal(`oc whoami > ${fileForVerificationTerminalCommands}`);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Add verification of running the WebTerminal under a regular user

### Screenshot/screencast of this PR
```
################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://devspaces.apps.ocp413-mmusiie.crw-qe.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: user
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: false
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java 11 with Lombok,Java 11 with Quarkus,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DIRECTORY: web-terminal
      USERSTORY: WebTerminalUnderRegularUser

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


(node:275514) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
            ‣ DriverHelper.getDriver
  Login to Openshift console and check WebTerminal 
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - login to the "OC" client.
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.isUserLoggedIn - oc
          ▼ ShellExecutor.executeCommand - oc whoami && oc whoami --show-server=true
user
https://api.ocp413-mmusiie.crw-qe.com:6443
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - user already logged
          ▼ BrowserTabsUtil.navigateTo - https://console-openshift-console.apps.ocp413-mmusiie.crw-qe.com
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ OcpUserLoginPage.login
          ▼ OcpLoginPage.waitAndClickOnLoginProviderTitle
            ‣ DriverHelper.waitAndClick - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - By(xpath, //a[text()="htpasswd"])
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //a[text()="htpasswd"])
  Wait timed out after 1053ms
            ‣ DriverHelper.waitAndClick - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //a[text()="htpasswd"])
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //a[text()="htpasswd"])
  Wait timed out after 1042ms
            ‣ DriverHelper.waitAndClick - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitVisibility - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterUserNameOpenShift - "user"
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputUsername"]) text: user
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputUsername"]) text: user
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterPasswordOpenShift
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.clickOnLoginButton
            ‣ DriverHelper.waitAndClick - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitDisappearanceOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitDisappearance - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.isVisible - By(xpath, //*[contains(text(), "Welcome")])
            ‣ BrowserTabsUtil.maximize
          ▼ BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
            ‣ DriverHelper.getDriver
          ▼ OcpMainPage.waitOpenMainPage
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="page-main-header"])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.refreshPage
          ▼ WebTerminalPage.clickOnWebTerminalIcon
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-quickstart-id="qs-masthead-cloudshell"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-quickstart-id="qs-masthead-cloudshell"])
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //button[@data-quickstart-id="qs-masthead-cloudshell"])
  Wait timed out after 1085ms
            ‣ DriverHelper.waitAndClick - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-quickstart-id="qs-masthead-cloudshell"])
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //button[@data-quickstart-id="qs-masthead-cloudshell"])
  Wait timed out after 1016ms
            ‣ DriverHelper.waitAndClick - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-quickstart-id="qs-masthead-cloudshell"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Open WebTerminal after first installation
          ▼ ShellExecutor.executeArbitraryShellScript - oc delete dw --all -n wto-under-regular-user-test
          ▼ ShellExecutor.executeCommand - oc delete dw --all -n wto-under-regular-user-test
..............................
}
            ‣ DriverHelper.waitPresence - By(css selector, button#form-ns-dropdown-namespace-field)
            ‣ DriverHelper.type - By(css selector, input#form-input-newNamespace-field) text: wto-under-regular-user-test
            ‣ DriverHelper.waitVisibility - By(css selector, input#form-input-newNamespace-field)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WebTerminalPage.clickOnStartWebTerminalButton
            ‣ DriverHelper.waitAndClick - By(css selector, button[data-test-id="submit-button"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[data-test-id="submit-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WebTerminalPage.waitTerminalIsStarted
            ‣ DriverHelper.waitPresence - By(xpath, //*[@class="xterm-helper-textarea"])
            ‣ DriverHelper.waitPresence - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #6, retrying with 1000ms timeout
          ▼ WebTerminalPage.typeAndEnterIntoWebTerminal
            ‣ DriverHelper.waitPresence - By(xpath, //*[@class="xterm-helper-textarea"])
            ‣ DriverHelper.typeToInvisible - By(xpath, //*[@class="xterm-helper-textarea"]) text: oc whoami > result.txt
            ‣ DriverHelper.waitPresence - By(xpath, //*[@class="xterm-helper-textarea"])
          ▼ ShellExecutor.executeArbitraryShellScript - oc get dw -n wto-under-regular-user-test -o yaml
          ▼ ShellExecutor.executeCommand - oc get dw -n wto-under-regular-user-test -o yaml
apiVersion: v1
items:
- apiVersion: workspace.devfile.io/v1alpha2
  kind: DevWorkspace
  metadata:
    annotations:
      controller.devfile.io/devworkspace-source: web-terminal
      controller.devfile.io/restricted-access: "true"
      controller.devfile.io/started-at: "1705012348567"
    creationTimestamp: "2024-01-11T22:32:22Z"
    finalizers:
    - rbac.controller.devfile.io
    generation: 1
    labels:
      console.openshift.io/terminal: "true"
      controller.devfile.io/creator: 80fbd364-6601-4be2-bd5e-ad4226e427d7
    name: terminal-bhqlb1
    namespace: wto-under-regular-user-test
    resourceVersion: "93340820"
    uid: d46ba9f7-e10d-4a94-ba5c-f90a675c5fd2
  spec:
    routingClass: web-terminal
    started: true
    template:
      components:
      - name: web-terminal-tooling
        plugin:
          kubernetes:
            name: web-terminal-tooling
            namespace: openshift-operators
      - name: web-terminal-exec
        plugin:
          kubernetes:
            name: web-terminal-exec
            namespace: openshift-operators
  status:
    conditions:
    - lastTransitionTime: "2024-01-11T22:32:22Z"
      message: DevWorkspace is starting
      status: "True"
      type: Started
    - lastTransitionTime: "2024-01-11T22:32:23Z"
      message: Resolved plugins and parents from DevWorkspace
      status: "True"
      type: DevWorkspaceResolved
    - lastTransitionTime: "2024-01-11T22:32:23Z"
      message: Storage ready
      status: "True"
      type: StorageReady
    - lastTransitionTime: "2024-01-11T22:32:23Z"
      message: Networking ready
      status: "True"
      type: RoutingReady
    - lastTransitionTime: "2024-01-11T22:32:23Z"
      message: DevWorkspace serviceaccount ready
      status: "True"
      type: ServiceAccountReady
    - lastTransitionTime: "2024-01-11T22:32:23Z"
      message: DevWorkspace secrets ready
      status: "True"
      type: PullSecretsReady
    - lastTransitionTime: "2024-01-11T22:32:28Z"
      message: DevWorkspace deployment ready
      status: "True"
      type: DeploymentReady
    - lastTransitionTime: "2024-01-11T22:32:28Z"
      status: "True"
      type: Ready
    devworkspaceId: workspaced46ba9f7e10d4a94
    mainUrl: https://workspaced46ba9f7e10d4a94-service.wto-under-regular-user-test.svc:4444
    message: https://workspaced46ba9f7e10d4a94-service.wto-under-regular-user-test.svc:4444
    phase: Running
kind: List
metadata:
  resourceVersion: ""
          ▼ KubernetesCommandLineToolsExecutor.getPodAndContainerNames - oc
          ▼ KubernetesCommandLineToolsExecutor.getWorkspacePodName - oc - get workspace pod name.
          ▼ ShellExecutor.executeCommand - oc get pod -l controller.devfile.io/devworkspace_name=terminal-bhqlb1 -n wto-under-regular-user-test -o name
pod/workspaced46ba9f7e10d4a94-bfd6db4d4-r7m55
          ▼ KubernetesCommandLineToolsExecutor.getContainerName - oc - get container name.
          ▼ ShellExecutor.executeCommand - oc get pod/workspaced46ba9f7e10d4a94-bfd6db4d4-r7m55 -o jsonpath='{.spec.containers[*].name}' -n wto-under-regular-user-test
web-terminal-tooling web-terminal-exec

          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspaced46ba9f7e10d4a94-bfd6db4d4-r7m55 -n wto-under-regular-user-test -c web-terminal-tooling -- sh -c 'cat /home/user/result.txt'
user
            ‣ DriverHelper.waitAndGetText - By(css selector, span[data-test="username"])
            ‣ DriverHelper.waitVisibility - By(css selector, span[data-test="username"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Check WebTerminal with creating new Openshift Project
          ▼ ShellExecutor.executeArbitraryShellScript - oc delete dw --all -n wto-under-regular-user-test
          ▼ ShellExecutor.executeCommand - oc delete dw --all -n wto-under-regular-user-test
devworkspace.workspace.devfile.io "terminal-bhqlb1" deleted
            ‣ DriverHelper.waitAndClick - By(css selector, button#form-ns-dropdown-namespace-field)
            ‣ DriverHelper.waitVisibility - By(css selector, button#form-ns-dropdown-namespace-field)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, input[data-test-id="dropdown-text-filter"]) text: wto-under-regular-user-test
            ‣ DriverHelper.waitVisibility - By(css selector, input[data-test-id="dropdown-text-filter"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //span[@class="pf-c-menu__item-text" and text()="wto-under-regular-user-test"])
            ‣ DriverHelper.waitVisibility - By(xpath, //span[@class="pf-c-menu__item-text" and text()="wto-under-regular-user-test"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[(text()="Timeout")])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[(text()="Timeout")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(css selector, div.request-size-input__unit button)
            ‣ DriverHelper.waitVisibility - By(css selector, div.request-size-input__unit button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-test-id='dropdown-menu' and text()='Seconds'])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-test-id='dropdown-menu' and text()='Seconds'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, input[aria-describedby="form-resource-limit-advancedOptions-timeout-limit-field-helper"]) text: 20
            ‣ DriverHelper.waitVisibility - By(css selector, input[aria-describedby="form-resource-limit-advancedOptions-timeout-limit-field-helper"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WebTerminalPage.clickOnStartWebTerminalButton
            ‣ DriverHelper.waitAndClick - By(css selector, button[data-test-id="submit-button"])
            ‣ DriverHelper.waitVisibility - By(css selector, button[data-test-id="submit-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WebTerminalPage.waitTerminalIsStarted
            ‣ DriverHelper.waitPresence - By(xpath, //*[@class="xterm-helper-textarea"])
 ..............................
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Restart terminal"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Check running WebTerminal in the existed Project with custom timeout (38706ms)
          ▼ ShellExecutor.executeArbitraryShellScript - oc delete dw --all -n wto-under-regular-user-test
          ▼ ShellExecutor.executeCommand - oc delete dw --all -n wto-under-regular-user-test
devworkspace.workspace.devfile.io "terminal-ylpjg4" deleted
          ▼ KubernetesCommandLineToolsExecutor.deleteProject - oc - delete "wto-under-regular-user-test".
          ▼ ShellExecutor.executeCommand - oc delete project wto-under-regular-user-test -n wto-under-regular-user-test
Warning: deleting cluster-scoped resources, not scoped to the provided namespace
project.project.openshift.io "wto-under-regular-user-test" deleted

            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.quit
            ‣ DriverHelper.getDriver

  3 passing (1m)
```


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-235


### How to test this PR?
Set up dedicated env. vars and run directly or using the e2e container


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
