### PR TITLE
Fix devfile API tests to run against Eclipse Che with default environment variables; fix linter errors

### DIFF
--- a/tests/e2e/specs/api/CppDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/CppDevFileAPI.spec.ts
@@ -43,7 +43,7 @@ suite('Cpp devfile API test', function (): void {
 
 	test(`Create  ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/DotnetDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/DotnetDevFileAPI.spec.ts
@@ -39,7 +39,7 @@ suite('Dotnet devfile API test', function (): void {
 
 	test(`Create  ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/GoDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/GoDevFileAPI.spec.ts
@@ -40,7 +40,7 @@ suite('Go devfile API test', function (): void {
 
 	test(`Create ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/JBossEapDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/JBossEapDevFileAPI.spec.ts
@@ -39,7 +39,7 @@ suite('JBoss EAP devfile API test', function (): void {
 
 	test(`Create ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/LombokDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/LombokDevFileAPI.spec.ts
@@ -39,7 +39,7 @@ suite('Lombok devfile API test', function (): void {
 
 	test(`Create ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/NodeJSMongoDBDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/NodeJSMongoDBDevFileAPI.spec.ts
@@ -39,7 +39,7 @@ suite('NodeJS MongoDB devfile API test', function (): void {
 
 	test(`Create ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/NodeJsExpressDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/NodeJsExpressDevFileAPI.spec.ts
@@ -39,7 +39,7 @@ suite('NodeJS Express devfile API test', function (): void {
 
 	test(`Create ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/PhpDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/PhpDevFileAPI.spec.ts
@@ -39,7 +39,7 @@ suite('PHP devfile API test', function (): void {
 
 	test(`Create ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/PythonDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/PythonDevFileAPI.spec.ts
@@ -40,7 +40,7 @@ suite('Python devfile API test', function (): void {
 
 	test(`Create ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/api/QuarkusDevFileAPI.spec.ts
+++ b/tests/e2e/specs/api/QuarkusDevFileAPI.spec.ts
@@ -39,7 +39,7 @@ suite('Quarkus devfile API test', function (): void {
 
 	test(`Create ${devfileID} workspace`, async function (): Promise<void> {
 		const randomPref: string = crypto.randomBytes(4).toString('hex');
-		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE || 'admin-devspaces';
+		kubernetesCommandLineToolsExecutor.namespace = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE;
 		devfileContent = devfilesRegistryHelper.getDevfileContent(devfileID);
 		const editorDevfileContent: string = devfilesRegistryHelper.obtainCheDevFileEditorFromCheConfigMap('editors-definitions');
 		devfileName = YAML.parse(devfileContent).metadata.name;

--- a/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
+++ b/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
@@ -65,7 +65,6 @@ suite(
 		let viewsActionsButton: boolean;
 
 		// test specific data
-		let numberOfCreatedWorkspaces: number = 0;
 		const timeToRefresh: number = 1500;
 		const changesToCommit: string = new Date().getTime().toString();
 		const fileToChange: string = 'Date.txt';
@@ -78,12 +77,6 @@ suite(
 
 		suiteSetup('Login', async function (): Promise<void> {
 			await loginTests.loginIntoChe();
-		});
-
-		test('Get number of previously created workspaces', async function (): Promise<void> {
-			await dashboard.clickWorkspacesButton();
-			await workspaces.waitPage();
-			numberOfCreatedWorkspaces = (await workspaces.getAllCreatedWorkspacesNames()).length;
 		});
 
 		test(`Navigate to the ${isPrivateRepo} repository factory URL`, async function (): Promise<void> {

--- a/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
+++ b/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
@@ -33,7 +33,6 @@ import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTes
 import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
-import { Workspaces } from '../../pageobjects/dashboard/Workspaces';
 import { Logger } from '../../utils/Logger';
 import { LoginTests } from '../../tests-library/LoginTests';
 import { FACTORY_TEST_CONSTANTS, GitProviderType } from '../../constants/FACTORY_TEST_CONSTANTS';
@@ -53,7 +52,6 @@ suite(
 		const webCheCodeLocators: Locators = cheCodeLocatorLoader.webCheCodeLocators;
 		const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
 		const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
-		const workspaces: Workspaces = e2eContainer.get(CLASSES.Workspaces);
 		const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
 		const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
 		const createWorkspace: CreateWorkspace = e2eContainer.get(CLASSES.CreateWorkspace);


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
It removes hard-coded `admin-devspaces` namespace name in devfile API tests and makes it possible to run devfile API tests against Eclipse Che with default environment variables.

Also, it fixes linter errors in file `NoSetupRepoFactory.spec.ts`:
- 'numberOfCreatedWorkspaces' is assigned a value but never used.
- 'workspaces' is assigned a value but never used

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-7914

### How to test this PR?
Test run: "[job/functional-tests/1743/](https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/complex/job/latest/job/functional-tests/1743/)"


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
