### PR TITLE
Add delay for correct finishing command results

### DIFF
--- a/tests/e2e/specs/web-terminal/WebTerminalUnderAdmin.spec.ts
+++ b/tests/e2e/specs/web-terminal/WebTerminalUnderAdmin.spec.ts
@@ -80,6 +80,9 @@ suite(`Login to Openshift console and start WebTerminal ${BASE_TEST_CONSTANTS.TE
 			'jq.*\\d+\\.\\d+.*jq';
 
 		await webTerminal.typeAndEnterIntoWebTerminal(`help > ${fileForVerificationTerminalCommands}`);
+
+		// need 5 sec. delay for finishing writing results of help command into txt file. The 5 sec delay is enough for the most cases
+		await driverHelper.wait(5000);
 		const commandResult: string = kubernetesCommandLineToolsExecutor.execInContainerCommand(
 			`cat /home/user/${fileForVerificationTerminalCommands}`,
 			webTerminalToolContainerName


### PR DESCRIPTION

### What does this PR do?

Trivial commit which add delay for correct finishing command and stabilize the test 
### Screenshot/screencast of this PR

https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/WTO/job/WTO-smee/job/wto-smee/93/

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/WTO-282


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
