### PR TITLE
fix (tests) : update userstory path to `specs/dashboard-samples` (#23514)

### DIFF
--- a/tests/e2e/configs/sh-scripts/initDevfileTests.sh
+++ b/tests/e2e/configs/sh-scripts/initDevfileTests.sh
@@ -11,7 +11,7 @@ launchUserstories(){
 }
 
 checkUserstoryName(){
-    local checkedName="$(ls specs/devfiles | grep ${USERSTORY}.spec.ts)";
+    local checkedName="$(ls specs/dashboard-samples | grep ${USERSTORY}.spec.ts)";
 
     if [ -z "$TS_SELENIUM_EDITOR" ]; then
         echo ""
@@ -26,7 +26,7 @@ checkUserstoryName(){
         echo ""
         echo "Current value USERSTORY=\"${USERSTORY}\" doesn't match to any of existing tests:"
         echo ""
-        echo "$(ls specs/devfiles | sed -e 's/.spec.ts//g')"
+        echo "$(ls specs/dashboard-samples | sed -e 's/.spec.ts//g')"
         echo ""
         echo "Please choose one of the tests above, or unset the \"USERSTORY\" variable for launching all of them."
         echo ""


### PR DESCRIPTION

<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?

The test script was previously checking for user stories under `specs/devfiles`, which no longer exists or contains relevant test specs. This commit updates the `checkUserstoryName` function to look in `specs/dashboard-samples`, where the current user story specs (e.g., `*.spec.ts`) are now located.

This resolves issues where valid USERSTORY values were incorrectly reported as missing.


### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->
This PR is fixing Che Happy Path E2E test. It is currently failing with this error:

Run `./launch.sh` in `tests/devworkspace-happy-path`, you'd see this error:
```

TS_SELENIUM_VALUE_TLS_SUPPORT =       
TS_SELENIUM_VALUE_OPENSHIFT_OAUTH =   true
TS_OCP_LOGIN_PAGE_PROVIDER_TITLE =    dev-htpasswd
E2E_OCP_CLUSTER_VERSION =             4.x
TS_SELENIUM_LOG_LEVEL =               TRACE
TS_SELENIUM_OCP_USERNAME =            happypath-dev
TS_SELENIUM_W3C_CHROME_OPTION =       true
NODE_TLS_REJECT_UNAUTHORIZED =        0
TS_SELENIUM_EDITOR =                  che-code
ls: cannot access 'specs/devfiles': No such file or directory

Variable TS_SELENIUM_EDITOR is unset. It will be assign to default value.

TS_SELENIUM_EDITOR = che-code


Current value USERSTORY="EmptyWorkspace" doesn't match to any of existing tests:

ls: cannot access 'specs/devfiles': No such file or directory


Please choose one of the tests above, or unset the "USERSTORY" variable for launching all of them.
```
With these changes, I'm able to see Happy Path Test getting fully executed and passing. Here are logs:

```
TS_SELENIUM_VALUE_TLS_SUPPORT =       
TS_SELENIUM_VALUE_OPENSHIFT_OAUTH =   true
TS_OCP_LOGIN_PAGE_PROVIDER_TITLE =    dev-htpasswd
E2E_OCP_CLUSTER_VERSION =             4.x
TS_SELENIUM_LOG_LEVEL =               TRACE
TS_SELENIUM_OCP_USERNAME =            happypath-dev
TS_SELENIUM_W3C_CHROME_OPTION =       true
NODE_TLS_REJECT_UNAUTHORIZED =        0
TS_SELENIUM_EDITOR =                  che-code

Variable TS_SELENIUM_EDITOR is unset. It will be assign to default value.

TS_SELENIUM_EDITOR = che-code


Launching the "EmptyWorkspace" userstory

MOCHA_DIRECTORY = dashboard-samples

> @eclipse-che/che-e2e@7.107.0-next lint
> eslint --fix .


> @eclipse-che/che-e2e@7.107.0-next tsc
> rm -rf ./dist && ./configs/sh-scripts/generateIndex.sh && tsc -p .

Generating index.ts file...

################## Launch Information ##################

      TS_SELENIUM_BASE_URL: http://eclipse-che.apps-crc.testing
      TS_SELENIUM_HEADLESS: false
      TS_SELENIUM_OCP_USERNAME: happypath-dev
      TS_SELENIUM_EDITOR:   che-code

      TS_SELENIUM_HAPPY_PATH_WORKSPACE_NAME: EmptyWorkspace
      TS_SELENIUM_DELAY_BETWEEN_SCREENSHOTS: 1000
      TS_SELENIUM_REPORT_FOLDER: ./report
      TS_SELENIUM_EXECUTION_SCREENCAST: false
      DELETE_SCREENCAST_IF_TEST_PASS: true
      TS_SELENIUM_REMOTE_DRIVER_URL: http://localhost:4444/wd/hub
      DELETE_WORKSPACE_ON_FAILED_TEST: true
      TS_SELENIUM_LOG_LEVEL: TRACE
      TS_SELENIUM_LAUNCH_FULLSCREEN: true

      

      TS_COMMON_DASHBOARD_WAIT_TIMEOUT: 5000
      TS_SELENIUM_START_WORKSPACE_TIMEOUT: 540000
      TS_WAIT_LOADER_PRESENCE_TIMEOUT: 60000

      TS_SAMPLE_LIST: Node.js MongoDB,Node.js Express,Java Lombok,Quarkus REST API,Python,.NET,C/C++,Go,PHP,Ansible

      MOCHA_DIRECTORY: dashboard-samples
      USERSTORY: EmptyWorkspace

      to output timeout variables, set TS_SELENIUM_PRINT_TIMEOUT_VARIABLES to true
 ######################################################## 


            ‣ DriverHelper.getDriver
  Empty Workspace test 
          ▼ LoginTests.loginIntoChe
            ‣ BrowserTabsUtil.getCurrentUrl
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.navigateTo - http://eclipse-che.apps-crc.testing
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
  [ERROR] DriverHelper.waitVisibility - failed with exception, out of attempts - TimeoutError: Waiting for element to be located By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
  Wait timed out after 1179ms
          ▼ LoginTests.loginIntoChe - try to login into application
          ▼ RegularUserOcpCheLoginPage.login
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@class="panel-login"]/div[contains(@class, "panel-content")]/form/button)
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@class="panel-login"]/div[contains(@class, "panel-content")]/form/button)
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.isIdentityProviderLinkVisible
            ‣ DriverHelper.waitVisibilityBoolean - By(xpath, //a[text()="dev-htpasswd"])
            ‣ DriverHelper.isVisible - By(xpath, //a[text()="dev-htpasswd"])
          ▼ OcpLoginPage.waitAndClickOnLoginProviderTitle
            ‣ DriverHelper.waitAndClick - By(xpath, //a[text()="dev-htpasswd"])
            ‣ DriverHelper.waitVisibility - By(xpath, //a[text()="dev-htpasswd"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitVisibility - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterUserNameOpenShift - "happypath-dev"
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputUsername"]) text: happypath-dev
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputUsername"]) text: happypath-dev
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputUsername"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputUsername"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.enterPasswordOpenShift
            ‣ DriverHelper.enterValue - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.clear - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.type - By(css selector, *[id="inputPassword"]) text: ***
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitAttributeValue - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitAndGetElementAttribute - By(css selector, *[id="inputPassword"]) attribute: 'value'
            ‣ DriverHelper.waitVisibility - By(css selector, *[id="inputPassword"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.clickOnLoginButton
            ‣ DriverHelper.waitAndClick - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - By(css selector, button[type=submit])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ OcpLoginPage.waitDisappearanceOpenShiftLoginWelcomePage
            ‣ DriverHelper.waitDisappearance - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.waitDisappearanceBoolean - By(xpath, //*[contains(text(), "Welcome")])
            ‣ DriverHelper.isVisible - By(xpath, //*[contains(text(), "Welcome")])
          ▼ OcpLoginPage.isAuthorizeOpenShiftIdentityProviderPageVisible
            ‣ DriverHelper.isVisible - By(xpath, //h1[text()="Authorize Access"])
            ‣ BrowserTabsUtil.maximize
          ▼ BrowserTabsUtil.maximize - TS_SELENIUM_LAUNCH_FULLSCREEN is set to true, maximizing window.
            ‣ DriverHelper.getDriver
          ▼ Dashboard.waitStartingPageLoaderDisappearance
            ‣ DriverHelper.waitDisappearance - By(css selector, .main-page-loader)
            ‣ DriverHelper.waitDisappearanceBoolean - By(css selector, .main-page-loader)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.isVisible - By(css selector, .main-page-loader)
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ Dashboard.clickWorkspacesButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ WorkspaceHandlingTests.createAndOpenWorkspace - fetching user kubernetes namespace, storing auth token by getting workspaces API URL.
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
(node:231) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
          ▼ ApiUrlResolver.obtainUserNamespace - kubeapi success: happypath-dev-che
          ▼ Dashboard.clickCreateWorkspaceButton
            ‣ DriverHelper.waitAndClick - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ CreateWorkspace.waitPage
          ▼ CreateWorkspace.waitTitleContains - text: "Create Workspace"
            ‣ DriverHelper.waitVisibility - By(xpath, //h1[contains(text(), 'Create Workspace')])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ CreateWorkspace.clickOnSampleNoEditorSelection - sampleName: "Empty Workspace"
            ‣ CreateWorkspace.getSampleLocator - sampleName: Empty Workspace, used default editor
            ‣ DriverHelper.waitAndClick - By(xpath, //article[contains(@class, 'sample-card')]//div[text()='Empty Workspace'])
            ‣ DriverHelper.waitVisibility - By(xpath, //article[contains(@class, 'sample-card')]//div[text()='Empty Workspace'])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ BrowserTabsUtil.waitAndSwitchToAnotherWindow
            ‣ DriverHelper.waitUntilTrue
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
    ✔ Create and open new workspace, stack:Empty Workspace
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - failed to obtain name from workspace start page, element not visible yet. Retrying.
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained starting workspace getText():Starting workspace empty-3gom
            ‣ WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - trimmed workspace name from getText():empty-3gom
      • WorkspaceHandlingTests.obtainWorkspaceNameFromStartingPage - obtained workspace name from workspace loader page: empty-3gom
    ✔ Obtain workspace name from workspace loader page
          ▼ registerRunningWorkspace - with workspaceName:empty-3gom
    ✔ Register running workspace
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - waiting for editor.
            ‣ DriverHelper.waitVisibility - By(css selector, .monaco-workbench)
            ‣ DriverHelper.waitVisibility - polling timed out attempt #1, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #2, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #3, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #4, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #5, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #6, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #7, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #8, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #9, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #10, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #11, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #12, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #13, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - polling timed out attempt #14, retrying with 1000ms timeout
            ‣ DriverHelper.waitVisibility - element is located and is visible.
          ▼ ProjectAndFileTests.waitWorkspaceReadinessForCheCodeEditor - editor was opened in 17994 seconds.
          ▼ Editor sections:
          ▼ Explorer (Ctrl+Shift+E)
          ▼ Search (Ctrl+Shift+F)
          ▼ Source Control (Ctrl+Shift+G)
          ▼ Run and Debug (Ctrl+Shift+D)
          ▼ Extensions (Ctrl+Shift+X)
    ✔ Wait workspace readiness
          ▼ Dashboard.openDashboard
            ‣ DriverHelper.navigateToUrl
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ Dashboard.openDashboard - No alert detected
          ▼ Dashboard.waitPage
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[contains(text(), "Workspaces (")])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ DriverHelper.waitVisibility - By(xpath, //div[@id="page-sidebar"]//a[text()="Create Workspace"])
            ‣ DriverHelper.waitVisibility - element is located and is visible.
            ‣ BrowserTabsUtil.closeAllTabsExceptCurrent
          ▼ BrowserTabsUtil.getAllWindowHandles
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.getCurrentWindowHandle
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
          ▼ BrowserTabsUtil.switchToWindow
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.stopAndDeleteWorkspaceByName
          ▼ TestWorkspaceUtil.stopWorkspaceByName - empty-3gom
          ▼ ApiUrlResolver.obtainUserNamespace
            ‣ ApiUrlResolver.obtainUserNamespace - USER_NAMESPACE.length = 0, calling kubernetes API
            ‣ DriverHelper.getDriver
          ▼ ApiUrlResolver.obtainUserNamespace - kubeapi success: happypath-dev-che
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.waitWorkspaceStatus
          ▼ ApiUrlResolver.obtainUserNamespace - happypath-dev-che
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
          ▼ ApiUrlResolver.obtainUserNamespace - happypath-dev-che
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.stopWorkspaceByName - empty-3gom stopped successfully
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - empty-3gom
          ▼ ApiUrlResolver.obtainUserNamespace - happypath-dev-che
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
            ‣ DriverHelper.wait - (1000 milliseconds)
            ‣ DriverHelper.getDriver
          ▼ TestWorkspaceUtil.deleteWorkspaceByName - empty-3gom deleted successfully
          ▼     at /tmp/e2e/specs/MochaHooks.ts:39:12 - delete workspace name


  4 passing (52s)

+ EXIT_CODE=0
+ '[' true == true ']'
+ kill_ffmpeg
Killing ffmpeg with PID=134
+ echo 'Killing ffmpeg with PID=134'
+ kill -2 134
+ wait 134
+ mkdir -p /tmp/e2e/report/
+ cp /tmp/ffmpeg_report/ffmpeg_err.txt /tmp/ffmpeg_report/ffmpeg_std.txt /tmp/ffmpeg_report/output.webm /tmp/e2e/report/
+ exit 0
[INFO] Downloading test report.
WARNING: cannot use rsync: rsync not available in container
./ffmpeg_err.txt
./ffmpeg_std.txt
./output.webm
[INFO] Happy-path test succeed.
[INFO] Happy-path execution took 126.171823671 seconds.
```


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->
Fix #23514

Related to https://github.com/devfile/devworkspace-operator/pull/1474

### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
- Checkout to this branch
- `cd tests/e2e`
- Create container image for test image based on these changes: `docker build -t ${REGISTRY}/${USER}/che-e2e:next -f build/dockerfiles/Dockerfile .`
- Update `tests/devworkspace-happy-path/start-happypath-tests.sh` to use this custom image
```diff
-export E2E_TEST_IMAGE="${E2E_TEST_IMAGE:-quay.io/eclipse/che-e2e:next}"
+export E2E_TEST_IMAGE="${E2E_TEST_IMAGE:-docker.io/rohankanojia/che-e2e:next}"
```
- `cd tests/devworkspace-happy-path`
- Run `./launch.sh`

You should be able to see all the specs getting tested and logged in test output.


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
