### PR TITLE
Automate `Check ssh address of private repo with SSH key with no OAuth or PAT` test-case

### DIFF
--- a/tests/e2e/pageobjects/dashboard/Dashboard.ts
+++ b/tests/e2e/pageobjects/dashboard/Dashboard.ts
@@ -185,7 +185,7 @@ export class Dashboard {
 		await this.driverHelper.waitDisappearance(Dashboard.USER_SETTINGS_DROPDOWN, timeout);
 	}
 
-	async clickContinueWithDefaultDevfileButton(timeout: number = TIMEOUT_CONSTANTS.TS_CLICK_DASHBOARD_ITEM_TIMEOUT): Promise<void> {
+	async clickContinueWithDefaultDevfileButton(timeout: number = TIMEOUT_CONSTANTS.TS_COMMON_DASHBOARD_WAIT_TIMEOUT): Promise<void> {
 		Logger.debug();
 
 		await this.driverHelper.waitAndClick(Dashboard.CONTINUE_WITH_DEFAULT_DEVFILE_BUTTON, timeout);

--- a/tests/e2e/specs/miscellaneous/SshFactoryWithoutPAT.spec.ts
+++ b/tests/e2e/specs/miscellaneous/SshFactoryWithoutPAT.spec.ts
@@ -1,0 +1,74 @@
+/** *******************************************************************
+ * copyright (c) 2025 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { ViewSection } from 'monaco-page-objects';
+import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
+import { CLASSES } from '../../configs/inversify.types';
+import { e2eContainer } from '../../configs/inversify.config';
+import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
+import { registerRunningWorkspace } from '../MochaHooks';
+import { LoginTests } from '../../tests-library/LoginTests';
+import { StringUtil } from '../../utils/StringUtil';
+import { FACTORY_TEST_CONSTANTS } from '../../constants/FACTORY_TEST_CONSTANTS';
+import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { expect } from 'chai';
+import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+
+suite(`The SshFactoryWithoutPAT userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
+	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
+	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
+	const browserTabsUtil: BrowserTabsUtil = e2eContainer.get(CLASSES.BrowserTabsUtil);
+	const factoryUrl: string =
+		FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL.length === 0
+			? BASE_TEST_CONSTANTS.TS_SELENIUM_BASE_URL + '/dashboard/#/' + 'git@github.com:crw-qe/private-repo-check.git'
+			: BASE_TEST_CONSTANTS.TS_SELENIUM_BASE_URL + '/dashboard/#/' + FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL;
+
+	const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+
+	let projectSection: ViewSection;
+	suite(`Create workspace from factory:${factoryUrl}`, function (): void {
+		suiteSetup('Login', async function (): Promise<void> {
+			await loginTests.loginIntoChe();
+		});
+
+		test('Check creating workspace using default devfile', async function (): Promise<void> {
+			await browserTabsUtil.navigateTo(factoryUrl);
+			await dashboard.waitLoader();
+			await dashboard.clickContinueWithDefaultDevfileButton();
+			await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+			registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+			await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+		});
+
+		test('Check a project folder has been created', async function (): Promise<void> {
+			const projectName: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_PROJECT_NAME || StringUtil.getProjectNameFromGitUrl(factoryUrl);
+			projectSection = await projectAndFileTests.getProjectViewSession();
+			expect(await projectAndFileTests.getProjectTreeItem(projectSection, projectName), 'Project folder was not imported').not
+				.undefined;
+		});
+		test('Check the project files was imported', async function (): Promise<void> {
+			expect(
+				await projectAndFileTests.getProjectTreeItem(projectSection, BASE_TEST_CONSTANTS.TS_SELENIUM_PROJECT_ROOT_FILE_NAME),
+				'Project files were not imported'
+			).not.undefined;
+		});
+		test('Stop the workspace by UI', async function (): Promise<void> {
+			await workspaceHandlingTests.stopWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+			await browserTabsUtil.closeAllTabsExceptCurrent();
+		});
+		test('Delete the workspace by UI', async function (): Promise<void> {
+			await workspaceHandlingTests.removeWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+		});
+		suiteTeardown('Unregister running workspace', function (): void {
+			registerRunningWorkspace('');
+		});
+	});
+});


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
https://issues.redhat.com/browse/CRW-7904

### Screenshot/screencast of this PR

`  The SshFactoryWithoutPAT userstory 
    Create workspace from factory:https://devspaces.apps.ocp417-sskoryk.crw-qe.com/dashboard/#/git@github.com:crw-qe/private-repo-check.git
          ▼ LoginTests.loginIntoChe
            ‣ BrowserTabsUtil.getCurrentUrl
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.navigateTo - https://devspaces.apps.ocp417-sskoryk.crw-qe.com
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
  Wait timed out after 1074ms
          ▼ LoginTests.loginIntoChe - try to login into application
          ▼ RegularUserOcpCheLoginPage.login
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="panel-login"]/div[contains(@class, "panel-content")]/form/button)
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="panel-login"]/div[contains(@class, "panel-content")]/form/button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.isIdentityProviderLinkVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.isVisible - By(xpath, //a[text()="htpasswd"])
          ▼ OcpLoginPage.waitAndClickOnLoginProviderTitle
            ‣ DriverHelper.waitAndClick - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - By(xpath, //a[text()="htpasswd"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitVisibility - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterUserNameOpenShift - "admin"
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputUsername"]) text: admin
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputUsername"]) text: admin
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterPasswordOpenShift
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.clickOnLoginButton
            ‣ DriverHelper.waitAndClick - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitDisappearanceOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitDisappearance - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.isVisible - By(xpath, //*[contains(text(), "Welcome")])
          ▼ OcpLoginPage.isAuthorizeOpenShiftIdentityProviderPageVisible
            ‣ DriverHelper.isVisible - By(xpath, //h1[text()="Authorize Access"])
            ‣ BrowserTabsUtil.maximize
          ▼ BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitStartingPageLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, .main-page-loader)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, .main-page-loader)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ BrowserTabsUtil.navigateTo - https://devspaces.apps.ocp417-sskoryk.crw-qe.com/dashboard/#/git@github.com:crw-qe/private-repo-check.git
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitLoader
            ‣ DriverHelper.waitAllPresence - By(xpath, //*[@data-testid="step-title"])
            ‣ DriverHelper.waitAllPresence - polling timed out attempt #1, retrying with 1000ms timeout
          ▼ Dashboard.clickContinueWithDefaultDevfileButton
            ‣ DriverHelper.waitAndClick - By(xpath, //button[text()="Continue with default devfile"])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Continue with default devfile"])
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //button[text()="Continue with default devfile"])
  Wait timed out after 1115ms
            ‣ DriverHelper.waitAndClick - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Continue with default devfile"])
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //button[text()="Continue with default devfile"])
  Wait timed out after 1095ms
            ‣ DriverHelper.waitAndClick - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Continue with default devfile"])
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //button[text()="Continue with default devfile"])
  Wait timed out after 1114ms
            ‣ DriverHelper.waitAndClick - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Continue with default devfile"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace private-repo-check-vut0
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():private-repo-check-vut0
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: private-repo-check-vut0
          ▼ registerRunningWorkspace - with workspaceName:private-repo-check-vut0
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #15, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #16, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #17, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #18, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #19, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #20, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #21, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #22, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #23, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #24, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #25, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #26, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #27, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #28, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #29, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #30, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #31, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #32, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #33, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #34, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #35, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #36, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #37, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #38, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #39, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #40, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #41, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #42, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #43, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #44, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #45, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #46, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #47, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #48, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #49, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #50, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 76757 seconds.
      ✔ Check creating workspace using default devfile (86847ms)
          ▼ Function.getProjectNameFromGitUrl - https://devspaces.apps.ocp417-sskoryk.crw-qe.com/dashboard/#/git@github.com:crw-qe/private-repo-check.git
          ▼ Function.getProjectNameFromGitUrl - private-repo-check
          ▼ ProjectAndFileTests.getProjectViewSession
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-list-row)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.getProjectTreeItem - private-repo-check
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
      ✔ Check a project folder has been created
          ▼ ProjectAndFileTests.getProjectTreeItem - devfile.yaml
            ‣ DriverHelper.waitVisibility - By(xpath, .//div[@role='treeitem' and @aria-level='2'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
      ✔ Check the project files was imported
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.stopWorkspaceByUI - "private-repo-check-vut0"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "private-repo-check-vut0"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithRunningStatus - "private-repo-check-vut0"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Running'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.stopWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "private-repo-check-vut0"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'private-repo-check-vut0' list item
          ▼ Workspaces.clickActionsButton - of the 'private-repo-check-vut0' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]/td/div/button[@aria-label='Actions'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]/td/div/button[@aria-label='Actions'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'private-repo-check-vut0' list item
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]//button[@aria-label='Actions' and @aria-expanded='true'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsStopWorkspaceButton - for the 'private-repo-check-vut0' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]//button[text()='Stop Workspace'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]//button[text()='Stop Workspace'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceWithStoppedStatus - "private-repo-check-vut0"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]//span[@data-testid='workspace-status-indicator' and @aria-label='Workspace status is Stopped'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
      ✔ Stop the workspace by UI
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.deleteStoppedWorkspaceByUI - "private-repo-check-vut0"
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItem - "private-repo-check-vut0"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.deleteWorkspaceByActionsButton
          ▼ Workspaces.waitWorkspaceListItem - "private-repo-check-vut0"
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.openActionsPopup - for the 'private-repo-check-vut0' list item
          ▼ Workspaces.clickActionsButton - of the 'private-repo-check-vut0' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]/td/div/button[@aria-label='Actions'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]/td/div/button[@aria-label='Actions'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitActionsPopup - of the 'private-repo-check-vut0' list item
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]//button[@aria-label='Actions' and @aria-expanded='true'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickActionsDeleteButton - for the 'private-repo-check-vut0' list item
            ‣ DriverHelper.waitAndClick - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]//button[text()='Delete Workspace'])
            ‣ DriverHelper.waitVisibility - By(xpath, //tr[td//a[text()='private-repo-check-vut0']]//button[text()='Delete Workspace'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitDeleteWorkspaceConfirmationWindow
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@aria-label="Delete workspaces confirmation window"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.clickToDeleteConfirmationCheckbox
            ‣ DriverHelper.waitAndClick - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - By(xpath, //input[@data-testid="confirmation-checkbox"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitAndClickEnabledConfirmationWindowDeleteButton
            ‣ DriverHelper.waitAndClick - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - By(xpath, //button[@data-testid="delete-workspace-button" and not(@disabled)])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //button[text()="Add Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Workspaces.waitWorkspaceListItemAbsence - "private-repo-check-vut0"
            ‣ DriverHelper.waitDisappearance - By(xpath, //tr[td//a[text()='private-repo-check-vut0']])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //tr[td//a[text()='private-repo-check-vut0']])
            ‣ DriverHelper.isVisible - By(xpath, //tr[td//a[text()='private-repo-check-vut0']])
      ✔ Delete the workspace by UI
          ▼     at /home/sskoryk/codenvy-projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name


  5 passing (2m)`

### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)