### PR TITLE
[Tests] Load tests should work correctly on macOs

### DIFF
--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -65,7 +65,7 @@ function setCompletitionsCount() {
 function runTest() {
   # start COMPLETITIONS_COUNT workspaces in parallel
   for ((i = 1; i <= $COMPLETITIONS_COUNT; i++)); do
-    cat devworkspace.yaml | sed "0,/name: code-latest/s//name: dw$i/" | kubectl apply -f - &
+    awk '/name:/ && !modif { sub(/name: .*/, "name: '"dw$i"'"); modif=1 } {print}' devworkspace.yaml | kubectl apply -f - &
   done
   wait
 

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -8,6 +8,8 @@ NC='\033[0m' # No Color
 
 # Do cleanup if the script is interrupted or fails
 trap cleanup ERR SIGINT
+# Detect the operating system
+OS="$(uname)"
 
 function print() {
   echo -e "${GREEN}$1${NC}"
@@ -49,7 +51,6 @@ function setCompletitionsCount() {
   if [ -z $COMPLETITIONS_COUNT ]; then
     echo "Parameter -c wasn't set, setting completitions count to 3."
     export COMPLETITIONS_COUNT=3
-  else
     echo "Parameter -c was set to  $COMPLETITIONS_COUNT ."
   fi
 
@@ -59,6 +60,15 @@ function setCompletitionsCount() {
     export WORKSPACE_IDLE_TIMEOUT=120
   else
     echo "Parameter -t was set to $WORKSPACE_IDLE_TIMEOUT second."
+  fi
+}
+
+function getTimestamp() {
+  if [ "$OS" = "Darwin" ]; then
+    date -j -f "%Y-%m-%dT%H:%M:%S" "$1" "+%s"
+  else
+    [ "$OS" = "Linux" ]
+    date -d $1 +%s
   fi
 }
 
@@ -88,8 +98,8 @@ function runTest() {
     if [ "$(kubectl get dw dw$i --template='{{.status.phase}}')" == "Running" ]; then
       start_time=$(kubectl get dw dw$i --template='{{range .status.conditions}}{{if eq .type "Started"}}{{.lastTransitionTime}}{{end}}{{end}}')
       end_time=$(kubectl get dw dw$i --template='{{range .status.conditions}}{{if eq .type "Ready"}}{{.lastTransitionTime}}{{end}}{{end}}')
-      start_timestamp=$(date -d $start_time +%s)
-      end_timestamp=$(date -d $end_time +%s)
+      start_timestamp=$(getTimestamp $start_time)
+      end_timestamp=$(getTimestamp $end_time)
       dw_starting_time=$((end_timestamp - start_timestamp))
 
       print "Devworkspace dw$i starting time: $dw_starting_time seconds"

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -78,6 +78,8 @@ function runTest() {
 
   # Delete logs on file system if it exists
   rm -f logs/dw*
+  # Create logs directory
+  mkdir logs || true
 
   total_time=0
   succeeded=0


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Load tests should work correctly on macOs

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5633

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Log in to Openshift cluster with DevSpaces deployed from terminal
2. Start `load-test.sh` script from test/e2e/performance/load-tests. Set number of started workspaces by -c parameter(like`./load-test.sh -c 5`)
3. This script uses local dewvorspace.yaml to start workspaces.
4. As results there are average time of workspace starting and number of failed workspaces.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
