### PR TITLE
[Test]: Changed WTO test to use kubeadmin login & fix getServerUrl

### DIFF
--- a/tests/e2e/specs/web-terminal/WebTerminalUnderAdmin.spec.ts
+++ b/tests/e2e/specs/web-terminal/WebTerminalUnderAdmin.spec.ts
@@ -33,7 +33,7 @@ suite(`Login to Openshift console and start WebTerminal ${BASE_TEST_CONSTANTS.TE
 	const fileForVerificationTerminalCommands: string = 'result.txt';
 
 	suiteSetup(function (): void {
-		kubernetesCommandLineToolsExecutor.loginToOcp('admin');
+		kubernetesCommandLineToolsExecutor.loginToOcp('kubeadmin');
 	});
 
 	suiteTeardown(function (): void {
@@ -63,7 +63,7 @@ suite(`Login to Openshift console and start WebTerminal ${BASE_TEST_CONSTANTS.TE
 			`cat /home/user/${fileForVerificationTerminalCommands}`,
 			webTerminalToolContainerName
 		);
-		expect(commandResult).contains('admin');
+		expect(commandResult).contains('kube:admin');
 	});
 	test('Verify help command under admin user', async function (): Promise<void> {
 		const helpCommandExpectedResult: string =

--- a/tests/e2e/utils/KubernetesCommandLineToolsExecutor.ts
+++ b/tests/e2e/utils/KubernetesCommandLineToolsExecutor.ts
@@ -202,8 +202,20 @@ export class KubernetesCommandLineToolsExecutor implements IKubernetesCommandLin
 
 	getServerUrl(): string {
 		Logger.debug(`${this.kubernetesCommandLineTool} - get server api url.`);
+		const baseUrl: URL = new URL(BASE_TEST_CONSTANTS.TS_SELENIUM_BASE_URL);
+		let apiHostname: string;
 
-		return BASE_TEST_CONSTANTS.TS_SELENIUM_BASE_URL.replace('devspaces.apps', 'api') + ':6443';
+		if (baseUrl.hostname.includes('devspaces.apps')) {
+			apiHostname = baseUrl.hostname.replace('devspaces.apps', 'api');
+		} else if (baseUrl.hostname.includes('console-openshift-console.apps')) {
+			apiHostname = baseUrl.hostname.replace('console-openshift-console.apps', 'api');
+		} else {
+			throw new Error(`Unexpected base URL hostname format: ${baseUrl.hostname}`);
+		}
+
+		const apiUrl: string = `https://${apiHostname}:6443`;
+		Logger.debug(`Generated API server URL: ${apiUrl}`);
+		return apiUrl;
 	}
 }
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
In job [/WTO/job/WTO-smee/job/wto-smee/](https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/WTO/job/WTO-smee/job/wto-smee/) changed the login to use kube:admin based on credentials from specific Flexy-install based on build number. In this PR i edited the test code to reflect changes and to login as kubeadmin during WTO test as admin.

The server URL was incorrectly parsed (the getServerURL()  expects URL in format `https://devspaces.apps.ocp417......com/` ) resulting in test failing, So i fixed it by adding a case where the BASE URL contains the `https://console-openshift-console.apps......com/` format which was used in this test case.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
[https://issues.redhat.com/browse/CRW-7483](https://issues.redhat.com/browse/CRW-7483)

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

tested on [https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/WTO/job/WTO-smee/job/wto-smee/126/](https://main-jenkins-csb-crwqe.apps.ocp-c1.prod.psi.redhat.com/job/WTO/job/WTO-smee/job/wto-smee/126/)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
