### PR TITLE
[Test] Add 'Restricted Mode' button handler to switch on 'Trust Mode' in IDE in E2E tests

### DIFF
--- a/tests/e2e/CODE_STYLE.md
+++ b/tests/e2e/CODE_STYLE.md
@@ -33,8 +33,8 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
 pre-commit hook.
 Full set of rules can be found:
 
-- [.eslintrc](.eslintrc.js)
-- [.prettierrc](.prettierrc.json)
+-   [.eslintrc](.eslintrc.js)
+-   [.prettierrc](.prettierrc.json)
 
 ### Preferable code style
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -2,33 +2,33 @@
 
 ## Requirements
 
-- node 16.x
-- "Chrome" browser 114.x or later
-- deployed Che 7 with accessible URL
+-   node 16.x
+-   "Chrome" browser 114.x or later
+-   deployed Che 7 with accessible URL
 
 ## Before launch
 
 **Perform commands:**
 
-- `export TS_SELENIUM_BASE_URL=<Che7 URL>`
-- `npm ci`
+-   `export TS_SELENIUM_BASE_URL=<Che7 URL>`
+-   `npm ci`
 
 Note: If there is any modifications in package.json, manually execute the `npm install` to update the package-lock.json. So that errors can be avoided while executing npm ci
 
 ## Default launch
 
-- Provide connection credentials:
-    - `export TS_SELENIUM_OCP_USERNAME=<username>`
-    - `export TS_SELENIUM_OCP_PASSWORD=<password>`
-    - `npm run test`
+-   Provide connection credentials:
+    -   `export TS_SELENIUM_OCP_USERNAME=<username>`
+    -   `export TS_SELENIUM_OCP_PASSWORD=<password>`
+    -   `npm run test`
 
 ## Custom launch
 
