### PR TITLE
[Test] Fix 'DevConsoleIntegrationTest' for OCP4.19+

### DIFF
--- a/tests/e2e/pageobjects/openshift/OcpImportFromGitPage.ts
+++ b/tests/e2e/pageobjects/openshift/OcpImportFromGitPage.ts
@@ -24,7 +24,7 @@ export class OcpImportFromGitPage {
 	private static readonly GIT_REFERENCE_INPUT: By = By.id('form-input-git-ref-field');
 	private static readonly EDIT_IMPORT_STRATEGY_LINK: By = By.xpath('//*[text()="Edit Import Strategy"]//ancestor::button');
 	private static readonly BUILDER_IMAGE_STRATEGY_ITEM: By = By.xpath('//*[text()="Builder Image"]//parent::div//parent::div');
-	private static readonly ADD_LABEL_LINK: By = By.xpath('//button[text()="Labels"]');
+	private static readonly ADD_LABEL_LINK: By = By.xpath('//button[text()="Labels" or .//span[text()="Labels"]]');
 	private static readonly ADD_LABEL_INPUT: By = By.id('form-selector-labels-field');
 	private static readonly SUBMIT_BUTTON: By = By.xpath('//*[@data-test-id="submit-button"]');
 


### PR DESCRIPTION
Assisted-by: Gemini

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- **Updates UI Locators**: Fixes XPath locator for Labels button that was updated in OCP 4.19+
- **Enables Developer Perspective on OCP 4.19+**: Automatically configures the developer perspective which is disabled by default on new OCP 4.19+ clusters
### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-8931

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->

Run the test on your 4.19 cluster with devspaces deployed
```
export USERSTORY=DevConsoleIntegration
export NODE_TLS_REJECT_UNAUTHORIZED=0
export TS_OCP_LOGIN_PAGE_PROVIDER_TITLE=htpasswd
export TS_SELENIUM_VALUE_OPENSHIFT_OAUTH=true
export TS_SELENIUM_HEADLESS=false
export OCP_VERSION=4.19
export TS_SELENIUM_BASE_URL=https://devspaces.apps.
export OCP_CONSOLE_URL=https://console-openshift-console.apps.
export TS_SELENIUM_OCP_PASSWORD=
export TS_SELENIUM_OCP_USERNAME=

npm run test
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
