### PR TITLE
add a new workflow to mark new issues with need-triage label

### DIFF
--- a/.github/workflows/need-triage-label.yaml
+++ b/.github/workflows/need-triage-label.yaml
@@ -1,0 +1,32 @@
+name: Label New Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Add Label "status/need-triage" if no label starting with "severity" exists
+      env:
+        GITHUB_TOKEN: ${{ secrets.CHE_BOT_GITHUB_TOKEN }}
+      run: |
+        ISSUE_NUMBER=${{ github.event.issue.number }}
+        REPO=${{ github.repository }}
+        LABEL_TO_ADD="status/need-triage"
+        LABEL_PREFIX="severity"
+        # Get the issue labels
+        ISSUE_LABELS=$(gh issue view $ISSUE_NUMBER --json labels --jq '.labels[].name')
+        # Check if any label starts with 'severity'
+        if echo "$ISSUE_LABELS" | grep -q "^$LABEL_PREFIX"; then
+          echo "A label starting with '$LABEL_PREFIX' exists. No action needed."
+        else
+          echo "No label starting with '$LABEL_PREFIX' found. Adding '$LABEL_TO_ADD'."
+          # Add the label to the issue
+          gh issue edit $ISSUE_NUMBER --add-label "$LABEL_TO_ADD"
+        fi


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Add a new workflow to mark new issues with need-triage label in case when no severity label exists

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/22942

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