-- Use environment variables which described in the "constants" folder
-- Use environment variables for setting timeouts if needed. You can see the list in **`'TimeoutConstants.ts'`**. You can see the list of those variables and their value if you set the `'TS_SELENIUM_PRINT_TIMEOUT_VARIABLES = true'`
-- To test one specification export file name as `export USERSTORY=<spec-file-name-without-extension> && npm run test` (example: `-e USERSTORY=Quarkus`)
-- To run test without Selenium WebDriver (API tests etc.) use `export USERSTORY=<spec-file-name-without-extension> && npm run driver-less-test` (example: `-e USERSTORY=CloneGitRepoAPI`)
-- This project support application testing deployed on Kubernetes or Openshift platform. Openshift is default value. To switch into Kubernetes, please, use `TS_PLATFORM=kubernetes` environmental variable and `TS_SELENIUM_K8S_PASSWORD`, `TS_SELENIUM_K8S_USERNAME` to provide credentials. The sample of test command in this case:
+-   Use environment variables which described in the "constants" folder
+-   Use environment variables for setting timeouts if needed. You can see the list in **`'TimeoutConstants.ts'`**. You can see the list of those variables and their value if you set the `'TS_SELENIUM_PRINT_TIMEOUT_VARIABLES = true'`
+-   To test one specification export file name as `export USERSTORY=<spec-file-name-without-extension> && npm run test` (example: `-e USERSTORY=Quarkus`)
+-   To run test without Selenium WebDriver (API tests etc.) use `export USERSTORY=<spec-file-name-without-extension> && npm run driver-less-test` (example: `-e USERSTORY=CloneGitRepoAPI`)
+-   This project support application testing deployed on Kubernetes or Openshift platform. Openshift is default value. To switch into Kubernetes, please, use `TS_PLATFORM=kubernetes` environmental variable and `TS_SELENIUM_K8S_PASSWORD`, `TS_SELENIUM_K8S_USERNAME` to provide credentials. The sample of test command in this case:
     ```
     export TS_PLATFORM=kubernetes && \
     export TS_SELENIUM_K8S_USERNAME=<username> && \
@@ -37,21 +37,21 @@ Note: If there is any modifications in package.json, manually execute the `npm i
     npm run test
     ```
     Also, environmental variables can be set in files in "constants" folder.
-- Local test results can be represented with Allure reporter `npm run open-allure-dasboard`
+-   Local test results can be represented with Allure reporter `npm run open-allure-dasboard`
 
 ## Docker launch
 
-- open terminal and go to the "e2e" directory
-- export the `"TS_SELENIUM_BASE_URL"` variable with "Che" url
-- run command `"npm run test-docker"`
+-   open terminal and go to the "e2e" directory
+-   export the `"TS_SELENIUM_BASE_URL"` variable with "Che" url
+-   run command `"npm run test-docker"`
 
 ## Docker launch with changed tests
 
 **For launching tests with local changes perform next steps:**
 
-- open terminal and go to the "e2e" directory
-- export the `"TS_SELENIUM_BASE_URL"` variable with "Che" url
-- run command `"npm run test-docker-mount-e2e"`
+-   open terminal and go to the "e2e" directory
+-   export the `"TS_SELENIUM_BASE_URL"` variable with "Che" url
+-   run command `"npm run test-docker-mount-e2e"`
 
 ## Debug docker launch
 
@@ -62,27 +62,27 @@ The `'eclipse/che-e2e'` docker image has VNC server installed inside. For connec
 **The easiest way to do that is to perform steps which are described in the "Docker launch" paragraph.
 For running tests without docker, please perform next steps:**
 
-- Deploy Che on Kubernetes infrastructure by using 'Minikube' and 'Chectl' <https://github.com/eclipse-che/che-server/blob/HEAD/deploy/kubernetes/README.md>
-- Create workspace by using 'Chectl' and devfile
-    - link to 'Chectl' manual <https://github.com/che-incubator/chectl#chectl-workspacestart>
-    - link to devfile ( **`For successfull test passing, exactly provided devfile should be used`** )
-      <https://gist.githubusercontent.com/Ohrimenko1988/93f5426f4ebc1705c55feb8ff0396a49/raw/cbea89ad145ba33ed34a151a12c50f045f9f3b78/yaml-ls-bug.yaml>
-- Provide the **`'TS_SELENIUM_BASE_URL'`** environment variable as described above
-- export TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME=EmptyWorkspace (default value, see BASE_TEST_CONSTANTS.ts)
-- perform command **`export USERSTORY=$TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME && npm run test-all-devfiles`**
+-   Deploy Che on Kubernetes infrastructure by using 'Minikube' and 'Chectl' <https://github.com/eclipse-che/che-server/blob/HEAD/deploy/kubernetes/README.md>
+-   Create workspace by using 'Chectl' and devfile
+    -   link to 'Chectl' manual <https://github.com/che-incubator/chectl#chectl-workspacestart>
+    -   link to devfile ( **`For successfull test passing, exactly provided devfile should be used`** )
+        <https://gist.githubusercontent.com/Ohrimenko1988/93f5426f4ebc1705c55feb8ff0396a49/raw/cbea89ad145ba33ed34a151a12c50f045f9f3b78/yaml-ls-bug.yaml>
+-   Provide the **`'TS_SELENIUM_BASE_URL'`** environment variable as described above
+-   export TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME=EmptyWorkspace (default value, see BASE_TEST_CONSTANTS.ts)
+-   perform command **`export USERSTORY=$TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME && npm run test-all-devfiles`**
 
 ## Launching the DevWorkspaceHappyPath spec file using Che with oauth authentication
 
 **Setup next environment variables:**
 
-- export TS_SELENIUM_BASE_URL=\<Che-URL\>
-- export TS_SELENIUM_OCP_USERNAME=\<cluster-username\>
-- export TS_SELENIUM_OCP_PASSWORD=\<cluster-password\>
-- export TS_SELENIUM_VALUE_OPENSHIFT_OAUTH="true"
-- export TS_OCP_LOGIN_PAGE_PROVIDER_TITLE=\<login-provide-title\>
-- export TS_SELENIUM_DEVWORKSPACE_URL=\<devworkspace-url\>
-- export TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME=EmptyWorkspace (default value, see BASE_TEST_CONSTANTS.ts)
+-   export TS_SELENIUM_BASE_URL=\<Che-URL\>
+-   export TS_SELENIUM_OCP_USERNAME=\<cluster-username\>
+-   export TS_SELENIUM_OCP_PASSWORD=\<cluster-password\>
+-   export TS_SELENIUM_VALUE_OPENSHIFT_OAUTH="true"
+-   export TS_OCP_LOGIN_PAGE_PROVIDER_TITLE=\<login-provide-title\>
+-   export TS_SELENIUM_DEVWORKSPACE_URL=\<devworkspace-url\>
+-   export TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME=EmptyWorkspace (default value, see BASE_TEST_CONSTANTS.ts)
 
 **Execute the npm command:**
 
-- perform command `export USERSTORY=$TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME && npm run test-all-devfiles`
+-   perform command `export USERSTORY=$TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME && npm run test-all-devfiles`

--- a/tests/e2e/configs/inversify.config.ts
+++ b/tests/e2e/configs/inversify.config.ts
@@ -55,6 +55,7 @@ import { UserPreferences } from '../pageobjects/dashboard/UserPreferences';
 import { WebTerminalPage } from '../pageobjects/webterminal/WebTerminalPage';
 import { TrustAuthorPopup } from '../pageobjects/dashboard/TrustAuthorPopup';
 import { ViewsMoreActionsButton } from '../pageobjects/ide/ViewsMoreActionsButton';
+import { RestrictedModeButton } from '../pageobjects/ide/RestrictedModeButton';
 
 const e2eContainer: Container = new Container({ defaultScope: 'Transient', skipBaseClassChecks: true });
 
@@ -95,6 +96,7 @@ e2eContainer.bind<LocatorLoader>(EXTERNAL_CLASSES.LocatorLoader).to(LocatorLoade
 e2eContainer.bind<LocatorLoader>(EXTERNAL_CLASSES.LocatorLoader).to(LocatorLoader);
 e2eContainer.bind<TrustAuthorPopup>(CLASSES.TrustAuthorPopup).to(TrustAuthorPopup);
 e2eContainer.bind<ViewsMoreActionsButton>(CLASSES.ViewsMoreActionsButton).to(ViewsMoreActionsButton);
+e2eContainer.bind<RestrictedModeButton>(CLASSES.RestrictedModeButton).to(RestrictedModeButton);
 
 if (BASE_TEST_CONSTANTS.TS_PLATFORM === Platform.OPENSHIFT) {
 	if (OAUTH_CONSTANTS.TS_SELENIUM_VALUE_OPENSHIFT_OAUTH) {

--- a/tests/e2e/configs/inversify.types.ts
+++ b/tests/e2e/configs/inversify.types.ts
@@ -52,7 +52,8 @@ const CLASSES: any = {
 	WebTerminalPage: 'WebTerminalPage',
 	RevokeOauthPage: 'RevokeOauthPage',
 	TrustAuthorPopup: 'TrustAuthorPopup',
-	ViewsMoreActionsButton: 'ViewsMoreActionsButton'
+	ViewsMoreActionsButton: 'ViewsMoreActionsButton',
+	RestrictedModeButton: 'RestrictedModeButton'
 };
 
 const EXTERNAL_CLASSES: any = {

--- a/tests/e2e/index.ts
+++ b/tests/e2e/index.ts
@@ -31,6 +31,7 @@ export * from './pageobjects/dashboard/Workspaces';
 export * from './pageobjects/git-providers/OauthPage';
 export * from './pageobjects/ide/CheCodeLocatorLoader';
 export * from './pageobjects/ide/ViewsMoreActionsButton';
+export * from './pageobjects/ide/RestrictedModeButton';
 export * from './pageobjects/login/interfaces/ICheLoginPage';
 export * from './pageobjects/login/interfaces/IOcpLoginPage';
 export * from './pageobjects/login/kubernetes/DexLoginPage';

--- a/tests/e2e/pageobjects/ide/CheCodeLocatorLoader.ts
+++ b/tests/e2e/pageobjects/ide/CheCodeLocatorLoader.ts
@@ -54,6 +54,9 @@ export class CheCodeLocatorLoader extends LocatorLoader {
 				},
 				TreeItem: {
 					projectFolderItem: By.className('pane-header expanded')
+				},
+				Workbench: {
+					workspaceTrustButton: By.xpath('//a[@role="button" and text()="Trust"]')
 				}
 			}
 		};

--- a/tests/e2e/pageobjects/ide/CheCodeLocatorLoader.ts
+++ b/tests/e2e/pageobjects/ide/CheCodeLocatorLoader.ts
@@ -54,13 +54,6 @@ export class CheCodeLocatorLoader extends LocatorLoader {
 				},
 				TreeItem: {
 					projectFolderItem: By.className('pane-header expanded')
-				},
-				ScmView: {
-					manageWorkspaceTrust: By.xpath('.//a[@class="monaco-button monaco-text-button"]'),
-					modifiedFile: By.xpath('//div[@class="monaco-list-row" and contains(@aria-label, "Modified")]')
-				},
-				Workbench: {
-					workspaceTrustButton: By.xpath('//a[@role="button" and text()="Trust"]')
 				}
 			}
 		};

--- a/tests/e2e/pageobjects/ide/CheCodeLocatorLoader.ts
+++ b/tests/e2e/pageobjects/ide/CheCodeLocatorLoader.ts
@@ -1,5 +1,5 @@
 /** *******************************************************************
- * copyright (c) 2019 Red Hat, Inc.
+ * copyright (c) 2019-2025 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
+++ b/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
@@ -16,7 +16,7 @@ import { Logger } from '../../utils/Logger';
 
 @injectable()
 export class RestrictedModeButton {
-	private static readonly RESTRICTED_MODE_BUTTON: By = By.id('status.workspaceTrust]');
+	private static readonly RESTRICTED_MODE_BUTTON: By = By.id('status.workspaceTrust');
 
 	constructor(
 		@inject(CLASSES.DriverHelper)

--- a/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
+++ b/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
@@ -1,0 +1,31 @@
+/** *******************************************************************
+ * copyright (c) 2025 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { inject, injectable } from 'inversify';
+import 'reflect-metadata';
+import { CLASSES } from '../../configs/inversify.types';
+import { By } from 'selenium-webdriver';
+import { DriverHelper } from '../../utils/DriverHelper';
+import { Logger } from '../../utils/Logger';
+
+@injectable()
+export class RestrictedModeButton {
+	private static readonly RESTRICTED_MODE_BUTTON: By = By.id('status.workspaceTrust]');
+
+	constructor(
+		@inject(CLASSES.DriverHelper)
+		readonly driverHelper: DriverHelper
+	) {}
+
+	async clickOnRestrictedModeButton(): Promise<void> {
+		Logger.debug();
+
+		await this.driverHelper.waitAndClick(RestrictedModeButton.RESTRICTED_MODE_BUTTON);
+	}
+}

--- a/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
+++ b/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
@@ -29,9 +29,9 @@ export class RestrictedModeButton {
 		await this.driverHelper.waitAndClick(RestrictedModeButton.RESTRICTED_MODE_BUTTON);
 	}
 
-	async isRestrictedModeButtonDisappearance(): Promise<boolean> {
+	async isRestrictedModeButtonDisappearance(): Promise<void> {
 		Logger.debug();
 
-		return this.driverHelper.waitDisappearanceBoolean(RestrictedModeButton.RESTRICTED_MODE_BUTTON);
+		await this.driverHelper.waitDisappearance(RestrictedModeButton.RESTRICTED_MODE_BUTTON);
 	}
 }

--- a/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
+++ b/tests/e2e/pageobjects/ide/RestrictedModeButton.ts
@@ -28,4 +28,10 @@ export class RestrictedModeButton {
 
 		await this.driverHelper.waitAndClick(RestrictedModeButton.RESTRICTED_MODE_BUTTON);
 	}
+
+	async isRestrictedModeButtonDisappearance(): Promise<boolean> {
+		Logger.debug();
+
+		return this.driverHelper.waitDisappearanceBoolean(RestrictedModeButton.RESTRICTED_MODE_BUTTON);
+	}
 }

--- a/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
+++ b/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
@@ -153,17 +153,10 @@ for (const sample of samples) {
 		});
 
 		test(`Get recommended extensions list from ${extensionsListFileName}`, async function (): Promise<void> {
-			// sometimes the Trust Dialog does not appear as expected - as result we need to execute "projectAndFileTests.performManageWorkspaceTrustBox()" method. In this case.
-			try {
-				await (
-					await projectAndFileTests.getProjectTreeItem(projectSection, pathToExtensionsListFileName, vsCodeFolderItemLevel)
-				)?.select();
-			} catch (err) {
-				await projectAndFileTests.performManageWorkspaceTrustBox();
-				await (
-					await projectAndFileTests.getProjectTreeItem(projectSection, pathToExtensionsListFileName, vsCodeFolderItemLevel)
-				)?.select();
-			}
+			await (
+				await projectAndFileTests.getProjectTreeItem(projectSection, pathToExtensionsListFileName, vsCodeFolderItemLevel)
+			)?.select();
+
 			await (
 				await projectAndFileTests.getProjectTreeItem(projectSection, extensionsListFileName, vsCodeFolderItemLevel + 1)
 			)?.select();
@@ -185,13 +178,8 @@ for (const sample of samples) {
 
 		test('Open "Extensions" view section', async function (): Promise<void> {
 			Logger.debug('ActivityBar().getViewControl("Extensions"))?.openView(): open Extensions view.');
-			// sometimes the Trust Dialog does not appear as expected - as result we need to execute "projectAndFileTests.performManageWorkspaceTrustBox()" method. In this case.
-			try {
-				extensionsView = await (await new ActivityBar().getViewControl('Extensions'))?.openView();
-			} catch (err) {
-				await projectAndFileTests.performManageWorkspaceTrustBox();
-				extensionsView = await (await new ActivityBar().getViewControl('Extensions'))?.openView();
-			}
+			
+			extensionsView = await (await new ActivityBar().getViewControl('Extensions'))?.openView();
 			expect(extensionsView, 'Can`t find Extension section').not.undefined;
 		});
 

