### PR TITLE
Add 'DotnetDevFileAPI' E2E test

### DIFF
--- a/tests/e2e/specs/api/DotnetDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/DotnetDevFileAPI.spec.ts
@@ -1,0 +1,99 @@
+/** *******************************************************************
+ * copyright (c) 2024 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { e2eContainer } from '../../configs/inversify.config';
+import { CLASSES } from '../../configs/inversify.types';
+import { DevfilesHelper } from '../../utils/DevfilesHelper';
+import { ContainerTerminal, KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesCommandLineToolsExecutor';
+import { DevWorkspaceConfigurationHelper } from '../../utils/DevWorkspaceConfigurationHelper';
+import { DevfileContext } from '@eclipse-che/che-devworkspace-generator/lib/api/devfile-context';
+import { ShellString } from 'shelljs';
+import { expect } from 'chai';
+import { API_TEST_CONSTANTS } from '../../constants/API_TEST_CONSTANTS';
+import YAML from 'yaml';
+import { Logger } from '../../utils/Logger';
+import crypto from 'crypto';
+
+suite('Dotnet devfile API test', function (): void {
+	const devfilesRegistryHelper: DevfilesHelper = e2eContainer.get(CLASSES.DevfilesRegistryHelper);
+	const kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor = e2eContainer.get(
+		CLASSES.KubernetesCommandLineToolsExecutor
+	);
+	const devfileID: string = 'dotnet';
+	const containerTerminal: ContainerTerminal = e2eContainer.get(CLASSES.ContainerTerminal);
+	let devWorkspaceConfigurationHelper: DevWorkspaceConfigurationHelper;
+	let devfileContext: DevfileContext;
+	let devfileContent: string = '';
+	let dwtName: string = '';
+
+	suiteSetup(`Prepare login ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+		kubernetesCommandLineToolsExecutor.loginToOcp();
+	});
+
+	test(`Create  ${devfileID} workspace`, async function (): Promise<void> {
+		const randomPref: string = crypto.randomBytes(4).toString('hex');
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
+		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
+		dwtName = YAML.parse(devfileContent).metadata.name;
+		const uniqName: string = YAML.parse(devfileContent).metadata.name + randomPref;
+		kubernetesCommandLineToolsExecutor.workspaceName = uniqName;
+
+		devWorkspaceConfigurationHelper = new DevWorkspaceConfigurationHelper({
+			editorContent: editorDevfileContent,
+			devfileContent: devfileContent
+		});
+		devfileContext = await devWorkspaceConfigurationHelper.generateDevfileContext();
+		if (devfileContext.devWorkspace.metadata) {
+			devfileContext.devWorkspace.metadata.name = uniqName;
+		}
+		const devWorkspaceConfigurationYamlString: string =
+			devWorkspaceConfigurationHelper.getDevWorkspaceConfigurationYamlAsString(devfileContext);
+		const output: ShellString = kubernetesCommandLineToolsExecutor.applyAndWaitDevWorkspace(devWorkspaceConfigurationYamlString);
+		expect(output.stdout).contains('condition met');
+	});
+
+	test('Check devfile commands', function (): void {
+		const workdir: string = YAML.parse(devfileContent).commands[0].exec.workingDir;
+		const containerName: string = YAML.parse(devfileContent).commands[0].exec.component;
+		const updateCommandLine: string = YAML.parse(devfileContent).commands[0].exec.commandLine;
+		Logger.info(`workdir from exec section of DevFile: ${workdir}`);
+		Logger.info(`containerName from exec section of DevFile: ${containerName}`);
+
+		Logger.info('"Test \'update-dependencies\' command execution"');
+		Logger.info(`commandLine from exec section of DevFile file: ${updateCommandLine}`);
+		const runCommandInBash: string = `cd ${workdir} && ${updateCommandLine}`;
+		const output: ShellString = containerTerminal.execInContainerCommand(runCommandInBash, containerName);
+		expect(output.code).eqls(0);
+		expect(output.stdout.trim()).contains('Restored /projects/dotnet-web-simple/web.csproj');
+
+		Logger.info('"Test \'build\' command execution"');
+		const buildCommandLine: string = YAML.parse(devfileContent).commands[1].exec.commandLine;
+		Logger.info(`commandLine from exec section of DevFile: ${buildCommandLine}`);
+		const runCommandInBash2: string = `cd ${workdir} && ${buildCommandLine}`;
+		const output2: ShellString = containerTerminal.execInContainerCommand(runCommandInBash2, containerName);
+		expect(output2.code).eqls(0);
+		expect(output2.stdout.trim()).contains('Build succeeded');
+
+		Logger.info('"Test \'run\' command execution"');
+		const runCommandLine: string = YAML.parse(devfileContent).commands[2].exec.commandLine;
+		Logger.info(`commandLine from exec section of DevFile: ${runCommandLine}`);
+		const runCommandInBash3: string = `cd ${workdir} && sh -c "(${runCommandLine} > server.log 2>&1 &) && sleep 20s && exit"`;
+		const output3: ShellString = containerTerminal.execInContainerCommand(runCommandInBash3, containerName);
+		expect(output3.code).eqls(0);
+		const logOutput: ShellString = containerTerminal.execInContainerCommand(`cat ${workdir}/server.log`, containerName);
+		Logger.info(`Log output: ${logOutput.stdout}`);
+		expect(logOutput.stdout.trim()).contains('Content root path: /projects/dotnet-web-simple');
+	});
+
+	suiteTeardown('Delete DevWorkspace', function (): void {
+		kubernetesCommandLineToolsExecutor.deleteDevWorkspace(dwtName);
+	});
+});

--- a/tests/e2e/specs/api/GoDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/GoDevFileAPI.spec.ts
@@ -32,6 +32,7 @@ suite('Go devfile API test', function (): void {
 	let devWorkspaceConfigurationHelper: DevWorkspaceConfigurationHelper;
 	let devfileContext: DevfileContext;
 	let devfileContent: string = '';
+	let dwtName: string = '';
 
 	suiteSetup(`Prepare login ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 		kubernetesCommandLineToolsExecutor.loginToOcp();
@@ -42,6 +43,7 @@ suite('Go devfile API test', function (): void {
 		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
+		dwtName = YAML.parse(devfileContent).metadata.name;
 		const uniqName: string = YAML.parse(devfileContent).metadata.name + randomPref;
 		kubernetesCommandLineToolsExecutor.workspaceName = uniqName;
 
@@ -84,7 +86,7 @@ suite('Go devfile API test', function (): void {
 		expect(logOutput.stdout.trim()).contains('Web server running on port 8080');
 	});
 
-	suiteTeardown('Delete workspace', function (): void {
-		kubernetesCommandLineToolsExecutor.deleteDevWorkspace();
+	suiteTeardown('Delete DevWorkspace', function (): void {
+		kubernetesCommandLineToolsExecutor.deleteDevWorkspace(dwtName);
 	});
 });

--- a/tests/e2e/specs/api/PhpDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/PhpDevFileAPI.spec.ts
@@ -31,6 +31,7 @@ suite('PHP devfile API test', function (): void {
 	let devWorkspaceConfigurationHelper: DevWorkspaceConfigurationHelper;
 	let devfileContext: DevfileContext;
 	let devfileContent: string = '';
+	let dwtName: string = '';
 
 	suiteSetup(`Prepare login ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 		kubernetesCommandLineToolsExecutor.loginToOcp();
@@ -41,6 +42,7 @@ suite('PHP devfile API test', function (): void {
 		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
+		dwtName = YAML.parse(devfileContent).metadata.name;
 		const uniqName: string = YAML.parse(devfileContent).metadata.name + randomPref;
 		kubernetesCommandLineToolsExecutor.workspaceName = uniqName;
 
@@ -70,7 +72,7 @@ suite('PHP devfile API test', function (): void {
 		expect(output.stdout.trim()).contains('Hello, world!');
 	});
 
-	suiteTeardown('Delete workspace', function (): void {
-		kubernetesCommandLineToolsExecutor.deleteDevWorkspace();
+	suiteTeardown('Delete DevWorkspace', function (): void {
+		kubernetesCommandLineToolsExecutor.deleteDevWorkspace(dwtName);
 	});
 });

--- a/tests/e2e/specs/api/PythonDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/PythonDevFileAPI.spec.ts
@@ -32,6 +32,7 @@ suite('Python devfile API test', function (): void {
 	let devWorkspaceConfigurationHelper: DevWorkspaceConfigurationHelper;
 	let devfileContext: DevfileContext;
 	let devfileContent: string = '';
+	let dwtName: string = '';
 
 	suiteSetup(`Prepare login ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 		kubernetesCommandLineToolsExecutor.loginToOcp();
@@ -42,6 +43,7 @@ suite('Python devfile API test', function (): void {
 		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
+		dwtName = YAML.parse(devfileContent).metadata.name;
 		const uniqName: string = YAML.parse(devfileContent).metadata.name + randomPref;
 		kubernetesCommandLineToolsExecutor.workspaceName = uniqName;
 
@@ -71,7 +73,7 @@ suite('Python devfile API test', function (): void {
 		expect(output.stdout.trim()).contains('Hello, world!');
 	});
 
-	suiteTeardown('Delete workspace', function (): void {
-		kubernetesCommandLineToolsExecutor.deleteDevWorkspace();
+	suiteTeardown('Delete DevWorkspace', function (): void {
+		kubernetesCommandLineToolsExecutor.deleteDevWorkspace(dwtName);
 	});
 });

--- a/tests/e2e/utils/KubernetesCommandLineToolsExecutor.ts
+++ b/tests/e2e/utils/KubernetesCommandLineToolsExecutor.ts
@@ -94,16 +94,33 @@ export class KubernetesCommandLineToolsExecutor implements IKubernetesCommandLin
 		return output.stderr ? output.stderr : output.stdout.replace('\n', '');
 	}
 
-	deleteDevWorkspace(): void {
-		Logger.debug(`${this.kubernetesCommandLineTool} - delete '${this.workspaceName}' workspace`);
+	// used to delete when devWorkspace and devWorkspaceTemplate have the same names
+	deleteDevWorkspace(): void;
+
+	// used to delete when devWorkspace and devWorkspaceTemplate have different names
+	deleteDevWorkspace(dwTemplateName: string): void;
+
+	deleteDevWorkspace(dwTemplateName?: string): void {
+		Logger.debug(`${this.kubernetesCommandLineTool} - delete '${this.workspaceName}' devWorkspace`);
 
 		this.shellExecutor.executeCommand(
 			`${this.kubernetesCommandLineTool} patch dw ${this.workspaceName} -n ${this.namespace} -p '{ "metadata": { "finalizers": null }}' --type merge || true`
 		);
 		this.shellExecutor.executeCommand(`${this.kubernetesCommandLineTool} delete dw ${this.workspaceName} -n ${this.namespace} || true`);
-		this.shellExecutor.executeCommand(
-			`${this.kubernetesCommandLineTool} delete dwt ${BASE_TEST_CONSTANTS.TS_SELENIUM_EDITOR}-${this.workspaceName} -n ${this.namespace} || true`
-		);
+
+		if (dwTemplateName === undefined) {
+			Logger.debug(`${this.kubernetesCommandLineTool} - delete '${this.workspaceName}' devWorkspaceTemplate`);
+
+			this.shellExecutor.executeCommand(
+				`${this.kubernetesCommandLineTool} delete dwt ${BASE_TEST_CONSTANTS.TS_SELENIUM_EDITOR}-${this.workspaceName} -n ${this.namespace} || true`
+			);
+		} else {
+			Logger.debug(`${this.kubernetesCommandLineTool} - delete '${dwTemplateName}' devWorkspaceTemplate`);
+
+			this.shellExecutor.executeCommand(
+				`${this.kubernetesCommandLineTool} delete dwt ${BASE_TEST_CONSTANTS.TS_SELENIUM_EDITOR}-${dwTemplateName} -n ${this.namespace} || true`
+			);
+		}
 	}
 
 	applyAndWaitDevWorkspace(yamlConfiguration: string): ShellString {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- Adds `DotnetDevFileAPI` test to check command execution of `dotnet` sample
- Updates `deleteDevWorkspace` method to avoid the error of deleting DevWorkspaceTemplate:
```
          ▼ ShellExecutor.executeCommand - oc delete dwt che-code-dotneta274375b -n admin-devspaces || true
Error from server (NotFound): devworkspacetemplates.workspace.devfile.io "che-code-dotneta274375b" not found
```
- Updates exist 'DevFileAPI' tests according to changes in `deleteDevWorkspace` method


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
$ npm run test

> @eclipse-che/che-e2e@7.97.0-next test
> ./configs/sh-scripts/initDefaultValues.sh npm run lint && npm run tsc && export USERSTORY=$USERSTORY && mocha --config dist/configs/mocharc.js

Initialized default values

TS_SELENIUM_VALUE_TLS_SUPPORT =       
TS_SELENIUM_VALUE_OPENSHIFT_OAUTH =   false
TS_OCP_LOGIN_PAGE_PROVIDER_TITLE =    htpasswd
E2E_OCP_CLUSTER_VERSION =             4.x
TS_SELENIUM_LOG_LEVEL =               TRACE
TS_SELENIUM_OCP_USERNAME =            admin
TS_SELENIUM_W3C_CHROME_OPTION =       true
NODE_TLS_REJECT_UNAUTHORIZED =        0
TS_SELENIUM_EDITOR =                  che-code

> @eclipse-che/che-e2e@7.97.0-next tsc
> rm -rf ./dist && ./configs/sh-scripts/generateIndex.sh && tsc -p .

Generating index.ts file...
Warning: Cannot find any files matching pattern "dist/specs/DotnetDevFileAPI.spec.js"

################## Launch Information ##################

      TS_SELENIUM_BASE_URL: https://devspaces.apps.cluster-4g7jd.4g7jd.sandbox235.opentlc.com
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: admin
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: 
      DELETE_WORKSPACE_ON_FAILED_TEST: true
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 360000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java Lombok,Quarkus REST API,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DIRECTORY is not set
      USERSTORY: DotnetDevFileAPI

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


            ‣ DriverHelper.getDriver
  Dotnet devfile API test
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - login to the "OC" client.
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.isUserLoggedIn - oc
          ▼ ShellExecutor.executeCommand - oc whoami && oc whoami --show-server=true
admin
https://api.cluster-4g7jd.4g7jd.sandbox235.opentlc.com:6443
          ▼ KubernetesCommandLineToolsExecutor.getServerUrl - oc - get server api url.
          ▼ KubernetesCommandLineToolsExecutor.loginToOcp - oc - user already logged
command: oc get pods -n openshift-devspaces
          ▼ ShellExecutor.executeArbitraryShellScript - oc get pods -n openshift-devspaces | grep dashboard | awk '{print $1}'
          ▼ ShellExecutor.executeCommand - oc get pods -n openshift-devspaces | grep dashboard | awk '{print $1}'
devspaces-dashboard-5bcc59c94-dcmp2
          ▼ ShellExecutor.executeArbitraryShellScript - oc get pod -n openshift-devspaces devspaces-dashboard-5bcc59c94-dcmp2 -o jsonpath='{.spec.containers[*].name}'
          ▼ ShellExecutor.executeCommand - oc get pod -n openshift-devspaces devspaces-dashboard-5bcc59c94-dcmp2 -o jsonpath='{.spec.containers[*].name}'
devspaces-dashboard          ▼ ShellExecutor.executeArbitraryShellScript - oc get svc devspaces-dashboard -n  openshift-devspaces -o=jsonpath='{.spec.clusterIP}'
          ▼ ShellExecutor.executeCommand - oc get svc devspaces-dashboard -n  openshift-devspaces -o=jsonpath='{.spec.clusterIP}'
172.30.149.34          ▼ ShellExecutor.executeArbitraryShellScript - oc get svc devspaces-dashboard -n  openshift-devspaces -o=jsonpath='{.spec.ports[*].port}'
          ▼ ShellExecutor.executeCommand - oc get svc devspaces-dashboard -n  openshift-devspaces -o=jsonpath='{.spec.ports[*].port}'
8080          ▼ ShellExecutor.executeCommand - oc exec -i devspaces-dashboard-5bcc59c94-dcmp2 -n  openshift-devspaces -c devspaces-dashboard -- sh -c 'curl -o /tmp/dotnet-devfile.yaml http://172.30.149.34:8080/dashboard/api/airgap-sample/devfile/download?id=dotnet'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1359  100  1359    0     0   189k      0 --:--:-- --:--:-- --:--:--  189k
          ▼ ShellExecutor.executeArbitraryShellScript - oc exec -i devspaces-dashboard-5bcc59c94-dcmp2 -n  openshift-devspaces -c devspaces-dashboard -- cat /tmp/dotnet-devfile.yaml
          ▼ ShellExecutor.executeCommand - oc exec -i devspaces-dashboard-5bcc59c94-dcmp2 -n  openshift-devspaces -c devspaces-dashboard -- cat /tmp/dotnet-devfile.yaml
schemaVersion: 2.2.2
metadata:
  name: dotnet
components:
  - name: tools
    container:
      image: registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
      memoryLimit: '2Gi'
      memoryRequest: '1Gi'
      cpuLimit: '1'
      cpuRequest: '0.5'
      mountSources: true
      endpoints:
        - exposure: public
          name: 'hello-endpoint'
          protocol: https
          targetPort: 5032
      volumeMounts:
        - name: nuget
          path: /home/user/.nuget
  - name: nuget
    volume:
      size: 1G
commands:
  - id: 1-update-dependencies
    exec:
      label: 1.Update dependencies
      component: tools
      workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
      commandLine: "dotnet restore"
      group:
        kind: build
  - id: 2-build
    exec:
      label: 2.Build
      component: tools
      workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
      commandLine: "dotnet build"
      group:
        kind: build
  - id: 3-run
    exec:
      label: 3.Run
      component: tools
      workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
      commandLine: "dotnet run"
      group:
        kind: run
projects:
  - name: dotnet-web-simple
    zip:
      location: http://devspaces-dashboard.openshift-devspaces.svc:8080/dashboard/api/airgap-sample/project/download?id=dotnet
          ▼ ShellExecutor.executeCommand - oc get configmap editors-definitions -o jsonpath="{.data.che-code\.yaml}" -n openshift-devspaces
commands:
- apply:
    component: che-code-injector
  id: init-container-command
- exec:
    commandLine: nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
      2>&1 &
    component: che-code-runtime-description
  id: init-che-code-command
components:
- container:
    command:
    - /entrypoint-init-container.sh
    cpuLimit: 500m
    cpuRequest: 30m
    image: registry.redhat.io/devspaces/code-rhel8@sha256:02c8f907dc2e18c61fa643accbf8378f385d3368af49794a78b9529cc63eb636
    memoryLimit: 256Mi
    memoryRequest: 32Mi
    volumeMounts:
    - name: checode
      path: /checode
  name: che-code-injector
- attributes:
    app.kubernetes.io/component: che-code-runtime
    app.kubernetes.io/part-of: che-code.eclipse.org
    controller.devfile.io/container-contribution: true
  container:
    cpuLimit: 500m
    cpuRequest: 30m
    endpoints:
    - attributes:
        cookiesAuthEnabled: true
        discoverable: false
        type: main
        urlRewriteSupported: true
      exposure: public
      name: che-code
      protocol: https
      secure: true
      targetPort: 3100
    - attributes:
        discoverable: false
        urlRewriteSupported: false
      exposure: public
      name: code-redirect-1
      protocol: https
      targetPort: 13131
    - attributes:
        discoverable: false
        urlRewriteSupported: false
      exposure: public
      name: code-redirect-2
      protocol: https
      targetPort: 13132
    - attributes:
        discoverable: false
        urlRewriteSupported: false
      exposure: public
      name: code-redirect-3
      protocol: https
      targetPort: 13133
    image: registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
    memoryLimit: 1024Mi
    memoryRequest: 256Mi
    volumeMounts:
    - name: checode
      path: /checode
  name: che-code-runtime-description
- name: checode
  volume: {}
events:
  postStart:
  - init-che-code-command
  preStart:
  - init-container-command
metadata:
  attributes:
    firstPublicationDate: "2022-07-19"
    iconData: |
      <svg width="100" height="100" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
      <mask id="mask0" mask-type="alpha" maskUnits="userSpaceOnUse" x="0" y="0" width="100" height="100">
      <path fill-rule="evenodd" clip-rule="evenodd" d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z" fill="white"/>
      </mask>
      <g mask="url(#mask0)">
      <path d="M96.4614 10.7962L75.8569 0.875542C73.4719 -0.272773 70.6217 0.211611 68.75 2.08333L1.29858 63.5832C-0.515693 65.2373 -0.513607 68.0937 1.30308 69.7452L6.81272 74.754C8.29793 76.1042 10.5347 76.2036 12.1338 74.9905L93.3609 13.3699C96.086 11.3026 100 13.2462 100 16.6667V16.4275C100 14.0265 98.6246 11.8378 96.4614 10.7962Z" fill="#0065A9"/>
      <g filter="url(#filter0_d)">
      <path d="M96.4614 89.2038L75.8569 99.1245C73.4719 100.273 70.6217 99.7884 68.75 97.9167L1.29858 36.4169C-0.515693 34.7627 -0.513607 31.9063 1.30308 30.2548L6.81272 25.246C8.29793 23.8958 10.5347 23.7964 12.1338 25.0095L93.3609 86.6301C96.086 88.6974 100 86.7538 100 83.3334V83.5726C100 85.9735 98.6246 88.1622 96.4614 89.2038Z" fill="#007ACC"/>
      </g>
      <g filter="url(#filter1_d)">
      <path d="M75.8578 99.1263C73.4721 100.274 70.6219 99.7885 68.75 97.9166C71.0564 100.223 75 98.5895 75 95.3278V4.67213C75 1.41039 71.0564 -0.223106 68.75 2.08329C70.6219 0.211402 73.4721 -0.273666 75.8578 0.873633L96.4587 10.7807C98.6234 11.8217 100 14.0112 100 16.4132V83.5871C100 85.9891 98.6234 88.1786 96.4586 89.2196L75.8578 99.1263Z" fill="#1F9CF0"/>
      </g>
      <g style="mix-blend-mode:overlay" opacity="0.25">
      <path fill-rule="evenodd" clip-rule="evenodd" d="M70.8511 99.3171C72.4261 99.9306 74.2221 99.8913 75.8117 99.1264L96.4 89.2197C98.5634 88.1787 99.9392 85.9892 99.9392 83.5871V16.4133C99.9392 14.0112 98.5635 11.8217 96.4001 10.7807L75.8117 0.873695C73.7255 -0.13019 71.2838 0.115699 69.4527 1.44688C69.1912 1.63705 68.942 1.84937 68.7082 2.08335L29.2943 38.0414L12.1264 25.0096C10.5283 23.7964 8.29285 23.8959 6.80855 25.246L1.30225 30.2548C-0.513334 31.9064 -0.515415 34.7627 1.29775 36.4169L16.1863 50L1.29775 63.5832C-0.515415 65.2374 -0.513334 68.0937 1.30225 69.7452L6.80855 74.754C8.29285 76.1042 10.5283 76.2036 12.1264 74.9905L29.2943 61.9586L68.7082 97.9167C69.3317 98.5405 70.0638 99.0104 70.8511 99.3171ZM74.9544 27.2989L45.0483 50L74.9544 72.7012V27.2989Z" fill="url(#paint0_linear)"/>
      </g>
      </g>
      <defs>
      <filter id="filter0_d" x="-8.39411" y="15.8291" width="116.727" height="92.2456" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
      <feOffset/>
      <feGaussianBlur stdDeviation="4.16667"/>
      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
      <feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
      </filter>
      <filter id="filter1_d" x="60.4167" y="-8.07558" width="47.9167" height="116.151" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
      <feFlood flood-opacity="0" result="BackgroundImageFix"/>
      <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
      <feOffset/>
      <feGaussianBlur stdDeviation="4.16667"/>
      <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
      <feBlend mode="overlay" in2="BackgroundImageFix" result="effect1_dropShadow"/>
      <feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
      </filter>
      <linearGradient id="paint0_linear" x1="49.9392" y1="0.257812" x2="49.9392" y2="99.7423" gradientUnits="userSpaceOnUse">
      <stop stop-color="white"/>
      <stop offset="1" stop-color="white" stop-opacity="0"/>
      </linearGradient>
      </defs>
      </svg>
    iconMediatype: image/svg+xml
    publisher: che-incubator
    repository: https://github.com/che-incubator/che-code
    skipMetaYaml: true
    title: Red Hat OpenShift Dev Spaces with Microsoft Visual Studio Code - Open Source
      IDE
    version: latest
  description: Red Hat OpenShift Dev Spaces with Microsoft Visual Studio Code - Open
    Source IDE
  displayName: VS Code - Open Source
  name: che-code
schemaVersion: 2.2.2
          ▼ DevWorkspaceConfigurationHelper.generateDevfileContext
No plug-in registry url. Setting to https://eclipse-che.github.io/che-plugin-registry/main/v3
Validating devfile
Devfile is valid with schema version 2.2.2
DevWorkspace che-code-dotnet was generated
          ▼ DevWorkspaceConfigurationHelper.getDevWorkspaceConfigurationYamlAsString
          ▼ KubernetesCommandLineToolsExecutor.applyAndWaitDevWorkspace - oc
          ▼ KubernetesCommandLineToolsExecutor.applyYamlConfigurationAsStringOutput - oc
          ▼ ShellExecutor.executeCommand - cat <<EOF | oc apply -n admin-devspaces -f - 
          apiVersion: workspace.devfile.io/v1alpha2
          kind: DevWorkspaceTemplate
          metadata:
            name: che-code-dotnet
          spec:
            commands:
              - apply:
                  component: che-code-injector
                id: init-container-command
              - exec:
                  commandLine: nohup /checode/entrypoint-volume.sh > /checode/entrypoint-logs.txt
                    2>&1 &
                  component: che-code-runtime-description
                id: init-che-code-command
            components:
              - container:
                  command:
                    - /entrypoint-init-container.sh
                  cpuLimit: 500m
                  cpuRequest: 30m
                  image: registry.redhat.io/devspaces/code-rhel8@sha256:02c8f907dc2e18c61fa643accbf8378f385d3368af49794a78b9529cc63eb636
                  memoryLimit: 256Mi
                  memoryRequest: 32Mi
                  volumeMounts:
                    - name: checode
                      path: /checode
                name: che-code-injector
              - attributes:
                  app.kubernetes.io/component: che-code-runtime
                  app.kubernetes.io/part-of: che-code.eclipse.org
                  controller.devfile.io/container-contribution: true
                container:
                  cpuLimit: 500m
                  cpuRequest: 30m
                  endpoints:
                    - attributes:
                        cookiesAuthEnabled: true
                        discoverable: false
                        type: main
                        urlRewriteSupported: true
                      exposure: public
                      name: che-code
                      protocol: https
                      secure: true
                      targetPort: 3100
                    - attributes:
                        discoverable: false
                        urlRewriteSupported: false
                      exposure: public
                      name: code-redirect-1
                      protocol: https
                      targetPort: 13131
                    - attributes:
                        discoverable: false
                        urlRewriteSupported: false
                      exposure: public
                      name: code-redirect-2
                      protocol: https
                      targetPort: 13132
                    - attributes:
                        discoverable: false
                        urlRewriteSupported: false
                      exposure: public
                      name: code-redirect-3
                      protocol: https
                      targetPort: 13133
                  image: registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
                  memoryLimit: 1024Mi
                  memoryRequest: 256Mi
                  volumeMounts:
                    - name: checode
                      path: /checode
                name: che-code-runtime-description
              - name: checode
                volume: {}
            events:
              postStart:
                - init-che-code-command
              preStart:
                - init-container-command
          ---
          apiVersion: workspace.devfile.io/v1alpha2
          kind: DevWorkspace
          metadata:
            name: dotnetafab38d2
            annotations:
              che.eclipse.org/devfile: >
                schemaVersion: 2.2.2
          
                metadata:
                  name: dotnet
                components:
                  - name: tools
                    container:
                      image: >-
                        registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
                      memoryLimit: 2Gi
                      memoryRequest: 1Gi
                      cpuLimit: '1'
                      cpuRequest: '0.5'
                      mountSources: true
                      endpoints:
                        - exposure: public
                          name: hello-endpoint
                          protocol: https
                          targetPort: 5032
                      volumeMounts:
                        - name: nuget
                          path: /home/user/.nuget
                  - name: nuget
                    volume:
                      size: 1G
                commands:
                  - id: 1-update-dependencies
                    exec:
                      label: 1.Update dependencies
                      component: tools
                      workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
                      commandLine: dotnet restore
                      group:
                        kind: build
                  - id: 2-build
                    exec:
                      label: 2.Build
                      component: tools
                      workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
                      commandLine: dotnet build
                      group:
                        kind: build
                  - id: 3-run
                    exec:
                      label: 3.Run
                      component: tools
                      workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
                      commandLine: dotnet run
                      group:
                        kind: run
                projects:
                  - name: dotnet-web-simple
                    zip:
                      location: >-
                        http://devspaces-dashboard.openshift-devspaces.svc:8080/dashboard/api/airgap-sample/project/download?id=dotnet
          spec:
            started: true
            routingClass: che
            template:
              components:
                - name: tools
                  container:
                    image: registry.redhat.io/devspaces/udi-rhel8@sha256:d147892c643a0127cfcf868daee0ff416a8df922fe2a7c716ebfc457ff526fa2
                    memoryLimit: 2Gi
                    memoryRequest: 1Gi
                    cpuLimit: "1"
                    cpuRequest: "0.5"
                    mountSources: true
                    endpoints:
                      - exposure: public
                        name: hello-endpoint
                        protocol: https
                        targetPort: 5032
                    volumeMounts:
                      - name: nuget
                        path: /home/user/.nuget
                - name: nuget
                  volume:
                    size: 1G
              commands:
                - id: 1-update-dependencies
                  exec:
                    label: 1.Update dependencies
                    component: tools
                    workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
                    commandLine: dotnet restore
                    group:
                      kind: build
                - id: 2-build
                  exec:
                    label: 2.Build
                    component: tools
                    workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
                    commandLine: dotnet build
                    group:
                      kind: build
                - id: 3-run
                  exec:
                    label: 3.Run
                    component: tools
                    workingDir: ${PROJECTS_ROOT}/dotnet-web-simple
                    commandLine: dotnet run
                    group:
                      kind: run
              projects:
                - name: dotnet-web-simple
                  zip:
                    location: http://devspaces-dashboard.openshift-devspaces.svc:8080/dashboard/api/airgap-sample/project/download?id=dotnet
            contributions:
              - name: editor
                kubernetes:
                  name: che-code-dotnet
          
          EOF
devworkspacetemplate.workspace.devfile.io/che-code-dotnet created
devworkspace.workspace.devfile.io/dotnetafab38d2 created
          ▼ KubernetesCommandLineToolsExecutor.waitDevWorkspace - oc - wait till workspace ready.
          ▼ ShellExecutor.executeCommand - oc wait -n admin-devspaces --for=condition=Ready dw dotnetafab38d2 --timeout=360s
devworkspace.workspace.devfile.io/dotnetafab38d2 condition met
          ▼ KubernetesCommandLineToolsExecutor.getPodAndContainerNames - oc
          ▼ KubernetesCommandLineToolsExecutor.getWorkspacePodName - oc - get workspace pod name.
          ▼ ShellExecutor.executeCommand - oc get pod -l controller.devfile.io/devworkspace_name=dotnetafab38d2 -n admin-devspaces -o name
pod/workspace22be75b7037c400e-5d9c75bc8b-mp88b
          ▼ KubernetesCommandLineToolsExecutor.getContainerName - oc - get container name.
          ▼ ShellExecutor.executeCommand - oc get pod/workspace22be75b7037c400e-5d9c75bc8b-mp88b -o jsonpath='{.spec.containers[*].name}' -n admin-devspaces
tools che-gateway

    ✔ Create  dotnet workspace (39340ms)
      • workdir from exec section of DevFile: ${PROJECTS_ROOT}/dotnet-web-simple
      • containerName from exec section of DevFile: tools
      • "Test 'update-dependencies' command execution"
      • commandLine from exec section of DevFile file: dotnet restore
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace22be75b7037c400e-5d9c75bc8b-mp88b -n admin-devspaces -c tools -- sh -c 'cd ${PROJECTS_ROOT}/dotnet-web-simple && dotnet restore'

Welcome to .NET 9.0!
---------------------
SDK Version: 9.0.100

----------------
Installed an ASP.NET Core HTTPS development certificate.
To trust the certificate, run 'dotnet dev-certs https --trust'
Learn about HTTPS: https://aka.ms/dotnet-https

----------------
Write your first app: https://aka.ms/dotnet-hello-world
Find out what's new: https://aka.ms/dotnet-whats-new
Explore documentation: https://aka.ms/dotnet-docs
Report issues and find source on GitHub: https://github.com/dotnet/core
Use 'dotnet --help' to see available commands or visit: https://aka.ms/dotnet-cli
--------------------------------------------------------------------------------------
  Determining projects to restore...
  Restored /projects/dotnet-web-simple/web.csproj (in 1.38 sec).
      • "Test 'build' command execution"
      • commandLine from exec section of DevFile: dotnet build
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace22be75b7037c400e-5d9c75bc8b-mp88b -n admin-devspaces -c tools -- sh -c 'cd ${PROJECTS_ROOT}/dotnet-web-simple && dotnet build'
  Determining projects to restore...
  All projects are up-to-date for restore.
  web -> /projects/dotnet-web-simple/bin/Debug/net8.0/web.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:09.02
      • "Test 'run' command execution"
      • commandLine from exec section of DevFile: dotnet run
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace22be75b7037c400e-5d9c75bc8b-mp88b -n admin-devspaces -c tools -- sh -c 'cd ${PROJECTS_ROOT}/dotnet-web-simple && sh -c "(dotnet run > server.log 2>&1 &) && sleep 20s && exit"'
          ▼ ContainerTerminal.execInContainerCommand - oc
          ▼ ShellExecutor.executeCommand - oc exec -i pod/workspace22be75b7037c400e-5d9c75bc8b-mp88b -n admin-devspaces -c tools -- sh -c 'cat ${PROJECTS_ROOT}/dotnet-web-simple/server.log'
Using launch settings from /projects/dotnet-web-simple/Properties/launchSettings.json...
Building...
info: Microsoft.Hosting.Lifetime[14]
      Now listening on: http://localhost:5032
info: Microsoft.Hosting.Lifetime[0]
      Application started. Press Ctrl+C to shut down.
info: Microsoft.Hosting.Lifetime[0]
      Hosting environment: Development
info: Microsoft.Hosting.Lifetime[0]
      Content root path: /projects/dotnet-web-simple
      • Log output: Using launch settings from /projects/dotnet-web-simple/Properties/launchSettings.json...
      Building...
      info: Microsoft.Hosting.Lifetime[14]
            Now listening on: http://localhost:5032
      info: Microsoft.Hosting.Lifetime[0]
            Application started. Press Ctrl+C to shut down.
      info: Microsoft.Hosting.Lifetime[0]
            Hosting environment: Development
      info: Microsoft.Hosting.Lifetime[0]
            Content root path: /projects/dotnet-web-simple
      
    ✔ Check devfile commands (42914ms)
          ▼ KubernetesCommandLineToolsExecutor.deleteDevWorkspace - oc - delete 'dotnetafab38d2' devWorkspace
          ▼ ShellExecutor.executeCommand - oc patch dw dotnetafab38d2 -n admin-devspaces -p '{ "metadata": { "finalizers": null }}' --type merge || true
devworkspace.workspace.devfile.io/dotnetafab38d2 patched
          ▼ ShellExecutor.executeCommand - oc delete dw dotnetafab38d2 -n admin-devspaces || true
devworkspace.workspace.devfile.io "dotnetafab38d2" deleted
          ▼ KubernetesCommandLineToolsExecutor.deleteDevWorkspace - oc - delete 'dotnet' devWorkspaceTemplate
          ▼ ShellExecutor.executeCommand - oc delete dwt che-code-dotnet -n admin-devspaces || true
devworkspacetemplate.workspace.devfile.io "che-code-dotnet" deleted


  2 passing (1m)
```

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Run the `DotnetDevFileAPI.spec.ts` as usual

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
