### PR TITLE
Stabilize devconsole integration tests

### DIFF
--- a/tests/e2e/pageobjects/openshift/OcpMainPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpMainPage.ts
@@ -16,6 +16,7 @@ import { Logger } from '../../utils/Logger';
 import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 import { OcpImportFromGitPage } from './OcpImportFromGitPage';
 import { e2eContainer } from '../../configs/inversify.config';
+import {BrowserTabsUtil} from "../../utils/BrowserTabsUtil";
 
 @injectable()
 export class OcpMainPage {
@@ -29,7 +30,9 @@ export class OcpMainPage {
 
 	constructor(
 		@inject(CLASSES.DriverHelper)
-		private readonly driverHelper: DriverHelper
+		private readonly driverHelper: DriverHelper,
+		@inject(CLASSES.BrowserTabsUtil)
+		private readonly browserTabsUtil: BrowserTabsUtil
 	) {}
 
 	async waitOpenMainPage(): Promise<void> {
@@ -106,5 +109,13 @@ export class OcpMainPage {
 		} else {
 			Logger.debug('welcome tour modal dialog was not located');
 		}
+	}
+	async clickOnAppLauncherAndDevSpaceItem(): Promise<void> {
+		Logger.debug('click on app launcher menu');
+		const parentGUID: string = await this.browserTabsUtil.getCurrentWindowHandle();
+		await this.driverHelper.waitAndClick(By.css('nav[data-test-id=\'application-launcher\']'));
+		await this.driverHelper.waitAndClick(By.xpath('//span[contains(.,\'Red Hat OpenShift Dev Spaces\')]'));
+		await this.browserTabsUtil.waitAndSwitchToAnotherWindow(parentGUID, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+
 	}
 }

--- a/tests/e2e/pageobjects/openshift/OcpMainPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpMainPage.ts
@@ -16,7 +16,7 @@ import { Logger } from '../../utils/Logger';
 import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 import { OcpImportFromGitPage } from './OcpImportFromGitPage';
 import { e2eContainer } from '../../configs/inversify.config';
-import {BrowserTabsUtil} from "../../utils/BrowserTabsUtil";
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 
 @injectable()
 export class OcpMainPage {
@@ -85,6 +85,14 @@ export class OcpMainPage {
 		await this.driverHelper.waitAndClick(this.getProjectDropdownItemLocator(projectName));
 	}
 
+	async clickOnAppLauncherAndDevSpaceItem(): Promise<void> {
+		Logger.debug('click on app launcher menu');
+		const parentGUID: string = await this.browserTabsUtil.getCurrentWindowHandle();
+		await this.driverHelper.waitAndClick(By.css('nav[data-test-id="application-launcher"]'));
+		await this.driverHelper.waitAndClick(By.xpath('//span[contains(.,"Red Hat OpenShift Dev Spaces")]'));
+		await this.browserTabsUtil.waitAndSwitchToAnotherWindow(parentGUID, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
+	}
+
 	private getRoleLocator(role: string): By {
 		return By.xpath(`//a//*[text()="${role}"]`);
 	}
@@ -98,7 +106,6 @@ export class OcpMainPage {
 
 		await this.driverHelper.waitAndClick(this.getRoleLocator(role));
 	}
-
 	private async tryToSkipWebTour(): Promise<void> {
 		Logger.debug();
 
@@ -109,13 +116,5 @@ export class OcpMainPage {
 		} else {
 			Logger.debug('welcome tour modal dialog was not located');
 		}
-	}
-	async clickOnAppLauncherAndDevSpaceItem(): Promise<void> {
-		Logger.debug('click on app launcher menu');
-		const parentGUID: string = await this.browserTabsUtil.getCurrentWindowHandle();
-		await this.driverHelper.waitAndClick(By.css('nav[data-test-id=\'application-launcher\']'));
-		await this.driverHelper.waitAndClick(By.xpath('//span[contains(.,\'Red Hat OpenShift Dev Spaces\')]'));
-		await this.browserTabsUtil.waitAndSwitchToAnotherWindow(parentGUID, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
-
 	}
 }

--- a/tests/e2e/specs/devconsole-intergration/DevConsoleIntegration.spec.ts
+++ b/tests/e2e/specs/devconsole-intergration/DevConsoleIntegration.spec.ts
@@ -14,7 +14,6 @@ import { LoginTests } from '../../tests-library/LoginTests';
 import { e2eContainer } from '../../configs/inversify.config';
 import { CLASSES } from '../../configs/inversify.types';
 import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
-import { DriverHelper } from '../../utils/DriverHelper';
 import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
 import { expect } from 'chai';
 import { OcpMainPage } from '../../pageobjects/openshift/OcpMainPage';
@@ -26,14 +25,14 @@ import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
-import {Logger} from "../../utils/Logger";
-import {ShellExecutor} from "../../utils/ShellExecutor";
-import {ShellString} from "shelljs";
+import { Logger } from '../../utils/Logger';
+import { ShellExecutor } from '../../utils/ShellExecutor';
+import { ShellString } from 'shelljs';
 
 suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 	let ocpImportPage: OcpImportFromGitPage;
 	let ocpApplicationPage: OcpApplicationPage;
-	let parentGUID=''
+	let parentGUID: string = '';
 	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
 	const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
 	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
@@ -41,7 +40,6 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 	const shellExecutor: ShellExecutor = e2eContainer.get(CLASSES.ShellExecutor);
 	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 	const ocpMainPage: OcpMainPage = e2eContainer.get(CLASSES.OcpMainPage);
-	const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 	const kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor = e2eContainer.get(
 		CLASSES.KubernetesCommandLineToolsExecutor
 	);
@@ -54,7 +52,7 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 	suiteSetup('Create new empty project using ocp', function (): void {
 		kubernetesCommandLineToolsExecutor.loginToOcp();
 		// delete the test project on a cluster if it has not been deleted properly in the previous run
-		const expectedProject :ShellString = shellExecutor.executeCommand(`oc get project ${projectName}`);
+		const expectedProject: ShellString = shellExecutor.executeCommand(`oc get project ${projectName}`);
 		if (expectedProject.stderr.length === 0) {
 			kubernetesCommandLineToolsExecutor.deleteProject(projectName);
 		}
@@ -62,8 +60,6 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 	});
 
 	loginTests.loginIntoOcpConsole();
-
-
 
 	test('Select test project and Developer role on DevConsole', async function (): Promise<void> {
 		parentGUID = await browserTabsUtil.getCurrentWindowHandle();
@@ -120,12 +116,12 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 		).not.undefined;
 	});
 
-	test ('Check redirection to DevSpaces from App launcher', async function (): Promise<void> {
+	test('Check redirection to DevSpaces from App launcher', async function (): Promise<void> {
 		await browserTabsUtil.switchToWindow(parentGUID);
 		await browserTabsUtil.closeAllTabsExceptCurrent();
 		await ocpMainPage.clickOnAppLauncherAndDevSpaceItem();
 		await loginTests.loginIntoChe();
-		await dashboard.waitPage()
+		await dashboard.waitPage();
 	});
 
 	suiteTeardown('Delete project using ocp', function (): void {
@@ -133,14 +129,12 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 			WorkspaceHandlingTests.getWorkspaceName() !== '' ? WorkspaceHandlingTests.getWorkspaceName() : 'spring-music';
 		try {
 			kubernetesCommandLineToolsExecutor.deleteDevWorkspace();
-		}
-		catch (err) {
+		} catch (err) {
 			Logger.error(`Error while deleting workspace: ${err}`);
 		}
 		try {
 			kubernetesCommandLineToolsExecutor.deleteProject(projectName);
-		}
-		catch (err) {
+		} catch (err) {
 			Logger.error(`Cannot delete the project: ${err}`);
 		}
 	});

--- a/tests/e2e/specs/devconsole-intergration/DevConsoleIntegration.spec.ts
+++ b/tests/e2e/specs/devconsole-intergration/DevConsoleIntegration.spec.ts
@@ -14,6 +14,7 @@ import { LoginTests } from '../../tests-library/LoginTests';
 import { e2eContainer } from '../../configs/inversify.config';
 import { CLASSES } from '../../configs/inversify.types';
 import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
+import { DriverHelper } from '../../utils/DriverHelper';
 import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
 import { expect } from 'chai';
 import { OcpMainPage } from '../../pageobjects/openshift/OcpMainPage';
@@ -25,17 +26,22 @@ import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
+import {Logger} from "../../utils/Logger";
+import {ShellExecutor} from "../../utils/ShellExecutor";
+import {ShellString} from "shelljs";
 
 suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 	let ocpImportPage: OcpImportFromGitPage;
 	let ocpApplicationPage: OcpApplicationPage;
-
+	let parentGUID=''
 	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
 	const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
 	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+	const shellExecutor: ShellExecutor = e2eContainer.get(CLASSES.ShellExecutor);
 	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
 	const ocpMainPage: OcpMainPage = e2eContainer.get(CLASSES.OcpMainPage);
+	const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 	const kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor = e2eContainer.get(
 		CLASSES.KubernetesCommandLineToolsExecutor
 	);
@@ -47,12 +53,20 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 
 	suiteSetup('Create new empty project using ocp', function (): void {
 		kubernetesCommandLineToolsExecutor.loginToOcp();
+		// delete the test project on a cluster if it has not been deleted properly in the previous run
+		const expectedProject :ShellString = shellExecutor.executeCommand(`oc get project ${projectName}`);
+		if (expectedProject.stderr.length === 0) {
+			kubernetesCommandLineToolsExecutor.deleteProject(projectName);
+		}
 		kubernetesCommandLineToolsExecutor.createProject(projectName);
 	});
 
 	loginTests.loginIntoOcpConsole();
 
+
+
 	test('Select test project and Developer role on DevConsole', async function (): Promise<void> {
+		parentGUID = await browserTabsUtil.getCurrentWindowHandle();
 		await ocpMainPage.selectDeveloperRole();
 		await ocpMainPage.selectProject(projectName);
 	});
@@ -106,16 +120,29 @@ suite(`DevConsole Integration ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function
 		).not.undefined;
 	});
 
-	suiteTeardown('Open dashboard and close all other tabs', async function (): Promise<void> {
-		await dashboard.openDashboard();
+	test ('Check redirection to DevSpaces from App launcher', async function (): Promise<void> {
+		await browserTabsUtil.switchToWindow(parentGUID);
 		await browserTabsUtil.closeAllTabsExceptCurrent();
+		await ocpMainPage.clickOnAppLauncherAndDevSpaceItem();
+		await loginTests.loginIntoChe();
+		await dashboard.waitPage()
 	});
 
 	suiteTeardown('Delete project using ocp', function (): void {
 		kubernetesCommandLineToolsExecutor.workspaceName =
 			WorkspaceHandlingTests.getWorkspaceName() !== '' ? WorkspaceHandlingTests.getWorkspaceName() : 'spring-music';
-		kubernetesCommandLineToolsExecutor.deleteDevWorkspace();
-		kubernetesCommandLineToolsExecutor.deleteProject(projectName);
+		try {
+			kubernetesCommandLineToolsExecutor.deleteDevWorkspace();
+		}
+		catch (err) {
+			Logger.error(`Error while deleting workspace: ${err}`);
+		}
+		try {
+			kubernetesCommandLineToolsExecutor.deleteProject(projectName);
+		}
+		catch (err) {
+			Logger.error(`Cannot delete the project: ${err}`);
+		}
 	});
 
 	suiteTeardown('Unregister running workspace', function (): void {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
*Add stabilization parts to the test: it checks the existing test-project. It removes before the test, adds try/catch blocks for correct finishing all steps in afterAll block, adds verification of DevConsole integration from run-app. menu




```
### Screenshot/screencast of this PR
################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://devspaces.apps.ocp417-mmusiie.crw-qe.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: admin
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: false
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java Lombok,Quarkus REST API,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DIRECTORY is not set
      USERSTORY: DevConsoleIntegration

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


            ‣ DriverHelper.getDriver
  DevConsole Integration 
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - login to the "OC" client.
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.isUserLoggedIn - oc
          ▼ ShellExecutor.executeCommand - oc whoami && oc whoami --show-server=true
admin
https://api.ocp417-mmusiie.crw-qe.com:6443
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - user already logged
          ▼ ShellExecutor.executeCommand - oc get project devconsole-integration-test
Error from server (NotFound): namespaces "devconsole-integration-test" not found
          ▼ KubernetesCommandLineToolsExecutor.createProject - oc - create new project "devconsole-integration-test".
          ▼ ShellExecutor.executeCommand - oc new-project devconsole-integration-test -n admin-devspaces
Already on project "devconsole-integration-test" on server "https://api.ocp417-mmusiie.crw-qe.com:6443".

You can add applications to this project with the 'new-app' command. For example, try:

    oc new-app rails-postgresql-example

to build a new example application in Ruby. Or use kubectl to deploy a simple Kubernetes application:

    kubectl create deployment hello-node --image=registry.k8s.io/e2e-test-images/agnhost:2.43 -- /agnhost serve-hostname

          ▼ BrowserTabsUtil.navigateTo - https://console-openshift-console.apps.ocp417-mmusiie.crw-qe.com
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ OcpUserLoginPage.login
          ▼ OcpLoginPage.isIdentityProviderLinkVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.isVisible - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.wait - (5000 milliseconds)
            ‣ DriverHelper.isVisible - By(xpath, //a[text()="htpasswd"])
          ▼ OcpLoginPage.waitAndClickOnLoginProviderTitle
            ‣ DriverHelper.waitAndClick - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitVisibility - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterUserNameOpenShift - "admin"
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputUsername"]) text: admin
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputUsername"]) text: admin
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterPasswordOpenShift
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.clickOnLoginButton
            ‣ DriverHelper.waitAndClick - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitDisappearanceOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitDisappearance - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.isVisible - By(xpath, //*[contains(text(), "Welcome")])
            ‣ BrowserTabsUtil.maximize
          ▼ BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ OcpMainPage.selectDeveloperRole
          ▼ OcpMainPage.waitOpenMainPage
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="page-main-header"])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpMainPage.tryToSkipWebTour
            ‣ DriverHelper.isVisible - By(xpath, //*[text()="Skip tour"])
          ▼ OcpMainPage.tryToSkipWebTour - welcome tour modal dialog was not located
          ▼ OcpMainPage.clickOnSelectRoleButton
            ‣ DriverHelper.waitAndClick - By(xpath, //*[@data-test-id="perspective-switcher-toggle"])
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test-id="perspective-switcher-toggle"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpMainPage.selectRole - selecting role Developer
            ‣ DriverHelper.waitAndClick - By(xpath, //a//*[text()="Developer"])
            ‣ DriverHelper.waitVisibility - By(xpath, //a//*[text()="Developer"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpMainPage.tryToSkipWebTour
            ‣ DriverHelper.isVisible - By(xpath, //*[text()="Skip tour"])
          ▼ OcpMainPage.tryToSkipWebTour - welcome tour modal dialog was not located
          ▼ OcpMainPage.selectProject
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="co-namespace-dropdown"]//button)
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="co-namespace-dropdown"]//button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.enterValue - By(xpath, //*[@data-test="dropdown-text-filter"]) text: devconsole-integration-test
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test="dropdown-text-filter"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(xpath, //*[@data-test="dropdown-text-filter"])
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test="dropdown-text-filter"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(xpath, //*[@data-test="dropdown-text-filter"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(xpath, //*[@data-test="dropdown-text-filter"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test="dropdown-text-filter"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(xpath, //*[@data-test="dropdown-text-filter"]) text: devconsole-integration-test
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test="dropdown-text-filter"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(xpath, //*[@data-test="dropdown-text-filter"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(xpath, //*[@data-test="dropdown-text-filter"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test="dropdown-text-filter"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //button//*[text()="devconsole-integration-test"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button//*[text()="devconsole-integration-test"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Select test project and Developer role on DevConsole
          ▼ OcpMainPage.openImportFromGitPage
          ▼ OcpMainPage.clickAddToProjectButton
            ‣ DriverHelper.waitAndClick - By(xpath, //*[@data-test-id="+Add-header"])
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test-id="+Add-header"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpMainPage.selectImportFromGitMethod
            ‣ DriverHelper.waitAndClick - By(xpath, //*[@data-test="item import-from-git"])
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test="item import-from-git"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Open import from git project page
          ▼ OcpImportFromGitPage.fitAndSubmitConfiguration
          ▼ OcpImportFromGitPage.enterGitRepoUrl
            ‣ DriverHelper.enterValue - By(css selector, *[id="form-input-git-url-field"]) text: https://github.com/crw-qe/summit-lab-spring-music.git
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-url-field"])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="form-input-git-url-field"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-url-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="form-input-git-url-field"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="form-input-git-url-field"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-url-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="form-input-git-url-field"]) text: https://github.com/crw-qe/summit-lab-spring-music.git
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-url-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="form-input-git-url-field"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="form-input-git-url-field"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-url-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpImportFromGitPage.clickOnAdvancedOptionsButton
            ‣ DriverHelper.isVisible - By(xpath, //*[text()="Hide advanced Git options"])
            ‣ DriverHelper.waitAndClick - By(xpath, //*[text()="Show advanced Git options"]//ancestor::button)
            ‣ DriverHelper.waitVisibility - By(xpath, //*[text()="Show advanced Git options"]//ancestor::button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpImportFromGitPage.enterGitReference - "pipeline"
            ‣ DriverHelper.enterValue - By(css selector, *[id="form-input-git-ref-field"]) text: pipeline
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-ref-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="form-input-git-ref-field"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-ref-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="form-input-git-ref-field"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="form-input-git-ref-field"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-ref-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="form-input-git-ref-field"]) text: pipeline
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-ref-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="form-input-git-ref-field"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="form-input-git-ref-field"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-input-git-ref-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpImportFromGitPage.selectBuilderImageImportStrategy
            ‣ DriverHelper.scrollToAndClick
            ‣ DriverHelper.scrollTo - By(xpath, //*[text()="Edit Import Strategy"]//ancestor::button)
            ‣ DriverHelper.waitPresence - By(xpath, //*[text()="Edit Import Strategy"]//ancestor::button)
            ‣ DriverHelper.waitPresence - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.scrollTo - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - By(xpath, //*[text()="Edit Import Strategy"]//ancestor::button)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(xpath, //*[text()="Edit Import Strategy"]//ancestor::button)
            ‣ DriverHelper.waitVisibility - By(xpath, //*[text()="Edit Import Strategy"]//ancestor::button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.scrollToAndClick
            ‣ DriverHelper.scrollTo - By(xpath, //*[text()="Builder Image"]//parent::div//parent::div)
            ‣ DriverHelper.waitPresence - By(xpath, //*[text()="Builder Image"]//parent::div//parent::div)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(xpath, //*[text()="Builder Image"]//parent::div//parent::div)
            ‣ DriverHelper.waitVisibility - By(xpath, //*[text()="Builder Image"]//parent::div//parent::div)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpImportFromGitPage.addLabel - "app.openshift.io/runtime=spring"
            ‣ DriverHelper.scrollToAndClick
            ‣ DriverHelper.scrollTo - By(xpath, //button[text()="Labels"])
            ‣ DriverHelper.waitPresence - By(xpath, //button[text()="Labels"])
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="Labels"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Labels"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.scrollToAndEnterValue
            ‣ DriverHelper.scrollTo - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitPresence - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.enterValue - By(css selector, *[id="form-selector-labels-field"]) text: app.openshift.io/runtime=spring
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="form-selector-labels-field"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="form-selector-labels-field"]) text: app.openshift.io/runtime=spring
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="form-selector-labels-field"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="form-selector-labels-field"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpImportFromGitPage.submitConfiguration
            ‣ DriverHelper.waitAndClick - By(xpath, //*[@data-test-id="submit-button"])
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@data-test-id="submit-button"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Fill and submit import data
          ▼ OcpApplicationPage.waitApplicationIcon
            ‣ DriverHelper.waitPresence - By(xpath, //*[@data-test-id="base-node-handler"])
            ‣ DriverHelper.waitPresence - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitPresence - polling timed out attempt #3, retrying with 1000ms timeout
    ✔ Wait until application creates
          ▼ OcpApplicationPage.waitAndOpenEditSourceCodeIcon
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(xpath, //*[@aria-label="Edit source code"])
            ‣ DriverHelper.waitVisibility - By(xpath, //*[@aria-label="Edit source code"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
    ✔ Check if application has worked link "Open Source Code"
          ▼ Dashboard.waitLoader
            ‣ DriverHelper.waitAllPresence - By(xpath, //*[@data-testid="step-title"])
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #19, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #20, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #21, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #22, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #23, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #24, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #25, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #26, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #27, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #28, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #29, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #30, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #31, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #32, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #33, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #34, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #35, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #36, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #37, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #38, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #39, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #40, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #41, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #42, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #43, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #44, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #45, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #46, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #47, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #48, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #49, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #50, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #51, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #52, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #53, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #54, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #55, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #56, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #57, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #58, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #59, retrying with 1000ms timeout
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #60, retrying with 1000ms timeout
          ▼ LoginTests.loginIntoChe
            ‣ BrowserTabsUtil.getCurrentUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
  Wait timed out after 1063ms
          ▼ LoginTests.loginIntoChe - try to login into application
          ▼ RegularUserOcpCheLoginPage.login
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="panel-login"]/div[contains(@class, "panel-content")]/form/button)
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="panel-login"]/div[contains(@class, "panel-content")]/form/button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.isIdentityProviderLinkVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.isVisible - By(xpath, //a[text()="htpasswd"])
          ▼ OcpLoginPage.waitAndClickOnLoginProviderTitle
            ‣ DriverHelper.waitAndClick - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitVisibility - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterUserNameOpenShift - "admin"
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputUsername"]) text: admin
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputUsername"]) text: admin
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterPasswordOpenShift
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.clickOnLoginButton
            ‣ DriverHelper.waitAndClick - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitDisappearanceOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitDisappearance - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.isVisible - By(xpath, //*[contains(text(), "Welcome")])
          ▼ OcpLoginPage.isAuthorizeOpenShiftIdentityProviderPageVisible
            ‣ DriverHelper.isVisible - By(xpath, //h1[text()="Authorize Access"])
            ‣ BrowserTabsUtil.maximize
          ▼ BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitStartingPageLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, .main-page-loader)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, .main-page-loader)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
    ✔ Login (79935ms)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace spring-music
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():spring-music
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: spring-music
    ✔ Obtain workspace name from workspace loader page
          ▼ registerRunningWorkspace - with workspaceName:spring-music
    ✔ Registering the running workspace
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #19, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 29383 seconds.
    ✔ Check if application source code opens in workspace
          ▼ Function.getProjectNameFromGitUrl - https://github.com/crw-qe/summit-lab-spring-music.git
          ▼ Function.getProjectNameFromGitUrl - summit-lab-spring-music
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - summit-lab-spring-music
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Check if project and files imported
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ OcpMainPage.clickOnAppLauncherAndDevSpaceItem - click on app launcher menu
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.waitAndClick - By(css selector, nav[data-test-id='application-launcher'])
            ‣ DriverHelper.waitVisibility - By(css selector, nav[data-test-id='application-launcher'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAndClick - By(xpath, //span[contains(.,'Red Hat OpenShift Dev Spaces')])
            ‣ DriverHelper.waitVisibility - By(xpath, //span[contains(.,'Red Hat OpenShift Dev Spaces')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ LoginTests.loginIntoChe
            ‣ BrowserTabsUtil.getCurrentUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ LoginTests.loginIntoChe - user already logged in
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
    ✔ Check redirection to DevSpaces from App launcher
          ▼ KubernetesCommandLineToolsExecutor.deleteDevWorkspace - oc - delete 'spring-music' workspace
          ▼ ShellExecutor.executeCommand - oc patch dw spring-music -n admin-devspaces -p '{ "metadata": { "finalizers": null }}' --type merge || true
devworkspace.workspace.devfile.io/spring-music patched
          ▼ ShellExecutor.executeCommand - oc delete dw spring-music -n admin-devspaces || true
devworkspace.workspace.devfile.io "spring-music" deleted
          ▼ ShellExecutor.executeCommand - oc delete dwt che-code-spring-music -n admin-devspaces || true
Error from server (NotFound): devworkspacetemplates.workspace.devfile.io "che-code-spring-music" not found
          ▼ KubernetesCommandLineToolsExecutor.deleteProject - oc - delete "devconsole-integration-test".
          ▼ ShellExecutor.executeCommand - oc delete project devconsole-integration-test -n admin-devspaces
Warning: deleting cluster-scoped resources, not scoped to the provided namespace
project.project.openshift.io "devconsole-integration-test" deleted
          ▼     at /home/mmusiien/che-projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name
  11 passing (3m)
```


### What issues does this PR fix or reference?
https://issues.redhat.com/projects/CRW/issues/CRW-7591


### How to test this PR?
run as usual


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
