### PR TITLE
[Test] Fix: Update OCP UI element selectors for compatibility with OpenShift 4.18+

### DIFF
--- a/tests/e2e/pageobjects/openshift/OcpMainPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpMainPage.ts
@@ -1,5 +1,5 @@
 /** *******************************************************************
- * copyright (c) 2019-2023 Red Hat, Inc.
+ * copyright (c) 2019-2025 Red Hat, Inc.
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -17,6 +17,8 @@ import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 import { OcpImportFromGitPage } from './OcpImportFromGitPage';
 import { e2eContainer } from '../../configs/inversify.config';
 import { BrowserTabsUtil } from '../../utils/BrowserTabsUtil';
+import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
+import { satisfies } from 'compare-versions';
 
 @injectable()
 export class OcpMainPage {
@@ -27,6 +29,10 @@ export class OcpMainPage {
 	private static readonly SELECT_PROJECT_DROPDOWN: By = By.xpath('//div[@class="co-namespace-dropdown"]//button');
 	private static readonly PROJECT_FILTER_INPUT: By = By.xpath('//*[@data-test="dropdown-text-filter"]');
 	private static readonly SKIP_TOUR_BUTTON: By = By.xpath('//*[text()="Skip tour"]');
+	private static readonly APP_LAUNCHER_BUTTON: By = By.css(
+		'nav[data-test-id="application-launcher"], button[data-test-id="application-launcher"], button[aria-label="Application launcher"]'
+	);
+	private static readonly DEVSPACES_MENU_ITEM: By = By.xpath('//span[contains(.,"Red Hat OpenShift Dev Spaces")]');
 
 	constructor(
 		@inject(CLASSES.DriverHelper)
@@ -88,12 +94,17 @@ export class OcpMainPage {
 	async clickOnAppLauncherAndDevSpaceItem(): Promise<void> {
 		Logger.debug('click on app launcher menu');
 		const parentGUID: string = await this.browserTabsUtil.getCurrentWindowHandle();
-		await this.driverHelper.waitAndClick(By.css('nav[data-test-id="application-launcher"]'));
-		await this.driverHelper.waitAndClick(By.xpath('//span[contains(.,"Red Hat OpenShift Dev Spaces")]'));
+		await this.driverHelper.waitAndClick(OcpMainPage.APP_LAUNCHER_BUTTON);
+		await this.driverHelper.waitAndClick(OcpMainPage.DEVSPACES_MENU_ITEM);
 		await this.browserTabsUtil.waitAndSwitchToAnotherWindow(parentGUID, TIMEOUT_CONSTANTS.TS_SELENIUM_LOAD_PAGE_TIMEOUT);
 	}
 
 	private getRoleLocator(role: string): By {
+		if (BASE_TEST_CONSTANTS.OCP_VERSION && satisfies(BASE_TEST_CONSTANTS.OCP_VERSION, '>=4.18')) {
+			return By.xpath(
+				`//button[@role='option'][.//h2[@data-test-id='perspective-switcher-menu-option' and contains(text(), '${role}')]]`
+			);
+		}
 		return By.xpath(`//a//*[text()="${role}"]`);
 	}
 


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Updating the `clickOnAppLauncherAndDevSpaceItem` method in `OcpMainPage` to use expanded selector for newer OCP versions and it's UI changes
Making the `getRoleLocator` method in `OcpMainPage` version-aware to handle UI differences between OCP versions


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8561
Fixes test failures in the DevConsole integration tests when running on OpenShift 4.18+. The tests were working on 4.17 but failing on 4.18 with the error:
```
TimeoutError: Waiting for element to be located By(css selector, nav[data-test-id="application-launcher"])
TimeoutError: Waiting for element to be located By(xpath, //a//*[text()="Developer"])
```

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

1. Run the DevConsoleIntegration test on OpenShift 4.18+ :heavy_check_mark: 
2. Run the same tests on OpenShift 4.17 to confirm backward compatibility is maintained :heavy_check_mark: 

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.