### PR TITLE
Fix the RecommendedExtensions test

### DIFF
--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -40,7 +40,7 @@
 		"axios": "^0.25.0",
 		"chai": "^4.3.4",
 		"chrome-har": "^0.13.2",
-		"chromedriver": "^124.0",
+		"chromedriver": "^122.0",
 		"clone-deep": "^4.0.1",
 		"eslint": "^8.45.0",
 		"eslint-config-prettier": "^8.10.0",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -40,7 +40,7 @@
 		"axios": "^0.25.0",
 		"chai": "^4.3.4",
 		"chrome-har": "^0.13.2",
-		"chromedriver": "^122.0",
+		"chromedriver": "^124.0",
 		"clone-deep": "^4.0.1",
 		"eslint": "^8.45.0",
 		"eslint-config-prettier": "^8.10.0",

--- a/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
+++ b/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
@@ -81,8 +81,8 @@ for (const sample of samples) {
 		});
 
 		test('Check the project files were imported', async function (): Promise<void> {
-			// add 20 sec timeout for waiting for finishing animation of all IDE parts (Welcome parts. bottom widgets. etc.)
-			// using 20 sec easier than performing of finishing animation  all elements
+			// add TS_IDE_LOAD_TIMEOUT timeout for waiting for finishing animation of all IDE parts (Welcome parts. bottom widgets. etc.)
+			// using TS_IDE_LOAD_TIMEOUT easier than performing of finishing animation  all elements
 			await driverHelper.wait(TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
 			projectSection = await projectAndFileTests.getProjectViewSession();
 			expect(await projectAndFileTests.getProjectTreeItem(projectSection, pathToExtensionsListFileName), 'Files not imported').not
@@ -94,8 +94,7 @@ for (const sample of samples) {
 		});
 
 		test(`Get recommended extensions list from ${extensionsListFileName}`, async function (): Promise<void> {
-			// sometimes the Trust Dialog does not appear as expected - as result we can get opened Trust Box dialog. In this case.
-			// we need to perform this case
+			// sometimes the Trust Dialog does not appear as expected - as result we need to execute "projectAndFileTests.performManageWorkspaceTrustBox()" method. In this case.
 			try {
 				await (await projectAndFileTests.getProjectTreeItem(projectSection, pathToExtensionsListFileName))?.select();
 			} catch (err) {
@@ -119,8 +118,7 @@ for (const sample of samples) {
 
 		test('Open "Extensions" view section', async function (): Promise<void> {
 			Logger.debug('ActivityBar().getViewControl("Extensions"))?.openView(): open Extensions view.');
-			// sometimes the Trust Dialog does not appear as expected - as result we can get opened Trust Box dialog. In this case.
-			// we need to perform this case
+			// sometimes the Trust Dialog does not appear as expected - as result we need to execute "projectAndFileTests.performManageWorkspaceTrustBox()" method. In this case.
 			try {
 				extensionsView = await (await new ActivityBar().getViewControl('Extensions'))?.openView();
 			} catch (err) {
@@ -152,10 +150,15 @@ for (const sample of samples) {
 				TIMEOUT_CONSTANTS.TS_EDITOR_TAB_INTERACTION_TIMEOUT
 			);
 
+
 			for (const extension of parsedRecommendations) {
 				Logger.debug(`extensionSection.findItem(${extension.name}).`);
-				await extensionSection.findItem(extension.name);
-
+				try {
+					await extensionSection.findItem('@recommended');
+				} catch (err) {
+					await driverHelper.wait(TIMEOUT_CONSTANTS.TS_EXPAND_PROJECT_TREE_ITEM_TIMEOUT);
+					await extensionSection.findItem('@recommended');
+				}
 				const isReloadRequired: boolean = await driverHelper.isVisible(
 					(webCheCodeLocators.ExtensionsViewSection as any).requireReloadButton
 				);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix problem for performing when recommended extension more than one. And correct select and search extensions by author with the find menu. Also was improved and simplified mapping of recommended extension objects. Add blocks which close WorkspaceTrustBox menus in typical places

### Screenshot/screencast of this PR
```
> @eclipse-che/che-e2e@7.86.0-next test
> ./configs/sh-scripts/initDefaultValues.sh npm run lint && npm run tsc && export USERSTORY=$USERSTORY && mocha --config dist/configs/mocharc.js

Initialized default values

TS_SELENIUM_VALUE_TLS_SUPPORT =       
TS_SELENIUM_VALUE_OPENSHIFT_OAUTH =   true
TS_OCP_LOGIN_PAGE_PROVIDER_TITLE =    htpasswd
E2E_OCP_CLUSTER_VERSION =             4.x
TS_SELENIUM_LOG_LEVEL =               DEBUG
TS_SELENIUM_OCP_USERNAME =            admin
TS_SELENIUM_W3C_CHROME_OPTION =       true
NODE_TLS_REJECT_UNAUTHORIZED =        0
TS_SELENIUM_EDITOR =                  che-code

> @eclipse-che/che-e2e@7.86.0-next tsc
> rm -rf ./dist && ./configs/sh-scripts/generateIndex.sh && tsc -p .

Generating index.ts file...

################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://devspaces.apps.ocp414-mmusiie.crw-qe.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: admin
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: false
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java Lombok,Quarkus REST API,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DIRECTORY: dashboard-samples
      USERSTORY: RecommendedExtensions

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


            ‣ DriverHelper.getDriver
  Check if recommended extensions installed for Node.js MongoDB 
          ▼ LoginTests.loginIntoChe
.......................................
    ✔ Check if extensions are installed and enabled
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
.......................................
          ▼     at /home/mmusiien/che-projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name

  Check if recommended extensions installed for Ansible 
          ▼ LoginTests.loginIntoChe
            ‣ BrowserTabsUtil.getCurrentUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
.......................................
            ‣ DriverHelper.getDriver
    ✔ Create and open new workspace, stack:Ansible
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
  .......................................
    ✔ Obtain workspace name from workspace loader page
          ▼ registerRunningWorkspace - with workspaceName:ansible-demo
    ✔ Registering the running workspace
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
 .......................................
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 49655 seconds.
    ✔ Wait workspace readiness (49655ms)
            ‣ DriverHelper.wait - (20000 milliseconds)
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - .vscode
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Check the project files were imported
          ▼ ProjectAndFileTests.performTrustAuthorDialog
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Accept the project as a trusted one
          ▼ ProjectAndFileTests.getProjectTreeItem - .vscode
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - extensions.json
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='3'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ EditorView().openEditor(extensions.json)
            ‣ DriverHelper.waitVisibility - By(css selector, .inputarea)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ editor.getText(): get recommended extensions as text from editor, delete comments and parse to object.
          ▼ recommendedExtensions.recommendations: Get recommendations clear names using map().
          ▼ Recommended extension for this workspace:
          [{"publisher":"ms-python","name":"python"},{"publisher":"redhat","name":"ansible"},{"publisher":"redhat","name":"vscode-openshift-connector"},{"publisher":"ms-python","name":"black-formatter"}].
    ✔ Get recommended extensions list from extensions.json
          ▼ ActivityBar().getViewControl("Extensions"))?.openView(): open Extensions view.
    ✔ Open "Extensions" view section
          ▼ Time for extensions installation TimeoutConstants.TS_COMMON_PLUGIN_TEST_TIMEOUT=30000
            ‣ DriverHelper.wait - (30000 milliseconds)
    ✔ Let extensions complete installation (30033ms)
          ▼ ActivityBar().getViewControl("Extensions"))?.openView(): open Extensions view.
.......................................
            ‣ extensionMenuItems -> item.getLabel(): get menu items names.
          ▼ extensionMenuItemLabels: Disable Disable (Workspace) Install Another Version... Uninstall Copy Copy Extension ID Extension Settings Apply Extension to all Profiles Ignore Recommendation Remove from Workspace Recommendations .
    ✔ Check if extensions are installed and enabled
          ▼ Dashboard.openDashboard
 .......................................

            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.quit
            ‣ DriverHelper.getDriver

  100 passing (19m)


Process finished with exit code 0
```


### What issues does this PR fix or reference?
https://issues.redhat.com/projects/CRW/issues/CRW-6339


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
