### PR TITLE
Add missed attributes to the devfile content in API tests

### DIFF
--- a/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
+++ b/tests/e2e/specs/dashboard-samples/RecommendedExtensions.spec.ts
@@ -160,6 +160,7 @@ async function findItem(extSection: ExtensionsViewSection, title: string): Promi
 	Logger.debug(`Extension with title "${searchTitle}" not found in section "${sectionTitle}"`);
 	return undefined;
 }
+
 // get visible items from Extension view, transform this from array to sorted string and compares it with existed recommended extensions
 async function getVisibleFilteredItemsAndCompareWithRecommended(recommendations: string[]): Promise<boolean> {
 	const extensionsView: SideBarView | undefined = await (await new ActivityBar().getViewControl('Extensions'))?.openView();
@@ -180,20 +181,23 @@ async function getVisibleFilteredItemsAndCompareWithRecommended(recommendations:
 	}
 	Logger.debug('marketplaceSection.getVisibleItems()');
 	const allFoundRecommendedItems: ExtensionsViewItem[] = await marketplaceSection.getVisibleItems();
+
 	const allFoundRecommendedAuthors: string[] = await Promise.all(
 		allFoundRecommendedItems.map(async (item: ExtensionsViewItem): Promise<string> => await item.getAuthor())
 	);
 
 	const allFoundAuthorsAsSortedString: string = allFoundRecommendedAuthors.sort().toString();
-	const allPublisherNamesAsSorString: string = recommendations.sort().toString();
-	return allFoundAuthorsAsSortedString === allPublisherNamesAsSorString;
+	const allPublisherNamesAsSortedString: string = recommendations.sort().toString();
+	return allFoundAuthorsAsSortedString === allPublisherNamesAsSortedString;
 }
