### PR TITLE
[Test] Update RevokeOauth test to work correctly with github service status after revoking

### DIFF
--- a/tests/e2e/pageobjects/dashboard/UserPreferences.ts
+++ b/tests/e2e/pageobjects/dashboard/UserPreferences.ts
@@ -14,6 +14,7 @@ import { By } from 'selenium-webdriver';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { Logger } from '../../utils/Logger';
 import { GitProviderType } from '../../constants/FACTORY_TEST_CONSTANTS';
+import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 
 @injectable()
 export class UserPreferences {
@@ -83,7 +84,13 @@ export class UserPreferences {
 		await this.driverHelper.waitVisibility(UserPreferences.CONFIRMATION_WINDOW);
 		await this.driverHelper.waitAndClick(UserPreferences.DELETE_CONFIRMATION_CHECKBOX);
 		await this.driverHelper.waitAndClick(UserPreferences.DELETE_ITEM_BUTTON_ENABLED);
-		await this.driverHelper.waitDisappearance(this.getServicesListItemLocator(servicesName));
+
+		await this.driverHelper.waitAttributeValue(
+			this.getServicesListItemLocator(servicesName),
+			'disabled',
+			'true',
+			TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT
+		);
 	}
 
 	async selectListItem(servicesName: string): Promise<void> {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Previously github service after revoking was deleted from Services list(and Oauth secret from openshift-devspaces namespace also). For now it is only revoking OAuth from github.com and github service still in list. 
We need to update RevokeOauth test to wait not github service is disappeared but that its Autorization status is false.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5756

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### RevokeOauth test logs

```          ▼ Dashboard.waitStartingPageLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, .main-page-loader)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, .main-page-loader)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ UserPreferences.openUserPreferencesPage
            ‣ DriverHelper.waitAndClick - By(xpath, //header//button/span[text()!=""]//parent::button)
            ‣ DriverHelper.waitVisibility - By(xpath, //header//button/span[text()!=""]//parent::button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="User Preferences"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="User Preferences"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[text()="User Preferences"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ UserPreferences.openGitServicesTab
            ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="Git Services"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Git Services"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ UserPreferences.revokeGitService
          ▼ UserPreferences.selectListItem - of the 'GitHub' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="Revoke"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Revoke"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //span[text()="Revoke Git Services"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="warning-info-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="warning-info-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="revoke-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="revoke-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitAndGetElementAttribute - By(xpath, //tr[td[text()='GitHub']]//input) attribute: 'disabled'
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndGetElementAttribute - By(xpath, //tr[td[text()='GitHub']]//input) attribute: 'disabled'
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndGetElementAttribute - By(xpath, //tr[td[text()='GitHub']]//input) attribute: 'disabled'
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td[text()='GitHub']]//input)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Revoke OAuth test
```

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
