### PR TITLE
Print error message from start workspace page in E2E test logs

### DIFF
--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -16,6 +16,7 @@ import { Logger } from '../utils/Logger';
 import { TIMEOUT_CONSTANTS } from '../constants/TIMEOUT_CONSTANTS';
 import { CheCodeLocatorLoader } from '../pageobjects/ide/CheCodeLocatorLoader';
 import { By, SideBarView, ViewContent, ViewItem, ViewSection, Workbench } from 'monaco-page-objects';
+import { WorkspaceHandlingTests } from '../tests-library/WorkspaceHandlingTests';
 
 @injectable()
 export class ProjectAndFileTests {
@@ -25,7 +26,9 @@ export class ProjectAndFileTests {
 		@inject(CLASSES.DriverHelper)
 		private readonly driverHelper: DriverHelper,
 		@inject(CLASSES.CheCodeLocatorLoader)
-		private readonly cheCodeLocatorLoader: CheCodeLocatorLoader
+		private readonly cheCodeLocatorLoader: CheCodeLocatorLoader,
+		@inject(CLASSES.WorkspaceHandlingTests)
+		private readonly workspaceHandlingTests: WorkspaceHandlingTests
 	) {}
 
 	async waitWorkspaceReadinessForCheCodeEditor(): Promise<void> {
@@ -40,6 +43,10 @@ export class ProjectAndFileTests {
 			Logger.debug(`editor was opened in ${end - start} seconds.`);
 		} catch (err) {
 			Logger.error(`waiting for workspace readiness failed: ${err}`);
+
+			// assume that start workspace page is still opened
+			await this.workspaceHandlingTests.logStartWorkspaceInfo();
+
 			throw err;
 		}
 	}

--- a/tests/e2e/tests-library/WorkspaceHandlingTests.ts
+++ b/tests/e2e/tests-library/WorkspaceHandlingTests.ts
@@ -23,6 +23,9 @@ import { By, error } from 'selenium-webdriver';
 @injectable()
 export class WorkspaceHandlingTests {
 	private static WORKSPACE_NAME: By = By.xpath('//h1[contains(.,"Starting workspace ")]');
+	private static WORKSPACE_STATUS: By = By.xpath('//*/span[@class="pf-c-label__content"]/text()');
+	private static WORKSPACE_ALERT_TITLE: By = By.xpath('//*/h4[@class="pf-c-alert__title"]/text()');
+	private static WORKSPACE_ALERT_DESCRIPTION: By = By.xpath('//*/div[@class="pf-c-alert__description"]');
 	private static workspaceName: string = 'undefined';
 	private static parentGUID: string;
 
@@ -111,10 +114,9 @@ export class WorkspaceHandlingTests {
 			Logger.info(`obtained workspace name from workspace loader page: ${WorkspaceHandlingTests.workspaceName}`);
 			return;
 		}
-		Logger.error(`failed to obtain workspace name:${WorkspaceHandlingTests.workspaceName}`);
-		throw new error.InvalidArgumentError(
-			`WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage failed to obtain workspace name:${WorkspaceHandlingTests.workspaceName}`
-		);
+		Logger.error('failed to obtain workspace name');
+		await this.logStartWorkspaceInfo();
+		throw new error.InvalidArgumentError('WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage failed to obtain workspace name.');
 	}
 
 	async stopWorkspace(workspaceName: string): Promise<void> {
@@ -130,5 +132,40 @@ export class WorkspaceHandlingTests {
 	async stopAndRemoveWorkspace(workspaceName: string): Promise<void> {
 		await this.dashboard.openDashboard();
 		await this.dashboard.stopAndRemoveWorkspaceByUI(workspaceName);
+	}
+
+	async getWorkspaceAlertDescription(): Promise<string> {
+		try {
+			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_ALERT_DESCRIPTION).getText();
+		} catch (err) {
+			return '';
+		}
+	}
+
+	async getWorkspaceStatus(): Promise<string> {
+		try {
+			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_STATUS).getText();
+		} catch (err) {
+			return '';
+		}
+	}
+
+	async getWorkspaceAlertTitle(): Promise<string> {
+		try {
+			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_ALERT_TITLE).getText();
+		} catch (err) {
+			return '';
+		}
+	}
+
+	async logStartWorkspaceInfo(): Promise<void> {
+		const status: string = await this.getWorkspaceStatus();
+		const alertTitle: string = await this.getWorkspaceAlertTitle();
+		const alertDescription: string = await this.getWorkspaceAlertDescription();
+
+		Logger.info('Start workspace status: ' + status);
+		if (status === 'Failed') {
+			Logger.info('Start workspace details: ' + alertTitle + ' - ' + alertDescription);
+		}
 	}
 }

--- a/tests/e2e/tests-library/WorkspaceHandlingTests.ts
+++ b/tests/e2e/tests-library/WorkspaceHandlingTests.ts
@@ -134,30 +134,6 @@ export class WorkspaceHandlingTests {
 		await this.dashboard.stopAndRemoveWorkspaceByUI(workspaceName);
 	}
 
