### PR TITLE
[Test] Dev Spaces load tests based on `kubect apply`

### DIFF
--- a/tests/performance/load-tests/README.md
+++ b/tests/performance/load-tests/README.md
@@ -1,0 +1,19 @@
+# Load tests
+
+Load tests should test the behaviour of server when user will run simultaneously several of workspaces. 
+
+## Prerequisites
+What do you need to run those tests
+- `kubectl` client installed
+- Openshift cluster with running Openshift DevSpaces
+- test user logged into DevSpaces Dashboard(this quaranies that user namespaces are created)
+
+## Running load tests
+1. Log in to Openshift cluster with DevSpaces deployed from terminal
+2. Start `load-test.sh` script from `test/e2e/performance/load-tests`. Set number of started workspaces by -c parameter(like ./load-test.sh -c 5).
+3. This script gets `cpp` sample devfile.yaml from DevSpaces devfile registry and starts workspaces.
+4. As results there are average time of workspace starting and number of failed workspaces.
+
+
+## Results and logs
+If workspace failed to start, logs are saved in current directory.

--- a/tests/performance/load-tests/README.md
+++ b/tests/performance/load-tests/README.md
@@ -1,6 +1,5 @@
-# Load tests
-
-Load tests should test the behaviour of server when user will run simultaneously several of workspaces. 
+# Overview
+This script tests how well OpenShift environment can handle running simultaneously many of workspaces. It evaluates the performance of the system under test by checking the average results across all pods and identifying failures that occur during the testing process. 
 
 ## Prerequisites
 What do you need to run those tests
@@ -9,7 +8,7 @@ What do you need to run those tests
 - test user logged into DevSpaces Dashboard(this quaranies that user namespaces are created)
 
 ## Running load tests
-1. Log in to Openshift cluster with DevSpaces deployed from terminal
+1. Log in to Openshift cluster with Openshift DevSpaces or Eclipse Che deployed from terminal
 2. Start `load-test.sh` script from `test/e2e/performance/load-tests`. Set number of started workspaces by -c parameter(like ./load-test.sh -c 5).
 3. This script gets `cpp` sample devfile.yaml from DevSpaces devfile registry and starts workspaces.
 4. As results there are average time of workspace starting and number of failed workspaces.

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -e
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+function print() {
+  echo -e "${GREEN}$1${NC}"
+}
+
+function print_error() {
+  echo -e "${RED}$1${NC}"
+}
+
+function cleanup() {
+  echo "Clean up the environment"
+  kubectl delete dw --all > /dev/null
+  kubectl delete dwt --all > /dev/null
+}
+
+while getopts "c:" opt; do 
+  case $opt in
+    c) export COMPLETITIONS_COUNT=$OPTARG
+      ;;
+    \?) # invalid option
+      exit 1
+      ;;
+    :)
+      echo "Option \"$opt\" needs an argument."
+      exit 1
+      ;;
+  esac
+done
+
+# Set the number of workspaces to start
+if [ -z $COMPLETITIONS_COUNT ]; then
+  echo "Parameter -c wasn't set, setting completitions count to 3."
+  export COMPLETITIONS_COUNT=3
+fi
+
+# Checkout to user devspaces namespace
+export userName=$(kubectl config view --minify -o jsonpath='{.users[0].name}' | sed 's|/.*||')
+kubectl config set-context --current --namespace=$userName-devspaces
+
+# Delete all dw and dwt objects from test namespace
+cleanup
+
+# Delete logs
+rm dw* || true
+
+# Get Openshift DevSpaces url and path to sample devfile yaml from devfile-registry
+export devworkspaceUrl=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}' | sed 's/:6443//' | sed 's/api/devspaces.apps/')
+export testDevfilePath="devfile-registry/devfiles/TP__cpp__c-plus-plus/devworkspace-che-code-latest.yaml"
+
+echo "Download the devfile"
+curl --insecure "$devworkspaceUrl/$testDevfilePath" -o devfile.yaml
+
+echo "Start workspaces from sample devfile"
+csplit devfile.yaml /---/
+mv xx00 dwt.yaml
+mv xx01 dw.yaml
+kubectl apply -f dwt.yaml
+
+for ((i=1; i<=$COMPLETITIONS_COUNT; i++)); do
+  cat dw.yaml | sed "0,/name: cpp/s//name: dw$i/" | kubectl apply -f -
+done
+
+total_time=0
+succeeded=0
+echo  "Wait for all workspaces are started and calculate average workspaces starting time"
+for ((i=1; i<=$COMPLETITIONS_COUNT; i++)); do
+  if kubectl wait --for=condition=Ready "dw/dw$i" --timeout=120s; then
+    start_time=$(kubectl get dw dw$i --template='{{range .status.conditions}}{{if eq .type "Started"}}{{.lastTransitionTime}}{{end}}{{end}}')
+    end_time=$(kubectl get dw dw$i --template='{{range .status.conditions}}{{if eq .type "Ready"}}{{.lastTransitionTime}}{{end}}{{end}}')
+    start_timestamp=$(date -d $start_time +%s)
+    end_timestamp=$(date -d $end_time +%s)
+    dw_starting_time=$((end_timestamp - start_timestamp))
+
+    print "Devworkspace dw$i starting time: $dw_starting_time seconds"
+    total_time=$((total_time + dw_starting_time))
+    succeeded=$((succeeded + 1))
+  else
+    print_error "Timeout waiting for dw$i to become ready or an error occurred."
+    kubectl describe dw dw$i > dw$i-log.log
+    kubectl logs $(oc get dw dw$i --template='{{.status.devworkspaceId}}') > dw$i-pod.log || true
+fi        
+done
+
+print "==================== Test results ===================="
+print "Average workspace starting time for $succeeded workspaces from $COMPLETITIONS_COUNT started: $((total_time / succeeded)) seconds"
+print "$((COMPLETITIONS_COUNT - succeeded)) workspaces failed. See logs for details."
+
+trap cleanup ERR EXIT
+

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -90,7 +90,7 @@ done
 
 print "==================== Test results ===================="
 print "Average workspace starting time for $succeeded workspaces from $COMPLETITIONS_COUNT started: $((total_time / succeeded)) seconds"
