### PR TITLE
[Test] Format load-test script, correct 'no workspaces started' error handling

### DIFF
--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -96,7 +96,7 @@ function runTest() {
     else
       print_error "Timeout waiting for dw$i to become ready or an error occurred."
       kubectl describe dw dw$i >logs/dw$i-log.log
-      kubectl logs $(oc get dw dw$i --template='{{.status.devworkspaceId}}') >logs/dw$i-pod.log || true
+      kubectl logs $(kubectl get dw dw$i --template='{{.status.devworkspaceId}}') >logs/dw$i-pod.log || true
     fi
   done
 

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -10,101 +10,107 @@ NC='\033[0m' # No Color
 trap cleanup ERR SIGINT
 
 function print() {
-    echo -e "${GREEN}$1${NC}"
+  echo -e "${GREEN}$1${NC}"
 }
 
 function print_error() {
-    echo -e "${RED}$1${NC}"
+  echo -e "${RED}$1${NC}"
 }
 
 function cleanup() {
-    echo "Clean up the environment"
-    kubectl delete dw --all > /dev/null
-    kubectl delete dwt --all > /dev/null
+  echo "Clean up the environment"
+  kubectl delete dw --all >/dev/null
+  kubectl delete dwt --all >/dev/null
 }
 
 function parseArguments() {
   while getopts "t:c:" opt; do
-      case $opt in
-        t) export WORKSPACE_IDLE_TIMEOUT=$OPTARG
-          ;;      
-        c) # Check if the argument to -c is a number
-         if  ! [[ $OPTARG =~ ^[0-9]+$ ]]; then
-            print_error "Error: Option -c requires a numeric argument." >&2
-            exit 1
-         fi
-          export COMPLETITIONS_COUNT=$OPTARG
-          ;;
-        \?)
-          print_error "Invalid option -c. Try for example something like ./load-test.sh -c 7"
-          exit 1
-          ;;
-      esac
-    done
+    case $opt in
+    t)
+      export WORKSPACE_IDLE_TIMEOUT=$OPTARG
+      ;;
+    c) # Check if the argument to -c is a number
+      if ! [[ $OPTARG =~ ^[0-9]+$ ]]; then
+        print_error "Error: Option -c requires a numeric argument." >&2
+        exit 1
+      fi
+      export COMPLETITIONS_COUNT=$OPTARG
+      ;;
+    \?)
+      print_error "Invalid option -c. Try for example something like ./load-test.sh -c 7"
+      exit 1
+      ;;
+    esac
+  done
 }
 
 function setCompletitionsCount() {
-   # Set the number of workspaces to start
-   if [ -z $COMPLETITIONS_COUNT ]; then
-     echo "Parameter -c wasn't set, setting completitions count to 3."
-     export COMPLETITIONS_COUNT=3
-   else
-     echo "Parameter -c was set to  $COMPLETITIONS_COUNT ."
-   fi
+  # Set the number of workspaces to start
+  if [ -z $COMPLETITIONS_COUNT ]; then
+    echo "Parameter -c wasn't set, setting completitions count to 3."
+    export COMPLETITIONS_COUNT=3
+  else
+    echo "Parameter -c was set to  $COMPLETITIONS_COUNT ."
+  fi
 
-   # Set the number of timeouts for waiting for workspaces to start
-   if [ -z $WORKSPACE_IDLE_TIMEOUT ]; then
-     echo "Parameter -t wasn't set, setting timeout to 120 second."
-     export WORKSPACE_IDLE_TIMEOUT=120
-   else
-     echo "Parameter -t was set to $WORKSPACE_IDLE_TIMEOUT second."
-   fi   
+  # Set the number of timeouts for waiting for workspaces to start
+  if [ -z $WORKSPACE_IDLE_TIMEOUT ]; then
+    echo "Parameter -t wasn't set, setting timeout to 120 second."
+    export WORKSPACE_IDLE_TIMEOUT=120
+  else
+    echo "Parameter -t was set to $WORKSPACE_IDLE_TIMEOUT second."
+  fi
 }
 
 function runTest() {
-    # start COMPLETITIONS_COUNT workspaces in parallel
-    for ((i=1; i<=$COMPLETITIONS_COUNT; i++)); do
-      cat devworkspace.yaml | sed "0,/name: code-latest/s//name: dw$i/" | kubectl apply -f -  &
-    done
-    wait
+  # start COMPLETITIONS_COUNT workspaces in parallel
+  for ((i = 1; i <= $COMPLETITIONS_COUNT; i++)); do
+    cat devworkspace.yaml | sed "0,/name: code-latest/s//name: dw$i/" | kubectl apply -f - &
+  done
+  wait
 
-    # wait for all workspaces to be started
-    echo  "Wait for all workspaces are started"
-    for ((i=1; i<=$COMPLETITIONS_COUNT; i++)); do
-      kubectl wait --for=condition=Ready "dw/dw$i" --timeout=${WORKSPACE_IDLE_TIMEOUT}s || true &
-    done
-    wait
+  # wait for all workspaces to be started
+  echo "Wait for all workspaces are started"
+  for ((i = 1; i <= $COMPLETITIONS_COUNT; i++)); do
+    kubectl wait --for=condition=Ready "dw/dw$i" --timeout=${WORKSPACE_IDLE_TIMEOUT}s || true &
+  done
+  wait
 
-    # Delete logs on file system if it exists
-    rm -f logs/dw*
+  # Delete logs on file system if it exists
+  rm -f logs/dw*
 
-    total_time=0
-    succeeded=0
-    echo  "Calculate average workspaces starting time"
-    for ((i=1; i<=$COMPLETITIONS_COUNT; i++)); do
-      if [ "$(kubectl get dw dw$i --template='{{.status.phase}}')" == "Running" ]; then
-        start_time=$(kubectl get dw dw$i --template='{{range .status.conditions}}{{if eq .type "Started"}}{{.lastTransitionTime}}{{end}}{{end}}')
-        end_time=$(kubectl get dw dw$i --template='{{range .status.conditions}}{{if eq .type "Ready"}}{{.lastTransitionTime}}{{end}}{{end}}')
-        start_timestamp=$(date -d $start_time +%s)
-        end_timestamp=$(date -d $end_time +%s)
-        dw_starting_time=$((end_timestamp - start_timestamp))
+  total_time=0
+  succeeded=0
+  echo "Calculate average workspaces starting time"
+  for ((i = 1; i <= $COMPLETITIONS_COUNT; i++)); do
+    if [ "$(kubectl get dw dw$i --template='{{.status.phase}}')" == "Running" ]; then
+      start_time=$(kubectl get dw dw$i --template='{{range .status.conditions}}{{if eq .type "Started"}}{{.lastTransitionTime}}{{end}}{{end}}')
+      end_time=$(kubectl get dw dw$i --template='{{range .status.conditions}}{{if eq .type "Ready"}}{{.lastTransitionTime}}{{end}}{{end}}')
+      start_timestamp=$(date -d $start_time +%s)
+      end_timestamp=$(date -d $end_time +%s)
+      dw_starting_time=$((end_timestamp - start_timestamp))
 
-        print "Devworkspace dw$i starting time: $dw_starting_time seconds"
-        total_time=$((total_time + dw_starting_time))
-        succeeded=$((succeeded + 1))
-      else
-        print_error "Timeout waiting for dw$i to become ready or an error occurred."
-        kubectl describe dw dw$i > logs/dw$i-log.log
-        kubectl logs $(oc get dw dw$i --template='{{.status.devworkspaceId}}') > logs/dw$i-pod.log || true
+      print "Devworkspace dw$i starting time: $dw_starting_time seconds"
+      total_time=$((total_time + dw_starting_time))
+      succeeded=$((succeeded + 1))
+    else
+      print_error "Timeout waiting for dw$i to become ready or an error occurred."
+      kubectl describe dw dw$i >logs/dw$i-log.log
+      kubectl logs $(oc get dw dw$i --template='{{.status.devworkspaceId}}') >logs/dw$i-pod.log || true
     fi
-    done
+  done
 
 }
 
 function printResults() {
-   print "==================== Test results ===================="
-   print "Average workspace starting time for $succeeded workspaces from $COMPLETITIONS_COUNT started: $((total_time / succeeded)) seconds"
-   print "$((COMPLETITIONS_COUNT - succeeded)) workspaces failed. See failed workspace pod logs in the current folder for details."
+  print "==================== Test results ===================="
+  if [ $succeeded -eq 0 ]; then
+    print_error "No workspaces started successfully."
+    exit 1
+  else
+    print "Average workspace starting time for $succeeded workspaces from $COMPLETITIONS_COUNT started: $((total_time / succeeded)) seconds"
+  fi
+  print "$((COMPLETITIONS_COUNT - succeeded)) workspaces failed. See failed workspace pod logs in the current folder for details."
 }
 
 parseArguments "$@"


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Format load-test script, correct 'no workspaces started' error handling(script fails if all workspaces failed)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5633

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Log in to Openshift cluster with DevSpaces deployed from terminal
2. Start `load-test.sh` script from test/e2e/performance/load-tests. Set number of started workspaces by -c parameter(like`./load-test.sh -c 5`)
3. This script uses local dewvorspace.yaml to start workspaces.
4. As results there are average time of workspace starting and number of failed workspaces.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
