### PR TITLE
[Test] Make SSH key file paths configurable via environment variables in factory tests

### DIFF
--- a/tests/e2e/constants/FACTORY_TEST_CONSTANTS.ts
+++ b/tests/e2e/constants/FACTORY_TEST_CONSTANTS.ts
@@ -25,6 +25,8 @@ export const FACTORY_TEST_CONSTANTS: {
 	TS_SELENIUM_IS_PRIVATE_FACTORY_GIT_REPO: boolean;
 	TS_SELENIUM_FACTORY_GIT_PROVIDER: string;
 	TS_SELENIUM_FACTORY_GIT_REPO_BRANCH: string;
+	TS_SELENIUM_SSH_PRIVATE_KEY_PATH: string;
+	TS_SELENIUM_SSH_PUBLIC_KEY_PATH: string;
 	TS_SELENIUM_FACTORY_URL(): string;
 } = {
 	/**
@@ -56,6 +58,16 @@ export const FACTORY_TEST_CONSTANTS: {
 	 * git repository main branch name (main or master)
 	 */
 	TS_SELENIUM_FACTORY_GIT_REPO_BRANCH: process.env.TS_SELENIUM_FACTORY_GIT_REPO_BRANCH || 'master',
+
+	/**
+	 * path to SSH private key file
+	 */
+	TS_SELENIUM_SSH_PRIVATE_KEY_PATH: process.env.TS_SELENIUM_SSH_PRIVATE_KEY_PATH || 'resources/factory/pr-k.txt',
+
+	/**
+	 * path to SSH public key file
+	 */
+	TS_SELENIUM_SSH_PUBLIC_KEY_PATH: process.env.TS_SELENIUM_SSH_PUBLIC_KEY_PATH || 'resources/factory/pub-k.txt',
 
 	/**
 	 * full factory URL

--- a/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
+++ b/tests/e2e/specs/factory/SshUrlNoOauthPatFactory.spec.ts
@@ -36,8 +36,8 @@ suite(`The SshUrlNoOauthPatFactory userstory ${BASE_TEST_CONSTANTS.TEST_ENVIRONM
 	const factoryUrl: string =
 		FACTORY_TEST_CONSTANTS.TS_SELENIUM_FACTORY_GIT_REPO_URL ||
 		'ssh://git@bitbucket-ssh.apps.ds-airgap2-v15.crw-qe.com/~admin/private-bb-repo.git';
-	const privateSshKeyPath: string = 'resources/factory/pr-k.txt';
-	const publicSshKeyPath: string = 'resources/factory/pub-k.txt';
+	const privateSshKeyPath: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_SSH_PRIVATE_KEY_PATH;
+	const publicSshKeyPath: string = FACTORY_TEST_CONSTANTS.TS_SELENIUM_SSH_PUBLIC_KEY_PATH;
 	let projectSection: ViewSection;
 
 	async function deleteSshKeys(): Promise<void> {


### PR DESCRIPTION
<!-- Please review the following before submitting a PR:
Che's Contributing Guide: https://github.com/eclipse/che/blob/master/CONTRIBUTING.md
Pull Request Policy: https://github.com/eclipse/che/wiki/Development-Workflow#pull-requests
-->

### What does this PR do?
Make SSH key file paths configurable via environment variables in factory tests. 

### Screenshot/screencast of this PR
<!-- Please include a screenshot or a screencast explaining what is doing this PR -->


### What issues does this PR fix or reference?
<!-- Please include any related issue from eclipse che repository (or from another issue tracker).
     Include link to other pull requests like documentation PR from [the docs repo](https://github.com/eclipse/che-docs)
-->


### How to test this PR?
<!-- Please explain for example :
  - The test platform (openshift, kubernetes, minikube, CodeReady Container, docker-desktop, etc)
  - Installation method: chectl / che-operator
  - steps to reproduce
 -->
1. Create files with private and public ssh keys and encode they by `base64`
2. Set private and public ssh keys path to `TS_SELENIUM_SSH_PRIVATE_KEY_PATH` and `TS_SELENIUM_SSH_PUBLIC_KEY_PATH`
3. Set `TS_SELENIUM_FACTORY_GIT_REPO_URL` with ssh repo url
4. Start `SshUrlNoOauthPatFactory` test

Example:
```
export TS_SELENIUM_FACTORY_GIT_REPO_URL="git@github.com:crw-qe/private-repo-check.git"
export TS_SELENIUM_SSH_PRIVATE_KEY_PATH="resources/factory/github-ssh.txt"
export TS_SELENIUM_SSH_PUBLIC_KEY_PATH="resources/factory/github-ssh-public.txt"
export USERSTORY=SshUrlNoOauthPatFactory
npm run test
```

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [ ] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [ ] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [ ] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix or new feature ](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix-or-new-feature)
- [ ] [The repository devfile is up to date and works](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [ ] [Sections `What issues does this PR fix or reference` and `How to test this PR` completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [ ] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [ ] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.