-print "$((COMPLETITIONS_COUNT - succeeded)) workspaces failed. See logs for details."
+print "$((COMPLETITIONS_COUNT - succeeded)) workspaces failed. See failed workspace pod logs in the current folder for details."
 
 trap cleanup ERR EXIT
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Currently, for load tests we use UI e2e approach - https://github.com/eclipse/che/tree/main/tests/e2e/specs

This is not the best way to do the load testing. Need to reconsider this approach and use
`kubectl apply` which would run simultaneously hundreds of workspaces. We should time:

- number of failures
- startup time (avg / median)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5633

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Log in to Openshift cluster with DevSpaces deployed from terminal
2. Start `load-test.sh` script from test/e2e/performance/load-tests. Set number of started workspaces by -c parameter(like`./load-test.sh -c 5`).
3. This script gets cpp sample devfile.yaml from DevSpaces devfile registry and starts workspaces.
4. As results there are average time of workspace starting and number of failed workspaces.

### Test logs
```
[user@fedora load-tests]$ ./load-test.sh -c 15
Context "user-devspaces/api-ocp413-crw-qe-com:6443/user" modified.
Clean up the environment
Download the devfile
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3811  100  3811    0     0   9274      0 --:--:-- --:--:-- --:--:--  9295
Start workspaces from sample devfile
2502
1309
devworkspacetemplate.workspace.devfile.io/che-code-cpp created
devworkspace.workspace.devfile.io/dw1 created
devworkspace.workspace.devfile.io/dw2 created
devworkspace.workspace.devfile.io/dw3 created
devworkspace.workspace.devfile.io/dw4 created
devworkspace.workspace.devfile.io/dw5 created
devworkspace.workspace.devfile.io/dw6 created
devworkspace.workspace.devfile.io/dw7 created
devworkspace.workspace.devfile.io/dw8 created
devworkspace.workspace.devfile.io/dw9 created
devworkspace.workspace.devfile.io/dw10 created
devworkspace.workspace.devfile.io/dw11 created
devworkspace.workspace.devfile.io/dw12 created
devworkspace.workspace.devfile.io/dw13 created
devworkspace.workspace.devfile.io/dw14 created
devworkspace.workspace.devfile.io/dw15 created
Wait for all workspaces are started and calculate average workspaces starting time
devworkspace.workspace.devfile.io/dw1 condition met
Devworkspace dw1 starting time: 13 seconds
devworkspace.workspace.devfile.io/dw2 condition met
Devworkspace dw2 starting time: 23 seconds
error: timed out waiting for the condition on devworkspaces/dw3
Timeout waiting for dw3 to become ready or an error occurred.
Error from server (NotFound): pods "workspace447d6cf327464a20" not found
error: timed out waiting for the condition on devworkspaces/dw4
Timeout waiting for dw4 to become ready or an error occurred.
Error from server (NotFound): pods "workspace30636f3ff61144ff" not found
devworkspace.workspace.devfile.io/dw5 condition met
Devworkspace dw5 starting time: 21 seconds
error: timed out waiting for the condition on devworkspaces/dw6
Timeout waiting for dw6 to become ready or an error occurred.
Error from server (NotFound): pods "workspace60b59ef1d3584e05" not found
devworkspace.workspace.devfile.io/dw7 condition met
Devworkspace dw7 starting time: 18 seconds
devworkspace.workspace.devfile.io/dw8 condition met
Devworkspace dw8 starting time: 16 seconds
devworkspace.workspace.devfile.io/dw9 condition met
Devworkspace dw9 starting time: 26 seconds
devworkspace.workspace.devfile.io/dw10 condition met
Devworkspace dw10 starting time: 13 seconds
devworkspace.workspace.devfile.io/dw11 condition met
Devworkspace dw11 starting time: 12 seconds
devworkspace.workspace.devfile.io/dw12 condition met
Devworkspace dw12 starting time: 11 seconds
devworkspace.workspace.devfile.io/dw13 condition met
Devworkspace dw13 starting time: 11 seconds
devworkspace.workspace.devfile.io/dw14 condition met
Devworkspace dw14 starting time: 10 seconds
devworkspace.workspace.devfile.io/dw15 condition met
Devworkspace dw15 starting time: 9 seconds
==================== Test results ====================
Average workspace starting time for 12 workspaces from 15 started: 15 seconds
3 workspaces failed. See logs for details.
```
![image](https://github.com/eclipse/che/assets/7760565/0261f12a-6436-4d69-b6f7-6c98611b2efc)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
