### PR TITLE
Add 'CppDevFileAPI' E2E test

### DIFF
--- a/tests/e2e/specs/api/CppDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/CppDevFileAPI.spec.ts
@@ -1,0 +1,86 @@
+/** *******************************************************************
+ * copyright (c) 2024 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+
+import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { e2eContainer } from '../../configs/inversify.config';
+import { CLASSES } from '../../configs/inversify.types';
+import { DevfilesHelper } from '../../utils/DevfilesHelper';
+import { ContainerTerminal, KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesCommandLineToolsExecutor';
+import { DevWorkspaceConfigurationHelper } from '../../utils/DevWorkspaceConfigurationHelper';
+import { DevfileContext } from '@eclipse-che/che-devworkspace-generator/lib/api/devfile-context';
+import { ShellString } from 'shelljs';
+import { expect } from 'chai';
+import { API_TEST_CONSTANTS } from '../../constants/API_TEST_CONSTANTS';
+import YAML from 'yaml';
+import { Logger } from '../../utils/Logger';
+import crypto from 'crypto';
+
+suite('Cpp devfile API test', function (): void {
+	const devfilesRegistryHelper: DevfilesHelper = e2eContainer.get(CLASSES.DevfilesRegistryHelper);
+	const kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor = e2eContainer.get(
+		CLASSES.KubernetesCommandLineToolsExecutor
+	);
+	const devfileID: string = 'cpp';
+	const containerTerminal: ContainerTerminal = e2eContainer.get(CLASSES.ContainerTerminal);
+	let devWorkspaceConfigurationHelper: DevWorkspaceConfigurationHelper;
+	let devfileContext: DevfileContext;
+	let devfileContent: string = '';
+	const workDirPath: string = 'c-plus-plus/strings';
+	const buildCommand: string = 'rm -f bin.out && g++ -g "knuth_morris_pratt.cpp" -o bin.out && echo "Build complete"';
+	const runCommand: string = './bin.out';
+
+	suiteSetup(`Prepare login ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+		kubernetesCommandLineToolsExecutor.loginToOcp();
+	});
+
+	test(`Create  ${devfileID} workspace`, async function (): Promise<void> {
+		const randomPref: string = crypto.randomBytes(4).toString('hex');
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
+		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
+		const uniqName: string = YAML.parse(devfileContent).metadata.name + randomPref;
+		kubernetesCommandLineToolsExecutor.workspaceName = uniqName;
+
+		devWorkspaceConfigurationHelper = new DevWorkspaceConfigurationHelper({
+			editorContent: editorDevfileContent,
+			devfileContent: devfileContent
+		});
+		devfileContext = await devWorkspaceConfigurationHelper.generateDevfileContext();
+		if (devfileContext.devWorkspace.metadata) {
+			devfileContext.devWorkspace.metadata.name = uniqName;
+		}
+		const devWorkspaceConfigurationYamlString: string =
+			devWorkspaceConfigurationHelper.getDevWorkspaceConfigurationYamlAsString(devfileContext);
+		const output: ShellString = kubernetesCommandLineToolsExecutor.applyAndWaitDevWorkspace(devWorkspaceConfigurationYamlString);
+		expect(output.stdout).contains('condition met');
+	});
+
+	test('Check commands', function (): void {
+		let runCommandInBash: string;
+		let output: ShellString;
+		const toolsComponent: any = YAML.parse(devfileContent).components.find((component: any): boolean => component.name === 'tools');
+		const containerName: string = toolsComponent ? toolsComponent.name : 'Component not found';
+		Logger.info(`container from components section of Devfile:: ${containerName}`);
+		runCommandInBash = `cd ${workDirPath} && ${buildCommand}`;
+		Logger.info('Check build command');
+		output = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
+		expect(output.code).eqls(0);
+		expect(output.stdout.trim()).contains('Build complete');
+		Logger.info('Check run command');
+		runCommandInBash = `cd ${workDirPath} && ${runCommand}`;
+		output = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
+		expect(output.code).eqls(0);
+		expect(output.stdout.trim()).contains('Found');
+	});
+
+	suiteTeardown('Delete workspace', function (): void {
+		kubernetesCommandLineToolsExecutor.deleteDevWorkspace();
+	});
+});


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Adds `CppDevFileAPI` test to check command execution of `cpp` sample

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
$ npm run test

> @eclipse-che/che-e2e@7.97.0-next test
> ./configs/sh-scripts/initDefaultValues.sh npm run lint && npm run tsc && export USERSTORY=$USERSTORY && mocha --config dist/configs/mocharc.js

Initialized default values

TS_SELENIUM_VALUE_TLS_SUPPORT =       
TS_SELENIUM_VALUE_OPENSHIFT_OAUTH =   true
TS_OCP_LOGIN_PAGE_PROVIDER_TITLE =    htpasswd
E2E_OCP_CLUSTER_VERSION =             4.x
TS_SELENIUM_LOG_LEVEL =               TRACE
TS_SELENIUM_OCP_USERNAME =            admin
TS_SELENIUM_W3C_CHROME_OPTION =       true
NODE_TLS_REJECT_UNAUTHORIZED =        0
TS_SELENIUM_EDITOR =                  che-code

> @eclipse-che/che-e2e@7.97.0-next tsc
> rm -rf ./dist && ./configs/sh-scripts/generateIndex.sh && tsc -p .

Generating index.ts file...
Warning: Cannot find any files matching pattern "dist/specs/CppDevFileAPI.spec.js"

################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://devspaces.apps.cluster-4g7jd.4g7jd.sandbox235.opentlc.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: admin
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: true
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java Lombok,Quarkus REST API,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DIRECTORY is not set
      USERSTORY: CppDevFileAPI

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


            ‣ DriverHelper.getDriver
  Cpp devfile API test
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - login to the "OC" client.
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.isUserLoggedIn - oc
          ▼ ShellExecutor.executeCommand - oc whoami && oc whoami --show-server=true
admin
https://api.cluster-4g7jd.4g7jd.sandbox235.opentlc.com:6443
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - user already logged
command: oc get pods -n openshift-devspaces
          ▼ ShellExecutor.executeArbitraryShellScript - oc get pods -n openshift-devspaces | grep dashboard | awk '{print $1}'
          ▼ ShellExecutor.executeCommand - oc get pods -n openshift-devspaces | grep dashboard | awk '{print $1}'
devspaces-dashboard-5bcc59c94-dcmp2
          ▼ ShellExecutor.executeArbitraryShellScript - oc get pod -n openshift-devspaces devspaces-dashboard-5bcc59c94-dcmp2 -o jsonpath='{.spec.containers[*].name}'
          ▼ ShellExecutor.executeCommand - oc get pod -n openshift-devspaces devspaces-dashboard-5bcc59c94-dcmp2 -o jsonpath='{.spec.containers[*].name}'
devspaces-dashboard          ▼ ShellExecutor.executeArbitraryShellScript - oc get svc devspaces-dashboard -n  openshift-devspaces -o=jsonpath='{.spec.clusterIP}'
          ▼ ShellExecutor.executeCommand - oc get svc devspaces-dashboard -n  openshift-devspaces -o=jsonpath='{.spec.clusterIP}'
172.30.149.34          ▼ ShellExecutor.executeArbitraryShellScript - oc get svc devspaces-dashboard -n  openshift-devspaces -o=jsonpath='{.spec.ports[*].port}'
          ▼ ShellExecutor.executeCommand - oc get svc devspaces-dashboard -n  openshift-devspaces -o=jsonpath='{.spec.ports[*].port}'
8080          ▼ ShellExecutor.executeCommand - oc exec -i devspaces-dashboard-5bcc59c94-dcmp2 -n  openshift-devspaces -c devspaces-dashboard -- sh -c 'curl -o /tmp/cpp-devfile.yaml http://172.30.149.34:8080/dashboard/api/airgap-sample/devfile/download?id=cpp'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   496  100   496    0     0  70857      0 --:--:-- --:--:-- --:--:-- 82666
          ▼ ShellExecutor.executeArbitraryShellScript - oc exec -i devspaces-dashboard-5bcc59c94-dcmp2 -n  openshift-devspaces -c devspaces-dashboard -- cat /tmp/cpp-devfile.yaml
          ▼ ShellExecutor.executeCommand - oc exec -i devspaces-dashboard-5bcc59c94-dcmp2 -n  openshift-devspaces -c devspaces-dashboard -- cat /tmp/cpp-devfile.yaml
schemaVersion: 2.2.2
metadata:
  name: cpp
components:
  - name: tools
    container:
      image: registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
      memoryLimit: '2Gi'
      memoryRequest: '1Gi'
      cpuLimit: '1'
      cpuRequest: '0.5'
      mountSources: true
projects:
  - name: c-plus-plus
    zip:
      location: http://devspaces-dashboard.openshift-devspaces.svc:8080/dashboard/api/airgap-sample/project/download?id=cpp
          ▼ ShellExecutor.executeCommand - oc get configmap editors-definitions -o jsonpath="{.data.che-code\.yaml}" -n openshift-devspaces
commands:
- apply:
    component: che-code-injector
  id: init-container-command
- exec:
    commandLine: nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
      2>&1 &
    component: che-code-runtime-description
  id: init-che-code-command
components:
- container:
    command:
    - /entrypoint-init-container.sh
    cpuLimit: 500m
    cpuRequest: 30m
    image: registry.redhat.io/devspaces/code-rhel8@sha256:02c8f907dc2e18c61fa643accbf8378f385d3368af49794a78b9529cc63eb636
    memoryLimit: 256Mi
    memoryRequest: 32Mi
    volumeMounts:
    - name: checode
      path: /checode
  name: che-code-injector
- attributes:
    app.kubernetes.io/component: che-code-runtime
    app.kubernetes.io/part-of: che-code.eclipse.org
    controller.devfile.io/container-contribution: true
  container:
    cpuLimit: 500m
    cpuRequest: 30m
    endpoints:
    - attributes:
        cookiesAuthEnabled: true
        discoverable: false
        type: main
        urlRewriteSupported: true
      exposure: public
      name: che-code
      protocol: https
      secure: true
      targetPort: 3100
    - attributes:
        discoverable: false
        urlRewriteSupported: false
      exposure: public
      name: code-redirect-1
      protocol: https
      targetPort: 13131
    - attributes:
        discoverable: false
        urlRewriteSupported: false
      exposure: public
      name: code-redirect-2
      protocol: https
      targetPort: 13132
    - attributes:
        discoverable: false
        urlRewriteSupported: false
      exposure: public
      name: code-redirect-3
      protocol: https
      targetPort: 13133
    image: registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
    memoryLimit: 1024Mi
    memoryRequest: 256Mi
    volumeMounts:
    - name: checode
      path: /checode
  name: che-code-runtime-description
- name: checode
  volume: {}
events:
  postStart:
  - init-che-code-command
  preStart:
  - init-container-command
metadata:
  attributes:
    firstPublicationDate: "2022-07-19"
    iconData: |
      <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
      <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
      <path fill-rule="evenodd" clip-rule="evenodd" d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z" fill="white"/>
      </mask>
      <g mask="url(#mask0)">
      <path d="M96.4614 10.7962L75.8569 0.875542C73.4719 -0.272773 70.6217 0.211611 68.75 2.08333L1.29858 63.5832C-0.515693 65.2373 -0.513607 68.0937 1.30308 69.7452L6.81272 74.754C8.29793 76.1042 10.5347 76.2036 12.1338 74.9905L93.3609 13.3699C96.086 11.3026 100 13.2462 100 16.6667V16.4275C100 14.0265 98.6246 11.8378 96.4614 10.7962Z" fill="#0065A9"/>
      <g filter="url(#filter0_d)">
      <path d="M96.4614 89.2038L75.8569 99.1245C73.4719 100.273 70.6217 99.7884 68.75 97.9167L1.29858 36.4169C-0.515693 34.7627 -0.513607 31.9063 1.30308 30.2548L6.81272 25.246C8.29793 23.8958 10.5347 23.7964 12.1338 25.0095L93.3609 86.6301C96.086 88.6974 100 86.7538 100 83.3334V83.5726C100 85.9735 98.6246 88.1622 96.4614 89.2038Z" fill="#007ACC"/>
      </g>
      <g filter="url(#filter1_d)">
      <path d="M75.8578 99.1263C73.4721 100.274 70.6219 99.7885 68.75 97.9166C71.0564 100.223 75 98.5895 75 95.3278V4.67213C75 1.41039 71.0564 -0.223106 68.75 2.08329C70.6219 0.211402 73.4721 -0.273666 75.8578 0.873633L96.4587 10.7807C98.6234 11.8217 100 14.0112 100 16.4132V83.5871C100 85.9891 98.6234 88.1786 96.4586 89.2196L75.8578 99.1263Z" fill="#1F9CF0"/>
      </g>
      <g style="mix-blend-mode:overlay" opacity="0.25">
      <path fill-rule="evenodd" clip-rule="evenodd" d="M70.8511 99.3171C72.4261 99.9306 74.2221 99.8913 75.8117 99.1264L96.4 89.2197C98.5634 88.1787 99.9392 85.9892 99.9392 83.5871V16.4133C99.9392 14.0112 98.5635 11.8217 96.4001 10.7807L75.8117 0.873695C73.7255 -0.13019 71.2838 0.115699 69.4527 1.44688C69.1912 1.63705 68.942 1.84937 68.7082 2.08335L29.2943 38.0414L12.1264 25.0096C10.5283 23.7964 8.29285 23.8959 6.80855 25.246L1.30225 30.2548C-0.513334 31.9064 -0.515415 34.7627 1.29775 36.4169L16.1863 50L1.29775 63.5832C-0.515415 65.2374 -0.513334 68.0937 1.30225 69.7452L6.80855 74.754C8.29285 76.1042 10.5283 76.2036 12.1264 74.9905L29.2943 61.9586L68.7082 97.9167C69.3317 98.5405 70.0638 99.0104 70.8511 99.3171ZM74.9544 27.2989L45.0483 50L74.9544 72.7012V27.2989Z" fill="url(#paint0_linear)"/>
      </g>
      </g>
      <defs>
      <filter id="filter0_d" x="-8.39411" y="15.8291" width="116.727" height="92.2456" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
      <feOffset/>
      <feGaussianBlur stdDeviation="4.16667"/>
      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
      <feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
      </filter>
      <filter id="filter1_d" x="60.4167" y="-8.07558" width="47.9167" height="116.151" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
      <feOffset/>
      <feGaussianBlur stdDeviation="4.16667"/>
      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
      <feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
      </filter>
      <linearGradient id="paint0_linear" x1="49.9392" y1="0.257812" x2="49.9392" y2="99.7423" gradientUnits="userSpaceOnUse">
      <stop stop-color="white"/>
      <stop offset="1" stop-color="white" stop-opacity="0"/>
      </linearGradient>
      </defs>
      </svg>
    iconMediatype: image/svg+xml
    publisher: che-incubator
    repository: https://github.com/che-incubator/che-code
    skipMetaYaml: true
    title: Red Hat OpenShift Dev Spaces with Microsoft Visual Studio Code - Open Source
      IDE
    version: latest
  description: Red Hat OpenShift Dev Spaces with Microsoft Visual Studio Code - Open
    Source IDE
  displayName: VS Code - Open Source
  name: che-code
schemaVersion: 2.2.2
          ▼ DevWorkspaceConfigurationHelper.generateDevfileContext
No plug-in registry url. Setting to https://eclipse-che.github.io/che-plugin-registry/main/v3
Validating devfile
Devfile is valid with schema version 2.2.2
DevWorkspace che-code-cpp was generated
          ▼ DevWorkspaceConfigurationHelper.getDevWorkspaceConfigurationYamlAsString
          ▼ KubernetesCommandLineToolsExecutor.applyAndWaitDevWorkspace - oc
          ▼ KubernetesCommandLineToolsExecutor.applyYamlConfigurationAsStringOutput - oc
          ▼ ShellExecutor.executeCommand - cat <<EOF | oc apply -n admin-devspaces -f - 
          apiVersion: workspace.devfile.io/v1alpha2
          kind: DevWorkspaceTemplate
          metadata:
            name: che-code-cpp
          spec:
            commands:
              - apply:
                  component: che-code-injector
                id: init-container-command
              - exec:
                  commandLine: nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
                    2>&1 &
                  component: che-code-runtime-description
                id: init-che-code-command
            components:
              - container:
                  command:
                    - /entrypoint-init-container.sh
                  cpuLimit: 500m
                  cpuRequest: 30m
                  image: registry.redhat.io/devspaces/code-rhel8@sha256:02c8f907dc2e18c61fa643accbf8378f385d3368af49794a78b9529cc63eb636
                  memoryLimit: 256Mi
                  memoryRequest: 32Mi
                  volumeMounts:
                    - name: checode
                      path: /checode
                name: che-code-injector
              - attributes:
                  app.kubernetes.io/component: che-code-runtime
                  app.kubernetes.io/part-of: che-code.eclipse.org
                  controller.devfile.io/container-contribution: true
                container:
                  cpuLimit: 500m
                  cpuRequest: 30m
                  endpoints:
                    - attributes:
                        cookiesAuthEnabled: true
                        discoverable: false
                        type: main
                        urlRewriteSupported: true
                      exposure: public
                      name: che-code
                      protocol: https
                      secure: true
                      targetPort: 3100
                    - attributes:
                        discoverable: false
                        urlRewriteSupported: false
                      exposure: public
                      name: code-redirect-1
                      protocol: https
                      targetPort: 13131
                    - attributes:
                        discoverable: false
                        urlRewriteSupported: false
                      exposure: public
                      name: code-redirect-2
                      protocol: https
                      targetPort: 13132
                    - attributes:
                        discoverable: false
                        urlRewriteSupported: false
                      exposure: public
                      name: code-redirect-3
                      protocol: https
                      targetPort: 13133
                  image: registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
                  memoryLimit: 1024Mi
                  memoryRequest: 256Mi
                  volumeMounts:
                    - name: checode
                      path: /checode
                name: che-code-runtime-description
              - name: checode
                volume: {}
            events:
              postStart:
                - init-che-code-command
              preStart:
                - init-container-command
          ---
          apiVersion: workspace.devfile.io/v1alpha2
          kind: DevWorkspace
          metadata:
            name: cpp77cc3f65
            annotations:
              che.eclipse.org/devfile: >
                schemaVersion: 2.2.2
          
                metadata:
                  name: cpp
                components:
                  - name: tools
                    container:
                      image: >-
                        registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
                      memoryLimit: 2Gi
                      memoryRequest: 1Gi
                      cpuLimit: '1'
                      cpuRequest: '0.5'
                      mountSources: true
                projects:
                  - name: c-plus-plus
                    zip:
                      location: >-
                        http://devspaces-dashboard.openshift-devspaces.svc:8080/dashboard/api/airgap-sample/project/download?id=cpp
          spec:
            started: true
            routingClass: che
            template:
              components:
                - name: tools
                  container:
                    image: registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
                    memoryLimit: 2Gi
                    memoryRequest: 1Gi
                    cpuLimit: "1"
                    cpuRequest: "0.5"
                    mountSources: true
              projects:
                - name: c-plus-plus
                  zip:
                    location: http://devspaces-dashboard.openshift-devspaces.svc:8080/dashboard/api/airgap-sample/project/download?id=cpp
            contributions:
              - name: editor
                kubernetes:
                  name: che-code-cpp
          
          EOF
devworkspacetemplate.workspace.devfile.io/che-code-cpp configured
devworkspace.workspace.devfile.io/cpp77cc3f65 created
          ▼ KubernetesCommandLineToolsExecutor.waitDevWorkspace - oc - wait till workspace ready.
          ▼ ShellExecutor.executeCommand - oc wait -n admin-devspaces --for=condition=Ready dw cpp77cc3f65 --timeout=360s
devworkspace.workspace.devfile.io/cpp77cc3f65 condition met
          ▼ KubernetesCommandLineToolsExecutor.getPodAndContainerNames - oc
          ▼ KubernetesCommandLineToolsExecutor.getWorkspacePodName - oc - get workspace pod name.
          ▼ ShellExecutor.executeCommand - oc get pod -l controller.devfile.io/devworkspace_name=cpp77cc3f65 -n admin-devspaces -o name
pod/workspace7c7a725f43914954-545dff649c-m6rvz
          ▼ KubernetesCommandLineToolsExecutor.getContainerName - oc - get container name.
          ▼ ShellExecutor.executeCommand - oc get pod/workspace7c7a725f43914954-545dff649c-m6rvz -o jsonpath='{.spec.containers[*].name}' -n admin-devspaces
tools che-gateway

    ✔ Create  cpp workspace (36670ms)
      • container from components section of Devfile:: tools
      • Check build command
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace7c7a725f43914954-545dff649c-m6rvz -n admin-devspaces -c tools -- sh -c 'cd c-plus-plus/strings && rm -f bin.out && g++ -g "knuth_morris_pratt.cpp" -o bin.out && echo "Build complete"'
Build complete
      • Check run command
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace7c7a725f43914954-545dff649c-m6rvz -n admin-devspaces -c tools -- sh -c 'cd c-plus-plus/strings && ./bin.out'
Not Found
Found
    ✔ Check commands
          ▼ KubernetesCommandLineToolsExecutor.deleteDevWorkspace - oc - delete 'cpp77cc3f65' workspace
          ▼ ShellExecutor.executeCommand - oc patch dw cpp77cc3f65 -n admin-devspaces -p '{ "metadata": { "finalizers": null }}' --type merge || true
devworkspace.workspace.devfile.io/cpp77cc3f65 patched
          ▼ ShellExecutor.executeCommand - oc delete dw cpp77cc3f65 -n admin-devspaces || true
devworkspace.workspace.devfile.io "cpp77cc3f65" deleted
          ▼ ShellExecutor.executeCommand - oc delete dwt che-code-cpp77cc3f65 -n admin-devspaces || true
Error from server (NotFound): devworkspacetemplates.workspace.devfile.io "che-code-cpp77cc3f65" not found


  2 passing (49s)
```  

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Run the `CppDevFileAPI.spec.ts` as usual

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