+
 // get visible items from Extension view, transform this from array to sorted string and compares it with existed installed extensions
 async function getVisibleFilteredItemsAndCompareWithInstalled(recommendations: string[]): Promise<boolean> {
 	const extensionsView: SideBarView | undefined = await (await new ActivityBar().getViewControl('Extensions'))?.openView();
 	const [marketplaceSection]: ExtensionsViewSection[] = (await extensionsView?.getContent().getSections()) as ExtensionsViewSection[];
 	Logger.debug('marketplaceSection.getVisibleItems()');
 	const allFoundRecommendedItems: ExtensionsViewItem[] = await marketplaceSection.getVisibleItems();
+
 	const allFoundRecommendedAuthors: string[] = await Promise.all(
 		allFoundRecommendedItems.map(async (item: ExtensionsViewItem): Promise<string> => await item.getAuthor())
 	);
@@ -203,6 +207,7 @@ async function getVisibleFilteredItemsAndCompareWithInstalled(recommendations: s
 	// in some cases we can have installed not only recommended extensions with some samples (for example .Net)
 	return allFoundAuthorsAsSortedString.includes(allPublisherNamesAsSortString);
 }
+
 for (const sample of samples) {
 	suite(`Check if recommended extensions installed for ${sample} ${BASE_TEST_CONSTANTS.TEST_ENVIRONMENT}`, function (): void {
 		const projectAndFileTests: ProjectAndFileTests = e2eContainer.get(CLASSES.ProjectAndFileTests);
@@ -292,10 +297,15 @@ for (const sample of samples) {
 			recommendedExtensions = JSON.parse(text.replace(/\/\*[\s\S]*?\*\/|(?<=[^:])\/\/.*|^\/\/.*/g, '').trim());
 
 			Logger.debug('recommendedExtensions.recommendations: Get recommendations clear names using map().');
-			parsedRecommendations = recommendedExtensions.recommendations.map((rec: string): { name: string; publisher: string } => {
-				const [publisher, name] = rec.split('.');
-				return { publisher, name };
-			});
+
+			// filter out the fabric8-analytics extension to work around an issue CRW-9186
+			parsedRecommendations = recommendedExtensions.recommendations
+				.filter((rec: string): boolean => !rec.includes('redhat.fabric8-analytics'))
+				.map((rec: string): { name: string; publisher: string } => {
+					const [publisher, name] = rec.split('.');
+					return { publisher, name };
+				});
+
 			Logger.debug(`Recommended extension for this workspace:\n${JSON.stringify(parsedRecommendations)}.`);
 			publisherNames = parsedRecommendations.map((rec: { name: string; publisher: string }): string => rec.publisher);
 			expect(parsedRecommendations, 'Recommendations not found').not.empty;

--- a/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
+++ b/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
@@ -109,14 +109,15 @@ export class DevWorkspaceConfigurationHelper {
 	 */
 	addMissedDevWorkspaceConfigAttributes(
 		devfileContextDevWorkspace: DevfileContext,
-		storageType: string = API_TEST_CONSTANTS.TS_API_TEST_STORAGE_TYPE
+		storageType: string | undefined = API_TEST_CONSTANTS.TS_API_TEST_STORAGE_TYPE,
+		namespace: string | undefined = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE,
 	): void {
 		Logger.debug();
 		devfileContextDevWorkspace.devWorkspace?.spec?.template &&
 			(devfileContextDevWorkspace.devWorkspace.spec.template.attributes = YAML.parse(`
                     controller.devfile.io/devworkspace-config:
                       name: devworkspace-config
-                      namespace: openshift-devspaces
+                      namespace: ${namespace}
                     controller.devfile.io/scc: container-build
                     controller.devfile.io/storage-type: ${storageType}`));
 	}

--- a/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
+++ b/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
@@ -105,7 +105,7 @@ export class DevWorkspaceConfigurationHelper {
 	}
 
 	/**
-	 * Add missed attributes to fix issues CRW-8922, CRW-9187.
+	 * add missed attributes to fix issues CRW-8922, CRW-9187.
 	 */
 	addMissedDevWorkspaceConfigAttributes(
 		devfileContextDevWorkspace: DevfileContext,

--- a/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
+++ b/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
@@ -112,15 +112,14 @@ export class DevWorkspaceConfigurationHelper {
 	 */
 	addMissedDevWorkspaceConfigAttributes(
 		devfileContextDevWorkspace: DevfileContext,
-		storageType: string | undefined = API_TEST_CONSTANTS.TS_API_TEST_STORAGE_TYPE,
-		namespace: string | undefined = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE
+		storageType: string | undefined = API_TEST_CONSTANTS.TS_API_TEST_STORAGE_TYPE
 	): void {
 		Logger.debug();
 		devfileContextDevWorkspace.devWorkspace?.spec?.template &&
 			(devfileContextDevWorkspace.devWorkspace.spec.template.attributes = YAML.parse(`
                     controller.devfile.io/devworkspace-config:
                       name: devworkspace-config
-                      namespace: ${namespace}
+                      namespace: openshift-devspaces
                     controller.devfile.io/scc: container-build
                     controller.devfile.io/storage-type: ${storageType}`));
 	}

--- a/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
+++ b/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
@@ -15,6 +15,7 @@ import * as axios from 'axios';
 import { Logger } from './Logger';
 import { ShellExecutor } from './ShellExecutor';
 import { API_TEST_CONSTANTS } from '../constants/API_TEST_CONSTANTS';
+import { BASE_TEST_CONSTANTS } from '../constants/BASE_TEST_CONSTANTS';
 import { injectable } from 'inversify';
 import { IContextParams } from './IContextParams';
 import { e2eContainer } from '../configs/inversify.config';
@@ -69,7 +70,9 @@ export class DevWorkspaceConfigurationHelper {
 			axios.default as any
 		);
 
-		this.addMissedDevWorkspaceConfigAttributes(devfileContext);
+		if (BASE_TEST_CONSTANTS.TESTING_APPLICATION_NAME() === 'devspaces') {
+			this.addMissedDevWorkspaceConfigAttributes(devfileContext);
+		}
 
 		return devfileContext;
 	}

--- a/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
+++ b/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
@@ -69,7 +69,7 @@ export class DevWorkspaceConfigurationHelper {
 			axios.default as any
 		);
 
-		this.patchDevWorkspaceConfigWithStorageTypeAttribute(devfileContext);
+		this.addMissedDevWorkspaceConfigAttributes(devfileContext);
 
 		return devfileContext;
 	}
@@ -104,26 +104,20 @@ export class DevWorkspaceConfigurationHelper {
 		return content;
 	}
 
-	patchDevWorkspaceConfigWithBuildContainerAttribute(devfileContextDevWorkspace: any): void {
-		Logger.debug();
-		devfileContextDevWorkspace.spec.template.attributes = YAML.parse(`
-                    controller.devfile.io/devworkspace-config:
-                      name: devworkspace-config
-                      namespace: openshift-devspaces
-                    controller.devfile.io/scc: container-build
-                    controller.devfile.io/storage-type: per-user`);
-	}
-
 	/**
-	 * add storage type attribute to fix issue CRW-8922.
+	 * Add missed attributes to fix issues CRW-8922, CRW-9187.
 	 */
-	patchDevWorkspaceConfigWithStorageTypeAttribute(
+	addMissedDevWorkspaceConfigAttributes(
 		devfileContextDevWorkspace: DevfileContext,
 		storageType: string = API_TEST_CONSTANTS.TS_API_TEST_STORAGE_TYPE
 	): void {
 		Logger.debug();
 		devfileContextDevWorkspace.devWorkspace?.spec?.template &&
 			(devfileContextDevWorkspace.devWorkspace.spec.template.attributes = YAML.parse(`
-					controller.devfile.io/storage-type: ${storageType}`));
+                    controller.devfile.io/devworkspace-config:
+                      name: devworkspace-config
+                      namespace: openshift-devspaces
+                    controller.devfile.io/scc: container-build
+                    controller.devfile.io/storage-type: ${storageType}`));
 	}
 }

--- a/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
+++ b/tests/e2e/utils/DevWorkspaceConfigurationHelper.ts
@@ -110,7 +110,7 @@ export class DevWorkspaceConfigurationHelper {
 	addMissedDevWorkspaceConfigAttributes(
 		devfileContextDevWorkspace: DevfileContext,
 		storageType: string | undefined = API_TEST_CONSTANTS.TS_API_TEST_STORAGE_TYPE,
-		namespace: string | undefined = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE,
+		namespace: string | undefined = API_TEST_CONSTANTS.TS_API_TEST_NAMESPACE
 	): void {
 		Logger.debug();
 		devfileContextDevWorkspace.devWorkspace?.spec?.template &&


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
- PR fixes automated devfile API test startup
- Ignore redhat.fabric8-analytics recommended extension to work around [CRW-9186](https://issues.redhat.com//browse/CRW-9186) issue


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
https://issues.redhat.com/browse/CRW-9187
https://issues.redhat.com/browse/CRW-9186


### How to test this PR?
Local run:
#### Recommended extension test `Java Lombok` RecommendedExtensions
```
...
    ✔ Check if extensions are installed and enabled (88044ms)
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 2000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 2000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 2000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.stopAndDeleteWorkspaceByName
          ▼ TestWorkspaceUtil.stopWorkspaceByName - java-lombok
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
          ▼ ApiUrlResolver.obtainUserNamespace - kubeapi success: admin-devspaces
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.waitWorkspaceStatus
          ▼ ApiUrlResolver.obtainUserNamespace - admin-devspaces
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.stopWorkspaceByName - java-lombok stopped successfully
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - java-lombok
          ▼ ApiUrlResolver.obtainUserNamespace - admin-devspaces
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - java-lombok deleted successfully
          ▼     at /home/ndp/projects/che/tests/e2e/specs/MochaHooks.ts:39:12 - delete workspace name


  10 passing (8m)
```

#### GoDevFileAPI test local run
```
...
    ✔ Check devfile commands (37305ms)
          ▼ KubernetesCommandLineToolsExecutor.deleteDevWorkspace - oc - delete 'golang65e1d5f5' devWorkspace
          ▼ ShellExecutor.executeCommand - oc patch dw golang65e1d5f5 -n admin-devspaces -p '{ "metadata": { "finalizers": null }}' --type merge || true
Debugger attached.
devworkspace.workspace.devfile.io/golang65e1d5f5 patched
Waiting for the debugger to disconnect...
          ▼ ShellExecutor.executeCommand - oc delete dw golang65e1d5f5 -n admin-devspaces || true
Debugger attached.
devworkspace.workspace.devfile.io "golang65e1d5f5" deleted
Waiting for the debugger to disconnect...
          ▼ KubernetesCommandLineToolsExecutor.deleteDevWorkspace - oc - delete 'che-code-golang' devWorkspaceTemplate
          ▼ ShellExecutor.executeCommand - oc delete dwt che-code-golang -n admin-devspaces || true
Debugger attached.
devworkspacetemplate.workspace.devfile.io "che-code-golang" deleted
Waiting for the debugger to disconnect...


  2 passing (1m)
```


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
