### PR TITLE
Fix WorkspaceWithParent test

### DIFF
--- a/tests/e2e/constants/BASE_TEST_CONSTANTS.ts
+++ b/tests/e2e/constants/BASE_TEST_CONSTANTS.ts
@@ -66,8 +66,8 @@ export const BASE_TEST_CONSTANTS: {
 		return BASE_TEST_CONSTANTS.TS_SELENIUM_BASE_URL.includes('devspaces')
 			? 'devspaces'
 			: BASE_TEST_CONSTANTS.TS_SELENIUM_BASE_URL.includes('che')
-				? 'che'
-				: 'default';
+			? 'che'
+			: 'default';
 	},
 	/**
 	 * testing application version

--- a/tests/e2e/specs/miscellaneous/WorkspaceWithParent.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceWithParent.spec.ts
@@ -22,6 +22,8 @@ import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTes
 import { registerRunningWorkspace } from '../MochaHooks';
 import { KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesCommandLineToolsExecutor';
 import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
+import { DriverHelper } from '../../utils/DriverHelper';
+import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 
 suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -34,6 +36,8 @@ suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMEN
 	const kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor = e2eContainer.get(
 		CLASSES.KubernetesCommandLineToolsExecutor
 	);
+	const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+
 	let podName: string = '';
 
 	suiteSetup(function (): void {
@@ -51,6 +55,7 @@ suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMEN
 		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
 		registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
 		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_WAIT_FOR_URL);
 		await projectAndFileTests.performTrustAuthorDialog();
 	});
 
@@ -68,8 +73,10 @@ suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMEN
 		await input.setText('>Tasks: Run Task');
 		const runTaskItem: QuickPickItem | undefined = await input.findQuickPick('Tasks: Run Task');
 		await runTaskItem?.click();
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_DEFAULT_POLLING);
 		const devFileTask: QuickPickItem | undefined = await input.findQuickPick('devfile');
 		await devFileTask?.click();
+		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_DEFAULT_POLLING);
 		const firstExpectedQuickPick: QuickPickItem | undefined = await input.findQuickPick('1. This command from the devfile');
 		const secondExpectedQuickPick: QuickPickItem | undefined = await input.findQuickPick('2. This command from the parent');
 		expect(firstExpectedQuickPick).not.undefined;

--- a/tests/e2e/specs/miscellaneous/WorkspaceWithParent.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceWithParent.spec.ts
@@ -55,6 +55,8 @@ suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMEN
 		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
 		registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
 		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+		// add 10 sec timeout for waiting for finishing animation of all IDE parts (Welcome parts. bottom widgets. etc.)
+		// using 10 sec easier than performing of finishing animation a all elements
 		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_WAIT_FOR_URL);
 		await projectAndFileTests.performTrustAuthorDialog();
 	});
@@ -73,9 +75,11 @@ suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMEN
 		await input.setText('>Tasks: Run Task');
 		const runTaskItem: QuickPickItem | undefined = await input.findQuickPick('Tasks: Run Task');
 		await runTaskItem?.click();
+		// pause for avoiding StaleElement exception. It is easier solution than try/catch or writing separate function for this
 		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_DEFAULT_POLLING);
 		const devFileTask: QuickPickItem | undefined = await input.findQuickPick('devfile');
 		await devFileTask?.click();
+		// pause for avoiding StaleElement exception. It is easier solution than try/catch or writing separate function for this
 		await driverHelper.wait(TIMEOUT_CONSTANTS.TS_SELENIUM_DEFAULT_POLLING);
 		const firstExpectedQuickPick: QuickPickItem | undefined = await input.findQuickPick('1. This command from the devfile');
 		const secondExpectedQuickPick: QuickPickItem | undefined = await input.findQuickPick('2. This command from the parent');

--- a/tests/e2e/specs/miscellaneous/WorkspaceWithParent.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceWithParent.spec.ts
@@ -88,16 +88,16 @@ suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMEN
 	});
 
 	test('Check expected containers in the parent POD', function (): void {
-		const getPodNameCommand: string = `${API_TEST_CONSTANTS.TS_API_TEST_KUBERNETES_COMMAND_LINE_TOOL} get pods -n ${BASE_TEST_CONSTANTS.TEST_NAMESPACE} --selector=controller.devfile.io/devworkspace_name=sample-using-parent --output jsonpath=\'{.items[0].metadata.name}\'`;
+		const getPodNameCommand: string = `${API_TEST_CONSTANTS.TS_API_TEST_KUBERNETES_COMMAND_LINE_TOOL} get pods -n ${kubernetesCommandLineToolsExecutor.namespace} --selector=controller.devfile.io/devworkspace_name=sample-using-parent --output jsonpath=\'{.items[0].metadata.name}\'`;
 
 		podName = shellExecutor.executeArbitraryShellScript(getPodNameCommand);
 		const containerNames: string = shellExecutor.executeArbitraryShellScript(
-			`${API_TEST_CONSTANTS.TS_API_TEST_KUBERNETES_COMMAND_LINE_TOOL} get pod ${podName} -n ${BASE_TEST_CONSTANTS.TEST_NAMESPACE} --output jsonpath=\'{.spec.containers[*].name}\'`
+			`${API_TEST_CONSTANTS.TS_API_TEST_KUBERNETES_COMMAND_LINE_TOOL} get pod ${podName} -n ${kubernetesCommandLineToolsExecutor.namespace} --output jsonpath=\'{.spec.containers[*].name}\'`
 		);
 		expect(containerNames).contains('tools').and.contains('che-gateway');
 
 		const initContainerName: string = shellExecutor.executeArbitraryShellScript(
-			`${API_TEST_CONSTANTS.TS_API_TEST_KUBERNETES_COMMAND_LINE_TOOL} get pod ${podName} -n ${BASE_TEST_CONSTANTS.TEST_NAMESPACE} --output jsonpath=\'{.spec.initContainers[].name}\'`
+			`${API_TEST_CONSTANTS.TS_API_TEST_KUBERNETES_COMMAND_LINE_TOOL} get pod ${podName} -n ${kubernetesCommandLineToolsExecutor.namespace} --output jsonpath=\'{.spec.initContainers[].name}\'`
 		);
 		expect(initContainerName).contains('che-code-injector');
 	});


### PR DESCRIPTION
### What does this PR do?
Add stabilization parts for the WorkspaceWithParent test. The main reason for failures was the long animation of different parts of UI, the most reliable solution using the driver waits. Because waiting for each web element adds complex parts to the test code.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://devspaces.apps.ocp413-mmusiie.crw-qe.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: admin
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: false
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java Lombok,Quarkus REST API,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DIRECTORY is not set
      USERSTORY: WorkspaceWithParent

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


            ‣ DriverHelper.getDriver
  Workspace using a parent test suite 
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - login to the "OC" client.
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.isUserLoggedIn - oc
          ▼ ShellExecutor.executeCommand - oc whoami && oc whoami --show-server=true
admin
https://api.ocp413-mmusiie.crw-qe.com:6443
.................
          ▼ OcpLoginPage.waitDisappearanceOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitDisappearance - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.isVisible - By(xpath, //*[contains(text(), "Welcome")])
          ▼ OcpLoginPage.isAuthorizeOpenShiftIdentityProviderPageVisible
            ‣ DriverHelper.isVisible - By(xpath, //h1[text()="Authorize Access"])
            ‣ BrowserTabsUtil.maximize
          ▼ BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitStartingPageLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, .main-page-loader)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, .main-page-loader)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.navigateTo - https://devspaces.apps.ocp413-mmusiie.crw-qe.com/dashboard/#https://github.com/testsfactory/parentDevfile
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace sample-using-parent
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():sample-using-parent
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: sample-using-parent
          ▼ registerRunningWorkspace - with workspaceName:sample-using-parent
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 20392 seconds.
            ‣ DriverHelper.wait - (10000 milliseconds)
          ▼ ProjectAndFileTests.performTrustAuthorDialog
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Create a workspace using a parent (35798ms)
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - .devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - parent.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - README.md
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - parentdevfile
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Check cloning of the test project
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.wait - (1000 milliseconds)
    ✔ Check devfile VS Code tasks 
          ▼ ShellExecutor.executeArbitraryShellScript - oc get pods -n admin-devspaces --selector=controller.devfile.io/devworkspace_name=sample-using-parent --output jsonpath='{.items[0].metadata.name}'
 .................
            ‣ DriverHelper.getDriver

  5 passing (1m)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
Set up env vars and run tests from the image or directly. form user environment


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
