### PR TITLE
[Test] Get workspace starting time in threads in load-tests script, simplify devworkspace yaml

### DIFF
--- a/tests/performance/load-tests/example.yaml
+++ b/tests/performance/load-tests/example.yaml
@@ -11,12 +11,3 @@ spec:
       - name: dev
         container:
           image: quay.io/devfile/universal-developer-image:latest
-  contributions:
-    - name: che-code
-      uri: https://eclipse-che.github.io/che-plugin-registry/main/v3/plugins/che-incubator/che-code/latest/devfile.yaml
-      components:
-        - name: che-code-runtime-description
-          container:
-            env:
-              - name: CODE_HOST
-                value: 0.0.0.0


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Get workspace starting time in threads in load-tests script, simplify devworkspace yaml. Getting dw start and succeeded time takes to much time if number of started workspace more then 100. This PR do it in threads and store starting time in file.

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-5633

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Log in to Openshift cluster with DevSpaces deployed from terminal
2. Start `load-test.sh` script from test/e2e/performance/load-tests. Set number of started workspaces by -c parameter(like`./load-test.sh -c 5`)
3. To use devworkspace yaml file from lint use -l option(like`./load-test.sh -l https://gist.githubusercontent.com/SkorikSergey/2eb152db36ed27a0736e0b367ee7f435/raw/dffdb84aaa8336977d9a1f25afe7749bb5c06e9a/simple-devworskpace.yaml`)
4. As results there are average time of workspace starting and number of failed workspaces.

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
