### PR TITLE
[Test] Add WorkspaceRunTimeout test

### DIFF
--- a/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceIdleTimeout.spec.ts
@@ -15,7 +15,6 @@ import { LoginTests } from '../../tests-library/LoginTests';
 import { registerRunningWorkspace } from '../MochaHooks';
 import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
 import { Workspaces } from '../../pageobjects/dashboard/Workspaces';
-import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
 import { DriverHelper } from '../../utils/DriverHelper';
 import { CheCodeLocatorLoader } from '../../pageobjects/ide/CheCodeLocatorLoader';
 import { By, Locators, ModalDialog } from 'monaco-page-objects';
@@ -39,9 +38,10 @@ suite('"Check workspace idle timeout" test', function (): void {
 	const shellExecutor: ShellExecutor = e2eContainer.get(CLASSES.ShellExecutor);
 	const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
 
+	const SECONDS_OF_INACTIVITY_BEFORE_IDLING: number = Number(process.env.TS_SELENIUM_SECONDS_OF_INACTIVITY_BEFORE_IDLING) || 60;
 	const stackName: string = 'Empty Workspace';
 	const cheClusterName: string = 'devspaces';
-	let stopWorkspaceTimeout: number = 0;
+	let defaultIdleTimeoutValue: number = 0;
 
 	async function checkDialogButton(buttonName: string): Promise<void> {
 		await driverHelper.waitVisibility(By.xpath(`//div[@class='dialog-buttons']//a[text()='${buttonName}']`));
@@ -52,22 +52,24 @@ suite('"Check workspace idle timeout" test', function (): void {
 		shellExecutor.executeCommand('oc project openshift-devspaces');
 
 		// get current value of spec.devEnvironments.secondsOfInactivityBeforeIdling
-		stopWorkspaceTimeout = Number(
+		defaultIdleTimeoutValue = Number(
 			shellExecutor.executeCommand(
 				`oc get checluster/${cheClusterName} -o "jsonpath={.spec.devEnvironments.secondsOfInactivityBeforeIdling}"`
 			)
 		);
 
-		// set spec.devEnvironments.secondsOfInactivityBeforeIdling to 60
+		// set spec.devEnvironments.secondsOfInactivityBeforeIdling to SECONDS_OF_INACTIVITY_BEFORE_IDLING
 		shellExecutor.executeCommand(
-			`oc patch checluster ${cheClusterName} --type=merge -p '{"spec":{"devEnvironments":{"secondsOfInactivityBeforeIdling": 60}}}'`
+			`oc patch checluster ${cheClusterName} --type=merge ` +
+				`-p '{"spec":{"devEnvironments":{"secondsOfInactivityBeforeIdling": ${SECONDS_OF_INACTIVITY_BEFORE_IDLING}}}}'`
 		);
 	});
 
 	suiteTeardown(function (): void {
 		// restore spec.devEnvironments.secondsOfInactivityBeforeIdling to original value
 		shellExecutor.executeCommand(
-			`oc patch checluster ${cheClusterName} --type=merge -p '{"spec":{"devEnvironments":{"secondsOfInactivityBeforeIdling": ${stopWorkspaceTimeout}}}}'`
+			`oc patch checluster ${cheClusterName} --type=merge ` +
+				`-p '{"spec":{"devEnvironments":{"secondsOfInactivityBeforeIdling": ${defaultIdleTimeoutValue}}}}'`
 		);
 	});
 
@@ -87,7 +89,7 @@ suite('"Check workspace idle timeout" test', function (): void {
 	});
 
 	test('Wait idle timeout dialog and check Dialog buttons', async function (): Promise<void> {
-		await driverHelper.waitVisibility(webCheCodeLocators.Dialog.details, TIMEOUT_CONSTANTS.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
+		await driverHelper.waitVisibility(webCheCodeLocators.Dialog.details, SECONDS_OF_INACTIVITY_BEFORE_IDLING * 1000); // ms
 		const dialog: ModalDialog = new ModalDialog();
 		expect(await dialog.getDetails()).includes('Your workspace has stopped due to inactivity.');
 		await checkDialogButton('Cancel');

--- a/tests/e2e/specs/miscellaneous/WorkspaceRunTimeout.spec.ts
+++ b/tests/e2e/specs/miscellaneous/WorkspaceRunTimeout.spec.ts
@@ -1,0 +1,112 @@
+/** *******************************************************************
+ * copyright (c) 2025 Red Hat, Inc.
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ **********************************************************************/
+import { e2eContainer } from '../../configs/inversify.config';
+import { CLASSES, TYPES } from '../../configs/inversify.types';
+import { WorkspaceHandlingTests } from '../../tests-library/WorkspaceHandlingTests';
+import { ProjectAndFileTests } from '../../tests-library/ProjectAndFileTests';
+import { LoginTests } from '../../tests-library/LoginTests';
+import { registerRunningWorkspace } from '../MochaHooks';
+import { Dashboard } from '../../pageobjects/dashboard/Dashboard';
+import { Workspaces } from '../../pageobjects/dashboard/Workspaces';
+import { TIMEOUT_CONSTANTS } from '../../constants/TIMEOUT_CONSTANTS';
+import { DriverHelper } from '../../utils/DriverHelper';
+import { CheCodeLocatorLoader } from '../../pageobjects/ide/CheCodeLocatorLoader';
+import { By, Locators, ModalDialog } from 'monaco-page-objects';
+import { expect } from 'chai';
+import { KubernetesCommandLineToolsExecutor } from '../../utils/KubernetesCommandLineToolsExecutor';
+import { ShellExecutor } from '../../utils/ShellExecutor';
+import { ITestWorkspaceUtil } from '../../utils/workspace/ITestWorkspaceUtil';
+
+suite('"Check workspace run timeout" test', function (): void {
+	const workspaceHandlingTests: WorkspaceHandlingTests = e2eContainer.get(CLASSES.WorkspaceHandlingTests);
+	const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
+	const loginTests: LoginTests = e2eContainer.get(CLASSES.LoginTests);
+	const dashboard: Dashboard = e2eContainer.get(CLASSES.Dashboard);
+	const workspaces: Workspaces = e2eContainer.get(CLASSES.Workspaces);
+	const driverHelper: DriverHelper = e2eContainer.get(CLASSES.DriverHelper);
+	const cheCodeLocatorLoader: CheCodeLocatorLoader = e2eContainer.get(CLASSES.CheCodeLocatorLoader);
+	const webCheCodeLocators: Locators = cheCodeLocatorLoader.webCheCodeLocators;
+	const kubernetesCommandLineToolsExecutor: KubernetesCommandLineToolsExecutor = e2eContainer.get(
+		CLASSES.KubernetesCommandLineToolsExecutor
+	);
+	const shellExecutor: ShellExecutor = e2eContainer.get(CLASSES.ShellExecutor);
+	const testWorkspaceUtil: ITestWorkspaceUtil = e2eContainer.get(TYPES.WorkspaceUtil);
+
+	const stackName: string = 'Empty Workspace';
+	const cheClusterName: string = 'devspaces';
+	let runTimeoutValue: number = 0;
+
+	async function checkDialogButton(buttonName: string): Promise<void> {
+		await driverHelper.waitVisibility(By.xpath(`//div[@class='dialog-buttons']//a[text()='${buttonName}']`));
+	}
+
+	suiteSetup(function (): void {
+		kubernetesCommandLineToolsExecutor.loginToOcp();
+		shellExecutor.executeCommand('oc project openshift-devspaces');
+
+		// get current value of spec.devEnvironments.secondsOfRunBeforeIdling
+		runTimeoutValue = Number(
+			shellExecutor.executeCommand(
+				`oc get checluster/${cheClusterName} -o "jsonpath={.spec.devEnvironments.secondsOfRunBeforeIdling}"`
+			)
+		);
+
+		// set spec.devEnvironments.secondsOfRunBeforeIdling to 60
+		shellExecutor.executeCommand(
+			`oc patch checluster ${cheClusterName} --type=merge -p '{"spec":{"devEnvironments":{"secondsOfRunBeforeIdling": 60}}}'`
+		);
+	});
+
+	suiteTeardown(function (): void {
+		// restore spec.devEnvironments.secondsOfRunBeforeIdling to original value
+		shellExecutor.executeCommand(
+			`oc patch checluster ${cheClusterName} --type=merge -p '{"spec":{"devEnvironments":{"secondsOfRunBeforeIdling": ${runTimeoutValue}}}}'`
+		);
+	});
+
+	suiteSetup('Login', async function (): Promise<void> {
+		await loginTests.loginIntoChe();
+	});
+
+	test(`Create and open new workspace, stack:${stackName}`, async function (): Promise<void> {
+		await workspaceHandlingTests.createAndOpenWorkspace(stackName);
+		await workspaceHandlingTests.obtainWorkspaceNameFromStartingPage();
+	});
+
+	test('Wait workspace readiness', async function (): Promise<void> {
+		registerRunningWorkspace(WorkspaceHandlingTests.getWorkspaceName());
+		await projectAndFileTests.waitWorkspaceReadinessForCheCodeEditor();
+		await projectAndFileTests.performTrustAuthorDialog();
+	});
+
+	test('Wait run timeout dialog and check Dialog buttons', async function (): Promise<void> {
+		await driverHelper.waitVisibility(webCheCodeLocators.Dialog.details, TIMEOUT_CONSTANTS.TS_SELENIUM_START_WORKSPACE_TIMEOUT);
+		const dialog: ModalDialog = new ModalDialog();
+		expect(await dialog.getDetails()).includes('Your workspace has stopped because it has reached the run timeout.');
+		await checkDialogButton('Cancel');
+		await checkDialogButton('Return to dashboard');
+		await checkDialogButton('Restart your workspace');
+	});
+
+	test('Check that the workspace has Stopped state', async function (): Promise<void> {
+		await dashboard.openDashboard();
+		await dashboard.clickWorkspacesButton();
+		await workspaces.waitPage();
+		await workspaces.waitWorkspaceWithStoppedStatus(WorkspaceHandlingTests.getWorkspaceName());
+	});
+
+	suiteTeardown('Stop and delete the workspace by API', async function (): Promise<void> {
+		await testWorkspaceUtil.deleteWorkspaceByName(WorkspaceHandlingTests.getWorkspaceName());
+	});
+
+	suiteTeardown('Unregister running workspace', function (): void {
+		registerRunningWorkspace('');
+	});
+});


### PR DESCRIPTION
Test automatic workspace timeout after configured run duration

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Adds an automated test for workspace stop after configured `secondsOfRunBeforeIdling`.
The test patches CheCluster to 60s, starts a workspace, waits for the timeout dialog, checks buttons, verifies “Stopped” status in Dashboard, and restores the original value.

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-7918

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

Successful test run: https://jenkins-csb-crwqe-main.dno.corp.redhat.com/job/Testing/job/e2e/job/basic/job/typescript-tests/35673/

1. Run the test on Dev Spaces
2. It should patch secondsOfRunBeforeIdling to 60s, open a workspace, wait 1 min, detect the timeout dialog, and confirm stopped status.

```
export USERSTORY=WorkspaceRunTimeout
export NODE_TLS_REJECT_UNAUTHORIZED=0
export TS_OCP_LOGIN_PAGE_PROVIDER_TITLE=htpasswd
export TS_SELENIUM_VALUE_OPENSHIFT_OAUTH=true
export TS_SELENIUM_HEADLESS=false
export OCP_VERSION=4.18
export TS_SELENIUM_BASE_URL=
export OCP_CONSOLE_URL=
export TS_SELENIUM_OCP_PASSWORD=
export TS_SELENIUM_OCP_USERNAME=
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
