### PR TITLE
[Test] Check existed buttons in `Your workspace stopped by timeout` dialog

### DIFF
--- a/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
@@ -18,12 +18,11 @@ import { Workspaces } from '../../pageobjects/dashboard/Workspaces';
 import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { CheCodeLocatorLoader } from '../../pageobjects/ide/CheCodeLocatorLoader';
-import { Locators, ModalDialog } from 'monaco-page-objects';
+import { By, Locators, ModalDialog } from 'monaco-page-objects';
 import { expect } from 'chai';
 import { KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesCommandLineToolsExecutor';
 import { ShellExecutor } from '../../utils/ShellExecutor';
 import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
-import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 
 suite('"Check workspace idle timeout" test', function (): void {
 	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
@@ -39,11 +38,14 @@ suite('"Check workspace idle timeout" test', function (): void {
 	);
 	const shellExecutor: ShellExecutor = e2eContainer.get(CLASSES.ShellExecutor);
 	const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
-	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 
 	const stackName: string = 'Empty Workspace';
 	const cheClusterName: string = 'devspaces';
 	let stopWorkspaceTimeout: number = 0;
+
+	async function checkDialogButton(buttonName: string): Promise<void> {
+		await driverHelper.waitVisibility(By.xpath(`//div[@class='dialog-buttons']//a[text()='${buttonName}']`));
+	}
 
 	suiteSetup(function (): void {
 		kubernetesCommandLineToolsExecutor.loginToOcp();
@@ -84,21 +86,18 @@ suite('"Check workspace idle timeout" test', function (): void {
 		await projectAndFileTests.performTrustAuthorDialog();
 	});
 
-	test('Wait idle timeout dialog and click on "Return to Dashboard" button', async function (): Promise<void> {
+	test('Wait idle timeout dialog and check Dialog buttons', async function (): Promise<void> {
 		await driverHelper.waitVisibility(webCheCodeLocators.Dialog.details, TIMEOUT_CONSTANTS.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
 		const dialog: ModalDialog = new ModalDialog();
 		expect(await dialog.getDetails()).includes('Your workspace has stopped due to inactivity.');
-		await dialog.pushButton('Return to dashboard');
+		await checkDialogButton('Cancel');
+		await checkDialogButton('Return to dashboard');
+		await checkDialogButton('Restart your workspace');
 	});
 
 	test('Check that the workspace has Stopped state', async function (): Promise<void> {
-		await dashboard.waitPage();
-		await workspaces.waitWorkspaceWithStoppedStatus(WorkspaceHandlingTests.getWorkspaceName());
-	});
-
-	suiteTeardown('Open dashboard and close all other tabs', async function (): Promise<void> {
 		await dashboard.openDashboard();
-		await browserTabsUtil.closeAllTabsExceptCurrent();
+		await workspaces.waitWorkspaceWithStoppedStatus(WorkspaceHandlingTests.getWorkspaceName());
 	});
 
 	suiteTeardown('Stop and delete the workspace by API', async function (): Promise<void> {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Check existed buttons in `Your workspace stopped by timeout` dialog

### Screenshots
![Selection_240](https://github.com/eclipse/che/assets/7760565/adee22d3-557e-4e84-87f9-8cc59fd3a4cd)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-6003

### Logs

```
✔ Create and open new workspace, stack:Empty Workspace
          ▼ registerRunningWorkspace - with workspaceName:empty-2nsm
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout

            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 23394 seconds.
          ▼ ProjectAndFileTests.performTrustAuthorDialog
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Wait workspace readiness
            ‣ DriverHelper.waitVisibility - By(css selector, .dialog-message-detail)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout

            ‣ DriverHelper.waitVisibility - polling timed out attempt #97, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #98, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class='dialog-buttons']//a[text()='Cancel'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class='dialog-buttons']//a[text()='Return to dashboard'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class='dialog-buttons']//a[text()='Restart your workspace'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Wait idle timeout dialog and check Dialog buttons (107884ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "empty-2nsm"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='empty-2nsm']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Check that the workspace has Stopped state
          ▼ ShellExecutor.executeCommand - oc patch checluster devspaces --type=merge -p '{"spec":{"devEnvironments":{"secondsOfInactivityBeforeIdling": 60}}}'
checluster.org.eclipse.che/devspaces patched (no change)
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - empty-2nsm
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
          ▼ ApiUrlResolver.obtainUserNamespace - kubeapi success: admin-devspaces
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - empty-2nsm deleted successfully
          ▼     at /home/sskoryk/codenvy-projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name

            ‣ Context.deleteAllWorkspacesOnFinish - Property DELETE_WORKSPACE_ON_FAILED_TEST is true - trying to stop and delete all running workspace after test run with API.
          ▼ TestWorkspaceUtil.stopAndDeleteAllRunningWorkspaces
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
          ▼ ApiUrlResolver.obtainUserNamespace - kubeapi success: admin-devspaces
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.stopAllRunningWorkspaces
          ▼ ApiUrlResolver.obtainUserNamespace - admin-devspaces
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.quit
            ‣ DriverHelper.getDriver

  4 passing (3m)
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
