### PR TITLE
Handle 'TrustAuthor' popup in factory and WorkspaceWithParent tests

### DIFF
--- a/tests/e2e/specs/factory/Factory.spec.ts
+++ b/tests/e2e/specs/factory/Factory.spec.ts
@@ -39,6 +39,7 @@ import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { FACTORY_TEST_CONSTANTS } from '../../constants/FACTORY_TEST_CONSTANTS';
 import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { CreateWorkspace } from '../../pageobjects/dashboard/CreateWorkspace';
 
 suite(
 	`Create a workspace via launching a factory from the ${FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER} repository ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`,
@@ -53,6 +54,7 @@ suite(
 		const oauthPage: OauthPage = e2eContainer.get(CLASSES.OauthPage);
 		const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
 		const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+		const createWorkspace: CreateWorkspace = e2eContainer.get(CLASSES.CreateWorkspace);
 
 		let projectSection: ViewSection;
 		let scmProvider: SingleScmProvider;
@@ -72,6 +74,7 @@ suite(
 		});
 		test('Navigate to the factory URL', async function (): Promise<void> {
 			await browserTabsUtil.navigateTo(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_URL());
+			await createWorkspace.performTrustAuthorPopup();
 		});
 
 		if (OAUTH_CONSTANTS.TS_SELENIUM_GIT_PROVIDER_OAUTH) {

--- a/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
+++ b/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
@@ -40,6 +40,7 @@ import { FACTORY_TEST_CONSTANTS, GitProviderType } from '../../constants/FACTORY
 import { OAUTH_CONSTANTS } from '../../constants/OAUTH_CONSTANTS';
 import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
+import { CreateWorkspace } from '../../pageobjects/dashboard/CreateWorkspace';
 
 suite(
 	`Create a workspace via launching a factory from the ${FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER} repository without PAT/OAuth setup ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`,
@@ -54,6 +55,7 @@ suite(
 		const workspaces: Workspaces = e2eContainer.get(CLASSES.Workspaces);
 		const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 		const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
+		const createWorkspace: CreateWorkspace = e2eContainer.get(CLASSES.CreateWorkspace);
 
 		let projectSection: ViewSection;
 		let scmProvider: SingleScmProvider;
@@ -83,6 +85,7 @@ suite(
 
 		test(`Navigate to the ${isPrivateRepo} repository factory URL`, async function (): Promise<void> {
 			await browserTabsUtil.navigateTo(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_URL());
+			await createWorkspace.performTrustAuthorPopup();
 		});
 
 		if (FACTORY_TEST_CONSTANTS.TS_SELENIUM_IS_PRIVATE_FACTORY_GIT_REPO) {

--- a/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
+++ b/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
@@ -39,6 +39,7 @@ import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { FACTORY_TEST_CONSTANTS, GitProviderType } from '../../constants/FACTORY_TEST_CONSTANTS';
 import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { CreateWorkspace } from '../../pageobjects/dashboard/CreateWorkspace';
 
 suite(
 	`Create a workspace via launching a factory from the ${FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER} repository and deny the access ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`,
@@ -53,6 +54,7 @@ suite(
 		const oauthPage: OauthPage = e2eContainer.get(CLASSES.OauthPage);
 		const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
 		const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+		const createWorkspace: CreateWorkspace = e2eContainer.get(CLASSES.CreateWorkspace);
 
 		let projectSection: ViewSection;
 		let scmProvider: SingleScmProvider;
@@ -76,6 +78,7 @@ suite(
 
 		test(`Navigate to the ${isPrivateRepo} repository factory URL`, async function (): Promise<void> {
 			await browserTabsUtil.navigateTo(FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_URL());
+			await createWorkspace.performTrustAuthorPopup();
 		});
 
 		test(`Authorize with a ${FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_PROVIDER} OAuth and deny access`, async function (): Promise<void> {

--- a/tests/e2e/specs/miscellaneous/WorkspaceWithParent.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceWithParent.spec.ts
@@ -25,6 +25,7 @@ import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 import { FACTORY_TEST_CONSTANTS } from '../../constants/FACTORY_TEST_CONSTANTS';
+import { CreateWorkspace } from '../../pageobjects/dashboard/CreateWorkspace';
 
 suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -38,6 +39,7 @@ suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMEN
 		CLASSES.KubernetesCommandLineToolsExecutor
 	);
 	const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+	const createWorkspace: CreateWorkspace = e2eContainer.get(CLASSES.CreateWorkspace);
 
 	let podName: string = '';
 
@@ -56,6 +58,7 @@ suite(`Workspace using a parent test suite ${BASE_TEST_CONSTANTS.TEST_ENVIRONMEN
 				: BASE_TEST_CONSTANTS.TS_SELENIUM_BASE_URL + '/dashboard/#/' + FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL;
 		await dashboard.waitPage();
 		await browserTabsUtil.navigateTo(factoryUrl);
+		await createWorkspace.performTrustAuthorPopup();
 		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
 		registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
 		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();

--- a/tests/e2e/tests-library/WorkspaceHandlingTests.ts
+++ b/tests/e2e/tests-library/WorkspaceHandlingTests.ts
@@ -77,8 +77,6 @@ export class WorkspaceHandlingTests {
 	}
 
 	async obtainWorkspaceNameFromStartingPage(): Promise<void> {
-		await this.createWorkspace.performTrustAuthorPopup();
-
 		const timeout: number = TIMEOUT_CONSTANTS.TS_SELENIUM_START_WORKSPACE_TIMEOUT;
 		const polling: number = TIMEOUT_CONSTANTS.TS_SELENIUM_DEFAULT_POLLING;
 		const attempts: number = Math.ceil(timeout / polling);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fix Factory test failure https://github.com/eclipse-che/che-server/pull/708#issuecomment-2293669012

Failed test logs:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/eclipse-che_che-server/708/pull-ci-eclipse-che-che-server-main-v14-gitlab-with-oauth-setup-flow/1824432770110197760/build-log.txt

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://github.com/eclipse-che/che/issues/23063

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

Factory test has passed `Trust author` popup: https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/24953/console
```
...
14:32:48            ▼ BrowserTabsUtil.navigateTo - https://devspaces.apps.ocp416.crw-qe.com/dashboard/#/https://github.com/eclipse-che/che-server.git
14:32:48              ‣ DriverHelper.navigateToUrl
14:32:48              ‣ DriverHelper.getDriver
14:32:48            ▼ CreateWorkspace.performTrustAuthorPopup
14:32:48            ▼ TrustAuthorPopup.clickContinue
14:32:48            ▼ TrustAuthorPopup.waitPopupIsOpened
14:32:48              ‣ DriverHelper.waitVisibility - By(xpath, //span[contains(text(), "Do you trust the authors of this repository?")])
14:32:48              ‣ DriverHelper.waitVisibility - element is located and is visible.
14:32:48              ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="Continue"])
14:32:48              ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Continue"])
14:32:48              ‣ DriverHelper.waitVisibility - element is located and is visible.
14:32:48      ✔ Navigate to the factory URL
14:32:48              ‣ DriverHelper.getDriver
...
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
