### PR TITLE
[Test] Save events from failed workspaces in load-tests script

### DIFF
--- a/tests/performance/load-tests/devworkspace.yaml
+++ b/tests/performance/load-tests/devworkspace.yaml
@@ -11,12 +11,3 @@ spec:
       - name: dev
         container:
           image: quay.io/devfile/universal-developer-image:latest
-  contributions:
-    - name: che-code
-      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
-      components:
-        - name: che-code-runtime-description
-          container:
-            env:
-              - name: CODE_HOST
-                value: 0.0.0.0

--- a/tests/performance/load-tests/devworkspace.yaml
+++ b/tests/performance/load-tests/devworkspace.yaml
@@ -11,3 +11,12 @@ spec:
       - name: dev
         container:
           image: quay.io/devfile/universal-developer-image:latest
+  contributions:
+    - name: che-code
+      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
+      components:
+        - name: che-code-runtime-description
+          container:
+            env:
+              - name: CODE_HOST
+                value: 0.0.0.0

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -110,10 +110,9 @@ function runTest() {
       succeeded=$((succeeded + 1))
     else
       print_error "Timeout waiting for dw$i to become ready or an error occurred."
-      ws_name=$(kubectl get dw dw$i --template='{{.status.devworkspaceId}}')
-      kubectl describe dw dw$i >logs/dw$i-log.log
-      cat logs/events.log | grep $ws_name >logs/dw$i-events.log
-      kubectl logs $ws_name >logs/dw$i-pod.log || true
+      devworkspace_id=$(kubectl get dw dw$i --template='{{.status.devworkspaceId}}')
+      kubectl describe dw dw$i >logs/dw$i-describe.log
+      cat logs/events.log | grep $devworkspace_id >logs/dw$i-$devworkspace_id-events.log
     fi
   done
 

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -107,8 +107,10 @@ function runTest() {
       succeeded=$((succeeded + 1))
     else
       print_error "Timeout waiting for dw$i to become ready or an error occurred."
+      ws_name=$(kubectl get dw dw$i --template='{{.status.devworkspaceId}}')
       kubectl describe dw dw$i >logs/dw$i-log.log
-      kubectl logs $(kubectl get dw dw$i --template='{{.status.devworkspaceId}}') >logs/dw$i-pod.log || true
+      kubectl get events | grep $ws_name >logs/dw$i-events.log
+      kubectl logs $ws_name >logs/dw$i-pod.log || true
     fi
   done
 

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -109,7 +109,7 @@ function runTest() {
       print_error "Timeout waiting for dw$i to become ready or an error occurred."
       ws_name=$(kubectl get dw dw$i --template='{{.status.devworkspaceId}}')
       kubectl describe dw dw$i >logs/dw$i-log.log
-      kubectl get events | grep $ws_name >logs/dw$i-events.log
+      kubectl get events --field-selector involvedObject.kind=Pod | grep $ws_name >logs/dw$i-events.log
       kubectl logs $ws_name >logs/dw$i-pod.log || true
     fi
   done

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -91,6 +91,7 @@ function runTest() {
   # Create logs directory
   mkdir logs || true
 
+  # Get all events
   kubectl get events --field-selector involvedObject.kind=Pod >logs/events.log
 
   total_time=0

--- a/tests/performance/load-tests/load-test.sh
+++ b/tests/performance/load-tests/load-test.sh
@@ -91,6 +91,8 @@ function runTest() {
   # Create logs directory
   mkdir logs || true
 
+  kubectl get events --field-selector involvedObject.kind=Pod >logs/events.log
+
   total_time=0
   succeeded=0
   echo "Calculate average workspaces starting time"
@@ -109,7 +111,7 @@ function runTest() {
       print_error "Timeout waiting for dw$i to become ready or an error occurred."
       ws_name=$(kubectl get dw dw$i --template='{{.status.devworkspaceId}}')
       kubectl describe dw dw$i >logs/dw$i-log.log
-      kubectl get events --field-selector involvedObject.kind=Pod | grep $ws_name >logs/dw$i-events.log
+      cat logs/events.log | grep $ws_name >logs/dw$i-events.log
       kubectl logs $ws_name >logs/dw$i-pod.log || true
     fi
   done


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Save events from failed workspaces in load-tests script. Events saving takes time but kubectl doen't have command like oc client(`oc get events --since=1h`).

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5633

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Log in to Openshift cluster with DevSpaces deployed from terminal
2. Start `load-test.sh` script from test/e2e/performance/load-tests. Set number of started workspaces by -c parameter(like`./load-test.sh -c 5`)
3. This script uses local dewvorspace.yaml to start workspaces.
4. As results there are average time of workspace starting and number of failed workspaces.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
