### PR TITLE
[Test] Use test constants to get OCP user name and password in WorkspaceIdleTimeout test

### DIFF
--- a/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
@@ -24,6 +24,7 @@ import { KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesComman
 import { ShellExecutor } from '../../utils/ShellExecutor';
 import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { OAUTH_CONSTANTS } from '../../constants/OAUTH_CONSTANTS';
 
 suite('"Check workspace idle timeout" test', function (): void {
 	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
@@ -46,7 +47,7 @@ suite('"Check workspace idle timeout" test', function (): void {
 	let stopWorkspaceTimeout: number = 0;
 
 	suiteSetup(function (): void {
-		kubernetesCommandLineToolsExecutor.loginToOcp('admin');
+		kubernetesCommandLineToolsExecutor.loginToOcp(OAUTH_CONSTANTS.TS_SELENIUM_OCP_USERNAME, OAUTH_CONSTANTS.TS_SELENIUM_OCP_PASSWORD);
 		shellExecutor.executeCommand('oc project openshift-devspaces');
 
 		// get current value of spec.devEnvironments.secondsOfInactivityBeforeIdling

--- a/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
@@ -47,7 +47,7 @@ suite('"Check workspace idle timeout" test', function (): void {
 	let stopWorkspaceTimeout: number = 0;
 
 	suiteSetup(function (): void {
-		kubernetesCommandLineToolsExecutor.loginToOcp(OAUTH_CONSTANTS.TS_SELENIUM_OCP_USERNAME, OAUTH_CONSTANTS.TS_SELENIUM_OCP_PASSWORD);
+		kubernetesCommandLineToolsExecutor.loginToOcp();
 		shellExecutor.executeCommand('oc project openshift-devspaces');
 
 		// get current value of spec.devEnvironments.secondsOfInactivityBeforeIdling

--- a/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
@@ -24,7 +24,6 @@ import { KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesComman
 import { ShellExecutor } from '../../utils/ShellExecutor';
 import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
-import { OAUTH_CONSTANTS } from '../../constants/OAUTH_CONSTANTS';
 
 suite('"Check workspace idle timeout" test', function (): void {
 	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
[WorkspaceIdleTimeout](https://github.com/eclipse/che/blob/main/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts#L49) test works only with `admin` username. To work correcty we need to update login function to use OAUTH_CONSTANTS.TS_SELENIUM_OCP_USERNAME   and OAUTH_CONSTANTS.TS_SELENIUM_OCP_PASSWORD constants.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5738

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Set OCP user name and password in OAUTH_CONSTANTS constants for kubeadmin user like here:
export TS_SELENIUM_OCP_USERNAME="kubeadmin"
export TS_SELENIUM_OCP_PASSWORD="password"
2. Start WorkspaceIdleTimeout test and wait that test workspaces stopped by timeout.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