--- a/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
+++ b/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
@@ -1,5 +1,5 @@
 /** *******************************************************************
- * copyright (c) 2019-2023 Red Hat, Inc.
+ * copyright (c) 2019-2025 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0

--- a/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
+++ b/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
@@ -178,7 +178,7 @@ for (const sample of samples) {
 
 		test('Open "Extensions" view section', async function (): Promise<void> {
 			Logger.debug('ActivityBar().getViewControl("Extensions"))?.openView(): open Extensions view.');
-			
+
 			extensionsView = await (await new ActivityBar().getViewControl('Extensions'))?.openView();
 			expect(extensionsView, 'Can`t find Extension section').not.undefined;
 		});

--- a/tests/e2e/specs/factory/Factory.spec.ts
+++ b/tests/e2e/specs/factory/Factory.spec.ts
@@ -150,10 +150,6 @@ suite(
 			const scmView: NewScmView = new NewScmView();
 			await driverHelper.waitVisibility(webCheCodeLocators.ScmView.inputField);
 			[scmProvider, ...rest] = await scmView.getProviders();
-			if (scmProvider === undefined) {
-				await projectAndFileTests.performManageWorkspaceTrustBox();
-				[scmProvider, ...rest] = await scmView.getProviders();
-			}
 			Logger.debug(`scmView.getProviders: "${JSON.stringify(scmProvider)}, ${rest}"`);
 		});
 

--- a/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
+++ b/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
@@ -148,10 +148,6 @@ suite(
 				await driverHelper.waitVisibility(webCheCodeLocators.ScmView.inputField);
 				let rest: SingleScmProvider[];
 				[scmProvider, ...rest] = await scmView.getProviders();
-				if (scmProvider === undefined) {
-					await projectAndFileTests.performManageWorkspaceTrustBox();
-					[scmProvider, ...rest] = await scmView.getProviders();
-				}
 				Logger.debug(`scmView.getProviders: "${JSON.stringify(scmProvider)}, ${rest}"`);
 			});
 

--- a/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
+++ b/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
@@ -153,10 +153,6 @@ suite(
 				const scmView: NewScmView = new NewScmView();
 				await driverHelper.waitVisibility(webCheCodeLocators.ScmView.inputField);
 				[scmProvider, ...rest] = await scmView.getProviders();
-				if (scmProvider === undefined) {
-					await projectAndFileTests.performManageWorkspaceTrustBox();
-					[scmProvider, ...rest] = await scmView.getProviders();
-				}
 				Logger.debug(`scmView.getProviders: "${JSON.stringify(scmProvider)}, ${rest}"`);
 			});
 

--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -73,8 +73,11 @@ export class ProjectAndFileTests {
 				this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.button,
 				TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM
 			);
+			await this.restrictedModeButton.isRestrictedModeButtonDisappearance();
 		} catch (e) {
-			Logger.info('"Do you trust authors of the files in this workspace?" dialog box was not shown');
+			Logger.info(
+				'"Do you trust authors of the files in this workspace?" dialog box was not shown, or Restricted Mode is still active'
+			);
 
 			try {
 				await this.restrictedModeButton.clickOnRestrictedModeButton();

--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -1,5 +1,5 @@
 /** *******************************************************************
- * copyright (c) 2019-2023 Red Hat, Inc.
+ * copyright (c) 2019-2025 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -89,36 +89,9 @@ export class ProjectAndFileTests {
 	}
 
 	/**
-	 * manage to 'Trusted' Workspace Mode, when the trust author dialog does not appear
-	 * the "Manage Workspace Trust" box is appeared in Source Control View
-	 */
-	async performManageWorkspaceTrustBox(): Promise<void> {
-		Logger.debug();
-
-		try {
-			await this.driverHelper.waitAndClick(
-				(this.cheCodeLocatorLoader.webCheCodeLocators.ScmView as any).manageWorkspaceTrust,
-				TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT
-			);
-			await this.driverHelper.waitAndClick(
-				(this.cheCodeLocatorLoader.webCheCodeLocators.Workbench as any).workspaceTrustButton,
-				TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT
-			);
-			await this.driverHelper.waitAndClick(
-				(this.cheCodeLocatorLoader.webCheCodeLocators.ScmView as any).modifiedFile,
-				TIMEOUT_CONSTANTS.TS_DIALOG_WINDOW_DEFAULT_TIMEOUT
-			);
-		} catch (err) {
-			Logger.error(`Manage Workspace Trust box was not shown: ${err}`);
-			throw err;
-		}
-	}
-
-	/**
 	 * find an ViewSection with project tree.
 	 * @returns Promise resolving to ViewSection object
 	 */
