### PR TITLE
Change regexp for mocha expect which include verification for rhoas tool

### DIFF
--- a/tests/e2e/specs/web-terminal/WebTerminalUnderAdmin.spec.ts
+++ b/tests/e2e/specs/web-terminal/WebTerminalUnderAdmin.spec.ts
@@ -69,13 +69,14 @@ suite(`Login to Openshift console and start WebTerminal ${BASE_TEST_CONSTANTS.TE
 		const helpCommandExpectedResult: string =
 			'oc.*\\d+\\.\\d+\\.\\d+.*OpenShift CLI\n' +
 			'kubectl.*\\d+\\.\\d+\\.\\d+.*Kubernetes CLI\n' +
-			'kustomize.*\\d+\\.\\d+\\.\\d+.*Kustomize CLI \\(built-in to kubectl\\)\n' +
+			'kustomize.*\\d+\\.\\d+\\.\\d+.*Kustomize CLI\n' +
 			'helm.*\\d+\\.\\d+\\.\\d+.*Helm CLI\n' +
 			'kn.*\\d+\\.\\d+\\.\\d+.*KNative CLI\n' +
 			'tkn.*\\d+\\.\\d+\\.\\d+.*Tekton CLI\n' +
 			'subctl.*\\d+\\.\\d+\\.\\d+.*Submariner CLI\n' +
 			'odo.*\\d+\\.\\d+\\.\\d+.*Red Hat OpenShift Developer CLI\n' +
 			'virtctl.*\\d+\\.\\d+\\.\\d+.*KubeVirt CLI\n' +
+			'rhoas.*\\d+\\.\\d+\\.\\d+.*Red Hat OpenShift Application Services CLI\n' +
 			'jq.*\\d+\\.\\d+.*jq';
 
 		await webTerminal.typeAndEnterIntoWebTerminal(`help > ${fileForVerificationTerminalCommands}`);


### PR DESCRIPTION
### What does this PR do?
After several failures  Jenkins job for checking WTO I figure out that WTO v1.10 includes a new tool - rhoas. This PR adds into mocha regexp verification of this.

### Screenshot/screencast of this PR
```
.......
To customize this terminal, see 'wtoctl'
    ✔ Verify help command under admin user
          ▼ WebTerminalPage.typeAndEnterIntoWebTerminal
            ‣ DriverHelper.waitPresence - By(xpath, //*[@class="xterm-helper-textarea"])
            ‣ DriverHelper.typeToInvisible - By(xpath, //*[@class="xterm-helper-textarea"]) text: wtoctl set timeout 30s
            ‣ DriverHelper.waitPresence - By(xpath, //*[@class="xterm-helper-textarea"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[contains(text(),"The terminal connection has closed")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Restart terminal"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Verify help command under admin user
          ▼ ShellExecutor.executeArbitraryShellScript - oc delete dw --all -n openshift-terminal
          ▼ ShellExecutor.executeCommand - oc delete dw --all -n openshift-terminal
devworkspace.workspace.devfile.io "terminal-ltnl2v" deleted

            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.quit
            ‣ DriverHelper.getDriver

  5 passing (58s)
```



### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-277


### How to test this PR?
Set up environments and run the test as well 


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
