### PR TITLE
Update 'login form' locator of 'Bitbucket.org'

### DIFF
--- a/tests/e2e/pageobjects/git-providers/OauthPage.ts
+++ b/tests/e2e/pageobjects/git-providers/OauthPage.ts
@@ -50,9 +50,9 @@ export class OauthPage {
 					OauthPage.DENY_ACCESS_BUTTON = By.xpath('//span[text()="Deny"]');
 				}
 				break;
-			case GitProviderType.BITBUCKET_CLOUD_OAUTH2:
+			case GitProviderType.BITBUCKET_CLOUD_OAUTH2: 
 				{
-					OauthPage.LOGIN_FORM = By.id('username');
+					OauthPage.LOGIN_FORM = By.css('[data-testid="username"]');
 					OauthPage.PASSWORD_FORM = By.id('password');
 					OauthPage.SUBMIT_BUTTON = By.id('login-submit');
 					OauthPage.APPROVE_BUTTON = By.xpath('//button[@value="approve"]');


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Fixes 'login form' locator of Bitbucket.org provider

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
<img width="1920" height="968" alt="screenshot-Authorize_with_a_bitbucket-org_OAuth" src="https://github.com/user-attachments/assets/97f9d77d-210b-43e9-a014-5f95fadf0f09" />


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
https://issues.redhat.com/browse/CRW-9226

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
Run `Factory.spec.ts /RefusedOAuthFactory.spec.ts` usually with OAuth setup

### PR Checklist
```
[ashmaraiev@fedora e2e]$ npm run prettier

> @eclipse-che/che-e2e@7.107.0-next prettier
> prettier --config .prettierrc.json . --write

.eslintrc.js 68ms (unchanged)
.prettierrc.json 2ms (unchanged)
CODE_STYLE.md 64ms (unchanged)
configs/inversify.config.ts 97ms (unchanged)
configs/inversify.types.ts 12ms (unchanged)
configs/mocharc.ts 10ms (unchanged)
configs/reporters.config.js 9ms (unchanged)
constants/API_TEST_CONSTANTS.ts 16ms (unchanged)
constants/BASE_TEST_CONSTANTS.ts 20ms (unchanged)
constants/CHROME_DRIVER_CONSTANTS.ts 8ms (unchanged)
constants/FACTORY_TEST_CONSTANTS.ts 7ms (unchanged)
constants/MOCHA_CONSTANTS.ts 7ms (unchanged)
constants/MONACO_CONSTANTS.ts 2ms (unchanged)
constants/OAUTH_CONSTANTS.ts 6ms (unchanged)
constants/PLUGIN_TEST_CONSTANTS.ts 3ms (unchanged)
constants/REPORTER_CONSTANTS.ts 18ms (unchanged)
constants/TIMEOUT_CONSTANTS.ts 10ms (unchanged)
driver/ChromeDriver.ts 19ms (unchanged)
driver/IDriver.ts 4ms (unchanged)
package-lock.json 117ms (unchanged)
package.json 2ms (unchanged)
pageobjects/dashboard/CreateWorkspace.ts 30ms (unchanged)
pageobjects/dashboard/Dashboard.ts 36ms (unchanged)
pageobjects/dashboard/TrustAuthorPopup.ts 6ms (unchanged)
pageobjects/dashboard/UserPreferences.ts 19ms (unchanged)
pageobjects/dashboard/workspace-details/WorkspaceDetails.ts 23ms (unchanged)
pageobjects/dashboard/Workspaces.ts 38ms (unchanged)
pageobjects/git-providers/OauthPage.ts 23ms (unchanged)
pageobjects/ide/CheCodeLocatorLoader.ts 13ms (unchanged)
pageobjects/ide/CommandPalette.ts 11ms (unchanged)
pageobjects/ide/ExplorerView.ts 13ms (unchanged)
pageobjects/ide/ExtensionsView.ts 19ms (unchanged)
pageobjects/ide/NotificationHandler.ts 7ms (unchanged)
pageobjects/ide/RestrictedModeButton.ts 5ms (unchanged)
pageobjects/ide/ViewsMoreActionsButton.ts 7ms (unchanged)
pageobjects/login/interfaces/ICheLoginPage.ts 2ms (unchanged)
pageobjects/login/interfaces/IOcpLoginPage.ts 2ms (unchanged)
pageobjects/login/kubernetes/DexLoginPage.ts 9ms (unchanged)
pageobjects/login/kubernetes/KubernetesLoginPage.ts 6ms (unchanged)
pageobjects/login/openshift/OcpLoginPage.ts 10ms (unchanged)
pageobjects/login/openshift/OcpRedHatLoginPage.ts 7ms (unchanged)
pageobjects/login/openshift/OcpUserLoginPage.ts 3ms (unchanged)
pageobjects/login/openshift/RedHatLoginPage.ts 8ms (unchanged)
pageobjects/login/openshift/RegularUserOcpCheLoginPage.ts 7ms (unchanged)
pageobjects/openshift/OcpApplicationPage.ts 8ms (unchanged)
pageobjects/openshift/OcpImportFromGitPage.ts 10ms (unchanged)
pageobjects/openshift/OcpMainPage.ts 16ms (unchanged)
pageobjects/webterminal/WebTerminalPage.ts 30ms (unchanged)
README.md 28ms (unchanged)
specs/api/AnsibleDevFileAPI.spec.ts 55ms (unchanged)
specs/api/BuildPushRunPodmanContainerAPI.spec.ts 29ms (unchanged)
specs/api/ContainerOverridesAPI.spec.ts 5ms (unchanged)
specs/api/CppDevFileAPI.spec.ts 19ms (unchanged)
specs/api/DevfileAcceptanceTestAPI.spec.ts 22ms (unchanged)
specs/api/DotnetDevFileAPI.spec.ts 18ms (unchanged)
specs/api/EmptyWorkspaceAPI.spec.ts 12ms (unchanged)
specs/api/GoDevFileAPI.spec.ts 19ms (unchanged)
specs/api/InbuiltApplicationDevWorkspacesAPI.spec.ts 41ms (unchanged)
specs/api/JBossEapDevFileAPI.spec.ts 30ms (unchanged)
specs/api/LombokDevFileAPI.spec.ts 16ms (unchanged)
specs/api/NodeJsExpressDevFileAPI.spec.ts 21ms (unchanged)
specs/api/NodeJSMongoDBDevFileAPI.spec.ts 22ms (unchanged)
specs/api/PhpDevFileAPI.spec.ts 13ms (unchanged)
specs/api/PodOverridesAPI.spec.ts 9ms (unchanged)
specs/api/PythonDevFileAPI.spec.ts 10ms (unchanged)
specs/api/QuarkusDevFileAPI.spec.ts 24ms (unchanged)
specs/dashboard-samples/Documentation.spec.ts 18ms (unchanged)
specs/dashboard-samples/EmptyWorkspace.spec.ts 9ms (unchanged)
specs/dashboard-samples/Quarkus.spec.ts 8ms (unchanged)
specs/dashboard-samples/RecommendedExtensions.spec.ts 75ms (unchanged)
specs/devconsole-intergration/DevConsoleIntegration.spec.ts 26ms (unchanged)
specs/factory/Factory.spec.ts 52ms (unchanged)
specs/factory/FactoryWithGitRepoOptions.spec.ts 12ms (unchanged)
specs/factory/NoSetupRepoFactory.spec.ts 63ms (unchanged)
specs/factory/RefusedOAuthFactory.spec.ts 52ms (unchanged)
specs/miscellaneous/CreateWorkspaceWithExistedName.spec.ts 15ms (unchanged)
specs/miscellaneous/CustomOpenVSXRegistry.spec.ts 35ms (unchanged)
specs/miscellaneous/KubedockPodmanTest.spec.ts 15ms (unchanged)
specs/miscellaneous/PredefinedNamespace.spec.ts 9ms (unchanged)
specs/miscellaneous/RevokeOauth.spec.ts 4ms (unchanged)
specs/miscellaneous/UserPreferencesTest.spec.ts 4ms (unchanged)
specs/miscellaneous/UserSecretsInWorkspace.spec.ts 10ms (unchanged)
specs/miscellaneous/VsixInstallationDisableTest.spec.ts 40ms (unchanged)
specs/miscellaneous/WorkspaceIdleTimeout.spec.ts 16ms (unchanged)
specs/miscellaneous/WorkspaceRunTimeout.spec.ts 16ms (unchanged)
specs/miscellaneous/WorkspaceWithParent.spec.ts 23ms (unchanged)
specs/MochaHooks.ts 11ms (unchanged)
specs/SmokeTest.spec.ts 7ms (unchanged)
specs/web-terminal/WebTerminalTest.spec.ts 8ms (unchanged)
specs/web-terminal/WebTerminalUnderAdmin.spec.ts 8ms (unchanged)
specs/web-terminal/WebTerminalUnderRegularUser.spec.ts 9ms (unchanged)
suites/devfile-acceptance-test-suite/DynamicallyGeneratingAPITest.suite.ts 1ms (unchanged)
suites/disconnected-ocp/APITest.suite.ts 1ms (unchanged)
suites/disconnected-ocp/DynamicallyGeneratingAPITest.suite.ts 1ms (unchanged)
suites/disconnected-ocp/UITest.suite.ts 1ms (unchanged)
suites/online-ocp/APITest.suite.ts 1ms (unchanged)
suites/online-ocp/DynamicallyGeneratingAPITest.suite.ts 1ms (unchanged)
suites/online-ocp/UITest.suite.ts 1ms (unchanged)
tests-library/LoginTests.ts 7ms (unchanged)
tests-library/ProjectAndFileTests.ts 16ms (unchanged)
tests-library/WorkspaceHandlingTests.ts 19ms (unchanged)
tsconfig.json 2ms (unchanged)
utils/BrowserTabsUtil.ts 16ms (unchanged)
utils/CheReporter.ts 35ms (unchanged)
utils/DevfilesHelper.ts 22ms (unchanged)
utils/DevWorkspaceConfigurationHelper.ts 14ms (unchanged)
utils/DriverHelper.ts 64ms (unchanged)
utils/IContextParams.ts 2ms (unchanged)
utils/IKubernetesCommandLineToolsExecutor.ts 3ms (unchanged)
utils/KubernetesCommandLineToolsExecutor.ts 38ms (unchanged)
utils/Logger.ts 12ms (unchanged)
utils/request-handlers/CheApiRequestHandler.ts 11ms (unchanged)
utils/request-handlers/headers/CheMultiuserAuthorizationHeaderHandler.ts 4ms (unchanged)
utils/request-handlers/headers/IAuthorizationHeaderHandler.ts 2ms (unchanged)
utils/ScreenCatcher.ts 11ms (unchanged)
utils/ShellExecutor.ts 4ms (unchanged)
utils/StringUtil.ts 9ms (unchanged)
utils/workspace/ApiUrlResolver.ts 5ms (unchanged)
utils/workspace/ITestWorkspaceUtil.ts 3ms (unchanged)
utils/workspace/TestWorkspaceUtil.ts 25ms (unchanged)
utils/workspace/WorkspaceStatus.ts 2ms (unchanged)

[ashmaraiev@fedora e2e]$ npm run lint

> @eclipse-che/che-e2e@7.107.0-next lint
> eslint --fix .

[ashmaraiev@fedora e2e]$ 
```

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