-	async getWorkspaceAlertDescription(): Promise<string> {
-		try {
-			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_ALERT_DESCRIPTION).getText();
-		} catch (err) {
-			return '';
-		}
-	}
-
-	async getWorkspaceStatus(): Promise<string> {
-		try {
-			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_STATUS).getText();
-		} catch (err) {
-			return '';
-		}
-	}
-
-	async getWorkspaceAlertTitle(): Promise<string> {
-		try {
-			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_ALERT_TITLE).getAttribute('innerHTML');
-		} catch (err) {
-			return '';
-		}
-	}
-
 	async logStartWorkspaceInfo(): Promise<void> {
 		const status: string = await this.getWorkspaceStatus();
 		const alertTitle: string = await this.getWorkspaceAlertTitle();
@@ -166,5 +142,29 @@ export class WorkspaceHandlingTests {
 		Logger.info('Start workspace status: ' + status);
 		Logger.info('Start workspace progress title: ' + alertTitle);
 		Logger.info('Start workspace progress description: ' + alertDescription);
+	}
+
+	private async getWorkspaceAlertDescription(): Promise<string> {
+		try {
+			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_ALERT_DESCRIPTION).getText();
+		} catch (err) {
+			return '(unknown)';
+		}
+	}
+
+	private async getWorkspaceStatus(): Promise<string> {
+		try {
+			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_STATUS).getText();
+		} catch (err) {
+			return '(unknown)';
+		}
+	}
+
+	private async getWorkspaceAlertTitle(): Promise<string> {
+		try {
+			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_ALERT_TITLE).getAttribute('innerHTML');
+		} catch (err) {
+			return '(unknown)';
+		}
 	}
 }

--- a/tests/e2e/tests-library/WorkspaceHandlingTests.ts
+++ b/tests/e2e/tests-library/WorkspaceHandlingTests.ts
@@ -23,8 +23,8 @@ import { By, error } from 'selenium-webdriver';
 @injectable()
 export class WorkspaceHandlingTests {
 	private static WORKSPACE_NAME: By = By.xpath('//h1[contains(.,"Starting workspace ")]');
-	private static WORKSPACE_STATUS: By = By.xpath('//*/span[@class="pf-c-label__content"]/text()');
-	private static WORKSPACE_ALERT_TITLE: By = By.xpath('//*/h4[@class="pf-c-alert__title"]/text()');
+	private static WORKSPACE_STATUS: By = By.xpath('//*/span[@class="pf-c-label__content"]');
+	private static WORKSPACE_ALERT_TITLE: By = By.xpath('//h4[@class="pf-c-alert__title"]');
 	private static WORKSPACE_ALERT_DESCRIPTION: By = By.xpath('//*/div[@class="pf-c-alert__description"]');
 	private static workspaceName: string = 'undefined';
 	private static parentGUID: string;
@@ -152,7 +152,7 @@ export class WorkspaceHandlingTests {
 
 	async getWorkspaceAlertTitle(): Promise<string> {
 		try {
-			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_ALERT_TITLE).getText();
+			return await this.driverHelper.getDriver().findElement(WorkspaceHandlingTests.WORKSPACE_ALERT_TITLE).getAttribute('innerHTML');
 		} catch (err) {
 			return '';
 		}
@@ -164,8 +164,7 @@ export class WorkspaceHandlingTests {
 		const alertDescription: string = await this.getWorkspaceAlertDescription();
 
 		Logger.info('Start workspace status: ' + status);
-		if (status === 'Failed') {
-			Logger.info('Start workspace details: ' + alertTitle + ' - ' + alertDescription);
-		}
+		Logger.info('Start workspace progress title: ' + alertTitle);
+		Logger.info('Start workspace progress description: ' + alertDescription);
 	}
 }


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
It is extracting `Start workspace status` , `Start workspace progress title` , `Start workspace progress description`   information from "Creating workspace" page to improve test log analysis and give more patterns to ReportPortal automatic TFA.

### Screenshot/screencast of this PR
For the next workspace start failure:

![Screenshot from 2024-11-08 00-34-40](https://github.com/user-attachments/assets/b63b186c-9487-4f7e-b0a9-648c369ec9ca)

there was next test log with extracted `Start workspace status` , `Start workspace progress title` , `Start workspace progress description`  :
```
...
      ✔ Create and open new workspace from factory:https://github.com/dmytro-ndp/devfile-with-typo
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
  [ERROR] WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain workspace name
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
      • WorkspaceHandlingTests.logStartWorkspaceInfo - Start workspace status: Stopped
      • WorkspaceHandlingTests.logStartWorkspaceInfo - Start workspace progress title: <span class="pf-u-screen-reader">Warning alert:</span>Existing workspace found
      • WorkspaceHandlingTests.logStartWorkspaceInfo - Start workspace progress description: A workspace with the same name (devfile-with-typo) has been found. Should you want to open the existing workspace or proceed to create a new one, please choose the corresponding action.
      1) Obtain workspace name from workspace loader page
  [ERROR] CheReporter runner.on.fail: The SmokeTest userstory  Create workspace from factory:https://github.com/dmytro-ndp/devfile-with-typo Obtain workspace name from workspace loader page failed after 20768ms
            ‣ FullTitle:The SmokeTest userstory  Create workspace from factory:https://github.com/dmytro-ndp/devfile-with-typo Obtain workspace name from workspace loader page
            ‣ Function.sanitizeTitle
            ‣ FullTitleSanitized:The_SmokeTest_userstory__Create_workspace_from_factory-https-++github.com+dmytro-ndp+devfile-with-typo_Obtain_workspace_name_from_workspace_loader_page
            ‣ TestTitle:Obtain workspace name from workspace loader page
            ‣ Function.sanitizeTitle
            ‣ TestTitleSanitized:Obtain_workspace_name_from_workspace_loader_page
            ‣ DriverHelper.getDriver
          ▼     at /home/ndp/projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name


  1 passing (1m)
  1 failing

  1) The SmokeTest userstory 
       Create workspace from factory:https://github.com/dmytro-ndp/devfile-with-typo
         Obtain workspace name from workspace loader page:
     InvalidArgumentError: WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage failed to obtain workspace name.
...
```


### What issues does this PR fix or reference?
#22967 


### How to test this PR?
Functional tests run from this PR: https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/Testing/job/e2e/job/complex/job/latest/job/functional-tests/1669/


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
