### PR TITLE
[Test] Adapt Podman tests to airgap disconnected cluster

### DIFF
--- a/tests/e2e/constants/FACTORY_TEST_CONSTANTS.ts
+++ b/tests/e2e/constants/FACTORY_TEST_CONSTANTS.ts
@@ -20,6 +20,7 @@ export enum GitProviderType {
 
 export const FACTORY_TEST_CONSTANTS: {
 	TS_SELENIUM_FACTORY_GIT_REPO_URL: string;
+	TS_SELENIUM_AIRGAP_FACTORY_GIT_REPO_URL: string;
 	TS_SELENIUM_PROJECT_NAME: string;
 	TS_SELENIUM_IS_PRIVATE_FACTORY_GIT_REPO: boolean;
 	TS_SELENIUM_FACTORY_GIT_PROVIDER: string;
@@ -35,6 +36,11 @@ export const FACTORY_TEST_CONSTANTS: {
 	 * url to create factory
 	 */
 	TS_SELENIUM_FACTORY_GIT_REPO_URL: process.env.TS_SELENIUM_FACTORY_GIT_REPO_URL || '',
+
+	/**
+	 * url to create factory for airgap/disconnected environments
+	 */
+	TS_SELENIUM_AIRGAP_FACTORY_GIT_REPO_URL: process.env.TS_SELENIUM_AIRGAP_FACTORY_GIT_REPO_URL || '',
 
 	/**
 	 * git repository name

--- a/tests/e2e/specs/miscellaneous/KubedockPodmanTest.spec.ts
+++ b/tests/e2e/specs/miscellaneous/KubedockPodmanTest.spec.ts
@@ -21,6 +21,7 @@ import { ShellString } from 'shelljs';
 import { BASE_TEST_CONSTANTS } from '../../constants/BASE_TEST_CONSTANTS';
 import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { FACTORY_TEST_CONSTANTS } from '../../constants/FACTORY_TEST_CONSTANTS';
 
 suite(
 	`Check possibility to manage containers within a workspace with kubedock and podman ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`,
@@ -35,6 +36,16 @@ suite(
 		let kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor;
 		let workspaceName: string = '';
 
+		/**
+		 * test requires the following files to be present in the workspace root:
+		 * - A Dockerfile named Dockerfile.${ARCH} with content:
+		 * FROM scratch
+		 * COPY hello /hello
+		 * CMD ["/hello"]
+		 * - A compiled 'hello' binary, that prints "Hello from Kubedock!" to output.
+		 *
+		 * Used to build and run a container in a pod for verifying Podman functionality.
+		 */
 		const testScript: string =
 			'# Enable Kubedock\n' +
 			'export KUBEDOCK_ENABLED=true\n' +
@@ -66,7 +77,10 @@ suite(
 			'podman login --tls-verify=false --username ${USER} --password ${TKN} ${REG}\n' +
 			'podman run --rm ${IMG}';
 
-		const factoryUrl: string = 'https://github.com/crw-qe/dockerfile-hello-world';
+		const factoryUrl: string = BASE_TEST_CONSTANTS.IS_CLUSTER_DISCONNECTED()
+			? FACTORY_TEST_CONSTANTS.TS_SELENIUM_AIRGAP_FACTORY_GIT_REPO_URL ||
+				'https://gh.crw-qe.com/test-automation-only/dockerfile-hello-world'
+			: FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL || 'https://github.com/crw-qe/dockerfile-hello-world';
 
 		suiteSetup('Login', async function (): Promise<void> {
 			await loginTests.loginIntoChe();


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
BuildPushRunPodmanContainerAPI & KubedockPodmanTest now use dockerfile-hello-world from internal and public github repositories available on airgap & online clusters.
Solution:
 - Created a mirror of the [dockerfile-hello-world](https://github.com/crw-qe/dockerfile-hello-world) repository on the internal GitHub accessible in air-gapped environments at [https://gh.crw-qe.com/test-automation-only/dockerfile-hello-world](https://gh.crw-qe.com/test-automation-only/dockerfile-hello-world)
 - Added new environment variable `TS_SELENIUM_AIRGAP_FACTORY_GIT_REPO_URL` to specify Git repository URL for disconnected environments
 - Modified both test classes to dynamically select the appropriate repository URL based on cluster connectivity



Successful test runs:
online:

- [Build #35305: BuildPushRunPodmanContainerAPI | (OCP 4.18 on PSI) (Apr 10, 2025, 3:28:02 PM)
](https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/35305/)
- [Build #35308: KubedockPodmanTest | (OCP 4.18 on PSI) (Apr 10, 2025, 3:34:09 PM)
](https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/35308/)

airgap:

- [Build #35307: KubedockPodmanTest | (OCP 4.15 on PSI) (Apr 10, 2025, 3:34:03 PM)
](https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/35307/)
- [Build #35306: BuildPushRunPodmanContainerAPI | (OCP 4.15 on PSI) (Apr 10, 2025, 3:28:10 PM)
](https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/35306/)

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8365

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [x] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [x] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
