### PR TITLE
Fix up 'Factory' E2E tests 

### DIFF
--- a/tests/e2e/CODE_STYLE.md
+++ b/tests/e2e/CODE_STYLE.md
@@ -28,6 +28,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
 ### Preferable code style
 
 1. Page-object and util classes
+
     1. ✔ Class declaration using dependency injection (inversify library)
 
         ```
@@ -37,6 +38,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
         ```
 
     2. Public methods
+
         - ✔ Declare public methods without "public "keyword
         - ✔ Add Logger.debug() inside method to log its name (with optional message)
 
@@ -49,6 +51,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
         ```
 
     3. Locators
+
         - ✔ For static locators - private static readonly fields type of By
 
         ```
@@ -102,6 +105,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
         ```
 
 2. Mocha framework
+
     - ✔ TDD framework (`suite()`, `test()`)
     - ✔ Inject class instances, declare all test data inside test `suit()` function to avoid unnecessary code execution if test suit will not be run
 
@@ -118,6 +122,7 @@ Automated lint checking and code format performs with ESLint and Prettier tools 
     - ✔ Use test [./constants](constants) to make test flexible
 
 3. Packages
+
     1. Add packages as dev dependencies
     2. If any changes re-create package-lock.json before push
 

--- a/tests/e2e/pageobjects/ide/CheCodeLocatorLoader.ts
+++ b/tests/e2e/pageobjects/ide/CheCodeLocatorLoader.ts
@@ -48,10 +48,10 @@ export class CheCodeLocatorLoader extends LocatorLoader {
 					contextView: By.className('monaco-menu-container')
 				},
 				Editor: {
-					inputArea: By.className('native-edit-context-textarea')
+					inputArea: By.className('editor-container')
 				},
 				ExtensionsViewSection: {
-					searchBox: By.className('native-edit-context-textarea')
+					searchBox: By.className('ime-text-area')
 				},
 				ExtensionsViewItem: {
 					author: By.className('publisher')

--- a/tests/e2e/specs/factory/Factory.spec.ts
+++ b/tests/e2e/specs/factory/Factory.spec.ts
@@ -11,18 +11,7 @@
 import 'reflect-metadata';
 
 import { e2eContainer } from '../../configs/inversify.config';
-import {
-	ActivityBar,
-	ContextMenu,
-	EditorView,
-	Key,
-	Locators,
-	NewScmView,
-	SingleScmProvider,
-	TextEditor,
-	ViewControl,
-	ViewSection
-} from 'monaco-page-objects';
+import { ActivityBar, ContextMenu, Key, Locators, NewScmView, SingleScmProvider, ViewControl, ViewSection } from 'monaco-page-objects';
 import { expect } from 'chai';
 import { OauthPage } from '../../pageobjects/git-providers/OauthPage';
 import { StringUtil } from '../../utils/StringUtil';
@@ -135,10 +124,17 @@ suite(
 		test('Make changes to the file', async function (): Promise<void> {
 			Logger.debug(`projectSection.openItem: "${fileToChange}"`);
 			await projectSection.openItem(testRepoProjectName, fileToChange);
-			const editor: TextEditor = (await new EditorView().openEditor(fileToChange)) as TextEditor;
 			await driverHelper.waitVisibility(webCheCodeLocators.Editor.inputArea);
-			Logger.debug(`editor.setText: "${changesToCommit}"`);
-			await editor.setText(changesToCommit);
+			await driverHelper.getDriver().findElement(webCheCodeLocators.Editor.inputArea).click();
+
+			Logger.debug('Clearing the editor with Ctrl+A');
+			await driverHelper.getDriver().actions().keyDown(Key.CONTROL).sendKeys('a').keyUp(Key.CONTROL).perform();
+			await driverHelper.wait(500);
+			Logger.debug('Deleting selected text');
+			await driverHelper.getDriver().actions().sendKeys(Key.DELETE).perform();
+			await driverHelper.wait(500);
+			Logger.debug(`Entering text: "${changesToCommit}"`);
+			await driverHelper.getDriver().actions().sendKeys(changesToCommit).perform();
 		});
 
 		test('Open a source control manager', async function (): Promise<void> {

--- a/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
+++ b/tests/e2e/specs/factory/NoSetupRepoFactory.spec.ts
@@ -13,14 +13,12 @@ import { e2eContainer } from '../../configs/inversify.config';
 import {
 	ActivityBar,
 	ContextMenu,
-	EditorView,
 	InputBox,
 	Key,
 	Locators,
 	ModalDialog,
 	NewScmView,
 	SingleScmProvider,
-	TextEditor,
 	ViewControl,
 	ViewSection
 } from 'monaco-page-objects';
@@ -132,10 +130,17 @@ suite(
 			test('Make changes to the file', async function (): Promise<void> {
 				Logger.debug(`projectSection.openItem: "${fileToChange}"`);
 				await projectSection.openItem(testRepoProjectName, fileToChange);
-				const editor: TextEditor = (await new EditorView().openEditor(fileToChange)) as TextEditor;
 				await driverHelper.waitVisibility(webCheCodeLocators.Editor.inputArea);
-				Logger.debug(`editor.setText: "${changesToCommit}"`);
-				await editor.setText(changesToCommit);
+				await driverHelper.getDriver().findElement(webCheCodeLocators.Editor.inputArea).click();
+
+				Logger.debug('Clearing the editor with Ctrl+A');
+				await driverHelper.getDriver().actions().keyDown(Key.CONTROL).sendKeys('a').keyUp(Key.CONTROL).perform();
+				await driverHelper.wait(500);
+				Logger.debug('Deleting selected text');
+				await driverHelper.getDriver().actions().sendKeys(Key.DELETE).perform();
+				await driverHelper.wait(500);
+				Logger.debug(`Entering text: "${changesToCommit}"`);
+				await driverHelper.getDriver().actions().sendKeys(changesToCommit).perform();
 			});
 
 			test('Open a source control manager', async function (): Promise<void> {

--- a/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
+++ b/tests/e2e/specs/factory/RefusedOAuthFactory.spec.ts
@@ -13,13 +13,11 @@ import { e2eContainer } from '../../configs/inversify.config';
 import {
 	ActivityBar,
 	ContextMenu,
-	EditorView,
 	InputBox,
 	Key,
 	Locators,
 	NewScmView,
 	SingleScmProvider,
-	TextEditor,
 	ViewControl,
 	ViewSection
 } from 'monaco-page-objects';
@@ -138,10 +136,17 @@ suite(
 			test('Make changes to the file', async function (): Promise<void> {
 				Logger.debug(`projectSection.openItem: "${fileToChange}"`);
 				await projectSection.openItem(testRepoProjectName, fileToChange);
-				const editor: TextEditor = (await new EditorView().openEditor(fileToChange)) as TextEditor;
 				await driverHelper.waitVisibility(webCheCodeLocators.Editor.inputArea);
-				Logger.debug(`editor.setText: "${changesToCommit}"`);
-				await editor.setText(changesToCommit);
+				await driverHelper.getDriver().findElement(webCheCodeLocators.Editor.inputArea).click();
+
+				Logger.debug('Clearing the editor with Ctrl+A');
+				await driverHelper.getDriver().actions().keyDown(Key.CONTROL).sendKeys('a').keyUp(Key.CONTROL).perform();
+				await driverHelper.wait(500);
+				Logger.debug('Deleting selected text');
+				await driverHelper.getDriver().actions().sendKeys(Key.DELETE).perform();
+				await driverHelper.wait(500);
+				Logger.debug(`Entering text: "${changesToCommit}"`);
+				await driverHelper.getDriver().actions().sendKeys(changesToCommit).perform();
 			});
 
 			test('Open a source control manager', async function (): Promise<void> {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
* Fixes the `Factory` flow E2E tests due to the changes in `che-editor`
* Formats `CODE_STYLE` file

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
```
[ashmaraiev@fedora e2e]$ npm run prettier

