### PR TITLE
Add test for verification applying custom VSX plugin

### DIFF
--- a/tests/e2e/constants/BASE_TEST_CONSTANTS.ts
+++ b/tests/e2e/constants/BASE_TEST_CONSTANTS.ts
@@ -71,7 +71,7 @@ export const BASE_TEST_CONSTANTS: {
 	/**
 	 * testing application version
 	 */
-	TESTING_APPLICATION_VERSION: process.env.TESTING_APPLICATION_VERSION || '3.9',
+	TESTING_APPLICATION_VERSION: process.env.TESTING_APPLICATION_VERSION || 'next',
 
 	/**
 	 * is "https://access.redhat.com/documentation/en-us/red_hat_openshift_dev_spaces/{TESTING_APPLICATION_VERSION}/" available online

--- a/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
@@ -1,0 +1,217 @@
+/** *******************************************************************
+ * copyright (c) 2023 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { FACTORY_TEST_CONSTANTS } from '../../constants/FACTORY_TEST_CONSTANTS';
+import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { e2eContainer } from '../../configs/inversify.config';
+import { CLASSES, TYPES } from '../../configs/inversify.types';
+import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
+import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
+import { LoginTests } from '../../tests-library/LoginTests';
+import { ActivityBar, SideBarView, ViewItem, ViewSection } from 'monaco-page-objects';
+import { registerRunningWorkspace } from '../MochaHooks';
+import { Logger } from '../../utils/Logger';
+import { expect } from 'chai';
+import { ShellString } from 'shelljs';
+import { KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesCommandLineToolsExecutor';
+import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
+import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
+import { DriverHelper } from '../../utils/DriverHelper';
+import { error } from 'selenium-webdriver';
+
+suite(
+	`Create a workspace via launching a factory from the ${FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER} repository ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`,
+	function (): void {
+		const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+		const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+		const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
+		const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
+		const pathToPluginRegistry: string = '/projects/devspaces/dependencies/che-plugin-registry/';
+		const internalRegistry: string = 'image-registry.openshift-image-registry.svc:5000';
+		const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
+		const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+		const viewItems: ViewItem[] | undefined = [];
+		const imageTag: string = 'next';
+		const testRepoProjectName: string = 'devspaces';
+		let currentNamespace: string | undefined = '';
+		let cheClusterNamespace: string | undefined = '';
+		let cheClusterName: string | undefined = '';
+		let projectSection: ViewSection;
+		let kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor;
+		let workspaceName: string = '';
+		suiteSetup('Login', async function (): Promise<void> {
+			await loginTests.loginIntoChe();
+		});
+
+		test('Navigate to the factory URL', async function (): Promise<void> {
+			await browserTabsUtil.navigateTo(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_URL());
+		});
+
+		test('Obtain workspace name from workspace loader page', async function (): Promise<void> {
+			await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+			workspaceName = WorkspaceHandlingTests.getWorkspaceName();
+			expect(workspaceName, 'Workspace name was not fetched from the loading page').not.undefined;
+		});
+
+		test('Registering the running workspace', function (): void {
+			registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+		});
+
+		test('Wait the workspace readiness', async function (): Promise<void> {
+			await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+		});
+
+		test('Check if a project folder has been created', async function (): Promise<void> {
+			Logger.debug(`new SideBarView().getContent().getSection: get ${testRepoProjectName}`);
+			projectSection = await projectAndFileTests.getProjectViewSession();
+			expect(await projectAndFileTests.getProjectTreeItem(projectSection, testRepoProjectName), 'Project folder was not imported').not
+				.undefined;
+		});
+		test('Accept the project as a trusted one', async function (): Promise<void> {
+			await projectAndFileTests.performTrustAuthorDialog();
+		});
+		test('Edit VSX plugin list', function (): void {
+			// modify the openvsx-sync.json file with just one item - for speeding up the build an image
+			kubernetesCommandLineToolsExecutor = e2eContainer.get(CLASSES.KubernetesCommandLineToolsExecutor);
+			kubernetesCommandLineToolsExecutor.workspaceName = workspaceName;
+			kubernetesCommandLineToolsExecutor.loginToOcp('admin');
+			kubernetesCommandLineToolsExecutor.getPodAndContainerNames();
+			const pathToOpenVSXOriginFile: string = `${pathToPluginRegistry}openvsx-sync.json`;
+			const pathToOpenVSXTmpFile: string = `${pathToPluginRegistry}temp.json`;
+			const editVSCListCommand: string = `jq "[.[] | select(.id == \\"redhat.vscode-xml\\")]" ${pathToOpenVSXOriginFile} > ${pathToOpenVSXTmpFile} && mv ${pathToOpenVSXTmpFile} ${pathToOpenVSXOriginFile}`;
+			const output: ShellString = kubernetesCommandLineToolsExecutor.execInContainerCommand(editVSCListCommand);
+			expect(output.code).to.equals(0);
+			const getCheClusterNamespaceCommand: string = 'oc get checluster --all-namespaces -o json | jq -r ".items[0].metadata.name"';
+			const getCheClusterNameSpace: string = 'oc get checluster --all-namespaces -o json | jq -r ".items[0].metadata.namespace"';
+
+			// get che cluster name and namespace and init variables
+			cheClusterName = kubernetesCommandLineToolsExecutor.execInContainerCommand(getCheClusterNamespaceCommand).replace('\n', '');
+			cheClusterNamespace = kubernetesCommandLineToolsExecutor.execInContainerCommand(getCheClusterNameSpace).replace('\n', '');
+		});
+
+		test('Login podman into official registry', function (): void {
+			const commandToAuthenticateInRegistry: string = `podman login -u \"${process.env.REGISTRY_LOGIN}\" -p ${process.env.REGISTRY_PASSWORD} registry.redhat.io`;
+			const output: ShellString = kubernetesCommandLineToolsExecutor.execInContainerCommand(commandToAuthenticateInRegistry);
+			expect(output).contains('Login Succeeded!');
+		});
+
+		test('Build and push custom image', function (): void {
+			currentNamespace = kubernetesCommandLineToolsExecutor.namespace;
+			const podmanPushCommand: string = `podman push ${internalRegistry}/${currentNamespace}/che-plugin-registry:${imageTag}`;
+			const commandToBuildCustomVSXImage: string = `cd ${pathToPluginRegistry} && yes | ./build.sh`;
+			const commandLoginIntoInternalRegistry: string =
+				'podman login -u $(oc whoami | tr -d :) -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000';
+			const retagImageCommand: string = `podman tag quay.io/devspaces/pluginregistry-rhel8:next  ${internalRegistry}/${currentNamespace}/che-plugin-registry:${imageTag}`;
+
+			const output: ShellString = kubernetesCommandLineToolsExecutor.execInContainerCommand(commandToBuildCustomVSXImage);
+			expect(output.code).equals(0);
+
+			const outputRetagCommand: ShellString = kubernetesCommandLineToolsExecutor.execInContainerCommand(retagImageCommand);
+			expect(outputRetagCommand.code).equals(0);
+
+			const loginIntoInternalRegistryOutput: ShellString =
+				kubernetesCommandLineToolsExecutor.execInContainerCommand(commandLoginIntoInternalRegistry);
+			expect(loginIntoInternalRegistryOutput).contains('Login Succeeded!');
+
+			const outputPushCommand: ShellString = kubernetesCommandLineToolsExecutor.execInContainerCommand(podmanPushCommand);
+			expect(outputPushCommand.code).equals(0);
+		});
+
+		test('Configure Che to use the embedded Eclipse Open VSX server', function (): void {
+			// create secret for using internal registry
+			const createRegistrySecretCommand: string = `oc create secret -n ${cheClusterNamespace} docker-registry regcred --docker-server=${internalRegistry} --docker-username=\$(oc whoami | tr -d :) --docker-password=\$(oc whoami -t)`;
+			const createSecretOutput: string = kubernetesCommandLineToolsExecutor.execInContainerCommand(createRegistrySecretCommand);
+			expect(createSecretOutput).contains('regcred created');
+
+			// add secret to service account
+			const patchPart: string = '{\\"imagePullSecrets\\": [{\\"name\\": \\"regcred\\"}]}';
+			const addSecretToServiceAccountCommand: string = `oc patch serviceaccount default -n ${cheClusterNamespace} -p "${patchPart}"`;
+			const addSecretOutput: string = kubernetesCommandLineToolsExecutor.execInContainerCommand(addSecretToServiceAccountCommand);
+			expect(addSecretOutput).contains('default patched');
+
+			// patch che cluster with custom plugin registry
+			const patchVSXRegistryCommand: string = `cd ${pathToPluginRegistry} && ./patch-cluster.sh  ${internalRegistry}/${currentNamespace}/che-plugin-registry:${imageTag}`;
+			const patchVSXOutput: string = kubernetesCommandLineToolsExecutor.execInContainerCommand(patchVSXRegistryCommand);
+			expect(patchVSXOutput).contains('Patched CheCluster ');
+
+			// wait for deployment readiness after patching CHE cluster
+			const waitDeploymentReadiness: string = `oc rollout status deployment plugin-registry -n ${cheClusterNamespace} --timeout=120s`;
+			const waitDeploymentOutput: string = kubernetesCommandLineToolsExecutor.execInContainerCommand(waitDeploymentReadiness);
+			expect(waitDeploymentOutput).contains('successfully rolled out');
+		});
+
+		test('Recreate workspace and check VSX custom plugin ', async function (): Promise<void> {
+			await testWorkspaceUtil.deleteWorkspaceByName(WorkspaceHandlingTests.getWorkspaceName());
+			registerRunningWorkspace('');
+			await browserTabsUtil.navigateTo(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_URL());
+		});
+		test('Registering the running workspace', function (): void {
+			registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+		});
+
+		test('Check Custom VSX plugin', async function (): Promise<void> {
+			await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+			Logger.debug(`new SideBarView().getContent().getSection: get ${testRepoProjectName}`);
+			projectSection = await projectAndFileTests.getProjectViewSession();
+			expect(await projectAndFileTests.getProjectTreeItem(projectSection, testRepoProjectName), 'Project folder was not imported').not
+				.undefined;
+			await projectAndFileTests.performTrustAuthorDialog();
+			const extensionsView: SideBarView | undefined = await (await new ActivityBar().getViewControl('Extensions'))?.openView();
+			await driverHelper.wait(TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT);
+			const sections: ViewSection[] | undefined = await extensionsView?.getContent().getSections();
+			if (sections !== undefined) {
+				for (const section of sections) {
+					let currentItem: ViewItem[] = [];
+					// sometimes the item (not related with custom VSX) can be empty or not extended, but it is not an error for the test
+					// we do not need to control none VSX items
+					try {
+						currentItem = await section.getVisibleItems();
+					} catch (err) {
+						if (err instanceof error.ElementNotInteractableError) {
+							Logger.error('Current item is not interactable but test will continue');
+						} else {
+							throw err;
+						}
+					}
+					if (currentItem.length > 0) {
+						viewItems?.push(...currentItem);
+					}
+				}
+			}
+			expect(viewItems.length).equals(1);
+			expect(await viewItems[0].getText()).contains('XML Language Support by Red Hat');
+		});
+
+		suiteTeardown('Clean up resources and restore default CHE cluster CR', function (): void {
+			try {
+				kubernetesCommandLineToolsExecutor.execInContainerCommand(`oc delete secret regcred -n ${cheClusterNamespace}`);
+			} catch (error) {
+				Logger.error(`Error during deleting the secret: ${error}`);
+			}
+			try {
+				const patch: string = '[{"op": "remove", "path": "/imagePullSecrets", "value": {"name": "regcred"}}]';
+				const commandForRestoreServiceAccount: string = `oc patch serviceaccount default -n  ${cheClusterNamespace} --type=json -p="${patch}"`;
+				kubernetesCommandLineToolsExecutor.execInContainerCommand(commandForRestoreServiceAccount);
+			} catch (error) {
+				Logger.error(`Error during restoring the service account: ${error}`);
+			}
+			try {
+				const patchDeployment: string = '[{"op": "remove", "path": "/spec/components/pluginRegistry/deployment"}]';
+				const patchPluginRegistry: string = '[{"op": "remove", "path": "/spec/components/pluginRegistry/openVSXURL"}]';
+				const restoreDefaultDeploymentPluginRegistry: string = `oc patch checluster ${cheClusterName} --type=json -p="${patchDeployment}" -n ${cheClusterNamespace}`;
+				const restoreOpenVSXRegistry: string = `oc patch checluster ${cheClusterName} --type=json -p="${patchPluginRegistry}" -n ${cheClusterNamespace}`;
+				kubernetesCommandLineToolsExecutor.execInContainerCommand(restoreDefaultDeploymentPluginRegistry);
+				kubernetesCommandLineToolsExecutor.execInContainerCommand(restoreOpenVSXRegistry);
+			} catch (error) {
+				Logger.error(`Error during restoring the VSX registry: ${error}`);
+			}
+		});
+	}
+);

--- a/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
@@ -39,7 +39,9 @@ suite(
 		const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 		const viewItems: ViewItem[] | undefined = [];
 		const testRepoProjectName: string = 'devspaces';
-		const appVersion: string = BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION?BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION.replace(/(\.\d+)$/, ''):'next'
+		const appVersion: string = BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION
+			? BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION.split('.').slice(0, 2).join('.')
+			: 'next';
 		let currentNamespace: string | undefined = '';
 		let cheClusterNamespace: string | undefined = '';
 		let cheClusterName: string | undefined = '';

--- a/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
@@ -27,7 +27,7 @@ import { DriverHelper } from '../../utils/DriverHelper';
 import { error } from 'selenium-webdriver';
 
 suite(
-	`Create a workspace via launching a factory from the ${FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER} repository ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`,
+	`Create a workspace via launching a factory from the ${FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER} repository`,
 	function (): void {
 		const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 		const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
@@ -38,7 +38,6 @@ suite(
 		const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
 		const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 		const viewItems: ViewItem[] | undefined = [];
-		const imageTag: string = 'next';
 		const testRepoProjectName: string = 'devspaces';
 		let currentNamespace: string | undefined = '';
 		let cheClusterNamespace: string | undefined = '';
@@ -77,7 +76,7 @@ suite(
 		test('Accept the project as a trusted one', async function (): Promise<void> {
 			await projectAndFileTests.performTrustAuthorDialog();
 		});
-		test('Edit VSX plugin list', function (): void {
+		test('Remove VSX plugins and set redhat.vscode-xml', function (): void {
 			// modify the openvsx-sync.json file with just one item - for speeding up the build an image
 			kubernetesCommandLineToolsExecutor = e2eContainer.get(CLASSES.KubernetesCommandLineToolsExecutor);
 			kubernetesCommandLineToolsExecutor.workspaceName = workspaceName;
@@ -104,7 +103,7 @@ suite(
 
 		test('Build and push custom image', function (): void {
 			currentNamespace = kubernetesCommandLineToolsExecutor.namespace;
-			const podmanPushCommand: string = `podman push ${internalRegistry}/${currentNamespace}/che-plugin-registry:${imageTag}`;
+			const podmanPushCommand: string = `podman push ${internalRegistry}/${currentNamespace}/che-plugin-registry:${BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION}`;
 			const commandToBuildCustomVSXImage: string = `cd ${pathToPluginRegistry} && yes | ./build.sh`;
 			const commandLoginIntoInternalRegistry: string =
 				'podman login -u $(oc whoami | tr -d :) -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000';

--- a/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
@@ -53,7 +53,9 @@ suite(
 		});
 
 		test('Navigate to the factory URL', async function (): Promise<void> {
-			await browserTabsUtil.navigateTo(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_URL());
+			await browserTabsUtil.navigateTo(
+				FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_URL() || 'https://github.com/redhat-developer/devspaces/'
+			);
 		});
 
 		test('Obtain workspace name from workspace loader page', async function (): Promise<void> {

--- a/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
+++ b/tests/e2e/specs/miscellaneous/CustomOpenVSXRegistry.spec.ts
@@ -39,6 +39,7 @@ suite(
 		const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 		const viewItems: ViewItem[] | undefined = [];
 		const testRepoProjectName: string = 'devspaces';
+		const appVersion: string = BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION?BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION.replace(/(\.\d+)$/, ''):'next'
 		let currentNamespace: string | undefined = '';
 		let cheClusterNamespace: string | undefined = '';
 		let cheClusterName: string | undefined = '';
@@ -103,11 +104,11 @@ suite(
 
 		test('Build and push custom image', function (): void {
 			currentNamespace = kubernetesCommandLineToolsExecutor.namespace;
-			const podmanPushCommand: string = `podman push ${internalRegistry}/${currentNamespace}/che-plugin-registry:${BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION}`;
+			const podmanPushCommand: string = `podman push ${internalRegistry}/${currentNamespace}/che-plugin-registry:${appVersion}`;
 			const commandToBuildCustomVSXImage: string = `cd ${pathToPluginRegistry} && yes | ./build.sh`;
 			const commandLoginIntoInternalRegistry: string =
 				'podman login -u $(oc whoami | tr -d :) -p $(oc whoami -t) image-registry.openshift-image-registry.svc:5000';
-			const retagImageCommand: string = `podman tag quay.io/devspaces/pluginregistry-rhel8:next  ${internalRegistry}/${currentNamespace}/che-plugin-registry:${BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION}`;
+			const retagImageCommand: string = `podman tag quay.io/devspaces/pluginregistry-rhel8:next  ${internalRegistry}/${currentNamespace}/che-plugin-registry:${appVersion}`;
 
 			const output: ShellString = kubernetesCommandLineToolsExecutor.execInContainerCommand(commandToBuildCustomVSXImage);
 			expect(output.code).equals(0);
@@ -136,7 +137,7 @@ suite(
 			expect(addSecretOutput).contains('default patched');
 
 			// patch che cluster with custom plugin registry
-			const patchVSXRegistryCommand: string = `cd ${pathToPluginRegistry} && ./patch-cluster.sh  ${internalRegistry}/${currentNamespace}/che-plugin-registry:${BASE_TEST_CONSTANTS.TESTING_APPLICATION_VERSION}`;
+			const patchVSXRegistryCommand: string = `cd ${pathToPluginRegistry} && ./patch-cluster.sh  ${internalRegistry}/${currentNamespace}/che-plugin-registry:${appVersion}`;
 			const patchVSXOutput: string = kubernetesCommandLineToolsExecutor.execInContainerCommand(patchVSXRegistryCommand);
 			expect(patchVSXOutput).contains('Patched CheCluster ');
 


### PR DESCRIPTION
### What does this PR do?
The test automates workflow for building custom VSX images with customized plugins.:
* Create devworkspace using a factory from the appropriated GitHub project: https://github.com/redhat-developer/devspaces, checks the created workspaces
* Login to the official registry and change the default plugin list
* Build the custom VSX image, and create a secret for accessing the internal registry
* Re-tad and push this image into the internal cluster registry. 
* Change CHE cluster CR for consuming this image, wait to reconcile deployment
* Remove the previous DevSpace, create a new one, and verify that the custom plugin has been applied properly
* Clenup all previus resoirses


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from Eclipse che repository (or from another issue tracker).
     Include a link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
* Run using docker or natively
```
> @eclipse-che/che-e2e@7.90.0-next test
> ./configs/sh-scripts/initDefaultValues.sh npm run lint && npm run tsc && export USERSTORY=$USERSTORY && mocha --config dist/configs/mocharc.js

Initialized default values

TS_SELENIUM_VALUE_TLS_SUPPORT =       
TS_SELENIUM_VALUE_OPENSHIFT_OAUTH =   true
TS_OCP_LOGIN_PAGE_PROVIDER_TITLE =    htpasswd
E2E_OCP_CLUSTER_VERSION =             4.x
TS_SELENIUM_LOG_LEVEL =               DEBUG
TS_SELENIUM_OCP_USERNAME =            admin
TS_SELENIUM_W3C_CHROME_OPTION =       true
NODE_TLS_REJECT_UNAUTHORIZED =        0
TS_SELENIUM_EDITOR =                  che-code

> @eclipse-che/che-e2e@7.90.0-next tsc
> rm -rf ./dist && ./configs/sh-scripts/generateIndex.sh && tsc -p .

Generating index.ts file...
Warning: Cannot find any files matching pattern "dist/specs/CustomOpenVSXRegistry.spec.js"

################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://devspaces.apps.ocp416-mmusiie.crw-qe.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: admin
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: false
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java Lombok,Quarkus REST API,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DIRECTORY is not set
      USERSTORY: CustomOpenVSXRegistry

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


            ‣ DriverHelper.getDriver
  Create a workspace via launching a factory from the github repository 
          ▼ LoginTests.loginIntoChe
            ‣ BrowserTabsUtil.getCurrentUrl
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.navigateTo - https://devspaces.apps.ocp416-mmusiie.crw-qe.com
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
-------------------------
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
  Wait timed out after 1095ms
          ▼ LoginTests.loginIntoChe - try to login into application
          ▼ RegularUserOcpCheLoginPage.login
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="panel-login"]/div[contains(@class, "panel-content")]/form/button)
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="panel-login"]/div[contains(@class, "panel-content")]/form/button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.isIdentityProviderLinkVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.isVisible - By(xpath, //a[text()="htpasswd"])
          ▼ OcpLoginPage.waitAndClickOnLoginProviderTitle
            ‣ DriverHelper.waitAndClick - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitVisibility - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
-------------------------
            ‣ DriverHelper.getDriver
    ✔ Navigate to the factory URL
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
--------------------------
    ✔ Obtain workspace name from workspace loader page
          ▼ registerRunningWorkspace - with workspaceName:ds-plugin-registry-dev
    ✔ Registering the running workspace
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
 -------------------------
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 38083 seconds.
    ✔ Wait the workspace readiness (38085ms)
          ▼ new SideBarView().getContent().getSection: get devspaces
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devspaces
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Check if a project folder has been created
          ▼ ProjectAndFileTests.performTrustAuthorDialog
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
  Wait timed out after 1129ms
            ‣ DriverHelper.waitAndClick - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
 -------------------------
      • ProjectAndFileTests.performTrustAuthorDialog - Second welcome content dialog box was not shown
    ✔ Accept the project as a trusted one
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - login to the "OC" client.
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.isUserLoggedIn - oc
          ▼ ShellExecutor.executeCommand - oc whoami && oc whoami --show-server=true
admin
https://api.ocp416-mmusiie.crw-qe.com:6443
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - user already logged
          ▼ KubernetesCommandLineToolsExecutor.getPodAndContainerNames - oc
          ▼ KubernetesCommandLineToolsExecutor.getWorkspacePodName - oc - get workspace pod name.
          ▼ ShellExecutor.executeCommand - oc get pod -l controller.devfile.io/devworkspace_name=ds-plugin-registry-dev -n admin-devspaces -o name
pod/workspace506aa95bf7964e13-585786dd77-c7mvh
          ▼ KubernetesCommandLineToolsExecutor.getContainerName - oc - get container name.
          ▼ ShellExecutor.executeCommand - oc get pod/workspace506aa95bf7964e13-585786dd77-c7mvh -o jsonpath='{.spec.containers[*].name}' -n admin-devspaces
builder che-gateway

          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'jq "[.[] | select(.id == \"redhat.vscode-xml\")]" /projects/devspaces/dependencies/che-plugin-registry/openvsx-sync.json > /projects/devspaces/dependencies/che-plugin-registry/temp.json && mv /projects/devspaces/dependencies/che-plugin-registry/temp.json /projects/devspaces/dependencies/che-plugin-registry/openvsx-sync.json'
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc get checluster --all-namespaces -o json | jq -r ".items[0].metadata.name"'
devspaces
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc get checluster --all-namespaces -o json | jq -r ".items[0].metadata.namespace"'
devspaces
    ✔ Edit VSX plugin list
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'podman login -u "12698628|crw-bot" -p eyJhbGciOiJSUzUxMiJ9.eyJzdWIiOiI0NzhiMDY1ODJkZTE0ZmI4YWRmMzhiODJmNDJkMDMxOCJ9.JIl4MgEmiBvgk2hmaKhq-0vLF2UZ_r8iDb38BHzGOVT-OHZWU8JV1CzrEC2LrhAYsA0n5R0XgyfxipJG2JbaCa4N9Z-gD3u_bJyPZEJb127ke2yqDhE01zLxFFPXpy_mIK_Ca_oWUDYrveo9X5cJEuG8LfjrVhNDR9Y0BhWTEG7sDPhOK0EGy_GWA7gziaN5tcxLSY8CHbrWsfWm5SLvrzwyNIvvGWNb2Q8Ey0SclSGAe0z0v1JZsHTRggc1qHgDHUjUp8EGFRGa2L2JMlsw99kwdzY63T-8hDED1iMUF2XSUKqVc6NpsuKLMiKWwOALPvxhU6naIoqI3mEOrKPlrpahD1HBiXbpcntSQ_G2ug3O6syyxI_eGCMsFaKo5T4jIikx-q9tuASDXAieE05WMwclsTew-lxDg6-ioZpYnVly_G2R2Mv_loC3IMQVrbNcmF9ZosTyOoA_wUgOi-1Tc5IX0qEDMNDdwVqfCHgsrmVGtPXjgz1zQPYSnUF15wDJ9_Zekd3oVuwVAjAJ53VYcCDmgTw6510AItzLevEea8yDWTbjQ2A0fzkqyNlWOb8bkUirZLMKy_EloseQqlZ30PDpwBlnj4sW6T9qIBgpzaSSR7V95im6YTzh6r3zRy5JD5j-DUm-8IEd6MF-3ySQfP7tLI5kLJvRh7QDDm6oryY  registry.redhat.io'
Login Succeeded!
    ✔ Login podman into official registry
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'cd /projects/devspaces/dependencies/che-plugin-registry/ && yes | ./build.sh'
Load /projects/devspaces/dependencies/job-config.json [2]
Generate artifacts
npm WARN exec The following package was not found and will be installed: @eclipse-che/plugin-registry-generator@7.90.0-dev-aaaa682
- Analyze che-editors.yaml file
✔ Analyze che-editors.yaml file
- Generate v3/plugins/index.json file
✔ Generate v3/plugins/index.json file
- Generate v3/external_images.txt
✔ Generate v3/external_images.txt
- Write devfile.yamls in v3/plugins folder
✔ Write devfile.yamls in v3/plugins folder
🎉 Successfully generated in /projects/devspaces/dependencies/che-plugin-registry/output. Took a few seconds.
-------------------------
Writing manifest to image destination
    ✔ Build and push custom image (907769ms)
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc create secret -n devspaces docker-registry regcred --docker-server=image-registry.openshift-image-registry.svc:5000 --docker-username=$(oc whoami | tr -d :) --docker-password=$(oc whoami -t)'
secret/regcred created
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc patch serviceaccount default -n devspaces -p "{\"imagePullSecrets\": [{\"name\": \"regcred\"}]}"'
serviceaccount/default patched
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'cd /projects/devspaces/dependencies/che-plugin-registry/ && ./patch-cluster.sh  image-registry.openshift-image-registry.svc:5000/admin-devspaces/che-plugin-registry:next'
Patching CheCluster devspaces in namespace devspaces to use image-registry.openshift-image-registry.svc:5000/admin-devspaces/che-plugin-registry:next as plugin registry image.

Original CheCluster .spec.components.pluginRegistry:
{}

Patch file:
spec:
  components:
    pluginRegistry:
      deployment:
        containers:
          - name: plugin-registry
            image: image-registry.openshift-image-registry.svc:5000/admin-devspaces/che-plugin-registry:next

checluster.org.eclipse.che/devspaces patched

Patched CheCluster .spec.components.pluginRegistry:
{
  "deployment": {
    "containers": [
      {
        "image": "image-registry.openshift-image-registry.svc:5000/admin-devspaces/che-plugin-registry:next",
        "name": "plugin-registry"
      }
    ]
  }
}
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc rollout status deployment plugin-registry -n devspaces --timeout=120s'
Waiting for deployment "plugin-registry" rollout to finish: 1 old replicas are pending termination...
Waiting for deployment "plugin-registry" rollout to finish: 1 old replicas are pending termination...
deployment "plugin-registry" successfully rolled out
    ✔ Configure Che to use the embedded Eclipse Open VSX server
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - ds-plugin-registry-dev
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
(node:24762) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
          ▼ ApiUrlResolver.obtainUserNamespace - kubeapi success: admin-devspaces
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - ds-plugin-registry-dev deleted successfully
          ▼     at /home/mmusiien/che-projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name
          ▼ BrowserTabsUtil.navigateTo - https://devspaces.apps.ocp416-mmusiie.crw-qe.com/dashboard/#/https://github.com/redhat-developer/devspaces/tree/sv-fix-commands
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
    ✔ Recreate workspace and check VSX custom plugin 
          ▼ registerRunningWorkspace - with workspaceName:undefined
    ✔ Registering the running workspace
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            -------------------------
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 79684 seconds.
          ▼ new SideBarView().getContent().getSection: get devspaces
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devspaces
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.performTrustAuthorDialog
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.wait - (5000 milliseconds)
  [ERROR] Current item is not interactable but test will continue
    ✔ Wait the workspace readiness (89092ms)
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc delete secret regcred -n devspaces'
Error from server (NotFound): pods "workspace506aa95bf7964e13-585786dd77-c7mvh" not found
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc patch serviceaccount default -n  devspaces --type=json -p="[{"op": "remove", "path": "/imagePullSecrets", "value": {"name": "regcred"}}]"'
Error from server (NotFound): pods "workspace506aa95bf7964e13-585786dd77-c7mvh" not found
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc patch checluster devspaces --type=json -p="[{"op": "remove", "path": "/spec/components/pluginRegistry/deployment"}]" -n devspaces'
Error from server (NotFound): pods "workspace506aa95bf7964e13-585786dd77-c7mvh" not found
          ▼ KubernetesCommandLineToolsExecutor.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace506aa95bf7964e13-585786dd77-c7mvh -n admin-devspaces -c builder che-gateway -- sh -c 'oc patch checluster devspaces --type=json -p="[{"op": "remove", "path": "/spec/components/pluginRegistry/openVSXURL"}]" -n devspaces'
Error from server (NotFound): pods "workspace506aa95bf7964e13-585786dd77-c7mvh" not found


  13 passing (19m)


Process finished with exit code 0
```

### PR Checklist
!!! Note this is a "heavy" - test and we need to INCREASE MOCHA_DEFAULT_TIMEOUT approximately 1200 000ms
We need to pass the login and password for the official registry

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