-
 	async getProjectViewSession(): Promise<ViewSection> {
 		Logger.debug();
 

--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -65,6 +65,7 @@ export class ProjectAndFileTests {
 
 		try {
 			await workbench.click();
+			await this.driverHelper.refreshPage()
 			await this.driverHelper.waitVisibility(
 				this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.text,
 				TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM
@@ -73,7 +74,6 @@ export class ProjectAndFileTests {
 				this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.button,
 				TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM
 			);
-			await this.driverHelper.refreshPage()
 			await this.restrictedModeButton.isRestrictedModeButtonDisappearance();
 		} catch (e) {
 			Logger.info(

--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -65,7 +65,6 @@ export class ProjectAndFileTests {
 
 		try {
 			await workbench.click();
-			await this.driverHelper.refreshPage()
 			await this.driverHelper.waitVisibility(
 				this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.text,
 				TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM
@@ -74,6 +73,8 @@ export class ProjectAndFileTests {
 				this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.button,
 				TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM
 			);
+			// add TS_IDE_LOAD_TIMEOUT timeout for waiting for reloading the IDE
+			await this.driverHelper.wait(TIMEOUT_CONSTANTS.TS_IDE_LOAD_TIMEOUT);
 			await this.restrictedModeButton.isRestrictedModeButtonDisappearance();
 		} catch (e) {
 			Logger.info(

--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -65,6 +65,10 @@ export class ProjectAndFileTests {
 
 		try {
 			await workbench.click();
+			await this.driverHelper.waitVisibility(
+				this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.text,
+				TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM
+			);
 			await this.driverHelper.waitAndClick(
 				this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.button,
 				TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM

--- a/tests/e2e/tests-library/ProjectAndFileTests.ts
+++ b/tests/e2e/tests-library/ProjectAndFileTests.ts
@@ -73,6 +73,7 @@ export class ProjectAndFileTests {
 				this.cheCodeLocatorLoader.webCheCodeLocators.WelcomeContent.button,
 				TIMEOUT_CONSTANTS.TS_SELENIUM_CLICK_ON_VISIBLE_ITEM
 			);
+			await this.driverHelper.refreshPage()
 			await this.restrictedModeButton.isRestrictedModeButtonDisappearance();
 		} catch (e) {
 			Logger.info(


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* This PR fixes the problem with, in particular, `Recommended Extensions` E2E tests. The main reason of fail tests - the IDE continues to work in the `Restricted Mode`, that breaks tests (see screenshots).
The fix is encapsulated in the `tests/e2e/tests-library/ProjectAndFileTests.ts` and it handles `Restricted Mode` button to switch the IDE on `Trust Mode` and potentially can improve others tests which use this method.

* Below are provided logs from launch the `RecomendedExtensions` tests, where reflect two possible cases related to handle `Restricted Mode` button:
-- Dialog box `Do you trust authors of the files in this workspace?` is displayed and processed:
```
---------------------
00:36:49      ✔ Wait workspace readiness
00:36:49            ▼ ProjectAndFileTests.performTrustAuthorDialog
00:36:51              ‣ DriverHelper.waitVisibility - By(xpath, //*[@class="dialog-message-text" and contains(text(), "trust")])
00:36:52              ‣ DriverHelper.waitVisibility - element is located and is visible.
00:36:52              ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
00:36:52              ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
00:36:52              ‣ DriverHelper.waitVisibility - element is located and is visible.
00:36:52              ‣ DriverHelper.wait - (20000 milliseconds)
00:37:14            ▼ RestrictedModeButton.isRestrictedModeButtonDisappearance
00:37:14              ‣ DriverHelper.waitDisappearance - By(css selector, *[id="status\.workspaceTrust"])
00:37:14              ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, *[id="status\.workspaceTrust"])
00:37:14              ‣ DriverHelper.isVisible - By(css selector, *[id="status\.workspaceTrust"])
===================================================
```
-- Dialog box `Do you trust authors of the files in this workspace?` is not displayed or 'Restricted Mode' is still active:
```
-------------------------
00:37:42      ✔ Wait workspace readiness
00:37:42            ▼ ProjectAndFileTests.performTrustAuthorDialog
00:37:43              ‣ DriverHelper.waitVisibility - By(xpath, //*[@class="dialog-message-text" and contains(text(), "trust")])
00:37:43              ‣ DriverHelper.waitVisibility - element is located and is visible.
00:37:43              ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
00:37:43              ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="monaco-dialog-box"]//a[@class="monaco-button monaco-text-button"])
00:37:44              ‣ DriverHelper.waitVisibility - element is located and is visible.
00:37:44              ‣ DriverHelper.wait - (20000 milliseconds)
00:38:06            ▼ RestrictedModeButton.isRestrictedModeButtonDisappearance
00:38:06              ‣ DriverHelper.waitDisappearance - By(css selector, *[id="status\.workspaceTrust"])
00:38:06              ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, *[id="status\.workspaceTrust"])
00:38:06              ‣ DriverHelper.isVisible - By(css selector, *[id="status\.workspaceTrust"])
00:38:06              ‣ DriverHelper.wait - (1000 milliseconds)
00:38:06              ‣ DriverHelper.isVisible - By(css selector, *[id="status\.workspaceTrust"])
00:38:06              ‣ DriverHelper.wait - (1000 milliseconds)
00:38:06              ‣ DriverHelper.isVisible - By(css selector, *[id="status\.workspaceTrust"])
00:38:06              ‣ DriverHelper.wait - (1000 milliseconds)
00:38:07              ‣ DriverHelper.isVisible - By(css selector, *[id="status\.workspaceTrust"])
00:38:07              ‣ DriverHelper.wait - (1000 milliseconds)
00:38:08              ‣ DriverHelper.isVisible - By(css selector, *[id="status\.workspaceTrust"])
00:38:08              ‣ DriverHelper.wait - (1000 milliseconds)
00:38:09        • ProjectAndFileTests.performTrustAuthorDialog - "Do you trust authors of the files in this workspace?" dialog box was not shown, or Restricted Mode is still active
00:38:09            ▼ RestrictedModeButton.clickOnRestrictedModeButton
00:38:09              ‣ DriverHelper.waitAndClick - By(css selector, *[id="status\.workspaceTrust"])
00:38:09              ‣ DriverHelper.waitVisibility - By(css selector, *[id="status\.workspaceTrust"])
00:38:10              ‣ DriverHelper.waitVisibility - element is located and is visible.
00:38:10              ‣ DriverHelper.waitAndClick - By(xpath, //a[@role="button" and text()="Trust"])
00:38:10              ‣ DriverHelper.waitVisibility - By(xpath, //a[@role="button" and text()="Trust"])
00:38:10              ‣ DriverHelper.waitVisibility - element is located and is visible.
00:38:10      ✔ Accept the project as a trusted one
=============================================
```

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
![restricted-mode-button-handler](https://github.com/user-attachments/assets/f7fa2bfb-540c-4190-9afd-155812eb6d6c)
![Fix-RecommendedExtensions-tests-resticted-mode](https://github.com/user-attachments/assets/3481ed60-8dd6-425d-8514-a149f60604e2)
![Fix-RecommendedExtensions-tests-extensions-are-installed-and-enabled](https://github.com/user-attachments/assets/d70b322c-0429-47cf-8edc-e30a72af8fd5)


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Run the `RecommendedExtensions.spec.ts` as usual

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