> @eclipse-che/che-e2e@7.107.0-next prettier
> prettier --config .prettierrc.json . --write

.eslintrc.js 72ms (unchanged)
.prettierrc.json 3ms (unchanged)
CODE_STYLE.md 67ms
configs/inversify.config.ts 111ms (unchanged)
configs/inversify.types.ts 12ms (unchanged)
configs/mocharc.ts 12ms (unchanged)
configs/reporters.config.js 11ms (unchanged)
constants/API_TEST_CONSTANTS.ts 17ms (unchanged)
constants/BASE_TEST_CONSTANTS.ts 21ms (unchanged)
constants/CHROME_DRIVER_CONSTANTS.ts 9ms (unchanged)
constants/FACTORY_TEST_CONSTANTS.ts 11ms (unchanged)
constants/MOCHA_CONSTANTS.ts 7ms (unchanged)
constants/MONACO_CONSTANTS.ts 3ms (unchanged)
constants/OAUTH_CONSTANTS.ts 9ms (unchanged)
constants/PLUGIN_TEST_CONSTANTS.ts 3ms (unchanged)
constants/REPORTER_CONSTANTS.ts 18ms (unchanged)
constants/TIMEOUT_CONSTANTS.ts 14ms (unchanged)
driver/ChromeDriver.ts 23ms (unchanged)
driver/IDriver.ts 3ms (unchanged)
package-lock.json 135ms (unchanged)
package.json 3ms (unchanged)
pageobjects/dashboard/CreateWorkspace.ts 27ms (unchanged)
pageobjects/dashboard/Dashboard.ts 46ms (unchanged)
pageobjects/dashboard/TrustAuthorPopup.ts 18ms (unchanged)
pageobjects/dashboard/UserPreferences.ts 24ms (unchanged)
pageobjects/dashboard/workspace-details/WorkspaceDetails.ts 24ms (unchanged)
pageobjects/dashboard/Workspaces.ts 42ms (unchanged)
pageobjects/git-providers/OauthPage.ts 31ms (unchanged)
pageobjects/ide/CheCodeLocatorLoader.ts 13ms (unchanged)
pageobjects/ide/CommandPalette.ts 16ms (unchanged)
pageobjects/ide/ExplorerView.ts 11ms (unchanged)
pageobjects/ide/ExtensionsView.ts 19ms (unchanged)
pageobjects/ide/NotificationHandler.ts 10ms (unchanged)
pageobjects/ide/RestrictedModeButton.ts 5ms (unchanged)
pageobjects/ide/ViewsMoreActionsButton.ts 8ms (unchanged)
pageobjects/login/interfaces/ICheLoginPage.ts 2ms (unchanged)
pageobjects/login/interfaces/IOcpLoginPage.ts 3ms (unchanged)
pageobjects/login/kubernetes/DexLoginPage.ts 7ms (unchanged)
pageobjects/login/kubernetes/KubernetesLoginPage.ts 5ms (unchanged)
pageobjects/login/openshift/OcpLoginPage.ts 12ms (unchanged)
pageobjects/login/openshift/OcpRedHatLoginPage.ts 6ms (unchanged)
pageobjects/login/openshift/OcpUserLoginPage.ts 5ms (unchanged)
pageobjects/login/openshift/RedHatLoginPage.ts 11ms (unchanged)
pageobjects/login/openshift/RegularUserOcpCheLoginPage.ts 7ms (unchanged)
pageobjects/openshift/OcpApplicationPage.ts 6ms (unchanged)
pageobjects/openshift/OcpImportFromGitPage.ts 18ms (unchanged)
pageobjects/openshift/OcpMainPage.ts 13ms (unchanged)
pageobjects/webterminal/WebTerminalPage.ts 25ms (unchanged)
README.md 32ms (unchanged)
specs/api/AnsibleDevFileAPI.spec.ts 60ms (unchanged)
specs/api/BuildPushRunPodmanContainerAPI.spec.ts 25ms (unchanged)
specs/api/ContainerOverridesAPI.spec.ts 9ms (unchanged)
specs/api/CppDevFileAPI.spec.ts 21ms (unchanged)
specs/api/DevfileAcceptanceTestAPI.spec.ts 31ms (unchanged)
specs/api/DotnetDevFileAPI.spec.ts 22ms (unchanged)
specs/api/EmptyWorkspaceAPI.spec.ts 15ms (unchanged)
specs/api/GoDevFileAPI.spec.ts 20ms (unchanged)
specs/api/InbuiltApplicationDevWorkspacesAPI.spec.ts 34ms (unchanged)
specs/api/JBossEapDevFileAPI.spec.ts 29ms (unchanged)
specs/api/LombokDevFileAPI.spec.ts 16ms (unchanged)
specs/api/NodeJsExpressDevFileAPI.spec.ts 33ms (unchanged)
specs/api/NodeJSMongoDBDevFileAPI.spec.ts 20ms (unchanged)
specs/api/PhpDevFileAPI.spec.ts 18ms (unchanged)
specs/api/PodOverridesAPI.spec.ts 10ms (unchanged)
specs/api/PythonDevFileAPI.spec.ts 13ms (unchanged)
specs/api/QuarkusDevFileAPI.spec.ts 24ms (unchanged)
specs/dashboard-samples/Documentation.spec.ts 22ms (unchanged)
specs/dashboard-samples/EmptyWorkspace.spec.ts 8ms (unchanged)
specs/dashboard-samples/Quarkus.spec.ts 13ms (unchanged)
specs/dashboard-samples/RecommendedExtensions.spec.ts 92ms (unchanged)
specs/devconsole-intergration/DevConsoleIntegration.spec.ts 32ms (unchanged)
specs/factory/Factory.spec.ts 43ms (unchanged)
specs/factory/FactoryWithGitRepoOptions.spec.ts 14ms (unchanged)
specs/factory/NoSetupRepoFactory.spec.ts 45ms (unchanged)
specs/factory/RefusedOAuthFactory.spec.ts 51ms (unchanged)
specs/miscellaneous/CreateWorkspaceWithExistedName.spec.ts 12ms (unchanged)
specs/miscellaneous/CustomOpenVSXRegistry.spec.ts 37ms (unchanged)
specs/miscellaneous/KubedockPodmanTest.spec.ts 10ms (unchanged)
specs/miscellaneous/PredefinedNamespace.spec.ts 11ms (unchanged)
specs/miscellaneous/RevokeOauth.spec.ts 5ms (unchanged)
specs/miscellaneous/UserPreferencesTest.spec.ts 4ms (unchanged)
specs/miscellaneous/UserSecretsInWorkspace.spec.ts 10ms (unchanged)
specs/miscellaneous/VsixInstallationDisableTest.spec.ts 35ms (unchanged)
specs/miscellaneous/WorkspaceIdleTimeout.spec.ts 16ms (unchanged)
specs/miscellaneous/WorkspaceRunTimeout.spec.ts 15ms (unchanged)
specs/miscellaneous/WorkspaceWithParent.spec.ts 21ms (unchanged)
specs/MochaHooks.ts 11ms (unchanged)
specs/SmokeTest.spec.ts 13ms (unchanged)
specs/web-terminal/WebTerminalTest.spec.ts 7ms (unchanged)
specs/web-terminal/WebTerminalUnderAdmin.spec.ts 9ms (unchanged)
specs/web-terminal/WebTerminalUnderRegularUser.spec.ts 9ms (unchanged)
suites/devfile-acceptance-test-suite/DynamicallyGeneratingAPITest.suite.ts 1ms (unchanged)
suites/disconnected-ocp/APITest.suite.ts 2ms (unchanged)
suites/disconnected-ocp/DynamicallyGeneratingAPITest.suite.ts 1ms (unchanged)
suites/disconnected-ocp/UITest.suite.ts 1ms (unchanged)
suites/online-ocp/APITest.suite.ts 2ms (unchanged)
suites/online-ocp/DynamicallyGeneratingAPITest.suite.ts 2ms (unchanged)
suites/online-ocp/UITest.suite.ts 2ms (unchanged)
tests-library/LoginTests.ts 7ms (unchanged)
tests-library/ProjectAndFileTests.ts 12ms (unchanged)
tests-library/WorkspaceHandlingTests.ts 15ms (unchanged)
tsconfig.json 2ms (unchanged)
utils/BrowserTabsUtil.ts 15ms (unchanged)
utils/CheReporter.ts 41ms (unchanged)
utils/DevfilesHelper.ts 29ms (unchanged)
utils/DevWorkspaceConfigurationHelper.ts 12ms (unchanged)
utils/DriverHelper.ts 102ms (unchanged)
utils/IContextParams.ts 4ms (unchanged)
utils/IKubernetesCommandLineToolsExecutor.ts 3ms (unchanged)
utils/KubernetesCommandLineToolsExecutor.ts 40ms (unchanged)
utils/Logger.ts 13ms (unchanged)
utils/request-handlers/CheApiRequestHandler.ts 13ms (unchanged)
utils/request-handlers/headers/CheMultiuserAuthorizationHeaderHandler.ts 6ms (unchanged)
utils/request-handlers/headers/IAuthorizationHeaderHandler.ts 2ms (unchanged)
utils/ScreenCatcher.ts 12ms (unchanged)
utils/ShellExecutor.ts 4ms (unchanged)
utils/StringUtil.ts 6ms (unchanged)
utils/workspace/ApiUrlResolver.ts 5ms (unchanged)
utils/workspace/ITestWorkspaceUtil.ts 4ms (unchanged)
utils/workspace/TestWorkspaceUtil.ts 24ms (unchanged)
utils/workspace/WorkspaceStatus.ts 2ms (unchanged)

[ashmaraiev@fedora e2e]$ npm run lint

> @eclipse-che/che-e2e@7.107.0-next lint
> eslint --fix .

[ashmaraiev@fedora e2e]$ 
```
### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://github.com/eclipse-che/che/issues/23492

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Run `Factory.spec.ts / NoSetupRepoFactory.spec.ts/RefusedOAuthFactory.spec.ts` usually

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
